### PR TITLE
fix(gui-app): navigate TUI notifications to terminal agents

### DIFF
--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -1261,8 +1261,9 @@ describe("NotificationsPopover", () => {
     renderRouter(router);
 
     const entry = await screen.findByTestId("notification-entry");
-    const trigger = entry.querySelector("button");
-    if (trigger === null) throw new Error("button not found");
+    const trigger = within(entry).getByRole<HTMLButtonElement>("button", {
+      name: /TUI task/,
+    });
 
     await act(async () => {
       fireEvent.click(trigger);

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -1225,6 +1225,56 @@ describe("NotificationsPopover", () => {
     ).toBeTypeOf("number");
   });
 
+  it("navigates a TUI completion row to its terminal agent", async () => {
+    applyHostSnapshot(
+      [
+        {
+          id: "agent.stopped:tui-1",
+          updatedAt: 10,
+          readAt: null,
+          kind: "agent.stopped",
+          sourceRef: "tui-1",
+          severity: "done",
+          outcome: "completed",
+          epicId: "epic-tui",
+          chatId: "tui-1",
+          payload: {
+            kind: "epic",
+            epicId: "epic-tui",
+            tuiAgentId: "tui-1",
+            agentName: "Terminal agent",
+            taskTitle: "TUI task",
+            outcome: "completed",
+          },
+        },
+      ],
+      { unreadCount: 1, attentionCount: 0 },
+    );
+    const captured: TargetCapture = {
+      epicId: null,
+      tabId: null,
+      focusArtifactId: null,
+      focusThreadId: null,
+    };
+    const onNavigate = vi.fn();
+    const { router } = buildRouterWithCapture(captured, onNavigate);
+    renderRouter(router);
+
+    const entry = await screen.findByTestId("notification-entry");
+    const trigger = entry.querySelector("button");
+    if (trigger === null) throw new Error("button not found");
+
+    await act(async () => {
+      fireEvent.click(trigger);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(captured.epicId).toBe("epic-tui");
+    expect(captured.focusArtifactId).toBe("tui-1");
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
   it("marks every notification as read when Mark all read is clicked", async () => {
     const captured: TargetCapture = {
       epicId: null,

--- a/clients/gui-app/src/hooks/notifications/__tests__/use-notification-activation.test.tsx
+++ b/clients/gui-app/src/hooks/notifications/__tests__/use-notification-activation.test.tsx
@@ -589,6 +589,51 @@ describe("useNotificationActivation", () => {
     );
   });
 
+  it("routes TUI agent notifications to the exact open terminal-agent tile", () => {
+    const store = useEpicCanvasStore.getState();
+    const notifiedTabId = store.openEpicTab("epic-tui", "TUI task");
+    store.openTileInTab(notifiedTabId, {
+      id: "tui-notified",
+      instanceId: "tui-notified-instance",
+      type: "terminal-agent",
+      name: "Notified terminal agent",
+      hostId: "host-1",
+    });
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[notifiedTabId];
+    if (canvas === undefined || canvas.activePaneId === null) {
+      throw new Error("expected notified TUI agent canvas");
+    }
+    const paneId = canvas.activePaneId;
+    store.openEpicTab("epic-tui", "Other task view");
+    const hook = renderHook(() => useNotificationActivation(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      hook.result.current.activate({
+        payload: {
+          kind: "chat",
+          epicId: "epic-tui",
+          chatId: "tui-notified",
+        },
+        receivedAt: 904,
+        feedId: "host:tui",
+        onResult: null,
+      });
+    });
+
+    expect(navigateSpy.mock.calls[0][0]).toMatchObject({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: "epic-tui", tabId: notifiedTabId },
+      search: {
+        focusedAt: 904,
+        focusArtifactId: "tui-notified",
+        focusPaneId: paneId,
+        focusTileInstanceId: "tui-notified-instance",
+      },
+    });
+  });
+
   it("reopens a closed Task at its exact open chat tile", () => {
     const store = useEpicCanvasStore.getState();
     const notifiedChatTabId = store.openEpicTab("epic-hidden", "Hidden task");

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -101,6 +101,34 @@ describe("merged notifications feed", () => {
     });
   });
 
+  it("targets the terminal agent from TUI completion rows", () => {
+    const entry: HostNotificationEntry = {
+      id: "agent.stopped:tui-1",
+      updatedAt: 10,
+      readAt: null,
+      kind: "agent.stopped",
+      sourceRef: "tui-1",
+      severity: "done",
+      outcome: "completed",
+      epicId: "epic-1",
+      chatId: "tui-1",
+      payload: {
+        kind: "epic",
+        epicId: "epic-1",
+        tuiAgentId: "tui-1",
+        agentName: "Terminal agent",
+        taskTitle: "Checkout notifications",
+        outcome: "completed",
+      },
+    };
+
+    expect(rowFromHostEntry(entry).payload).toEqual({
+      kind: "chat",
+      epicId: "epic-1",
+      chatId: "tui-1",
+    });
+  });
+
   it("uses embedded cloud payload titles when the presentation snapshot is absent", () => {
     const embedded: HostNotificationsCloudFeedRow = {
       entryId: "entry-legacy",

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -1490,7 +1490,16 @@ function navigationPayloadFromKnown(
     case "workspace_operation_failed":
       return { kind: "chat", epicId: known.epicId, chatId: known.chatId };
     case "epic":
-      return { kind: "epic", epicId: known.epicId };
+      // TUI agent-stopped rows use the persisted `epic` payload shape, but
+      // their actionable entity is the terminal agent itself. The canvas
+      // addresses that record through the same chat-shaped route used for
+      // `terminal-agent` tiles, so retain `tuiAgentId` instead of degrading
+      // the click to the owning epic.
+      return {
+        kind: "chat",
+        epicId: known.epicId,
+        chatId: known.tuiAgentId,
+      };
     case "approval":
       return {
         kind: "approval",


### PR DESCRIPTION
## Summary

- preserve `tuiAgentId` when converting TUI completion notifications into navigation payloads
- route notification activation through the existing chat-shaped terminal-agent focus path
- add regression coverage at payload conversion, activation-hook, and popover integration layers

## Related issue

No linked issue.

## Validation

- 118 focused notification tests passed
- React Doctor reported no issues
- commit hooks passed affected build, compile, lint, and format checks
- `git diff --check` passed

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
