### PR TITLE
fix(gui-app,shared,desktop): abort the session-list read on query cancellation

### DIFF
--- a/clients/desktop/src/electron-main/ipc/auth-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/auth-ipc.ts
@@ -149,7 +149,14 @@ export function registerAuthIpc(bridge: RunnerIpcBridge): void {
     RunnerHostInvoke.listUserSessions,
     async (_event, bearerToken: unknown) => {
       assertString(bearerToken, "listUserSessions.bearerToken");
-      return listUserSessionsViaHttp(bridge.options.authnBaseUrl, bearerToken);
+      // No caller signal: an `AbortSignal` cannot cross the context bridge, so
+      // a renderer that cancels settles its own side (`settleOnAbort`) and this
+      // GET simply runs out its bounded timeout with nobody reading the reply.
+      return listUserSessionsViaHttp(
+        bridge.options.authnBaseUrl,
+        bearerToken,
+        null,
+      );
     },
   );
 

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -744,7 +744,9 @@ describe("DesktopRunnerHost.onLocalHostChange", () => {
       signInUrl: "https://auth.example.invalid/sign-in",
     });
 
-    await expect(host.listUserSessions("jwt")).resolves.toEqual({
+    await expect(
+      host.listUserSessions("jwt", new AbortController().signal),
+    ).resolves.toEqual({
       kind: "network-error",
     });
     await expect(
@@ -760,11 +762,58 @@ describe("DesktopRunnerHost.onLocalHostChange", () => {
       kind: "network-error",
     });
 
+    // Deliberately still one argument: an `AbortSignal` is not cloneable
+    // across the context bridge, so the signal is consumed on this side and
+    // never forwarded into main.
     expect(listUserSessions).toHaveBeenCalledWith("jwt");
     expect(revokeUserSession).toHaveBeenCalledWith("jwt", "family-1", true);
     expect(revokeAllSessions).toHaveBeenCalledWith("jwt");
     expect(requestStepUpChallenge).toHaveBeenCalledWith("jwt");
     expect(verifyStepUpChallenge).toHaveBeenCalledWith("jwt", "123456");
+  });
+
+  it("settles a cancelled session list without waiting for the main-process reply", async () => {
+    // Main keeps running the GET (bounded by the fetcher's own timeout) because
+    // the signal cannot cross the bridge. What must not happen is the caller
+    // waiting it out: `AuthService.fetchUserSessions()` follows a list with a
+    // repair that spends a single-use refresh rotation, so cancellation has to
+    // reach it now rather than seconds later.
+    const fake = buildFakeBridge(null);
+    fake.bridge.listUserSessions = vi.fn(
+      () => new Promise<never>(() => undefined),
+    );
+    const host = new DesktopRunnerHost({
+      bridge: fake.bridge,
+      signInUrl: "https://auth.example.invalid/sign-in",
+    });
+
+    const controller = new AbortController();
+    const pending = host.listUserSessions("jwt", controller.signal);
+    const reason = new Error("cancelled by the sessions query");
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+  });
+
+  it("rejects a session list requested with an already-aborted signal", async () => {
+    const fake = buildFakeBridge(null);
+    const listUserSessions = vi.fn(async () => ({
+      kind: "network-error" as const,
+    }));
+    fake.bridge.listUserSessions = listUserSessions;
+    const host = new DesktopRunnerHost({
+      bridge: fake.bridge,
+      signInUrl: "https://auth.example.invalid/sign-in",
+    });
+
+    const controller = new AbortController();
+    const reason = new Error("cancelled before the request went out");
+    controller.abort(reason);
+
+    await expect(host.listUserSessions("jwt", controller.signal)).rejects.toBe(
+      reason,
+    );
+    expect(listUserSessions).not.toHaveBeenCalled();
   });
 
   it("exposes the desktop-only windows bridge without changing IRunnerHost", async () => {

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -749,8 +749,14 @@ export class DesktopRunnerHost implements IRunnerHost {
     return this.bridge.validateAuthTokenIdentity(token);
   }
 
-  listUserSessions(bearerToken: string): Promise<ListUserSessionsFetchResult> {
-    return this.bridge.listUserSessions(bearerToken);
+  listUserSessions(
+    bearerToken: string,
+    signal: AbortSignal,
+  ): Promise<ListUserSessionsFetchResult> {
+    return settleOnAbort(
+      () => this.bridge.listUserSessions(bearerToken),
+      signal,
+    );
   }
 
   revokeUserSession(
@@ -862,6 +868,39 @@ export class DesktopRunnerHost implements IRunnerHost {
       },
     };
   }
+}
+
+/**
+ * Runs `start()` and settles as soon as `signal` aborts, without waiting for
+ * the request it began.
+ *
+ * An `AbortSignal` is not cloneable across the context bridge, so the request
+ * itself lives in Electron main and cannot be cancelled from the renderer; it
+ * stays bounded by the fetcher's own 10s timeout and its reply is dropped. That
+ * is an acceptable amount of waste for an idempotent GET - what is NOT
+ * acceptable is the caller continuing. `AuthService.fetchUserSessions()` can
+ * follow a list with a repair that spends a single-use refresh rotation, so
+ * cancellation has to reach it promptly rather than 10s later.
+ */
+function settleOnAbort<T>(
+  start: () => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  // A thunk, not a promise: an already-cancelled read should not put a request
+  // on the wire at all, and an argument would have been evaluated by now.
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  const pending = start();
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    pending.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", onAbort);
+    });
+  });
 }
 
 function toDisposable(subscription: { dispose: () => void }): Disposable {

--- a/clients/gui-app/src/hooks/auth/__tests__/use-user-sessions-query.test.tsx
+++ b/clients/gui-app/src/hooks/auth/__tests__/use-user-sessions-query.test.tsx
@@ -1,16 +1,16 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ListUserSessionsResponse } from "@traycer/protocol/auth/devices-sessions";
 import type { AuthService } from "@/lib/auth/auth-service";
 import { authQueryKeys } from "@/lib/query-keys";
 import { useAuthStore } from "@/stores/auth/auth-store";
 
 const fetchUserSessions =
