### PR TITLE
fix(gui-app): show message edit/delete once the turn actually settles

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -35,12 +35,14 @@ vi.mock("sonner", () => ({
 }));
 
 import {
+  canModifyChatMessages,
   chatActivityIndicator,
   chatMessageEditingForInlineEdit,
   resolvedTurnStatus,
   showRestoreResultToast,
   type InlineEditState,
 } from "../chat-tile-session-state";
+import type { PendingUserMessage } from "@/stores/chats/chat-session-store";
 
 beforeEach(() => {
   toastSuccess.mockClear();
@@ -639,5 +641,135 @@ describe("chatActivityIndicator", () => {
         turnInProgress: undefined,
       }),
     ).toBe("turn");
+  });
+});
+
+describe("canModifyChatMessages", () => {
+  const PENDING_USER_MESSAGE: PendingUserMessage = {
+    clientActionId: "action-1",
+    messageId: "message-1",
+    content: CONTENT,
+    sender: { type: "user", userId: "owner-1" },
+    settings: SETTINGS,
+    timestamp: 0,
+  };
+
+  function gateState(
+    overrides: Partial<Parameters<typeof canModifyChatMessages>[0]["state"]>,
+  ): Parameters<typeof canModifyChatMessages>[0]["state"] {
+    return {
+      runStatus: "idle",
+      activeTurn: null,
+      queue: EMPTY_QUEUE,
+      backgroundItems: undefined,
+      turnInProgress: undefined,
+      pendingUserMessages: [],
+      pendingActions: {},
+      ...overrides,
+    };
+  }
+
+  it("allows edit/delete on a fully idle chat", () => {
+    expect(canModifyChatMessages({ canAct: true, state: gateState({}) })).toBe(
+      true,
+    );
+  });
+
+  it("denies when the viewer cannot act", () => {
+    expect(canModifyChatMessages({ canAct: false, state: gateState({}) })).toBe(
+      false,
+    );
+  });
+
+  it("denies while the host reports a turn genuinely in progress (pre-turn activating window included)", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({ runStatus: "running", turnInProgress: true }),
+      }),
+    ).toBe(false);
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({ runStatus: "stopping", turnInProgress: true }),
+      }),
+    ).toBe(false);
+  });
+
+  it("allows when runStatus is running purely because visible background work outlives the settled turn - the reported regression", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({
+          runStatus: "running",
+          turnInProgress: false,
+          backgroundItems: [
+            {
+              taskId: "t1",
+              kind: "command",
+              title: "bun test",
+              blockId: "t1",
+              parentTaskId: null,
+              scheduledFor: null,
+            },
+          ],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("older-host fallback: background-only running phase opens the gate without turnInProgress", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({
+          runStatus: "running",
+          turnInProgress: undefined,
+          backgroundItems: [
+            {
+              taskId: "t1",
+              kind: "monitor",
+              title: "Monitor",
+              blockId: "t1",
+              parentTaskId: null,
+              scheduledFor: null,
+            },
+          ],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("older-host fallback: an unexplained running status (activating window) keeps the gate closed", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({ runStatus: "running", turnInProgress: undefined }),
+      }),
+    ).toBe(false);
+  });
+
+  it("denies while a queued item is pending, even with no turn in progress", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({
+          runStatus: "running",
+          turnInProgress: false,
+          queue: runnableQueue(1),
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("denies while an optimistic user message is still unconfirmed", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        state: gateState({
+          pendingUserMessages: [PENDING_USER_MESSAGE],
+        }),
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -309,17 +309,30 @@ export function canModifyChatMessages(input: {
     | "runStatus"
     | "activeTurn"
     | "queue"
+    | "backgroundItems"
+    | "turnInProgress"
     | "pendingUserMessages"
     | "pendingActions"
   >;
 }): boolean {
   if (!input.canAct) return false;
-  // `runStatus` is the host-owned source of truth for an in-progress run and
-  // covers windows `activeTurn` misses - the pre-turn `turnActivating` phase
-  // (provider/worktree setup) and stop-during-activation both report a non-idle
-  // `runStatus` while `activeTurn` is still null. Gate on it so edit/delete stay
-  // disabled for the whole run, matching the composer's `runStatus`-driven UX.
-  if (input.state.runStatus !== "idle") return false;
+  // Narrowed via `resolvedTurnStatus`, not the raw `runStatus`: the raw value
+  // also reads "running" while visible background work outlives the settled
+  // turn (Bash `run_in_background` / a subagent / Monitor), which would keep
+  // edit/delete hidden indefinitely with no turn to wait for - the composer
+  // and restore gating already read the narrowed value for the same reason.
+  // The narrowed signal still covers the windows `activeTurn` misses: the
+  // pre-turn `turnActivating` phase (provider/worktree setup) and
+  // stop-during-activation both keep the host's `turnInProgress` true until
+  // the run truly unwinds. Queued sends are handled by the queue check below.
+  if (
+    resolvedTurnStatus(
+      input.state,
+      composerTurnStatus(input.state.runStatus),
+    ) !== null
+  ) {
+    return false;
+  }
   if (input.state.activeTurn !== null) return false;
   if (input.state.queue.items.length > 0) return false;
   if (input.state.pendingUserMessages.length > 0) return false;

--- a/clients/gui-app/src/stores/chats/__tests__/chat-queue-reconciler.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-queue-reconciler.test.ts
@@ -6,9 +6,12 @@ import {
   pruneAcceptedActions,
   reconcileQueueChange,
   reconcileSnapshotChange,
+  reconcileTurnSettled,
   sweepStalePendingActions,
+  turnSettledFromStatus,
   type ReconcileQueueInput,
   type ReconcileSnapshotInput,
+  type ReconcileTurnSettledInput,
 } from "@/stores/chats/chat-queue-reconciler";
 import type {
   AcceptedChatAction,
@@ -663,6 +666,147 @@ describe("chat-queue-reconciler", () => {
       const result = sweepStalePendingActions(pendingActions, 0);
       expect(result.pendingActions).toBe(pendingActions);
       expect(result.sweptActionIds.size).toBe(0);
+    });
+  });
+
+  describe("turnSettledFromStatus", () => {
+    it("prefers the host-sent turnInProgress when present", () => {
+      expect(turnSettledFromStatus(false, "running")).toBe(true);
+      expect(turnSettledFromStatus(true, "running")).toBe(false);
+      expect(turnSettledFromStatus(true, "stopping")).toBe(false);
+    });
+
+    it("falls back to runStatus idle for an older host that omits the field", () => {
+      expect(turnSettledFromStatus(undefined, "idle")).toBe(true);
+      expect(turnSettledFromStatus(undefined, "running")).toBe(false);
+      expect(turnSettledFromStatus(undefined, "stopping")).toBe(false);
+    });
+  });
+
+  describe("reconcileTurnSettled", () => {
+    function settledInput(
+      overrides: Partial<ReconcileTurnSettledInput>,
+    ): ReconcileTurnSettledInput {
+      return {
+        pendingActions: {},
+        pendingUserMessages: [createPendingUserMessage("action-1", "msg-1")],
+        messages: [],
+        queue: { status: "idle", items: [] },
+        failedSendRestoration: null,
+        ...overrides,
+      };
+    }
+
+    it("drops a stranded entry (accepted ack, no messageAccepted) and restores its content to the composer", () => {
+      const result = reconcileTurnSettled(true, settledInput({}));
+
+      expect(result.pendingUserMessages).toEqual([]);
+      expect(result.failedSendRestoration).toEqual({
+        clientActionId: "action-1",
+        content: CONTENT,
+        reason: "The message was not recorded before the turn stopped.",
+      });
+    });
+
+    it("keeps an entry whose ack is still in flight", () => {
+      const input = settledInput({
+        pendingActions: {
+          "action-1": createPendingAction("action-1", "msg-1", "send"),
+        },
+      });
+
+      const result = reconcileTurnSettled(true, input);
+
+      expect(result.pendingUserMessages).toBe(input.pendingUserMessages);
+      expect(result.failedSendRestoration).toBeNull();
+    });
+
+    it("drops an entry whose message reached the transcript as stale bookkeeping, without restoration", () => {
+      const confirmedMessage: Message = {
+        role: "user",
+        messageId: "msg-1",
+        sender: SENDER,
+        message: { kind: "user", content: CONTENT },
+        timestamp: 1000,
+        sessionAnchor: null,
+      };
+      const input = settledInput({ messages: [confirmedMessage] });
+
+      const result = reconcileTurnSettled(true, input);
+
+      expect(result.pendingUserMessages).toEqual([]);
+      expect(result.failedSendRestoration).toBeNull();
+    });
+
+    it("keeps an entry parked in the queue", () => {
+      const input = settledInput({
+        queue: { status: "paused", items: [createQueueItem("msg-1", CONTENT)] },
+      });
+
+      const result = reconcileTurnSettled(true, input);
+
+      expect(result.pendingUserMessages).toBe(input.pendingUserMessages);
+      expect(result.failedSendRestoration).toBeNull();
+    });
+
+    it("restores from the first dead entry, skipping confirmed stale bookkeeping", () => {
+      const confirmedMessage: Message = {
+        role: "user",
+        messageId: "msg-1",
+        sender: SENDER,
+        message: { kind: "user", content: CONTENT },
+        timestamp: 1000,
+        sessionAnchor: null,
+      };
+      const deadEntry: PendingUserMessage = {
+        clientActionId: "action-2",
+        messageId: "msg-2",
+        content: CONTENT_2,
+        sender: SENDER,
+        settings: SETTINGS,
+        timestamp: 1000,
+      };
+      const result = reconcileTurnSettled(
+        true,
+        settledInput({
+          pendingUserMessages: [
+            createPendingUserMessage("action-1", "msg-1"),
+            deadEntry,
+          ],
+          messages: [confirmedMessage],
+        }),
+      );
+
+      expect(result.pendingUserMessages).toEqual([]);
+      expect(result.failedSendRestoration).toEqual({
+        clientActionId: "action-2",
+        content: CONTENT_2,
+        reason: "The message was not recorded before the turn stopped.",
+      });
+    });
+
+    it("is a no-op when the report is not settled", () => {
+      const input = settledInput({});
+
+      const result = reconcileTurnSettled(false, input);
+
+      expect(result.pendingUserMessages).toBe(input.pendingUserMessages);
+      expect(result.failedSendRestoration).toBeNull();
+    });
+
+    it("never overwrites an occupied failedSendRestoration slot", () => {
+      const occupied = {
+        clientActionId: "action-0",
+        content: CONTENT_2,
+        reason: "Message was not accepted.",
+      };
+      const result = reconcileTurnSettled(
+        true,
+        settledInput({ failedSendRestoration: occupied }),
+      );
+
+      expect(result.pendingUserMessages).toEqual([]);
+      expect(result.failedSendRestoration).toBe(occupied);
     });
   });
 });

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -5412,3 +5412,197 @@ describe("createChatSessionStore - persisted auth-error provider nudge", () => {
     expect(harness.nudgeCount()).toBe(1);
   });
 });
+
+describe("turn-settled stranded-send reconciliation", () => {
+  it("drops the optimistic user message and restores its content when a stop lands before messageAccepted", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    harness.handle.store
+      .getState()
+      .sendMessage(
+        CONTENT,
+        { type: "user", userId: OWNER_ID },
+        SETTINGS,
+        "auto",
+      );
+    const frame = harness.sent[0];
+    if (frame.kind !== "send") throw new Error("Expected send frame");
+    expect(harness.handle.store.getState().pendingUserMessages).toHaveLength(1);
+
+    // The pre-turn activation window: the host accepts the send and reports
+    // the run as in progress before the message is appended.
+    acceptLastAction(harness);
+    callbacks.onTurnStateChanged({
+      kind: "turnStateChanged",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      runStatus: "running",
+      activeTurn: null,
+      turnInProgress: true,
+    });
+    // The accepted ack deliberately keeps the optimistic entry alive - the
+    // durable messageAccepted frame is what normally clears it.
+    expect(harness.handle.store.getState().pendingUserMessages).toHaveLength(1);
+
+    // A stop aborts activation: the turn settles without the host ever
+    // appending the message - no messageAccepted or rejected ack will arrive.
+    callbacks.onTurnStateChanged({
+      kind: "turnStateChanged",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      runStatus: "idle",
+      activeTurn: null,
+      turnInProgress: false,
+    });
+
+    const state = harness.handle.store.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    expect(state.failedSendRestoration).toEqual({
+      clientActionId: frame.clientActionId,
+      content: CONTENT,
+      reason: "The message was not recorded before the turn stopped.",
+    });
+  });
+
+  it("keeps an optimistic entry whose ack is still in flight when an unrelated settle frame arrives", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    harness.handle.store
+      .getState()
+      .sendMessage(
+        CONTENT,
+        { type: "user", userId: OWNER_ID },
+        SETTINGS,
+        "auto",
+      );
+    expect(harness.handle.store.getState().pendingUserMessages).toHaveLength(1);
+
+    // e.g. a background task settling broadcasts a turn-settled frame while
+    // the fresh send's ack is still on the wire - the entry must survive.
+    callbacks.onTurnStateChanged({
+      kind: "turnStateChanged",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      runStatus: "idle",
+      activeTurn: null,
+      turnInProgress: false,
+    });
+
+    const state = harness.handle.store.getState();
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.failedSendRestoration).toBeNull();
+  });
+
+  it("heals on an older host via runStatus idle when the frame omits turnInProgress", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    harness.handle.store
+      .getState()
+      .sendMessage(
+        CONTENT,
+        { type: "user", userId: OWNER_ID },
+        SETTINGS,
+        "auto",
+      );
+    const frame = harness.sent[0];
+    if (frame.kind !== "send") throw new Error("Expected send frame");
+    acceptLastAction(harness);
+
+    callbacks.onTurnStateChanged({
+      kind: "turnStateChanged",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      runStatus: "idle",
+      activeTurn: null,
+    });
+
+    const state = harness.handle.store.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    expect(state.failedSendRestoration?.clientActionId).toBe(
+      frame.clientActionId,
+    );
+  });
+
+  it("reconciles an accepted-but-unrecorded send from a settled reconnect snapshot", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    harness.handle.store
+      .getState()
+      .sendMessage(
+        CONTENT,
+        { type: "user", userId: OWNER_ID },
+        SETTINGS,
+        "auto",
+      );
+    const frame = harness.sent[0];
+    if (frame.kind !== "send") throw new Error("Expected send frame");
+    // The accepted ack removes the pending action but keeps the optimistic
+    // entry; the connection then dies before any settling frame arrives.
+    acceptLastAction(harness);
+    callbacks.onConnectionStatus("reconnecting", null);
+
+    // The reconnect snapshot is the only authoritative settled state: no
+    // turn in progress, and the message never reached the transcript.
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+
+    const state = harness.handle.store.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    expect(state.failedSendRestoration).toEqual({
+      clientActionId: frame.clientActionId,
+      content: CONTENT,
+      reason: "The message was not recorded before the turn stopped.",
+    });
+  });
+
+  it("clears stale optimistic bookkeeping without restoration when the reconnect snapshot carries the message", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    harness.handle.store
+      .getState()
+      .sendMessage(
+        CONTENT,
+        { type: "user", userId: OWNER_ID },
+        SETTINGS,
+        "auto",
+      );
+    const frame = harness.sent[0];
+    if (frame.kind !== "send") throw new Error("Expected send frame");
+    acceptLastAction(harness);
+    callbacks.onConnectionStatus("reconnecting", null);
+
+    // The send did land host-side; the lost frame was `messageAccepted`, not
+    // the message itself. The persisted row is authoritative - no composer
+    // restoration.
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [persistedUserMessage(frame.messageId)],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+
+    const state = harness.handle.store.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    expect(state.failedSendRestoration).toBeNull();
+  });
+});

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -1976,6 +1976,55 @@ describe("createChatSessionStore", () => {
     expect(harness.handle.store.getState().pendingUserMessages).toEqual([]);
   });
 
