### PR TITLE
feat(protocol,gui): add the JCode harness and repair the V60 freeze gap

### DIFF
--- a/clients/gui-app/src/components/home/data/harness-icon-map.ts
+++ b/clients/gui-app/src/components/home/data/harness-icon-map.ts
@@ -8,6 +8,7 @@ import {
   DroidIcon,
   GrokIcon,
   HermesIcon,
+  JCodeIcon,
   KiroIcon,
   KiloCodeIcon,
   KimiIcon,
@@ -45,4 +46,5 @@ export const PROVIDER_ICON_CONFIG: Record<ProviderId, HarnessIconConfig> = {
   pi: { Icon: PiIcon, className: "text-foreground" },
   hermes: { Icon: HermesIcon, className: "text-foreground" },
   omp: { Icon: OmpIcon, className: "text-foreground" },
+  jcode: { Icon: JCodeIcon, className: "text-foreground" },
 };

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -126,3 +126,29 @@ export const TraycerIcon: HarnessIcon = (props) => (
     />
   </svg>
 );
+
+// JCode (Solo Systems / jcode.sh) has no lobehub entry. Official brand mark is
+// the shell-prompt chevron + cursor bar (`>_`) from the product AppIcon /
+// GitHub identity — not a generic code-bracket glyph. Monochrome
+// `currentColor` so it tracks light/dark theme (same convention as Traycer /
+// Omp strokes); the mint plate from the AppIcon is omitted for the same
+// reason Omp dropped its near-white plate fill.
+export const JCodeIcon: HarnessIcon = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="none">
+    <path
+      d="M6 5.5 L14.5 12 L6 18.5"
+      stroke="currentColor"
+      strokeWidth="3.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect
+      x="14"
+      y="15.25"
+      width="6"
+      height="3.25"
+      rx="1.5"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -43,6 +43,7 @@ describe("OnboardingDetectedAgents", () => {
       "Pi",
       "Hermes Agent",
       "Oh My Pi",
+      "JCode",
     ];
     const textOrEmpty = (text: string | null): string => text ?? "";
     // Longest match, not first match: display names overlap ("Pi" is a

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
@@ -45,6 +45,7 @@ describe("OnboardingDiorama", () => {
       "Pi",
       "Hermes Agent",
       "Oh My Pi",
+      "JCode",
     ];
     const textOrEmpty = (text: string | null): string => text ?? "";
     // Longest match, not first match: display names overlap ("Pi" is a

--- a/clients/gui-app/src/components/settings/panels/provider-env-name-placeholder.ts
+++ b/clients/gui-app/src/components/settings/panels/provider-env-name-placeholder.ts
@@ -31,6 +31,10 @@ const ENV_NAME_PLACEHOLDER: Record<ProviderId, string> = {
   // OpenRouter, ...) in its own credential store; the env name is illustrative
   // only, same as Hermes above.
   omp: "OPENROUTER_API_KEY",
+  // JCode is a meta-harness: it authenticates ~46 sub-providers (OAuth logins
+  // and per-provider keys), not a single Traycer-stored API key. OPENROUTER is
+  // one common sub-provider path — illustrative only.
+  jcode: "OPENROUTER_API_KEY",
 };
 
 export function envNamePlaceholder(providerId: ProviderId): string {

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -10,7 +10,10 @@ import type {
   ProviderRateLimitWindow,
   RateLimitUnavailableReason,
 } from "@traycer/protocol/host";
-import { classifyProviderRateLimitWindow } from "@traycer/protocol/host/rate-limit";
+import {
+  classifyProviderRateLimitWindow,
+  jcodeSubProviderRateLimitLabel,
+} from "@traycer/protocol/host/rate-limit";
 import type { ProviderRateLimitEnvelope } from "@/lib/rate-limits/rate-limit-envelope";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -1179,14 +1182,21 @@ export function JCodeRateLimitView({
   }
   return (
     <div className="flex flex-col gap-3">
-      {data.subProviders.map((sub) => {
+      {data.subProviders.map((sub, index) => {
+        // One sub-provider can contribute SEVERAL rows (jcode reports a list
+        // of named quotas per provider), so `subProviderId` is neither unique
+        // nor self-describing. The row's position in the host-built list is
+        // the only guaranteed-unique key — these rows are never locally
+        // reordered, inserted, or keyed into component state.
+        const key = `${index}:${sub.subProviderId}`;
+        const label = jcodeSubProviderRateLimitLabel(sub);
         if (sub.error !== null) {
           return (
             <div
-              key={`err:${sub.subProviderId}`}
+              key={key}
               className="flex items-start justify-between gap-2 text-ui-sm"
             >
-              <span className="text-muted-foreground">{sub.subProviderId}</span>
+              <span className="text-muted-foreground">{label}</span>
               <span className="text-right text-ui-xs text-destructive">
                 {sub.error}
               </span>
@@ -1195,11 +1205,7 @@ export function JCodeRateLimitView({
         }
         if (sub.window === null) return null;
         return (
-          <RateLimitWindowRow
-            key={`win:${sub.subProviderId}-${sub.window.resetsAt}`}
-            label={sub.subProviderId}
-            window={sub.window}
-          />
+          <RateLimitWindowRow key={key} label={label} window={sub.window} />
         );
       })}
     </div>

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -109,6 +109,7 @@ type OpenRouterRateLimits = Extract<
 >;
 type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
 type GrokRateLimits = Extract<ProviderRateLimits, { provider: "grok" }>;
+type JCodeRateLimits = Extract<ProviderRateLimits, { provider: "jcode" }>;
 
 const MINUTES_PER_HOUR = 60;
 // A manual reset expiring inside this window is tinted `text-destructive` in the
@@ -1155,6 +1156,56 @@ export function GrokRateLimitView({
   );
 }
 
+/**
+ * JCode meta-harness: one row per connected sub-provider. Live windows use the
+ * shared meter; failed fetches render as muted error copy (never a 0% bar).
+ * Sub-providers with no measurable quota and no error contribute nothing.
+ * Overview and detail show the same list — every peer quota matters.
+ */
+export function JCodeRateLimitView({
+  data,
+}: {
+  readonly data: JCodeRateLimits;
+  // Kept for call-site parity with sibling views; peer quotas are not trimmed
+  // for Overview.
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  if (data.subProviders.length === 0) {
+    return (
+      <p className="text-ui-xs text-muted-foreground">
+        No connected sub-provider reported a quota.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      {data.subProviders.map((sub) => {
+        if (sub.error !== null) {
+          return (
+            <div
+              key={`err:${sub.subProviderId}`}
+              className="flex items-start justify-between gap-2 text-ui-sm"
+            >
+              <span className="text-muted-foreground">{sub.subProviderId}</span>
+              <span className="text-right text-ui-xs text-destructive">
+                {sub.error}
+              </span>
+            </div>
+          );
+        }
+        if (sub.window === null) return null;
+        return (
+          <RateLimitWindowRow
+            key={`win:${sub.subProviderId}-${sub.window.resetsAt}`}
+            label={sub.subProviderId}
+            window={sub.window}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 export function ProviderRateLimitBody(
   props: ProviderRateLimitQueryState & {
     readonly codexResetAction: CodexResetCreditActionRenderer | null;
@@ -1299,5 +1350,9 @@ export function ProviderRateLimitDetail({
     // `variant` drives just the Overview-vs-detail trim.
     case "grok":
       return <GrokRateLimitView data={data} variant={variant} />;
+    // JCode is a list of peer sub-provider quotas (not a single primary/secondary
+    // pair); Overview and detail share the same rows.
+    case "jcode":
+      return <JCodeRateLimitView data={data} variant={variant} />;
   }
 }

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -203,6 +203,8 @@ const PROVIDER_DESCRIPTIONS: Record<ProviderId, string> = {
   pi: "Pi agent - pi.dev coding agent via your configured model API key (BYOK).",
   hermes: "Hermes Agent - Nous Research's coding CLI via your Hermes account.",
   omp: "Oh My Pi - can1357's coding CLI via your linked provider subscriptions.",
+  jcode:
+    "JCode agent - Solo Systems' terminal coding agent via your linked provider accounts.",
 };
 
 function hasPendingProviderProbe(

--- a/clients/gui-app/src/components/settings/panels/terminal-agent-args-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/terminal-agent-args-section.tsx
@@ -30,6 +30,7 @@ const TERMINAL_AGENT_ARGS_PLACEHOLDER: Record<ProviderId, string> = {
   pi: "CLI arguments (optional)",
   hermes: "CLI arguments (optional)",
   omp: "CLI arguments (optional)",
+  jcode: "CLI arguments (optional)",
 };
 
 function terminalAgentArgsPlaceholder(providerId: ProviderId): string {

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -76,12 +76,15 @@ function fiveHourWindow(
       return rateLimits.primary;
     case "claude-code":
       return rateLimits.fiveHour;
-    // OpenRouter/Kilo Code/Grok are never queried for a glyph slot (grok stays
-    // out of `GLYPH_PROVIDER_IDS` - its billing period isn't a short rolling
-    // window); kept for exhaustiveness over the union.
+    // OpenRouter/Kilo Code/Grok/JCode are never queried for a glyph slot
+    // (grok: billing period isn't a short rolling window; jcode: per-
+    // sub-provider quotas don't fit a single glyph bar). Kept for
+    // exhaustiveness over the union — deliberately not in
+    // `GLYPH_PROVIDER_IDS`.
     case "openrouter":
     case "kilocode":
     case "grok":
+    case "jcode":
       return null;
   }
 }
@@ -99,6 +102,7 @@ function weeklyWindow(
     case "openrouter":
     case "kilocode":
     case "grok":
+    case "jcode":
       return null;
   }
 }

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -79,6 +79,7 @@ export type AnalyticsHarness =
   | "droid"
   | "grok"
   | "hermes"
+  | "jcode"
   | "kilocode"
   | "kimi"
   | "kiro"
@@ -163,6 +164,7 @@ export type AnalyticsProvider =
   | "droid"
   | "grok"
   | "hermes"
+  | "jcode"
   | "kilocode"
   | "kimi"
   | "kiro"
@@ -871,6 +873,7 @@ const ANALYTICS_HARNESSES = new Set<string>([
   "droid",
   "grok",
   "hermes",
+  "jcode",
   "kilocode",
   "kimi",
   "kiro",
@@ -892,6 +895,7 @@ const ANALYTICS_PROVIDERS = new Set<string>([
   "droid",
   "grok",
   "hermes",
+  "jcode",
   "kilocode",
   "kimi",
   "kiro",

--- a/clients/gui-app/src/lib/chat/sender-display.ts
+++ b/clients/gui-app/src/lib/chat/sender-display.ts
@@ -153,6 +153,7 @@ const AGENT_PROVIDER_LABEL: Record<GuiHarnessId, string> = {
   pi: "Pi",
   hermes: "Hermes Agent",
   omp: "Oh My Pi",
+  jcode: "JCode",
 };
 
 export function agentProviderLabel(provider: GuiHarnessId): string {

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -28,6 +28,7 @@ const PROVIDER_ID_ORDER = [
   "pi",
   "hermes",
   "omp",
+  "jcode",
 ] as const satisfies ReadonlyArray<ProviderId>;
 
 type MissingProviderIdFromOrder = Exclude<
@@ -61,6 +62,7 @@ const GUI_HARNESS_BY_PROVIDER_ID = {
   pi: "pi",
   hermes: "hermes",
   omp: "omp",
+  jcode: "jcode",
 } satisfies Readonly<Record<ProviderId, GuiHarnessId>>;
 
 export const ORDERED_PROVIDERS: ExhaustiveOrderedProviders =

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -270,8 +270,12 @@ export function resolveProviderPlanLabel(
     // intra-word capital ("Supergrok").
     case "grok":
       return data.subscriptionTier;
+    // OpenRouter and Kilo Code expose no plan/tier field. JCode is a
+    // meta-harness: tier is per sub-provider, not a single plan/tier field on
+    // the account, so no chip is the honest render.
     case "openrouter":
     case "kilocode":
+    case "jcode":
       return null;
   }
 }

--- a/clients/gui-app/src/lib/rate-limit-providers.ts
+++ b/clients/gui-app/src/lib/rate-limit-providers.ts
@@ -30,8 +30,8 @@ export type RateLimitProviderId = RateLimitCapableProviderId;
  *   their observers opt into the table-owned fixed cadence and never enter the
  *   serial queue.
  * - `"ephemeralProcess"`: the host spawns a real CLI subprocess to read usage
- *   (codex, claude-code). Expensive; these are funnelled through a shared
- *   queue so background and single-profile triggers cannot overlap. The
+ *   (codex, claude-code, grok, jcode). Expensive; these are funnelled through a
+ *   shared queue so background and single-profile triggers cannot overlap. The
  *   deliberate exception is the popover's "Refresh all" queue item, which fans
  *   out its configured profiles together before the next item begins.
  */
@@ -89,6 +89,16 @@ export function rateLimitFetchLane(
       // extension (a subprocess RPC, so Traycer never touches the grok OAuth
       // token) - an ephemeral spawn like codex/claude-code, despite grok's
       // credit-shaped payload resembling the httpFetch providers'.
+      return "ephemeralProcess";
+    case "jcode":
+      // JCode spawns `jcode usage --json` (CLI subprocess). That lane is the
+      // serial ephemeral queue (`ephemeral-fetch-queue.ts`): every automatic
+      // trigger appends to one shared promise chain, so process spawns never
+      // overlap. Two jcode-specific reasons this matters: (1) the CLI fans out
+      // real upstream network calls per connected sub-provider, so tight
+      // concurrent polling would thrash credentials/rate limits; (2) the host
+      // must inherit the adapter's per-tab `JCODE_RUNTIME_DIR` — an unqueued
+      // parallel spawn can attach to the wrong daemon. Not `httpFetch`.
       return "ephemeralProcess";
   }
 }

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -95,6 +95,19 @@ function grok(
   };
 }
 
+function jcode(
+  subProviders: Extract<
+    ProviderRateLimits,
+    { provider: "jcode"; available: true }
+  >["subProviders"],
+): Extract<ProviderRateLimits, { provider: "jcode"; available: true }> {
+  return {
+    provider: "jcode",
+    available: true,
+    subProviders: [...subProviders],
+  };
+}
+
 function envelope(
   data: Extract<ProviderRateLimits, { available: true }>,
   lastGoodAt: number,
@@ -216,6 +229,93 @@ describe("projectProfileUsage", () => {
       windows: [],
       checkedAt: null,
     });
+  });
+
+  it("projects one JCode window per live sub-provider, named by subProviderId", () => {
+    const projection = project(
+      "ok",
+      NOW,
+      envelope(
+        jcode([
+          {
+            subProviderId: "openrouter",
+            window: window(10, null, null),
+            hardLimitReached: false,
+            error: null,
+          },
+          {
+            subProviderId: "copilot",
+            window: window(85, 300, NOW + 1),
+            hardLimitReached: false,
+            error: null,
+          },
+        ]),
+        NOW,
+      ),
+      false,
+    );
+    expect(projection.kind).toBe("detail");
+    expect(projection.windows.map((entry) => entry.name)).toEqual([
+      "openrouter",
+      "copilot",
+    ]);
+    // Most constrained (running_low at 85%) becomes the compact bar.
+    expect(projection.compactWindow?.name).toBe("copilot");
+    expect(projection.compactWindow?.window.usedPercent).toBe(85);
+  });
+
+  it("omits JCode sub-providers whose error is set (never a 0% bar)", () => {
+    // Schema separates error from window:null so a broken credential must not
+    // look like a healthy unused quota. Failed rows are omitted entirely.
+    const projection = project(
+      "ok",
+      NOW,
+      envelope(
+        jcode([
+          {
+            subProviderId: "anthropic",
+            window: null,
+            hardLimitReached: false,
+            error: "401 after token refresh",
+          },
+          {
+            subProviderId: "openrouter",
+            window: window(12, null, null),
+            hardLimitReached: false,
+            error: null,
+          },
+        ]),
+        NOW,
+      ),
+      false,
+    );
+    expect(projection.kind).toBe("detail");
+    expect(projection.windows).toHaveLength(1);
+    expect(projection.windows[0]?.name).toBe("openrouter");
+    expect(projection.windows[0]?.window.usedPercent).toBe(12);
+  });
+
+  it("never projects a JCode error row even if a window sneaks through", () => {
+    // Defensive: if host ever sent both error and a window, still omit —
+    // better a missing bar than a false healthy meter.
+    const projection = project(
+      "ok",
+      NOW,
+      envelope(
+        jcode([
+          {
+            subProviderId: "anthropic",
+            window: window(0, null, null),
+            hardLimitReached: false,
+            error: "credential missing",
+          },
+        ]),
+        NOW,
+      ),
+      false,
+    );
+    expect(projection.windows).toEqual([]);
+    expect(projection.compactWindow).toBeNull();
   });
 
   it("selects the most consumed live window and ignores expired windows", () => {

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -239,12 +239,14 @@ describe("projectProfileUsage", () => {
         jcode([
           {
             subProviderId: "openrouter",
+            limitName: null,
             window: window(10, null, null),
             hardLimitReached: false,
             error: null,
           },
           {
             subProviderId: "copilot",
+            limitName: null,
             window: window(85, 300, NOW + 1),
             hardLimitReached: false,
             error: null,
@@ -264,6 +266,41 @@ describe("projectProfileUsage", () => {
     expect(projection.compactWindow?.window.usedPercent).toBe(85);
   });
 
+  it("distinguishes two quotas reported by the same JCode sub-provider", () => {
+    // jcode returns a LIST of named limits per provider, so `subProviderId`
+    // repeats. Two identically-named bars are unreadable — the user cannot
+    // tell which quota is at 92%.
+    const projection = project(
+      "ok",
+      NOW,
+      envelope(
+        jcode([
+          {
+            subProviderId: "copilot",
+            limitName: "Premium requests",
+            window: window(92, 300, NOW + 1),
+            hardLimitReached: false,
+            error: null,
+          },
+          {
+            subProviderId: "copilot",
+            limitName: "Chat",
+            window: window(11, 300, NOW + 1),
+            hardLimitReached: false,
+            error: null,
+          },
+        ]),
+        NOW,
+      ),
+      false,
+    );
+    expect(projection.windows.map((entry) => entry.name)).toEqual([
+      "copilot · Premium requests",
+      "copilot · Chat",
+    ]);
+    expect(projection.compactWindow?.name).toBe("copilot · Premium requests");
+  });
+
   it("omits JCode sub-providers whose error is set (never a 0% bar)", () => {
     // Schema separates error from window:null so a broken credential must not
     // look like a healthy unused quota. Failed rows are omitted entirely.
@@ -274,12 +311,14 @@ describe("projectProfileUsage", () => {
         jcode([
           {
             subProviderId: "anthropic",
+            limitName: null,
             window: null,
             hardLimitReached: false,
             error: "401 after token refresh",
           },
           {
             subProviderId: "openrouter",
+            limitName: null,
             window: window(12, null, null),
             hardLimitReached: false,
             error: null,
@@ -305,6 +344,7 @@ describe("projectProfileUsage", () => {
         jcode([
           {
             subProviderId: "anthropic",
+            limitName: null,
             window: window(0, null, null),
             hardLimitReached: false,
             error: "credential missing",

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -2,6 +2,7 @@ import {
   classifyProviderRateLimits,
   classifyProviderRateLimitWindow,
   isProviderRateLimitWindowLive,
+  jcodeSubProviderRateLimitLabel,
   providerRateLimitWindows,
   type LiveProviderRateLimitSeverity,
   type ProviderRateLimits,
@@ -325,7 +326,7 @@ function projectedLiveWindows(
               // first *surviving* window is primary even when earlier rows
               // were null/expired/errored.
               role: "extra",
-              name: subProvider.subProviderId,
+              name: jcodeSubProviderRateLimitLabel(subProvider),
               window: subProvider.window,
               now,
             }),

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -294,6 +294,48 @@ function projectedLiveWindows(
       ].filter((window): window is ProfileUsageWindow => window !== null);
     case "kilocode":
       return [];
+    case "jcode":
+      // Meta-harness: one window per connected sub-provider that reported a
+      // measurable quota, named by `subProviderId` (same multi-window shape as
+      // claude-code model-scoped). `usage_percent` is already percent CONSUMED
+      // — no inversion. `resetsAt: null` means "not reported", not "never
+      // resets"; `isProviderRateLimitWindowLive` treats null reset as live.
+      //
+      // Roles: peer sub-providers are not "extras" on a primary meter — each
+      // is an independent quota the user tracks. Using primary (first live)
+      // + secondary (rest) keeps healthy peers visible through the
+      // projectProfileUsage filter that drops healthy `extra` rows; labeling
+      // them all `extra` would hide a 10% OpenRouter row next to an 85%
+      // Copilot bar, which is the wrong meta-harness UX.
+      //
+      // Error trap: a sub-provider with non-null `error` must never render as
+      // a 0% bar. Schema separates `error` from `window: null` so a broken
+      // credential is distinct from "no quota". We **omit** failed rows rather
+      // than invent an error-window UI primitive — `ProfileUsageWindow` has no
+      // error field, and a missing row is honest (severity still rolls up via
+      // protocol `classifyProviderRateLimits` / `hardLimitReached` on remaining
+      // live windows). Never synthesize a zero window for an error.
+      return rateLimits.subProviders
+        .flatMap((subProvider, index) => {
+          if (subProvider.error !== null) return [];
+          return [
+            windowProjection({
+              id: `sub:${subProvider.subProviderId}:${index}`,
+              // Provisional role; reassigned on the live list below so the
+              // first *surviving* window is primary even when earlier rows
+              // were null/expired/errored.
+              role: "extra",
+              name: subProvider.subProviderId,
+              window: subProvider.window,
+              now,
+            }),
+          ];
+        })
+        .filter((entry): entry is ProfileUsageWindow => entry !== null)
+        .map((entry, liveIndex) => ({
+          ...entry,
+          role: liveIndex === 0 ? "primary" : "secondary",
+        }));
   }
 }
 

--- a/protocol/scripts/compat/snapshot-frozen-catalog-lines.ts
+++ b/protocol/scripts/compat/snapshot-frozen-catalog-lines.ts
@@ -14,6 +14,7 @@ import {
   listAgentsResponseSchemaV30,
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
+  listAgentsResponseSchemaV60,
 } from "../../src/host/agent/shared";
 import {
   listGuiHarnessesResponseSchemaV10,
@@ -22,6 +23,7 @@ import {
   listGuiHarnessesResponseSchemaV30,
   listGuiHarnessesResponseSchemaV40,
   listGuiHarnessesResponseSchemaV50,
+  listGuiHarnessesResponseSchemaV60,
 } from "../../src/host/agent/gui/unary-schemas";
 import {
   providersListResponseSchemaV10,
@@ -29,6 +31,7 @@ import {
   providersListResponseSchemaV30,
   providersListResponseSchemaV40,
   providersListResponseSchemaV50,
+  providersListResponseSchemaV60,
 } from "../../src/host/provider-schemas";
 
 function dump(schema: z.ZodType): unknown {
@@ -48,11 +51,18 @@ const FIXTURES = {
   "agent.gui.listHarnesses@3.0": dump(listGuiHarnessesResponseSchemaV30),
   "agent.gui.listHarnesses@4.0": dump(listGuiHarnessesResponseSchemaV40),
   "agent.gui.listHarnesses@5.0": dump(listGuiHarnessesResponseSchemaV50),
+  // `cli-v1.1.9` shipped v6.0 while these two lines still served the LIVE
+  // response, so they absorbed every id added afterwards - the omp-on-v5.0
+  // defect one version later, and the reason the v6.0 rows appear here only
+  // now. `providers.list@6.0` was already pinned (its registry-field leak was
+  // caught first), which is why only it had a frozen export before jcode.
+  "agent.gui.listHarnesses@6.0": dump(listGuiHarnessesResponseSchemaV60),
   "agent.list@1.0": dump(listAgentsResponseSchemaV10),
   "agent.list@2.0": dump(listAgentsResponseSchemaV20),
   "agent.list@3.0": dump(listAgentsResponseSchemaV30),
   "agent.list@4.0": dump(listAgentsResponseSchemaV40),
   "agent.list@5.0": dump(listAgentsResponseSchemaV50),
+  "agent.list@6.0": dump(listAgentsResponseSchemaV60),
   "providers.list@1.0": dump(providersListResponseSchemaV10),
   "providers.list@2.0": dump(providersListResponseSchemaV20),
   // Frozen with Amp, before `profiles` (the v4.0 cut) - pinned now that this
@@ -62,6 +72,7 @@ const FIXTURES = {
   "providers.list@3.0": dump(providersListResponseSchemaV30),
   "providers.list@4.0": dump(providersListResponseSchemaV40),
   "providers.list@5.0": dump(providersListResponseSchemaV50),
+  "providers.list@6.0": dump(providersListResponseSchemaV60),
 };
 
 const HEADER =

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -17,6 +17,7 @@
  *
  * `--json` bypasses all of this and emits the RPC DTO unchanged.
  */
+import { jcodeSubProviderRateLimitLabel } from "@traycer/protocol/host/rate-limit";
 import type {
   AgentConfigureResponse,
   AgentGetProviderProfileRateLimitsResponse,
@@ -179,11 +180,14 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
         // A failed fetch is reported as a failure, never as an unknown window:
         // both carry `window: null`, and collapsing them would make a broken
         // credential look identical to a provider that simply has no quota.
+        const label = jcodeSubProviderRateLimitLabel(subProvider);
         if (subProvider.error !== null) {
-          return `${subProvider.subProviderId}: fetch failed - ${subProvider.error}`;
+          return `${label}: fetch failed - ${subProvider.error}`;
         }
-        const line = formatWindowLine(subProvider.subProviderId, subProvider.window);
-        return subProvider.hardLimitReached ? `${line} (hard limit reached)` : line;
+        const line = formatWindowLine(label, subProvider.window);
+        return subProvider.hardLimitReached
+          ? `${line} (hard limit reached)`
+          : line;
       })
       .join("\n");
   }

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -167,6 +167,26 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
       .filter((line): line is string => line !== null)
       .join("\n");
   }
+  if (rateLimits.provider === "jcode") {
+    // jcode is a meta-harness: quota is per connected sub-provider, so this
+    // renders one line each rather than a single roll-up. An empty list is
+    // stated explicitly - an agent must not read a silent blank as headroom.
+    if (rateLimits.subProviders.length === 0) {
+      return "no connected sub-provider reported quota";
+    }
+    return rateLimits.subProviders
+      .map((subProvider) => {
+        // A failed fetch is reported as a failure, never as an unknown window:
+        // both carry `window: null`, and collapsing them would make a broken
+        // credential look identical to a provider that simply has no quota.
+        if (subProvider.error !== null) {
+          return `${subProvider.subProviderId}: fetch failed - ${subProvider.error}`;
+        }
+        const line = formatWindowLine(subProvider.subProviderId, subProvider.window);
+        return subProvider.hardLimitReached ? `${line} (hard limit reached)` : line;
+      })
+      .join("\n");
+  }
   return [
     `credit balance: ${formatNumber(rateLimits.creditBalance)}`,
     `pass: ${rateLimits.passState ?? "unknown"}`,

--- a/protocol/src/common/_internal/schemas.ts
+++ b/protocol/src/common/_internal/schemas.ts
@@ -67,4 +67,5 @@ export const harnessIdSchema = z.enum([
   "pi",
   "hermes",
   "omp",
+  "jcode",
 ]);

--- a/protocol/src/host/__tests__/__fixtures__/frozen-catalog-lines.ts
+++ b/protocol/src/host/__tests__/__fixtures__/frozen-catalog-lines.ts
@@ -595,6 +595,112 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
       ],
       "additionalProperties": false
     },
+    "agent.gui.listHarnesses@6.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "harnesses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
+                  "claude",
+                  "codex",
+                  "opencode",
+                  "traycer",
+                  "cursor",
+                  "grok",
+                  "qwen",
+                  "kiro",
+                  "droid",
+                  "kimi",
+                  "copilot",
+                  "kilocode",
+                  "openrouter",
+                  "amp",
+                  "devin",
+                  "pi",
+                  "hermes",
+                  "omp"
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "enabled": {
+                "default": true,
+                "type": "boolean"
+              },
+              "available": {
+                "type": "boolean"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "gui",
+                    "tui"
+                  ]
+                }
+              },
+              "requiresApiKey": {
+                "type": "boolean"
+              },
+              "supportedPermissionModes": {
+                "default": [
+                  "supervised",
+                  "auto_accept_edits",
+                  "full_access"
+                ],
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "supervised",
+                    "auto_accept_edits",
+                    "full_access"
+                  ]
+                }
+              },
+              "availabilityPending": {
+                "default": false,
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "label",
+              "enabled",
+              "available",
+              "error",
+              "modes",
+              "requiresApiKey",
+              "supportedPermissionModes",
+              "availabilityPending"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "harnesses"
+      ],
+      "additionalProperties": false
+    },
     "agent.list@1.0": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -1271,6 +1377,161 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                       "devin",
                       "pi",
                       "hermes"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "isSelf": {
+                "type": "boolean"
+              },
+              "title": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "capabilities": {
+                "type": "object",
+                "properties": {
+                  "readTranscript": {
+                    "type": "boolean"
+                  },
+                  "sendMessage": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "readTranscript",
+                  "sendMessage"
+                ],
+                "additionalProperties": false
+              },
+              "active": {
+                "type": "boolean"
+              },
+              "folderPaths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "isWorktree": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "parentId",
+              "hostId",
+              "isLocal",
+              "surface",
+              "harnessId",
+              "isSelf",
+              "title",
+              "capabilities",
+              "active",
+              "folderPaths",
+              "isWorktree"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "caller",
+        "scope",
+        "agents"
+      ],
+      "additionalProperties": false
+    },
+    "agent.list@6.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "caller": {
+          "type": "object",
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "canSendMessages": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "agentId",
+            "canSendMessages"
+          ],
+          "additionalProperties": false
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "user",
+            "all"
+          ]
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "parentId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "hostId": {
+                "type": "string"
+              },
+              "isLocal": {
+                "type": "boolean"
+              },
+              "surface": {
+                "type": "string",
+                "enum": [
+                  "gui",
+                  "tui"
+                ]
+              },
+              "harnessId": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "claude",
+                      "codex",
+                      "opencode",
+                      "traycer",
+                      "cursor",
+                      "grok",
+                      "qwen",
+                      "kiro",
+                      "droid",
+                      "kimi",
+                      "copilot",
+                      "kilocode",
+                      "openrouter",
+                      "amp",
+                      "devin",
+                      "pi",
+                      "hermes",
+                      "omp"
                     ]
                   },
                   {
@@ -3143,6 +3404,702 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                   "devin",
                   "pi",
                   "hermes"
+                ]
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "disabledBy": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "userId": {
+                        "type": "string"
+                      },
+                      "handle": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "at": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "userId",
+                      "handle",
+                      "at"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "selected": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "bundled"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "path"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "custom"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "path"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "candidates": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "bundled",
+                        "path",
+                        "custom"
+                      ]
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "versionPending": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "path",
+                    "version",
+                    "available",
+                    "versionPending"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "authPending": {
+                "type": "boolean"
+              },
+              "checkedAt": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "apiKey": {
+                "type": "object",
+                "properties": {
+                  "supported": {
+                    "type": "boolean"
+                  },
+                  "configured": {
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "stored",
+                          "env"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "supported",
+                  "configured",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              "terminalAgentArgs": {
+                "default": "",
+                "type": "string"
+              },
+              "envOverrides": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "loginCapability": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "oauthArgs": {
+                        "anyOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "token": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "vars": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "vars"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "codePaste": {
+                        "default": null,
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "oauthArgs",
+                      "token",
+                      "codePaste"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "availabilityPending": {
+                "default": false,
+                "type": "boolean"
+              },
+              "profiles": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "profileId": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "ambient",
+                        "managed"
+                      ]
+                    },
+                    "authType": {
+                      "type": "string",
+                      "enum": [
+                        "oauth"
+                      ]
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "auth": {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "authenticated",
+                            "unauthenticated",
+                            "configured",
+                            "unavailable",
+                            "unknown"
+                          ]
+                        },
+                        "badgeText": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "label": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "detail": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "badgeText",
+                        "label",
+                        "detail"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "identity": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "tier": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "accountUuid": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "email",
+                            "tier",
+                            "accountUuid"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "usageUpdatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "rateLimitStatus": {
+                      "default": "unknown",
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "near_limit",
+                        "hard_limit",
+                        "unknown"
+                      ]
+                    },
+                    "rateLimitLimitedScopes": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "family": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "severity": {
+                                "type": "string",
+                                "enum": [
+                                  "near_limit",
+                                  "hard_limit"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "family",
+                              "severity"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "duplicateOfProfileId": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ambientDriftNotice": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "previousEmail": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "changedAt": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "previousEmail",
+                            "changedAt"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "accentColor": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "#ef4444",
+                            "#f97316",
+                            "#f59e0b",
+                            "#84cc16",
+                            "#10b981",
+                            "#14b8a6",
+                            "#06b6d4",
+                            "#3b82f6",
+                            "#8b5cf6",
+                            "#a855f7",
+                            "#d946ef",
+                            "#ec4899"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "reusedTombstone": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "accentColor": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "#ef4444",
+                                    "#f97316",
+                                    "#f59e0b",
+                                    "#84cc16",
+                                    "#10b981",
+                                    "#14b8a6",
+                                    "#06b6d4",
+                                    "#3b82f6",
+                                    "#8b5cf6",
+                                    "#a855f7",
+                                    "#d946ef",
+                                    "#ec4899"
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "label",
+                            "accentColor"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "profileId",
+                    "kind",
+                    "authType",
+                    "label",
+                    "auth",
+                    "identity",
+                    "usageUpdatedAt",
+                    "rateLimitStatus",
+                    "rateLimitLimitedScopes",
+                    "duplicateOfProfileId",
+                    "ambientDriftNotice",
+                    "accentColor"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "auth": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "authenticated",
+                      "unauthenticated",
+                      "configured",
+                      "unavailable",
+                      "unknown"
+                    ]
+                  },
+                  "badgeText": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "detail": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "status",
+                  "badgeText",
+                  "label",
+                  "detail"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "providerId",
+              "enabled",
+              "disabledBy",
+              "selected",
+              "candidates",
+              "authPending",
+              "checkedAt",
+              "apiKey",
+              "terminalAgentArgs",
+              "envOverrides",
+              "loginCapability",
+              "availabilityPending",
+              "profiles",
+              "auth"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "providers"
+      ],
+      "additionalProperties": false
+    },
+    "providers.list@6.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "providerId": {
+                "type": "string",
+                "enum": [
+                  "claude-code",
+                  "codex",
+                  "opencode",
+                  "cursor",
+                  "traycer",
+                  "grok",
+                  "qwen",
+                  "kiro",
+                  "droid",
+                  "kimi",
+                  "copilot",
+                  "kilocode",
+                  "openrouter",
+                  "amp",
+                  "devin",
+                  "pi",
+                  "hermes",
+                  "omp"
                 ]
               },
               "enabled": {

--- a/protocol/src/host/__tests__/frozen-catalog-lines.test.ts
+++ b/protocol/src/host/__tests__/frozen-catalog-lines.test.ts
@@ -6,6 +6,7 @@ import {
   listAgentsResponseSchemaV30,
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
+  listAgentsResponseSchemaV60,
 } from "@traycer/protocol/host/agent/shared";
 import {
   listGuiHarnessesResponseSchemaV10,
@@ -14,6 +15,7 @@ import {
   listGuiHarnessesResponseSchemaV30,
   listGuiHarnessesResponseSchemaV40,
   listGuiHarnessesResponseSchemaV50,
+  listGuiHarnessesResponseSchemaV60,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   providersListResponseSchemaV10,
@@ -21,6 +23,7 @@ import {
   providersListResponseSchemaV30,
   providersListResponseSchemaV40,
   providersListResponseSchemaV50,
+  providersListResponseSchemaV60,
 } from "@traycer/protocol/host/provider-schemas";
 import { FROZEN_CATALOG_LINE_SNAPSHOTS } from "./__fixtures__/frozen-catalog-lines";
 
@@ -47,16 +50,19 @@ const LIVE_FROZEN_EXPORTS = {
   "agent.gui.listHarnesses@3.0": listGuiHarnessesResponseSchemaV30,
   "agent.gui.listHarnesses@4.0": listGuiHarnessesResponseSchemaV40,
   "agent.gui.listHarnesses@5.0": listGuiHarnessesResponseSchemaV50,
+  "agent.gui.listHarnesses@6.0": listGuiHarnessesResponseSchemaV60,
   "agent.list@1.0": listAgentsResponseSchemaV10,
   "agent.list@2.0": listAgentsResponseSchemaV20,
   "agent.list@3.0": listAgentsResponseSchemaV30,
   "agent.list@4.0": listAgentsResponseSchemaV40,
   "agent.list@5.0": listAgentsResponseSchemaV50,
+  "agent.list@6.0": listAgentsResponseSchemaV60,
   "providers.list@1.0": providersListResponseSchemaV10,
   "providers.list@2.0": providersListResponseSchemaV20,
   "providers.list@3.0": providersListResponseSchemaV30,
   "providers.list@4.0": providersListResponseSchemaV40,
   "providers.list@5.0": providersListResponseSchemaV50,
+  "providers.list@6.0": providersListResponseSchemaV60,
 } as const;
 
 describe("frozen catalog line snapshots", () => {

--- a/protocol/src/host/__tests__/list-harnesses-enabled-compat.test.ts
+++ b/protocol/src/host/__tests__/list-harnesses-enabled-compat.test.ts
@@ -106,7 +106,7 @@ describe("frozen agent.gui.listHarnesses lines predate enabled/availabilityPendi
     // value so 2.1 callers are never fed a fabricated default.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["agent.gui.listHarnesses"],
-      6,
+      7,
       2,
       { harnesses: [harnessRow("claude", false)] },
     );
@@ -125,7 +125,7 @@ describe("frozen agent.gui.listHarnesses lines predate enabled/availabilityPendi
   it("latest → major-1 downgrade strips both fields before the frozen 1.0 parse", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["agent.gui.listHarnesses"],
-      6,
+      7,
       1,
       { harnesses: [harnessRow("claude", false)] },
     );

--- a/protocol/src/host/__tests__/provider-registry-fields-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-registry-fields-compat.test.ts
@@ -240,14 +240,17 @@ describe("old-client behavior on the error arm", () => {
     },
   });
 
-  it.each([1, 2, 3, 4, 5] as const)(
-    "v6.0 -> v%i.0 strips the error arm instead of failing the downgrade",
+  it.each([1, 2, 3, 4, 5, 6] as const)(
+    "v7.0 -> v%i.0 strips the error arm instead of failing the downgrade",
     (targetMajor) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        6,
+        7,
         targetMajor,
-        { providers: [erroredState] },
+        // Sourced from v7.0, the live line the host actually produces: the
+        // registry fields (and `native`) only exist there, and v6.0 froze
+        // before any of them.
+        { providers: [erroredState], native: null },
       );
       expect(downgraded.ok).toBe(true);
       if (!downgraded.ok) return;
@@ -437,9 +440,9 @@ describe("providers.list latest -> v2.0/v3.0 downgrade strips the new fields", (
   it("latest -> v2.0 downgrade never leaks the new fields to a v2.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      6,
+      7,
       2,
-      { providers: [stateWithRegistryFields] },
+      { providers: [stateWithRegistryFields], native: null },
     );
     expect(downgraded.ok).toBe(true);
     if (!downgraded.ok) return;
@@ -453,9 +456,9 @@ describe("providers.list latest -> v2.0/v3.0 downgrade strips the new fields", (
   it("latest -> v3.0 downgrade never leaks the new fields to a v3.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      6,
+      7,
       3,
-      { providers: [stateWithRegistryFields] },
+      { providers: [stateWithRegistryFields], native: null },
     );
     expect(downgraded.ok).toBe(true);
     if (!downgraded.ok) return;
@@ -589,16 +592,16 @@ describe("providers.list v6.0 is frozen against the registry fields", () => {
 });
 
 describe("providers.list v5.0 is frozen against the registry fields", () => {
-  it("v5.0 does not model them, so a v6.0 -> v5.0 downgrade strips them", () => {
+  it("v5.0 does not model them, so a v7.0 -> v5.0 downgrade strips them", () => {
     // `cli-v1.1.8` shipped v5.0. Growing it is the same defect class as the
     // original mutation-echo break, on the carrier line itself. v5.0 pins the
     // frozen v4.0 base shape precisely so a field added to the LIVE base shape
     // cannot reach it.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      6,
+      7,
       5,
-      { providers: [stateWithRegistryFields] },
+      { providers: [stateWithRegistryFields], native: null },
     );
     expect(downgraded.ok).toBe(true);
     if (!downgraded.ok) return;

--- a/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
@@ -1146,6 +1146,7 @@ describe("jcode v4.0 profile-method bridges", () => {
             subProviders: [
               {
                 subProviderId: "openrouter",
+                limitName: "Credits",
                 window: {
                   usedPercent: 99.607,
                   resetsAt: null,

--- a/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
@@ -11,6 +11,9 @@ import {
   agentConfigureDowngradeV20ToV10,
   agentConfigureDowngradeV30ToV10,
   agentConfigureDowngradeV30ToV20,
+  agentConfigureDowngradeV40ToV10,
+  agentConfigureDowngradeV40ToV20,
+  agentConfigureDowngradeV40ToV30,
   agentConfigureUpgradeV10ToV20,
   agentCreateDowngradeV20ToV10,
   agentCreateUpgradeV10ToV20,
@@ -18,12 +21,18 @@ import {
   agentGetProviderProfileRateLimitsDowngradeV20ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV20,
+  agentGetProviderProfileRateLimitsDowngradeV40ToV10,
+  agentGetProviderProfileRateLimitsDowngradeV40ToV20,
+  agentGetProviderProfileRateLimitsDowngradeV40ToV30,
   agentGetProviderProfileRateLimitsRequestSchema,
   agentGetProviderProfileRateLimitsResponseSchema,
   agentGetProviderProfileRateLimitsUpgradeV10ToV20,
   agentListProviderProfilesDowngradeV20ToV10,
   agentListProviderProfilesDowngradeV30ToV10,
   agentListProviderProfilesDowngradeV30ToV20,
+  agentListProviderProfilesDowngradeV40ToV10,
+  agentListProviderProfilesDowngradeV40ToV20,
+  agentListProviderProfilesDowngradeV40ToV30,
   agentListProviderProfilesRequestSchema,
   agentListProviderProfilesResponseSchema,
   agentListProviderProfilesUpgradeV10ToV20,
@@ -34,7 +43,9 @@ import {
   createAgentRequestSchemaV30,
   hostRpcRegistry,
   profileSelectionSchema,
+  type GuiHarnessId,
 } from "@traycer/protocol/host/index";
+import type { ProviderId } from "@traycer/protocol/host/provider-ids";
 import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
 
 describe("ProfileSelection / ConcreteProfileSelection schemas", () => {
@@ -570,17 +581,17 @@ describe("optional-method capability negotiation", () => {
       split.manifest["agent.getProviderProfileRateLimits"],
     ).toBeUndefined();
     expect(split.manifest["agent.configure"]).toBeUndefined();
-    // v3.0 is the advertised latest: the v1.1.8 tags froze v2.0 with the
-    // pre-omp id sets, so omp opened a new major on all three methods.
+    // v4.0 is the advertised latest: the v1.1.9 tags froze v3.0 with the
+    // pre-jcode id sets, so jcode opened a new major on all three methods.
     expect(split.optionalManifest["agent.listProviderProfiles"]).toEqual({
-      major: 3,
+      major: 4,
       minor: 0,
     });
     expect(
       split.optionalManifest["agent.getProviderProfileRateLimits"],
-    ).toEqual({ major: 3, minor: 0 });
+    ).toEqual({ major: 4, minor: 0 });
     expect(split.optionalManifest["agent.configure"]).toEqual({
-      major: 3,
+      major: 4,
       minor: 0,
     });
   });
@@ -1019,5 +1030,211 @@ describe("agent.configure v1 <-> v2 hermes-harness response translation", () => 
     expect(downgraded.ok).toBe(false);
     if (downgraded.ok) return;
     expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
+  });
+});
+
+// ─── jcode: the v4.0 line on all three profile methods ─────────────────────
+//
+// These bridges exist because `cli-v1.1.9` shipped v3.0 - but v3.0 was still
+// WIRED to the live response until the jcode work froze it, so before that
+// repair these three methods absorbed `jcode` at an already-released version
+// and no bridge ran at all. A mutation probe against the released baselines
+// confirmed exactly that: reverting the freeze produces blocking findings on
+// `agent.listProviderProfiles@3.0`, `agent.getProviderProfileRateLimits@3.0`
+// and `agent.configure@3.0`.
+//
+// Every assertion below matches on the STABLE part of the fail-closed message
+// ("newer Traycer client"), never a provider or harness name: a message naming
+// one vendor is only ever correct for the first id added after a freeze.
+describe("jcode v4.0 profile-method bridges", () => {
+  const profilesResponse = {
+    providerId: "codex" as const,
+    profiles: [
+      {
+        selection: { kind: "ambient" as const },
+        label: "Terminal account",
+        authStatus: "authenticated" as const,
+        rateLimitStatus: "unknown" as const,
+        usageUpdatedAt: null,
+        isEffectiveLastUsed: false,
+      },
+    ],
+  };
+
+  describe("agent.listProviderProfiles", () => {
+    it("passes an omp response through the v4->v3 downgrade (v3.0 shipped with omp)", () => {
+      const response = { ...profilesResponse, providerId: "omp" as const };
+      const downgraded =
+        agentListProviderProfilesDowngradeV40ToV30.downgradeResponse(response);
+      expect(downgraded).toEqual({ ok: true, value: response });
+    });
+
+    it.each([3, 2, 1] as const)(
+      "fails closed downgrading a jcode response to v%i.0",
+      (targetMajor) => {
+        const bridge = {
+          3: agentListProviderProfilesDowngradeV40ToV30,
+          2: agentListProviderProfilesDowngradeV40ToV20,
+          1: agentListProviderProfilesDowngradeV40ToV10,
+        }[targetMajor];
+        const downgraded = bridge.downgradeResponse({
+          ...profilesResponse,
+          providerId: "jcode",
+        });
+        expect(downgraded.ok).toBe(false);
+        if (downgraded.ok) return;
+        expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
+        expect(downgraded.error.message).toMatch(/newer Traycer client/i);
+        expect(downgraded.error.message).not.toMatch(/jcode/i);
+      },
+    );
+  });
+
+  describe("agent.getProviderProfileRateLimits", () => {
+    const unavailable = (provider: ProviderId) => ({
+      rateLimits: {
+        provider,
+        available: false as const,
+        reason: "timeout" as const,
+      },
+      usageUpdatedAt: null,
+    });
+
+    it("passes an omp read through the v4->v3 downgrade (v3.0 shipped with omp)", () => {
+      const response = unavailable("omp");
+      const downgraded =
+        agentGetProviderProfileRateLimitsDowngradeV40ToV30.downgradeResponse(
+          response,
+        );
+      expect(downgraded).toEqual({ ok: true, value: response });
+    });
+
+    it.each([3, 2, 1] as const)(
+      "fails closed downgrading a jcode UNAVAILABLE read to v%i.0",
+      (targetMajor) => {
+        const bridge = {
+          3: agentGetProviderProfileRateLimitsDowngradeV40ToV30,
+          2: agentGetProviderProfileRateLimitsDowngradeV40ToV20,
+          1: agentGetProviderProfileRateLimitsDowngradeV40ToV10,
+        }[targetMajor];
+        const downgraded = bridge.downgradeResponse(unavailable("jcode"));
+        expect(downgraded.ok).toBe(false);
+        if (downgraded.ok) return;
+        expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
+        expect(downgraded.error.message).toMatch(/newer Traycer client/i);
+      },
+    );
+
+    // The arm the issue said would never exist. jcode DOES expose a real quota
+    // API, so it populates `available: true` with a per-sub-provider list - and
+    // that arm is unrepresentable in every frozen union, so it must fail closed
+    // rather than degrade. Degrading to `{ available: false, provider: "jcode" }`
+    // would not help either: the frozen unions pin `providerIdSchemaV40/50/60`,
+    // none of which contain `jcode`.
+    it.each([3, 2, 1] as const)(
+      "fails closed downgrading a jcode AVAILABLE read to v%i.0",
+      (targetMajor) => {
+        const bridge = {
+          3: agentGetProviderProfileRateLimitsDowngradeV40ToV30,
+          2: agentGetProviderProfileRateLimitsDowngradeV40ToV20,
+          1: agentGetProviderProfileRateLimitsDowngradeV40ToV10,
+        }[targetMajor];
+        const downgraded = bridge.downgradeResponse({
+          rateLimits: {
+            provider: "jcode" as const,
+            available: true as const,
+            subProviders: [
+              {
+                subProviderId: "openrouter",
+                window: {
+                  usedPercent: 99.607,
+                  resetsAt: null,
+                  durationMinutes: null,
+                },
+                hardLimitReached: false,
+                error: null,
+              },
+            ],
+          },
+          usageUpdatedAt: null,
+        });
+        expect(downgraded.ok).toBe(false);
+        if (downgraded.ok) return;
+        expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
+      },
+    );
+  });
+
+  describe("agent.configure", () => {
+    const settings = (harnessId: GuiHarnessId) => ({
+      harnessId,
+      model: "opus-4.7",
+      profileSelection: { kind: "ambient" as const },
+      reasoningEffort: null,
+      fastMode: false,
+      permissionMode: "supervised" as const,
+      agentMode: "regular" as const,
+    });
+
+    it("passes an omp-configured response through the v4->v3 downgrade", () => {
+      const response = { settings: settings("omp"), warnings: [] };
+      const downgraded =
+        agentConfigureDowngradeV40ToV30.downgradeResponse(response);
+      expect(downgraded).toEqual({ ok: true, value: response });
+    });
+
+    it.each([3, 2, 1] as const)(
+      "fails closed downgrading a jcode-configured response to v%i.0",
+      (targetMajor) => {
+        const bridge = {
+          3: agentConfigureDowngradeV40ToV30,
+          2: agentConfigureDowngradeV40ToV20,
+          1: agentConfigureDowngradeV40ToV10,
+        }[targetMajor];
+        const downgraded = bridge.downgradeResponse({
+          settings: settings("jcode"),
+          warnings: [],
+        });
+        expect(downgraded.ok).toBe(false);
+        if (downgraded.ok) return;
+        expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
+        expect(downgraded.error.message).toMatch(/newer Traycer client/i);
+        expect(downgraded.error.message).not.toMatch(/jcode/i);
+      },
+    );
+
+    it("keeps the v4->v3 REQUEST downgrade open (v4.0 added no request field)", () => {
+      // Unlike the v*->v1 bridges, which must refuse because v1.0 has no
+      // `permissionMode`, v4.0 reuses the v2.0 request shape verbatim.
+      const downgraded = agentConfigureDowngradeV40ToV30.downgradeRequest({
+        epicId: "e",
+        senderAgentId: "s",
+        agentId: "a",
+        harnessId: "claude",
+        model: "opus-4.7",
+        profileSelection: { kind: "ambient" },
+        reasoningEffort: null,
+        fastMode: false,
+        permissionMode: "supervised",
+      });
+      expect(downgraded.ok).toBe(true);
+    });
+
+    it("still refuses the v4->v1 request downgrade", () => {
+      const downgraded = agentConfigureDowngradeV40ToV10.downgradeRequest({
+        epicId: "e",
+        senderAgentId: "s",
+        agentId: "a",
+        harnessId: "claude",
+        model: "opus-4.7",
+        profileSelection: { kind: "ambient" },
+        reasoningEffort: null,
+        fastMode: false,
+        permissionMode: "supervised",
+      });
+      expect(downgraded.ok).toBe(false);
+      if (downgraded.ok) return;
+      expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
+    });
   });
 });

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -30,11 +30,13 @@ import {
   listAgentsResponseSchemaV30,
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
+  listAgentsResponseSchemaV60,
   agentSummarySchemaV10,
   agentSummarySchemaV20,
   agentSummarySchemaV30,
   agentSummarySchemaV40,
   agentSummarySchemaV50,
+  agentSummarySchemaV60,
   sendAgentMessageRequestSchema,
   sendAgentMessageResponseSchema,
   stopAgentRequestSchema,
@@ -586,7 +588,12 @@ export const agentListV60 = defineRpcContract({
   method: "agent.list",
   schemaVersion: { major: 6, minor: 0 } as const,
   requestSchema: listAgentsRequestSchema,
-  responseSchema: listAgentsResponseSchema,
+  // Frozen: the v1.1.9 tags shipped this line, so it must serve the v6.0
+  // harness id set rather than the live one. Until this repair it still pointed
+  // at the canonical schema - the same defect that let `omp` first ride v5.0,
+  // one version later and unnoticed because the release froze the line without
+  // anyone repointing it.
+  responseSchema: listAgentsResponseSchemaV60,
 });
 
 export const agentListUpgradeV5ToV6 = defineUpgradePath<
@@ -685,6 +692,142 @@ export const agentListDowngradeV6ToV1 = defineDowngradePath<
   typeof agentListV10
 >({
   from: { major: 6, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV10.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV10.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListV70 = defineRpcContract({
+  method: "agent.list",
+  schemaVersion: { major: 7, minor: 0 } as const,
+  requestSchema: listAgentsRequestSchema,
+  responseSchema: listAgentsResponseSchema,
+});
+
+export const agentListUpgradeV6ToV7 = defineUpgradePath<
+  typeof agentListV60,
+  typeof agentListV70
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 7, minor: 0 },
+  // A v6.0 response without jcode agents is a valid v7.0 response (purely
+  // additive), and the request shape is identical - both upgrades are
+  // identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListDowngradeV7ToV6 = defineDowngradePath<
+  typeof agentListV70,
+  typeof agentListV60
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop jcode agents so an already-shipped v6.0 client's strict decode never
+  // sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV60.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV60.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV7ToV5 = defineDowngradePath<
+  typeof agentListV70,
+  typeof agentListV50
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop omp/jcode agents so an already-shipped v5.0 client's strict decode
+  // never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV50.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV50.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV7ToV4 = defineDowngradePath<
+  typeof agentListV70,
+  typeof agentListV40
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Hermes/omp/jcode agents so an already-shipped v4.0 client's strict
+  // decode never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV40.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV40.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV7ToV3 = defineDowngradePath<
+  typeof agentListV70,
+  typeof agentListV30
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Devin/Pi/Hermes/omp/jcode agents so an already-shipped v3.0 client's
+  // strict decode never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV30.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV30.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV7ToV2 = defineDowngradePath<
+  typeof agentListV70,
+  typeof agentListV20
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV20.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV20.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV7ToV1 = defineDowngradePath<
+  typeof agentListV70,
+  typeof agentListV10
+>({
+  from: { major: 7, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
   downgradeResponse: (response) => ({

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -16,6 +16,12 @@ import {
   agentListDowngradeV6ToV3,
   agentListDowngradeV6ToV4,
   agentListDowngradeV6ToV5,
+  agentListDowngradeV7ToV1,
+  agentListDowngradeV7ToV2,
+  agentListDowngradeV7ToV3,
+  agentListDowngradeV7ToV4,
+  agentListDowngradeV7ToV5,
+  agentListDowngradeV7ToV6,
 } from "@traycer/protocol/host/agent/contracts";
 import {
   listAgentsResponseSchema,
@@ -24,6 +30,7 @@ import {
   listAgentsResponseSchemaV30,
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
+  listAgentsResponseSchemaV60,
 } from "@traycer/protocol/host/agent/shared";
 import {
   agentGuiListHarnessesDowngradeV2ToV1,
@@ -41,6 +48,12 @@ import {
   agentGuiListHarnessesDowngradeV6ToV3,
   agentGuiListHarnessesDowngradeV6ToV4,
   agentGuiListHarnessesDowngradeV6ToV5,
+  agentGuiListHarnessesDowngradeV7ToV1,
+  agentGuiListHarnessesDowngradeV7ToV2,
+  agentGuiListHarnessesDowngradeV7ToV3,
+  agentGuiListHarnessesDowngradeV7ToV4,
+  agentGuiListHarnessesDowngradeV7ToV5,
+  agentGuiListHarnessesDowngradeV7ToV6,
 } from "@traycer/protocol/host/agent/gui/contracts";
 import {
   guiHarnessOptionSchema,
@@ -51,6 +64,7 @@ import {
   listGuiHarnessesResponseSchemaV30,
   listGuiHarnessesResponseSchemaV40,
   listGuiHarnessesResponseSchemaV50,
+  listGuiHarnessesResponseSchemaV60,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   PROVIDER_AUTH_STATUS_SCHEMA,
@@ -62,12 +76,13 @@ import {
   providersListResponseSchemaV30,
   providersListResponseSchemaV40,
   providersListResponseSchemaV50,
+  providersListResponseSchemaV60,
   providersSetApiKeyResponseSchemaV10,
 } from "@traycer/protocol/host/provider-schemas";
 // Importing from the registry runs `defineVersionedRpcRegistry` (full structural
 // + schema-compatibility validation) at module load, so this import alone
-// asserts the new v2.0/v3.0/v4.0/v5.0/v6.0 lines and their upgrade/downgrade
-// bridges are well-formed.
+// asserts the new v2.0/v3.0/v4.0/v5.0/v6.0/v7.0 lines and their
+// upgrade/downgrade bridges are well-formed.
 import {
   providersAwaitLoginDowngradeV21ToV10,
   providersListDowngradeV2ToV1,
@@ -83,6 +98,12 @@ import {
   providersListDowngradeV6ToV3,
   providersListDowngradeV6ToV4,
   providersListDowngradeV6ToV5,
+  providersListDowngradeV7ToV1,
+  providersListDowngradeV7ToV2,
+  providersListDowngradeV7ToV3,
+  providersListDowngradeV7ToV4,
+  providersListDowngradeV7ToV5,
+  providersListDowngradeV7ToV6,
   providersSetApiKeyDowngradeV21ToV10,
 } from "@traycer/protocol/host/registry";
 
@@ -413,7 +434,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       ],
     });
 
-    const toV3 = providersListDowngradeV6ToV3.downgradeResponse(liveResponse);
+    const toV3 = providersListDowngradeV7ToV3.downgradeResponse(liveResponse);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -423,7 +444,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       providersListResponseSchemaV30.parse(toV3.value),
     ).not.toThrow();
 
-    const toV2 = providersListDowngradeV6ToV2.downgradeResponse(liveResponse);
+    const toV2 = providersListDowngradeV7ToV2.downgradeResponse(liveResponse);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -433,7 +454,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       providersListResponseSchemaV20.parse(toV2.value),
     ).not.toThrow();
 
-    const toV1 = providersListDowngradeV6ToV1.downgradeResponse(liveResponse);
+    const toV1 = providersListDowngradeV7ToV1.downgradeResponse(liveResponse);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -579,12 +600,18 @@ describe("post-v3.0 Devin/Pi downgrade bridges (agent.gui.listHarnesses/agent.li
   });
 });
 
-describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
-  // These three catalog methods all had to open a new major when the v1.1.8
-  // tags froze their previous line: omp cannot ride a released version, so
-  // the live shape sits on v6.0 and every older caller gets omp filtered out.
-  it("drops omp from agent.gui.listHarnesses for every released caller down to v1.0", () => {
-    const v6Response = listGuiHarnessesResponseSchema.parse({
+describe("post-v6.0 jcode non-breaking downgrade bridges", () => {
+  // These three catalog methods all had to open a new major when the v1.1.9
+  // tags froze their previous line: jcode cannot ride a released version, so
+  // the live shape sits on v7.0 and every older caller gets jcode filtered out.
+  //
+  // v6.0 is the interesting new row. It was released by `cli-v1.1.9` but two of
+  // these three methods still served the LIVE response until the jcode work
+  // repaired them, so "v6.0 keeps omp and loses only jcode" is precisely the
+  // assertion that was impossible to state before - a live-bound v6.0 would
+  // have carried jcode straight through.
+  it("drops jcode from agent.gui.listHarnesses for every released caller down to v1.0", () => {
+    const v7Response = listGuiHarnessesResponseSchema.parse({
       harnesses: [
         harnessOption("claude"),
         harnessOption("cursor"),
@@ -593,12 +620,30 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
         harnessOption("pi"),
         harnessOption("hermes"),
         harnessOption("omp"),
+        harnessOption("jcode"),
       ],
     });
 
-    // v5.0 shipped with Hermes, so it keeps Hermes and loses only omp.
+    // v6.0 shipped with omp, so it keeps omp and loses only jcode.
+    const toV6 =
+      agentGuiListHarnessesDowngradeV7ToV6.downgradeResponse(v7Response);
+    expect(toV6.ok).toBe(true);
+    if (!toV6.ok) return;
+    expect(toV6.value.harnesses.map((harness) => harness.id)).toEqual([
+      "claude",
+      "cursor",
+      "amp",
+      "devin",
+      "pi",
+      "hermes",
+      "omp",
+    ]);
+    expect(() =>
+      listGuiHarnessesResponseSchemaV60.parse(toV6.value),
+    ).not.toThrow();
+
     const toV5 =
-      agentGuiListHarnessesDowngradeV6ToV5.downgradeResponse(v6Response);
+      agentGuiListHarnessesDowngradeV7ToV5.downgradeResponse(v7Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -614,7 +659,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV4 =
-      agentGuiListHarnessesDowngradeV6ToV4.downgradeResponse(v6Response);
+      agentGuiListHarnessesDowngradeV7ToV4.downgradeResponse(v7Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -629,7 +674,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV3 =
-      agentGuiListHarnessesDowngradeV6ToV3.downgradeResponse(v6Response);
+      agentGuiListHarnessesDowngradeV7ToV3.downgradeResponse(v7Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -642,7 +687,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV2 =
-      agentGuiListHarnessesDowngradeV6ToV2.downgradeResponse(v6Response);
+      agentGuiListHarnessesDowngradeV7ToV2.downgradeResponse(v7Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -654,7 +699,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV1 =
-      agentGuiListHarnessesDowngradeV6ToV1.downgradeResponse(v6Response);
+      agentGuiListHarnessesDowngradeV7ToV1.downgradeResponse(v7Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -666,8 +711,8 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ).not.toThrow();
   });
 
-  it("drops omp agents from agent.list for every released caller down to v1.0", () => {
-    const v6Response = listAgentsResponseSchema.parse({
+  it("drops jcode agents from agent.list for every released caller down to v1.0", () => {
+    const v7Response = listAgentsResponseSchema.parse({
       caller: { agentId: "self", canSendMessages: true },
       scope: "all",
       agents: [
@@ -677,12 +722,27 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
         agentSummary("a-pi", "pi"),
         agentSummary("a-hermes", "hermes"),
         agentSummary("a-omp", "omp"),
+        agentSummary("a-jcode", "jcode"),
         agentSummary("a-null", null),
       ],
     });
 
-    // v5.0 shipped with Hermes, so a Hermes agent row survives; only omp goes.
-    const toV5 = agentListDowngradeV6ToV5.downgradeResponse(v6Response);
+    // v6.0 shipped with omp, so an omp agent row survives; only jcode goes.
+    const toV6 = agentListDowngradeV7ToV6.downgradeResponse(v7Response);
+    expect(toV6.ok).toBe(true);
+    if (!toV6.ok) return;
+    expect(toV6.value.agents.map((agent) => agent.id)).toEqual([
+      "a-claude",
+      "a-amp",
+      "a-devin",
+      "a-pi",
+      "a-hermes",
+      "a-omp",
+      "a-null",
+    ]);
+    expect(() => listAgentsResponseSchemaV60.parse(toV6.value)).not.toThrow();
+
+    const toV5 = agentListDowngradeV7ToV5.downgradeResponse(v7Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.agents.map((agent) => agent.id)).toEqual([
@@ -695,7 +755,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ]);
     expect(() => listAgentsResponseSchemaV50.parse(toV5.value)).not.toThrow();
 
-    const toV4 = agentListDowngradeV6ToV4.downgradeResponse(v6Response);
+    const toV4 = agentListDowngradeV7ToV4.downgradeResponse(v7Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.agents.map((agent) => agent.id)).toEqual([
@@ -707,7 +767,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ]);
     expect(() => listAgentsResponseSchemaV40.parse(toV4.value)).not.toThrow();
 
-    const toV3 = agentListDowngradeV6ToV3.downgradeResponse(v6Response);
+    const toV3 = agentListDowngradeV7ToV3.downgradeResponse(v7Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.agents.map((agent) => agent.id)).toEqual([
@@ -717,7 +777,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ]);
     expect(() => listAgentsResponseSchemaV30.parse(toV3.value)).not.toThrow();
 
-    const toV2 = agentListDowngradeV6ToV2.downgradeResponse(v6Response);
+    const toV2 = agentListDowngradeV7ToV2.downgradeResponse(v7Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.agents.map((agent) => agent.id)).toEqual([
@@ -726,7 +786,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     ]);
     expect(() => listAgentsResponseSchemaV20.parse(toV2.value)).not.toThrow();
 
-    const toV1 = agentListDowngradeV6ToV1.downgradeResponse(v6Response);
+    const toV1 = agentListDowngradeV7ToV1.downgradeResponse(v7Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.agents.map((agent) => agent.id)).toEqual([
@@ -736,10 +796,10 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
     expect(() => listAgentsResponseSchemaV10.parse(toV1.value)).not.toThrow();
   });
 
-  it("drops omp from providers.list for every released caller down to v1.0", () => {
-    // v6.0 is the live line: `cli-v1.1.8` shipped v5.0, so omp could not join
-    // it and every v5.0-and-older caller must have omp filtered out.
-    const v6Response = providersListResponseSchema.parse({
+  it("drops jcode from providers.list for every released caller down to v1.0", () => {
+    // v7.0 is the live line: `cli-v1.1.9` shipped v6.0, so jcode could not join
+    // it and every v6.0-and-older caller must have jcode filtered out.
+    const v7Response = providersListResponseSchema.parse({
       providers: [
         providerState("cursor", "unknown"),
         providerState("amp", "unknown"),
@@ -747,20 +807,25 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
         providerState("pi", "unknown"),
         providerState("hermes", "unknown"),
         providerState("omp", "unknown"),
+        providerState("jcode", "unknown"),
       ],
     });
 
-    const toV4 = providersListDowngradeV6ToV4.downgradeResponse(v6Response);
-    expect(toV4.ok).toBe(true);
-    if (!toV4.ok) return;
-    expect(toV4.value.providers.map((provider) => provider.providerId)).toEqual(
-      ["cursor", "amp", "devin", "pi"],
+    // The v7 -> v6 hop used to be a straight reparse (the two id sets were
+    // identical, so it only had to strip the registry fields). With jcode on
+    // the live enum it must FILTER first - an unfiltered reparse would throw
+    // on the jcode row rather than drop it.
+    const toV6 = providersListDowngradeV7ToV6.downgradeResponse(v7Response);
+    expect(toV6.ok).toBe(true);
+    if (!toV6.ok) return;
+    expect(toV6.value.providers.map((provider) => provider.providerId)).toEqual(
+      ["cursor", "amp", "devin", "pi", "hermes", "omp"],
     );
     expect(() =>
-      providersListResponseSchemaV40.parse(toV4.value),
+      providersListResponseSchemaV60.parse(toV6.value),
     ).not.toThrow();
 
-    const toV5 = providersListDowngradeV6ToV5.downgradeResponse(v6Response);
+    const toV5 = providersListDowngradeV7ToV5.downgradeResponse(v7Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -770,7 +835,17 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
       providersListResponseSchemaV50.parse(toV5.value),
     ).not.toThrow();
 
-    const toV3 = providersListDowngradeV6ToV3.downgradeResponse(v6Response);
+    const toV4 = providersListDowngradeV7ToV4.downgradeResponse(v7Response);
+    expect(toV4.ok).toBe(true);
+    if (!toV4.ok) return;
+    expect(toV4.value.providers.map((provider) => provider.providerId)).toEqual(
+      ["cursor", "amp", "devin", "pi"],
+    );
+    expect(() =>
+      providersListResponseSchemaV40.parse(toV4.value),
+    ).not.toThrow();
+
+    const toV3 = providersListDowngradeV7ToV3.downgradeResponse(v7Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -780,7 +855,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
       providersListResponseSchemaV30.parse(toV3.value),
     ).not.toThrow();
 
-    const toV2 = providersListDowngradeV6ToV2.downgradeResponse(v6Response);
+    const toV2 = providersListDowngradeV7ToV2.downgradeResponse(v7Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -790,7 +865,7 @@ describe("post-v4.0 Hermes/omp non-breaking downgrade bridges", () => {
       providersListResponseSchemaV20.parse(toV2.value),
     ).not.toThrow();
 
-    const toV1 = providersListDowngradeV6ToV1.downgradeResponse(v6Response);
+    const toV1 = providersListDowngradeV7ToV1.downgradeResponse(v7Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.providers.map((provider) => provider.providerId)).toEqual(

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -946,6 +946,15 @@ export const ompUserMessageAnchorResolvedSchema = z.object({
   ompSessionId: z.string().nullable(),
 });
 
+export const jcodeUserMessageAnchorResolvedSchema = z.object({
+  harnessId: z.literal("jcode"),
+  sessionId: z.string(),
+  // The ACP session id the `jcode acp` process assigned for this turn. Null
+  // until `session/new` resolves; used to resume the same jcode session on a
+  // later turn.
+  jcodeSessionId: z.string().nullable(),
+});
+
 export const userMessageAnchorResolvedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("user_message.anchor_resolved"),
@@ -969,6 +978,7 @@ export const userMessageAnchorResolvedEventSchema = z.object({
     piUserMessageAnchorResolvedSchema,
     hermesUserMessageAnchorResolvedSchema,
     ompUserMessageAnchorResolvedSchema,
+    jcodeUserMessageAnchorResolvedSchema,
   ]),
 });
 export type UserMessageAnchorResolvedEvent = z.infer<

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -18,11 +18,13 @@ import {
   listGuiHarnessesResponseSchemaV30,
   listGuiHarnessesResponseSchemaV40,
   listGuiHarnessesResponseSchemaV50,
+  listGuiHarnessesResponseSchemaV60,
   guiHarnessOptionSchemaV10,
   guiHarnessOptionSchemaV21,
   guiHarnessOptionSchemaV30,
   guiHarnessOptionSchemaV40,
   guiHarnessOptionSchemaV50,
+  guiHarnessOptionSchemaV60,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   chatSubscribeV10,
@@ -39,8 +41,9 @@ import {
 // harness ids would reach every caller. v1.0 is frozen without the ACP GUI
 // harnesses; v2.0 carries them and is frozen without Amp; v3.0 carries Amp and
 // is frozen without Devin/Pi; v4.0 carries Devin/Pi and is frozen without
-// Hermes; v5.0 carries Hermes and is frozen without omp; v6.0 carries omp.
-// Bridges drop ids an older caller can't decode.
+// Hermes; v5.0 carries Hermes and is frozen without omp; v6.0 carries omp and
+// is frozen without jcode; v7.0 carries jcode. Bridges drop ids an older caller
+// can't decode.
 export const agentGuiListHarnessesV10 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 1, minor: 0 } as const,
@@ -357,7 +360,13 @@ export const agentGuiListHarnessesV60 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 6, minor: 0 } as const,
   requestSchema: listGuiHarnessesRequestSchema,
-  responseSchema: listGuiHarnessesResponseSchema,
+  // Frozen: the v1.1.9 tags shipped this line, so it must serve the v6.0 id
+  // set rather than the live one. Until this repair it still pointed at the
+  // canonical schema - the same defect that let `omp` first ride v5.0, one
+  // version later and unnoticed because the release froze the line without
+  // anyone repointing it. The REQUEST stays live: it is a client→host slot, so
+  // widening the harness enum a caller may send is not a released-peer break.
+  responseSchema: listGuiHarnessesResponseSchemaV60,
 });
 
 export const agentGuiListHarnessesUpgradeV5ToV6 = defineUpgradePath<
@@ -452,6 +461,136 @@ export const agentGuiListHarnessesDowngradeV6ToV1 = defineDowngradePath<
   typeof agentGuiListHarnessesV10
 >({
   from: { major: 6, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV10.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV10.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesV70 = defineRpcContract({
+  method: "agent.gui.listHarnesses",
+  schemaVersion: { major: 7, minor: 0 } as const,
+  requestSchema: listGuiHarnessesRequestSchema,
+  responseSchema: listGuiHarnessesResponseSchema,
+});
+
+export const agentGuiListHarnessesUpgradeV6ToV7 = defineUpgradePath<
+  typeof agentGuiListHarnessesV60,
+  typeof agentGuiListHarnessesV70
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 7, minor: 0 },
+  // Request shape is identical; a v6.0 response without jcode is a valid v7.0
+  // response (purely additive), so both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentGuiListHarnessesDowngradeV7ToV6 = defineDowngradePath<
+  typeof agentGuiListHarnessesV70,
+  typeof agentGuiListHarnessesV60
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop jcode so an already-shipped v6.0 client's strict decode never sees it.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV60.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV60.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV7ToV5 = defineDowngradePath<
+  typeof agentGuiListHarnessesV70,
+  typeof agentGuiListHarnessesV50
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop omp/jcode so an already-shipped v5.0 client's strict decode never
+  // sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV50.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV50.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV7ToV4 = defineDowngradePath<
+  typeof agentGuiListHarnessesV70,
+  typeof agentGuiListHarnessesV40
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Hermes/omp/jcode so an already-shipped v4.0 client's strict decode
+  // never sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV40.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV40.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV7ToV3 = defineDowngradePath<
+  typeof agentGuiListHarnessesV70,
+  typeof agentGuiListHarnessesV30
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Devin/Pi/Hermes/omp/jcode so an already-shipped v3.0 client's strict
+  // decode never sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV30.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV30.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV7ToV2 = defineDowngradePath<
+  typeof agentGuiListHarnessesV70,
+  typeof agentGuiListHarnessesV21
+>({
+  from: { major: 7, minor: 0 },
+  // Lands on 2.1, major 2's latest installed minor; a frozen-2.0 caller's
+  // contract parse then strips the 2.1-only `enabled` field.
+  to: { major: 2, minor: 1 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV21.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV21.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV7ToV1 = defineDowngradePath<
+  typeof agentGuiListHarnessesV70,
+  typeof agentGuiListHarnessesV10
+>({
+  from: { major: 7, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
   downgradeResponse: (response) => ({

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -6,6 +6,7 @@ import {
   guiHarnessIdSchemaV30,
   guiHarnessIdSchemaV40,
   guiHarnessIdSchemaV50,
+  guiHarnessIdSchemaV60,
 } from "@traycer/protocol/host/agent/shared";
 import {
   ALL_PERMISSION_MODES,
@@ -256,6 +257,24 @@ export const guiHarnessOptionSchemaV50 = guiHarnessOptionSchema.extend({
 });
 export const listGuiHarnessesResponseSchemaV50 = z.object({
   harnesses: z.array(guiHarnessOptionSchemaV50),
+});
+
+// ── Frozen protocol-v6.0 catalog row + response (with omp, before jcode) ────
+// v6.0 shipped with omp in `cli-v1.1.9` / `host-v1.1.9` (tagged 2026-07-29);
+// the v7.0 line of `agent.gui.listHarnesses` adds jcode, and the v7→v6
+// downgrade bridge filters it out for already-shipped v6.0 callers so their
+// strict decode never sees a value it can't parse.
+//
+// This line was NOT pinned when that release shipped - `agentGuiListHarnessesV60`
+// still served the LIVE `listGuiHarnessesResponseSchema`, so it absorbed every
+// id added afterwards, exactly the way v5.0 did before `cli-v1.1.8` froze it.
+// Pinning the id here keeps a future `.extend()` on the live row from leaking
+// into this shipped line.
+export const guiHarnessOptionSchemaV60 = guiHarnessOptionSchema.extend({
+  id: guiHarnessIdSchemaV60,
+});
+export const listGuiHarnessesResponseSchemaV60 = z.object({
+  harnesses: z.array(guiHarnessOptionSchemaV60),
 });
 export type ListGuiHarnessesResponse = z.infer<
   typeof listGuiHarnessesResponseSchema

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -22,6 +22,7 @@ import {
   providerIdSchema,
   providerIdSchemaV40,
   providerIdSchemaV50,
+  providerIdSchemaV60,
   providerProfileRateLimitStatusSchema,
 } from "@traycer/protocol/host/provider-schemas";
 import {
@@ -29,6 +30,7 @@ import {
   providerRateLimitsSchema,
   providerRateLimitsSchemaV40,
   providerRateLimitsSchemaV50,
+  providerRateLimitsSchemaV60,
 } from "@traycer/protocol/host/rate-limit/schemas";
 import {
   agentFacingHarnessIdSchema,
@@ -36,6 +38,7 @@ import {
   guiHarnessIdSchema,
   guiHarnessIdSchemaV40,
   guiHarnessIdSchemaV50,
+  guiHarnessIdSchemaV60,
 } from "@traycer/protocol/host/agent/shared";
 
 // ─── `agent.listProviderProfiles@1.0` ─────────────────────────────────────
@@ -141,9 +144,38 @@ export const agentListProviderProfilesV20 = defineRpcContract({
   responseSchema: agentListProviderProfilesResponseSchemaV2,
 });
 
+/**
+ * Frozen `agent.listProviderProfiles@3.0` response, pinned to the pre-jcode
+ * provider id set (`providerIdSchemaV60`) so an already-shipped v3.0 caller's
+ * strict decode never sees `jcode`.
+ *
+ * This line IS released - the v1.1.9 tags (2026-07-29) shipped it - but it kept
+ * pointing at the live `agentListProviderProfilesResponseSchema` until this
+ * repair, so it silently absorbed every provider id added after the release.
+ * That is the same defect that let `omp` first ride v2.0, one version later.
+ * The v4.0 line now carries the live schema, with a v4->v3 downgrade bridge
+ * that fails closed (`DOWNGRADE_UNSUPPORTED`) for a post-v6.0-only provider id.
+ * Do NOT widen this schema - extend the latest schema and use the v4 bridge
+ * instead.
+ */
+export const agentListProviderProfilesResponseSchemaV3 = z.object({
+  providerId: providerIdSchemaV60,
+  profiles: z.array(agentProviderProfileSummarySchema),
+});
+export type AgentListProviderProfilesResponseV3 = z.infer<
+  typeof agentListProviderProfilesResponseSchemaV3
+>;
+
 export const agentListProviderProfilesV30 = defineRpcContract({
   method: "agent.listProviderProfiles",
   schemaVersion: { major: 3, minor: 0 } as const,
+  requestSchema: agentListProviderProfilesRequestSchema,
+  responseSchema: agentListProviderProfilesResponseSchemaV3,
+});
+
+export const agentListProviderProfilesV40 = defineRpcContract({
+  method: "agent.listProviderProfiles",
+  schemaVersion: { major: 4, minor: 0 } as const,
   requestSchema: agentListProviderProfilesRequestSchema,
   responseSchema: agentListProviderProfilesResponseSchema,
 });
@@ -257,6 +289,99 @@ export const agentListProviderProfilesDowngradeV30ToV10 = defineDowngradePath<
   },
 });
 
+export const agentListProviderProfilesUpgradeV30ToV40 = defineUpgradePath<
+  typeof agentListProviderProfilesV30,
+  typeof agentListProviderProfilesV40
+>({
+  from: { major: 3, minor: 0 },
+  to: { major: 4, minor: 0 },
+  // Request shape is identical across both majors - only the response's
+  // `providerId` enum grows (jcode).
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListProviderProfilesDowngradeV40ToV30 = defineDowngradePath<
+  typeof agentListProviderProfilesV40,
+  typeof agentListProviderProfilesV30
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Same fail-closed rule as every older bridge on this method: the response
+    // carries exactly one provider, so there is nothing to filter out and the
+    // only honest options are pass-through or refuse. `jcode` is the sole
+    // provider unrepresentable on the frozen v3.0 wire today; the message
+    // names no provider so it stays honest as the enum grows.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV40ToV20 = defineDowngradePath<
+  typeof agentListProviderProfilesV40,
+  typeof agentListProviderProfilesV20
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Anything post-v5.0 (omp, jcode) is unrepresentable on the frozen v2.0
+    // wire.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV40ToV10 = defineDowngradePath<
+  typeof agentListProviderProfilesV40,
+  typeof agentListProviderProfilesV10
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Same fail-closed rule against the narrower v1.0 enum: anything post-v4.0
+    // (Hermes, omp, jcode) is unrepresentable here.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV1.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
 // ─── `agent.getProviderProfileRateLimits@1.0` ─────────────────────────────
 //
 // On-demand detailed rate-limit read for one concrete profile selection
@@ -343,9 +468,38 @@ export const agentGetProviderProfileRateLimitsV20 = defineRpcContract({
   responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV2,
 });
 
+/**
+ * Frozen `agent.getProviderProfileRateLimits@3.0` response, pinned to the
+ * pre-jcode `rateLimits.provider` enum (`providerRateLimitsSchemaV60`, whose
+ * `available: false` arm carries `providerIdSchemaV60`) so an already-shipped
+ * v3.0 caller's strict decode never sees `jcode`.
+ *
+ * This line IS released - the v1.1.9 tags (2026-07-29) shipped it - but it kept
+ * pointing at the live response until this repair, so it absorbed every
+ * provider id added after the release (the `omp`-on-v2.0 defect, one version
+ * later). Like the v2.0 freeze this union KEEPS the grok available arm, which
+ * predates those tags. The v4.0 line carries the live schema, with a v4->v3
+ * downgrade bridge that fails closed (`DOWNGRADE_UNSUPPORTED`). Do NOT widen
+ * this schema - extend the latest schema and use the v4 bridge instead.
+ */
+export const agentGetProviderProfileRateLimitsResponseSchemaV3 = z.object({
+  rateLimits: providerRateLimitsSchemaV60,
+  usageUpdatedAt: z.number().nullable(),
+});
+export type AgentGetProviderProfileRateLimitsResponseV3 = z.infer<
+  typeof agentGetProviderProfileRateLimitsResponseSchemaV3
+>;
+
 export const agentGetProviderProfileRateLimitsV30 = defineRpcContract({
   method: "agent.getProviderProfileRateLimits",
   schemaVersion: { major: 3, minor: 0 } as const,
+  requestSchema: agentGetProviderProfileRateLimitsRequestSchema,
+  responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV3,
+});
+
+export const agentGetProviderProfileRateLimitsV40 = defineRpcContract({
+  method: "agent.getProviderProfileRateLimits",
+  schemaVersion: { major: 4, minor: 0 } as const,
   requestSchema: agentGetProviderProfileRateLimitsRequestSchema,
   responseSchema: agentGetProviderProfileRateLimitsResponseSchema,
 });
@@ -458,6 +612,118 @@ export const agentGetProviderProfileRateLimitsDowngradeV30ToV10 =
       // becomes the `unsupported_provider` row a v1.0 host returns for grok
       // today (shared map) rather than being dropped. Post-v4.0 providers
       // (Hermes, omp) stay unrepresentable and still fail closed.
+      const rateLimits = mapGrokAvailableToUnavailable(response.rateLimits);
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse({
+          ...response,
+          rateLimits,
+        });
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsUpgradeV30ToV40 =
+  defineUpgradePath<
+    typeof agentGetProviderProfileRateLimitsV30,
+    typeof agentGetProviderProfileRateLimitsV40
+  >({
+    from: { major: 3, minor: 0 },
+    to: { major: 4, minor: 0 },
+    // Request shape is identical across both majors - only the response's
+    // `rateLimits.provider` enum grows (jcode).
+    upgradeRequest: (request) => request,
+    upgradeResponse: (response) => response,
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV40ToV30 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV40,
+    typeof agentGetProviderProfileRateLimitsV30
+  >({
+    from: { major: 4, minor: 0 },
+    to: { major: 3, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // No grok degrade here: the frozen v3.0 union keeps the grok available
+      // arm (grok rate limits predate the v1.1.9 tags), so a grok snapshot
+      // reparses as-is. Only `jcode` is unrepresentable, and this response
+      // carries exactly one provider - so fail closed rather than mis-decode.
+      //
+      // Deliberately NOT `mapJcodeAvailableToUnavailable` (the degrade the
+      // `host.getRateLimitUsage` bridges use). jcode does expose a real quota
+      // API (`jcode usage --json`), so it populates an `available: true` arm -
+      // but degrading it here would only produce `{ provider: "jcode",
+      // available: false }`, and `providerRateLimitsSchemaV60` pins its
+      // unavailable arm to `providerIdSchemaV60`, which has no `jcode`. The
+      // degrade cannot help on this method; failing closed is the only honest
+      // outcome. See that helper's doc comment for why the two methods differ.
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV3.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV40ToV20 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV40,
+    typeof agentGetProviderProfileRateLimitsV20
+  >({
+    from: { major: 4, minor: 0 },
+    to: { major: 2, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // The frozen v2.0 union also keeps the grok available arm, so no degrade
+      // is needed; anything post-v5.0 (omp, jcode) fails closed.
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV2.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV40ToV10 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV40,
+    typeof agentGetProviderProfileRateLimitsV10
+  >({
+    from: { major: 4, minor: 0 },
+    to: { major: 1, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // Unlike the v4->v3 / v4->v2 bridges this one DOES degrade grok: the
+      // frozen v1.0 union predates the grok available arm, so a grok-available
+      // snapshot becomes the `unsupported_provider` row a v1.0 host returns for
+      // grok today (shared map). Post-v4.0 providers (Hermes, omp, jcode) stay
+      // unrepresentable and still fail closed.
       const rateLimits = mapGrokAvailableToUnavailable(response.rateLimits);
       const parsed =
         agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse({
@@ -609,9 +875,55 @@ export const agentConfigureV20 = defineRpcContract({
   responseSchema: agentConfigureResponseSchemaV2,
 });
 
+/**
+ * Frozen `agent.configure@3.0` settings/response, pinned to the pre-jcode
+ * harness id set (`guiHarnessIdSchemaV60`) so an already-shipped v3.0 caller's
+ * strict decode never sees `harnessId: "jcode"`.
+ *
+ * This line IS released - the v1.1.9 tags (2026-07-29) shipped it - but it kept
+ * pointing at the live `agentConfigureResponseSchema` until this repair, so it
+ * absorbed every harness id added after the release (the `omp`-on-v2.0 defect,
+ * one version later). The v4.0 line carries the live schema;
+ * `agentConfigureDowngradeV40ToV30`'s response bridge fails closed
+ * (`DOWNGRADE_UNSUPPORTED`) instead of silently mis-decoding a jcode-configured
+ * agent for a v3.0 caller. Do NOT widen this schema - extend the latest schema
+ * and use the v4 bridge instead.
+ *
+ * Only the RESPONSE is frozen. `agentConfigureRequestSchemaV20` keeps the live
+ * harness enum because the request is a client→host slot: a released client
+ * simply never sends `jcode`, and widening what the host accepts breaks nobody.
+ */
+export const agentConfigureSettingsSchemaV3 = z.object({
+  harnessId: guiHarnessIdSchemaV60,
+  model: z.string().min(1),
+  profileSelection: concreteProfileSelectionSchema,
+  reasoningEffort: z.string().nullable(),
+  fastMode: z.boolean(),
+  permissionMode: permissionModeSchema,
+  agentMode: agentModeSchema,
+});
+export type AgentConfigureSettingsV3 = z.infer<
+  typeof agentConfigureSettingsSchemaV3
+>;
+
+export const agentConfigureResponseSchemaV3 = z.object({
+  settings: agentConfigureSettingsSchemaV3,
+  warnings: z.array(z.string()),
+});
+export type AgentConfigureResponseV3 = z.infer<
+  typeof agentConfigureResponseSchemaV3
+>;
+
 export const agentConfigureV30 = defineRpcContract({
   method: "agent.configure",
   schemaVersion: { major: 3, minor: 0 } as const,
+  requestSchema: agentConfigureRequestSchemaV20,
+  responseSchema: agentConfigureResponseSchemaV3,
+});
+
+export const agentConfigureV40 = defineRpcContract({
+  method: "agent.configure",
+  schemaVersion: { major: 4, minor: 0 } as const,
   requestSchema: agentConfigureRequestSchemaV20,
   responseSchema: agentConfigureResponseSchema,
 });
@@ -694,6 +1006,109 @@ export const agentConfigureDowngradeV30ToV20 = defineDowngradePath<
     // if that ever changes) cannot be represented on the frozen v2.0 wire, so
     // this fails closed instead of silently mis-decoding it.
     const parsed = agentConfigureResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureUpgradeV30ToV40 = defineUpgradePath<
+  typeof agentConfigureV30,
+  typeof agentConfigureV40
+>({
+  from: { major: 3, minor: 0 },
+  to: { major: 4, minor: 0 },
+  // Request shape is identical across both majors (v4.0 reuses
+  // `agentConfigureRequestSchemaV20`) - only the response's `harnessId` enum
+  // grows (jcode). Both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentConfigureDowngradeV40ToV30 = defineDowngradePath<
+  typeof agentConfigureV40,
+  typeof agentConfigureV30
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 3, minor: 0 },
+  // Like the v3->v2 bridge this request downgrade succeeds: v4.0 added no
+  // request field, so a v4.0 request is already a valid v3.0 one.
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // `settings.harnessId` echoes the configured agent's harness; a v3.0
+    // caller only ever configures a pre-jcode harness, so the common case
+    // reparses cleanly through the frozen schema. A jcode-configured response
+    // (unreachable from a v3.0 REQUEST today, but this bridge must still hold
+    // if that ever changes) cannot be represented on the frozen v3.0 wire, so
+    // this fails closed instead of silently mis-decoding it. The message names
+    // no single harness so it stays honest as the enum grows.
+    const parsed = agentConfigureResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV40ToV20 = defineDowngradePath<
+  typeof agentConfigureV40,
+  typeof agentConfigureV20
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Fails closed for any post-v5.0 harness (omp, jcode).
+    const parsed = agentConfigureResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV40ToV10 = defineDowngradePath<
+  typeof agentConfigureV40,
+  typeof agentConfigureV10
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 1, minor: 0 },
+  // Same refusal as the v2->v1 / v3->v1 bridges: v1.0 has no `permissionMode`
+  // field, so the explicit choice a v2.0+ caller makes cannot be carried to a
+  // v1.0 host.
+  downgradeRequest: () => ({
+    ok: false,
+    error: {
+      code: "DOWNGRADE_UNSUPPORTED",
+      message:
+        "Selecting an agent permission mode requires a newer Traycer host. Upgrade the host before configuring this agent.",
+    },
+  }),
+  downgradeResponse: (response) => {
+    // Fails closed for any post-v4.0 harness (Hermes, omp, jcode).
+    const parsed = agentConfigureResponseSchemaV1.safeParse(response);
     if (!parsed.success) {
       return {
         ok: false,

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -67,6 +67,7 @@ export const guiHarnessIdSchema = harnessIdSchema.extract([
   "pi",
   "hermes",
   "omp",
+  "jcode",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 
@@ -193,6 +194,43 @@ export const guiHarnessIdSchemaV50 = harnessIdSchema.extract([
 ]);
 export type GuiHarnessIdV50 = z.infer<typeof guiHarnessIdSchemaV50>;
 
+/**
+ * Frozen harness id set as shipped in protocol v6.0 (with omp, before jcode).
+ *
+ * This line IS released - `cli-v1.1.9` (tagged 2026-07-29) shipped v6.0, so a
+ * client in the field strict-decodes exactly these 18 ids.
+ *
+ * It was NOT pinned when that release shipped: `agent.gui.listHarnesses@6.0`,
+ * `agent.list@6.0` and the three `@3.0` profile methods all still pointed at
+ * the LIVE `guiHarnessIdSchema`, so those released lines silently absorbed
+ * every id added afterwards - the same defect that let `omp` first ride v5.0.
+ * This snapshot (and the frozen response schemas built on it) repairs that
+ * gap; jcode opens v7.0 instead, with v7→v6 … v7→v1 bridges that drop
+ * post-v6.0 ids. Do NOT add new harnesses here - extend the latest
+ * `guiHarnessIdSchema` and use the v7 bridge instead.
+ */
+export const guiHarnessIdSchemaV60 = harnessIdSchema.extract([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+  "grok",
+  "qwen",
+  "kiro",
+  "droid",
+  "kimi",
+  "copilot",
+  "kilocode",
+  "openrouter",
+  "amp",
+  "devin",
+  "pi",
+  "hermes",
+  "omp",
+]);
+export type GuiHarnessIdV60 = z.infer<typeof guiHarnessIdSchemaV60>;
+
 export const tuiHarnessIdSchema = harnessIdSchema.extract([
   "claude",
   "codex",
@@ -257,6 +295,7 @@ export const AGENT_FACING_HARNESS_IDS = [
   "pi",
   "hermes",
   "omp",
+  "jcode",
 ] as const;
 
 export const AGENT_FACING_HARNESS_ID_LIST = AGENT_FACING_HARNESS_IDS.join(", ");
@@ -742,6 +781,24 @@ export const listAgentsResponseSchemaV50 = listAgentsResponseSchema.extend({
   agents: z.array(agentSummarySchemaV50),
 });
 export type ListAgentsResponseV50 = z.infer<typeof listAgentsResponseSchemaV50>;
+
+// ── Frozen protocol-v6.0 agent.list response (with omp, before jcode) ───────
+// `agent.list` enumerates every agent in the epic - including jcode GUI harness
+// chats a newer client created - so an already-shipped v6.0 client would hit a
+// strict enum on those rows. This line IS released (`cli-v1.1.9` /
+// `host-v1.1.9`, tagged 2026-07-29) and, until now, still pointed at the LIVE
+// `listAgentsResponseSchema`, so it absorbed every id added after the release -
+// the same defect that let `omp` first ride v5.0. Frozen here as actually
+// shipped; the v7.0 line carries jcode rows and v7→v6 … v7→v1 bridges drop them
+// for older callers. Do not add new harnesses here - use the existing v7
+// bridge.
+export const agentSummarySchemaV60 = agentSummarySchema.extend({
+  harnessId: guiHarnessIdSchemaV60.nullable(),
+});
+export const listAgentsResponseSchemaV60 = listAgentsResponseSchema.extend({
+  agents: z.array(agentSummarySchemaV60),
+});
+export type ListAgentsResponseV60 = z.infer<typeof listAgentsResponseSchemaV60>;
 
 /**
  * `agent.sendMessage@1.0` - fire-and-forget enqueue from one agent to

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -295,7 +295,14 @@ export const AGENT_FACING_HARNESS_IDS = [
   "pi",
   "hermes",
   "omp",
-  "jcode",
+  // jcode is deliberately ABSENT. This set gates `traycer_create_agent`, i.e.
+  // which harnesses an agent may spawn a CHILD on. jcode has no A2A tool
+  // surface: its ACP transport rejects `mcpServers` outright, and the only
+  // config-driven route would mean writing an MCP file into the user's own
+  // workspace or home, which we will not do. A jcode child could therefore
+  // never call `traycer_send_message` to report back, and would strand its
+  // parent waiting for a reply that cannot arrive. Humans can still open jcode
+  // tabs - that is `guiHarnessIdSchema`, which does include it.
 ] as const;
 
 export const AGENT_FACING_HARNESS_ID_LIST = AGENT_FACING_HARNESS_IDS.join(", ");

--- a/protocol/src/host/provider-ids.ts
+++ b/protocol/src/host/provider-ids.ts
@@ -19,6 +19,7 @@ export const providerIdSchema = z.enum([
   "pi",
   "hermes",
   "omp",
+  "jcode",
 ]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
 

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -180,6 +180,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   pi: "Pi",
   hermes: "Hermes Agent",
   omp: "Oh My Pi",
+  jcode: "JCode",
 };
 
 /**
@@ -2195,6 +2196,26 @@ export function downgradeProviderCliStateListToV50(
 ): ProviderCliStateV50[] {
   return states.flatMap((state) => {
     const parsed = providerCliStateSchemaV50.safeParse(state);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+/**
+ * Drop post-v6.0 providers (currently `jcode`) for an already-shipped v6.0
+ * client. Same filter-by-reparse shape as the older bridges.
+ *
+ * The v7->v6 hop needed this the moment a provider id landed after `cli-v1.1.9`:
+ * until then the two id sets were identical, so that bridge could reparse the
+ * whole list through the frozen v6.0 schema purely to strip the
+ * provider-pack-registry fields. With `jcode` on the live enum that straight
+ * reparse would THROW on the jcode row instead of dropping it, so the hop must
+ * filter first - the reparse still strips the unmodeled registry keys.
+ */
+export function downgradeProviderCliStateListToV60(
+  states: readonly unknown[],
+): ProviderCliStateV60[] {
+  return states.flatMap((state) => {
+    const parsed = providerCliStateSchemaV60.safeParse(state);
     return parsed.success ? [parsed.data] : [];
   });
 }

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -5,12 +5,16 @@ import {
   hostGetRateLimitUsageDowngradeV2ToV1,
   hostGetRateLimitUsageDowngradeV3ToV1,
   hostGetRateLimitUsageDowngradeV3ToV2,
+  hostGetRateLimitUsageDowngradeV4ToV1,
+  hostGetRateLimitUsageDowngradeV4ToV2,
+  hostGetRateLimitUsageDowngradeV4ToV3,
   hostGetRateLimitUsageUpgradeV20ToV21,
   hostGetRateLimitUsageUpgradeV21ToV30,
 } from "@traycer/protocol/host/rate-limit/contracts";
 import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
   providerRateLimitsSchema,
+  providerRateLimitsSchemaV30,
   providersConsumeRateLimitResetCreditRequestSchema,
   providersConsumeRateLimitResetCreditResponseSchema,
   rateLimitUnavailableReasonSchemaV1,
@@ -914,5 +918,186 @@ describe("host.getRateLimitUsage v3.0 -> v2.1 / v1.2 grok downgrade bridges", ()
       hostRpcRegistry["host.getRateLimitUsage"][2].versions[1].contract
         .schemaVersion,
     ).toEqual({ major: 2, minor: 1 });
+  });
+});
+
+// ─── jcode: the v4.0 available arm ─────────────────────────────────────────
+//
+// `host.getRateLimitUsage@3.0` IS released (`host-v1.1.9`), and it served the
+// LIVE union until the jcode work pinned it to `providerRateLimitsSchemaV30`.
+// Without that pin the jcode available arm would have landed on an
+// already-released response - and the registry's own validator proves the pin
+// is load-bearing: reverting it makes the 3 -> 4 major bump non-breaking and
+// `defineFloorAwareVersionedRpcRegistry` refuses to load at all.
+describe("jcode rate-limit available arm and the 4.0 bridges", () => {
+  // Local copies of the two cross-arm fixtures: the originals are scoped to the
+  // v3.0 describe above, and the grok pair is needed here to prove the jcode
+  // degrade does not take grok down with it.
+  const grokAvailableWithPeriod = {
+    provider: "grok" as const,
+    available: true as const,
+    subscriptionTier: "SuperGrok",
+    periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+    periodStart: 1753142400000,
+    periodEnd: 1753747200000,
+    period: {
+      usedPercent: 12,
+      resetsAt: 1753747200000,
+      durationMinutes: 10080,
+    },
+    monthlyLimit: null,
+    onDemandCap: 0,
+    onDemandUsed: 0,
+    prepaidBalance: 0,
+  };
+
+  const grokUnavailable = {
+    provider: "grok" as const,
+    available: false as const,
+    reason: "unsupported_provider" as const,
+  };
+
+  const codexAvailable = {
+    provider: "codex" as const,
+    available: true as const,
+    planType: "plus",
+    limitId: "plus-primary",
+    limitName: "Plus",
+    primary: {
+      usedPercent: 42,
+      resetsAt: 1735689600000,
+      durationMinutes: 300,
+    },
+    secondary: null,
+    extraWindows: [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+
+  const jcodeAvailable = {
+    provider: "jcode" as const,
+    available: true as const,
+    subProviders: [
+      {
+        // Percent CONSUMED, straight from jcode's `usage_percent`.
+        subProviderId: "openrouter",
+        window: { usedPercent: 99.607, resetsAt: null, durationMinutes: null },
+        hardLimitReached: false,
+        error: null,
+      },
+      {
+        // Only Antigravity and Copilot report a reset instant upstream.
+        subProviderId: "copilot",
+        window: {
+          usedPercent: 12,
+          resetsAt: 1_700_000_000_000,
+          durationMinutes: null,
+        },
+        hardLimitReached: false,
+        error: null,
+      },
+      {
+        // A failed fetch, NOT a healthy zero - distinguished by `error`.
+        subProviderId: "anthropic",
+        window: null,
+        hardLimitReached: false,
+        error: "401 after token refresh",
+      },
+    ],
+  };
+
+  const jcodeUnavailable = {
+    provider: "jcode" as const,
+    available: false as const,
+    reason: "unsupported_provider" as const,
+  };
+
+  it("accepts the per-sub-provider list on the live union", () => {
+    expect(providerRateLimitsSchema.safeParse(jcodeAvailable).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts an empty sub-provider list as available (nothing to show != could not ask)", () => {
+    expect(
+      providerRateLimitsSchema.safeParse({
+        provider: "jcode",
+        available: true,
+        subProviders: [],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("keeps the jcode arm OFF the frozen v3.0 union", () => {
+    // The whole reason v4.0 exists. If this ever passes, the freeze has been
+    // widened and a released `host-v1.1.9` peer would receive an arm it cannot
+    // decode.
+    expect(providerRateLimitsSchemaV30.safeParse(jcodeAvailable).success).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ["4.0 -> 3.0", hostGetRateLimitUsageDowngradeV4ToV3],
+    ["4.0 -> 2.1", hostGetRateLimitUsageDowngradeV4ToV2],
+    ["4.0 -> 1.2", hostGetRateLimitUsageDowngradeV4ToV1],
+  ] as const)(
+    "degrades a jcode-available snapshot to unsupported_provider through the %s bridge",
+    (_label, bridge) => {
+      const downgraded = bridge.downgradeResponse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: jcodeAvailable,
+      });
+      expect(downgraded.ok).toBe(true);
+      if (!downgraded.ok) return;
+      expect(downgraded.value.providerRateLimits).toEqual(jcodeUnavailable);
+    },
+  );
+
+  it("passes non-jcode arms and null through the 4.0 -> 3.0 bridge unchanged", () => {
+    const withCodex = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: codexAvailable,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV4ToV3.downgradeResponse(withCodex),
+    ).toEqual({ ok: true, value: withCodex });
+
+    const withNull = {
+      totalTokens: 100,
+      remainingTokens: 50,
+      providerRateLimits: null,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV4ToV3.downgradeResponse(withNull),
+    ).toEqual({ ok: true, value: withNull });
+  });
+
+  it("still degrades grok on the 4.0 -> 1.2 bridge (both maps compose)", () => {
+    const downgraded = hostGetRateLimitUsageDowngradeV4ToV1.downgradeResponse({
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailableWithPeriod,
+    });
+    expect(downgraded.ok).toBe(true);
+    if (!downgraded.ok) return;
+    expect(downgraded.value.providerRateLimits).toEqual(grokUnavailable);
+  });
+
+  it("keeps the grok available arm on the 4.0 -> 3.0 bridge (v3.0 shipped with grok)", () => {
+    // The jcode degrade must not accidentally take grok down with it - v3.0's
+    // frozen union genuinely carries the grok arm.
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailableWithPeriod,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV4ToV3.downgradeResponse(response),
+    ).toEqual({ ok: true, value: response });
   });
 });

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -983,6 +983,7 @@ describe("jcode rate-limit available arm and the 4.0 bridges", () => {
       {
         // Percent CONSUMED, straight from jcode's `usage_percent`.
         subProviderId: "openrouter",
+        limitName: "Credits",
         window: { usedPercent: 99.607, resetsAt: null, durationMinutes: null },
         hardLimitReached: false,
         error: null,
@@ -990,6 +991,7 @@ describe("jcode rate-limit available arm and the 4.0 bridges", () => {
       {
         // Only Antigravity and Copilot report a reset instant upstream.
         subProviderId: "copilot",
+        limitName: "Premium requests",
         window: {
           usedPercent: 12,
           resetsAt: 1_700_000_000_000,
@@ -1001,6 +1003,7 @@ describe("jcode rate-limit available arm and the 4.0 bridges", () => {
       {
         // A failed fetch, NOT a healthy zero - distinguished by `error`.
         subProviderId: "anthropic",
+        limitName: null,
         window: null,
         hardLimitReached: false,
         error: "401 after token refresh",

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-semantics.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-semantics.test.ts
@@ -53,6 +53,30 @@ function codex(
   };
 }
 
+function jcode(
+  subProviders: readonly {
+    subProviderId: string;
+    window: ProviderRateLimitWindow | null;
+    hardLimitReached: boolean;
+    error: string | null;
+  }[],
+): ProviderRateLimits {
+  return {
+    provider: "jcode",
+    available: true,
+    subProviders: [...subProviders],
+  };
+}
+
+function jcodeSub(
+  subProviderId: string,
+  windowValue: ProviderRateLimitWindow | null,
+  hardLimitReached: boolean,
+  error: string | null,
+) {
+  return { subProviderId, window: windowValue, hardLimitReached, error };
+}
+
 describe("classifyProviderRateLimitWindow", () => {
   it("warns short windows at 80% and long or undated windows at 95%", () => {
     expect(classifyProviderRateLimitWindow(window(79, 300, null))).toBe(
@@ -138,5 +162,85 @@ describe("classifyProviderRateLimits", () => {
         NOW,
       ),
     ).toBe("unknown");
+  });
+});
+
+// jcode is the only provider whose quota is genuinely per SUB-provider, so its
+// arm contributes a LIST of windows the way claude-code's model-scoped windows
+// do. These pin that it folds into the shared rollup with no special casing -
+// and that a failed sub-provider fetch never reads as headroom.
+describe("jcode per-sub-provider severity folding", () => {
+  it("takes the worst live sub-provider window", () => {
+    expect(
+      classifyProviderRateLimits(
+        jcode([
+          jcodeSub("openrouter", window(10, null, null), false, null),
+          jcodeSub("copilot", window(85, 300, NOW + 1), false, null),
+        ]),
+        NOW,
+      ),
+    ).toBe("running_low");
+  });
+
+  it("stays Healthy when every live sub-provider is well under its threshold", () => {
+    expect(
+      classifyProviderRateLimits(
+        jcode([
+          jcodeSub("openrouter", window(10, null, null), false, null),
+          jcodeSub("anthropic", window(20, 300, NOW + 1), false, null),
+        ]),
+        NOW,
+      ),
+    ).toBe("healthy");
+  });
+
+  it("reports Unknown - never Healthy - when a sub-provider's fetch failed and nothing else reported", () => {
+    // Both "fetch failed" and "no quota" carry `window: null`. Neither may be
+    // read as 0% used.
+    expect(
+      classifyProviderRateLimits(
+        jcode([jcodeSub("anthropic", null, false, "401 after token refresh")]),
+        NOW,
+      ),
+    ).toBe("unknown");
+  });
+
+  it("reports Unknown for an empty sub-provider list", () => {
+    expect(classifyProviderRateLimits(jcode([]), NOW)).toBe("unknown");
+  });
+
+  it("honors hardLimitReached as authoritative, like Codex's reached-type", () => {
+    // jcode computes `hard_limit_reached` upstream but does not serialize it,
+    // so the host derives it. Reading the flag rather than re-deriving keeps a
+    // future upstream rule change honest.
+    expect(
+      classifyProviderRateLimits(
+        jcode([jcodeSub("copilot", window(12, 300, NOW + 1), true, null)]),
+        NOW,
+      ),
+    ).toBe("limited");
+  });
+
+  it("discards an authoritative hard-limit signal from a fully expired capture", () => {
+    // Same staleness guard Codex gets: an all-expired capture is Unknown, not
+    // a stale "limited" that outlives the window it came from.
+    expect(
+      classifyProviderRateLimits(
+        jcode([jcodeSub("copilot", window(100, 300, NOW - 1), true, null)]),
+        NOW,
+      ),
+    ).toBe("unknown");
+  });
+
+  it("drops expired sub-provider windows from the live set", () => {
+    expect(
+      liveProviderRateLimitWindows(
+        jcode([
+          jcodeSub("openrouter", window(90, 300, NOW - 1), false, null),
+          jcodeSub("copilot", window(30, 300, NOW + 1), false, null),
+        ]),
+        NOW,
+      ),
+    ).toEqual([window(30, 300, NOW + 1)]);
   });
 });

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-semantics.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-semantics.test.ts
@@ -56,6 +56,7 @@ function codex(
 function jcode(
   subProviders: readonly {
     subProviderId: string;
+    limitName: string | null;
     window: ProviderRateLimitWindow | null;
     hardLimitReached: boolean;
     error: string | null;
@@ -74,7 +75,13 @@ function jcodeSub(
   hardLimitReached: boolean,
   error: string | null,
 ) {
-  return { subProviderId, window: windowValue, hardLimitReached, error };
+  return {
+    subProviderId,
+    limitName: null,
+    window: windowValue,
+    hardLimitReached,
+    error,
+  };
 }
 
 describe("classifyProviderRateLimitWindow", () => {
@@ -230,6 +237,38 @@ describe("jcode per-sub-provider severity folding", () => {
         NOW,
       ),
     ).toBe("unknown");
+  });
+
+  it("does not let an EXPIRED hard-limit row limit a healthy live snapshot", () => {
+    // jcode is the only LIST arm, so one capture mixes rows with independent
+    // reset times. The all-expired guard above only fires when EVERY row is
+    // stale, so a rolled-over OpenRouter row must be dropped on its own
+    // liveness - otherwise a user with headroom everywhere reads as limited.
+    expect(
+      classifyProviderRateLimits(
+        jcode([
+          jcodeSub("openrouter", window(100, 300, NOW - 1), true, null),
+          jcodeSub("copilot", window(30, 300, NOW + 1), false, null),
+        ]),
+        NOW,
+      ),
+    ).toBe("healthy");
+  });
+
+  it("keeps a hard-limit row with no window authoritative", () => {
+    // No window is no evidence of rolling over, matching the null-reset rule
+    // in `isProviderRateLimitWindowLive`. Today the host never emits this
+    // pair; an upstream build that starts serializing `hard_limit_reached`
+    // without a percentage would, and it must not be silently discarded.
+    expect(
+      classifyProviderRateLimits(
+        jcode([
+          jcodeSub("copilot", null, true, null),
+          jcodeSub("openrouter", window(30, 300, NOW + 1), false, null),
+        ]),
+        NOW,
+      ),
+    ).toBe("limited");
   });
 
   it("drops expired sub-provider windows from the live set", () => {

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -15,7 +15,9 @@ import {
   rateLimitUsageResponseSchemaV20,
   rateLimitUsageResponseSchemaV21,
   rateLimitUsageResponseSchemaV30,
+  rateLimitUsageResponseSchemaV40,
   mapGrokAvailableToUnavailable,
+  mapJcodeAvailableToUnavailable,
   type ProviderRateLimits,
 } from "@traycer/protocol/host/rate-limit/schemas";
 
@@ -247,6 +249,104 @@ export const hostGetRateLimitUsageDowngradeV3ToV1 = defineDowngradePath<
       ...response,
       providerRateLimits: mapUsageFetchFailedToNotAvailable(
         mapGrokAvailableToUnavailable(response.providerRateLimits),
+      ),
+    }),
+  }),
+});
+
+// v4.0 adds the jcode available arm to the provider-account snapshot - the
+// per-sub-provider quota list `jcode usage --json` reports. Shipped as a major
+// for exactly the reason v3.0 was: a new available union arm isn't strippable
+// by the within-major skew handler, and `host-v1.1.9` already shipped v3.0, so
+// growing it in place would have grown a released response. The request shape
+// is unchanged, so this reuses `rateLimitUsageRequestSchemaV12` directly.
+export const hostGetRateLimitUsageV40 = defineRpcContract({
+  method: "host.getRateLimitUsage",
+  schemaVersion: { major: 4, minor: 0 } as const,
+  requestSchema: rateLimitUsageRequestSchemaV12,
+  responseSchema: rateLimitUsageResponseSchemaV40,
+});
+
+// A v3.0 request and a v4.0 request are identical shapes, so the request
+// upgrade is the identity. A v3.0 response only ever carries the frozen v3.0
+// union arms, every one of which is a valid v4.0 arm (the v4.0 union is a
+// strict superset), so the response upgrade is the identity too.
+export const hostGetRateLimitUsageUpgradeV30ToV40 = defineUpgradePath<
+  typeof hostGetRateLimitUsageV30,
+  typeof hostGetRateLimitUsageV40
+>({
+  from: hostGetRateLimitUsageV30.schemaVersion,
+  to: hostGetRateLimitUsageV40.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+// Downgrade bridge 4.0 -> 3.0: request is identity. A jcode-available snapshot
+// degrades to the unavailable `unsupported_provider` shape (jcode has no arm in
+// the frozen v3.0 union) - the exact row a pre-jcode host returns for an
+// unknown provider today; every other arm is already valid v3.0 and passes
+// through the re-parse unchanged.
+export const hostGetRateLimitUsageDowngradeV4ToV3 = defineDowngradePath<
+  typeof hostGetRateLimitUsageV40,
+  typeof hostGetRateLimitUsageV30
+>({
+  from: hostGetRateLimitUsageV40.schemaVersion,
+  to: hostGetRateLimitUsageV30.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: rateLimitUsageResponseSchemaV30.parse({
+      ...response,
+      providerRateLimits: mapJcodeAvailableToUnavailable(
+        response.providerRateLimits,
+      ),
+    }),
+  }),
+});
+
+// Downgrade bridge 4.0 -> 2.1: composes the jcode and grok degrades before the
+// v2.1 re-parse. Order matters only in that each map is a no-op for the other's
+// provider, so composing them is safe in either direction; jcode first keeps
+// the chain reading newest-arm-first, matching 4.0 -> 1.2 below.
+export const hostGetRateLimitUsageDowngradeV4ToV2 = defineDowngradePath<
+  typeof hostGetRateLimitUsageV40,
+  typeof hostGetRateLimitUsageV21
+>({
+  from: hostGetRateLimitUsageV40.schemaVersion,
+  to: hostGetRateLimitUsageV21.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: rateLimitUsageResponseSchemaV21.parse({
+      ...response,
+      providerRateLimits: mapGrokAvailableToUnavailable(
+        mapJcodeAvailableToUnavailable(response.providerRateLimits),
+      ),
+    }),
+  }),
+});
+
+// Downgrade bridge 4.0 -> 1.2: composes all three frozen-line maps before the
+// v1.2 re-parse - jcode- and grok-available snapshots degrade to
+// `unsupported_provider`, and the v2-only `usage_fetch_failed` reason degrades
+// to `rate_limits_not_available` - so a v1.2 client's frozen union and 8-value
+// reason enum both keep parsing. The available-arm degrades run first so a
+// genuinely available snapshot never lands on the usage-fetch-failed branch.
+export const hostGetRateLimitUsageDowngradeV4ToV1 = defineDowngradePath<
+  typeof hostGetRateLimitUsageV40,
+  typeof hostGetRateLimitUsageV12
+>({
+  from: hostGetRateLimitUsageV40.schemaVersion,
+  to: hostGetRateLimitUsageV12.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: rateLimitUsageResponseSchemaV12.parse({
+      ...response,
+      providerRateLimits: mapUsageFetchFailedToNotAvailable(
+        mapGrokAvailableToUnavailable(
+          mapJcodeAvailableToUnavailable(response.providerRateLimits),
+        ),
       ),
     }),
   }),

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -7,6 +7,7 @@ import {
   providerIdSchema,
   providerIdSchemaV40,
   providerIdSchemaV50,
+  providerIdSchemaV60,
 } from "@traycer/protocol/host/provider-schemas";
 
 // `host.getRateLimitUsage` v1.0 request: no fields. Non-strict on purpose so a
@@ -89,6 +90,7 @@ export const rateLimitCapableProviderIdSchema = z.enum([
   "openrouter",
   "kilocode",
   "grok",
+  "jcode",
 ]);
 export type RateLimitCapableProviderId = z.infer<
   typeof rateLimitCapableProviderIdSchema
@@ -250,6 +252,55 @@ const grokRateLimitsSchema = z
     }
   });
 
+// JCode arm - meta-harness, and the only arm in this union that is a LIST.
+// `jcode usage --json` fans out to a real upstream quota call PER CONNECTED
+// SUB-PROVIDER (OpenRouter `GET /api/v1/key` + `/credits`, plus dedicated
+// fetchers for Anthropic, OpenAI, Copilot, Antigravity, Gemini and Cursor), so
+// one jcode account routinely reports several independent quotas at once.
+// There is no single number that is honestly "the jcode quota", so this arm
+// refuses to synthesize one: it carries the per-sub-provider rows and lets the
+// shared severity rollup fold them, exactly the way claude-code's model-scoped
+// windows already fold (`FamilyScopedWindow` in the host's
+// `rate-limit-gauge-cache.ts` is a LIST of windows per provider - no new
+// primitive is needed for this).
+const jcodeSubProviderRateLimitSchema = z.object({
+  // jcode's own sub-provider key ("openrouter", "anthropic", "copilot", ...).
+  // Deliberately a bare string rather than a Traycer `ProviderId`: this
+  // namespace is jcode's, overlaps ours only by coincidence, and grows on
+  // jcode's release cadence - the same reason a provider's own plan/limit
+  // tokens stay bare strings elsewhere in this file. Constraining it would
+  // make every new jcode sub-provider a protocol change.
+  subProviderId: z.string(),
+  // Normalized rolling window. `usedPercent` is jcode's `usage_percent`, which
+  // is percent CONSUMED (verified upstream: 15990.63/16053.68 = 99.607%), so it
+  // maps onto the shared window primitive with no inversion. `resetsAt` is
+  // jcode's `resets_at`, which upstream populates ONLY for Antigravity and
+  // Copilot - every other fetcher passes `None` - so `null` here means "not
+  // reported", NOT "never resets". `null` for the whole window means this
+  // sub-provider reported no measurable quota.
+  window: providerRateLimitWindowSchema.nullable(),
+  // jcode COMPUTES `hard_limit_reached` upstream but does not serialize it, so
+  // the host derives it (`usedPercent >= 100`). Carried explicitly rather than
+  // re-derived per consumer so the derivation stays at the host boundary with
+  // the rest of the normalization - and so a future upstream build that DOES
+  // serialize it can be honoured without changing consumers.
+  hardLimitReached: z.boolean(),
+  // Per-sub-provider failure text from jcode's own `error` field. Non-null
+  // distinguishes "this sub-provider's quota fetch failed" from "this
+  // sub-provider has no quota to report" - both yield `window: null`, and a
+  // partial failure must not read as a healthy zero.
+  error: z.string().nullable(),
+});
+
+const jcodeRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.jcode),
+  available: z.literal(true),
+  // Empty when no connected sub-provider reports quota. Still `available: true`:
+  // the query itself succeeded and "nothing to show" is a different answer from
+  // the `available: false` arm's "could not ask".
+  subProviders: z.array(jcodeSubProviderRateLimitSchema),
+});
+
 // Closed, Traycer-owned set of reasons a provider pull can fail to report
 // rate limits - unlike a provider's own plan/reached-type tokens (owned by
 // that provider, legitimately forward-compat as a bare string), every one of
@@ -372,15 +423,38 @@ export const providerRateLimitsSchemaV21 = z.union([
 ]);
 export type ProviderRateLimitsV21 = z.infer<typeof providerRateLimitsSchemaV21>;
 
-// Latest provider union: identical to the frozen v2.1 union above plus the
-// grok available arm. Feeds the v3.0 host response and the unreleased,
-// still-growing a2a `agent.getProviderProfileRateLimits@2.0`.
+/**
+ * Frozen v3.0 provider union - the frozen v2.1 union plus the grok available
+ * arm, i.e. a byte-for-byte snapshot of the union as shipped in
+ * `rateLimitUsageResponseSchemaV30` (`host.getRateLimitUsage@3.0`).
+ *
+ * That line IS released: `host-v1.1.9` (tagged 2026-07-29) shipped it, and it
+ * pointed at the LIVE union until this pin - so the jcode available arm would
+ * have landed on an already-released response. Same defect the v2.1 pin exists
+ * to stop, one major later. New available arms travel behind a new major
+ * (`host.getRateLimitUsage@4.0`) with a downgrade bridge, never an in-place
+ * edit here. Do NOT widen this schema.
+ */
+export const providerRateLimitsSchemaV30 = z.union([
+  codexRateLimitsSchema,
+  claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
+  grokRateLimitsSchema,
+  unavailableProviderRateLimitsSchemaV2,
+]);
+export type ProviderRateLimitsV30 = z.infer<typeof providerRateLimitsSchemaV30>;
+
+// Latest provider union: identical to the frozen v3.0 union above plus the
+// jcode available arm. Feeds the v4.0 host response and the unreleased,
+// still-growing a2a `agent.getProviderProfileRateLimits@4.0`.
 export const providerRateLimitsSchema = z.union([
   codexRateLimitsSchema,
   claudeCodeRateLimitsSchema,
   openRouterRateLimitsSchema,
   kiloCodeRateLimitsSchema,
   grokRateLimitsSchema,
+  jcodeRateLimitsSchema,
   unavailableProviderRateLimitsSchemaV2,
 ]);
 export type ProviderRateLimits = z.infer<typeof providerRateLimitsSchema>;
@@ -405,6 +479,41 @@ export function mapGrokAvailableToUnavailable(
   ) {
     return {
       provider: "grok",
+      available: false,
+      reason: "unsupported_provider",
+    };
+  }
+  return providerRateLimits;
+}
+
+/**
+ * The jcode counterpart of {@link mapGrokAvailableToUnavailable}, and the
+ * reason it is a SEPARATE function rather than a widened one: the two degrade
+ * into different frozen unions and only one of them can survive there.
+ *
+ * `"grok"` is a member of every frozen `provider` enum (it predates
+ * Hermes/omp/jcode), so a degraded grok row reparses cleanly through any older
+ * union. `"jcode"` is in NONE of them. So this degrade is only meaningful for
+ * the `host.getRateLimitUsage` line, whose frozen unavailable arms carry the
+ * LIVE `providerIdSchema` and whose growing `**.provider.enum` is a recorded,
+ * catalog-gated exception (`compat-exceptions.json`) - a v3.0 client only ever
+ * asks about a provider it already has configured, so it never receives this
+ * row at all. On `agent.getProviderProfileRateLimits` the frozen unions pin
+ * `providerIdSchemaV40/V50/V60`, so a jcode read stays unrepresentable and
+ * those bridges must keep failing closed instead of calling this.
+ *
+ * Any other snapshot (or `null`) passes through unchanged.
+ */
+export function mapJcodeAvailableToUnavailable(
+  providerRateLimits: ProviderRateLimits | null,
+): ProviderRateLimits | null {
+  if (
+    providerRateLimits !== null &&
+    providerRateLimits.available &&
+    providerRateLimits.provider === "jcode"
+  ) {
+    return {
+      provider: "jcode",
       available: false,
       reason: "unsupported_provider",
     };
@@ -479,6 +588,43 @@ export const providerRateLimitsSchemaV50 = z.union([
 ]);
 export type ProviderRateLimitsV50 = z.infer<typeof providerRateLimitsSchemaV50>;
 
+// Frozen pre-jcode unavailable arm: same v2 reason enum, but `provider` is
+// pinned to `providerIdSchemaV60` (the provider id set as shipped in
+// cli-v1.1.9 / host-v1.1.9, with omp and before jcode) so an already-shipped
+// `agent.getProviderProfileRateLimits@3.0` caller's strict decode never sees
+// `"jcode"` in the `available: false` arm.
+const unavailableProviderRateLimitsSchemaV60 = z.object({
+  provider: providerIdSchemaV60,
+  available: z.literal(false),
+  reason: rateLimitUnavailableReasonSchemaV2,
+});
+
+/**
+ * Frozen pre-jcode provider union - identical to the latest
+ * `providerRateLimitsSchema` except the `available: false` arm's `provider` is
+ * pinned to `providerIdSchemaV60`. Like the v5.0 union it KEEPS the grok
+ * available arm; the v1.1.9 tags shipped that arm, so dropping it here would
+ * narrow an already-shipped contract.
+ *
+ * Feeds only `agent.getProviderProfileRateLimits@3.0`'s frozen response (see
+ * `host/agent/profiles.ts`). That line IS released (v1.1.9) but still pointed
+ * at the LIVE `providerRateLimitsSchema` until this repair, so it absorbed
+ * every provider id added afterwards - the same defect one version earlier let
+ * `omp` ride v2.0. The v4.0 line carries jcode via the live union, with a
+ * v4->v3 downgrade bridge that fails closed for such a rate-limit read instead
+ * of silently mis-decoding it. Do NOT widen this schema - extend the latest
+ * schema and use that v4 bridge instead.
+ */
+export const providerRateLimitsSchemaV60 = z.union([
+  codexRateLimitsSchema,
+  claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
+  grokRateLimitsSchema,
+  unavailableProviderRateLimitsSchemaV60,
+]);
+export type ProviderRateLimitsV60 = z.infer<typeof providerRateLimitsSchemaV60>;
+
 // v1.2 response = v1.0/v1.1 flat aperture fields (unchanged) + a nullable
 // provider-account snapshot, frozen at the v1 reason enum (see
 // `providerRateLimitsSchemaV1` above). Null both when the request didn't ask
@@ -521,20 +667,38 @@ export type RateLimitUsageResponseV21 = z.infer<
   typeof rateLimitUsageResponseSchemaV21
 >;
 
-// v3.0 response - identical to v2.1 except the provider-account snapshot ranges
-// over the live `providerRateLimitsSchema`, which adds the grok available arm.
-// The request shape is unchanged from v1.2/v2.x, so `hostGetRateLimitUsageV30`
-// in `contracts.ts` reuses `rateLimitUsageRequestSchemaV12` directly. Shipped
-// as a new major (not a v2.2 minor) because a new available union arm is not
-// strippable by the within-major skew handler - an old peer's frozen union has
-// no grok arm - so it needs an explicit downgrade bridge that degrades a
-// grok-available snapshot to the unavailable `unsupported_provider` shape.
+// v3.0 response - identical to v2.1 except the provider-account snapshot adds
+// the grok available arm. The request shape is unchanged from v1.2/v2.x, so
+// `hostGetRateLimitUsageV30` in `contracts.ts` reuses
+// `rateLimitUsageRequestSchemaV12` directly. Shipped as a new major (not a v2.2
+// minor) because a new available union arm is not strippable by the
+// within-major skew handler - an old peer's frozen union has no grok arm - so
+// it needs an explicit downgrade bridge that degrades a grok-available snapshot
+// to the unavailable `unsupported_provider` shape.
+//
+// Pinned to the frozen `providerRateLimitsSchemaV30` (NOT the live union):
+// `host-v1.1.9` shipped this line, and it pointed at the live union until that
+// pin, so the jcode arm added below would have grown an already-released
+// response. jcode travels on the v4.0 line.
 export const rateLimitUsageResponseSchemaV30 =
   rateLimitUsageResponseSchema.extend({
-    providerRateLimits: providerRateLimitsSchema.nullable(),
+    providerRateLimits: providerRateLimitsSchemaV30.nullable(),
   });
 export type RateLimitUsageResponseV30 = z.infer<
   typeof rateLimitUsageResponseSchemaV30
+>;
+
+// v4.0 response - identical to v3.0 except the provider-account snapshot ranges
+// over the live `providerRateLimitsSchema`, which adds the jcode available arm.
+// Same reasoning as the v2.1 -> v3.0 bump: a new available union arm is not
+// strippable within a major, so it needs an explicit bridge that degrades a
+// jcode-available snapshot to the unavailable `unsupported_provider` shape.
+export const rateLimitUsageResponseSchemaV40 =
+  rateLimitUsageResponseSchema.extend({
+    providerRateLimits: providerRateLimitsSchema.nullable(),
+  });
+export type RateLimitUsageResponseV40 = z.infer<
+  typeof rateLimitUsageResponseSchemaV40
 >;
 
 /**

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -271,6 +271,13 @@ const jcodeSubProviderRateLimitSchema = z.object({
   // tokens stay bare strings elsewhere in this file. Constraining it would
   // make every new jcode sub-provider a protocol change.
   subProviderId: z.string(),
+  // jcode's own `limits[].name` ("Credits", "Weekly", ...). ONE sub-provider
+  // can report SEVERAL independent quotas, each becoming its own row here, so
+  // `subProviderId` is not a key and is not a sufficient label: without this
+  // field two Copilot rows are indistinguishable in the UI and collide as
+  // React keys. `null` when jcode omits the name - unnamed, not unlabelled by
+  // choice.
+  limitName: z.string().nullable(),
   // Normalized rolling window. `usedPercent` is jcode's `usage_percent`, which
   // is percent CONSUMED (verified upstream: 15990.63/16053.68 = 99.607%), so it
   // maps onto the shared window primitive with no inversion. `resetsAt` is

--- a/protocol/src/host/rate-limit/semantics.ts
+++ b/protocol/src/host/rate-limit/semantics.ts
@@ -100,6 +100,23 @@ export function liveProviderRateLimitWindows(
 }
 
 /**
+ * Display name for one jcode quota row. jcode reports a LIST of named limits
+ * per connected sub-provider, so `subProviderId` alone is ambiguous the moment
+ * a provider returns more than one - two Copilot rows would read identically
+ * and, in a keyed list, collide. Shared by the settings meter, the
+ * agent-facing text formatter and the profile-usage projection so those three
+ * surfaces cannot drift apart on what a row is called.
+ */
+export function jcodeSubProviderRateLimitLabel(subProvider: {
+  readonly subProviderId: string;
+  readonly limitName: string | null;
+}): string {
+  return subProvider.limitName === null
+    ? subProvider.subProviderId
+    : `${subProvider.subProviderId} · ${subProvider.limitName}`;
+}
+
+/**
  * Classifies a whole provider snapshot. A Codex reached-type is authoritative,
  * except when every window from that same capture has expired. Missing,
  * unavailable, and fully expired detail is Unknown rather than Healthy.
@@ -122,7 +139,20 @@ export function classifyProviderRateLimits(
   }
   if (
     rateLimits.provider === "jcode" &&
-    rateLimits.subProviders.some((subProvider) => subProvider.hardLimitReached)
+    rateLimits.subProviders.some(
+      (subProvider) =>
+        subProvider.hardLimitReached &&
+        // Per-ROW liveness, not the snapshot-wide guard above. jcode is the
+        // only LIST arm, so one capture mixes rows with independent reset
+        // times: an OpenRouter row that hit 100% and has since rolled over
+        // must not make a healthy live Copilot row report limited. The
+        // all-expired guard cannot catch that - it only fires when EVERY row
+        // is stale. A row with no window (or no reset time) has no evidence
+        // of rolling over, so it stays authoritative, matching
+        // `isProviderRateLimitWindowLive`'s null rule.
+        (subProvider.window === null ||
+          isProviderRateLimitWindowLive(subProvider.window, now)),
+    )
   ) {
     // Authoritative for the same reason Codex's reached-type is, and placed
     // after the same staleness guard so an all-expired capture still reports

--- a/protocol/src/host/rate-limit/semantics.ts
+++ b/protocol/src/host/rate-limit/semantics.ts
@@ -65,6 +65,16 @@ export function providerRateLimitWindows(
       // severity/rollup path. A period-less snapshot (tier + dates only, no
       // usage percentage) carries no window.
       return rateLimits.period !== null ? [rateLimits.period] : [];
+    case "jcode":
+      // Meta-harness arm: one window per connected sub-provider that reported a
+      // measurable quota. This is the same many-windows-per-provider shape
+      // claude-code already contributes, so it folds into the shared severity
+      // rollup with no special casing. A sub-provider whose fetch failed (its
+      // `error` is non-null) carries a null window and simply contributes
+      // nothing - it must never read as a healthy zero.
+      return rateLimits.subProviders
+        .map((subProvider) => subProvider.window)
+        .filter((window): window is ProviderRateLimitWindow => window !== null);
     case "openrouter":
     case "kilocode":
       return [];
@@ -108,6 +118,20 @@ export function classifyProviderRateLimits(
     rateLimits.provider === "codex" &&
     rateLimits.rateLimitReachedType !== null
   ) {
+    return "limited";
+  }
+  if (
+    rateLimits.provider === "jcode" &&
+    rateLimits.subProviders.some((subProvider) => subProvider.hardLimitReached)
+  ) {
+    // Authoritative for the same reason Codex's reached-type is, and placed
+    // after the same staleness guard so an all-expired capture still reports
+    // Unknown. Today the host derives `hardLimitReached` from
+    // `usedPercent >= 100` (jcode computes `hard_limit_reached` upstream but
+    // does not serialize it), so this agrees with the window classifier by
+    // construction - reading the flag rather than re-deriving it means an
+    // upstream build that starts serializing a different rule is honoured here
+    // instead of silently disagreeing with itself.
     return "limited";
   }
   if (liveWindows.length === 0) return "unknown";

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -3,6 +3,7 @@ import {
   defineFloorAwareVersionedRpcRegistry,
   defineUpgradePath,
   type DowngradeResult,
+  type VersionedRpcRegistry,
 } from "@traycer/protocol/framework/index";
 import {
   defineVersionedStreamRpcRegistry,
@@ -38,17 +39,25 @@ import {
   agentListDowngradeV6ToV3,
   agentListDowngradeV6ToV4,
   agentListDowngradeV6ToV5,
+  agentListDowngradeV7ToV1,
+  agentListDowngradeV7ToV2,
+  agentListDowngradeV7ToV3,
+  agentListDowngradeV7ToV4,
+  agentListDowngradeV7ToV5,
+  agentListDowngradeV7ToV6,
   agentListUpgradeV1ToV2,
   agentListUpgradeV2ToV3,
   agentListUpgradeV3ToV4,
   agentListUpgradeV4ToV5,
   agentListUpgradeV5ToV6,
+  agentListUpgradeV6ToV7,
   agentListV10,
   agentListV20,
   agentListV30,
   agentListV40,
   agentListV50,
   agentListV60,
+  agentListV70,
   agentSelectionGuideV10,
   agentSelectionGuideGlobalGetV10,
   agentSelectionGuideGlobalOnboardingDraftGetV10,
@@ -61,27 +70,42 @@ import {
   agentConfigureDowngradeV20ToV10,
   agentConfigureDowngradeV30ToV10,
   agentConfigureDowngradeV30ToV20,
+  agentConfigureDowngradeV40ToV10,
+  agentConfigureDowngradeV40ToV20,
+  agentConfigureDowngradeV40ToV30,
   agentConfigureV10,
   agentConfigureV20,
   agentConfigureV30,
+  agentConfigureV40,
   agentConfigureUpgradeV10ToV20,
   agentConfigureUpgradeV20ToV30,
+  agentConfigureUpgradeV30ToV40,
   agentGetProviderProfileRateLimitsDowngradeV20ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV20,
+  agentGetProviderProfileRateLimitsDowngradeV40ToV10,
+  agentGetProviderProfileRateLimitsDowngradeV40ToV20,
+  agentGetProviderProfileRateLimitsDowngradeV40ToV30,
   agentGetProviderProfileRateLimitsV10,
   agentGetProviderProfileRateLimitsV20,
   agentGetProviderProfileRateLimitsV30,
+  agentGetProviderProfileRateLimitsV40,
   agentGetProviderProfileRateLimitsUpgradeV10ToV20,
   agentGetProviderProfileRateLimitsUpgradeV20ToV30,
+  agentGetProviderProfileRateLimitsUpgradeV30ToV40,
   agentListProviderProfilesDowngradeV20ToV10,
   agentListProviderProfilesDowngradeV30ToV10,
   agentListProviderProfilesDowngradeV30ToV20,
+  agentListProviderProfilesDowngradeV40ToV10,
+  agentListProviderProfilesDowngradeV40ToV20,
+  agentListProviderProfilesDowngradeV40ToV30,
   agentListProviderProfilesV10,
   agentListProviderProfilesV20,
   agentListProviderProfilesV30,
+  agentListProviderProfilesV40,
   agentListProviderProfilesUpgradeV10ToV20,
   agentListProviderProfilesUpgradeV20ToV30,
+  agentListProviderProfilesUpgradeV30ToV40,
 } from "@traycer/protocol/host/agent/profiles";
 import {
   agentInboxReadV10,
@@ -115,12 +139,19 @@ import {
   agentGuiListHarnessesDowngradeV6ToV3,
   agentGuiListHarnessesDowngradeV6ToV4,
   agentGuiListHarnessesDowngradeV6ToV5,
+  agentGuiListHarnessesDowngradeV7ToV1,
+  agentGuiListHarnessesDowngradeV7ToV2,
+  agentGuiListHarnessesDowngradeV7ToV3,
+  agentGuiListHarnessesDowngradeV7ToV4,
+  agentGuiListHarnessesDowngradeV7ToV5,
+  agentGuiListHarnessesDowngradeV7ToV6,
   agentGuiListHarnessesUpgradeV1ToV2,
   agentGuiListHarnessesUpgradeV20ToV21,
   agentGuiListHarnessesUpgradeV2ToV3,
   agentGuiListHarnessesUpgradeV3ToV4,
   agentGuiListHarnessesUpgradeV4ToV5,
   agentGuiListHarnessesUpgradeV5ToV6,
+  agentGuiListHarnessesUpgradeV6ToV7,
   agentGuiListHarnessesV10,
   agentGuiListHarnessesV20,
   agentGuiListHarnessesV21,
@@ -128,6 +159,7 @@ import {
   agentGuiListHarnessesV40,
   agentGuiListHarnessesV50,
   agentGuiListHarnessesV60,
+  agentGuiListHarnessesV70,
   agentGuiListModelsV10,
   chatSubscribeV10,
   chatSubscribeV11,
@@ -166,13 +198,18 @@ import {
   hostGetRateLimitUsageV20,
   hostGetRateLimitUsageV21,
   hostGetRateLimitUsageV30,
+  hostGetRateLimitUsageV40,
   hostGetRateLimitUsageUpgradeV10ToV11,
   hostGetRateLimitUsageUpgradeV11ToV12,
   hostGetRateLimitUsageUpgradeV12ToV20,
   hostGetRateLimitUsageUpgradeV20ToV21,
   hostGetRateLimitUsageUpgradeV21ToV30,
+  hostGetRateLimitUsageUpgradeV30ToV40,
   hostGetRateLimitUsageDowngradeV2ToV1,
   hostGetRateLimitUsageDowngradeV3ToV2,
+  hostGetRateLimitUsageDowngradeV4ToV1,
+  hostGetRateLimitUsageDowngradeV4ToV2,
+  hostGetRateLimitUsageDowngradeV4ToV3,
   hostGetRateLimitUsageDowngradeV3ToV1,
   providersConsumeRateLimitResetCreditV10,
 } from "@traycer/protocol/host/rate-limit/contracts";
@@ -445,6 +482,7 @@ import {
   downgradeProviderCliStateToMutationV20,
   downgradeProviderCliStateListToV40,
   downgradeProviderCliStateListToV50,
+  downgradeProviderCliStateListToV60,
   upgradeProviderCliStateV10ToV20,
   upgradeProviderCliStateListToLatest,
   upgradeProviderCliStateV10ToMutationV20,
@@ -1362,14 +1400,15 @@ export const providersListDowngradeV7ToV6 = defineDowngradePath<
   from: { major: 7, minor: 0 },
   to: { major: 6, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
-  // The id sets are identical, so this hop exists purely to strip the
-  // provider-pack-registry fields: reparsing through the frozen v6.0 schema
-  // drops the keys it does not model, which is exactly what `cli-v1.1.9`
-  // expects to receive.
+  // Two jobs now. It still strips the provider-pack-registry fields (reparsing
+  // through the frozen v6.0 schema drops the keys it does not model, which is
+  // exactly what `cli-v1.1.9` expects to receive) - but the id sets are no
+  // longer identical, so it must also DROP `jcode` first. A straight reparse of
+  // the whole list would throw on the jcode row rather than filtering it.
   downgradeResponse: (response) => ({
     ok: true,
     value: providersListResponseSchemaV60.parse({
-      providers: response.providers,
+      providers: downgradeProviderCliStateListToV60(response.providers),
     }),
   }),
 });
@@ -2818,7 +2857,8 @@ export const worktreeListBindingsForEpicUpgradeV11ToV12 = defineUpgradePath<
 // Note: git contract definitions are imported from git-contracts.ts above
 // and registered inline in hostRpcRegistry and hostStreamRpcRegistry below.
 
-const HOST_RPC_REGISTRY_DEFINITION = {
+// host status, lifecycle, rate limits, notifications, comments, snapshots.
+const HOST_RPC_REGISTRY_DEFINITION_CORE = {
   "host.status": {
     1: {
       latestMinor: 0,
@@ -2932,6 +2972,20 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       downgradePathsFromLatest: {
         2: hostGetRateLimitUsageDowngradeV3ToV2,
         1: hostGetRateLimitUsageDowngradeV3ToV1,
+      },
+    },
+    4: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: hostGetRateLimitUsageV40,
+          upgradeFromPreviousVersion: hostGetRateLimitUsageUpgradeV30ToV40,
+        },
+      },
+      downgradePathsFromLatest: {
+        3: hostGetRateLimitUsageDowngradeV4ToV3,
+        2: hostGetRateLimitUsageDowngradeV4ToV2,
+        1: hostGetRateLimitUsageDowngradeV4ToV1,
       },
     },
   },
@@ -3219,6 +3273,11 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
+} as const;
+type HostRpcMethodMapCore = typeof HOST_RPC_REGISTRY_DEFINITION_CORE;
+
+// the agent surface: gui + tui catalogs, create/list/send, roles, inbox, stop.
+const HOST_RPC_REGISTRY_DEFINITION_AGENT = {
   "agent.gui.listHarnesses": {
     1: {
       latestMinor: 0,
@@ -3300,6 +3359,23 @@ const HOST_RPC_REGISTRY_DEFINITION = {
         3: agentGuiListHarnessesDowngradeV6ToV3,
         4: agentGuiListHarnessesDowngradeV6ToV4,
         5: agentGuiListHarnessesDowngradeV6ToV5,
+      },
+    },
+    7: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGuiListHarnessesV70,
+          upgradeFromPreviousVersion: agentGuiListHarnessesUpgradeV6ToV7,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentGuiListHarnessesDowngradeV7ToV1,
+        2: agentGuiListHarnessesDowngradeV7ToV2,
+        3: agentGuiListHarnessesDowngradeV7ToV3,
+        4: agentGuiListHarnessesDowngradeV7ToV4,
+        5: agentGuiListHarnessesDowngradeV7ToV5,
+        6: agentGuiListHarnessesDowngradeV7ToV6,
       },
     },
   },
@@ -3626,6 +3702,23 @@ const HOST_RPC_REGISTRY_DEFINITION = {
         5: agentListDowngradeV6ToV5,
       },
     },
+    7: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListV70,
+          upgradeFromPreviousVersion: agentListUpgradeV6ToV7,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListDowngradeV7ToV1,
+        2: agentListDowngradeV7ToV2,
+        3: agentListDowngradeV7ToV3,
+        4: agentListDowngradeV7ToV4,
+        5: agentListDowngradeV7ToV5,
+        6: agentListDowngradeV7ToV6,
+      },
+    },
   },
   "agent.sendMessage": {
     1: {
@@ -3731,6 +3824,11 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
+} as const;
+type HostRpcMethodMapAgent = typeof HOST_RPC_REGISTRY_DEFINITION_AGENT;
+
+// epic, workspace, git, editor, terminal, resources, worktree.
+const HOST_RPC_REGISTRY_DEFINITION_EPIC = {
   "phase.migrateToEpic": {
     1: {
       latestMinor: 0,
@@ -4776,6 +4874,11 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
+} as const;
+type HostRpcMethodMapEpic = typeof HOST_RPC_REGISTRY_DEFINITION_EPIC;
+
+// providers, speech, and the A2A provider-profile methods.
+const HOST_RPC_REGISTRY_DEFINITION_PROVIDERS = {
   "providers.list": {
     1: {
       latestMinor: 0,
@@ -5391,6 +5494,20 @@ const HOST_RPC_REGISTRY_DEFINITION = {
         2: agentListProviderProfilesDowngradeV30ToV20,
       },
     },
+    4: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListProviderProfilesV40,
+          upgradeFromPreviousVersion: agentListProviderProfilesUpgradeV30ToV40,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListProviderProfilesDowngradeV40ToV10,
+        2: agentListProviderProfilesDowngradeV40ToV20,
+        3: agentListProviderProfilesDowngradeV40ToV30,
+      },
+    },
   },
   "agent.getProviderProfileRateLimits": {
     degrade: { kind: "unsupported" },
@@ -5431,6 +5548,21 @@ const HOST_RPC_REGISTRY_DEFINITION = {
         2: agentGetProviderProfileRateLimitsDowngradeV30ToV20,
       },
     },
+    4: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGetProviderProfileRateLimitsV40,
+          upgradeFromPreviousVersion:
+            agentGetProviderProfileRateLimitsUpgradeV30ToV40,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentGetProviderProfileRateLimitsDowngradeV40ToV10,
+        2: agentGetProviderProfileRateLimitsDowngradeV40ToV20,
+        3: agentGetProviderProfileRateLimitsDowngradeV40ToV30,
+      },
+    },
   },
   "agent.configure": {
     degrade: { kind: "unsupported" },
@@ -5467,6 +5599,20 @@ const HOST_RPC_REGISTRY_DEFINITION = {
         2: agentConfigureDowngradeV30ToV20,
       },
     },
+    4: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentConfigureV40,
+          upgradeFromPreviousVersion: agentConfigureUpgradeV30ToV40,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentConfigureDowngradeV40ToV10,
+        2: agentConfigureDowngradeV40ToV20,
+        3: agentConfigureDowngradeV40ToV30,
+      },
+    },
   },
   // Additive, post-v1.0.0 optional method: a PR's patch read from the local
   // checkout. A host that predates it simply lacks it and the PR view falls
@@ -5488,13 +5634,63 @@ const HOST_RPC_REGISTRY_DEFINITION = {
     },
   },
 } as const;
+type HostRpcMethodMapProviders = typeof HOST_RPC_REGISTRY_DEFINITION_PROVIDERS;
 
-export const hostRpcRegistry = defineFloorAwareVersionedRpcRegistry(
-  RELEASED_FLOOR_METHOD_NAMES,
-  HOST_RPC_REGISTRY_DEFINITION,
-);
+/**
+ * The registry's method map, as an intersection of the four named group types
+ * above rather than one anonymous literal type.
+ *
+ * This split exists for declaration emit, not for readability. `tsc -p
+ * tsconfig.build.json` has to SERIALIZE the type of every exported node, and a
+ * single 157-method literal exceeded TS7056's ceiling once jcode added six
+ * version lines at once. `tsc --noEmit` never serializes, which is why `bun run
+ * compile` stayed green while `bun run build` failed - the two gates genuinely
+ * cover different things.
+ *
+ * The ceiling is per NODE, so four smaller literals plus an intersection of
+ * four short names stays under it, and each future method lands in one group
+ * rather than growing the single node that overflowed. Nothing here is widened:
+ * the intersection is exactly the type the one literal had, so
+ * `defineFloorAwareVersionedRpcRegistry` still infers the precise `Registry`
+ * and still runs every structural, minor-additivity and
+ * major-bump-must-be-breaking check against it.
+ */
+export type HostRpcMethodMap = HostRpcMethodMapCore &
+  HostRpcMethodMapAgent &
+  HostRpcMethodMapEpic &
+  HostRpcMethodMapProviders;
 
-export type HostRpcRegistry = typeof hostRpcRegistry;
+// Annotated (not inferred) so this node prints as the short name above instead
+// of re-serializing all four groups inline.
+const HOST_RPC_REGISTRY_DEFINITION: HostRpcMethodMap = {
+  ...HOST_RPC_REGISTRY_DEFINITION_CORE,
+  ...HOST_RPC_REGISTRY_DEFINITION_AGENT,
+  ...HOST_RPC_REGISTRY_DEFINITION_EPIC,
+  ...HOST_RPC_REGISTRY_DEFINITION_PROVIDERS,
+};
+
+// Annotated for the same reason `hostStreamRpcRegistry` below is, and with the
+// same trade-off: without an explicit annotation the inferred type of this node
+// exceeds TS7056's declaration-emit ceiling. That limit is only reached on the
+// EMIT path - `tsc --noEmit` never has to serialize the type, so `bun run
+// compile` stays green while `bun run build` fails. jcode pushed it over by
+// adding six version lines at once (two catalogs at 7.0, three profile methods
+// and `host.getRateLimitUsage` at 4.0).
+//
+// `defineFloorAwareVersionedRpcRegistry` still receives the full precise
+// literal and still validates it at this call site - structural checks, the
+// minors-only-add rule, and the major-bump-must-be-breaking rule all run
+// exactly as before. The annotation names the type of the RESULT; it does not
+// weaken the argument's check. (Verified by re-running the probe that made the
+// registry refuse a non-breaking 3 -> 4 bump on `host.getRateLimitUsage`: it
+// still refuses.)
+export type HostRpcRegistry = VersionedRpcRegistry<HostRpcMethodMap>;
+
+export const hostRpcRegistry: HostRpcRegistry =
+  defineFloorAwareVersionedRpcRegistry(
+    RELEASED_FLOOR_METHOD_NAMES,
+    HOST_RPC_REGISTRY_DEFINITION,
+  );
 
 /**
  * Combined streaming-RPC registry for the `/stream` WS manifest.

--- a/protocol/src/persistence/COMPATIBILITY.md
+++ b/protocol/src/persistence/COMPATIBILITY.md
@@ -49,6 +49,23 @@ A breaking change requires a new registered persistence major and an explicit
 migration/downgrade strategy. Regenerating a fixture is not a substitute for
 versioning the contract.
 
+## Classification: additive harness/provider id growth
+
+Adding a harness/provider id to the persisted enums (`guiHarnessIdSchema` in
+`epic/foundation.ts`, the matching per-harness `chatSessionAnchorSchema` variant
+in `epic/senders.ts`) is a **same-major** change, even though the list above
+names enum growth.
+
+An older reader loses exactly the affected chat and nothing else: `harnessId`
+sits in `chatRunSettingsSchema`, the host reads a chat with one all-or-nothing
+`chatSchema.safeParse`, and `readChatSnapshot` turns that failure into
+`CHAT_INVALID` for that chat alone — the epic, its artifacts, its other chats
+and its TUI agents all still open.
+
+This covers *additive* id growth and its anchor variant only. Removing an id,
+changing what an existing id means, or growing any other enum still requires a
+new major.
+
 ## Frozen epic-schema guard
 
 `epic-schema-surface-compat.test.ts` resolves the latest epic schema through the

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
@@ -86,6 +86,7 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
+                        "jcode",
                       ],
                     },
                     model: {
@@ -173,6 +174,7 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
+                        "jcode",
                       ],
                     },
                     sessionId: {
@@ -320,6 +322,7 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
+                                  "jcode",
                                 ],
                               },
                               agentId: {
@@ -2376,6 +2379,109 @@ export const epicSchemaSurfaceBaseline = {
                                   "createdAt",
                                 ],
                               },
+                              {
+                                type: "object",
+                                properties: {
+                                  harnessId: {
+                                    type: "string",
+                                    const: "jcode",
+                                  },
+                                  hostId: {
+                                    type: "string",
+                                  },
+                                  sessionId: {
+                                    type: "string",
+                                  },
+                                  sessionWorkspaceSnapshot: {
+                                    type: "object",
+                                    properties: {
+                                      workspaceKind: {
+                                        type: "string",
+                                        const: "session-snapshot",
+                                      },
+                                      primaryWorkspace: {
+                                        type: "string",
+                                      },
+                                      secondaryWorkspaces: {
+                                        default: [],
+                                        type: "array",
+                                        items: {
+                                          type: "string",
+                                        },
+                                      },
+                                    },
+                                    required: [
+                                      "workspaceKind",
+                                      "primaryWorkspace",
+                                    ],
+                                  },
+                                  createdAt: {
+                                    type: "number",
+                                  },
+                                  coveredUntilMessageId: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  profileId: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  labelSnapshot: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  accountUuid: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  accentColor: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                },
+                                required: [
+                                  "harnessId",
+                                  "hostId",
+                                  "sessionId",
+                                  "sessionWorkspaceSnapshot",
+                                  "createdAt",
+                                ],
+                              },
                             ],
                           },
                           {
@@ -2432,6 +2538,7 @@ export const epicSchemaSurfaceBaseline = {
                               "pi",
                               "hermes",
                               "omp",
+                              "jcode",
                             ],
                           },
                           agentId: {
@@ -2557,6 +2664,7 @@ export const epicSchemaSurfaceBaseline = {
                                             "pi",
                                             "hermes",
                                             "omp",
+                                            "jcode",
                                           ],
                                         },
                                         noticeKind: {
@@ -3784,6 +3892,7 @@ export const epicSchemaSurfaceBaseline = {
                                     "pi",
                                     "hermes",
                                     "omp",
+                                    "jcode",
                                   ],
                                 },
                                 source: {
@@ -3810,6 +3919,7 @@ export const epicSchemaSurfaceBaseline = {
                                         "pi",
                                         "hermes",
                                         "omp",
+                                        "jcode",
                                       ],
                                     },
                                     sessionId: {
@@ -4430,6 +4540,7 @@ export const epicSchemaSurfaceBaseline = {
                                                 "pi",
                                                 "hermes",
                                                 "omp",
+                                                "jcode",
                                               ],
                                             },
                                             agentId: {
@@ -5041,6 +5152,7 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
+                                  "jcode",
                                 ],
                               },
                               agentId: {
@@ -6524,6 +6636,7 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
+                        "jcode",
                       ],
                     },
                     model: {
@@ -6614,6 +6727,7 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
+                        "jcode",
                       ],
                     },
                     sessionId: {
@@ -6771,6 +6885,7 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
+                                  "jcode",
                                 ],
                               },
                               agentId: {
@@ -8980,6 +9095,117 @@ export const epicSchemaSurfaceBaseline = {
                                 ],
                                 additionalProperties: false,
                               },
+                              {
+                                type: "object",
+                                properties: {
+                                  harnessId: {
+                                    type: "string",
+                                    const: "jcode",
+                                  },
+                                  hostId: {
+                                    type: "string",
+                                  },
+                                  sessionId: {
+                                    type: "string",
+                                  },
+                                  sessionWorkspaceSnapshot: {
+                                    type: "object",
+                                    properties: {
+                                      workspaceKind: {
+                                        type: "string",
+                                        const: "session-snapshot",
+                                      },
+                                      primaryWorkspace: {
+                                        type: "string",
+                                      },
+                                      secondaryWorkspaces: {
+                                        default: [],
+                                        type: "array",
+                                        items: {
+                                          type: "string",
+                                        },
+                                      },
+                                    },
+                                    required: [
+                                      "workspaceKind",
+                                      "primaryWorkspace",
+                                      "secondaryWorkspaces",
+                                    ],
+                                    additionalProperties: false,
+                                  },
+                                  createdAt: {
+                                    type: "number",
+                                  },
+                                  coveredUntilMessageId: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  profileId: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  labelSnapshot: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  accountUuid: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                  accentColor: {
+                                    default: null,
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        type: "null",
+                                      },
+                                    ],
+                                  },
+                                },
+                                required: [
+                                  "harnessId",
+                                  "hostId",
+                                  "sessionId",
+                                  "sessionWorkspaceSnapshot",
+                                  "createdAt",
+                                  "coveredUntilMessageId",
+                                  "profileId",
+                                  "labelSnapshot",
+                                  "accountUuid",
+                                  "accentColor",
+                                ],
+                                additionalProperties: false,
+                              },
                             ],
                           },
                           {
@@ -9037,6 +9263,7 @@ export const epicSchemaSurfaceBaseline = {
                               "pi",
                               "hermes",
                               "omp",
+                              "jcode",
                             ],
                           },
                           agentId: {
@@ -9167,6 +9394,7 @@ export const epicSchemaSurfaceBaseline = {
                                             "pi",
                                             "hermes",
                                             "omp",
+                                            "jcode",
                                           ],
                                         },
                                         noticeKind: {
@@ -10443,6 +10671,7 @@ export const epicSchemaSurfaceBaseline = {
                                     "pi",
                                     "hermes",
                                     "omp",
+                                    "jcode",
                                   ],
                                 },
                                 source: {
@@ -10469,6 +10698,7 @@ export const epicSchemaSurfaceBaseline = {
                                         "pi",
                                         "hermes",
                                         "omp",
+                                        "jcode",
                                       ],
                                     },
                                     sessionId: {
@@ -11072,6 +11302,7 @@ export const epicSchemaSurfaceBaseline = {
                                                 "pi",
                                                 "hermes",
                                                 "omp",
+                                                "jcode",
                                               ],
                                             },
                                             agentId: {
@@ -11705,6 +11936,7 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
+                                  "jcode",
                                 ],
                               },
                               agentId: {

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -75,6 +75,7 @@ export const guiHarnessIdSchema = z.enum([
   "pi",
   "hermes",
   "omp",
+  "jcode",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -411,6 +411,29 @@ export const ompChatSessionAnchorSchema = z.object({
 });
 export type OmpChatSessionAnchor = z.infer<typeof ompChatSessionAnchorSchema>;
 
+// JCode (`jcode acp`) resumes at session granularity only — its ACP surface
+// reloads a whole session id with no per-message truncation/fork point — so the
+// anchor carries just the session id. `sessionId` is the jcode ACP session id.
+//
+// The union is a `discriminatedUnion`, so a MISSING member is not a compile
+// error anywhere: it only shows up as an unparseable persisted anchor on a real
+// jcode chat. Session resume itself is a recorded deferral for jcode (an
+// upstream `attach_existing_session` bug), so this member may go unused until
+// that lands — it is registered now so the persisted shape is complete rather
+// than retro-fitted later.
+export const jcodeChatSessionAnchorSchema = z.object({
+  harnessId: z.literal("jcode"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  createdAt: z.number(),
+  coveredUntilMessageId: z.string().nullable().default(null),
+  ...profileSnapshotFields,
+});
+export type JCodeChatSessionAnchor = z.infer<
+  typeof jcodeChatSessionAnchorSchema
+>;
+
 export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   claudeChatSessionAnchorSchema,
   codexChatSessionAnchorSchema,
@@ -430,5 +453,6 @@ export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   piChatSessionAnchorSchema,
   hermesChatSessionAnchorSchema,
   ompChatSessionAnchorSchema,
+  jcodeChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;


### PR DESCRIPTION
Adds **JCode** (`jcode.sh`) as a Traycer coding-agent harness — the protocol + GUI half. The host adapter, auth probe and CLI vendoring land in the internal repo, gated on this PR.

Closes #864.

## What's here

| Area | Change |
|---|---|
| **Harness/provider ids** | `jcode` added to `GuiHarnessId` / `ProviderId` and to the live catalog lines |
| **Profiles** | `protocol/src/host/agent/profiles.ts` — JCode's profile shape and the `v4.0` profile-selection lines |
| **Rate limits** | JCode is the contract's only **LIST** arm: one capture carries a row per (sub-provider, quota) pair |
| **GUI** | Meter rendering + profile usage projection for that list shape |
| **V60 freeze gap** | Repaired — see below |

## The V60 freeze gap

Adding a harness id grows every *live* catalog union, and the freeze discipline says a released line must not grow. `cli-v1.1.9` shipped `v6.0` while `agent.gui.listHarnesses@6.0` and `agent.list@6.0` were still serving the **live** response, so they absorbed every id added afterwards — the omp-on-v5.0 defect one version later is the same shape. Only `providers.list@6.0` had a frozen export, because its registry-field leak was caught first.

So `frozen-catalog-lines.ts` could not have caught jcode leaking into the newest frozen line. This PR adds the two missing `V60` snapshots and extends `snapshot-frozen-catalog-lines.ts` to emit them, so the defence-in-depth test covers `v6.0` rather than stopping one version short of it.

## Rate-limit rows are per-quota, not per-sub-provider

The second commit fixes two defects that both came from treating a row as if `subProviderId` were its key:

- **Identity.** One sub-provider can report several independent quotas, so a Copilot weekly and a Copilot monthly both rendered as `copilot` — indistinguishable in the meter, in the agent-facing profile text, and as React keys. Rows now carry jcode's own `limits[].name` as `limitName`, and every surface formats through one shared `jcodeSubProviderRateLimitLabel`, so the three consumers cannot drift apart.
- **Liveness.** The hard-limit check sat under the snapshot-wide *all-expired* guard, which fires only when EVERY row is stale. An OpenRouter row that hit 100% and has since rolled over would therefore report the whole profile as limited while a healthy Copilot row sat beside it. Liveness is now tested per row; a row with no window has no evidence of having rolled over, so it stays authoritative, matching `isProviderRateLimitWindowLive`'s null rule.

## Compatibility

`limitName` lands on the **live v4.0 union only** — no frozen snapshot carries a jcode arm at all, so no released peer can observe it.

Verified the way CI does it, not against the in-tree fixture (which predates v1.1.7 and would have proved nothing):

- `resolve-baselines.ts` against the remote's release tags → **15 protected baselines**; each surface taken from the release's published `protocol-surface.json` asset where present, reconstructed from the tag otherwise.
- `check-protocol-compat.ts` against all 15 → compatible with every one.
- `released-baseline-handshake.test.ts` with `PROTOCOL_BASELINE_SURFACES_DIR` pointed at those real surfaces → **62 passed**.
- No compat-governance file is touched, so `guarded-files-tripwire` stays green without an override label.

## Verification

- `bun run compile` and `bun run build` green. The latter matters on its own: it is the only thing that catches the `TS7056` declaration-emit ceiling, which this harness's new version lines push on.
- Protocol suite **1587 tests** green; gui-app suite **9164 tests** green.
- Every fix in the second commit has a test that was **mutation-probed red** against the pre-fix behaviour.

## Recorded deferrals

Deliberate scope boundaries for the first pass, not gaps: A2A tools (JCode is not agent-facing), compaction settlement, image attachments, and managed profiles / multi-account. Permission modes ship as `full_access` only.
