### PR TITLE
fix(gui-app): align split tab top border

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
@@ -307,7 +307,7 @@ describe("app route tab-strip navigation", () => {
     });
   });
 
-  it("covers the header baseline beneath the active tab caps", async () => {
+  it("aligns active tab border joins and covers the header baseline", async () => {
     const epicTabId = useEpicCanvasStore
       .getState()
       .openEpicTab("epic-current", "Current Epic");
@@ -331,11 +331,20 @@ describe("app route tab-strip navigation", () => {
     expect(screen.getByTestId("tab-chrome-center").className).not.toContain(
       "z-10",
     );
+    expect(screen.getByTestId("tab-chrome-center").className).toContain(
+      "border-t",
+    );
     expect(
       screen.getByTestId("tab-cap-outline-left").getAttribute("d"),
     ).toContain("M -2 39.5 L 0 39.5");
     expect(
+      screen.getByTestId("tab-cap-outline-left").getAttribute("d"),
+    ).toContain("10.6 0.5 15 0.5 L 20 0.5");
+    expect(
       screen.getByTestId("tab-cap-outline-right").getAttribute("d"),
     ).toContain("L 22 39.5");
+    expect(
+      screen.getByTestId("tab-cap-outline-right").getAttribute("d"),
+    ).toContain("M 0 0.5 L 5 0.5 C 9.4 0.5");
   });
 });

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -797,10 +797,14 @@ function TabCap({
     side === "left"
       ? "M 20 0 L 15 0 C 10.6 0 8 2.8 8 7 L 8 32 C 8 36.8 4.8 40 0 40 L 20 40 Z"
       : "M 0 0 L 5 0 C 9.4 0 12 2.8 12 7 L 12 32 C 12 36.8 15.2 40 20 40 L 0 40 Z";
+  // SVG strokes are centered on their path. Inset the top edge by half the
+  // stroke width so it occupies the same inside pixel row as the center's CSS
+  // border; placing it at y=0 clips the outer half and makes the center look
+  // like a second line at display scaling.
   const outline =
     side === "left"
-      ? "M -2 39.5 L 0 39.5 C 4.8 39.5 8 36.8 8 32 L 8 7 C 8 2.8 10.6 0 15 0 L 20 0"
-      : "M 0 0 L 5 0 C 9.4 0 12 2.8 12 7 L 12 32 C 12 36.8 15.2 39.5 20 39.5 L 22 39.5";
+      ? "M -2 39.5 L 0 39.5 C 4.8 39.5 8 36.8 8 32 L 8 7 C 8 2.8 10.6 0.5 15 0.5 L 20 0.5"
+      : "M 0 0.5 L 5 0.5 C 9.4 0.5 12 2.8 12 7 L 12 32 C 12 36.8 15.2 39.5 20 39.5 L 22 39.5";
   return (
     <svg
       data-testid={`tab-cap-${side}`}


### PR DESCRIPTION
## Summary

- inset the SVG cap outlines by half a stroke so they paint on the same inside pixel row as the CSS center border
- remove the doubled top-edge appearance on focused split tabs at display scaling
- extend the tab-border regression test to cover the top cap/center alignment contract

## Related issue

None.

## Test plan

- [x] Focused Vitest suites: 38 tests passed
- [x] Affected build, compile, lint, and format checks passed in the commit hook
- [x] React Doctor reported no issues
- [x] All 18 GitHub checks passed

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass (affected checks and focused suites passed locally; full suites passed in CI)
- [x] Code is formatted (`bun run format` via the affected pre-commit hook)
- [x] Pre-commit hooks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
