### PR TITLE
fix(traycer-cli): survive Windows EBUSY on the host install swap

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/host-install-lock.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-install-lock.test.ts
@@ -92,6 +92,7 @@ vi.mock("../../service/install-lifecycle", () => ({
     lifecycle: {
       beforeSwap: async () => {},
       afterSwap: async () => {},
+      swapLockRecovery: null,
     },
   }),
 }));

--- a/clients/traycer-cli/src/commands/__tests__/host-install.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-install.test.ts
@@ -147,6 +147,7 @@ function sampleLifecycleHandle(): ServiceInstallLifecycleHandle {
     lifecycle: {
       beforeSwap: async () => {},
       afterSwap: async () => {},
+      swapLockRecovery: null,
     },
   };
 }
@@ -252,6 +253,7 @@ describe("buildHostInstallCommand", () => {
     const bytesOnlyLifecycle = {
       beforeSwap: vi.fn(async () => {}),
       afterSwap: vi.fn(async () => {}),
+      swapLockRecovery: null,
     };
     mocks.stageHostInstallSourceMock.mockResolvedValue(sampleStaged());
     mocks.createBytesOnlyInstallLifecycleMock.mockReturnValue(

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -67,7 +67,12 @@ describe("resolveHostStartTarget", () => {
     // Passes the resolved slot dir so a host baked for a different slot still
     // publishes pid.json where this environment expects it.
     expect(target.args).toEqual(["--host-data-dir", hostHomeDir("production")]);
-    expect(target.cwd).toBe(work);
+    // The host home dir, never the executable's own directory: a CWD inside
+    // `install/` is an open handle children inherit, and on Windows any such
+    // child that outlives the pre-update kill fails the install swap rename
+    // with EBUSY.
+    expect(target.cwd).toBe(hostHomeDir("production"));
+    expect(target.cwd).not.toBe(work);
     expect(target.record.version).toBe("1.0.0");
   });
 

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -5,7 +5,6 @@ import {
 } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { access } from "node:fs/promises";
-import { dirname } from "node:path";
 import type { Readable } from "node:stream";
 import {
   openBootstrapLogFd,
@@ -180,10 +179,18 @@ export async function resolveHostStartTarget(
   // publishes pid.json where this environment's desktop watches, instead of
   // self-resolving to its own baked slot. PATH-ONLY: this never selects the
   // host's cloud/auth target, which stays baked into the host binary.
+  // The host home dir, NOT the executable's own directory: on Windows a
+  // process's CWD is an open handle on that directory, and children the
+  // host spawns without an explicit cwd inherit it. With the CWD inside
+  // `install/`, any such child that outlives the pre-update kill blocks
+  // the install-dir swap rename with EBUSY - and the slot scan cannot see
+  // a process whose only tie to the install is its CWD. The host itself
+  // resolves nothing cwd-relative (SEA module loads anchor at
+  // `import.meta.url`; data paths come from `--host-data-dir`).
   return {
     executable: record.executablePath,
     args: ["--host-data-dir", hostHomeDir(opts.environment)],
-    cwd: opts.cwd ?? dirname(record.executablePath),
+    cwd: opts.cwd ?? hostHomeDir(opts.environment),
     record,
   };
 }

--- a/clients/traycer-cli/src/host/__tests__/auto-bootstrap.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/auto-bootstrap.test.ts
@@ -175,6 +175,7 @@ beforeEach(() => {
     lifecycle: {
       beforeSwap: vi.fn(),
       afterSwap: vi.fn(),
+      swapLockRecovery: null,
     },
   }));
 });

--- a/clients/traycer-cli/src/host/__tests__/ensure.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/ensure.test.ts
@@ -198,11 +198,16 @@ beforeEach(() => {
       postSwapAction: "install",
       postSwapError: null,
     },
-    lifecycle: { beforeSwap: vi.fn(), afterSwap: vi.fn() },
+    lifecycle: {
+      beforeSwap: vi.fn(),
+      afterSwap: vi.fn(),
+      swapLockRecovery: null,
+    },
   }));
   createBytesOnlyInstallLifecycleMock.mockImplementation(() => ({
     beforeSwap: vi.fn(),
     afterSwap: vi.fn(),
+    swapLockRecovery: null,
   }));
   stageHostInstallSourceMock.mockResolvedValue({
     stagingDir: "/tmp/staged",

--- a/clients/traycer-cli/src/host/__tests__/provision.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/provision.test.ts
@@ -190,6 +190,7 @@ function sampleLifecycleHandle(): ServiceInstallLifecycleHandle {
     lifecycle: {
       beforeSwap: async () => {},
       afterSwap: async () => {},
+      swapLockRecovery: null,
     },
   };
 }

--- a/clients/traycer-cli/src/installer/__tests__/apply.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/apply.test.ts
@@ -87,6 +87,7 @@ vi.mock("../../service/install-lifecycle", () => ({
           state.postSwapAction = mocks.lifecyclePostSwapAction;
           state.postSwapError = mocks.lifecyclePostSwapError;
         },
+        swapLockRecovery: null,
       },
     };
   },

--- a/clients/traycer-cli/src/installer/__tests__/install.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/install.test.ts
@@ -533,6 +533,64 @@ describe("atomicSwap - swap-lock recovery", () => {
     ]);
   });
 
