### PR TITLE
fix(gui-app): degrade signed-out providers in the model picker

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -1767,6 +1767,60 @@ describe("<HarnessModelPicker />", () => {
     ).not.toBeNull();
   });
 
+  it("degrades a signed-out provider even while its harness is still available", async () => {
+    // The Copilot-after-real-logout shape: the binary is installed, so the
+    // availability probe (which never consults auth) keeps reporting
+    // `available: true` - only the ambient account's definitive sign-out says
+    // this provider cannot run.
+    queryMock.providerStates = [
+      providerCliState({
+        providerId: "claude-code",
+        authStatus: "unauthenticated",
+        apiKey: { supported: false, configured: false, source: null },
+      }),
+    ];
+    const { selections } = renderPicker(undefined);
+
+    await openPicker();
+    const claudeTab = screen.getByRole("tab", { name: "Claude" });
+    expect(claudeTab.getAttribute("data-degraded")).toBe("true");
+
+    // Browse-only: clicking it rebases the rail but must NOT commit a switch.
+    fireEvent.click(claudeTab);
+    expect(claudeTab.getAttribute("aria-selected")).toBe("true");
+    expect(selections).toEqual([]);
+    // ...and the panel names the reason instead of leaving the gray-out mute.
+    expect(screen.getByText("Not authenticated")).not.toBeNull();
+  });
+
+  it("shows the ambient account's auth source for a single-profile provider", async () => {
+    // A single-profile provider can authenticate through a credential the user
+    // never handed to it (Copilot riding the GitHub CLI's login). The probe
+    // names the source and account; the picker surfaces both so the state is
+    // never mistaken for a stale catalog.
+    const codexState = providerCliState({
+      providerId: "codex",
+      authStatus: "authenticated",
+      apiKey: { supported: false, configured: false, source: null },
+    });
+    queryMock.providerStates = [
+      {
+        ...codexState,
+        auth: {
+          status: "authenticated",
+          badgeText: "GitHub CLI",
+          label: "Authenticated as hdkshingala",
+          detail: null,
+        },
+      },
+    ];
+    renderPicker(undefined);
+    await openPicker();
+
+    expect(screen.getByText("GitHub CLI")).not.toBeNull();
+    expect(screen.getByText("Authenticated as hdkshingala")).not.toBeNull();
+  });
+
   it("keeps a provider visible when its terminal profile reports the logout before the provider summary converges", async () => {
     const codex = codexModels();
     const signedOutClaude: HarnessOption = {

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-rail-providers.test.ts
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-rail-providers.test.ts
@@ -3,6 +3,7 @@ import type { HarnessOption } from "@/components/home/data/landing-options";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
 import {
+  railHarnessDegraded,
   resolveActiveProfileForHarness,
   visibleRailEntries,
 } from "@/components/home/pickers/harness-rail-providers";
@@ -282,6 +283,64 @@ describe("visibleRailEntries: managed-pack readiness", () => {
     });
 
     expect(entries[0].preparing).toBeNull();
+  });
+});
+
+describe("railHarnessDegraded", () => {
+  it("degrades a signed-out provider even while its harness reports available", () => {
+    // Availability probes binary presence, never auth - an installed but
+    // signed-out provider (Copilot after a real logout) keeps reporting
+    // `available: true`. The signed-out set must degrade WITHOUT the
+    // availability gate, or the rail offers a fully-lit, selectable tab for a
+    // provider the send gate then refuses to run.
+    expect(
+      railHarnessDegraded(harness("claude"), new Set<GuiHarnessId>(["claude"])),
+    ).toBe(true);
+  });
+
+  it("keeps a healthy available provider non-degraded", () => {
+    expect(railHarnessDegraded(harness("claude"), new Set())).toBe(false);
+  });
+
+  it("keeps the API-key arm availability-gated", () => {
+    const apiKeyHarness: HarnessOption = {
+      ...harness("codex"),
+      requiresApiKey: true,
+    };
+    // An available API-key provider is running on SOME key - not degraded.
+    expect(railHarnessDegraded(apiKeyHarness, new Set())).toBe(false);
+    // Unavailable, it stays visible-but-degraded for the add-key CTA.
+    expect(
+      railHarnessDegraded({ ...apiKeyHarness, available: false }, new Set()),
+    ).toBe(true);
+  });
+
+  it("leaves an unavailable keyless provider non-degraded - the hidden path", () => {
+    expect(
+      railHarnessDegraded({ ...harness("codex"), available: false }, new Set()),
+    ).toBe(false);
+  });
+});
+
+describe("visibleRailEntries: signed-out while available", () => {
+  it("sinks a signed-out-but-available provider below the ready ones", () => {
+    // Degrading codex, which sorts FIRST canonically (see the pack-readiness
+    // block above) - proving the deprioritization fires without
+    // `available: false`.
+    const entries = visibleRailEntries({
+      harnesses: [harness("claude"), harness("codex")],
+      fallbackHarnesses: [],
+      degradedHarnessIds: new Set<GuiHarnessId>(["codex"]),
+      preparingByHarnessId: NO_PREPARING,
+      profilesByHarnessId: new Map(),
+      activeProfileIdByHarnessId: NO_ACTIVE_PROFILE_OVERRIDES,
+    });
+
+    expect(entries.map((entry) => entry.harness.id)).toEqual([
+      "claude",
+      "codex",
+    ]);
+    expect(entries[1].degraded).toBe(true);
   });
 });
 

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import { Badge } from "@/components/ui/badge";
+import { isProviderAmbientSignedOut } from "@/lib/providers/provider-ambient-auth";
+
+/**
+ * The ambient account line for the browsed provider - rendered in the slot the
+ * profile dropdown occupies for multi-profile providers, so account identity
+ * always lives in the same place regardless of profile count.
+ *
+ * This exists because a single-profile provider can authenticate through a
+ * credential the user never handed to it (Copilot silently rides the GitHub
+ * CLI's login after its own token is cleared). The probe already names that
+ * source (`auth.badgeText`, e.g. "GitHub CLI") and the account
+ * (`auth.label`, "Authenticated as <login>") - the same fields Settings →
+ * Providers renders - so surfacing them here lets the picker explain a state
+ * that otherwise looks like a stale cache.
+ *
+ * Renders nothing when there is nothing definitive to say: a disabled
+ * provider, a probe still settling, or an authenticated account with no
+ * badge/label. The signed-out line is the one exception - it pairs with the
+ * rail tab's degraded treatment so the gray-out is never unexplained.
+ */
+export function PickerProviderAuthLine(props: {
+  readonly state: ProviderCliState | null;
+}): ReactNode {
+  const { state } = props;
+  if (state === null || !state.enabled) return null;
+  if (isProviderAmbientSignedOut(state)) {
+    return <AuthLineRow badgeText={null} label="Not authenticated" />;
+  }
+  const auth = state.auth;
+  if (auth.status !== "authenticated" && auth.status !== "configured") {
+    return null;
+  }
+  if (auth.badgeText === null && auth.label === null) return null;
+  return <AuthLineRow badgeText={auth.badgeText} label={auth.label} />;
+}
+
+function AuthLineRow(props: {
+  readonly badgeText: string | null;
+  readonly label: string | null;
+}): ReactNode {
+  return (
+    <div className="flex min-w-0 shrink-0 items-center gap-1.5 border-b px-3 py-1.5 text-ui-xs text-muted-foreground">
+      {props.badgeText === null ? null : (
+        <Badge
+          variant="outline"
+          className="h-4 max-w-full rounded-sm border-border/60 bg-muted/20 px-1.5 text-[10px] font-normal leading-none text-muted-foreground"
+        >
+          <span className="truncate">{props.badgeText}</span>
+        </Badge>
+      )}
+      {props.label === null ? null : (
+        <span className="min-w-0 truncate">{props.label}</span>
+      )}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
@@ -4,6 +4,7 @@ import { LEADER_SCOPE_MODEL_PICKER } from "@/lib/keybindings/leader-scope";
 import { HarnessModelPickerSearch } from "@/components/home/pickers/harness-model-picker-search";
 import { HarnessModelPickerList } from "@/components/home/pickers/harness-model-picker-list";
 import { ProviderRail } from "@/components/home/pickers/harness-model-picker-group";
+import { PickerProviderAuthLine } from "@/components/home/pickers/harness-model-picker-auth-line";
 import { PickerProfileDropdown } from "@/components/home/pickers/picker-profile-dropdown";
 import { isProfileUsageSidecarTarget } from "@/components/providers/profile-usage-sidecar-target";
 import { useProviderProfileAddFlowStore } from "@/stores/settings/provider-profile-add-flow-store";
@@ -13,7 +14,10 @@ import type {
   ProviderId,
 } from "@/components/home/data/landing-options";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
-import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
+import type {
+  ProviderCliState,
+  ProviderProfile,
+} from "@traycer/protocol/host/provider-schemas";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 import type { ProviderPackPreparing } from "@/components/providers/provider-pack-readiness";
 import type { HarnessModelRow } from "@/components/home/data/harness-model-search";
@@ -51,6 +55,10 @@ interface HarnessModelPickerPanelProps {
   readonly activeProfileId: string | null;
   readonly activeProfileIdByHarnessId: ReadonlyMap<GuiHarnessId, string | null>;
   readonly activeProviderProfiles: ReadonlyArray<ProviderProfile>;
+  /** The browsed provider's CLI state, for the ambient-auth line shown when
+   *  the provider has under 2 profiles (the profile dropdown owns identity
+   *  above that). `null` when `providers.list` hasn't resolved it. */
+  readonly activeProviderState: ProviderCliState | null;
   readonly lockedHarnessId: ProviderId | null;
   readonly degradedHarnessIds: ReadonlySet<GuiHarnessId>;
   readonly preparingByHarnessId: ReadonlyMap<
@@ -117,6 +125,7 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
     activeProfileId,
     activeProfileIdByHarnessId,
     activeProviderProfiles,
+    activeProviderState,
     lockedHarnessId,
     degradedHarnessIds,
     preparingByHarnessId,
@@ -222,7 +231,8 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
           {/* The dropdown is the picker's second interaction level: only when
               the active provider has 2+ profiles, and it persists while
               typing - search stays scoped to the active provider+profile
-              pair. */}
+              pair. Under 2 profiles the same slot carries the ambient-auth
+              line instead, so account identity has one home either way. */}
           {activeProviderProfiles.length >= 2 ? (
             <div className="shrink-0 border-b p-2">
               <PickerProfileDropdown
@@ -250,7 +260,9 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
                 runTargetHostId={runTargetHostId}
               />
             </div>
-          ) : null}
+          ) : (
+            <PickerProviderAuthLine state={activeProviderState} />
+          )}
           <div className="min-h-0 flex-1 overflow-hidden">
             <HarnessModelPickerList
               idPrefix={idPrefix}

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -562,6 +562,19 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     () => profilesByHarnessId.get(resolvedActiveProviderId) ?? [],
     [profilesByHarnessId, resolvedActiveProviderId],
   );
