### PR TITLE
fix(gui-app): restore split terminal drawer resizing

### DIFF
--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -20,6 +20,7 @@ import {
   matchDigitAction,
   type KeybindingRouter,
 } from "@/lib/keybindings/dispatch";
+import { pointerEvent } from "@/components/epic-canvas/canvas/__tests__/test-pointer-events";
 import { setSystemTabModalApi } from "@/stores/tabs/system-tab-modal-bridge";
 import type { SystemTabModalApi } from "@/stores/tabs/use-system-tab-modal";
 
@@ -159,6 +160,23 @@ function panelUiForDraft(draftId: string | null) {
     <TooltipProvider>
       <LandingTerminalGestureProvider draftId={draftId}>
         <LandingTerminalPanel />
+      </LandingTerminalGestureProvider>
+    </TooltipProvider>
+  );
+}
+
+function panelUiInBoxlessPaneAnchor() {
+  return (
+    <TooltipProvider>
+      <LandingTerminalGestureProvider draftId="draft-a">
+        <div className="flex" data-testid="landing-terminal-layout-row">
+          <div
+            data-testid="landing-terminal-pane-anchor"
+            style={{ display: "contents" }}
+          >
+            <LandingTerminalPanel />
+          </div>
+        </div>
       </LandingTerminalGestureProvider>
     </TooltipProvider>
   );
@@ -357,6 +375,64 @@ describe("<LandingTerminalPanel />", () => {
         "false",
       );
     });
+  });
+
+  it("resizes through the boxless split-pane portal anchor", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.clientActiveHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = emptyList("/Users/dev");
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    render(panelUiInBoxlessPaneAnchor());
+
+    const handle = await screen.findByTestId("landing-terminal-resize-handle");
+    const panel = screen.getByTestId("landing-terminal-panel");
+    const layoutRow = screen.getByTestId("landing-terminal-layout-row");
+    const paneAnchor = screen.getByTestId("landing-terminal-pane-anchor");
+    expect(window.getComputedStyle(paneAnchor).display).toBe("contents");
+    vi.spyOn(paneAnchor, "getBoundingClientRect").mockReturnValue(
+      testRect(0, 0, 0),
+    );
+    vi.spyOn(layoutRow, "getBoundingClientRect").mockReturnValue(
+      testRect(1_000, 800, 0),
+    );
+    vi.spyOn(panel, "getBoundingClientRect").mockReturnValue(
+      testRect(360, 800, 640),
+    );
+
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 7,
+        clientX: 640,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      handle,
+      pointerEvent("pointermove", {
+        pointerId: 7,
+        clientX: 540,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+
+    expect(panel.style.width).toBe("46%");
+    expect(useLandingTerminalStore.getState().panelWidthFraction).toBe(0.36);
+
+    fireEvent(
+      handle,
+      pointerEvent("pointerup", {
+        pointerId: 7,
+        clientX: 540,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(useLandingTerminalStore.getState().panelWidthFraction).toBe(0.46);
   });
 
   it("auto-spawns in the host home when nothing is pinned", async () => {

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -977,6 +977,20 @@ function isLandingTerminalPanelElement(
   );
 }
 
+function resolveLandingTerminalResizeContainer(
+  handle: HTMLElement,
+): HTMLElement | null {
+  const parent = handle.parentElement;
+  if (parent === null) return null;
+
+  // Split landing panes portal the handle and panel into a `display: contents`
+  // anchor. That anchor preserves flex layout but has no box of its own, so its
+  // bounding rect is always zero-sized. Measure the pane's flex row instead.
+  return window.getComputedStyle(parent).display === "contents"
+    ? parent.parentElement
+    : parent;
+}
+
 interface LandingTerminalPanelResizeArgs {
   readonly panelWidthFraction: number;
   readonly setPanelWidthFraction: (fraction: number) => void;
@@ -996,7 +1010,9 @@ function useLandingTerminalPanelResize(
     axis: "horizontal",
     onDragStart: (event) => {
       const panel = event.currentTarget.nextElementSibling;
-      const container = event.currentTarget.parentElement;
+      const container = resolveLandingTerminalResizeContainer(
+        event.currentTarget,
+      );
       if (!isLandingTerminalPanelElement(panel) || container === null) {
         return false;
       }


### PR DESCRIPTION
## Summary

- restore horizontal resizing for the landing terminal drawer inside split tabs
- resolve the real pane flex row when the portal anchor uses `display: contents`
- add a pointer-drag regression that proves a 36% drawer can be resized to 46%

## Root cause

The split-tab terminal panel is portaled through a `display: contents` anchor. The resize gesture measured that immediate parent, whose bounding box is always zero, so drag setup aborted before pointer movement could update the drawer.

## Related issue

None.

## Validation

- [x] Focused landing terminal panel suite: 47 tests passed
- [x] Affected build, compile, lint, and format checks passed through pre-commit
- [x] React Doctor reported no issues for the changed React files
- [x] Regression test added for the boxless split-pane portal anchor
- [x] Commit signed off with DCO
