### PR TITLE
fix(gui-app): let users dismiss an interview that renders no card

### DIFF
--- a/clients/gui-app/src/components/chat/segments/pending-interview/unanswerable-interview-notice.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/unanswerable-interview-notice.tsx
@@ -1,0 +1,87 @@
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
+import type { UnanswerableInterviewView } from "@/components/epic-canvas/renderers/chat-tile-types";
+
+/**
+ * Recorded as the durable `interview.errored` reason, so it becomes the settled
+ * block's error text in the transcript. Written to read as a user action rather
+ * than a failure - the question really did go unanswered.
+ */
+export const UNANSWERABLE_INTERVIEW_DISMISS_REASON =
+  "Dismissed by the user: this question could no longer be answered.";
+
+interface UnanswerableInterviewNoticeProps {
+  /** Non-empty; the caller does not render this notice for an empty set. */
+  readonly interviews: ReadonlyArray<UnanswerableInterviewView>;
+  /** True while a dismissal for any of these blocks is in flight. */
+  readonly isBusy: boolean;
+  /**
+   * Sends `interviewError` for one block. `null` disables the affordance while
+   * the chat cannot act (viewer, or the stream is not open) - the notice still
+   * renders so the deadlock is at least legible.
+   */
+  readonly onDismiss:
+    ((blockId: string, reason: string) => string | null) | null;
+}
+
+/**
+ * Last-resort escape hatch for a chat the host has send-locked on an interview
+ * that renders no card (see `UnanswerableInterviewView`). Dismissing settles
+ * every stuck block as errored, which clears the host's pending wait and
+ * unblocks the composer.
+ *
+ * One button dismisses all of them: the user's intent here is "get me unstuck",
+ * and leaving even one behind keeps the chat locked.
+ */
+export function UnanswerableInterviewNotice({
+  interviews,
+  isBusy,
+  onDismiss,
+}: UnanswerableInterviewNoticeProps) {
+  const count = interviews.length;
+  const plural = count > 1;
+  const headline = plural
+    ? `This chat is waiting on ${count} questions that can no longer be shown.`
+    : "This chat is waiting on a question that can no longer be shown.";
+  const detail = plural
+    ? "Sending is blocked until they are resolved. Dismissing them records the questions as unanswered and unblocks the composer."
+    : "Sending is blocked until it is resolved. Dismissing it records the question as unanswered and unblocks the composer.";
+  const dismissAll = (): void => {
+    if (onDismiss === null) return;
+    interviews.forEach((interview) => {
+      onDismiss(interview.blockId, UNANSWERABLE_INTERVIEW_DISMISS_REASON);
+    });
+  };
+
+  return (
+    <section
+      aria-label="Unanswerable question"
+      data-testid="unanswerable-interview-notice"
+      className="flex w-full flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-ui-sm"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle
+          className="mt-0.5 size-3.5 shrink-0 text-destructive"
+          aria-hidden
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="text-foreground/90">{headline}</span>
+          <span className="text-ui-xs text-muted-foreground">{detail}</span>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={onDismiss === null || isBusy}
+          onClick={dismissAll}
+        >
+          {isBusy ? <MutedAgentSpinner /> : null}
+          {plural ? `Dismiss ${count} questions` : "Dismiss question"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -146,6 +146,8 @@ const TURN_RUNNING: ChatLowerTurnState = {
 const INTERVIEW: ChatLowerInterviewState = {
   pending: null,
   isBusy: false,
+  unanswerable: [],
+  unanswerableBusy: false,
   onAnswer: () => null,
   onError: () => null,
   onFork: null,

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -7,7 +7,10 @@ import type {
   ChatQueueState,
   ChatRunSettings,
 } from "@traycer/protocol/host/agent/gui/subscribe";
-import type { ChatMessage } from "@/stores/composer/chat-store";
+import type {
+  ChatMessage,
+  InterviewSegment,
+} from "@/stores/composer/chat-store";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 const toastSuccess = vi.hoisted(() =>
@@ -38,6 +41,8 @@ import {
   canModifyChatMessages,
   chatActivityIndicator,
   chatMessageEditingForInlineEdit,
+  findPendingInterview,
+  findUnanswerableInterviews,
   resolvedTurnStatus,
   showRestoreResultToast,
   type InlineEditState,
@@ -771,5 +776,125 @@ describe("canModifyChatMessages", () => {
         }),
       }),
     ).toBe(false);
+  });
+});
+
+// ── Escape hatch: host-pending interviews with no answerable card ────────────
+
+function interviewMessage(
+  id: string,
+  segments: ReadonlyArray<{
+    readonly blockId: string;
+    readonly status: InterviewSegment["status"];
+  }>,
+): ChatMessage {
+  return {
+    ...MESSAGE,
+    id,
+    role: "assistant",
+    persistentMessageId: id,
+    segments: segments.map((segment) => ({
+      id: segment.blockId,
+      kind: "interview",
+      status: segment.status,
+      toolName: "AskUserQuestion",
+      title: null,
+      description: null,
+      questions: [],
+      answers: [],
+      error: null,
+      forkedWithoutAnswer: false,
+    })),
+  };
+}
+
+describe("findUnanswerableInterviews", () => {
+  it("flags a host-pending block the transcript already settled", () => {
+    // The phantom-interview shape: the harness errored the AskUserQuestion, the
+    // block persisted as `errored`, but the pending wait was rehydrated from a
+    // dangling `interview.requested`. No card renders, yet sends are rejected.
+    const messages = [
+      interviewMessage("m-1", [
+        { blockId: "settled-block", status: "errored" },
+      ]),
+    ];
+
+    expect(
+      findUnanswerableInterviews(messages, [
+        { blockId: "settled-block", requestedAt: 10 },
+      ]),
+    ).toEqual([{ blockId: "settled-block", requestedAt: 10 }]);
+  });
+
+  it("flags a host-pending block that is absent from the transcript", () => {
+    expect(
+      findUnanswerableInterviews(
+        [],
+        [{ blockId: "ghost-block", requestedAt: 7 }],
+      ),
+    ).toEqual([{ blockId: "ghost-block", requestedAt: 7 }]);
+  });
+
+  it("leaves an answerable streaming block to the interview card", () => {
+    const messages = [
+      interviewMessage("m-1", [
+        { blockId: "streaming-block", status: "streaming" },
+      ]),
+    ];
+    const pending = [{ blockId: "streaming-block", requestedAt: 10 }];
+
+    // The two derivations partition the host's pending set - a block routed to
+    // the card must never also raise the escape hatch.
+    expect(findUnanswerableInterviews(messages, pending)).toEqual([]);
+    expect(
+      findPendingInterview(messages, (id) => id === "streaming-block")?.blockId,
+    ).toBe("streaming-block");
+  });
+
+  it("separates a stuck block from an answerable one in the same chat", () => {
+    const messages = [
+      interviewMessage("m-1", [
+        { blockId: "settled-block", status: "errored" },
+      ]),
+      interviewMessage("m-2", [
+        { blockId: "streaming-block", status: "streaming" },
+      ]),
+    ];
+
+    expect(
+      findUnanswerableInterviews(messages, [
+        { blockId: "settled-block", requestedAt: 10 },
+        { blockId: "streaming-block", requestedAt: 20 },
+      ]),
+    ).toEqual([{ blockId: "settled-block", requestedAt: 10 }]);
+  });
+
+  it("orders stuck blocks oldest first", () => {
+    expect(
+      findUnanswerableInterviews(
+        [],
+        [
+          { blockId: "newer-block", requestedAt: 20 },
+          { blockId: "older-block", requestedAt: 10 },
+        ],
+      ).map((interview) => interview.blockId),
+    ).toEqual(["older-block", "newer-block"]);
+  });
+
+  it("returns one stable empty reference so the composer memo cannot churn", () => {
+    // `renderedMessages` changes on every streaming token; a fresh `[]` here
+    // would re-identify the composer's props each token.
+    const first = findUnanswerableInterviews([], []);
+    const second = findUnanswerableInterviews(
+      [
+        interviewMessage("m-1", [
+          { blockId: "streaming-block", status: "streaming" },
+        ]),
+      ],
+      [{ blockId: "streaming-block", requestedAt: 10 }],
+    );
+
+    expect(first).toEqual([]);
+    expect(second).toBe(first);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/unanswerable-interview-escape-hatch.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/unanswerable-interview-escape-hatch.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * Escape hatch for the composer deadlock: the host reports a pending interview,
+ * the transcript renders no answer card for it (the block is settled or
+ * missing), and every send is rejected with `DETACHED_INTERVIEW_PENDING`. The
+ * only way out from inside the chat is dismissing the stuck block, so these
+ * pin that the affordance appears and actually dispatches `interviewError`.
+ */
+import {
+  cleanup,
+  render as testingRender,
+  screen,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { domAnimation, LazyMotion } from "motion/react";
+import type { ReactElement } from "react";
+import type { InterviewQuestion } from "@traycer/protocol/persistence/epic/schemas";
+
+vi.mock("@/components/chat/composer/chat-composer", () => ({
+  ChatComposer: () => <div data-testid="composer-stub" />,
+}));
+vi.mock("@/components/chat/chat-lower-dock", () => ({
+  ChatLowerDock: () => <div data-testid="dock-stub" />,
+}));
+vi.mock("@/components/chat/chat-stop-children-dialog", () => ({
+  StopChildrenDialog: () => null,
+}));
+vi.mock("@/hooks/agent/use-agent-stop-controls", () => ({
+  useAgentStopControls: () => ({ self: null, descendants: [] }),
+}));
+vi.mock("@/hooks/agent/use-stop-agent-mutation", () => ({
+  useAgentStop: () => ({ mutate: () => undefined }),
+}));
+
+import {
+  ChatLowerInteractionSurfaces,
+  type ChatLowerInteractionSurfacesProps,
+  type ChatLowerInterviewState,
+} from "@/components/epic-canvas/renderers/chat-tile-lower-surfaces";
+import { UNANSWERABLE_INTERVIEW_DISMISS_REASON } from "@/components/chat/segments/pending-interview/unanswerable-interview-notice";
+import type { PendingInterviewView } from "@/components/epic-canvas/renderers/chat-tile-types";
+import { WORKSPACE_COMPOSER_READY } from "@/lib/composer/workspace-composer-availability";
+import type { ChatRestoreContextValue } from "@/components/chat/chat-restore-context-core";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const EMPTY_BACKGROUND_STOP_TASK_IDS: ReadonlySet<string> = new Set();
+
+const RESTORE_CONTEXT: ChatRestoreContextValue = {
+  accessRole: "owner",
+  currentUserId: "user-1",
+  activeHostId: "host-1",
+  activeTurnStatus: null,
+  localSnapshotsClearedAt: null,
+  restore: null,
+  restoreActionPending: false,
+  restoreCheckpoint: () => null,
+  accumulatedFileChanges: [],
+  revertFileChanges: () => null,
+};
+
+const QUESTION: InterviewQuestion = {
+  questionId: "q-1",
+  question: "Which one?",
+  header: null,
+  options: [{ label: "A", description: null, preview: null }],
+  multiSelect: false,
+};
+
+const ANSWERABLE_CARD: PendingInterviewView = {
+  blockId: "streaming-block",
+  toolName: "AskUserQuestion",
+  title: null,
+  description: null,
+  questions: [QUESTION],
+  assistantMessageId: null,
+};
+
+function render(ui: ReactElement) {
+  return testingRender(
+    <TooltipProvider delayDuration={0}>
+      <LazyMotion features={domAnimation}>{ui}</LazyMotion>
+    </TooltipProvider>,
+  );
+}
+
+function props(
+  interview: ChatLowerInterviewState,
+  canAct: boolean,
+): ChatLowerInteractionSurfacesProps {
+  return {
+    epicId: "epic-1",
+    viewTabId: "tab-1",
+    chatId: "chat-1",
+    runtime: { snapshotLoaded: true },
+    access: { isViewer: false, canAct },
+    turn: {
+      activeTurnStatus: null,
+      steerCapable: false,
+      steerProtocolSupported: true,
+      getActiveTurnForSteer: () => null,
+      stopDisabled: true,
+      onStopTurn: () => null,
+    },
+    interview,
+    approvals: {
+      pendingFileEditApprovals: [],
+      pendingApprovals: [],
+      onFileEditDecision: () => undefined,
+      onApprovalDecision: () => undefined,
+    },
+    queue: {
+      editingItem: null,
+      editingItemId: null,
+      value: { status: "idle", items: [] },
+      onPause: () => null,
+      onResume: () => null,
+      onEdit: () => undefined,
+      onCancel: () => undefined,
+      onAbortSteer: () => undefined,
+      onCancelEdit: () => undefined,
+      onStopBackgroundItem: () => null,
+      onStopAllBackgroundItems: () => null,
+      onReorder: () => undefined,
+      onSteerNow: () => undefined,
+    },
+    composer: {
+      sessionSettingsSeed: null,
+      fallbackSettingsSeed: null,
+      nodeId: "chat-1",
+      isActive: true,
+      mentionRoots: [],
+      fallbackToGlobalMentionRoots: true,
+      currentEpicId: "epic-1",
+      onSubmitMessage: () => false,
+      onSettingsChange: null,
+      workspaceControls: null,
+      workspaceAvailability: WORKSPACE_COMPOSER_READY,
+    },
+    todo: null,
+    restoreContext: RESTORE_CONTEXT,
+    backgroundItems: undefined,
+    backgroundStopPendingTaskIds: EMPTY_BACKGROUND_STOP_TASK_IDS,
+    backgroundStopAllPending: false,
+    onBackgroundItemClick: () => undefined,
+  };
+}
+
+function interviewState(
+  overrides: Partial<ChatLowerInterviewState>,
+): ChatLowerInterviewState {
+  return {
+    pending: null,
+    isBusy: false,
+    unanswerable: [],
+    unanswerableBusy: false,
+    onAnswer: () => null,
+    onError: () => null,
+    onFork: null,
+    ...overrides,
+  };
+}
+
+function dismissButton(): HTMLButtonElement {
+  return screen.getByRole<HTMLButtonElement>("button", {
+    name: "Dismiss question",
+  });
+}
+
+describe("unanswerable interview escape hatch", () => {
+  afterEach(cleanup);
+
+  it("shows no notice when every host-pending interview has a card", () => {
+    render(
+      <ChatLowerInteractionSurfaces {...props(interviewState({}), true)} />,
+    );
+
+    expect(screen.queryByTestId("unanswerable-interview-notice")).toBeNull();
+    expect(screen.queryByTestId("composer-stub")).not.toBeNull();
+  });
+
+  it("dismisses the stuck block as errored when the composer is deadlocked", async () => {
+    const user = userEvent.setup();
+    const onError = vi.fn<(blockId: string, reason: string) => string | null>(
+      () => "action-1",
+    );
+    render(
+      <ChatLowerInteractionSurfaces
+        {...props(
+          interviewState({
+            unanswerable: [{ blockId: "settled-block", requestedAt: 10 }],
+            onError,
+          }),
+          true,
+        )}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("unanswerable-interview-notice"),
+    ).not.toBeNull();
+    await user.click(dismissButton());
+
+    expect(onError.mock.calls).toEqual([
+      ["settled-block", UNANSWERABLE_INTERVIEW_DISMISS_REASON],
+    ]);
+  });
+
+  it("clears every stuck block in one dismissal, oldest first", async () => {
+    const user = userEvent.setup();
+    const onError = vi.fn<(blockId: string, reason: string) => string | null>(
+      () => "action-1",
+    );
+    render(
+      <ChatLowerInteractionSurfaces
+        {...props(
+          interviewState({
+            unanswerable: [
+              { blockId: "older-block", requestedAt: 10 },
+              { blockId: "newer-block", requestedAt: 20 },
+            ],
+            onError,
+          }),
+          true,
+        )}
+      />,
+    );
+
+    // Leaving even one behind keeps the host's send gate closed, so the single
+    // button has to settle all of them.
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss 2 questions" }),
+    );
+
+    expect(onError.mock.calls).toEqual([
+      ["older-block", UNANSWERABLE_INTERVIEW_DISMISS_REASON],
+      ["newer-block", UNANSWERABLE_INTERVIEW_DISMISS_REASON],
+    ]);
+  });
+
+  it("keeps the composer reachable beneath the notice", () => {
+    render(
+      <ChatLowerInteractionSurfaces
+        {...props(
+          interviewState({
+            unanswerable: [{ blockId: "settled-block", requestedAt: 10 }],
+          }),
+          true,
+        )}
+      />,
+    );
+
+    // Only `detached` waits gate sends host-side and the renderer cannot see
+    // that flag, so the notice must not take the composer away.
+    expect(screen.queryByTestId("composer-stub")).not.toBeNull();
+  });
+
+  it("shows the notice alongside an answerable card so neither hides the other", () => {
+    render(
+      <ChatLowerInteractionSurfaces
+        {...props(
+          interviewState({
+            pending: ANSWERABLE_CARD,
+            unanswerable: [{ blockId: "settled-block", requestedAt: 10 }],
+          }),
+          true,
+        )}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("unanswerable-interview-notice"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("interview-card")).not.toBeNull();
+  });
+
+  it("disables dismissal while one is already in flight", () => {
+    render(
+      <ChatLowerInteractionSurfaces
+        {...props(
+          interviewState({
+            unanswerable: [{ blockId: "settled-block", requestedAt: 10 }],
+            unanswerableBusy: true,
+          }),
+          true,
+        )}
+      />,
+    );
+
+    expect(dismissButton().disabled).toBe(true);
+  });
+
+  it("still explains the deadlock but cannot dismiss while the chat cannot act", () => {
+    render(
+      <ChatLowerInteractionSurfaces
+        {...props(
+          interviewState({
+            unanswerable: [{ blockId: "settled-block", requestedAt: 10 }],
+          }),
+          false,
+        )}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("unanswerable-interview-notice"),
+    ).not.toBeNull();
+    expect(dismissButton().disabled).toBe(true);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
@@ -26,6 +26,7 @@ import { useAgentStop } from "@/hooks/agent/use-stop-agent-mutation";
 import { StopChildrenDialog } from "@/components/chat/chat-stop-children-dialog";
 import type { ChatRestoreContextValue } from "@/components/chat/chat-restore-context-core";
 import { PendingInterviewCard } from "@/components/chat/segments/pending-interview/pending-interview-card";
+import { UnanswerableInterviewNotice } from "@/components/chat/segments/pending-interview/unanswerable-interview-notice";
 import { ComposerSlotApprovalQueue } from "@/components/chat/segments/composer-slot-approval-queue";
 import { ComposerSlotFileEditApprovalQueue } from "@/components/chat/segments/composer-slot-file-edit-approval-queue";
 import { ComposerReadonlyWorkspaceModeRow } from "@/components/home/composer/composer-workspace-mode-row";
@@ -33,7 +34,10 @@ import { lowerScrollRegionMaxHeightClass } from "@/lib/chat/chat-lower-scroll-bu
 import type { WorkspaceComposerAvailability } from "@/lib/composer/workspace-composer-availability";
 import type { ChatSessionState } from "@/stores/chats/chat-session-store";
 import { cn } from "@/lib/utils";
-import type { PendingInterviewView } from "./chat-tile-types";
+import type {
+  PendingInterviewView,
+  UnanswerableInterviewView,
+} from "./chat-tile-types";
 import {
   composerHasBlockingApprovals,
   visibleComposerApprovals,
@@ -103,6 +107,12 @@ export interface ChatLowerInterviewState {
   // but unresolved (derived from the chat session's pending/accepted actions).
   // Gates the card so the same action cannot be double-sent.
   readonly isBusy: boolean;
+  // Host-pending interviews with no answerable card in this transcript. Non-
+  // empty means the chat is send-locked with nothing to answer, so the escape-
+  // hatch notice renders above whatever else occupies the composer slot.
+  readonly unanswerable: ReadonlyArray<UnanswerableInterviewView>;
+  // True while a dismissal for any `unanswerable` block is in flight.
+  readonly unanswerableBusy: boolean;
   readonly onAnswer: (
     blockId: string,
     answers: ReadonlyArray<InterviewAnswer>,
@@ -441,32 +451,56 @@ function ComposerSurface(props: {
       </ComposerSlotShell>
     );
   }
-  if (model.interview.pending !== null) {
-    return (
+  // The escape hatch stacks ABOVE the card/composer rather than replacing
+  // either: a stuck block can coexist with an answerable one, and the composer
+  // must stay reachable in case the host would in fact accept a send (only
+  // `detached` waits gate it host-side, which the renderer cannot observe).
+  const escapeHatch =
+    model.interview.unanswerable.length > 0 ? (
       <ComposerSlotShell topSpacing={layout.topSpacing} bottomSpacing="normal">
-        <PendingInterviewCard
-          key={`${model.composer.nodeId}:${model.interview.pending.blockId}`}
-          chatId={model.composer.nodeId}
-          blockId={model.interview.pending.blockId}
-          toolName={model.interview.pending.toolName}
-          title={model.interview.pending.title}
-          description={model.interview.pending.description}
-          questions={model.interview.pending.questions}
-          isActive={model.composer.isActive}
-          isBusy={model.interview.isBusy}
-          onSubmit={model.access.canAct ? model.interview.onAnswer : null}
-          onSkip={model.access.canAct ? model.interview.onError : null}
-          onFork={model.access.canAct ? model.interview.onFork : null}
+        <UnanswerableInterviewNotice
+          interviews={model.interview.unanswerable}
+          isBusy={model.interview.unanswerableBusy}
+          onDismiss={model.access.canAct ? model.interview.onError : null}
         />
       </ComposerSlotShell>
+    ) : null;
+  // The notice already paid the surface's top spacing, so whatever follows it
+  // connects flush underneath.
+  const belowSpacing: ChatLowerSurfaceTopSpacing =
+    escapeHatch === null ? layout.topSpacing : "connected";
+  if (model.interview.pending !== null) {
+    return (
+      <>
+        {escapeHatch}
+        <ComposerSlotShell topSpacing={belowSpacing} bottomSpacing="normal">
+          <PendingInterviewCard
+            key={`${model.composer.nodeId}:${model.interview.pending.blockId}`}
+            chatId={model.composer.nodeId}
+            blockId={model.interview.pending.blockId}
+            toolName={model.interview.pending.toolName}
+            title={model.interview.pending.title}
+            description={model.interview.pending.description}
+            questions={model.interview.pending.questions}
+            isActive={model.composer.isActive}
+            isBusy={model.interview.isBusy}
+            onSubmit={model.access.canAct ? model.interview.onAnswer : null}
+            onSkip={model.access.canAct ? model.interview.onError : null}
+            onFork={model.access.canAct ? model.interview.onFork : null}
+          />
+        </ComposerSlotShell>
+      </>
     );
   }
   return (
-    <LiveChatComposer
-      model={model}
-      topSpacing={layout.topSpacing}
-      hasPendingApprovals={model.hasPendingApprovals}
-    />
+    <>
+      {escapeHatch}
+      <LiveChatComposer
+        model={model}
+        topSpacing={belowSpacing}
+        hasPendingApprovals={model.hasPendingApprovals}
+      />
+    </>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
+  ChatPendingInterviewState,
   ChatRunSettings,
   ChatRunStatus,
 } from "@traycer/protocol/host/agent/gui/subscribe";
@@ -17,7 +18,10 @@ import { isTransientLiveAssistantMessageId } from "@/lib/chat/transient-live-ass
 import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
 import { containsImageAtoms } from "@/lib/composer/image-atoms";
 import { reportableWarningToast } from "@/lib/reportable-error-toast";
-import type { PendingInterviewView } from "./chat-tile-types";
+import type {
+  PendingInterviewView,
+  UnanswerableInterviewView,
+} from "./chat-tile-types";
 
 /**
  * Fallback harness id used when the inline-edit settings do not carry a
@@ -588,4 +592,55 @@ export function findPendingInterview(
     }
   }
   return null;
+}
+
+// Stable identity for the (overwhelmingly common) "nothing is stuck" answer.
+// `findUnanswerableInterviews` runs off `renderedMessages`, which changes on
+// every streaming token, so returning a fresh `[]` would churn the composer
+// memo chain on every token - the exact regression
+// chat-tile-composer-rerender.test.tsx pins.
+const NO_UNANSWERABLE_INTERVIEWS: ReadonlyArray<UnanswerableInterviewView> = [];
+
+/**
+ * Host-pending interviews with no answerable card in this transcript.
+ *
+ * `findPendingInterview` renders a card only for a `streaming` interview block,
+ * so a host-pending blockId whose block is already settled - or missing from
+ * the transcript entirely - yields nothing to answer while the host keeps
+ * rejecting sends. This is the disjoint complement of `findPendingInterview`
+ * over the host's pending set: every id here has no streaming block, so the two
+ * can never name the same block.
+ *
+ * There is no transient window to debounce. The host broadcasts an interview's
+ * `blockDelta` before the `interviewRequested` frame that makes it pending
+ * (chat-session-manager `handleRuntimeEvent`), and hydration surfaces detached
+ * waits in the same snapshot that carries their persisted blocks - so a pending
+ * id without a streaming block is genuinely stuck, not mid-arrival.
+ */
+export function findUnanswerableInterviews(
+  messages: ReadonlyArray<ChatMessageModel>,
+  hostPendingInterviews: ReadonlyArray<ChatPendingInterviewState>,
+): ReadonlyArray<UnanswerableInterviewView> {
+  if (hostPendingInterviews.length === 0) return NO_UNANSWERABLE_INTERVIEWS;
+  const streamingBlockIds = new Set<string>();
+  for (const message of messages) {
+    for (const segment of message.segments) {
+      if (segment.kind !== "interview") continue;
+      if (segment.status !== "streaming") continue;
+      streamingBlockIds.add(segment.id);
+    }
+  }
+  const unanswerable: UnanswerableInterviewView[] = [];
+  for (const interview of hostPendingInterviews) {
+    if (streamingBlockIds.has(interview.blockId)) continue;
+    unanswerable.push({
+      blockId: interview.blockId,
+      requestedAt: interview.requestedAt,
+    });
+  }
+  if (unanswerable.length === 0) return NO_UNANSWERABLE_INTERVIEWS;
+  // Oldest first: the earliest dangling question is the one that has been
+  // blocking the chat, so it reads first in the notice.
+  unanswerable.sort((left, right) => left.requestedAt - right.requestedAt);
+  return unanswerable;
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-types.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-types.ts
@@ -12,3 +12,17 @@ export interface PendingInterviewView {
   // assistant. null when the owning message has no forkable persistent id yet.
   readonly assistantMessageId: string | null;
 }
+
+/**
+ * A host-pending interview this transcript can render no answer card for: its
+ * interview block is either already settled (`completed` / `errored`) or is
+ * absent from the transcript entirely. `findPendingInterview` only ever yields
+ * a `streaming` block, so such a block produces no card while the host still
+ * rejects every send with `DETACHED_INTERVIEW_PENDING` — a composer deadlock
+ * with nothing to answer. These drive the dismiss affordance that is the only
+ * in-chat way out.
+ */
+export interface UnanswerableInterviewView {
+  readonly blockId: string;
+  readonly requestedAt: number;
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -189,6 +189,7 @@ import {
   resolvedTurnStatus,
   chatTileCanAct,
   findPendingInterview,
+  findUnanswerableInterviews,
 } from "./chat-tile-session-state";
 import { ChatTileLoading, ChatTileError } from "./chat-tile-runtime-gate";
 import { SurfaceActivityProvider } from "@/components/home/composer/surface-activity-context";
@@ -1455,6 +1456,16 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const interviewBusy =
     pendingInterview !== null &&
     interviewActionBlockIds.has(pendingInterview.blockId);
+  // Host-pending blocks this transcript renders no card for. Yields a stable
+  // empty array whenever nothing is stuck, so the composer memo chain below
+  // does not churn per streaming token.
+  const unanswerableInterviews = useMemo(
+    () => findUnanswerableInterviews(renderedMessages, state.pendingInterviews),
+    [renderedMessages, state.pendingInterviews],
+  );
+  const unanswerableInterviewsBusy = unanswerableInterviews.some((interview) =>
+    interviewActionBlockIds.has(interview.blockId),
+  );
   const showCompletedRestoreToast = useCallback(() => {
     if (state.restore === null || state.restore.kind !== "completed") return;
     showRestoreResultToast(state.restore.results);
@@ -1911,6 +1922,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     () => ({
       pending: pendingInterview,
       isBusy: interviewBusy,
+      unanswerable: unanswerableInterviews,
+      unanswerableBusy: unanswerableInterviewsBusy,
       onAnswer: handleInterviewAnswer,
       onError: handleInterviewError,
       onFork: forkFromPendingInterview,
@@ -1918,6 +1931,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [
       pendingInterview,
       interviewBusy,
+      unanswerableInterviews,
+      unanswerableInterviewsBusy,
       handleInterviewAnswer,
       handleInterviewError,
       forkFromPendingInterview,

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -4820,6 +4820,60 @@ describe("blockDelta coalescing", () => {
     harness.manual.runAll();
     expect(liveText(harness.handle)).toBe("");
   });
+
+  it("publishes a pending interview only once its streaming block is observable", () => {
+    // The host emits the interview's `blockDelta` before the
+    // `interviewRequested` frame, but the delta sits in the coalescing buffer
+    // until the next tick. If the pending id lands first, a host-pending
+    // interview is briefly visible with no `streaming` segment - which
+    // `findUnanswerableInterviews` reads as permanently stuck and offers to
+    // dismiss, cancelling a live question mid-Q&A.
+    const harness = createCoalesceHarness();
+    const callbacks = harness.callbacks();
+    startRunningTurn(callbacks);
+
+    callbacks.onBlockDelta({
+      kind: "blockDelta",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      event: {
+        type: "interview.requested",
+        blockId: "interview-1",
+        timestamp: 10,
+        toolName: "AskUserQuestion",
+        questions: [],
+      },
+    });
+    // Still buffered: nothing has reached the store yet.
+    expect(harness.manual.pendingCount()).toBe(1);
+
+    callbacks.onInterviewRequested({
+      kind: "interviewRequested",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId: "interview-1",
+      requestedAt: 10,
+    });
+
+    // Read BEFORE any coordinator tick - this is the window the renderer would
+    // have rendered the escape hatch in.
+    const state = harness.handle.store.getState();
+    expect(state.pendingInterviews).toEqual([
+      { blockId: "interview-1", requestedAt: 10 },
+    ]);
+    const streamingInterviewIds = (
+      state.liveAssistantMessage?.blocks ?? []
+    ).flatMap((block) =>
+      block.type === "interview" && block.status === "streaming"
+        ? [block.blockId]
+        : [],
+    );
+    expect(streamingInterviewIds).toEqual(["interview-1"]);
+    // The consuming frame drained the buffer, so the tick has nothing left.
+    expect(harness.manual.pendingCount()).toBe(0);
+  });
 });
 
 describe("surface visibility rollup", () => {

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -788,8 +788,9 @@ export function createChatSessionStore(
     // `blockDelta` coalescing. Deltas accumulate here and are folded into a
     // single `set()` per coordinator tick (one animation frame in production)
     // instead of one `set()` per token. Every non-delta frame that consumes
-    // message/turn state (`onSnapshot`, `onTurnStateChanged`, `onMessageAccepted`)
-    // flushes the buffer first, so observable ordering matches arrival order.
+    // message/turn state (`onSnapshot`, `onTurnStateChanged`, `onMessageAccepted`,
+    // `onInterviewRequested`) flushes the buffer first, so observable ordering
+    // matches arrival order.
     let bufferedDeltas: RuntimeEvent[] = [];
 
     // `providers.list` nudge driven by the DURABLE auth-failure signal: an
@@ -1358,6 +1359,13 @@ export function createChatSessionStore(
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
           return;
         }
+        // Consuming frame: the host emits this interview's `blockDelta` first,
+        // but that delta is still buffered until the next coordinator tick.
+        // Publishing the pending id ahead of its block would expose a
+        // host-pending interview with no `streaming` segment - which
+        // `findUnanswerableInterviews` reads as permanently stuck and answers
+        // with the destructive dismiss affordance, mid-normal-Q&A.
+        flushBlockDeltas();
         set((state) => ({
           pendingInterviews: upsertPendingInterview(state.pendingInterviews, {
             blockId: frame.blockId,


### PR DESCRIPTION
## Problem

A chat could become permanently send-locked with no visible way out.

The host reports a pending interview in `snapshot.pendingInterviews` and rejects
every send with `DETACHED_INTERVIEW_PENDING`. But `findPendingInterview` only
renders an answer card for an interview segment whose `status === "streaming"`.
When that block is already settled (`errored` / `completed`) or missing from the
transcript entirely, there is nothing to answer and nothing to skip — the
composer is locked and the UI shows no reason why.

This is the last remaining gap from the phantom-detached-interview RCA. The
host-side cause was removed separately (internal `a7d89f51e`); this removes the
**dead end** that made it unrecoverable from inside the chat.

```mermaid
flowchart LR
  H["host: pendingInterviews[blockId]"] --> P{"block status<br/>in transcript?"}
  P -->|streaming| C["PendingInterviewCard<br/>answer / skip / fork"]
  P -->|settled| D["NO CARD"]
  P -->|missing| D
  D --> L["handleSend rejects<br/>DETACHED_INTERVIEW_PENDING"]
  L --> X["deadlock"]
  D -.new.-> N["UnanswerableInterviewNotice<br/>Dismiss"]
  N --> E["interviewError → host settles<br/>block errored, clears wait"]
```

## Change

`findUnanswerableInterviews` is the disjoint complement of `findPendingInterview`
over the host's pending set: every id it returns has no streaming block, so the
two can never name the same block. Whatever it returns renders as
`UnanswerableInterviewNotice`.

One button dismisses every stuck block through the existing `interviewError`
action — no new host surface. `handleInterviewError` already handles the
detached case end to end: settles the orphaned block to `errored`, clears the
wait, appends the durable terminal event. Verified it also works when the block
is absent from the transcript entirely (`settleDetachedInterviewBlock` no-ops,
the wait is still removed and `interviewErrored` broadcast).

### Ordering fix in `chat-session-store`

`onInterviewRequested` now calls `flushBlockDeltas()`.

The host emits an interview's `blockDelta` *before* the `interviewRequested`
frame — but the renderer did not observe that order. `onBlockDelta` coalesces
into one `set()` per stream-flush-coordinator tick, while `onInterviewRequested`
published the pending id immediately. During an ordinary question the pending id
became visible a tick ahead of its streaming block, so the new derivation read a
**live** question as permanently stuck and offered a button that would cancel it.

The fix uses the store's own documented idiom rather than a debounce, joining
`onSnapshot` / `onTurnStateChanged` / `onMessageAccepted` as a consuming frame.
A flush makes pending+segment observably atomic; a grace timer would only shrink
the window.

## Decisions

| Decision | Why |
|---|---|
| Detect renderer-side; no `detached` flag added to `ChatPendingInterviewState` | The UI question is "is there a card to answer", not "would the host reject a send". No protocol bump. |
| Notice stacks **above** the card/composer, never replaces either | Only `detached` waits gate sends host-side and the renderer cannot see that flag; a renderer-side inference must not remove an affordance the user may legitimately have. A stuck block can also coexist with an answerable one. |
| One button clears all | Leaving one behind keeps the host's send gate closed. |
| No confirmation dialog | The state is already broken, and the action is recorded honestly as unanswered in the transcript. |

Viewers do not see the notice (the read-only composer notice already explains).
When `canAct` is false the notice renders but its button is disabled, so the
deadlock stays legible while the stream is down.

## Tests

| Test | Pins |
|---|---|
| `chat-tile-session-state.test.ts` (6 new) | settled block flagged; absent block flagged; streaming block left to the card; mixed chat separated; oldest-first ordering; shared empty-array identity |
| `unanswerable-interview-escape-hatch.test.tsx` (7 new) | notice hidden when every pending has a card; dismissal dispatches `interviewError`; all blocks cleared in one click; composer stays reachable; notice coexists with an answerable card; disabled while in flight; disabled but visible when `canAct` is false |
| `chat-session-store.test.ts` (1 new) | with a manual coordinator, the streaming block is observable **before** `runAll()` at the moment the pending id is published |

Mutation-probed, each discriminating exactly:

- detection disabled → only the 4 detection tests red
- streaming filter dropped → 3 red, incl. disjointness with `findPendingInterview`
- fresh `[]` instead of the shared empty → only the identity test red
- sort reversed → only the ordering test red
- notice never rendered → 5 red
- dismiss-first-only → only the dismiss-all test red
- `disabled` forced false → only the 2 gate tests red
- notice replaces composer → only the reachability test red
- notice suppressed behind a card → only the coexistence test red
- **`flushBlockDeltas()` removed → only the new store test red**

## Verification

- 1401 passed / 1 skipped across `stores/chats` + `epic-canvas` + `pending-interview` (129 files), re-run after rebasing onto `ebb1e65f`
- compile, lint, prettier, react-doctor clean

Cold-reviewed by a fresh agent, which found the block-delta ordering bug as a
High; it is fixed here with the regression test above.