+  // The browsed provider's full CLI state, for the panel's ambient-auth line
+  // (which credential a single-profile provider is actually running on - e.g.
+  // Copilot riding the GitHub CLI's login). Same `providers.list` response the
+  // rail already reads for degraded/profile state - no extra query.
+  const activeProviderState = useMemo(
+    () =>
+      providersQuery.data?.providers.find(
+        (provider) =>
+          providerIdToGuiHarnessId(provider.providerId) ===
+          resolvedActiveProviderId,
+      ) ?? null,
+    [providersQuery.data, resolvedActiveProviderId],
+  );
   // Which profile each harness's rail dot reflects: the active provider's
   // browsed profile, plus the composer's already-committed selection's
   // profile when browsing a DIFFERENT provider (so its dot doesn't silently
@@ -862,6 +875,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         activeProfileId={activePanelProfileId}
         activeProfileIdByHarnessId={activeProfileIdByHarnessId}
         activeProviderProfiles={activeProviderProfiles}
+        activeProviderState={activeProviderState}
         lockedHarnessId={lockedHarnessId}
         degradedHarnessIds={degradedHarnessIds}
         preparingByHarnessId={preparingByHarnessId}
@@ -1024,12 +1038,16 @@ function degradedHarnessIdsFromProviderStates(
   );
 }
 
