### PR TITLE
fix(gui-app): stop restore toast replay across task tabs

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
@@ -46,11 +46,13 @@ const sonnerToastWarning = vi.hoisted(() =>
 );
 const sonnerToastError = vi.hoisted(() => vi.fn());
 const sonnerToast = vi.hoisted(() => vi.fn());
+const sonnerToastSuccess = vi.hoisted(() => vi.fn());
 
 vi.mock("sonner", () => ({
   toast: Object.assign(sonnerToast, {
     warning: sonnerToastWarning,
     error: sonnerToastError,
+    success: sonnerToastSuccess,
     dismiss: vi.fn(),
   }),
   __esModule: true,
@@ -70,6 +72,11 @@ import { useComposerDraftStore } from "@/stores/composer/composer-draft-store";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { ChatControlStrip } from "../chat-tile-control-strip";
 import { ChatTileErrorNoticeToasts } from "../chat-tile-error-notice-toasts";
+import { ChatTileRestoreResultToasts } from "../chat-tile-restore-result-toasts";
+import {
+  PaneSurfaceActivityContext,
+  PaneVisibilityContext,
+} from "@/components/epic-tabs/pane-visibility-context";
 import { useChatSetupFailureRestoreDriver } from "@/hooks/chats/use-chat-setup-failure-restore-driver";
 
 const EPIC_ID = "epic-x";
@@ -193,6 +200,7 @@ beforeEach(() => {
   sonnerToastWarning.mockReset();
   sonnerToastWarning.mockReturnValue("warning-toast");
   sonnerToastError.mockReset();
+  sonnerToastSuccess.mockReset();
   useComposerDraftStore.setState({ drafts: {} });
   useDesktopDialogStore.setState({
     activeDialog: null,
@@ -931,6 +939,79 @@ describe("<ChatTileErrorNoticeToasts />", () => {
     render(<ChatTileErrorNoticeToasts handle={harness.handle} />);
 
     expect(sonnerToastWarning).not.toHaveBeenCalled();
+  });
+});
+
+describe("<ChatTileRestoreResultToasts />", () => {
+  function RestoreToastHost(props: {
+    readonly active: boolean;
+    readonly handle: ChatSessionStoreHandle;
+  }) {
+    const activity = {
+      visible: props.active,
+      focused: props.active,
+    };
+    return (
+      <PaneSurfaceActivityContext.Provider value={activity}>
+        <PaneVisibilityContext.Provider value={activity.visible}>
+          <ChatTileRestoreResultToasts handle={props.handle} />
+        </PaneVisibilityContext.Provider>
+      </PaneSurfaceActivityContext.Provider>
+    );
+  }
+
+  function completeRestore(harness: Harness, finishedAt: number): void {
+    act(() => {
+      harness.callbacks().onRestoreCompleted({
+        kind: "restoreCompleted",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        checkpointId: "checkpoint-1",
+        finishedAt,
+        results: [
+          {
+            filePath: "/repo/src/app.ts",
+            status: "restored",
+            operation: "edit",
+            reason: null,
+          },
+        ],
+      });
+    });
+  }
+
+  it("shows each completion once across task-tab focus changes and remounts", () => {
+    const harness = createHarness();
+    emitSnapshot(harness.callbacks(), [], []);
+    const view = render(
+      <RestoreToastHost active={false} handle={harness.handle} />,
+    );
+
+    completeRestore(harness, 1);
+
+    expect(sonnerToastSuccess).not.toHaveBeenCalled();
+
+    view.rerender(<RestoreToastHost active handle={harness.handle} />);
+    expect(sonnerToastSuccess).toHaveBeenCalledTimes(1);
+    expect(sonnerToastSuccess).toHaveBeenLastCalledWith(
+      "1 restored, 0 skipped, 0 failed",
+    );
+
+    view.rerender(<RestoreToastHost active={false} handle={harness.handle} />);
+    view.rerender(<RestoreToastHost active handle={harness.handle} />);
+    expect(sonnerToastSuccess).toHaveBeenCalledTimes(1);
+
+    completeRestore(harness, 1);
+    expect(sonnerToastSuccess).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    render(<RestoreToastHost active handle={harness.handle} />);
+    expect(sonnerToastSuccess).toHaveBeenCalledTimes(1);
+
+    completeRestore(harness, 2);
+
+    expect(sonnerToastSuccess).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-restore-result-toasts.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-restore-result-toasts.tsx
@@ -1,0 +1,39 @@
+import { useCallback } from "react";
+import { useStore } from "zustand";
+import { useActivePaneEffect } from "@/components/epic-tabs/pane-visibility-context";
+import { addWithFifoEviction } from "@/lib/bounded-set";
+import {
+  MAX_DELIVERED_RESTORE_COMPLETIONS,
+  type ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
+import { showRestoreResultToast } from "./chat-tile-session-state";
+
+interface ChatTileRestoreResultToastsProps {
+  readonly handle: ChatSessionStoreHandle;
+}
+
+export function ChatTileRestoreResultToasts(
+  props: ChatTileRestoreResultToastsProps,
+): null {
+  const { handle } = props;
+  const restore = useStore(handle.store, (state) => state.restore);
+  const syncCompletedRestore = useCallback(() => {
+    if (restore === null || restore.kind !== "completed") return;
+
+    const completionKey = JSON.stringify([
+      restore.checkpointId,
+      restore.finishedAt,
+    ]);
+    const delivered = handle.deliveredRestoreCompletionKeys;
+    if (delivered.has(completionKey)) return;
+    addWithFifoEviction(
+      delivered,
+      completionKey,
+      MAX_DELIVERED_RESTORE_COMPLETIONS,
+    );
+    showRestoreResultToast(restore.results);
+  }, [handle, restore]);
+  useActivePaneEffect(syncCompletedRestore);
+
+  return null;
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -161,7 +161,6 @@ import {
   makeSnapshotSegmentDiffTile,
 } from "@/lib/chat/snapshot-diff-tile";
 import {
-  useActivePaneEffect,
   usePaneFocused,
   usePaneVisible,
 } from "@/components/epic-tabs/pane-visibility-context";
@@ -171,6 +170,7 @@ import {
   useLocalSnapshotClearStore,
 } from "@/stores/settings/local-snapshot-clear-store";
 import { ChatTileErrorNoticeToasts } from "./chat-tile-error-notice-toasts";
+import { ChatTileRestoreResultToasts } from "./chat-tile-restore-result-toasts";
 import { HostWorkspaceSelector } from "@/components/home/host-workspace-selector/host-workspace-selector";
 import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
 import type { TraycerNextStepOption } from "@/markdown/traycer-next-steps";
@@ -182,7 +182,6 @@ import {
   normalizeInlineEditForSession,
   canModifyChatMessages,
   shouldGenerateChatTitleForSubmittedMessage,
-  showRestoreResultToast,
   userMessageSenderForProfile,
   plainTextPromptContent,
   composerTurnStatus,
@@ -863,6 +862,7 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
             planActions={view.planActions}
           />
           <ChatTileErrorNoticeToasts handle={view.handle} />
+          <ChatTileRestoreResultToasts handle={view.handle} />
           {/*
            * SurfaceActivityProvider narrows catalog/provider query subscriptions
            * to the one focused pane+tab. A visible split partner keeps rendering
@@ -1466,11 +1466,6 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const unanswerableInterviewsBusy = unanswerableInterviews.some((interview) =>
     interviewActionBlockIds.has(interview.blockId),
   );
-  const showCompletedRestoreToast = useCallback(() => {
-    if (state.restore === null || state.restore.kind !== "completed") return;
-    showRestoreResultToast(state.restore.results);
-  }, [state.restore]);
-  useActivePaneEffect(showCompletedRestoreToast);
   // All pending approvals route to the composer slot - single or many
   // share one canonical surface. Inline rendering for pending approvals
   // is suppressed; resolved approvals stay inline as turn history.

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -603,6 +603,12 @@ export interface ChatSessionStoreHandle {
   readonly store: UseBoundStore<StoreApi<ChatSessionState>>;
   readonly deliveredNotices: DeliveredNoticeTracker;
   /**
+   * Completed restores already surfaced as toasts. Completion state remains in
+   * the store for the dialog, so delivery lives on the handle to survive task-
+   * tab focus changes and component remounts without replaying the result.
+   */
+  readonly deliveredRestoreCompletionKeys: Set<string>;
+  /**
    * Per-surface visibility report feeding the stream-flush coordinator's
    * tiered flush rate. The same chat can render in several surfaces (split
    * panes, keep-alive tabs); the chat counts as visible when ANY reporting
@@ -668,6 +674,8 @@ export const MAX_ERROR_NOTICE_RECORDS = 32;
  * memory bounded.
  */
 export const MAX_DELIVERED_CLIENT_ACTION_IDS = MAX_ERROR_NOTICE_RECORDS * 4;
+/** Bounds string-key retention while comfortably covering recent restores. */
+export const MAX_DELIVERED_RESTORE_COMPLETIONS = 32;
 
 function appendErrorNotice(
   notices: ReadonlyArray<ChatErrorNotice>,
@@ -2533,6 +2541,7 @@ export function createChatSessionStore(
       notices: new WeakSet<ChatErrorNotice>(),
       clientActionIds: new Set<string>(),
     },
+    deliveredRestoreCompletionKeys: new Set<string>(),
     setSurfaceVisibility: (surfaceId, visible) => {
       if (surfaceVisibility.get(surfaceId) === visible) return;
       surfaceVisibility.set(surfaceId, visible);


### PR DESCRIPTION
## Summary

- stop completed restore/revert result toasts from replaying whenever a task tab regains focus
- retain completed restore state for the restore dialog while tracking toast delivery on the chat session handle
- show a completion when its tab first becomes active, dedupe focus changes, remounts, and duplicate completion frames, and still show genuinely new restores

## Root cause

Completed restore state intentionally persists after the operation finishes. The toast was emitted from an active-pane effect that re-runs whenever the pane regains focus, so every task-tab shuffle replayed the same completed result.

The new focused-pane toast bridge keys each completion by checkpoint and finish time and records delivery in a bounded per-session set outside React component state. That keeps the one-shot marker alive across tab changes and remounts without consuming the restore state the dialog still needs.

## Related issue

None.

## Verification

- [x] focused chat-tile setup suite: 14/14 tests passed
- [x] regression covers inactive completion, first focus, repeated task-tab shuffles, remount, duplicate frame, and a subsequent restore
- [x] affected GUI lint and formatting passed in pre-commit
- [x] affected shared/protocol/GUI compile and build passed in pre-commit
- [x] React Doctor reported no issues for changed files
- [x] pre-commit hooks passed
- [x] commits are signed off per DCO

## Checklist

- [ ] full-repository `bun run build`, `bun run lint`, and `bun run test` pass (CI owns the broad suites)
- [x] code is formatted
- [x] pre-commit hooks pass
- [x] tests added/updated where it makes sense
- [x] commits are signed off
