### PR TITLE
fix(gui-app): preserve terminal mode in new agent dialog

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -16,6 +16,8 @@ import {
   type ChatSessionStoreHandle,
 } from "@/stores/chats/chat-session-store";
 import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
+import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 
 interface TestTreeNode {
   readonly id: string;
@@ -652,6 +654,8 @@ describe("epic sidebar selection mode", () => {
     testState.rowHostClient = { getActiveHostId: () => "host-1" };
     testState.activeHostClient = { getActiveHostId: () => "host-1" };
     testState.sessionHandleByChatId = {};
+    useNewConversationModalStore.getState().resetForTests();
+    useNewConversationModalOpenStore.getState().close();
   });
 
   it("selects chat rows explicitly and bulk-deletes topmost selected chat roots", async () => {
@@ -916,6 +920,9 @@ describe("epic sidebar selection mode", () => {
 
   it("consolidates row actions into one menu with 'New child agent' first, reachable from both the ⋯ dropdown and right-click", async () => {
     seedChatTree();
+    useNewConversationModalStore
+      .getState()
+      .setComposerMode(EPIC_ID, "terminal");
 
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
@@ -935,13 +942,25 @@ describe("epic sidebar selection mode", () => {
     expect(
       await screen.findByTestId("epic-sidebar-context-new-child-chat-root"),
     ).not.toBeNull();
-    expect(
-      screen.getByRole("menuitem", { name: "New child agent" }),
-    ).not.toBeNull();
+    const newChildAgent = screen.getByRole("menuitem", {
+      name: "New child agent",
+    });
     expect(
       await screen.findByRole("menuitem", { name: "Rename" }),
     ).not.toBeNull();
     expect(screen.getByRole("menuitem", { name: "Delete" })).not.toBeNull();
+
+    fireEvent.click(newChildAgent);
+
+    expect(
+      useNewConversationModalStore.getState().draftPatchesByEpicId[EPIC_ID]
+        ?.composerMode,
+    ).toBe("terminal");
+    expect(useNewConversationModalOpenStore.getState().request).toMatchObject({
+      epicId: EPIC_ID,
+      tabId: TAB_ID,
+      parentId: "chat-root",
+    });
   });
 
   it("keeps artifact add inline and exposes ellipsis actions on right-click", async () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-header.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-header.test.tsx
@@ -1,6 +1,8 @@
 import "../../../../../__tests__/test-browser-apis";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
+import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
 
 interface HeaderTestState {
   chats: { byId: Record<string, { readonly title: string }> };
@@ -20,13 +22,48 @@ vi.mock("@/hooks/use-epic-store", () => ({
     selector(testState),
 }));
 
-const { NewConversationModalHeader } =
+const { NewConversationModalAction, NewConversationModalHeader } =
   await import("../new-conversation-modal");
 
 afterEach(() => {
   cleanup();
   testState.chats = { byId: {} };
   testState.tuiAgents = { byId: {} };
+  useNewConversationModalStore.getState().resetForTests();
+  useNewConversationModalOpenStore.getState().close();
+});
+
+describe("<NewConversationModalAction />", () => {
+  it("preserves the remembered terminal interface when opening the modal", () => {
+    useNewConversationModalStore
+      .getState()
+      .setComposerMode("epic-1", "terminal");
+
+    render(
+      <NewConversationModalAction
+        epicId="epic-1"
+        tabId="tab-1"
+        parentId={null}
+        size="icon-sm"
+        disabled={false}
+        disabledTooltip={null}
+        triggerLabel="New agent"
+        triggerTestId="new-agent"
+        actionRevealClassName=""
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("new-agent"));
+
+    expect(
+      useNewConversationModalStore.getState().draftPatchesByEpicId["epic-1"]
+        ?.composerMode,
+    ).toBe("terminal");
+    expect(useNewConversationModalOpenStore.getState().request).toMatchObject({
+      epicId: "epic-1",
+      tabId: "tab-1",
+    });
+  });
 });
 
 describe("<NewConversationModalHeader />", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-header.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-header.test.tsx
@@ -53,7 +53,7 @@ describe("<NewConversationModalAction />", () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId("new-agent"));
+    fireEvent.click(screen.getByRole("button", { name: "New agent" }));
 
     expect(
       useNewConversationModalStore.getState().draftPatchesByEpicId["epic-1"]

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -187,7 +187,6 @@ import {
   type SidebarRowMenuEntry,
 } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
 import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
-import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
 import { useExistingChatSessionHandle } from "@/lib/registries/chat-session-registry";
 import { chatActivityIndicator } from "@/components/epic-canvas/renderers/chat-tile-session-state";
@@ -1339,13 +1338,13 @@ function ChatNodeShellBody(
   // "New child agent" opens the shared New Conversation modal seeded with this
   // row as the parent - the same action the standalone hover "+" used to
   // trigger, now consolidated into the row menu (right-click + ⋯) so there is a
-  // single hover affordance. Forcing chat mode mirrors `NewConversationModalAction`.
+  // single hover affordance. It preserves the modal's remembered interface,
+  // matching the top-level new-agent trigger.
   const openNewConversationModal = useNewConversationModalOpenStore(
     (state) => state.open,
   );
   const handleNewChildAgent = useCallback(() => {
     if (!canMutate) return;
-    useNewConversationModalStore.getState().setComposerMode(epicId, "chat");
     openNewConversationModal({
       epicId,
       tabId,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -168,11 +168,10 @@ interface NewConversationModalActionProps {
 
 /**
  * The single "+" trigger for the New Conversation modal, shared by the chats
- * panel header (top-level) and each chat row (child). It always opens in chat
- * mode; the modal's own switcher is the one way to flip to a terminal agent, so
- * there are no per-trigger dropdowns. Forcing chat mode here overrides the
- * projection-derived seed default and prevents a previously-dismissed
- * terminal/PaneOpener draft from leaking its mode in.
+ * panel header (top-level) and each chat row (child). The modal opens with its
+ * remembered draft mode, falling back to the latest conversation's interface
+ * when there is no draft, so a terminal-agent launch carries forward just like
+ * a chat launch. The modal's own switcher remains the one way to change modes.
  */
 export function NewConversationModalAction(
   props: NewConversationModalActionProps,
@@ -180,9 +179,6 @@ export function NewConversationModalAction(
   const openModal = useNewConversationModalOpenStore((state) => state.open);
   const handleOpen = useCallback((): void => {
     if (props.disabled) return;
-    useNewConversationModalStore
-      .getState()
-      .setComposerMode(props.epicId, "chat");
     openModal({
       epicId: props.epicId,
       tabId: props.tabId,


### PR DESCRIPTION
## Summary

- Preserve the remembered terminal/TUI interface when opening the New Conversation dialog from a task.
- Remove the sidebar trigger’s unconditional reset to chat mode.
- Add a regression test covering a remembered terminal mode.

## Related issue

- Reported via Traycer.

## Validation

- `bun run test -- src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-header.test.tsx src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx src/hooks/worktree/__tests__/use-latest-conversation-workspace-seed.test.ts`
- `bun run compile`
- Commit hook: affected lint, format, compile, and build
- `npx -y react-doctor@latest . --verbose --diff main --offline --no-score`

## Checklist

- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)