+// The definitive "this ambient account cannot run a turn" verdict - the same
+// predicate the composer's send gate reads, so the rail's degraded treatment
+// and the send gate cannot drift. Since `railHarnessDegraded` applies this set
+// regardless of availability, membership must stay limited to the definitive
+// signed-out verdict: a missing API key is NOT one (`requiresApiKey` handles
+// it under `!available`, and a keyless provider's auth probe reports its own
+// definitive `unauthenticated` anyway), and folding it in here would degrade
+// live providers on a transient probe state.
 function providerNeedsPickerReauth(provider: ProviderCliState): boolean {
-  return (
-    provider.enabled &&
-    (isProviderAmbientSignedOut(provider) ||
-      (provider.apiKey.supported && !provider.apiKey.configured))
-  );
+  return provider.enabled && isProviderAmbientSignedOut(provider);
 }
 
 function profilesByHarnessIdFromProviderStates(

--- a/clients/gui-app/src/components/home/pickers/harness-rail-providers.ts
+++ b/clients/gui-app/src/components/home/pickers/harness-rail-providers.ts
@@ -209,13 +209,30 @@ export function visibleRailHarnesses(
   );
 }
 
+/**
+ * A provider the picker treats as "needs attention": visible but browse-only,
+ * sorted below the ready providers, never auto-committed.
+ *
+ * Signed-out membership (`degradedHarnessIds`, derived from
+ * `isProviderAmbientSignedOut`) degrades REGARDLESS of `harness.available`.
+ * Availability is a binary-resolution/CLI probe that never consults auth, so
+ * an installed provider whose ambient account is signed out still reports
+ * `available: true` while every turn on it would bounce off the send gate -
+ * which reads the same signed-out predicate. Gating this arm on
+ * `!harness.available` is what let the rail offer a fully-lit, selectable tab
+ * for a provider the composer would then refuse to run.
+ *
+ * The API-key arm stays availability-gated: `requiresApiKey` means the
+ * provider authenticates BY key, and the point of degrading it is to keep an
+ * unavailable entry visible for its add-key CTA rather than hiding the row.
+ */
 export function railHarnessDegraded(
   harness: HarnessOption,
   degradedHarnessIds: ReadonlySet<GuiHarnessId>,
 ): boolean {
   return (
-    !harness.available &&
-    (harness.requiresApiKey || degradedHarnessIds.has(harness.id))
+    degradedHarnessIds.has(harness.id) ||
+    (!harness.available && harness.requiresApiKey)
   );
 }
 