+  it("keeps the first restoration when a second send is rejected before the composer consumes it", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    const rejectSend = (index: number, reason: string): string => {
+      harness.handle.store
+        .getState()
+        .sendMessage(
+          index === 0 ? CONTENT : IMAGE_CONTENT,
+          { type: "user", userId: OWNER_ID },
+          SETTINGS,
+          "auto",
+        );
+      const frame = harness.sent[index];
+      if (frame.kind !== "send") throw new Error("Expected send frame");
+      callbacks.onActionAck({
+        kind: "actionAck",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        clientActionId: frame.clientActionId,
+        action: "send",
+        status: "rejected",
+        reason,
+        code: "ACTION_REJECTED",
+        backgroundStopTaskIds: [],
+      });
+      return frame.clientActionId;
+    };
+
+    const firstActionId = rejectSend(0, "First rejection.");
+    rejectSend(1, "Second rejection.");
+
+    // The slot is single-consumer: the second rejection must not clobber
+    // content the composer has not restored yet.
+    expect(harness.handle.store.getState().failedSendRestoration).toMatchObject(
+      {
+        clientActionId: firstActionId,
+        content: CONTENT,
+        reason: "First rejection.",
+      },
+    );
+
+    // Once acked, the slot is free again for the next failure.
+    harness.handle.store.getState().ackFailedSendRestoration(firstActionId);
+    expect(harness.handle.store.getState().failedSendRestoration).toBeNull();
+  });
+
   it("does not send owner actions for read-only viewers", () => {
     const harness = createHarness();
     emitSnapshot(harness.callbacks(), "viewer");

--- a/clients/gui-app/src/stores/chats/chat-queue-reconciler.ts
+++ b/clients/gui-app/src/stores/chats/chat-queue-reconciler.ts
@@ -1,4 +1,7 @@
-import type { ChatQueueState } from "@traycer/protocol/host/agent/gui/subscribe";
+import type {
+  ChatQueueState,
+  ChatRunStatus,
+} from "@traycer/protocol/host/agent/gui/subscribe";
 import type { Message } from "@traycer/protocol/persistence/epic/schemas";
 import type {
   AcceptedChatAction,
@@ -173,6 +176,107 @@ export function reconcileSnapshotChange(
     },
     initial,
   );
+}
+
+/**
+ * Input for turn-settled reconciliation: the state slices needed to decide
+ * which optimistic pending user messages can no longer materialize.
+ */
+export type ReconcileTurnSettledInput = {
+  readonly pendingActions: Readonly<Record<string, PendingChatAction>>;
+  readonly pendingUserMessages: ReadonlyArray<PendingUserMessage>;
+  readonly messages: ReadonlyArray<Message>;
+  readonly queue: ChatQueueState;
+  readonly failedSendRestoration: FailedSendRestorationState | null;
+};
+
+export type ReconcileTurnSettledPatch = {
+  readonly pendingUserMessages: ReadonlyArray<PendingUserMessage>;
+  readonly failedSendRestoration: FailedSendRestorationState | null;
+};
+
+/**
+ * Whether a `turnStateChanged` frame or `chat.subscribe` snapshot reports the
+ * turn settled: the host's own `turnInProgress` when present, with the
+ * `runStatus` idle read as the fallback for an older host that predates the
+ * field. A settled report is the trigger for {@link reconcileTurnSettled}.
+ */
+export function turnSettledFromStatus(
+  turnInProgress: boolean | undefined,
+  runStatus: ChatRunStatus,
+): boolean {
+  return turnInProgress === undefined ? runStatus === "idle" : !turnInProgress;
+}
+
+/**
+ * Drop stranded optimistic user messages when the turn settles.
+ *
+ * An accepted send ack deliberately keeps its `pendingUserMessages` entry
+ * alive - the durable `messageAccepted` frame is what normally clears it. A
+ * stop during turn activation can abort the send after the accepted ack but
+ * before the host appends the message, in which case neither
+ * `messageAccepted` nor a rejected ack ever arrives and the entry would
+ * survive indefinitely - keeping edit/delete gated off and rendering a user
+ * message the host never recorded. A settled report is the authoritative
+ * "this send will never materialize" signal. It arrives two ways, and this
+ * runs on both: a live `turnStateChanged` frame, and a re-subscribe snapshot
+ * (`reconcileSnapshotChange` only settles sends still in `pendingActions`,
+ * so an already-acked entry needs this pass on reconnect too).
+ *
+ * An entry survives while a path to materialization remains open: its ack is
+ * still in flight (`pendingActions`) or it was parked in the queue (a later
+ * `queueChanged`/`messageAccepted` settles it, and the mutation gate stays
+ * closed on the queue anyway). An entry whose message already reached the
+ * transcript is stale bookkeeping - dropped without restoration. Truly dead
+ * entries are dropped and the first one's content is restored to the
+ * composer via the `failedSendRestoration` slot (single-slot; an occupied
+ * slot is never overwritten).
+ *
+ * Pure function - all state is passed explicitly. `settled` is
+ * {@link turnSettledFromStatus}'s answer for the triggering frame/snapshot; a
+ * non-settled report returns the input slices unchanged.
+ */
+export function reconcileTurnSettled(
+  settled: boolean,
+  input: ReconcileTurnSettledInput,
+): ReconcileTurnSettledPatch {
+  if (!settled) {
+    return {
+      pendingUserMessages: input.pendingUserMessages,
+      failedSendRestoration: input.failedSendRestoration,
+    };
+  }
+  const confirmedMessageIds = confirmedMessageIdsForMessages(input.messages);
+  const stranded = input.pendingUserMessages.filter(
+    (message) =>
+      !Object.hasOwn(input.pendingActions, message.clientActionId) &&
+      !queueContainsPendingSend(input.queue, message.messageId, message),
+  );
+  if (stranded.length === 0) {
+    return {
+      pendingUserMessages: input.pendingUserMessages,
+      failedSendRestoration: input.failedSendRestoration,
+    };
+  }
+  const restorable = stranded.find(
+    (message) => !confirmedMessageIds.has(message.messageId),
+  );
+  const strandedActionIds = new Set(
+    stranded.map((message) => message.clientActionId),
+  );
+  return {
+    pendingUserMessages: input.pendingUserMessages.filter(
+      (message) => !strandedActionIds.has(message.clientActionId),
+    ),
+    failedSendRestoration:
+      input.failedSendRestoration !== null || restorable === undefined
+        ? input.failedSendRestoration
+        : {
+            clientActionId: restorable.clientActionId,
+            content: restorable.content,
+            reason: "The message was not recorded before the turn stopped.",
+          },
+  };
 }
 
 export interface StalePendingActionsSweep {

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -1129,8 +1129,15 @@ export function createChatSessionStore(
               state.queue,
               frame.clientActionId,
             ),
+            // Single slot, first writer wins until `ackFailedSendRestoration`
+            // clears it - the same rule `reconcileSnapshotChange` and the
+            // settled-turn pass already follow. Two rejections landing before
+            // the composer consumes the first would otherwise leave the
+            // earlier (longer-waiting) content unreachable.
             failedSendRestoration:
-              pending?.action === "send" && pending.restoreContent !== null
+              state.failedSendRestoration === null &&
+              pending?.action === "send" &&
+              pending.restoreContent !== null
                 ? {
                     clientActionId: frame.clientActionId,
                     content: pending.restoreContent,

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -3,7 +3,9 @@ import {
   pruneAcceptedActions,
   reconcileQueueChange,
   reconcileSnapshotChange,
+  reconcileTurnSettled,
   sweepStalePendingActions,
+  turnSettledFromStatus,
   withoutPendingAction,
 } from "@/stores/chats/chat-queue-reconciler";
 import {
@@ -932,6 +934,26 @@ export function createChatSessionStore(
             failedSendRestoration: state.failedSendRestoration,
             nowMs: now,
           });
+          // `reconcileSnapshotChange` only settles sends still awaiting their
+          // ack. A send whose accepted ack landed before the connection died
+          // has already left `pendingActions`, so its optimistic user message
+          // needs its own settled pass: when this authoritative snapshot
+          // reports no turn in progress, an entry with no remaining path to
+          // materialization will never be cleared by a later frame - drop it
+          // (restoring its content if the transcript never recorded it).
+          const settled = reconcileTurnSettled(
+            turnSettledFromStatus(
+              frame.snapshot.turnInProgress,
+              frame.snapshot.runStatus,
+            ),
+            {
+              pendingActions: pending.pendingActions,
+              pendingUserMessages: pending.pendingUserMessages,
+              messages,
+              queue: frame.snapshot.queue,
+              failedSendRestoration: pending.failedSendRestoration,
+            },
+          );
           // A changed persisted tuple is an authoritative host-side update
           // (for example `agent.configure`) and must replace the live picker.
           // An unchanged tuple is ordinary stream traffic, so keep any local
@@ -998,8 +1020,8 @@ export function createChatSessionStore(
               },
               now,
             ),
-            pendingUserMessages: pending.pendingUserMessages,
-            failedSendRestoration: pending.failedSendRestoration,
+            pendingUserMessages: settled.pendingUserMessages,
+            failedSendRestoration: settled.failedSendRestoration,
             restore: sweepStaleRestoreSlot(state.restore, connectionEpoch),
             snapshotLoaded: true,
             worktreeBinding: frame.snapshot.worktreeBinding,
@@ -1212,7 +1234,24 @@ export function createChatSessionStore(
           const turnIdChanged = previousTurnId !== nextTurnId;
           const nextBackgroundItems =
             frame.backgroundItems ?? state.backgroundItems;
+          // A frame reporting the turn settled (the host's `turnInProgress`
+          // when present, `runStatus` idle for an older host) is the point
+          // where a send stopped during activation can be declared dead:
+          // its accepted ack kept the optimistic user message waiting for a
+          // `messageAccepted` that will now never arrive. Drop such stranded
+          // entries and restore their content to the composer.
+          const settledPatch = reconcileTurnSettled(
+            turnSettledFromStatus(frame.turnInProgress, frame.runStatus),
+            {
+              pendingActions: state.pendingActions,
+              pendingUserMessages: state.pendingUserMessages,
+              messages: nextMessages,
+              queue: state.queue,
+              failedSendRestoration: state.failedSendRestoration,
+            },
+          );
           return {
+            ...settledPatch,
             messages: nextMessages,
             runStatus: frame.runStatus,
             activeTurn: frame.activeTurn,


### PR DESCRIPTION
## Summary

The hover **edit / delete** actions on a user message could stay hidden long after a turn stopped, and a message the host never recorded could linger in the transcript. Reported as: submit a message, immediately press Stop, and edit/delete never appear — they show up "after a while", seemingly after navigating away and back.

Two independent causes:

**1. The gate read the raw `runStatus`.** `canModifyChatMessages` gated on `runStatus !== "idle"`, which also reads `"running"` while visible background work (Bash `run_in_background` / Monitor / a subagent) outlives the settled turn — hiding edit/delete indefinitely with no turn left to wait for. It now narrows through `resolvedTurnStatus`, as the composer's Stop/Send toggle, restore gating and the row indicator already do. The pre-turn activating window and stop-during-activation still gate correctly: the host keeps `turnInProgress` true until the run unwinds.

**2. A stop during turn activation stranded the optimistic send.** An accepted ack deliberately keeps the `pendingUserMessages` entry alive and the durable `messageAccepted` frame clears it, so a stop landing between the two leaves an entry no later frame settles — the mutation gate stays closed *and* the transcript shows an unrecorded message. New `reconcileTurnSettled` runs from both `turnStateChanged` and the re-subscribe snapshot (`reconcileSnapshotChange` only settles sends still awaiting an ack, so an already-acked entry needs its own pass on reconnect — this was the reconnect path the original report actually hit).

Note the two signals were never connected: "Stopped before responding" is painted from the durable `turn.stopped` event, which ships immediately, while the gate waited on `runStatus`. The UI could honestly say "stopped" while the gate still believed a run was in flight.

Survival rules in `reconcileTurnSettled`:

| Entry state | Action | Why |
|---|---|---|
| Ack still in `pendingActions` | keep | Send in flight; a later ack settles it |
| Parked in the queue | keep | `queueChanged`/`messageAccepted` settles it; the gate blocks on the queue anyway |
| `messageId` in the transcript | drop, no restore | Only `messageAccepted` was lost — the persisted row is authoritative; restoring would duplicate the user's text |
| None of the above | drop + restore | Truly dead; content returns to the composer via the existing single-slot `failedSendRestoration` |

One behavioral note: in the healed case the message now visibly leaves the transcript and returns to the composer. That is truthful — the host never recorded it — where before it lingered looking sent.

## Related issue

<!-- none -->

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

## Testing

167 tests green across the three touched suites (`chat-queue-reconciler`, `chat-session-store`, `chat-tile-session-state`), including:

- store-level replay of the reported sequence: send → accepted ack → activating → settle with no `messageAccepted`
- both reconnect variants: settled snapshot without the message → drop + restore; snapshot carrying the message → drop, no restore
- in-flight-ack survival (a fresh send must not be killed by an unrelated settle frame)
- gate coverage for the background-only phase, the older-host fallback, and queued/pending states

Also verified: `bun run compile`, ESLint, `react-doctor --scope changed`, a manual pass in the dev desktop app, and a cold adversarial review pass (one finding — the reconnect-snapshot gap above — found and fixed).