+  it("gives the rollback restore the SAME recovery-aware plan as the forward renames, not the bare default", async () => {
+    // CodeRabbit finding on PR #829: the restore rename (trash -> target,
+    // the worst failure path - it runs when the swap-in itself already
+    // failed, and its own failure leaves NO install dir at all) used the
+    // plain `renameWithRetry` default (~2.5s, no re-kill hook) while a
+    // comment claimed it "gets the same retry" as the forward renames.
+    // Both the swap-in and the restore target the SAME destination
+    // (`target`), so one shared call-count gate drives both: calls 1-4
+    // fail, call 5+ succeeds.
+    //   - swap-in: 3 calls (attempt, retry, retry) against a 2-entry test
+    //     schedule - exhausts and throws, invoking the kill hook twice.
+    //   - restore: call 4 fails (kill hook #3), call 5 succeeds.
+    // A regression back to the plain `renameWithRetry` restore would still
+    // retry (it has its own default schedule) but would NEVER invoke the
+    // kill hook, since that path hardcodes `onRetry: null` - so the fixed
+    // code is distinguished by the kill call COUNT, not merely by success.
+    await installVersion("v1", "1.0.0");
+    setSwapRenameDelaysForTests([1, 1]);
+    mocks.forceRenameFailureForDestination = installDirFor(ENV);
+    mocks.forceRenameFailureCode = "EBUSY";
+    mocks.forceRenameFailureUntilCall = 4;
+    const kill = vi.fn(async () => {});
+
+    const sourceDir = join(sandboxRoot, "source-v2");
+    writeLocalHostSource(sourceDir, "v2");
+    let thrown: unknown;
+    try {
+      await installHost({
+        environment: ENV,
+        source: { kind: "local-file", path: sourceDir },
+        onProgress: () => {},
+        lifecycle: {
+          beforeSwap: async () => {},
+          afterSwap: async () => {},
+          swapLockRecovery: {
+            killLingeringProcesses: kill,
+            describeLockHolders: async () => [],
+          },
+        },
+        recordVersionOverride: "2.0.0",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(CliError);
+    expect((thrown as CliError).message).toContain(
+      "failed to swap staging dir into place",
+    );
+    // 2 re-kills for the exhausted swap-in + 1 for the restore's own retry.
+    expect(kill).toHaveBeenCalledTimes(3);
+    // The restore itself succeeded (on its 2nd call) - the previous
+    // install is back in place rather than stranded as `install.old-*`.
+    expect(readFileSync(join(installDirFor(ENV), "traycer-host"), "utf8")).toBe(
+      "binary-v1",
+    );
+  });
+
   it("gives an actionable fallback when EBUSY exhausts every retry and the scan names nothing", async () => {
     // The field cohort the scan is structurally blind to: a CWD-only
     // holder has no install path in its exe or command line, so the

--- a/clients/traycer-cli/src/installer/__tests__/install.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/install.test.ts
@@ -43,6 +43,19 @@ const mocks = vi.hoisted(() => ({
   // of the plain destination match above. `null` preserves every existing
   // test's behavior (fail on every call to the matched destination).
   forceRenameFailureForDestinationOnCall: null as number | null,
+  // Prefix-matched variant of the destination match above, for renames
+  // whose destination the test cannot hardcode - atomicSwap's aside rename
+  // targets `install.old-<Date.now()>`. Call counting keys on the prefix.
+  forceRenameFailureForDestinationPrefix: null as string | null,
+  // Error code the simulated failure carries. "EIO" (non-retryable) by
+  // default so a matched rename fails on the first attempt instead of
+  // spending the swap retry schedule; the swap-lock-recovery tests set
+  // "EBUSY" to exercise the retries.
+  forceRenameFailureCode: "EIO" as string,
+  // Retry-until-success gate: when set, calls 1..N to the matched
+  // destination fail and later calls succeed. Mutually exclusive with the
+  // exact-call gate above.
+  forceRenameFailureUntilCall: null as number | null,
   renameCallCountByDestination: new Map<string, number>(),
 }));
 
@@ -67,17 +80,26 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       return actual.rm(path, options);
     },
     rename: async (from: PathLike, to: PathLike) => {
-      if (to === mocks.forceRenameFailureForDestination) {
-        const toKey = String(to);
+      const toKey = String(to);
+      const prefix = mocks.forceRenameFailureForDestinationPrefix;
+      const prefixMatched = prefix !== null && toKey.startsWith(prefix);
+      if (to === mocks.forceRenameFailureForDestination || prefixMatched) {
+        const countKey = prefixMatched && prefix !== null ? prefix : toKey;
         const callNumber =
-          (mocks.renameCallCountByDestination.get(toKey) ?? 0) + 1;
-        mocks.renameCallCountByDestination.set(toKey, callNumber);
+          (mocks.renameCallCountByDestination.get(countKey) ?? 0) + 1;
+        mocks.renameCallCountByDestination.set(countKey, callNumber);
         const gate = mocks.forceRenameFailureForDestinationOnCall;
-        if (gate === null || callNumber === gate) {
-          // A non-retryable code so `renameWithRetry` fails on the first
-          // attempt instead of spending ~2.5s retrying EBUSY/EPERM/etc.
+        const until = mocks.forceRenameFailureUntilCall;
+        const shouldFail =
+          until !== null
+            ? callNumber <= until
+            : gate === null || callNumber === gate;
+        if (shouldFail) {
+          // "EIO" (non-retryable) unless a test overrides the code, so
+          // `renameWithRetry` fails on the first attempt instead of
+          // spending the retry schedule on EBUSY/EPERM/etc.
           throw Object.assign(new Error("simulated rename failure"), {
-            code: "EIO",
+            code: mocks.forceRenameFailureCode,
           });
         }
       }
@@ -131,11 +153,15 @@ import {
   currentInstallArch,
   currentInstallPlatform,
   installHost,
+  setSwapRenameDelaysForTests,
+  SWAP_RENAME_DELAYS_MS,
+  SWAP_RENAME_MAX_TOTAL_MS,
   sweepOldTrash,
   type StagedHostInstallSource,
 } from "../install";
 import { readHostInstallRecord } from "../../manifest/host-install";
 import { createCliLogger } from "../../logger";
+import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
 
 const ENV: Environment = "production";
 
@@ -342,6 +368,268 @@ describe("commitInstallFromSource", () => {
     ).rejects.toThrow();
 
     expect(committed).toBe(false);
+  });
+});
+
+describe("atomicSwap - swap-lock recovery", () => {
+  beforeEach(() => {
+    sandboxRoot = mkdtempSync(join(tmpdir(), "traycer-install-test-"));
+    osHome.current = sandboxRoot;
+  });
+
+  afterEach(() => {
+    mocks.forceUnlinkFailureForPath = null;
+    mocks.forceRmFailureForPath = null;
+    mocks.forceRenameFailureForDestination = null;
+    mocks.forceRenameFailureForDestinationOnCall = null;
+    mocks.forceRenameFailureForDestinationPrefix = null;
+    mocks.forceRenameFailureCode = "EIO";
+    mocks.forceRenameFailureUntilCall = null;
+    mocks.renameCallCountByDestination.clear();
+    setSwapRenameDelaysForTests(null);
+    rmSync(sandboxRoot, { recursive: true, force: true });
+  });
+
+  async function installVersion(marker: string, version: string) {
+    const sourceDir = join(sandboxRoot, `source-${marker}`);
+    writeLocalHostSource(sourceDir, marker);
+    return installHost({
+      environment: ENV,
+      source: { kind: "local-file", path: sourceDir },
+      onProgress: () => {},
+      lifecycle: null,
+      recordVersionOverride: version,
+    });
+  }
+
+  it("re-kills lingering slot processes between retryable aside-rename attempts and then succeeds", async () => {
+    await installVersion("v1", "1.0.0");
+    // The aside rename targets `install.old-<Date.now()>` - only the
+    // prefix is predictable. Two EBUSY failures, then the rename goes
+    // through: the shape of a lingering handle that a re-kill releases.
+    mocks.forceRenameFailureForDestinationPrefix = `${installDirFor(ENV)}.old-`;
+    mocks.forceRenameFailureCode = "EBUSY";
+    mocks.forceRenameFailureUntilCall = 2;
+    const kill = vi.fn(async () => {});
+
+    const sourceDir = join(sandboxRoot, "source-v2");
+    writeLocalHostSource(sourceDir, "v2");
+    const { record } = await installHost({
+      environment: ENV,
+      source: { kind: "local-file", path: sourceDir },
+      onProgress: () => {},
+      lifecycle: {
+        beforeSwap: async () => {},
+        afterSwap: async () => {},
+        swapLockRecovery: {
+          killLingeringProcesses: kill,
+          describeLockHolders: async () => [],
+        },
+      },
+      recordVersionOverride: "2.0.0",
+    });
+
+    expect(record.version).toBe("2.0.0");
+    expect(kill).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(installDirFor(ENV), "traycer-host"), "utf8")).toBe(
+      "binary-v2",
+    );
+  });
+
+  it("wraps a stuck aside rename in a CliError naming the lock holders and leaves the previous install intact", async () => {
+    await installVersion("v1", "1.0.0");
+    // Default "EIO" fails the aside rename on the first attempt - the
+    // exhausted-retries shape without the schedule's wall-clock cost.
+    mocks.forceRenameFailureForDestinationPrefix = `${installDirFor(ENV)}.old-`;
+
+    const sourceDir = join(sandboxRoot, "source-v2");
+    writeLocalHostSource(sourceDir, "v2");
+    let thrown: unknown;
+    try {
+      await installHost({
+        environment: ENV,
+        source: { kind: "local-file", path: sourceDir },
+        onProgress: () => {},
+        lifecycle: {
+          beforeSwap: async () => {},
+          afterSwap: async () => {},
+          swapLockRecovery: {
+            killLingeringProcesses: async () => {},
+            describeLockHolders: async () => [
+              {
+                pid: 4242,
+                name: "claude.exe",
+                executablePath: "C:\\clients\\claude.exe",
+              },
+            ],
+          },
+        },
+        recordVersionOverride: "2.0.0",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(CliError);
+    const cliErr = thrown as CliError;
+    expect(cliErr.code).toBe(CLI_ERROR_CODES.HOST_INSTALL_FAILED);
+    expect(cliErr.message).toContain(
+      "failed to move the previous install aside",
+    );
+    expect(cliErr.message).toContain(
+      "processes still holding the install directory: pid 4242 (claude.exe) at C:\\clients\\claude.exe",
+    );
+    expect(cliErr.details?.lockHolders).toEqual([
+      {
+        pid: 4242,
+        name: "claude.exe",
+        executablePath: "C:\\clients\\claude.exe",
+      },
+    ]);
+    // The aside rename is the FIRST move - nothing has been swapped, so
+    // the previous install must still be fully in place.
+    expect(readFileSync(join(installDirFor(ENV), "traycer-host"), "utf8")).toBe(
+      "binary-v1",
+    );
+  });
+
+  it("names the lock holders when the swap-in rename fails too", async () => {
+    await installVersion("v1", "1.0.0");
+    mocks.forceRenameFailureForDestination = installDirFor(ENV);
+
+    const sourceDir = join(sandboxRoot, "source-v2");
+    writeLocalHostSource(sourceDir, "v2");
+    let thrown: unknown;
+    try {
+      await installHost({
+        environment: ENV,
+        source: { kind: "local-file", path: sourceDir },
+        onProgress: () => {},
+        lifecycle: {
+          beforeSwap: async () => {},
+          afterSwap: async () => {},
+          swapLockRecovery: {
+            killLingeringProcesses: async () => {},
+            describeLockHolders: async () => [
+              { pid: 77, name: null, executablePath: null },
+            ],
+          },
+        },
+        recordVersionOverride: "2.0.0",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(CliError);
+    const cliErr = thrown as CliError;
+    expect(cliErr.code).toBe(CLI_ERROR_CODES.HOST_INSTALL_FAILED);
+    expect(cliErr.message).toContain("failed to swap staging dir into place");
+    expect(cliErr.message).toContain(
+      "processes still holding the install directory: pid 77",
+    );
+    expect(cliErr.details?.lockHolders).toEqual([
+      { pid: 77, name: null, executablePath: null },
+    ]);
+  });
+
+  it("gives an actionable fallback when EBUSY exhausts every retry and the scan names nothing", async () => {
+    // The field cohort the scan is structurally blind to: a CWD-only
+    // holder has no install path in its exe or command line, so the
+    // re-kill runs on every retry, releases nothing, and the detail scan
+    // comes back empty. The user must get told what actually unblocks
+    // them instead of a bare errno. Production timing would sleep the
+    // whole ~24s schedule here - inject a short one.
+    await installVersion("v1", "1.0.0");
+    setSwapRenameDelaysForTests([1, 1]);
+    mocks.forceRenameFailureForDestinationPrefix = `${installDirFor(ENV)}.old-`;
+    mocks.forceRenameFailureCode = "EBUSY";
+    const kill = vi.fn(async () => {});
+
+    const sourceDir = join(sandboxRoot, "source-v2");
+    writeLocalHostSource(sourceDir, "v2");
+    let thrown: unknown;
+    try {
+      await installHost({
+        environment: ENV,
+        source: { kind: "local-file", path: sourceDir },
+        onProgress: () => {},
+        lifecycle: {
+          beforeSwap: async () => {},
+          afterSwap: async () => {},
+          swapLockRecovery: {
+            killLingeringProcesses: kill,
+            describeLockHolders: async () => [],
+          },
+        },
+        recordVersionOverride: "2.0.0",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(CliError);
+    const cliErr = thrown as CliError;
+    expect(cliErr.code).toBe(CLI_ERROR_CODES.HOST_INSTALL_FAILED);
+    // One re-kill per schedule entry - the retries genuinely ran.
+    expect(kill).toHaveBeenCalledTimes(2);
+    expect(cliErr.message).toContain(
+      "no Traycer process matches the install directory",
+    );
+    expect(cliErr.message).toContain("restart Windows");
+    expect(cliErr.details?.lockHolders).toEqual([]);
+    // The previous install must survive the failed update untouched.
+    expect(readFileSync(join(installDirFor(ENV), "traycer-host"), "utf8")).toBe(
+      "binary-v1",
+    );
+  });
+
+  it("keeps the raw error unembellished for a non-lock failure code", async () => {
+    // A genuine I/O failure is not lock contention - steering the user
+    // toward "close the program holding it" there would be a lie.
+    await installVersion("v1", "1.0.0");
+    mocks.forceRenameFailureForDestinationPrefix = `${installDirFor(ENV)}.old-`;
+
+    const sourceDir = join(sandboxRoot, "source-v2");
+    writeLocalHostSource(sourceDir, "v2");
+    let thrown: unknown;
+    try {
+      await installHost({
+        environment: ENV,
+        source: { kind: "local-file", path: sourceDir },
+        onProgress: () => {},
+        lifecycle: {
+          beforeSwap: async () => {},
+          afterSwap: async () => {},
+          swapLockRecovery: {
+            killLingeringProcesses: async () => {},
+            describeLockHolders: async () => [],
+          },
+        },
+        recordVersionOverride: "2.0.0",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(CliError);
+    expect((thrown as CliError).message).not.toContain(
+      "another program is holding it open",
+    );
+  });
+});
+
+describe("swap rename schedule contract", () => {
+  it("stays far above the default ~2.5s retry and is never truncated by its own ceiling", () => {
+    // The whole point of the schedule is outlasting AV scans and orphan
+    // handle release that the previous ~2.5s budget could not - pin the
+    // floor so a refactor cannot quietly regress it. The ceiling exists
+    // for slow RE-KILLS, so it must clear the sleep schedule itself with
+    // room for healthy (couple-of-seconds) hook passes.
+    const totalDelayMs = SWAP_RENAME_DELAYS_MS.reduce((sum, d) => sum + d, 0);
+    expect(totalDelayMs).toBeGreaterThanOrEqual(20_000);
+    expect(SWAP_RENAME_DELAYS_MS.length).toBeGreaterThanOrEqual(7);
+    expect(SWAP_RENAME_MAX_TOTAL_MS).toBeGreaterThanOrEqual(totalDelayMs * 2);
   });
 });
 

--- a/clients/traycer-cli/src/installer/__tests__/rename-retry.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/rename-retry.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Queue-driven rename stub: each entry is the error code the next call
+// throws; an exhausted queue means the call succeeds. Keeps the tests
+// independent of real filesystem lock behavior, which cannot be produced
+// deterministically cross-platform.
+const mocks = vi.hoisted(() => ({
+  failureCodes: [] as string[],
+  renameCalls: 0,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    rename: async () => {
+      mocks.renameCalls += 1;
+      const code = mocks.failureCodes.shift();
+      if (code !== undefined) {
+        throw Object.assign(new Error(`simulated ${code}`), { code });
+      }
+    },
+  };
+});
+
+import { renameWithRetryPlan } from "../rename-retry";
+
+describe("renameWithRetryPlan", () => {
+  beforeEach(() => {
+    mocks.failureCodes = [];
+    mocks.renameCalls = 0;
+  });
+
+  it("invokes onRetry between retryable attempts and succeeds once the lock clears", async () => {
+    mocks.failureCodes = ["EBUSY", "EPERM"];
+    const onRetry = vi.fn(async () => {});
+
+    await renameWithRetryPlan("/from", "/to", {
+      delaysMs: [1, 1, 1],
+      onRetry,
+      maxTotalMs: null,
+    });
+
+    expect(mocks.renameCalls).toBe(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a non-retryable code immediately without invoking onRetry", async () => {
+    mocks.failureCodes = ["EIO"];
+    const onRetry = vi.fn(async () => {});
+
+    await expect(
+      renameWithRetryPlan("/from", "/to", {
+        delaysMs: [1, 1],
+        onRetry,
+        maxTotalMs: null,
+      }),
+    ).rejects.toMatchObject({ code: "EIO" });
+
+    expect(mocks.renameCalls).toBe(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("exhausts the schedule and rethrows the final retryable error", async () => {
+    mocks.failureCodes = ["EBUSY", "EBUSY", "EBUSY"];
+    const onRetry = vi.fn(async () => {});
+
+    await expect(
+      renameWithRetryPlan("/from", "/to", {
+        delaysMs: [1, 1],
+        onRetry,
+        maxTotalMs: null,
+      }),
+    ).rejects.toMatchObject({ code: "EBUSY" });
+
+    // One initial attempt + one per schedule entry, with onRetry before
+    // each retry but NOT after the final failure - there is no attempt
+    // left for it to help.
+    expect(mocks.renameCalls).toBe(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows an onRetry failure rather than masking the rename outcome", async () => {
+    mocks.failureCodes = ["EBUSY"];
+
+    await renameWithRetryPlan("/from", "/to", {
+      delaysMs: [1],
+      onRetry: async () => {
+        throw new Error("kill failed");
+      },
+      maxTotalMs: null,
+    });
+
+    expect(mocks.renameCalls).toBe(2);
+  });
+
+  it("stops retrying once the wall-clock ceiling is exceeded, even with schedule entries left", async () => {
+    // A slow hook, not slow delays, is what blows the budget in the
+    // field: the Windows re-kill can spend tens of seconds per pass. The
+    // 60ms hook against a 20ms ceiling means the second failure lands
+    // over budget while two schedule entries remain unused.
+    mocks.failureCodes = ["EBUSY", "EBUSY", "EBUSY", "EBUSY"];
+    const onRetry = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+    });
+
+    await expect(
+      renameWithRetryPlan("/from", "/to", {
+        delaysMs: [1, 1, 1],
+        onRetry,
+        maxTotalMs: 20,
+      }),
+    ).rejects.toMatchObject({ code: "EBUSY" });
+
+    expect(mocks.renameCalls).toBe(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/traycer-cli/src/installer/index.ts
+++ b/clients/traycer-cli/src/installer/index.ts
@@ -6,6 +6,8 @@ export type {
   InstallHostResult,
   InstallSourceArg,
   StagedHostInstallSource,
+  SwapLockHolderProcess,
+  SwapLockRecovery,
 } from "./install";
 export {
   commitHostInstallSource,

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -32,11 +32,7 @@ import {
   listAsideDirsNewestFirst,
   sweepDeadAsideDirs,
 } from "./aside-dirs";
-import {
-  isRetryableRenameCode,
-  renameWithRetry,
-  renameWithRetryPlan,
-} from "./rename-retry";
+import { isRetryableRenameCode, renameWithRetryPlan } from "./rename-retry";
 import { reconcileHostStage } from "./stage-reconcile";
 
 // Host installer - verify-before-replace per the Tech Plan.
@@ -1024,17 +1020,24 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
     );
     // Restore the previous install if the rename of the new one fails. The
     // same transient Windows lock that failed the swap can also fail the
-    // restore, so it gets the same retry; if it still fails we log rather
-    // than mask the swap error about to be thrown - but a silent failure
-    // here would leave no install at all with nothing pointing at why.
+    // restore, so it gets the SAME recovery-aware plan as the forward
+    // renames (schedule + re-kill) rather than the bare ~2.5s default -
+    // this is the worst failure in the file (no `install/` at all, the
+    // previous install stranded as `install.old-*`), so it needs every bit
+    // of the retry budget the forward renames get. If it still fails we log
+    // rather than mask the swap error about to be thrown - but a silent
+    // failure here would leave no install at all with nothing pointing at
+    // why.
     if (targetExists) {
-      await renameWithRetry(trash, target).catch((restoreCause) => {
-        logger.error(
-          "Host install rollback failed - previous install left aside",
-          { target, trash },
-          errorFromUnknown(restoreCause),
-        );
-      });
+      await renameWithRetryPlan(trash, target, swapRenamePlan).catch(
+        (restoreCause) => {
+          logger.error(
+            "Host install rollback failed - previous install left aside",
+            { target, trash },
+            errorFromUnknown(restoreCause),
+          );
+        },
+      );
     }
     throw cliError({
       code: CLI_ERROR_CODES.HOST_INSTALL_FAILED,

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -32,7 +32,11 @@ import {
   listAsideDirsNewestFirst,
   sweepDeadAsideDirs,
 } from "./aside-dirs";
-import { renameWithRetry } from "./rename-retry";
+import {
+  isRetryableRenameCode,
+  renameWithRetry,
+  renameWithRetryPlan,
+} from "./rename-retry";
 import { reconcileHostStage } from "./stage-reconcile";
 
 // Host installer - verify-before-replace per the Tech Plan.
@@ -81,9 +85,37 @@ export type InstallSourceArg =
 //     non-readiness). The hook should therefore swallow start errors
 //     internally if it wants the install to report success; throwing
 //     propagates the error to `installHost`'s caller.
+//
+//   - `swapLockRecovery` is the Windows-only escalation seam for the swap
+//     renames themselves. `beforeSwap`'s service stop kills every host
+//     process the slot scan can SEE (exe path / command line under the
+//     install dir), but a process merely holding a handle inside it - an
+//     orphaned child with its CWD there, an AV scanner - is invisible to
+//     that scan and fails the rename with EBUSY. `killLingeringProcesses`
+//     re-runs the kill between rename attempts; `describeLockHolders` runs
+//     after the retries are exhausted so the error can name the processes
+//     still matching the slot instead of a bare EBUSY. `null` on platforms
+//     whose renames don't contend with open handles (POSIX) and for
+//     callers that manage the OS service themselves.
 export interface InstallHostLifecycle {
   readonly beforeSwap: () => Promise<void>;
   readonly afterSwap: () => Promise<void>;
+  readonly swapLockRecovery: SwapLockRecovery | null;
+}
+
+// A process the platform's slot scan still associates with the install
+// after the swap rename kept failing - the diagnostic payload for the
+// EBUSY error. `name`/`executablePath` are null when the scan could not
+// read them (access-denied on another user's process, for instance).
+export interface SwapLockHolderProcess {
+  readonly pid: number;
+  readonly name: string | null;
+  readonly executablePath: string | null;
+}
+
+export interface SwapLockRecovery {
+  readonly killLingeringProcesses: () => Promise<void>;
+  readonly describeLockHolders: () => Promise<readonly SwapLockHolderProcess[]>;
 }
 
 export interface InstallHostOptions {
@@ -552,6 +584,8 @@ export async function commitInstallFromSource(
   await atomicSwap({
     environment: opts.environment,
     stagingDir: opts.sourceDir,
+    swapLockRecovery:
+      opts.lifecycle === null ? null : opts.lifecycle.swapLockRecovery,
   });
   opts.onCommitted();
   logger.info("Host install atomic swap completed", {
@@ -781,9 +815,137 @@ async function stageRegistry(opts: StageRegistryOptions): Promise<StageResult> {
   };
 }
 
+// Both recovery calls are best-effort by construction: a broken scan or
+// kill must never mask the rename failure it was trying to explain or fix.
+function swapLockRetryHook(
+  recovery: SwapLockRecovery | null,
+  logger: ILogger,
+): (() => Promise<void>) | null {
+  if (recovery === null) return null;
+  return async () => {
+    try {
+      await recovery.killLingeringProcesses();
+    } catch (err) {
+      logger.warn("Host install swap-lock re-kill failed", {
+        errorName: errorFromUnknown(err).name,
+        errorMessage: errorFromUnknown(err).message,
+      });
+    }
+  };
+}
+
+async function collectSwapLockHolders(
+  recovery: SwapLockRecovery | null,
+  logger: ILogger,
+): Promise<readonly SwapLockHolderProcess[]> {
+  if (recovery === null) return [];
+  try {
+    return await recovery.describeLockHolders();
+  } catch (err) {
+    logger.warn("Host install swap-lock holder scan failed", {
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
+    return [];
+  }
+}
+
+// The logger's `LogValue` requires an index signature interfaces don't
+// carry - re-shape each holder as an anonymous literal for the log fields.
+function logLockHolder(holder: SwapLockHolderProcess): {
+  readonly pid: number;
+  readonly name: string | null;
+  readonly executablePath: string | null;
+} {
+  return {
+    pid: holder.pid,
+    name: holder.name,
+    executablePath: holder.executablePath,
+  };
+}
+
+// The diagnostic tail appended to the swap failure's message. Named
+// holders when the slot scan matched something; otherwise, for a
+// lock-class failure on a platform that HAS the scan (Windows), an
+// actionable fallback - a CWD-only orphan, an AV/indexer scan, or an open
+// Explorer/terminal window holds the directory without its exe or command
+// line ever mentioning it, so the scan legitimately comes back empty and
+// "retry" alone cannot clear it. A non-lock code (say a genuine EIO) gets
+// no suffix: claiming "another program is holding it" there would send
+// the user chasing a locker that does not exist.
+function swapLockFailureSuffix(
+  cause: unknown,
+  holders: readonly SwapLockHolderProcess[],
+  recovery: SwapLockRecovery | null,
+): string {
+  if (holders.length > 0) {
+    const rendered = holders
+      .map((holder) => {
+        const name = holder.name === null ? "" : ` (${holder.name})`;
+        const exe =
+          holder.executablePath === null ? "" : ` at ${holder.executablePath}`;
+        return `pid ${holder.pid}${name}${exe}`;
+      })
+      .join(", ");
+    return `; processes still holding the install directory: ${rendered}`;
+  }
+  if (recovery === null) return "";
+  const code =
+    cause && typeof cause === "object" && "code" in cause
+      ? String((cause as { code?: unknown }).code)
+      : "";
+  if (!isRetryableRenameCode(code)) return "";
+  return (
+    "; no Traycer process matches the install directory - another program" +
+    " is holding it open (an antivirus or indexer scan, a terminal or" +
+    " Explorer window inside it, or an orphaned child process whose" +
+    " working directory is inside it). Close it or restart Windows, then" +
+    " retry the update"
+  );
+}
+
 interface AtomicSwapOptions {
   readonly environment: Environment;
   readonly stagingDir: string;
+  readonly swapLockRecovery: SwapLockRecovery | null;
+}
+
+// The swap renames get a far longer runway than `renameWithRetry`'s
+// default ~2.5s: the field failure this heals is a Windows EBUSY from a
+// handle the pre-swap kill couldn't see (an orphaned child with its CWD in
+// the install dir, an AV scan of the just-killed executable), and those
+// outlast a 2.5s window while resolving well inside ~25s once the
+// between-attempt re-kill lands. POSIX renames never raise the retryable
+// codes, so the schedule costs nothing there. Exported for the schedule
+// contract pin in install.test.ts - production reads it only through
+// `swapRenameDelays()` below.
+export const SWAP_RENAME_DELAYS_MS: readonly number[] = [
+  250, 500, 1000, 2000, 4000, 8000, 8000,
+];
+
+// Wall-clock ceiling for one swap rename INCLUDING its re-kill hooks. The
+// schedule above sums to ~24s of sleeps, but each Windows re-kill pass can
+// legitimately spend a 10s WMI scan plus a 30s taskkill on a degraded
+// machine - seven such passes would keep the service down and the
+// environment cli-lock held for ~5 minutes. Healthy re-kills run in a
+// couple of seconds, so this ceiling never truncates the schedule where
+// the retries can actually work; it only stops the pathological machines
+// from wedging every other host mutation while they fail.
+export const SWAP_RENAME_MAX_TOTAL_MS = 120_000;
+
+// The exhausted-retries paths are untestable at production timing (a full
+// EBUSY exhaustion sleeps the whole ~24s schedule), so tests inject a
+// short schedule here. Mirrors `setWindowsTaskInstallDepsForTests`'s
+// shape. Never set in production.
+let swapRenameDelaysOverride: readonly number[] | null = null;
+export function setSwapRenameDelaysForTests(
+  delays: readonly number[] | null,
+): void {
+  swapRenameDelaysOverride = delays;
+}
+
+function swapRenameDelays(): readonly number[] {
+  return swapRenameDelaysOverride ?? SWAP_RENAME_DELAYS_MS;
 }
 
 async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
@@ -798,6 +960,12 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
   // continue.
   await sweepOldTrash(target, "install.json", logger);
 
+  const swapRenamePlan = {
+    delaysMs: swapRenameDelays(),
+    onRetry: swapLockRetryHook(opts.swapLockRecovery, logger),
+    maxTotalMs: SWAP_RENAME_MAX_TOTAL_MS,
+  };
+
   const targetExists = await access(target).then(
     () => true,
     () => false,
@@ -811,16 +979,46 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
     // so the rename target is empty. We delete the trash copy after
     // the new install is in place - there is no rollback cache by
     // design.
-    await renameWithRetry(target, trash);
+    try {
+      await renameWithRetryPlan(target, trash, swapRenamePlan);
+    } catch (cause) {
+      // Nothing has moved: the previous install is intact, only the update
+      // is blocked. Wrap the raw fs error (historically surfaced verbatim
+      // as "EBUSY: resource busy or locked, rename ...") and name the
+      // processes still holding the install dir so the report identifies
+      // the culprit instead of a bare errno.
+      const holders = await collectSwapLockHolders(
+        opts.swapLockRecovery,
+        logger,
+      );
+      logger.error(
+        "Host install failed to move the previous install aside",
+        {
+          environment: opts.environment,
+          target,
+          trash,
+          holders: holders.map(logLockHolder),
+        },
+        errorFromUnknown(cause),
+      );
+      throw cliError({
+        code: CLI_ERROR_CODES.HOST_INSTALL_FAILED,
+        message: `host install: failed to move the previous install aside: ${cause instanceof Error ? cause.message : String(cause)}${swapLockFailureSuffix(cause, holders, opts.swapLockRecovery)}`,
+        details: { target, trash, lockHolders: holders },
+        exitCode: 1,
+      });
+    }
   }
   try {
-    await renameWithRetry(opts.stagingDir, target);
+    await renameWithRetryPlan(opts.stagingDir, target, swapRenamePlan);
   } catch (cause) {
+    const holders = await collectSwapLockHolders(opts.swapLockRecovery, logger);
     logger.error(
       "Host install atomic swap failed",
       {
         environment: opts.environment,
         targetExists,
+        holders: holders.map(logLockHolder),
       },
       errorFromUnknown(cause),
     );
@@ -840,8 +1038,8 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
     }
     throw cliError({
       code: CLI_ERROR_CODES.HOST_INSTALL_FAILED,
-      message: `host install: failed to swap staging dir into place: ${cause instanceof Error ? cause.message : String(cause)}`,
-      details: { target, stagingDir: opts.stagingDir },
+      message: `host install: failed to swap staging dir into place: ${cause instanceof Error ? cause.message : String(cause)}${swapLockFailureSuffix(cause, holders, opts.swapLockRecovery)}`,
+      details: { target, stagingDir: opts.stagingDir, lockHolders: holders },
       exitCode: 1,
     });
   }

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -1030,10 +1030,21 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
     // why.
     if (targetExists) {
       await renameWithRetryPlan(trash, target, swapRenamePlan).catch(
-        (restoreCause) => {
+        async (restoreCause) => {
+          // The `holders` in the enclosing scope were collected right after
+          // the SWAP-IN failure, before this restore ever ran its own
+          // retries/re-kills - they don't necessarily describe who (if
+          // anyone) still holds `target` now that the restore has also
+          // exhausted. Re-scan so this, the worst failure in the file (no
+          // `install/` at all), gets a diagnosis of its own rather than a
+          // stale one.
+          const restoreHolders = await collectSwapLockHolders(
+            opts.swapLockRecovery,
+            logger,
+          );
           logger.error(
             "Host install rollback failed - previous install left aside",
-            { target, trash },
+            { target, trash, holders: restoreHolders.map(logLockHolder) },
             errorFromUnknown(restoreCause),
           );
         },

--- a/clients/traycer-cli/src/installer/rename-retry.ts
+++ b/clients/traycer-cli/src/installer/rename-retry.ts
@@ -14,8 +14,49 @@ import { rename } from "node:fs/promises";
 // them.
 const RENAME_RETRY_CODES = new Set(["EBUSY", "EPERM", "EACCES", "ENOTEMPTY"]);
 
+// Exported so the install swap's error reporting can distinguish "the
+// lock-contention class this retry exists for" from a genuine I/O failure
+// without duplicating the code list.
+export function isRetryableRenameCode(code: string): boolean {
+  return RENAME_RETRY_CODES.has(code);
+}
+
+const DEFAULT_DELAYS_MS: readonly number[] = [50, 100, 200, 400, 800, 1000];
+
+// A caller-tuned retry: `delaysMs` sets both the attempt count and the
+// backoff, and `onRetry` (when non-null) runs after each retryable failure
+// before the backoff sleep - the install swap uses it to re-kill lingering
+// host processes whose handles are exactly what made the rename fail. The
+// hook is best-effort: a throw from it is swallowed so it can never mask
+// the rename's own error.
+//
+// `maxTotalMs` is a wall-clock ceiling across ALL attempts, hooks, and
+// backoff sleeps. The schedule alone does not bound the retry when the
+// hook is slow - the Windows re-kill can spend a 10s WMI scan plus a 30s
+// taskkill per pass on a degraded machine, stretching a ~24s schedule
+// into minutes while the caller holds the cli-lock with the service
+// stopped. Once the ceiling is exceeded, the next retryable failure is
+// thrown as final. Null bounds the retry by the schedule alone.
+export interface RenameRetryPlan {
+  readonly delaysMs: readonly number[];
+  readonly onRetry: (() => Promise<void>) | null;
+  readonly maxTotalMs: number | null;
+}
+
 export async function renameWithRetry(from: string, to: string): Promise<void> {
-  const delaysMs = [50, 100, 200, 400, 800, 1000];
+  await renameWithRetryPlan(from, to, {
+    delaysMs: DEFAULT_DELAYS_MS,
+    onRetry: null,
+    maxTotalMs: null,
+  });
+}
+
+export async function renameWithRetryPlan(
+  from: string,
+  to: string,
+  plan: RenameRetryPlan,
+): Promise<void> {
+  const startedAt = Date.now();
   for (let attempt = 0; ; attempt++) {
     try {
       await rename(from, to);
@@ -25,10 +66,21 @@ export async function renameWithRetry(from: string, to: string): Promise<void> {
         cause && typeof cause === "object" && "code" in cause
           ? String((cause as { code?: unknown }).code)
           : "";
-      if (attempt >= delaysMs.length || !RENAME_RETRY_CODES.has(code)) {
+      if (attempt >= plan.delaysMs.length || !RENAME_RETRY_CODES.has(code)) {
         throw cause;
       }
-      await new Promise((resolve) => setTimeout(resolve, delaysMs[attempt]));
+      if (
+        plan.maxTotalMs !== null &&
+        Date.now() - startedAt >= plan.maxTotalMs
+      ) {
+        throw cause;
+      }
+      if (plan.onRetry !== null) {
+        await plan.onRetry().catch(() => undefined);
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, plan.delaysMs[attempt]),
+      );
     }
   }
 }

--- a/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
@@ -5,11 +5,13 @@ import type {
   ServiceLabel,
 } from "../index";
 import {
+  createBytesOnlyInstallLifecycle,
   createServiceInstallLifecycle,
   type BootstrapServiceOptions,
   type ServiceInstallLifecycleState,
 } from "../install-lifecycle";
 import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
+import type { SwapLockRecovery } from "../../installer";
 
 const mocks = vi.hoisted(() => ({
   createServiceControllerMock: vi.fn(),
@@ -17,6 +19,8 @@ const mocks = vi.hoisted(() => ({
   resolveServiceCliInvocationMock: vi.fn(),
   readRegisteredCliInvocationMock: vi.fn(),
   cliLoggerWarnMock: vi.fn(),
+  killLingeringSlotProcessesMock: vi.fn(),
+  describeSlotLockHoldersMock: vi.fn(),
 }));
 
 // The externally-managed branch reports an unforeseen repair failure through
@@ -50,6 +54,14 @@ vi.mock("../cli-binary", () => ({
 // registration.
 vi.mock("../platforms/macos", () => ({
   readRegisteredCliInvocation: mocks.readRegisteredCliInvocationMock,
+}));
+
+// The Windows swap-lock recovery functions shell out to schtasks /
+// powershell / taskkill - stub the module so the wiring tests can assert
+// the lifecycle hands the label through without touching the OS.
+vi.mock("../platforms/windows", () => ({
+  killLingeringSlotProcesses: mocks.killLingeringSlotProcessesMock,
+  describeSlotLockHolders: mocks.describeSlotLockHoldersMock,
 }));
 
 const label: ServiceLabel = {
@@ -451,5 +463,87 @@ describe("service install lifecycle re-registration", () => {
     });
     expect(harness.start).not.toHaveBeenCalled();
     expect(harness.restart).not.toHaveBeenCalled();
+  });
+});
+
+describe("swap-lock recovery wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.serviceLabelForMock.mockReturnValue(label);
+    mocks.killLingeringSlotProcessesMock.mockResolvedValue(undefined);
+    mocks.describeSlotLockHoldersMock.mockResolvedValue([]);
+  });
+
+  function withPlatform(platform: string, run: () => void): void {
+    const original = Object.getOwnPropertyDescriptor(process, "platform");
+    if (original === undefined) {
+      throw new Error("process.platform descriptor missing");
+    }
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+    });
+    try {
+      run();
+    } finally {
+      Object.defineProperty(process, "platform", original);
+    }
+  }
+
+  it("wires Windows recovery to the platform kill and detail scan on both lifecycle factories", async () => {
+    let recoveries: (SwapLockRecovery | null)[] = [];
+    withPlatform("win32", () => {
+      const harness = makeController("stopped");
+      mocks.createServiceControllerMock.mockReturnValue(harness.controller);
+      const serviceHandle = createServiceInstallLifecycle({
+        environment: "production",
+        bootstrap: null,
+      });
+      const bytesOnly = createBytesOnlyInstallLifecycle(
+        harness.controller,
+        label,
+      );
+      recoveries = [
+        serviceHandle.lifecycle.swapLockRecovery,
+        bytesOnly.swapLockRecovery,
+      ];
+    });
+
+    for (const recovery of recoveries) {
+      // A null here is exactly the quiet regression this test exists to
+      // catch: the installer would silently run without re-kill or
+      // holder diagnostics on the only platform that needs them.
+      expect(recovery).not.toBeNull();
+      if (recovery === null) throw new Error("unreachable");
+      await recovery.killLingeringProcesses();
+      const holders = [
+        { pid: 7, name: "orphan.exe", executablePath: "C:\\orphan.exe" },
+      ];
+      mocks.describeSlotLockHoldersMock.mockResolvedValueOnce(holders);
+      await expect(recovery.describeLockHolders()).resolves.toEqual(holders);
+    }
+    expect(mocks.killLingeringSlotProcessesMock).toHaveBeenCalledTimes(2);
+    expect(mocks.killLingeringSlotProcessesMock).toHaveBeenCalledWith(
+      label,
+      null,
+    );
+    expect(mocks.describeSlotLockHoldersMock).toHaveBeenCalledWith(label, null);
+  });
+
+  it("carries no swap-lock recovery off Windows", () => {
+    withPlatform("darwin", () => {
+      const harness = makeController("stopped");
+      mocks.createServiceControllerMock.mockReturnValue(harness.controller);
+      const serviceHandle = createServiceInstallLifecycle({
+        environment: "production",
+        bootstrap: null,
+      });
+      const bytesOnly = createBytesOnlyInstallLifecycle(
+        harness.controller,
+        label,
+      );
+      expect(serviceHandle.lifecycle.swapLockRecovery).toBeNull();
+      expect(bytesOnly.swapLockRecovery).toBeNull();
+    });
   });
 });

--- a/clients/traycer-cli/src/service/install-lifecycle.ts
+++ b/clients/traycer-cli/src/service/install-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { InstallHostLifecycle } from "../installer";
+import type { InstallHostLifecycle, SwapLockRecovery } from "../installer";
 import { createCliLogger } from "../logger";
 import { CLI_ERROR_CODES, CliError } from "../runner/errors";
 import { resolveServiceCliInvocation, type CliInvocation } from "./cli-binary";
@@ -10,7 +10,26 @@ import {
   type ServiceState,
 } from "./index";
 import { readRegisteredCliInvocation } from "./platforms/macos";
+import {
+  describeSlotLockHolders,
+  killLingeringSlotProcesses,
+} from "./platforms/windows";
 import type { Environment } from "../runner/environment";
+
+// Windows only: the pre-swap stop kills every process the slot scan can
+// see, but a handle it cannot (an orphaned child whose CWD is inside
+// `install/`, an AV scan) still fails the swap rename with EBUSY. This
+// seam lets the installer re-kill between rename attempts and, when the
+// retries exhaust anyway, name the processes still matching the slot in
+// the error it throws. POSIX renames don't contend with open handles, so
+// other platforms carry no recovery.
+function swapLockRecoveryFor(label: ServiceLabel): SwapLockRecovery | null {
+  if (process.platform !== "win32") return null;
+  return {
+    killLingeringProcesses: () => killLingeringSlotProcesses(label, null),
+    describeLockHolders: () => describeSlotLockHolders(label, null),
+  };
+}
 
 // State captured by the lifecycle hooks so the command can render an
 // accurate `serviceLifecycle` block in its result.
@@ -106,6 +125,7 @@ export function createServiceInstallLifecycle(
   // pre-cooperative contract this flag exists to scope.
   let cooperativeStopBeforeSwap = false;
   const lifecycle: InstallHostLifecycle = {
+    swapLockRecovery: swapLockRecoveryFor(label),
     beforeSwap: async () => {
       const status = await controller.status(label);
       state.priorState = status.state;
@@ -324,6 +344,7 @@ export function createBytesOnlyInstallLifecycle(
   label: ServiceLabel,
 ): InstallHostLifecycle {
   return {
+    swapLockRecovery: swapLockRecoveryFor(label),
     beforeSwap: (): Promise<void> =>
       process.platform === "win32" ? controller.stop(label) : Promise.resolve(),
     afterSwap: (): Promise<void> => Promise.resolve(),

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -2,9 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildScheduledTaskXml,
+  buildWindowsSlotProcessDetailScanScript,
   buildWindowsSlotProcessScanScript,
   createWindowsController,
+  describeSlotLockHolders,
+  killLingeringSlotProcesses,
   parseSchtasksLastRunResult,
+  parseWindowsProcessDetailJson,
   parseWindowsProcessIdJson,
   setWindowsStartEvidenceDepsForTests,
   setWindowsTaskInstallDepsForTests,
@@ -106,6 +110,100 @@ describe("Windows service stale host cleanup", () => {
       "c:\\users\\traycer dev\\.traycer\\host\\install\\",
     );
     expect(script).not.toContain("'c:\\users\\traycer dev\\.traycer\\host'");
+  });
+
+  it("builds a detail scan sharing the pid scan's filter but projecting name and executable path", () => {
+    const options = {
+      hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
+      currentPid: 1234,
+    };
+    const detail = buildWindowsSlotProcessDetailScanScript(options);
+    expect(detail).toContain("$excluded = @(1234, $PID)");
+    expect(detail).toContain(
+      "c:\\users\\traycer dev\\.traycer\\host\\install\\",
+    );
+    expect(detail).toContain("Select-Object ProcessId, Name, ExecutablePath");
+    // Everything but the projection line is byte-identical to the pid scan
+    // - the filter must never drift between the kill and the diagnostic.
+    const pidScan = buildWindowsSlotProcessScanScript(options);
+    expect(detail.split("\n").slice(0, -1)).toEqual(
+      pidScan.split("\n").slice(0, -1),
+    );
+  });
+
+  it("parses PowerShell process detail JSON in both array and single-object shape", () => {
+    expect(
+      parseWindowsProcessDetailJson(
+        '[{"ProcessId":401,"Name":"claude.exe","ExecutablePath":"C:\\\\clients\\\\claude.exe"},{"ProcessId":402,"Name":"","ExecutablePath":null}]',
+      ),
+    ).toEqual([
+      {
+        pid: 401,
+        name: "claude.exe",
+        executablePath: "C:\\clients\\claude.exe",
+      },
+      { pid: 402, name: null, executablePath: null },
+    ]);
+    // Windows PowerShell 5.1 emits a bare object for a single match even
+    // under `@(...)`.
+    expect(
+      parseWindowsProcessDetailJson(
+        '{"ProcessId":401,"Name":"node.exe","ExecutablePath":"C:\\\\node.exe"}',
+      ),
+    ).toEqual([{ pid: 401, name: "node.exe", executablePath: "C:\\node.exe" }]);
+    expect(parseWindowsProcessDetailJson("")).toEqual([]);
+    expect(parseWindowsProcessDetailJson("not-json")).toEqual([]);
+    expect(parseWindowsProcessDetailJson('{"Name":"no-pid.exe"}')).toEqual([]);
+  });
+
+  it("describes slot lock holders via the detail scan", async () => {
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      return success(
+        '[{"ProcessId":88,"Name":"orphan.exe","ExecutablePath":"C:\\\\orphan.exe"}]',
+      );
+    };
+
+    const holders = await describeSlotLockHolders(
+      serviceLabelFor("staging"),
+      runner,
+    );
+
+    expect(holders).toEqual([
+      { pid: 88, name: "orphan.exe", executablePath: "C:\\orphan.exe" },
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe("powershell.exe");
+    expect(calls[0]?.args.at(-1)).toContain(
+      "Select-Object ProcessId, Name, ExecutablePath",
+    );
+  });
+
+  it("reports no lock holders when the detail scan cannot run", async () => {
+    const runner: ProcessRunner = async () => {
+      throw new Error("spawn failed");
+    };
+
+    await expect(
+      describeSlotLockHolders(serviceLabelFor("staging"), runner),
+    ).resolves.toEqual([]);
+  });
+
+  it("re-kills scan-verified processes through killLingeringSlotProcesses", async () => {
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      return command === "powershell.exe" ? success("[401]") : success("");
+    };
+
+    await killLingeringSlotProcesses(serviceLabelFor("staging"), runner);
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([["/T", "/F", "/PID", "401"]]);
   });
 
   it("kills slot-scanned processes when pid metadata is missing", async () => {

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -519,6 +519,28 @@ interface SlotProcessScanOptions {
 }
 
 function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
+  return buildSlotProcessScanScriptWithProjection(
+    options,
+    "@($matches | Select-Object -ExpandProperty ProcessId) | ConvertTo-Json -Compress",
+  );
+}
+
+// Same filter as the pid scan, projecting name + executable path as well so
+// the install swap's EBUSY error can NAME the processes still matching the
+// slot instead of surfacing a bare errno.
+function buildSlotProcessDetailScanScript(
+  options: SlotProcessScanOptions,
+): string {
+  return buildSlotProcessScanScriptWithProjection(
+    options,
+    "@($matches | Select-Object ProcessId, Name, ExecutablePath) | ConvertTo-Json -Compress",
+  );
+}
+
+function buildSlotProcessScanScriptWithProjection(
+  options: SlotProcessScanOptions,
+  projection: string,
+): string {
   const hostPaths = powershellStringArray(
     slotHostProcessPaths(options.hostHome),
   );
@@ -541,7 +563,7 @@ function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
     "    $hostMatch",
     "  }",
     "}",
-    "@($matches | Select-Object -ExpandProperty ProcessId) | ConvertTo-Json -Compress",
+    projection,
   ].join("\n");
 }
 
@@ -585,6 +607,96 @@ function parseProcessIdJson(stdout: string): readonly number[] {
 
 function uniqueProcessIds(values: readonly number[]): readonly number[] {
   return Array.from(new Set(values.filter(isKillableProcessId)));
+}
+
+// A slot-matching process reported by the detail scan. Field names mirror
+// the installer's `SwapLockHolderProcess` so `install-lifecycle.ts` can
+// hand these through without an adapter layer.
+export interface WindowsSlotLockHolder {
+  readonly pid: number;
+  readonly name: string | null;
+  readonly executablePath: string | null;
+}
+
+function parseProcessDetailJson(
+  stdout: string,
+): readonly WindowsSlotLockHolder[] {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+  // `ConvertTo-Json` on `@(...)` still emits a bare object for a single
+  // match on Windows PowerShell 5.1 - accept both shapes, like
+  // `parseProcessIdJson` above.
+  const values = Array.isArray(parsed) ? parsed : [parsed];
+  const holders: WindowsSlotLockHolder[] = [];
+  for (const value of values) {
+    if (value === null || typeof value !== "object") continue;
+    const record = value as Record<string, unknown>;
+    const pid = record.ProcessId;
+    if (!isKillableProcessId(pid)) continue;
+    holders.push({
+      pid,
+      name: readNonEmptyString(record.Name),
+      executablePath: readNonEmptyString(record.ExecutablePath),
+    });
+  }
+  return holders;
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// The install swap's between-retry escalation (installer
+// `SwapLockRecovery.killLingeringProcesses`): re-run the same verified
+// kill `stopService` already performed. The first kill ran before the
+// swap; anything the rename now trips over either outlived it (an orphan
+// re-matching the scan) or spawned since, and both answer to another pass.
+// Pass `null` to use the real process runner.
+export async function killLingeringSlotProcesses(
+  label: ServiceLabel,
+  runner: ProcessRunner | null,
+): Promise<void> {
+  await killHostProcessTree(label, runner ?? runCommand);
+}
+
+// The install swap's post-mortem (`SwapLockRecovery.describeLockHolders`):
+// name the processes the slot scan still matches after the rename retries
+// exhausted. Best-effort - a scan that cannot run reports no holders
+// rather than failing the caller, which is already surfacing an error.
+export async function describeSlotLockHolders(
+  label: ServiceLabel,
+  runner: ProcessRunner | null,
+): Promise<readonly WindowsSlotLockHolder[]> {
+  const run = runner ?? runCommand;
+  try {
+    const result = await run(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        buildSlotProcessDetailScanScript({
+          hostHome: hostHomeDir(label.environment),
+          currentPid: process.pid,
+        }),
+      ],
+      {
+        env: undefined,
+        cwd: undefined,
+        timeoutMs: WINDOWS_PROCESS_SCAN_TIMEOUT_MS,
+        tolerateNonZeroExit: true,
+      },
+    );
+    return parseProcessDetailJson(result.stdout);
+  } catch {
+    return [];
+  }
 }
 
 function isKillableProcessId(value: unknown): value is number {
@@ -841,5 +953,7 @@ export {
   buildTaskXml as buildScheduledTaskXml,
   buildHiddenHostLauncher as buildWindowsHiddenHostLauncher,
   buildSlotProcessScanScript as buildWindowsSlotProcessScanScript,
+  buildSlotProcessDetailScanScript as buildWindowsSlotProcessDetailScanScript,
   parseProcessIdJson as parseWindowsProcessIdJson,
+  parseProcessDetailJson as parseWindowsProcessDetailJson,
 };


### PR DESCRIPTION
## Summary
- Spawn the host with `cwd = hostHomeDir` instead of the executable's own directory, so children that inherit the CWD no longer hold an open handle inside `install/` (the host resolves nothing CWD-relative).
- Give the install-swap renames a ~24s retry schedule that re-runs the verified slot-process kill between attempts (`InstallHostLifecycle.swapLockRecovery`, Windows-only), bounded by a 120s wall-clock ceiling so a degraded machine's slow scan/taskkill passes can't hold the CLI lock with the service down for minutes.
- On exhaustion, name the surviving processes (pid/name/exe) in the thrown `HOST_INSTALL_FAILED` error instead of a bare errno; when the scan matches nothing (a CWD-only orphan from a pre-fix host, structurally invisible to WMI), the error instead tells the user what actually unblocks them — close the holding program or restart Windows.

Field context: users hit a raw `EBUSY: resource busy or locked, rename '...\install' -> '...\install.old-<ts>'` during host updates that never cleared on Retry. Root cause was the host's own CWD sitting inside the install dir (inherited by children on stop) plus a pre-swap kill scan that only matches by exe path / command line, invisible to CWD-only holders.

Reviewed cold by an independent agent (findings tracked and resolved — see the ceiling, fallback message, and added wiring/schedule tests below).

## Test plan
- [x] `bun run compile` clean
- [x] ESLint + Prettier clean on all touched files
- [x] Full `traycer-cli` vitest suite: 1177 passed (1 pre-existing, unrelated failure in `registry/client.test.ts` present at base `main` too)
- [x] New coverage: `rename-retry.test.ts` (hook timing, non-retryable bypass, exhaustion, wall-clock ceiling, hook-failure swallow), `install.test.ts` swap-lock recovery suite (re-kill-then-succeed, stuck-aside-rename error with named holders, swap-in failure, empty-scan fallback message, non-lock error stays unembellished, schedule contract pin), `install-lifecycle.test.ts` (both lifecycle factories wire real recovery on win32, none off-Windows), Windows detail-scan tests (byte-identical filter vs. the kill scan, JSON parsing, holder description, re-kill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)