### PR TITLE
fix(transport): recover post-open host timeouts

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -48,3 +48,14 @@ paths = [
 regexes = [
   '''^dGhlIHNhbXBsZSBub25jZQ==$''',
 ]
+
+[[allowlists]]
+description = "JWT-shaped scrubber fixture. This exact dummy value verifies redaction of JWTs in user text and logs; require both its precise test path and full value."
+condition = "AND"
+regexTarget = "secret"
+paths = [
+  '''^clients/desktop/src/electron-main/app/__tests__/support-scrubber\.test\.ts$''',
+]
+regexes = [
+  '''^eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9[.]eyJzdWIiOiIxMjM0NTY3ODkwIn0[.]dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U$''',
+]

--- a/clients/gui-app/src/providers/host-runtime-provider.tsx
+++ b/clients/gui-app/src/providers/host-runtime-provider.tsx
@@ -16,7 +16,10 @@ import type {
 } from "@traycer-clients/shared/host-client/host-client";
 import { HostRuntime } from "@traycer-clients/shared/host-client/host-runtime";
 import type { IHostMessenger } from "@traycer-clients/shared/host-transport/host-messenger";
-import { WsRpcClient } from "@traycer-clients/shared/host-transport/ws-rpc-client";
+import {
+  HOST_POST_OPEN_ATTESTATION_WINDOW_MS,
+  WsRpcClient,
+} from "@traycer-clients/shared/host-transport/ws-rpc-client";
 import { createWhatwgWebSocketFactory } from "@traycer-clients/shared/host-transport/whatwg-ws-factory";
 import { createAuthAwareMessenger } from "@traycer-clients/shared/host-transport/auth-aware-messenger";
 import {
@@ -194,6 +197,13 @@ export function createHostRuntime<Registry extends VersionedRpcRegistry>(
               webSocketFactory: createWhatwgWebSocketFactory(),
               dialTimeoutMs: DEFAULT_DIAL_TIMEOUT_MS,
               frameTimeoutMs: DEFAULT_WS_FRAME_TIMEOUT_MS,
+              // The GUI's response deadline matches the host's post-`openAck`
+              // deadline, so which overdue timer runs first is up to scheduling
+              // (or a sleep/resume - and a stalled host fires its timer late,
+              // well past 30s). This window keeps the socket open long enough
+              // for the host's no-dispatch attestation when the client's timer
+              // wins that race.
+              hostAttestationWindowMs: HOST_POST_OPEN_ATTESTATION_WINDOW_MS,
             });
       // Closes the unary-RPC auth-recovery loop: a mid-call 401 from
       // the Traycer cloud backend is surfaced by the host as
@@ -202,11 +212,14 @@ export function createHostRuntime<Registry extends VersionedRpcRegistry>(
       // the existing context's credential lease in place (refresh
       // succeeded) or signs the user out (refresh rejected) instead of
       // leaving them staring at a generic failure toast.
-      // Retry is the outermost layer: a pre-send transient dial/handshake
-      // failure (`RetryableTransportError`) re-dials on a short backoff before
-      // the auth-aware wrapper or the query layer ever see it. The auth wrapper
-      // only acts on `UNAUTHORIZED`, never a retryable transport error, so the
-      // two never contend. When auth revalidation really rotates the bearer,
+      // Retry is the outermost layer: a transport failure the host provably
+      // never dispatched (`RetryableTransportError` - a pre-send dial/handshake
+      // failure, or a host-attested post-`openAck` request timeout) re-dials on
+      // a short backoff before the auth-aware wrapper or the query layer ever
+      // see it. That includes the legacy `UNAUTHORIZED` spelling of the
+      // post-open timeout, which is why the auth wrapper never sees it as a
+      // credential rejection. The auth wrapper only acts on `UNAUTHORIZED`,
+      // never a retryable transport error, so the two never contend. When auth revalidation really rotates the bearer,
       // retry the same RPC once against the fresh lease; some usage-limit
       // queries intentionally disable TanStack retry, so the refresh loop must
       // complete in the transport layer.

--- a/clients/shared/host-client/__tests__/host-client.test.ts
+++ b/clients/shared/host-client/__tests__/host-client.test.ts
@@ -367,6 +367,7 @@ describe("HostClient", () => {
       webSocketFactory: factory,
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: 0,
     });
 
     const client = new HostClient({
@@ -420,6 +421,7 @@ describe("HostClient", () => {
       webSocketFactory: factory,
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: 0,
     });
     const client = new HostClient({
       registry,

--- a/clients/shared/host-transport/__tests__/released-baseline-handshake.test.ts
+++ b/clients/shared/host-transport/__tests__/released-baseline-handshake.test.ts
@@ -263,6 +263,7 @@ function createReleasedPeerClient(
       webSocketFactory: factory,
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: 0,
     }),
   };
 }
@@ -385,6 +386,7 @@ describe.skipIf(baselines.length === 0)(
           webSocketFactory: factory,
           dialTimeoutMs: 1000,
           frameTimeoutMs: 1000,
+          hostAttestationWindowMs: 0,
         });
 
         const pending = client.request(
@@ -444,6 +446,7 @@ describe.skipIf(baselines.length === 0)(
           webSocketFactory: factory,
           dialTimeoutMs: 1000,
           frameTimeoutMs: 1000,
+          hostAttestationWindowMs: 0,
         });
 
         const pending = client.request(
@@ -513,6 +516,7 @@ describe.skipIf(baselines.length === 0)(
           webSocketFactory: factory,
           dialTimeoutMs: 1000,
           frameTimeoutMs: 1000,
+          hostAttestationWindowMs: 0,
         });
 
         const pending = client.request(

--- a/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   defineFallbackMethodDegrade,
@@ -15,6 +15,7 @@ import {
   HostTransportFailureError,
   RetryableTransportError,
   type HostRequestAuthority,
+  type IHostMessenger,
   type RequestOfMethod,
   type ResponseOfMethod,
 } from "../host-messenger";
@@ -34,7 +35,12 @@ import type {
   WebSocketMessageEvent,
   WebSocketOpenEvent,
 } from "../ws-factory";
-import { WsRpcClient } from "../ws-rpc-client";
+import {
+  HOST_POST_OPEN_ATTESTATION_WINDOW_MS,
+  WsRpcClient,
+} from "../ws-rpc-client";
+import { createAuthAwareMessenger } from "../auth-aware-messenger";
+import { createRetryingMessenger } from "../retrying-messenger";
 import type {
   ClientFrame,
   ClientOpenFrame,
@@ -198,6 +204,12 @@ function makeClient(options: {
   readonly requestId: string;
   readonly dialTimeoutMs: number;
   readonly frameTimeoutMs: number;
+  /**
+   * Omitted means `0` - no post-send attestation grace, so a response-wait
+   * timeout fails the call the moment the caller's deadline expires. Tests that
+   * exercise the grace pass a window explicitly.
+   */
+  readonly hostAttestationWindowMs?: number;
 }): BoundWsRpcClient<typeof testRegistry> {
   const inner = new WsRpcClient<typeof testRegistry>({
     registry: testRegistry,
@@ -205,8 +217,78 @@ function makeClient(options: {
     webSocketFactory: options.factory,
     dialTimeoutMs: options.dialTimeoutMs,
     frameTimeoutMs: options.frameTimeoutMs,
+    hostAttestationWindowMs: options.hostAttestationWindowMs ?? 0,
   });
   return new BoundWsRpcClient(inner, authorityForToken(options.authToken));
+}
+
+async function expectPostOpenTimeoutRecovery(fatal: HostFrame): Promise<void> {
+  const { factory, sockets } = makeFactory();
+  let requestNumber = 0;
+  const raw = new WsRpcClient<typeof testRegistry>({
+    registry: testRegistry,
+    requestId: () => {
+      requestNumber += 1;
+      return `req-post-open-${requestNumber}`;
+    },
+    webSocketFactory: factory,
+    dialTimeoutMs: 1_000,
+    frameTimeoutMs: 1_000,
+    hostAttestationWindowMs: 0,
+  });
+  const authCalls = { count: 0 };
+  const authAware = createAuthAwareMessenger<typeof testRegistry>(raw, {
+    revalidateExpectedBearer: async () => {
+      authCalls.count += 1;
+      return "rotated";
+    },
+  });
+  const client = createRetryingMessenger<typeof testRegistry>(authAware, {
+    maxRetries: 1,
+    initialDelayMs: 0,
+    maxDelayMs: 0,
+    sleep: () => Promise.resolve(),
+    random: () => 0,
+  });
+  const authority = authorityForToken("token-abc");
+
+  const pending = client.request("host.echo", { message: "hi" }, authority);
+  await flush();
+  sockets[0].socket.fireOpen();
+  await flush();
+  sockets[0].socket.fireMessage(
+    openAckWithOptionalHostEcho({ major: 1, minor: 0 }),
+  );
+  await flush();
+  expect(expectRequestFrame(sockets[0].sent[1])).toBeDefined();
+
+  // The client locally sent its request after receiving the buffered openAck,
+  // but this fatal is host attestation that the host timed out first and never
+  // dispatched it. That makes a fresh attempt safe even for non-idempotent RPCs.
+  sockets[0].socket.fireMessage(fatal);
+  for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+    await flush();
+  }
+  expect(sockets).toHaveLength(2);
+  expect(authCalls.count).toBe(0);
+
+  sockets[1].socket.fireOpen();
+  await flush();
+  sockets[1].socket.fireMessage(
+    openAckWithOptionalHostEcho({ major: 1, minor: 0 }),
+  );
+  await flush();
+  const replacementRequest = expectRequestFrame(sockets[1].sent[1]);
+  sockets[1].socket.fireMessage({
+    kind: "response",
+    requestId: replacementRequest.requestId,
+    method: replacementRequest.method,
+    schemaVersion: replacementRequest.schemaVersion,
+    result: { echoed: "HI" },
+    error: null,
+  });
+
+  await expect(pending).resolves.toEqual({ echoed: "HI" });
 }
 
 function makeRequestContext(bearer: string): RequestContext {
@@ -340,6 +422,7 @@ describe("WsRpcClient", () => {
       webSocketFactory: factory,
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: 0,
     });
     const lifetime = new AbortController();
     const pending = client.request(
@@ -399,6 +482,7 @@ describe("WsRpcClient", () => {
         webSocketFactory: factory,
         dialTimeoutMs: 1000,
         frameTimeoutMs: 1000,
+        hostAttestationWindowMs: 0,
       }),
       authorityForBearer(ctx.credentials),
     );
@@ -747,6 +831,978 @@ describe("WsRpcClient", () => {
     await expect(pending).rejects.toBeInstanceOf(RetryableTransportError);
   });
 
+  it("retries the new host's typed post-open request timeout", async () => {
+    await expectPostOpenTimeoutRecovery({
+      kind: "fatalError",
+      details: {
+        code: "RPC_REQUEST_TIMEOUT",
+        reason: "Timed out waiting for 'request' frame after openAck (30000ms)",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+        retryable: true,
+      },
+    });
+  });
+
+  it("recovers the legacy UNAUTHORIZED post-open timeout without revalidating auth", async () => {
+    await expectPostOpenTimeoutRecovery({
+      kind: "fatalError",
+      details: {
+        code: "UNAUTHORIZED",
+        reason: "Timed out waiting for 'request' frame after openAck (30000ms)",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      },
+    });
+  });
+
+  /**
+   * Issue #726: when the client's response timer fires before the host's
+   * post-open no-dispatch attestation, the socket is held open for a bounded
+   * remainder of the host attestation window rather than closing over an
+   * ambiguous in-flight request. These cases pin the production CLI/GUI timer
+   * orderings and the safety boundary around the grace.
+   *
+   * The behaviour cases inject the window as a literal rather than importing
+   * HOST_POST_OPEN_ATTESTATION_WINDOW_MS, so they pin the contract instead of
+   * restating whatever production currently ships. The first case below is the
+   * one exception - it exists precisely to tie the shipped constant to the stall
+   * class the rest of the block models.
+   */
+  describe("post-open attestation grace (production ordering)", () => {
+    const HOST_ATTESTATION_WINDOW_MS = 50_000;
+    const HOST_POST_OPEN_DEADLINE_MS = 30_000;
+    const CLI_FRAME_TIMEOUT_MS = 15_000;
+    const GUI_FRAME_TIMEOUT_MS = 30_000;
+    /** Stalled-host attestation wall time modelled by issue #726 (~45s awake). */
+    const STALLED_HOST_ATTESTATION_AT_MS = 45_000;
+    const LONG_POLL_RESPONSE_TIMEOUT_MS = 16 * 60 * 1_000;
+    /** Floor delivery leg after any post-send timeout (matches production slack). */
+    const ATTESTATION_DELIVERY_SLACK_MS = 5_000;
+    /** Overshoot past a delivery leg that counts as suspension, not mere jitter. */
+    const SUSPENSION_OVERSHOOT_TOLERANCE_MS = 1_000;
+    /** Wall-clock jump used to model suspend while a delivery timer is pending. */
+    const SUSPEND_JUMP_MS = 10 * 60 * 1_000;
+    /**
+     * Late delivery re-arms have no count cap. Crossing the former limit of 3
+     * decisively (5+) pins that removal while still ending on active time.
+     */
+    const REPEATED_SUSPENSION_CYCLES = 5;
+
+    const typedPostOpenTimeoutFatal: HostFrame = {
+      kind: "fatalError",
+      details: {
+        code: "RPC_REQUEST_TIMEOUT",
+        reason: "Timed out waiting for 'request' frame after openAck (30000ms)",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+        retryable: true,
+      },
+    };
+
+    const legacyPostOpenTimeoutFatal: HostFrame = {
+      kind: "fatalError",
+      details: {
+        code: "UNAUTHORIZED",
+        reason: "Timed out waiting for 'request' frame after openAck (30000ms)",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      },
+    };
+
+    async function flushFake(): Promise<void> {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    async function driveUntilRequestSent(
+      sockets: RecordedSocket[],
+    ): Promise<void> {
+      await flushFake();
+      expect(sockets).toHaveLength(1);
+      sockets[0].socket.fireOpen();
+      await flushFake();
+      sockets[0].socket.fireMessage(
+        openAckWithOptionalHostEcho({ major: 1, minor: 0 }),
+      );
+      await flushFake();
+      expect(expectRequestFrame(sockets[0].sent[1])).toBeDefined();
+    }
+
+    async function completeRetriedSocket(
+      sockets: RecordedSocket[],
+      socketIndex: number,
+    ): Promise<void> {
+      sockets[socketIndex].socket.fireOpen();
+      await flushFake();
+      sockets[socketIndex].socket.fireMessage(
+        openAckWithOptionalHostEcho({ major: 1, minor: 0 }),
+      );
+      await flushFake();
+      const replacementRequest = expectRequestFrame(
+        sockets[socketIndex].sent[1],
+      );
+      sockets[socketIndex].socket.fireMessage({
+        kind: "response",
+        requestId: replacementRequest.requestId,
+        method: replacementRequest.method,
+        schemaVersion: replacementRequest.schemaVersion,
+        result: { echoed: "HI" },
+        error: null,
+      });
+      await flushFake();
+    }
+
+    function makeGraceRecoveryStack(options: {
+      readonly factory: IWebSocketFactory;
+      readonly frameTimeoutMs: number;
+      readonly hostAttestationWindowMs: number;
+    }): {
+      readonly client: IHostMessenger<typeof testRegistry>;
+      readonly authCalls: { count: number };
+      readonly authority: HostRequestAuthority;
+    } {
+      let requestNumber = 0;
+      const raw = new WsRpcClient<typeof testRegistry>({
+        registry: testRegistry,
+        requestId: () => {
+          requestNumber += 1;
+          return `req-grace-${requestNumber}`;
+        },
+        webSocketFactory: options.factory,
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: options.frameTimeoutMs,
+        hostAttestationWindowMs: options.hostAttestationWindowMs,
+      });
+      const authCalls = { count: 0 };
+      const authAware = createAuthAwareMessenger<typeof testRegistry>(raw, {
+        revalidateExpectedBearer: async () => {
+          authCalls.count += 1;
+          return "rotated";
+        },
+      });
+      const client: IHostMessenger<typeof testRegistry> =
+        createRetryingMessenger<typeof testRegistry>(authAware, {
+          maxRetries: 1,
+          initialDelayMs: 0,
+          maxDelayMs: 0,
+          sleep: () => Promise.resolve(),
+          random: () => 0,
+        });
+      return {
+        client,
+        authCalls,
+        authority: authorityForToken("token-abc"),
+      };
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: false });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("ships a window that outlasts the stall class the recovery cases model", () => {
+      // Every other case here injects its own window, so nothing else in this
+      // suite fails if the shipped constant is lowered - only the CLI's
+      // composition-root test would, and the GUI has no equivalent. A host that
+      // stalls past this window never gets to attest, and the call stays
+      // ambiguous: the value is a safety decision, not a tuning knob.
+      expect(HOST_POST_OPEN_ATTESTATION_WINDOW_MS).toBeGreaterThan(
+        STALLED_HOST_ATTESTATION_AT_MS,
+      );
+      // Below the largest production response deadline there would be no grace
+      // at all, since the grace is the window minus the caller's own wait.
+      expect(HOST_POST_OPEN_ATTESTATION_WINDOW_MS).toBeGreaterThan(
+        GUI_FRAME_TIMEOUT_MS,
+      );
+    });
+
+    it("CLI ordering: client 15s timeout then host typed attestation at 30s recovers on a fresh socket", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authCalls, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      await driveUntilRequestSent(sockets);
+
+      // Client response deadline fires first at 15s; grace = 50_000 - 15_000.
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets).toHaveLength(1);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Host post-open deadline at 30s lands during grace.
+      await vi.advanceTimersByTimeAsync(
+        HOST_POST_OPEN_DEADLINE_MS - CLI_FRAME_TIMEOUT_MS,
+      );
+      sockets[0].socket.fireMessage(typedPostOpenTimeoutFatal);
+      await flushFake();
+
+      for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+        await flushFake();
+      }
+      expect(sockets).toHaveLength(2);
+      expect(authCalls.count).toBe(0);
+
+      await completeRetriedSocket(sockets, 1);
+      await expect(pending).resolves.toEqual({ echoed: "HI" });
+    });
+
+    it("GUI ordering: client 30s timeout then legacy attestation inside 20s grace recovers without auth revalidation", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authCalls, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: GUI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      await driveUntilRequestSent(sockets);
+
+      // Client deadline equals the host's 30s post-open timer; grace = 20s.
+      await vi.advanceTimersByTimeAsync(GUI_FRAME_TIMEOUT_MS);
+      expect(sockets).toHaveLength(1);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Host fatal arrives a moment later, still inside the remaining 20s grace.
+      await vi.advanceTimersByTimeAsync(1);
+      sockets[0].socket.fireMessage(legacyPostOpenTimeoutFatal);
+      await flushFake();
+
+      for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+        await flushFake();
+      }
+      expect(sockets).toHaveLength(2);
+      // Legacy UNAUTHORIZED spelling must not trigger auth revalidation.
+      expect(authCalls.count).toBe(0);
+
+      await completeRetriedSocket(sockets, 1);
+      await expect(pending).resolves.toEqual({ echoed: "HI" });
+    });
+
+    it("GUI delayed equal-deadline: stalled-host attestation at 45s still recovers within the 50s window", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authCalls, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: GUI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      await driveUntilRequestSent(sockets);
+
+      // Client fires first at 30s; grace = 50_000 - 30_000 = 20s (expires at 50s).
+      await vi.advanceTimersByTimeAsync(GUI_FRAME_TIMEOUT_MS);
+      expect(sockets).toHaveLength(1);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Stalled host: overdue post-open timer only runs on resume ~45s total
+      // (~15s into the 20s grace). Discriminates the 50s window from the old 35s
+      // window, under which grace would already have expired at 35s.
+      await vi.advanceTimersByTimeAsync(
+        STALLED_HOST_ATTESTATION_AT_MS - GUI_FRAME_TIMEOUT_MS,
+      );
+      expect(sockets[0].socket.closed).toBeNull();
+      sockets[0].socket.fireMessage(typedPostOpenTimeoutFatal);
+      await flushFake();
+
+      for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+        await flushFake();
+      }
+      expect(sockets).toHaveLength(2);
+      expect(authCalls.count).toBe(0);
+
+      await completeRetriedSocket(sockets, 1);
+      await expect(pending).resolves.toEqual({ echoed: "HI" });
+    });
+
+    it("grace expiry with no attestation rejects as non-retryable HostTransportFailureError without a second dial", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      // Attach before timers fire so the rejection is not unhandled under fake timers.
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Exhaust the remainder of the 50s window (grace = 35s). No attestation.
+      await vi.advanceTimersByTimeAsync(
+        HOST_ATTESTATION_WINDOW_MS - CLI_FRAME_TIMEOUT_MS,
+      );
+      await rejection;
+      expect(sockets).toHaveLength(1);
+    });
+
+    it("a late response frame during grace does not resolve the call", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-late-response",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      const requestFrame = expectRequestFrame(sockets[0].sent[1]);
+      sockets[0].socket.fireMessage({
+        kind: "response",
+        requestId: requestFrame.requestId,
+        method: requestFrame.method,
+        schemaVersion: requestFrame.schemaVersion,
+        result: { echoed: "LATE" },
+        error: null,
+      });
+      await rejection;
+    });
+
+    it("an unrelated retryable-marked fatal during grace does not become retryable", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-unrelated-fatal",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      // Without this the fatal would land on an already-closed socket and the
+      // assertion below would hold for the wrong reason.
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireMessage({
+        kind: "fatalError",
+        details: {
+          code: "HOST_BUSY_AFTER_DISPATCH",
+          reason: "host became busy after dispatch",
+          incompatibleMethods: null,
+          upgradeGuidance: null,
+          retryable: true,
+        },
+      });
+      await rejection;
+    });
+
+    /**
+     * The exact-legacy no-dispatch matcher requires all three guards:
+     * code === "UNAUTHORIZED", reason start-anchor, and reason end-anchor.
+     * Promoting a near-miss into RetryableTransportError would redial a
+     * non-idempotent method. Each row kills one guard if removed.
+     */
+    const EXACT_LEGACY_TIMEOUT_REASON =
+      "Timed out waiting for 'request' frame after openAck (30000ms)";
+
+    it.each([
+      {
+        name: "trailing text under UNAUTHORIZED",
+        code: "UNAUTHORIZED",
+        reason: `${EXACT_LEGACY_TIMEOUT_REASON} — token expired mid-flight`,
+      },
+      {
+        name: "leading text under UNAUTHORIZED",
+        code: "UNAUTHORIZED",
+        reason: `Session rejected: ${EXACT_LEGACY_TIMEOUT_REASON}`,
+      },
+      {
+        name: "exact historical reason under FORBIDDEN",
+        code: "FORBIDDEN",
+        reason: EXACT_LEGACY_TIMEOUT_REASON,
+      },
+    ] as const)(
+      "near-miss legacy attestation ($name) during grace stays non-retryable without a second dial",
+      async ({ code, reason }) => {
+        const { factory, sockets } = makeFactory();
+        const { client, authCalls, authority } = makeGraceRecoveryStack({
+          factory,
+          frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+          hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+        });
+
+        const pending = client.request(
+          "host.echo",
+          { message: "hi" },
+          authority,
+        );
+        const rejection = expect(pending).rejects.toSatisfy(
+          (error: unknown) =>
+            error instanceof HostTransportFailureError &&
+            !(error instanceof RetryableTransportError) &&
+            error.message.includes(
+              `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+            ),
+        );
+        await driveUntilRequestSent(sockets);
+
+        await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+        expect(sockets[0].socket.closed).toBeNull();
+
+        sockets[0].socket.fireMessage({
+          kind: "fatalError",
+          details: {
+            code,
+            reason,
+            incompatibleMethods: null,
+            upgradeGuidance: null,
+          },
+        });
+        await rejection;
+        expect(sockets).toHaveLength(1);
+        expect(authCalls.count).toBe(0);
+      },
+    );
+
+    /**
+     * Models suspend after the response deadline has already armed grace, then
+     * a wake batch that runs the overdue *window* leg first. Before the
+     * two-leg fix that callback closed the socket immediately; now it only
+     * arms the delivery leg, so the host's equally overdue attestation can
+     * still land.
+     *
+     * CLI 15s wait / 50s window: window leg is 30s (fires at t=45s), delivery
+     * leg is 5s (would fail at t=50s). Advancing to the window-leg fire is the
+     * discriminator - the socket must still be open.
+     */
+    it("suspend after grace armed: window-leg callback on wake keeps the socket open for typed attestation recovery", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authCalls, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      await driveUntilRequestSent(sockets);
+
+      // Response deadline → grace armed (window 30s + delivery 5s).
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets).toHaveLength(1);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Window leg fires (t=45s). Models the wake batch running the overdue
+      // client callback first; the socket must still be open so the host's
+      // equally overdue attestation can still arrive on this connection.
+      await vi.advanceTimersByTimeAsync(
+        HOST_ATTESTATION_WINDOW_MS -
+          CLI_FRAME_TIMEOUT_MS -
+          ATTESTATION_DELIVERY_SLACK_MS,
+      );
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireMessage(typedPostOpenTimeoutFatal);
+      await flushFake();
+
+      for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+        await flushFake();
+      }
+      expect(sockets).toHaveLength(2);
+      expect(authCalls.count).toBe(0);
+
+      await completeRetriedSocket(sockets, 1);
+      await expect(pending).resolves.toEqual({ echoed: "HI" });
+    });
+
+    /**
+     * Models suspend *inside* the delivery leg. Jumping the fake wall clock
+     * with `setSystemTime` before advancing the 5s delivery timer makes the
+     * callback observe a large overshoot (suspension), so production re-arms a
+     * fresh awake delivery leg instead of ending the call.
+     */
+    it("suspend during delivery leg: overdue expiry on wake keeps the socket open for typed attestation recovery", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authCalls, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      await driveUntilRequestSent(sockets);
+
+      // Response deadline → grace armed; window leg → delivery leg armed (t=45s).
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(
+        HOST_ATTESTATION_WINDOW_MS -
+          CLI_FRAME_TIMEOUT_MS -
+          ATTESTATION_DELIVERY_SLACK_MS,
+      );
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Suspend while the delivery timer is pending, then let it fire overdue.
+      vi.setSystemTime(Date.now() + SUSPEND_JUMP_MS);
+      await vi.advanceTimersByTimeAsync(ATTESTATION_DELIVERY_SLACK_MS);
+      // Discriminator: late-fire forgiveness re-armed the delivery leg.
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireMessage(typedPostOpenTimeoutFatal);
+      await flushFake();
+
+      for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+        await flushFake();
+      }
+      expect(sockets).toHaveLength(2);
+      expect(authCalls.count).toBe(0);
+
+      await completeRetriedSocket(sockets, 1);
+      await expect(pending).resolves.toEqual({ echoed: "HI" });
+    });
+
+    /**
+     * The bound is active time, not suspension count: every late delivery
+     * re-arms, and the grace ends only when a delivery leg gets its full
+     * awake slack with no wall-clock jump.
+     */
+    it("repeated delivery-leg suspensions re-arm past any count cap; an uninterrupted leg ends the grace", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(
+        HOST_ATTESTATION_WINDOW_MS -
+          CLI_FRAME_TIMEOUT_MS -
+          ATTESTATION_DELIVERY_SLACK_MS,
+      );
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Cross the former count cap (3) decisively — no suspension count limit.
+      for (let i = 0; i < REPEATED_SUSPENSION_CYCLES; i += 1) {
+        vi.setSystemTime(Date.now() + SUSPEND_JUMP_MS);
+        await vi.advanceTimersByTimeAsync(ATTESTATION_DELIVERY_SLACK_MS);
+        expect(sockets[0].socket.closed).toBeNull();
+      }
+
+      // Finite in active time: one uninterrupted delivery leg settles.
+      await vi.advanceTimersByTimeAsync(ATTESTATION_DELIVERY_SLACK_MS);
+      await rejection;
+      expect(sockets).toHaveLength(1);
+    });
+
+    it("ordinary delivery-leg jitter below suspension tolerance ends grace without re-arming", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "hi" }, authority);
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(
+        HOST_ATTESTATION_WINDOW_MS -
+          CLI_FRAME_TIMEOUT_MS -
+          ATTESTATION_DELIVERY_SLACK_MS,
+      );
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Overshoot of 500ms is below the 1s suspension tolerance → not forgiven.
+      vi.setSystemTime(
+        Date.now() + Math.floor(SUSPENSION_OVERSHOOT_TOLERANCE_MS / 2),
+      );
+      await vi.advanceTimersByTimeAsync(ATTESTATION_DELIVERY_SLACK_MS);
+      await rejection;
+      expect(sockets).toHaveLength(1);
+    });
+
+    /**
+     * Long-poll budgets (e.g. providers.awaitLogin at 16 min) outlast the 50s
+     * window. They no longer get zero grace: the response-timeout callback
+     * still arms a finite delivery floor so a late-firing host attestation can
+     * recover on a fresh socket when the client callback wins on wake.
+     */
+    it("long-poll deadline overdue on wake keeps a delivery floor and recovers on typed attestation", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authCalls, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: 1_000,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.requestWithResponseTimeout(
+        "host.echo",
+        { message: "slow" },
+        LONG_POLL_RESPONSE_TIMEOUT_MS,
+        authority,
+      );
+      await driveUntilRequestSent(sockets);
+
+      // Advance the full long-poll budget so the response-timeout callback wins
+      // on wake. Discriminator: socket stays open (delivery floor armed).
+      await vi.advanceTimersByTimeAsync(LONG_POLL_RESPONSE_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireMessage(typedPostOpenTimeoutFatal);
+      await flushFake();
+
+      for (let attempt = 0; attempt < 10 && sockets.length < 2; attempt += 1) {
+        await flushFake();
+      }
+      expect(sockets).toHaveLength(2);
+      expect(authCalls.count).toBe(0);
+
+      await completeRetriedSocket(sockets, 1);
+      await expect(pending).resolves.toEqual({ echoed: "HI" });
+    });
+
+    it("long-poll delivery-floor grace is finite: expires as original non-retryable timeout without a second dial", async () => {
+      const { factory, sockets } = makeFactory();
+      const { client, authority } = makeGraceRecoveryStack({
+        factory,
+        frameTimeoutMs: 1_000,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.requestWithResponseTimeout(
+        "host.echo",
+        { message: "slow" },
+        LONG_POLL_RESPONSE_TIMEOUT_MS,
+        authority,
+      );
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${LONG_POLL_RESPONSE_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(LONG_POLL_RESPONSE_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Delivery floor only; nothing arrives → original ambiguous timeout.
+      await vi.advanceTimersByTimeAsync(ATTESTATION_DELIVERY_SLACK_MS);
+      await rejection;
+      expect(sockets).toHaveLength(1);
+    });
+
+    it("close during grace keeps the original ambiguous response timeout without a second dial", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-sticky-close",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ) &&
+          !error.message.includes("WebSocket closed before next frame") &&
+          !error.message.includes("WebSocket transport error:") &&
+          !error.message.includes("Malformed host frame:"),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireClose(1006, "abnormal", false);
+      await rejection;
+      expect(sockets).toHaveLength(1);
+      // failAll must dispose the armed grace timer (window/delivery leg).
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("transport error during grace keeps the original ambiguous response timeout without a second dial", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-sticky-error",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ) &&
+          !error.message.includes("WebSocket closed before next frame") &&
+          !error.message.includes("WebSocket transport error:") &&
+          !error.message.includes("Malformed host frame:"),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireError("ECONNRESET");
+      await rejection;
+      expect(sockets).toHaveLength(1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("malformed JSON during grace keeps the original ambiguous response timeout without a second dial", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-sticky-raw",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ) &&
+          !error.message.includes("WebSocket closed before next frame") &&
+          !error.message.includes("WebSocket transport error:") &&
+          !error.message.includes("Malformed host frame:"),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      sockets[0].socket.fireRawMessage("not json");
+      await rejection;
+      expect(sockets).toHaveLength(1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("invalid frame shape during grace keeps the original ambiguous response timeout without a second dial", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-sticky-shape",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ) &&
+          !error.message.includes("WebSocket closed before next frame") &&
+          !error.message.includes("WebSocket transport error:") &&
+          !error.message.includes("Malformed host frame:"),
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      // Valid JSON that fails hostFrameSchema (missing required response fields).
+      sockets[0].socket.fireRawMessage(
+        JSON.stringify({ kind: "response", requestId: "x" }),
+      );
+      await rejection;
+      expect(sockets).toHaveLength(1);
+    });
+
+    it("zero attestation window settles a post-send response timeout at the caller deadline with no delivery tail", async () => {
+      const { factory, sockets } = makeFactory();
+      const client = makeClient({
+        factory,
+        authToken: "t",
+        requestId: "req-grace-zero-window",
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: 0,
+      });
+
+      const pending = client.request("host.echo", { message: "x" });
+      const rejection = expect(pending).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof HostTransportFailureError &&
+          !(error instanceof RetryableTransportError) &&
+          error.message.includes(
+            `frame timed out after ${CLI_FRAME_TIMEOUT_MS}ms`,
+          ),
+      );
+      await driveUntilRequestSent(sockets);
+
+      // Shared-transport half of the fast-fail guarantee: with window 0 the
+      // rejection settles at exactly the caller's deadline (no delivery floor).
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      await rejection;
+      expect(sockets).toHaveLength(1);
+    });
+
+    it("aborting the authority during grace settles with HostRequestAbortedError and closes the socket", async () => {
+      const { factory, sockets } = makeFactory();
+      const lifetime = new AbortController();
+      const client = new WsRpcClient<typeof testRegistry>({
+        registry: testRegistry,
+        requestId: () => "req-grace-abort",
+        webSocketFactory: factory,
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+      const pending = client.request(
+        "host.echo",
+        { message: "hi" },
+        {
+          endpoint: {
+            hostId: mockLocalHostEntry.hostId,
+            websocketUrl: mockLocalHostEntry.websocketUrl,
+          },
+          bearer: new MutableBearerLease("token-abc", "test-user"),
+          abortSignal: lifetime.signal,
+        },
+      );
+      const rejection = expect(pending).rejects.toBeInstanceOf(
+        HostRequestAbortedError,
+      );
+      await driveUntilRequestSent(sockets);
+
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      lifetime.abort("host-replaced");
+      await rejection;
+      expect(sockets[0].socket.closed).toEqual({
+        code: 1000,
+        reason: "authority-aborted",
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("aborting after a re-armed delivery leg clears timers and settles with HostRequestAbortedError", async () => {
+      const { factory, sockets } = makeFactory();
+      const lifetime = new AbortController();
+      const client = new WsRpcClient<typeof testRegistry>({
+        registry: testRegistry,
+        requestId: () => "req-grace-abort-rearmed",
+        webSocketFactory: factory,
+        dialTimeoutMs: 1_000,
+        frameTimeoutMs: CLI_FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: HOST_ATTESTATION_WINDOW_MS,
+      });
+      const pending = client.request(
+        "host.echo",
+        { message: "hi" },
+        {
+          endpoint: {
+            hostId: mockLocalHostEntry.hostId,
+            websocketUrl: mockLocalHostEntry.websocketUrl,
+          },
+          bearer: new MutableBearerLease("token-abc", "test-user"),
+          abortSignal: lifetime.signal,
+        },
+      );
+      const rejection = expect(pending).rejects.toBeInstanceOf(
+        HostRequestAbortedError,
+      );
+      await driveUntilRequestSent(sockets);
+
+      // Arm grace, fire the window leg, then suspend so delivery re-arms.
+      await vi.advanceTimersByTimeAsync(CLI_FRAME_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(
+        HOST_ATTESTATION_WINDOW_MS -
+          CLI_FRAME_TIMEOUT_MS -
+          ATTESTATION_DELIVERY_SLACK_MS,
+      );
+      vi.setSystemTime(Date.now() + SUSPEND_JUMP_MS);
+      await vi.advanceTimersByTimeAsync(ATTESTATION_DELIVERY_SLACK_MS);
+      expect(sockets[0].socket.closed).toBeNull();
+
+      lifetime.abort("host-replaced");
+      await rejection;
+      expect(sockets[0].socket.closed).toEqual({
+        code: 1000,
+        reason: "authority-aborted",
+      });
+      // Disposal must cover the re-armed delivery timer, not only the first leg.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
   it("does NOT classify a post-send response timeout as retryable", async () => {
     const { factory, sockets } = makeFactory();
     const client = makeClient({
@@ -773,6 +1829,45 @@ describe("WsRpcClient", () => {
         error instanceof HostTransportFailureError &&
         !(error instanceof RetryableTransportError) &&
         error.message.includes("frame timed out"),
+    );
+  });
+
+  it("does NOT retry an arbitrary host-marked fatal after request dispatch", async () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient({
+      factory,
+      authToken: "t",
+      requestId: "req-postsend-fatal",
+      dialTimeoutMs: 1000,
+      frameTimeoutMs: 1000,
+    });
+
+    const pending = client.request("host.echo", { message: "x" });
+    await flush();
+    sockets[0].socket.fireOpen();
+    await flush();
+    sockets[0].socket.fireMessage(
+      openAckWithOptionalHostEcho({ major: 1, minor: 0 }),
+    );
+    await flush();
+    expect(expectRequestFrame(sockets[0].sent[1])).toBeDefined();
+
+    sockets[0].socket.fireMessage({
+      kind: "fatalError",
+      details: {
+        code: "HOST_BUSY_AFTER_DISPATCH",
+        reason: "host became busy after dispatch",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+        retryable: true,
+      },
+    });
+
+    await expect(pending).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof HostRpcError &&
+        !(error instanceof RetryableTransportError) &&
+        error.fatalDetails?.code === "HOST_BUSY_AFTER_DISPATCH",
     );
   });
 
@@ -987,6 +2082,7 @@ describe("WsRpcClient", () => {
         webSocketFactory: factory,
         dialTimeoutMs: 1000,
         frameTimeoutMs: 1000,
+        hostAttestationWindowMs: 0,
       }),
       authorityForBearer(ctx.credentials),
     );
@@ -1075,6 +2171,7 @@ describe("WsRpcClient", () => {
         webSocketFactory: factory,
         dialTimeoutMs: 1000,
         frameTimeoutMs: 1000,
+        hostAttestationWindowMs: 0,
       }),
       authorityForBearer(ctx.credentials),
     );
@@ -1190,6 +2287,7 @@ describe("WsRpcClient", () => {
           webSocketFactory: options.factory,
           dialTimeoutMs: 1000,
           frameTimeoutMs: 1000,
+          hostAttestationWindowMs: 0,
         }),
         authorityForBearer(ctx.credentials),
       );
@@ -1443,6 +2541,7 @@ describe("WsRpcClient", () => {
           webSocketFactory: options.factory,
           dialTimeoutMs: 1000,
           frameTimeoutMs: 1000,
+          hostAttestationWindowMs: 0,
         }),
         authorityForBearer(ctx.credentials),
       );

--- a/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
@@ -205,11 +205,11 @@ function makeClient(options: {
   readonly dialTimeoutMs: number;
   readonly frameTimeoutMs: number;
   /**
-   * Omitted means `0` - no post-send attestation grace, so a response-wait
+   * `undefined` means `0` - no post-send attestation grace, so a response-wait
    * timeout fails the call the moment the caller's deadline expires. Tests that
    * exercise the grace pass a window explicitly.
    */
-  readonly hostAttestationWindowMs?: number;
+  readonly hostAttestationWindowMs: number | undefined;
 }): BoundWsRpcClient<typeof testRegistry> {
   const inner = new WsRpcClient<typeof testRegistry>({
     registry: testRegistry,
@@ -365,6 +365,7 @@ describe("WsRpcClient", () => {
       requestId: "req-1",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "hi" });
@@ -457,6 +458,7 @@ describe("WsRpcClient", () => {
       requestId: "req-no-auth",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     await expect(
@@ -507,6 +509,7 @@ describe("WsRpcClient", () => {
       requestId: "req-incompat",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -558,6 +561,7 @@ describe("WsRpcClient", () => {
       requestId: "req-unauth",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.status", {});
@@ -594,6 +598,7 @@ describe("WsRpcClient", () => {
       requestId: "req-mirror",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -631,6 +636,7 @@ describe("WsRpcClient", () => {
       requestId: "req-correlated",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -668,6 +674,7 @@ describe("WsRpcClient", () => {
       requestId: "req-dial-fail",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -694,6 +701,7 @@ describe("WsRpcClient", () => {
       requestId: "req-dial-timeout",
       dialTimeoutMs: 25,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -717,6 +725,7 @@ describe("WsRpcClient", () => {
       requestId: "req-frame-timeout",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 25,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -741,6 +750,7 @@ describe("WsRpcClient", () => {
       requestId: "req-malformed",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -782,6 +792,7 @@ describe("WsRpcClient", () => {
       requestId: "req-dial-retryable",
       dialTimeoutMs: 25,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -799,6 +810,7 @@ describe("WsRpcClient", () => {
       requestId: "req-close-retryable",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -821,6 +833,7 @@ describe("WsRpcClient", () => {
       requestId: "req-handshake-retryable",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 25,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -1811,6 +1824,7 @@ describe("WsRpcClient", () => {
       requestId: "req-postsend",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 25,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -1840,6 +1854,7 @@ describe("WsRpcClient", () => {
       requestId: "req-postsend-fatal",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -1879,6 +1894,7 @@ describe("WsRpcClient", () => {
       requestId: "req-longpoll",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 25,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.requestWithResponseTimeout(
@@ -1919,6 +1935,7 @@ describe("WsRpcClient", () => {
       requestId: "req-longpoll-handshake",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 25,
+      hostAttestationWindowMs: undefined,
     });
 
     // The extended budget covers ONLY the response wait - a host that never
@@ -1947,6 +1964,7 @@ describe("WsRpcClient", () => {
       requestId: "req-longpoll-elapsed",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 25,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.requestWithResponseTimeout(
@@ -1978,6 +1996,7 @@ describe("WsRpcClient", () => {
       requestId: "req-malformed-nonretry",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });
@@ -2002,6 +2021,7 @@ describe("WsRpcClient", () => {
       requestId: "req-error-env",
       dialTimeoutMs: 1000,
       frameTimeoutMs: 1000,
+      hostAttestationWindowMs: undefined,
     });
 
     const pending = client.request("host.echo", { message: "x" });

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -1879,6 +1879,15 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
       retryable: true,
     },
   } as const;
+  const LEGACY_SUBSCRIBE_TIMEOUT_FATAL = {
+    kind: "fatalError",
+    details: {
+      code: "STREAM_SUBSCRIBE_TIMEOUT",
+      reason: "Timed out waiting for 'subscribe' frame after openAck (30000ms)",
+      incompatibleMethods: null,
+      upgradeGuidance: null,
+    },
+  } as const;
 
   function wait(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -2081,6 +2090,26 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
     // Reconnected well past the no-progress bound (3) that a misclassified
     // UNAUTHORIZED would have hit - proof the transient path never gives up.
     expect(sockets.length).toBeGreaterThan(4);
+    session.close();
+  });
+
+  it("recovers an older host's subscribe timeout even when it omits `retryable`", async () => {
+    const { factory, sockets } = makeFactory();
+    const revalidator = makeAuthRevalidator(["rotated"]);
+    const client = makeAuthClient(factory, revalidator.auth, 5);
+    const statuses: StreamConnectionStatus[] = [];
+    const session = client.subscribe("epic.subscribe", { epicId: "e1" });
+    session.onStatusChange((status) => statuses.push(status));
+
+    await flush();
+    completeHandshake(sockets[0].socket);
+    sockets[0].socket.fireText(LEGACY_SUBSCRIBE_TIMEOUT_FATAL);
+    await wait(50);
+
+    expect(revalidator.calls.count).toBe(0);
+    expect(statuses).toContain("reconnecting");
+    expect(statuses).not.toContain("closed");
+    expect(sockets).toHaveLength(2);
     session.close();
   });
 

--- a/clients/shared/host-transport/host-messenger.ts
+++ b/clients/shared/host-transport/host-messenger.ts
@@ -223,16 +223,18 @@ export class HostTransportFailureError extends HostRpcError {
 }
 
 /**
- * A `HostTransportFailureError` that occurred *before* the request frame was
- * put on the wire - a dial timeout, an `onerror`/`onclose` during the
- * dial-or-handshake phase, or a handshake (`openAck`) frame timeout.
+ * A `HostTransportFailureError` for which the host is known not to have
+ * dispatched the request: either the request frame was never put on the wire
+ * (dial/handshake failure), or the host explicitly reported that its post-open
+ * request deadline elapsed while it was still awaiting that frame.
  *
- * The "before the request was sent" guarantee is what makes it safe to retry
- * even non-idempotent methods: the host never observed the call, so a fresh
- * dial cannot double-apply a side effect. `createRetryingMessenger` keys its
- * bounded retry off this subclass; a post-send drop stays a
+ * The "host did not dispatch the request" guarantee is what makes it safe to
+ * retry even non-idempotent methods: a fresh dial cannot double-apply a side
+ * effect. `createRetryingMessenger` keys its bounded retry off this subclass;
+ * an ambiguous post-send drop stays a
  * `HostTransportFailureError`, and a malformed frame or any host-originated
- * error stays a plain `HostRpcError` - both propagate on the first attempt.
+ * error without the no-dispatch guarantee stays a plain `HostRpcError` - both
+ * propagate on the first attempt.
  */
 export class RetryableTransportError extends HostTransportFailureError {
   constructor(details: {

--- a/clients/shared/host-transport/retrying-messenger.ts
+++ b/clients/shared/host-transport/retrying-messenger.ts
@@ -55,16 +55,15 @@ export const NO_RETRY_TRANSPORT_POLICY: TransportRetryPolicy = {
 
 /**
  * Wraps an `IHostMessenger` so a `RetryableTransportError` - a transient
- * transport failure that the transport proved happened *before* the request
- * frame was sent (dial timeout, handshake drop, `openAck` timeout) - is
- * retried on a fresh dial with jittered exponential backoff, up to
+ * transport failure for which the host is known not to have dispatched the
+ * request (dial/handshake failure, or an explicit post-open request timeout) -
+ * is retried on a fresh dial with jittered exponential backoff, up to
  * `policy.maxRetries` times.
  *
- * Only `RetryableTransportError` is retried: a post-send drop, a malformed
- * frame, an `UNAUTHORIZED`, or any other host-originated `HostRpcError` is a
- * plain `HostRpcError` and propagates on the first attempt. The "pre-send"
- * guarantee is what makes the retry safe even for non-idempotent methods - the
- * host never observed the original call.
+ * Only `RetryableTransportError` is retried: an ambiguous post-send drop, a
+ * malformed frame, an `UNAUTHORIZED`, or any other host-originated
+ * `HostRpcError` propagates on the first attempt. The no-dispatch guarantee is
+ * what makes the retry safe even for non-idempotent methods.
  *
  * Compose this *outside* `createAuthAwareMessenger`: the auth wrapper only acts
  * on `UNAUTHORIZED` (never a `RetryableTransportError`), so the two layers

--- a/clients/shared/host-transport/ws-rpc-client.ts
+++ b/clients/shared/host-transport/ws-rpc-client.ts
@@ -36,6 +36,7 @@ import type {
 import {
   checkCompatibility,
   hostFrameSchema,
+  RPC_REQUEST_TIMEOUT_FATAL_CODE,
   type ClientFrame,
   type ConnectionManifest,
   type HostFrame,
@@ -57,6 +58,65 @@ import { recordNegotiatedHostMethods } from "./negotiated-manifest-registry";
 export type { HostTransportEndpoint } from "./host-messenger";
 
 /**
+ * The complete reason emitted by hosts through 1.1.9 for the post-open timeout,
+ * anchored at both ends so only the host's timeout value may vary.
+ *
+ * A prefix test is not good enough here. This match is what promotes an
+ * `UNAUTHORIZED` - normally a hard credential rejection - into a no-dispatch
+ * attestation that permits retrying a non-idempotent method, so it must
+ * recognize the historical string and nothing that merely starts like it.
+ */
+const LEGACY_RPC_REQUEST_TIMEOUT_REASON =
+  /^Timed out waiting for 'request' frame after openAck \(\d+ms\)$/;
+
+/**
+ * Production value for `WsRpcClientOptions.hostAttestationWindowMs`.
+ *
+ * The host's own deadline is 30s (`DEFAULT_POST_OPEN_TIMEOUT_MS` in its RPC
+ * server), but that timer only *starts* counting event-loop time - a stalled
+ * host fires it late. Issue #726 measured awake stalls of 35.7-40.8s, and the
+ * profiled stall class reaches roughly 45s; 50s covers that class and leaves
+ * bounded slack for delivering the frame afterwards.
+ */
+export const HOST_POST_OPEN_ATTESTATION_WINDOW_MS = 50_000;
+
+/**
+ * Freshly-armed tail of every attestation grace, and the floor for a grace
+ * whose window share is already spent.
+ *
+ * Both peers' deadlines are plain `setTimeout`s, so a suspend/resume or an
+ * event-loop stall runs every overdue callback in a single wake batch. A client
+ * timer that ends the call from inside that batch wins against nothing: the
+ * host's equally overdue post-`openAck` timer has not run yet, let alone put its
+ * no-dispatch fatal on the wire. So no client timer ends the wait directly - it
+ * hands over to this tail, which was armed *after* that callback ran and
+ * therefore measures awake time. Issue #726 recorded 114ms between the desktop's
+ * `system resumed` line and the host firing its overdue post-open timer, so a
+ * few seconds of awake time is generous slack for emitting and delivering the
+ * frame.
+ *
+ * The same value floors the grace when the caller's own deadline already
+ * consumed the whole window - `providers.awaitLogin`'s 16-minute long poll, or
+ * any deadline that expired late because both processes were suspended. Such a
+ * deadline proves nothing about whether the host consumed the request, so it
+ * needs a delivery opportunity too; it just does not need a second full window.
+ */
+const ATTESTATION_DELIVERY_SLACK_MS = 5_000;
+
+/**
+ * Overshoot past a delivery leg's own duration that means the process was not
+ * *running* for most of it, rather than merely busy.
+ *
+ * A healthy event loop fires a timer within milliseconds of its deadline, and
+ * even a badly congested one is late by hundreds; issue #726 measured host
+ * event-loop gaps of 34-41 *seconds* and suspension gaps of minutes. A second
+ * cleanly separates ordinary jitter - which must still let the grace end - from
+ * a scheduling gap that froze this process, and with it the host's ability to
+ * emit and deliver its attestation.
+ */
+const SUSPENSION_OVERSHOOT_TOLERANCE_MS = 1_000;
+
+/**
  * Injectable source of the host endpoint the client should target. Returning
  * `null` means "no host currently bound" - the client rejects requests with
  * a `HostRpcError` rather than dialing.
@@ -72,6 +132,40 @@ export interface WsRpcClientOptions<Registry extends VersionedRpcRegistry> {
   readonly webSocketFactory: IWebSocketFactory;
   readonly dialTimeoutMs: number;
   readonly frameTimeoutMs: number;
+  /**
+   * How long after `openAck` this deployment's hosts are still expected to be
+   * sitting in `awaitingRequest`, and therefore still able to emit their
+   * no-dispatch attestation. Production clients pass
+   * `HOST_POST_OPEN_ATTESTATION_WINDOW_MS`; `0` disables the grace entirely.
+   *
+   * When the client's own response deadline expires first, the response wait is
+   * held open for whatever is left of this window instead of closing the socket
+   * over an ambiguous in-flight request - see `openSession`. Sizing the grace
+   * against this window rather than adding a fixed grace on top of the caller's
+   * deadline makes it shrink as the caller's deadline grows, so a long CLI wait
+   * never stacks a second full window on top of the first.
+   *
+   * It never shrinks to nothing, though: every post-send timeout keeps at least
+   * `ATTESTATION_DELIVERY_SLACK_MS`, because a caller deadline that expired late
+   * across a suspension - or a long-poll budget that outlasts this window
+   * outright - says nothing about whether the host ever consumed the request.
+   * `0` is the only way to opt out of the grace entirely, and means "this caller
+   * cannot act on an attestation even if it arrives" (see the CLI's fast-fail
+   * policy).
+   *
+   * The grace is a bound on *active* time, not on wall-clock time. Every leg is
+   * a `setTimeout`, so a suspend/resume can run any callback arbitrarily late;
+   * when that happens the wait gets a freshly measured delivery leg from
+   * whenever the callback actually ran, and total wall-clock can far exceed this
+   * window. That is the point - a resume is exactly when a host fires its
+   * overdue post-open timer. What is guaranteed is that a process running
+   * uninterrupted never waits longer than `hostAttestationWindowMs`, and that
+   * the grace always ends on the first delivery leg that gets its full duration
+   * of running time. Scheduling gaps neither peer could act through do not
+   * consume that bound - and are not counted, since a count of sleeps is not
+   * something the transport contract should encode.
+   */
+  readonly hostAttestationWindowMs: number;
 }
 
 /**
@@ -107,9 +201,17 @@ export interface WsRpcClientOptions<Registry extends VersionedRpcRegistry> {
  *   - dial timeout / transport unreachable / transport aborted / frame timeout
  *     → `HostTransportFailureError(code: "RPC_ERROR")` (the pre-send subset is
  *     a `RetryableTransportError`)
+ *   - host post-open request timeout (including the exact legacy `UNAUTHORIZED`
+ *     spelling) → `RetryableTransportError(code: "RPC_ERROR")`; the fatal is
+ *     host attestation that the request was never dispatched. If the client's
+ *     own response deadline expires first, the socket is held open for a
+ *     bounded remainder of `hostAttestationWindowMs` so that attestation can
+ *     still arrive; the ambiguous local timeout on its own stays non-retryable,
+ *     and once it has been recorded every other non-abort terminal event
+ *     reports it rather than its own error.
  *   - missing / released bearer before dial → `HostRpcError(code: "RPC_ERROR")`
- *   - host `fatalError { code }` (`INCOMPATIBLE`, `UNAUTHORIZED`, or a
- *     domain-specific code) → known RPC codes are preserved on
+ *   - every other host `fatalError { code }` (`INCOMPATIBLE`, `UNAUTHORIZED`,
+ *     or a domain-specific code) → known RPC codes are preserved on
  *     `HostRpcError.code`; domain-specific codes become `RPC_ERROR` while
  *     the original code stays in `fatalDetails`.
  *   - client mirror compat failure (other than cross-major no-bridge on the
@@ -136,6 +238,7 @@ export class WsRpcClient<
   private readonly webSocketFactory: IWebSocketFactory;
   private readonly dialTimeoutMs: number;
   private readonly frameTimeoutMs: number;
+  private readonly hostAttestationWindowMs: number;
 
   constructor(options: WsRpcClientOptions<Registry>) {
     this.registry = options.registry;
@@ -143,6 +246,7 @@ export class WsRpcClient<
     this.webSocketFactory = options.webSocketFactory;
     this.dialTimeoutMs = options.dialTimeoutMs;
     this.frameTimeoutMs = options.frameTimeoutMs;
+    this.hostAttestationWindowMs = options.hostAttestationWindowMs;
   }
 
   async request<Method extends keyof Registry & string>(
@@ -189,6 +293,7 @@ export class WsRpcClient<
     const session = openSession({
       socket: this.webSocketFactory.create(selected.websocketUrl),
       dialTimeoutMs: this.dialTimeoutMs,
+      hostAttestationWindowMs: this.hostAttestationWindowMs,
       requestId,
       method,
     });
@@ -216,7 +321,7 @@ export class WsRpcClient<
       const ackFrame = await session.next(this.frameTimeoutMs);
 
       if (ackFrame.kind === "fatalError") {
-        throw hostFatalError(ackFrame, requestId, method);
+        throw hostFatalError(ackFrame, requestId, method, "beforeRequest");
       }
       if (ackFrame.kind !== "openAck") {
         throw new HostRpcError({
@@ -352,7 +457,7 @@ async function executeAvailableMethodRequest<Payload, Response>(
   const responseFrame = await session.next(responseTimeoutMs);
 
   if (responseFrame.kind === "fatalError") {
-    throw hostFatalError(responseFrame, requestId, method);
+    throw hostFatalError(responseFrame, requestId, method, "afterRequest");
   }
   if (responseFrame.kind !== "response") {
     throw new HostRpcError({
@@ -730,8 +835,26 @@ function hostFatalError(
   frame: HostFatalErrorFrame,
   requestId: string,
   method: string,
+  phase: "beforeRequest" | "afterRequest",
 ): HostRpcError {
   const details = frame.details;
+  // Before the request, every host-marked transient is safe to retry. After the
+  // local send, retry only the post-open timeout: that fatal is host attestation
+  // that it remained `awaitingRequest` and never dispatched the call. The legacy
+  // reason match lets new clients recover against hosts through 1.1.9, which
+  // mislabeled the timeout as UNAUTHORIZED and omitted `retryable`.
+  if (
+    (phase === "beforeRequest" && details.retryable === true) ||
+    isRpcRequestTimeout(details)
+  ) {
+    return new RetryableTransportError({
+      code: "RPC_ERROR",
+      message: details.reason,
+      requestId,
+      method,
+      fatalDetails: details,
+    });
+  }
   return new HostRpcError({
     code: isRpcErrorCode(details.code) ? details.code : "RPC_ERROR",
     message: details.reason,
@@ -739,6 +862,26 @@ function hostFatalError(
     method,
     fatalDetails: details,
   });
+}
+
+/**
+ * True for the one host fatal that attests the request was never dispatched:
+ * the host's post-`openAck` deadline expired while it was still in
+ * `awaitingRequest`. Matched in the typed `RPC_REQUEST_TIMEOUT` spelling and in
+ * the exact legacy `UNAUTHORIZED` form emitted by hosts through 1.1.9.
+ */
+function isPostOpenTimeoutAttestation(frame: HostFrame): boolean {
+  return frame.kind === "fatalError" && isRpcRequestTimeout(frame.details);
+}
+
+function isRpcRequestTimeout(details: FatalErrorDetails): boolean {
+  if (details.code === RPC_REQUEST_TIMEOUT_FATAL_CODE) {
+    return true;
+  }
+  return (
+    details.code === "UNAUTHORIZED" &&
+    LEGACY_RPC_REQUEST_TIMEOUT_REASON.test(details.reason)
+  );
 }
 
 function decodeResponseFrame(
@@ -779,9 +922,29 @@ function decodeResponseFrame(
   return frame.result;
 }
 
+/**
+ * The two legs a post-send response timeout waits through before the call is
+ * declared ambiguously failed. Splitting the grace is what makes it
+ * resume-safe: the leg that finally gives up is always armed *after* the
+ * previous timer callback actually ran, so an overdue client timer can never
+ * end the call in the same wake batch that is about to deliver the host's
+ * equally overdue no-dispatch fatal.
+ */
+interface AttestationGrace {
+  /**
+   * Share of `hostAttestationWindowMs` this call has not yet spent. `0` when
+   * the caller's own deadline already consumed the window.
+   */
+  readonly windowMs: number;
+  /** Delivery tail, armed once `windowMs` elapses (immediately when it is 0). */
+  readonly deliveryMs: number;
+}
+
 interface SessionOptions {
   readonly socket: WebSocketLike;
   readonly dialTimeoutMs: number;
+  /** See `WsRpcClientOptions.hostAttestationWindowMs`. */
+  readonly hostAttestationWindowMs: number;
   readonly requestId: string;
   readonly method: string;
 }
@@ -793,6 +956,12 @@ interface Session {
    * not per session: the handshake (`openAck`) wait passes the transport's
    * default frame timeout, while the response wait may pass a caller-extended
    * budget for long-poll methods.
+   *
+   * `timeoutMs` bounds when this wait can *succeed*, not always when it
+   * rejects: a post-send timeout keeps the socket open for the remainder of the
+   * host's attestation window (see `attestationGraceFor`). A frame that arrives
+   * in that window can no longer complete the call - only the host's
+   * no-dispatch fatal is surfaced, and every other frame keeps the timeout.
    */
   next(timeoutMs: number): Promise<HostFrame>;
   send(frame: ClientFrame): void;
@@ -808,7 +977,8 @@ interface Session {
  * channel.
  */
 function openSession(options: SessionOptions): Session {
-  const { socket, dialTimeoutMs, requestId, method } = options;
+  const { socket, dialTimeoutMs, hostAttestationWindowMs, requestId, method } =
+    options;
 
   let opened = false;
   let closed = false;
@@ -816,9 +986,17 @@ function openSession(options: SessionOptions): Session {
   // point every transient failure is provably pre-send (the host never saw the
   // call), so it surfaces as a `RetryableTransportError`; after it, the same
   // failure shapes stay a non-retryable `HostTransportFailureError` because a
-  // retry could re-execute a non-idempotent method.
+  // retry could re-execute a non-idempotent method. Only the host itself can
+  // lift that ambiguity, by attesting it never dispatched the request - which
+  // is what the attestation grace below waits for.
   let requestSent = false;
   let failure: HostRpcError | null = null;
+  // Non-null only for the duration of the attestation grace: the ambiguous
+  // post-send response timeout that will be raised unless the host attests,
+  // within the remainder of its post-`openAck` window, that it never dispatched
+  // the request. While it is set it is the session's decided outcome - see the
+  // sticky rule in `failAll`.
+  let ambiguousResponseTimeout: HostRpcError | null = null;
 
   /**
    * Builds the failure for a transient transport/timeout event (dial timeout,
@@ -842,6 +1020,39 @@ function openSession(options: SessionOptions): Session {
           method,
           fatalDetails: null,
         });
+
+  /**
+   * The grace granted at the moment a frame wait times out, or `null` when
+   * there is nothing to wait for: the request frame was never sent (that
+   * failure is already provably no-dispatch and retryable on its own), or this
+   * caller opted out with a zero window.
+   *
+   * The response timer is armed immediately after `openAck` is consumed, so
+   * `waitTimeoutMs` is the share of the window this wait has nominally consumed
+   * - no clock reading needed. It is nominal rather than measured: if the
+   * response timer itself ran late (suspend/resume), more wall-clock has really
+   * elapsed than the window models. That is precisely when an attestation is
+   * about to arrive, which is why the remainder is floored at the delivery
+   * slack instead of collapsing to "no grace". The total stays bounded by
+   * `hostAttestationWindowMs` either way.
+   */
+  const attestationGraceFor = (
+    waitTimeoutMs: number,
+  ): AttestationGrace | null => {
+    if (!requestSent || hostAttestationWindowMs <= 0) {
+      return null;
+    }
+    const deliveryMs = Math.min(
+      ATTESTATION_DELIVERY_SLACK_MS,
+      hostAttestationWindowMs,
+    );
+    const totalMs = Math.max(
+      hostAttestationWindowMs - waitTimeoutMs,
+      deliveryMs,
+    );
+    return { windowMs: totalMs - deliveryMs, deliveryMs };
+  };
+
   const buffer: HostFrame[] = [];
   let dialResolver: {
     readonly resolve: () => void;
@@ -854,22 +1065,115 @@ function openSession(options: SessionOptions): Session {
     readonly timer: TimerHandle;
   } | null = null;
 
+  /**
+   * Single terminal transition for the session. Every failing event routes
+   * here, which is also where the post-deadline outcome is made sticky:
+   * once `ambiguousResponseTimeout` is recorded, that error *is* the call's
+   * answer, because the request may already have been dispatched and only the
+   * host's no-dispatch attestation - which resolves the wait rather than
+   * failing it - can change that. A close, a transport error, a malformed
+   * frame, a late/unrelated frame, and grace expiry are all downstream of a
+   * fate already decided, so none of them may substitute its own error and make
+   * the reported failure race-dependent. An authority abort is the one
+   * caller-owned cancellation that still overrides.
+   */
   const failAll = (error: HostRpcError): void => {
+    const ambiguous = ambiguousResponseTimeout;
+    const settled =
+      ambiguous !== null && !(error instanceof HostRequestAbortedError)
+        ? ambiguous
+        : error;
+    ambiguousResponseTimeout = null;
     if (failure === null) {
-      failure = error;
+      failure = settled;
     }
     if (dialResolver !== null) {
       const resolver = dialResolver;
       dialResolver = null;
       clearTimeout(resolver.timer);
-      resolver.reject(error);
+      resolver.reject(settled);
     }
     if (frameResolver !== null) {
       const resolver = frameResolver;
       frameResolver = null;
       clearTimeout(resolver.timer);
-      resolver.reject(error);
+      resolver.reject(settled);
     }
+  };
+
+  /**
+   * Ends a wait that is already inside its attestation grace. The sticky rule
+   * in `failAll` supplies the recorded timeout; this exists so the callers that
+   * merely observe "the grace produced nothing usable" don't have to invent an
+   * error the caller will never see.
+   */
+  const failWithAmbiguousTimeout = (): void => {
+    const ambiguous = ambiguousResponseTimeout;
+    if (ambiguous === null) {
+      return;
+    }
+    failAll(ambiguous);
+  };
+
+  /**
+   * Re-arms the pending response wait for one leg of the grace, keeping the
+   * caller's resolvers attached so an attestation arriving in any leg still
+   * settles the original `next()` promise. The window leg hands over to the
+   * delivery leg instead of ending the call - see `ATTESTATION_DELIVERY_SLACK_MS`
+   * for why the last word must belong to a freshly armed timer.
+   */
+  const armAttestationLeg = (grace: AttestationGrace): void => {
+    const resolver = frameResolver;
+    if (resolver === null) {
+      return;
+    }
+    const armedAt = Date.now();
+    frameResolver = {
+      resolve: resolver.resolve,
+      reject: resolver.reject,
+      timer:
+        grace.windowMs > 0
+          ? setTimeout(() => {
+              armAttestationLeg({ windowMs: 0, deliveryMs: grace.deliveryMs });
+            }, grace.windowMs)
+          : setTimeout(() => {
+              settleDeliveryLeg(armedAt, grace);
+            }, grace.deliveryMs),
+    };
+  };
+
+  /**
+   * The one place the attestation grace is allowed to end the call, and the
+   * reason it is not simply `failWithAmbiguousTimeout`.
+   *
+   * Handing the window leg over to a freshly armed delivery leg only moves the
+   * resume hazard: if the machine suspends *inside* that delivery leg, its
+   * callback is overdue on wake too and would again beat the host's equally
+   * overdue no-dispatch fatal. So the last leg reads the wall clock. Firing on
+   * time means this process really was running for the whole leg and nothing
+   * arrived - the honest end of the grace. Firing far late means the leg
+   * measured a scheduling gap rather than host silence, so it is re-armed to
+   * become the running delivery opportunity it was meant to be.
+   *
+   * There is deliberately no cap on how often that can happen. A cap would
+   * write a count of sleeps into the transport contract, and the call would
+   * eventually fail for the single reason this whole mechanism exists to rule
+   * out: the client's timer callback won the wake. What bounds the grace is
+   * *active* time - the first delivery leg that actually gets its full duration
+   * of running time ends the call - not wall-clock time or how many scheduling
+   * gaps preceded it. Time in which neither process could make progress is not
+   * evidence about dispatch.
+   */
+  const settleDeliveryLeg = (
+    armedAt: number,
+    grace: AttestationGrace,
+  ): void => {
+    const overshootMs = Date.now() - armedAt - grace.deliveryMs;
+    if (overshootMs > SUSPENSION_OVERSHOOT_TOLERANCE_MS) {
+      armAttestationLeg({ windowMs: 0, deliveryMs: grace.deliveryMs });
+      return;
+    }
+    failWithAmbiguousTimeout();
   };
 
   socket.onopen = () => {
@@ -914,8 +1218,21 @@ function openSession(options: SessionOptions): Session {
     }
     const frame = frameParse.data;
     if (frameResolver !== null) {
+      // Once the caller's response deadline has elapsed no frame can still
+      // satisfy this call. Only the host's no-dispatch attestation changes the
+      // outcome - it is handed to the caller, which maps it to a
+      // `RetryableTransportError`. Anything else, including a `response` that
+      // merely arrived late, keeps the recorded response-timeout failure.
+      if (
+        ambiguousResponseTimeout !== null &&
+        !isPostOpenTimeoutAttestation(frame)
+      ) {
+        failWithAmbiguousTimeout();
+        return;
+      }
       const resolver = frameResolver;
       frameResolver = null;
+      ambiguousResponseTimeout = null;
       clearTimeout(resolver.timer);
       resolver.resolve(frame);
       return;
@@ -976,9 +1293,24 @@ function openSession(options: SessionOptions): Session {
       }
       return new Promise<HostFrame>((resolve, reject) => {
         const timer = setTimeout(() => {
-          failAll(
-            transientFailure(`WebSocket frame timed out after ${timeoutMs}ms`),
+          const ambiguous = transientFailure(
+            `WebSocket frame timed out after ${timeoutMs}ms`,
           );
+          const grace = attestationGraceFor(timeoutMs);
+          if (grace === null || frameResolver === null) {
+            failAll(ambiguous);
+            return;
+          }
+          // The caller's deadline is up, but the host's post-`openAck` deadline
+          // may not be - and if this callback itself ran late, neither peer's
+          // timeline is where the numbers say it is. Closing here would discard
+          // the one frame that can tell us whether the request was ever
+          // dispatched, so hold the socket for the rest of the window plus its
+          // delivery tail instead. Nothing is decided here: the wait still fails
+          // with this same ambiguous, non-retryable timeout unless the host's
+          // no-dispatch fatal lands first.
+          ambiguousResponseTimeout = ambiguous;
+          armAttestationLeg(grace);
         }, timeoutMs);
         frameResolver = { resolve, reject, timer };
       });

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -28,6 +28,7 @@ import {
   streamMethodFrameEnvelopeSchema,
   STREAM_CAPABILITY_CREDENTIAL_UPDATE,
   STREAM_CAPABILITY_HOST_CREDENTIAL_PROVISION,
+  STREAM_SUBSCRIBE_TIMEOUT_FATAL_CODE,
   type ClientStreamOpenFrame,
   type ClientStreamSubscribeFrame,
   type ClientStreamFatalErrorFrame,
@@ -1441,14 +1442,15 @@ class StreamSession<
       return;
     }
     const details = termParse.data.details;
-    // `retryable` marks a transient, host-side rejection (e.g. the host's JWKS
-    // fetch timed out while verifying our bearer). Our credential is fine, so
-    // credential revalidation can't help and the no-progress give-up bound must
-    // not apply - treat it exactly like an ordinary transport drop and let the
-    // reconnect backoff ride until the host recovers. Checked before the
-    // `UNAUTHORIZED` branch because the host keeps the wire `code` as
-    // `UNAUTHORIZED` (so older clients still get the credential path).
-    if (details.retryable === true) {
+    // `retryable` marks a transient host-side rejection. The stable subscribe-
+    // timeout code is checked too because hosts through 1.1.9 emitted it without
+    // the additive flag; a new client must still recover when paired with one of
+    // those hosts. In either case credential recovery cannot help, so route it
+    // through ordinary transport reconnect before the `UNAUTHORIZED` branch.
+    if (
+      details.retryable === true ||
+      details.code === STREAM_SUBSCRIBE_TIMEOUT_FATAL_CODE
+    ) {
       // A transient host blip must not count toward the credential give-up
       // bound, mirroring the `network-error` revalidation outcome: clear any
       // streak left by a prior genuine `UNAUTHORIZED` episode so a later real

--- a/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
+++ b/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { callHostRpc, toAgentCliError } from "../host-rpc";
+import { callHostRpc, callHostRpcFastFail, toAgentCliError } from "../host-rpc";
 import { resolveHostAuth } from "../host-auth";
 import { readHostPidMetadata } from "../../host/pid-metadata";
 import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
@@ -36,15 +36,28 @@ vi.mock("../../logger", () => ({
     value instanceof Error ? value : new Error(String(value)),
 }));
 
-vi.mock("../../../../shared/host-transport/ws-rpc-client", () => ({
-  WsRpcClient: class {
-    constructor(options: unknown) {
-      rpcClientConstructorMock(options);
-    }
+vi.mock(
+  "../../../../shared/host-transport/ws-rpc-client",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../../shared/host-transport/ws-rpc-client")
+      >();
+    return {
+      // Only `WsRpcClient` is replaced; the real
+      // `HOST_POST_OPEN_ATTESTATION_WINDOW_MS` stays, so the constructor
+      // assertion below reads the value the CLI actually ships.
+      ...actual,
+      WsRpcClient: class {
+        constructor(options: unknown) {
+          rpcClientConstructorMock(options);
+        }
 
-    request = requestMock;
+        request = requestMock;
+      },
+    };
   },
-}));
+);
 
 vi.mock("../host-auth", () => ({
   resolveHostAuth: vi.fn(),
@@ -155,6 +168,49 @@ describe("callHostRpc", () => {
     // The per-run store is always disposed on the success path (finally), so a
     // `commit-failed` continuation timer can't outlive the command.
     expect(fakeStore.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dials with an attestation window that outlasts the host's post-openAck deadline", async () => {
+    requestMock.mockResolvedValue({ agents: [] });
+
+    await callHostRpc(METHOD, {
+      epicId: "e",
+      senderAgentId: "agent-1",
+      scope: "user",
+    });
+
+    // The CLI gives up on a response after 15s, but a stalled host only attests
+    // that it never dispatched the request once its own 30s post-`openAck`
+    // timer finally runs - measured at 35.7-40.8s in issue #726, and up to
+    // ~45s for the profiled stall class. Without a window that outlasts that,
+    // the CLI closes the socket early and the recoverable stall surfaces as an
+    // ambiguous, non-retryable failure.
+    expect(rpcClientConstructorMock).toHaveBeenCalledTimes(1);
+    const options: unknown = rpcClientConstructorMock.mock.calls[0]?.[0];
+    expect(options).toMatchObject({
+      frameTimeoutMs: 15_000,
+      hostAttestationWindowMs: 50_000,
+    });
+  });
+
+  it("fast-fail dials with a zero attestation window so a miss fails at the 15s response deadline", async () => {
+    requestMock.mockResolvedValue({ agents: [] });
+
+    await callHostRpcFastFail(METHOD, {
+      epicId: "e",
+      senderAgentId: "agent-1",
+      scope: "user",
+    });
+
+    // Latency-bound IDE hooks never redial, so waiting for an attestation they
+    // cannot act on would only inflate time-to-failure. The policy therefore
+    // opts out of the window entirely while keeping the same 15s frame budget.
+    expect(rpcClientConstructorMock).toHaveBeenCalledTimes(1);
+    const options: unknown = rpcClientConstructorMock.mock.calls[0]?.[0];
+    expect(options).toMatchObject({
+      frameTimeoutMs: 15_000,
+      hostAttestationWindowMs: 0,
+    });
   });
 
   it("rejects invalid host metadata endpoints before constructing the WS client", async () => {

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -20,7 +20,10 @@ import {
   HostRequestAuthority,
   HostTransportEndpoint,
 } from "../../../shared/host-transport/host-messenger";
-import { WsRpcClient } from "../../../shared/host-transport/ws-rpc-client";
+import {
+  HOST_POST_OPEN_ATTESTATION_WINDOW_MS,
+  WsRpcClient,
+} from "../../../shared/host-transport/ws-rpc-client";
 import { createWhatwgWebSocketFactory } from "../../../shared/host-transport/whatwg-ws-factory";
 import { config } from "../config";
 import { createCliLogger, errorFromUnknown } from "../logger";
@@ -100,6 +103,10 @@ export async function callHostRpc<
  * callers (IDE hook commands such as title/activity reporting) where blocking
  * the agent for a multi-attempt retry of a non-responsive host is worse than a
  * quick miss.
+ *
+ * Because it never redials, it also waives the host attestation window (see
+ * `attestationWindowForPolicy`): a post-send miss surfaces at the 15s response
+ * deadline instead of waiting out an attestation this caller could not act on.
  */
 export async function callHostRpcFastFail<
   Method extends keyof HostRpcRegistry & string,
@@ -208,6 +215,7 @@ async function requestAtEndpoint<Method extends keyof HostRpcRegistry & string>(
         webSocketFactory: createWhatwgWebSocketFactory(),
         dialTimeoutMs: DEFAULT_DIAL_TIMEOUT_MS,
         frameTimeoutMs: FRAME_TIMEOUT_MS,
+        hostAttestationWindowMs: attestationWindowForPolicy(retryPolicy),
       }),
       revalidator,
     ),
@@ -545,4 +553,27 @@ function retryPolicyLabel(
   policy: TransportRetryPolicy,
 ): "default" | "fast-fail" {
   return policy === NO_RETRY_TRANSPORT_POLICY ? "fast-fail" : "default";
+}
+
+/**
+ * The attestation window a call gets is a function of what it could do with an
+ * attestation.
+ *
+ * A retrying call gets the production window: the CLI's 15s response deadline
+ * is half the host's 30s post-`openAck` deadline - and a stalled host fires that
+ * timer later still - so without the window every stalled host would surface an
+ * ambiguous, non-retryable timeout long before it could attest that it never
+ * dispatched the request, and the retry wrapper would never get its one safe
+ * reason to redial a non-idempotent method.
+ *
+ * A `maxRetries: 0` policy has no such reason to wait. Its retry wrapper goes
+ * straight to the final attempt and propagates even a valid
+ * `RetryableTransportError` without redialing, so holding the socket open for an
+ * attestation would only delay a failure that is already decided - exactly what
+ * `callHostRpcFastFail`'s latency-bound IDE-hook callers must not pay. Keyed off
+ * `maxRetries` rather than policy identity so any future no-retry policy
+ * inherits the same wiring.
+ */
+function attestationWindowForPolicy(policy: TransportRetryPolicy): number {
+  return policy.maxRetries === 0 ? 0 : HOST_POST_OPEN_ATTESTATION_WINDOW_MS;
 }

--- a/protocol/src/framework/index.ts
+++ b/protocol/src/framework/index.ts
@@ -148,6 +148,7 @@ export type {
 } from "./ws-protocol";
 
 export {
+  RPC_REQUEST_TIMEOUT_FATAL_CODE,
   clientFrameSchema,
   clientOpenFrameSchema,
   clientRequestFrameSchema,

--- a/protocol/src/framework/stream-ws-protocol.ts
+++ b/protocol/src/framework/stream-ws-protocol.ts
@@ -76,6 +76,14 @@ export const hostCredentialStateSchema = z.enum([
   "needs-reauth",
 ]);
 
+/**
+ * Fatal code used by the stream host's pre-subscribe deadlines. In particular,
+ * when the host sent `openAck` but did not observe the client's `subscribe`, it
+ * pairs this code with `retryable: true`. Older hosts omit the additive flag, so
+ * clients also use this stable code as the backward-compatible recovery signal.
+ */
+export const STREAM_SUBSCRIBE_TIMEOUT_FATAL_CODE = "STREAM_SUBSCRIBE_TIMEOUT";
+
 /** First frame sent by the client: bearer token + per-method canonicals. */
 export type ClientStreamOpenFrame = {
   readonly kind: "open";

--- a/protocol/src/framework/ws-protocol.ts
+++ b/protocol/src/framework/ws-protocol.ts
@@ -59,6 +59,14 @@ export type IncompatibilityUpgradeGuidance = {
 };
 
 /**
+ * Fatal code emitted when the unary host sent `openAck` but did not observe the
+ * client's `request` before its bounded post-open deadline. This is a transport
+ * timeout, not an authentication rejection: the request was never dispatched,
+ * so a client may safely retry even a non-idempotent method on a fresh socket.
+ */
+export const RPC_REQUEST_TIMEOUT_FATAL_CODE = "RPC_REQUEST_TIMEOUT";
+
+/**
  * Full detail payload carried by a fatal error frame prior to WebSocket
  * close. The subsequent close event is only the fatal signal - all rich
  * detail MUST travel inside this frame.
@@ -70,8 +78,9 @@ export type FatalErrorDetails = {
   readonly upgradeGuidance: IncompatibilityUpgradeGuidance | null;
   /**
    * When `true`, the rejection is transient and host-side (e.g. the host's
-   * JWKS fetch timed out while verifying the bearer) - NOT a statement about
-   * the credential's authenticity. A client that understands this field should
+   * JWKS fetch timed out while verifying the bearer, or a post-open frame
+   * deadline elapsed while a process was suspended) - NOT a statement about the
+   * credential's authenticity. A client that understands this field should
    * reconnect with plain backoff instead of running credential recovery or
    * going terminal. Additive and optional: an older host omits it entirely and
    * a newer client then reads "not retryable".
@@ -213,8 +222,9 @@ export const fatalErrorDetailsSchema = z.object({
   upgradeGuidance: incompatibilityUpgradeGuidanceSchema.nullable(),
   // Additive/optional: an older host omits it, so a newer client parsing an
   // older host's frame reads `undefined` (not retryable). Set `true` only for
-  // transient host-side rejections (e.g. a JWKS fetch timeout) that the client
-  // recovers from with plain reconnect backoff, not credential revalidation.
+  // transient host-side rejections (e.g. a JWKS fetch or post-open frame
+  // timeout) that the client recovers from with plain reconnect backoff, not
+  // credential revalidation.
   retryable: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary

- Recover a unary RPC call only after the host attests that its post-open timeout fired before the request was dispatched. A local post-send timeout remains ambiguous and non-retryable.
- Add a bounded, suspend/resume-aware attestation grace for unary calls, including long polls. Grace expiry, malformed frames, close, and error keep the original ambiguous timeout sticky.
- Preserve released-host recovery through the exact legacy `UNAUTHORIZED` timeout shape while adding stable timeout codes for new hosts. Generic retryable fatals and post-dispatch errors remain non-retryable.
- Mark the post-open stream subscribe timeout retryable and reconnect it on a fresh socket. Pre-open stream timeouts remain terminal.
- Keep `callHostRpcFastFail` at its 15-second failure budget by opting its no-retry policy out of attestation grace.

## Related issue

Closes #726

## Verification

- [x] OSS pre-commit affected build, compile, lint, format, test, and DCO checks pass
- [x] Shared suites: 735 passed
- [x] Protocol suites: 1510 passed
- [x] CLI host-RPC suite: 9 passed
- [x] Regression coverage includes both suspend/resume timer orderings, delivery-leg rearming, long-poll recovery, exact legacy matching, timer cleanup, sticky outcomes, and fast-fail timing
- [x] Commit is signed off for DCO

The companion host PR updates the internal gitlink to this exact commit before importing the new protocol constants.