### PR TITLE
feat(protocol): add host-local agent activity stream

### DIFF
--- a/clients/shared/host-transport/__tests__/agent-activity-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/agent-activity-stream-client.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type {
+  IStreamSession,
+  ServerFrameHandler,
+  StatusChangeHandler,
+  StreamCloseReason,
+} from "../i-stream-session";
+import { AgentActivityStreamClient } from "../agent-activity-stream-client";
+import { WsStreamClient } from "../ws-stream-client";
+
+class StubSession implements IStreamSession {
+  private serverFrameHandler: ServerFrameHandler = () => undefined;
+  private statusChangeHandler: StatusChangeHandler = () => undefined;
+
+  readonly close = vi.fn();
+
+  sendClientFrame(): void {}
+
+  onServerFrame(handler: ServerFrameHandler): void {
+    this.serverFrameHandler = handler;
+  }
+
+  onStatusChange(handler: StatusChangeHandler): void {
+    this.statusChangeHandler = handler;
+  }
+
+  requestReconnect(): void {}
+
+  emitFrame(frame: Parameters<ServerFrameHandler>[0]): void {
+    this.serverFrameHandler(frame, null);
+  }
+
+  emitStatus(
+    status: Parameters<StatusChangeHandler>[0],
+    reason: StreamCloseReason | null,
+  ): void {
+    this.statusChangeHandler(status, reason);
+  }
+}
+
+function makeWsStreamClient(
+  session: IStreamSession,
+): WsStreamClient<typeof hostStreamRpcRegistry> {
+  const client = new WsStreamClient({
+    registry: hostStreamRpcRegistry,
+    endpoint: () => null,
+    bearer: () => null,
+    auth: null,
+    hostCredentialMint: null,
+    webSocketFactory: {
+      create: () => {
+        throw new Error("unexpected WebSocket creation");
+      },
+    },
+    dialTimeoutMs: 1_000,
+    openAckTimeoutMs: 1_000,
+    pingIntervalMs: 25_000,
+    pongTimeoutMs: 50_000,
+    initialBackoffMs: 10,
+    maxBackoffMs: 1_000,
+  });
+  vi.spyOn(client, "subscribe").mockReturnValue(session);
+  return client;
+}
+
+describe("AgentActivityStreamClient", () => {
+  it("dispatches frames and status changes, then closes idempotently", () => {
+    const session = new StubSession();
+    const wsStreamClient = makeWsStreamClient(session);
+    const onSnapshot = vi.fn();
+    const onUpdate = vi.fn();
+    const onConnectionStatus = vi.fn();
+    const client = new AgentActivityStreamClient({
+      wsStreamClient,
+      callbacks: { onSnapshot, onUpdate, onConnectionStatus },
+    });
+
+    expect(wsStreamClient.subscribe).toHaveBeenCalledWith(
+      "agent.activity.subscribe",
+      {},
+    );
+
+    const snapshot = {
+      "epic-1": { working: ["agent-1"], turn: ["agent-1"] },
+    };
+    const update = {
+      "epic-1": { working: ["agent-1", "agent-2"], turn: ["agent-2"] },
+    };
+    session.emitFrame({
+      kind: "snapshot",
+      byEpic: snapshot,
+      hasBinaryPayload: false,
+    });
+    session.emitFrame({
+      kind: "update",
+      byEpic: update,
+      hasBinaryPayload: false,
+    });
+
+    expect(onSnapshot).toHaveBeenCalledWith(snapshot);
+    expect(onUpdate).toHaveBeenCalledWith(update);
+
+    const reason: StreamCloseReason = { kind: "caller" };
+    session.emitStatus("closed", reason);
+    expect(onConnectionStatus).toHaveBeenCalledWith("closed", reason);
+
+    client.close();
+    client.close();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/shared/host-transport/agent-activity-stream-client.ts
+++ b/clients/shared/host-transport/agent-activity-stream-client.ts
@@ -1,0 +1,62 @@
+import {
+  agentActivitySubscribeServerFrameSchema,
+  type AgentActivityByEpic,
+} from "@traycer/protocol/host/agent/activity";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type {
+  IStreamSession,
+  StreamCloseReason,
+  StreamConnectionStatus,
+  StreamFrameEnvelope,
+} from "./i-stream-session";
+import type { WsStreamClient } from "./ws-stream-client";
+
+export interface AgentActivityStreamCallbacks {
+  readonly onSnapshot: (byEpic: AgentActivityByEpic) => void;
+  readonly onUpdate: (byEpic: AgentActivityByEpic) => void;
+  readonly onConnectionStatus: (
+    status: StreamConnectionStatus,
+    reason: StreamCloseReason | null,
+  ) => void;
+}
+
+export interface AgentActivityStreamClientOptions {
+  readonly wsStreamClient: WsStreamClient<HostStreamRpcRegistry>;
+  readonly callbacks: AgentActivityStreamCallbacks;
+}
+
+/** Typed client for the optional host-local activity stream. */
+export class AgentActivityStreamClient {
+  private readonly session: IStreamSession;
+  private closed = false;
+
+  constructor(private readonly options: AgentActivityStreamClientOptions) {
+    this.session = options.wsStreamClient.subscribe(
+      "agent.activity.subscribe",
+      {},
+    );
+    this.session.onServerFrame((envelope) => {
+      this.handleServerFrame(envelope);
+    });
+    this.session.onStatusChange((status, reason) => {
+      this.options.callbacks.onConnectionStatus(status, reason);
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.session.close();
+  }
+
+  private handleServerFrame(envelope: StreamFrameEnvelope): void {
+    const parsed = agentActivitySubscribeServerFrameSchema.safeParse(envelope);
+    if (!parsed.success) return;
+    const frame = parsed.data;
+    if (frame.kind === "snapshot") {
+      this.options.callbacks.onSnapshot(frame.byEpic);
+    } else if (frame.kind === "update") {
+      this.options.callbacks.onUpdate(frame.byEpic);
+    }
+  }
+}

--- a/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentActivitySubscribeClientFrameSchema,
+  agentActivitySubscribeServerFrameSchema,
+  agentActivitySubscribeV10,
+} from "@traycer/protocol/host/agent/activity";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+
+describe("agent.activity.subscribe@1.0", () => {
+  it("accepts full replacement snapshots and updates", () => {
+    for (const kind of ["snapshot", "update"] as const) {
+      expect(
+        agentActivitySubscribeServerFrameSchema.parse({
+          kind,
+          byEpic: {
+            "epic-1": { working: ["agent-1"], turn: ["agent-1"] },
+          },
+          hasBinaryPayload: false,
+        }),
+      ).toEqual({
+        kind,
+        byEpic: {
+          "epic-1": { working: ["agent-1"], turn: ["agent-1"] },
+        },
+        hasBinaryPayload: false,
+      });
+    }
+  });
+
+  it("rejects malformed buckets and binary activity frames", () => {
+    expect(
+      agentActivitySubscribeServerFrameSchema.safeParse({
+        kind: "snapshot",
+        byEpic: { "epic-1": { working: "agent-1", turn: [] } },
+        hasBinaryPayload: false,
+      }).success,
+    ).toBe(false);
+    expect(
+      agentActivitySubscribeServerFrameSchema.safeParse({
+        kind: "update",
+        byEpic: {},
+        hasBinaryPayload: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("registers the optional stream at v1.0", () => {
+    expect(
+      agentActivitySubscribeClientFrameSchema.parse({
+        kind: "ping",
+        hasBinaryPayload: false,
+      }),
+    ).toEqual({ kind: "ping", hasBinaryPayload: false });
+    const entry = hostStreamRpcRegistry["agent.activity.subscribe"];
+    expect(entry[1].latestMinor).toBe(0);
+    expect(entry[1].versions[0].contract).toBe(agentActivitySubscribeV10);
+  });
+});

--- a/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
@@ -25,6 +25,12 @@ describe("agent.activity.subscribe@1.0", () => {
         hasBinaryPayload: false,
       });
     }
+    expect(
+      agentActivitySubscribeServerFrameSchema.parse({
+        kind: "pong",
+        hasBinaryPayload: false,
+      }),
+    ).toEqual({ kind: "pong", hasBinaryPayload: false });
   });
 
   it("rejects malformed buckets and binary activity frames", () => {

--- a/protocol/src/host/agent/activity.ts
+++ b/protocol/src/host/agent/activity.ts
@@ -1,0 +1,69 @@
+/**
+ * `agent.activity.subscribe@1.0` - host-local, per-user agent activity.
+ *
+ * The authenticated connection supplies the user identity. Every activity
+ * frame is a complete replacement of that user's current host-local state;
+ * reconnect therefore needs no replay cursor or revision.
+ */
+import { z } from "zod";
+import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
+
+export const agentActivitySubscribeOpenRequestSchema = z.object({});
+export type AgentActivitySubscribeOpenRequest = z.infer<
+  typeof agentActivitySubscribeOpenRequestSchema
+>;
+
+export const agentActivityEpicBucketSchema = z.object({
+  working: z.array(z.string()),
+  turn: z.array(z.string()),
+});
+export type AgentActivityEpicBucket = z.infer<
+  typeof agentActivityEpicBucketSchema
+>;
+
+export const agentActivityByEpicSchema = z.record(
+  z.string(),
+  agentActivityEpicBucketSchema,
+);
+export type AgentActivityByEpic = z.infer<typeof agentActivityByEpicSchema>;
+
+const activityProjectionFields = {
+  byEpic: agentActivityByEpicSchema,
+  hasBinaryPayload: z.literal(false),
+} as const;
+
+export const agentActivitySubscribeServerFrameSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({ kind: z.literal("snapshot"), ...activityProjectionFields }),
+    z.object({ kind: z.literal("update"), ...activityProjectionFields }),
+    z.object({
+      kind: z.literal("pong"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ],
+);
+export type AgentActivitySubscribeServerFrame = z.infer<
+  typeof agentActivitySubscribeServerFrameSchema
+>;
+
+export const agentActivitySubscribeClientFrameSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("ping"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ],
+);
+export type AgentActivitySubscribeClientFrame = z.infer<
+  typeof agentActivitySubscribeClientFrameSchema
+>;
+
+export const agentActivitySubscribeV10 = defineStreamRpcContract({
+  method: "agent.activity.subscribe",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: agentActivitySubscribeOpenRequestSchema,
+  serverFrameSchema: agentActivitySubscribeServerFrameSchema,
+  clientFrameSchema: agentActivitySubscribeClientFrameSchema,
+});

--- a/protocol/src/host/agent/index.ts
+++ b/protocol/src/host/agent/index.ts
@@ -2,6 +2,7 @@ export * from "./shared";
 export * from "./contracts";
 export * from "./roles";
 export * from "./inbox";
+export * from "./activity";
 export * from "./profiles";
 export * from "./gui";
 export * from "./tui";

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -88,6 +88,7 @@ import {
   agentInboxSubscribeV10,
   agentInboxSubscribeV11,
 } from "@traycer/protocol/host/agent/inbox";
+import { agentActivitySubscribeV10 } from "@traycer/protocol/host/agent/activity";
 import {
   agentRolesClaimUpgradeV10ToV11,
   agentRolesClaimV10,
@@ -5703,6 +5704,20 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
         },
         1: {
           contract: agentInboxSubscribeV11,
+        },
+      },
+    },
+  },
+  // Optional host-local activity source reserved for a future explicit local
+  // desktop mode. Every current GUI environment continues using the per-user
+  // notification-room awareness path; entitlement must not select this method.
+  // Older hosts may omit it through ordinary optional-method negotiation.
+  "agent.activity.subscribe": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentActivitySubscribeV10,
         },
       },
     },


### PR DESCRIPTION
## Summary
- add optional agent.activity.subscribe@1.0 stream contract
- export a shared typed client wrapper for future desktop local mode
- keep the API dormant: current GUI environments continue using notification-room awareness

## Validation
- protocol activity contract tests (3 passed)
- protocol compile
- shared client compile
- targeted ESLint and Prettier

## Rollout
This PR does not activate the stream in GUI or desktop code. Activity source selection remains unchanged until an explicit local-mode capability exists.