-  vi.fn<() => Promise<ListUserSessionsResponse | null>>();
+  vi.fn<(signal: AbortSignal) => Promise<ListUserSessionsResponse | null>>();
 const auth = { fetchUserSessions } as Pick<AuthService, "fetchUserSessions">;
 
 vi.mock("@/lib/host", () => ({
@@ -52,7 +52,14 @@ describe("useAuthFetchUserSessions", () => {
     useAuthStore.getState().setSignedOut();
   });
 
-  it("keeps an account A response in A's cache when the signed-in identity changes to B", async () => {
+  // `globals: false` in this project, so Testing Library's auto-cleanup never
+  // runs. Without this an earlier test's hook stays mounted and refetches off
+  // the next test's sign-in, inflating the call counts asserted below.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("drops account A's in-flight read when the identity changes to B, and never lets it reach B", async () => {
     let resolveAccountA: (value: ListUserSessionsResponse) => void = () => {};
     fetchUserSessions
       .mockImplementationOnce(
@@ -99,16 +106,90 @@ describe("useAuthFetchUserSessions", () => {
       );
     });
 
+    const accountASignal = fetchUserSessions.mock.calls[0]?.[0];
     resolveAccountA(sessionsResponse("account-a-family"));
-    await waitFor(() => {
-      expect(
-        queryClient.getQueryData(authQueryKeys.userSessions(auth, "account-a")),
-      ).toEqual(sessionsResponse("account-a-family"));
+    await act(async () => {
+      await Promise.resolve();
     });
 
+    // Switching identity leaves A's query with no observer. Because the query
+    // function consumes the signal, TanStack cancels-and-reverts that read
+    // instead of letting it settle, so A's late response is discarded outright
+    // rather than parked in A's cache. Stronger than the by-key isolation this
+    // case was originally written for: the answer nobody asked for is gone, and
+    // a later switch back to A refetches instead of showing a pre-switch
+    // snapshot.
+    expect(accountASignal.aborted).toBe(true);
+    expect(
+      queryClient.getQueryData(authQueryKeys.userSessions(auth, "account-a")),
+    ).toBeUndefined();
+
+    // The property that actually matters: A's response never reaches B.
     expect(
       queryClient.getQueryData(authQueryKeys.userSessions(auth, "account-b")),
     ).toEqual(sessionsResponse("account-b-family"));
     expect(result.current.data?.sessions[0]?.familyId).toBe("account-b-family");
+  });
+
+  it("aborts the signal it handed the in-flight read when a revoke invalidates the query", async () => {
+    // The revoke mutations invalidate this exact key on success. The read that
+    // was already in flight is abandoned by that invalidation, and
+    // `fetchUserSessions` needs to hear about it: its repair path spends a
+    // single-use refresh rotation that must not run for a discarded answer.
+    let resolveInFlight: (value: ListUserSessionsResponse) => void = () => {};
+    fetchUserSessions
+      // The panel is already showing sessions...
+      .mockResolvedValueOnce(sessionsResponse("initial-family"))
+      // ...a 30s poll refetch is in flight...
+      .mockImplementationOnce(
+        () =>
+          new Promise<ListUserSessionsResponse>((resolve) => {
+            resolveInFlight = resolve;
+          }),
+      )
+      // ...and the revoke's invalidation supersedes it.
+      .mockResolvedValueOnce(sessionsResponse("post-revoke-family"));
+
+    useAuthStore
+      .getState()
+      .setSignedIn(
+        { userId: "account-a", userName: "Account A", email: "a@example.com" },
+        { userId: "account-a", username: "account-a" },
+        [],
+      );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => useAuthFetchUserSessions(), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.sessions[0]?.familyId).toBe("initial-family");
+    });
+
+    act(() => {
+      void result.current.refetch();
+    });
+    await waitFor(() => {
+      expect(fetchUserSessions).toHaveBeenCalledTimes(2);
+    });
+    const inFlightSignal = fetchUserSessions.mock.calls[1]?.[0];
+    expect(inFlightSignal).toBeInstanceOf(AbortSignal);
+    expect(inFlightSignal.aborted).toBe(false);
+
+    // Not awaited: the returned promise settles only once the replacement
+    // refetch chain does, and the point here is that the abort reaches the
+    // read that is still in flight right now.
+    act(() => {
+      void queryClient.invalidateQueries({
+        queryKey: authQueryKeys.userSessions(auth, "account-a"),
+      });
+    });
+
+    await waitFor(() => {
+      expect(inFlightSignal.aborted).toBe(true);
+    });
+    resolveInFlight(sessionsResponse("stale-pre-revoke-family"));
   });
 });

