### PR TITLE
fix(gui-app): restore compact communication graph action

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-open-button.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-open-button.test.tsx
@@ -36,7 +36,9 @@ describe("CommGraphOpenButton", () => {
       <CommGraphOpenButton epicId={EPIC_ID} disabled={false} className="" />,
     );
 
-    fireEvent.click(screen.getByTestId("epic-sidebar-open-comm-graph"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open communication graph" }),
+    );
 
     expect(tileNavigationMocks.openTileInEpic).toHaveBeenCalledWith(
       EPIC_ID,
@@ -61,7 +63,9 @@ describe("CommGraphOpenButton", () => {
       <CommGraphOpenButton epicId={EPIC_ID} disabled={false} className="" />,
     );
 
-    const button = screen.getByTestId("epic-sidebar-open-comm-graph");
+    const button = screen.getByRole("button", {
+      name: "Open communication graph",
+    });
     fireEvent.click(button);
     fireEvent.click(button);
 
@@ -84,7 +88,9 @@ describe("CommGraphOpenButton", () => {
   it("does not open while the panel is collapsed", () => {
     render(<CommGraphOpenButton epicId={EPIC_ID} disabled className="" />);
 
-    fireEvent.click(screen.getByTestId("epic-sidebar-open-comm-graph"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open communication graph" }),
+    );
 
     expect(tileNavigationMocks.openTileInEpic).not.toHaveBeenCalled();
   });
@@ -100,7 +106,9 @@ describe("CommGraphOpenMenuItem", () => {
       </DropdownMenu>,
     );
 
-    fireEvent.click(screen.getByTestId("epic-sidebar-more-open-comm-graph"));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Open communication graph" }),
+    );
 
     expect(tileNavigationMocks.openTileInEpic).toHaveBeenCalledWith(
       EPIC_ID,

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-open-button.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-open-button.test.tsx
@@ -2,6 +2,10 @@ import "../../../../../__tests__/test-browser-apis";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+} from "@/components/ui/dropdown-menu";
 
 const tileNavigationMocks = vi.hoisted(() => ({
   openTileInEpic: vi.fn(),
@@ -13,7 +17,10 @@ vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
   useEpicTileNavigation: () => tileNavigationMocks,
 }));
 
-import { CommGraphOpenButton } from "@/components/epic-canvas/comm-graph/comm-graph-open-button";
+import {
+  CommGraphOpenButton,
+  CommGraphOpenMenuItem,
+} from "@/components/epic-canvas/comm-graph/comm-graph-open-button";
 import { makeCommGraphTileRef } from "@/stores/epics/canvas/tile-schema/comm-graph-tile";
 
 const EPIC_ID = "epic-open-button";
@@ -80,5 +87,28 @@ describe("CommGraphOpenButton", () => {
     fireEvent.click(screen.getByTestId("epic-sidebar-open-comm-graph"));
 
     expect(tileNavigationMocks.openTileInEpic).not.toHaveBeenCalled();
+  });
+});
+
+describe("CommGraphOpenMenuItem", () => {
+  it("opens the epic's graph tile from the compact overflow menu", () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <CommGraphOpenMenuItem epicId={EPIC_ID} disabled={false} />
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    fireEvent.click(screen.getByTestId("epic-sidebar-more-open-comm-graph"));
+
+    expect(tileNavigationMocks.openTileInEpic).toHaveBeenCalledWith(
+      EPIC_ID,
+      expect.objectContaining({
+        id: makeCommGraphTileRef(EPIC_ID).id,
+        type: "comm-graph",
+        epicId: EPIC_ID,
+      }),
+    );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-open-button.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-open-button.tsx
@@ -16,6 +16,7 @@ import { useCallback } from "react";
 import { Waypoints } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { makeCommGraphTileRef } from "@/stores/epics/canvas/tile-schema/comm-graph-tile";
 
@@ -26,13 +27,17 @@ export interface CommGraphOpenButtonProps {
   readonly className: string;
 }
 
-export function CommGraphOpenButton(props: CommGraphOpenButtonProps) {
-  const { className, disabled, epicId } = props;
+function useOpenCommGraph(epicId: string): () => void {
   const tileNavigation = useEpicTileNavigation();
 
-  const openGraph = useCallback(() => {
+  return useCallback(() => {
     tileNavigation.openTileInEpic(epicId, makeCommGraphTileRef(epicId));
   }, [epicId, tileNavigation]);
+}
+
+export function CommGraphOpenButton(props: CommGraphOpenButtonProps) {
+  const { className, disabled, epicId } = props;
+  const openGraph = useOpenCommGraph(epicId);
 
   return (
     <Button
@@ -47,5 +52,23 @@ export function CommGraphOpenButton(props: CommGraphOpenButtonProps) {
     >
       <Waypoints className="size-4" />
     </Button>
+  );
+}
+
+export function CommGraphOpenMenuItem(props: {
+  readonly epicId: string;
+  readonly disabled: boolean;
+}) {
+  const openGraph = useOpenCommGraph(props.epicId);
+
+  return (
+    <DropdownMenuItem
+      disabled={props.disabled}
+      onSelect={openGraph}
+      data-testid="epic-sidebar-more-open-comm-graph"
+    >
+      <Waypoints className="size-4" />
+      Open communication graph
+    </DropdownMenuItem>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -877,6 +877,19 @@ describe("epic sidebar selection mode", () => {
     ).not.toBeNull();
   });
 
+  it("keeps the communication graph available in the compact Agents overflow", () => {
+    seedChatTree();
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    expect(
+      screen.getByTestId("epic-sidebar-open-comm-graph").className,
+    ).toContain("@max-[21rem]:hidden");
+    expect(
+      screen.getByTestId("epic-sidebar-more-open-comm-graph").textContent,
+    ).toContain("Open communication graph");
+  });
+
   it("renders loading chat and artifact panels before the epic session handle exists", () => {
     testState.sessionReady = false;
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -283,6 +283,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   }) => (
     <button
       type="button"
+      role="menuitem"
       data-testid={props["data-testid"]}
       disabled={props.disabled}
       onClick={props.onSelect}
@@ -883,11 +884,12 @@ describe("epic sidebar selection mode", () => {
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
     expect(
-      screen.getByTestId("epic-sidebar-open-comm-graph").className,
+      screen.getByRole("button", { name: "Open communication graph" })
+        .className,
     ).toContain("@max-[21rem]:hidden");
     expect(
-      screen.getByTestId("epic-sidebar-more-open-comm-graph").textContent,
-    ).toContain("Open communication graph");
+      screen.getByRole("menuitem", { name: "Open communication graph" }),
+    ).not.toBeNull();
   });
 
   it("renders loading chat and artifact panels before the epic session handle exists", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -35,7 +35,10 @@ import {
   ArtifactFilterMenu,
   ChatFilterMenu,
 } from "@/components/epic-canvas/sidebar/epic-sidebar-filter-menu";
-import { CommGraphOpenButton } from "@/components/epic-canvas/comm-graph/comm-graph-open-button";
+import {
+  CommGraphOpenButton,
+  CommGraphOpenMenuItem,
+} from "@/components/epic-canvas/comm-graph/comm-graph-open-button";
 import { FileTreeWorkspacePicker } from "@/components/epic-canvas/sidebar/file-tree-workspace-picker";
 import { FileTreePanelBodyForWorkspace } from "@/components/epic-canvas/sidebar/epic-sidebar-file-tree";
 import { WorkspacePickerWithOpener } from "@/components/worktree/workspace-picker-with-opener";
@@ -1793,6 +1796,7 @@ function CompactPanelHeaderMoreMenu(props: {
   }
   return (
     <CompactChatHeaderMoreMenu
+      epicId={props.epicId}
       tabId={props.tabId}
       collapsed={props.collapsed}
     />
@@ -1839,6 +1843,7 @@ function CompactMoreMenuTrigger(props: {
 }
 
 function CompactChatHeaderMoreMenu(props: {
+  readonly epicId: string;
   readonly tabId: string;
   readonly collapsed: boolean;
 }) {
@@ -1861,6 +1866,10 @@ function CompactChatHeaderMoreMenu(props: {
           <CopyMinus className="size-4" />
           Collapse all
         </DropdownMenuItem>
+        <CommGraphOpenMenuItem
+          epicId={props.epicId}
+          disabled={props.collapsed}
+        />
         {isEditableRole(permissionRole) ? (
           <DropdownMenuItem
             disabled={!selectionEnabled}


### PR DESCRIPTION
## Summary

- add “Open communication graph” to the compact Agents overflow menu
- share the existing singleton graph-opening behavior between the wide header button and compact menu item
- cover both the overflow wiring and compact-sidebar availability regression

## Validation

- canonical pre-commit hook: affected build, compile, lint, format, hygiene, and DCO checks
- targeted Vitest: 2 files, 87 tests passed