### PR DESCRIPTION
## Summary

The model picker showed a fully lit, selectable tab for providers the composer
would then refuse to run.

`railHarnessDegraded` gated **every** degraded signal on `!harness.available`,
but availability is a binary-resolution/CLI probe that never consults auth. An
installed provider whose ambient account is signed out therefore reports
`available: true`, short-circuits the guard, and renders as ready — while the
composer's send gate, reading the same `isProviderAmbientSignedOut` predicate,
bounces every turn on it. Copilot hits this after a real `/logout`.

Two changes:

**1. Signed-out membership degrades on its own** (`harness-rail-providers.ts`).
The tab now gets the existing degraded treatment — grayed, sorted below the
ready providers, browse-only (clicking never commits a switch), sr-only "Setup
required" — regardless of what the availability probe says. Picker and send gate
now answer from the same predicate.

The API-key arm keeps its availability gate: `requiresApiKey` means the provider
authenticates *by* key, and degrading it exists to keep an unavailable entry
visible for its add-key CTA rather than hiding the row.

`providerNeedsPickerReauth` drops its API-key clause. It was redundant while the
set was availability-gated — it always co-occurred with `requiresApiKey` under
`!available` — and once the set applies regardless of availability it would
degrade live providers on a transient probe state.

**2. The grayed tab gets a reason** (new `harness-model-picker-auth-line.tsx`).
The panel now surfaces the ambient account's credential source in the slot the
profile dropdown occupies for multi-profile providers: the host auth probe's own
`badgeText` + `label` (e.g. "GitHub CLI" · "Authenticated as \<login\>"), or
"Not authenticated" when signed out. Same badge styling as Settings' provider
auth line.

Note on Copilot specifically: its CLI falls back to the `gh` CLI's stored
credential, so an interactive `/logout` leaves the account authenticated
(`authType: "gh-cli"`) and functional. That state stays **selectable** by design
— the auth line just makes the identity visible instead of it looking like a
stale cache. Graying fires only on a definitive signed-out verdict.

## Related issue

Follow-up from #645 (does not close it).

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

## Verification

- Guard unit tests: signed-out-while-available degrades; API-key arm stays
  availability-gated; an unavailable keyless provider still stays hidden;
  a degraded provider sinks below the ready ones in `visibleRailEntries`.
- Picker integration tests: a signed-out-but-available provider renders
  `data-degraded="true"`, clicking it browses without committing a selection,
  and the panel shows "Not authenticated"; a single-profile provider shows its
  auth badge + label.
- Mutation-probed both ways — reverting the guard fails exactly the 3 new guard
  tests; unwiring the auth line fails exactly its 2 assertions.
- Full `gui-app` suite green; `react-doctor` clean on the diff.