--- a/clients/gui-app/src/hooks/auth/use-user-sessions-query.ts
+++ b/clients/gui-app/src/hooks/auth/use-user-sessions-query.ts
@@ -24,7 +24,12 @@ function userSessionsQueryOptions(
   }
   return queryOptions<ListUserSessionsResponse | null>({
     queryKey: authQueryKeys.userSessions(auth, userId),
-    queryFn: () => auth.fetchUserSessions(),
+    // The signal is forwarded rather than dropped because `fetchUserSessions`
+    // can spend a single-use refresh rotation on its repair path. A revoke
+    // invalidating this query, an unmount, or a focus refetch superseding the
+    // 30s poll all cancel here, and none of them should leave that spend in
+    // flight for an answer no one will read.
+    queryFn: ({ signal }) => auth.fetchUserSessions(signal),
     enabled: true,
     refetchInterval: USER_SESSIONS_POLL_MS,
     refetchOnWindowFocus: true,

--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -109,6 +109,14 @@ function createDeferredResponse(): DeferredResponse {
   };
 }
 
+/**
+ * The signal a live TanStack query hands `fetchUserSessions`: never aborted, so
+ * these cases exercise the ordinary read rather than the cancellation path.
+ */
+function liveQuerySignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
 function ok(): Promise<Response> {
   return Promise.resolve(new Response("{}", { status: 200 }));
 }
@@ -517,7 +525,7 @@ describe("AuthService", () => {
       return status(500);
     });
 
-    const response = await service.fetchUserSessions();
+    const response = await service.fetchUserSessions(liveQuerySignal());
 
     expect(response?.sessions).toEqual([
       expect.objectContaining({
@@ -566,7 +574,7 @@ describe("AuthService", () => {
 
     // First poll: repair is attempted once, then the unrepaired listing
     // still surfaces the error so the caller/UI can report the problem.
-    await expect(service.fetchUserSessions()).rejects.toThrow(
+    await expect(service.fetchUserSessions(liveQuerySignal())).rejects.toThrow(
       "Couldn't register this signed-in session yet.",
     );
     expect(refreshCalls).toHaveLength(1);
@@ -574,15 +582,60 @@ describe("AuthService", () => {
     // A later poll (every 30s, or on window focus) with the SAME
     // now-current bearer must not re-spend another refresh rotation or
     // throw indefinitely; it returns the unidentified listing instead.
-    await expect(service.fetchUserSessions()).resolves.toEqual({
-      sessions: [],
-    });
+    await expect(service.fetchUserSessions(liveQuerySignal())).resolves.toEqual(
+      {
+        sessions: [],
+      },
+    );
     expect(refreshCalls).toHaveLength(1);
     expect(seenSessionBearers).toEqual([
       "Bearer legacy-token",
       "Bearer repaired-1",
       "Bearer repaired-1",
     ]);
+  });
+
+  it("does not spend the repair refresh rotation for a read cancelled while the list is in flight", async () => {
+    // Identity fencing cannot cover this on its own: a revoke invalidating the
+    // panel query, an unmount, or a focus refetch superseding the 30s poll all
+    // leave the SAME account signed in, so every authority check still passes.
+    // Only the query's signal says nobody is waiting - and the repair below
+    // spends a single-use, cross-process refresh rotation.
+    const { service, host } = makeService();
+    await host.tokenStore.signIn(
+      { token: "legacy-token", refreshToken: "legacy-refresh" },
+      { id: "user-1", email: "test@example.com", name: "Test User" },
+    );
+    await service.start();
+
+    restoreFetch();
+    const listRequest = createDeferredResponse();
+    const refreshCalls: string[] = [];
+    restoreFetch = installFetch((input, init) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url === SESSIONS_URL) {
+        return listRequest.promise;
+      }
+      if (url === REFRESH_URL) {
+        refreshCalls.push(String(init?.headers?.Authorization));
+        return okWithRefreshToken("repaired-1");
+      }
+      if (url === VALIDATION_URL) {
+        return okWithProfile();
+      }
+      return status(500);
+    });
+
+    const controller = new AbortController();
+    const pending = service.fetchUserSessions(controller.signal);
+    controller.abort();
+
+    // The listing lands needing repair - an empty list for a pre-tracking
+    // credential is exactly the shape that would otherwise rotate.
+    listRequest.resolve(await okWithSessions([]));
+
+    await expect(pending).rejects.toThrow();
+    expect(refreshCalls).toEqual([]);
   });
 
   it("drops an account A session-list response that resolves after account B replaces it", async () => {
@@ -615,7 +668,7 @@ describe("AuthService", () => {
       return status(500);
     });
 
-    const staleList = service.fetchUserSessions();
+    const staleList = service.fetchUserSessions(liveQuerySignal());
     await vi.waitFor(() => {
       expect(initialListCalls).toBe(1);
     });
@@ -662,7 +715,7 @@ describe("AuthService", () => {
       ),
     );
 
-    const staleList = service.fetchUserSessions();
+    const staleList = service.fetchUserSessions(liveQuerySignal());
     await vi.waitFor(() => {
       expect(seenRefreshTokens).toEqual(["account-a-refresh"]);
     });

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -1153,15 +1153,39 @@ export class AuthService {
    * Fetches the signed-in user's device/session list via authn-v3. The raw
    * bearer remains inside this auth boundary; callers consume a parsed DTO from
    * TanStack Query and render signed-out as an empty state.
+   *
+   * `signal` is the reading query's cancellation, and it is load-bearing for
+   * more than the request: the repair below spends a single-use refresh
+   * rotation. Identity fencing alone does not cover this, because the common
+   * cancellations - a revoke invalidating the list, a panel unmount, a poll
+   * superseded by a focus refetch - leave the SAME account live, so every
+   * authority check still passes while nobody is waiting for the answer.
+   * Aborting is therefore checked on entry and after each list await, and
+   * throws rather than returning `null`, so a cancelled read can never be
+   * mistaken for the signed-out empty state.
    */
-  async fetchUserSessions(): Promise<ListUserSessionsResponse | null> {
+  async fetchUserSessions(
+    signal: AbortSignal,
+  ): Promise<ListUserSessionsResponse | null> {
+    signal.throwIfAborted();
     const initialAuthority = this.captureLiveSessionAuthority();
     if (initialAuthority === null) {
       return null;
     }
     const initial = await this.runnerHost.listUserSessions(
       initialAuthority.bearer,
+      signal,
     );
+    // This is the fence that keeps a cancelled read out of the repair below:
+    // everything between here and the rotation is synchronous, so bailing here
+    // is the same as bailing there.
+    //
+    // Ordered before the authority check on purpose: an aborted read is a
+    // non-answer, not an account change, and the two shells disagree on how an
+    // aborted request surfaces (in-process `fetch` collapses it into
+    // `network-error`; the desktop bridge rejects). Checking here makes both
+    // reach the caller as the same cancellation.
+    signal.throwIfAborted();
     if (!this.isLiveSessionAuthority(initialAuthority)) {
       return null;
     }
@@ -1204,7 +1228,9 @@ export class AuthService {
 
     const repaired = await this.runnerHost.listUserSessions(
       repairedAuthority.bearer,
+      signal,
     );
+    signal.throwIfAborted();
     if (!this.isLiveSessionAuthority(repairedAuthority)) {
       return null;
     }

--- a/clients/shared/auth/__tests__/devices-sessions-fetcher.test.ts
+++ b/clients/shared/auth/__tests__/devices-sessions-fetcher.test.ts
@@ -52,7 +52,7 @@ describe("devices/sessions authn fetcher", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await listUserSessionsViaHttp(AUTHN, "jwt-abc");
+    const result = await listUserSessionsViaHttp(AUTHN, "jwt-abc", null);
 
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") {
@@ -64,6 +64,39 @@ describe("devices/sessions authn fetcher", () => {
     expect((init?.headers as Record<string, string>).Authorization).toBe(
       "Bearer jwt-abc",
     );
+  });
+
+  it("aborts the session-list request when the reader's signal aborts", async () => {
+    // The in-process shells (browser/dev) own this request, so a cancelled
+    // read must abort the real fetch rather than just discard its reply. The
+    // per-call timeout has to survive alongside it.
+    const fetchMock = vi.fn(
+      async (_url: string, init: RequestInit | undefined) => {
+        await new Promise<void>((resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        });
+        return jsonResponse(200, sessionListBody());
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = new AbortController();
+    const pending = listUserSessionsViaHttp(
+      AUTHN,
+      "jwt-abc",
+      controller.signal,
+    );
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init?.signal?.aborted).toBe(false);
+
+    controller.abort();
+
+    expect(init?.signal?.aborted).toBe(true);
+    // An abort is indistinguishable from any other transport failure here; the
+    // only caller re-checks its own signal before reading this result.
+    await expect(pending).resolves.toEqual({ kind: "network-error" });
   });
 
   it("maps per-session 401 step_up_required to step-up-required", async () => {

--- a/clients/shared/auth/devices-sessions-fetcher.ts
+++ b/clients/shared/auth/devices-sessions-fetcher.ts
@@ -90,17 +90,31 @@ function jsonHeaders(bearerToken: string): Record<string, string> {
   };
 }
 
+/**
+ * Every call is bounded by the same timeout. `callerSignal` additionally lets a
+ * caller abandon the request early - today only the session list, whose reader
+ * is a TanStack query that can be cancelled by a refetch, an unmount, or an
+ * account switch. Callers with no cancellation of their own pass `null`.
+ */
+function requestSignal(callerSignal: AbortSignal | null): AbortSignal {
+  const timeout = AbortSignal.timeout(DEVICES_SESSIONS_FETCH_TIMEOUT_MS);
+  return callerSignal === null
+    ? timeout
+    : AbortSignal.any([callerSignal, timeout]);
+}
+
 async function fetchAuthn(
   authnBaseUrl: string,
   path: string,
   bearerToken: string,
   init: Omit<RequestInit, "headers" | "signal">,
+  callerSignal: AbortSignal | null,
 ): Promise<Response | null> {
   try {
     return await fetch(authnApiUrl(authnBaseUrl, path), {
       ...init,
       headers: jsonHeaders(bearerToken),
-      signal: AbortSignal.timeout(DEVICES_SESSIONS_FETCH_TIMEOUT_MS),
+      signal: requestSignal(callerSignal),
     });
   } catch {
     return null;
@@ -139,9 +153,16 @@ async function parseOk<T>(
   return parsed.success ? parsed.data : null;
 }
 
+/**
+ * Reads the account session list. `signal` is the reader's own cancellation
+ * (the TanStack query's); an abort collapses into `network-error` like any
+ * other transport failure, because the only caller re-checks its signal before
+ * interpreting this result and never reaches that branch.
+ */
 export async function listUserSessionsViaHttp(
   authnBaseUrl: string,
   bearerToken: string,
+  signal: AbortSignal | null,
 ): Promise<ListUserSessionsFetchResult> {
   const response = await fetchAuthn(
     authnBaseUrl,
@@ -150,6 +171,7 @@ export async function listUserSessionsViaHttp(
     {
       method: "GET",
     },
+    signal,
   );
   if (response === null) {
     return { kind: "network-error" };
@@ -172,9 +194,13 @@ export async function revokeUserSessionViaHttp(
   familyId: string,
 ): Promise<RevokeUserSessionFetchResult> {
   const path = `api/v3/user/sessions/${encodeURIComponent(familyId)}`;
-  const response = await fetchAuthn(authnBaseUrl, path, bearerToken, {
-    method: "DELETE",
-  });
+  const response = await fetchAuthn(
+    authnBaseUrl,
+    path,
+    bearerToken,
+    { method: "DELETE" },
+    null,
+  );
   if (response === null) {
     return { kind: "network-error" };
   }
@@ -208,6 +234,7 @@ export async function revokeAllSessionsViaHttp(
       method: "POST",
       body: "{}",
     },
+    null,
   );
   if (response === null) {
     return { kind: "network-error" };
@@ -249,6 +276,7 @@ export async function mintHostCredentialViaHttp(
       method: "POST",
       body: JSON.stringify(request),
     },
+    null,
   );
   if (response === null) {
     return { kind: "network-error" };
@@ -293,6 +321,7 @@ export async function requestStepUpChallengeViaHttp(
       method: "POST",
       body: "{}",
     },
+    null,
   );
   if (response === null) {
     return { kind: "network-error" };
@@ -322,6 +351,7 @@ export async function verifyStepUpChallengeViaHttp(
       method: "POST",
       body: JSON.stringify({ code }),
     },
+    null,
   );
   if (response === null) {
     return { kind: "network-error" };

--- a/clients/shared/host-client/mock/mock-runner-host.ts
+++ b/clients/shared/host-client/mock/mock-runner-host.ts
@@ -209,10 +209,15 @@ export class MockRunnerHost implements IRunnerHost {
     return validateAuthTokenIdentityAccessOnly(this.authnBaseUrl, token);
   }
 
-  listUserSessions(bearerToken: string): Promise<ListUserSessionsFetchResult> {
+  listUserSessions(
+    bearerToken: string,
+    signal: AbortSignal,
+  ): Promise<ListUserSessionsFetchResult> {
     // The in-memory shell has no CORS boundary, so it calls the shared HTTP
     // helper directly (browser/dev parity with the auth validators above).
-    return listUserSessionsViaHttp(this.authnBaseUrl, bearerToken);
+    // Owning the request in-process, it can hand the caller's signal straight
+    // to `fetch` and abort the real request.
+    return listUserSessionsViaHttp(this.authnBaseUrl, bearerToken, signal);
   }
 
   async revokeUserSession(

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -81,9 +81,19 @@ export interface IRunnerHost {
   /**
    * Fetches the signed-in user's account sessions from authn-v3. Desktop shells
    * run this in Electron main for the same renderer-origin CORS reason as token
-   * validation. Never throws: transport failures collapse into the result.
+   * validation. Transport failures collapse into the result rather than
+   * throwing; a cancellation via `signal` is the one case that may reject.
+   *
+   * `signal` is the reading TanStack query's cancellation. It matters beyond
+   * saving a request: the caller's repair path spends a single-use refresh
+   * rotation, so a list nobody is waiting on must stop before it gets there.
+   * Shells that own the request in-process abort it for real; shells that run it
+   * behind an IPC boundary settle the caller and let the bounded request finish.
    */
-  listUserSessions(bearerToken: string): Promise<ListUserSessionsFetchResult>;
+  listUserSessions(
+    bearerToken: string,
+    signal: AbortSignal,
+  ): Promise<ListUserSessionsFetchResult>;
 
   /**
    * Revokes one session family. Callers pass the user's normal session bearer


### PR DESCRIPTION
Closes #837.

## What this actually fixes

The issue was filed on the premise that a late session-list response could
"briefly repopulate the cache". **That premise does not hold**, and I checked it
rather than assumed it: on `@tanstack/query-core@5.101.4` the retryer rejects the
superseded thenable on cancel and guards `resolve` behind `isResolved()`, so a
late resolve is dropped whether or not the query function consumes the signal.
A probe driving a real `QueryObserver` through `invalidateQueries` and
`cancelQueries` confirmed the cache is never overwritten today.

What *is* real is the side effect further down. `AuthService.fetchUserSessions()`
can follow a listing with a repair that calls `forceRefreshExpectedSession()` →
`tokenStore.rotate()` — a **single-use, cross-process refresh rotation**. With the
signal dropped, that spend still happened for a read nobody was waiting on.

Identity fencing does not cover it. The ordinary cancellations here — a revoke
invalidating the list, a panel unmount, a focus refetch superseding the 30s poll —
all leave the **same account signed in**, so every authority check still passes.
Only the query's signal carries the information that the answer is unwanted.

## Change

The signal is threaded `useAuthFetchUserSessions` → `fetchUserSessions` →
`IRunnerHost.listUserSessions`, and checked on entry and after each list await,
so a cancelled read throws before it can reach the rotation.

Each shell consumes it according to what it owns:

| Shell | Behaviour |
|---|---|
| `MockRunnerHost` (browser/dev) | Owns the request in-process — the signal goes straight to `fetch` (combined with the existing 10s timeout via `AbortSignal.any`), aborting it for real. |
| `DesktopRunnerHost` | An `AbortSignal` is not cloneable across the context bridge, so it settles the caller immediately and lets the main-process GET run out its bounded timeout. Waste is one idempotent GET; the caller stops now rather than up to 10s later. |

An earlier draft also had a fence immediately before the repair. It was
unreachable — there is no `await` between it and the post-list check — so it was
removed rather than left as a guard that can never fire.

## Knock-on behaviour change (intentional, re-pinned)

Consuming the signal changes what TanStack does when a query loses its observer:
`query.ts:370-373` cancels-and-reverts an in-flight fetch when `abortSignalConsumed`
is set, instead of only stopping retries. So on an account switch, account A's
in-flight response is now **discarded outright** rather than parked in A's cache.

That is strictly stronger than the by-key isolation the existing test was written
for — A's response still never reaches B, and switching back to A refetches
instead of showing a pre-switch snapshot. The test is renamed and re-pinned to the
new behaviour rather than quietly adjusted.

## Coverage

- `auth-service` — a read cancelled while the list is in flight spends **no**
  refresh rotation. Mutation-probed: removing the fence turns exactly this test
  red and no other (81 tests in the file otherwise unchanged).
- `use-user-sessions-query` — the signal handed to the in-flight read is aborted
  when a revoke invalidates the query; and the re-pinned account-switch case.
  Both mutation-probed against dropping the signal.
- `devices-sessions-fetcher` — the caller's signal reaches `fetch` and aborts the
  real request, with the per-call timeout still composed alongside it.
- `desktop-runner-host` — settles without waiting for the main-process reply;
  rejects an already-aborted request without putting it on the wire; and an
  assertion pinning that the signal is deliberately **not** forwarded across the
  bridge.

Also added explicit Testing Library `cleanup()` to the query-hook suite — that
project runs `globals: false`, so auto-cleanup never ran and a second test in the
file would otherwise inherit the first one's mounted hook.

## Verification

- `bun run compile` — green across all 5 projects
- `bun run lint` / `prettier --check` — clean
- gui-app **8450 passed**, protocol **1470 passed**, shared + desktop suites green
- `react-doctor` on changed GUI code — no issues
- One `traycer-cli` failure (`waives the floor for an unreleased CLI build`) is
  **pre-existing**, verified identical against clean `HEAD` via stash; unrelated
  to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)