### PR TITLE
feat(gui-app): add Slack-style code fence input

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
@@ -1,6 +1,6 @@
 import "../../../../../__tests__/test-browser-apis";
 import { fireEvent, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { jsonContentToMarkdown } from "@traycer/protocol/common/json-content-serializer";
 
@@ -41,6 +41,7 @@ function makeFixture(): {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   editors.splice(0).forEach((editor) => editor.destroy());
   elements.splice(0).forEach((element) => element.remove());
 });
@@ -144,6 +145,51 @@ describe("composer Markdown-style input", () => {
     ]);
     expect(editor.state.doc.firstChild?.textContent).toBe("");
     expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
+  });
+
+  it("keeps a closing fence literal when text follows it on the same line", () => {
+    const { editor } = makeFixture();
+
+    typeText(editor, "```");
+    typeText(editor, "before");
+    fireEvent.keyDown(editor.view.dom, { key: "Enter", shiftKey: true });
+    typeText(editor, "suffix");
+    const codeBlockStart = editor.state.selection.$from.start();
+    editor.commands.setTextSelection(codeBlockStart + "before\n".length);
+
+    typeText(editor, "```");
+
+    expect(editor.state.doc.firstChild?.textContent).toBe("before\n```suffix");
+    expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+  });
+
+  it("restores the complete closing fence when undoing an automatic close", () => {
+    vi.useFakeTimers();
+    const { editor } = makeFixture();
+
+    typeText(editor, "```");
+    typeText(editor, "before");
+    fireEvent.keyDown(editor.view.dom, { key: "Enter", shiftKey: true });
+    typeText(editor, "``");
+    vi.advanceTimersByTime(1_000);
+    typeText(editor, "`");
+    expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
+
+    fireEvent.keyDown(editor.view.dom, { key: "z", ctrlKey: true });
+
+    expect(editor.state.doc.firstChild?.textContent).toBe("before\n```");
+    expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+  });
+
+  it("keeps an opening fence literal before existing paragraph content", () => {
+    const { editor } = makeFixture();
+
+    typeText(editor, "suffix");
+    editor.commands.setTextSelection(editor.state.selection.$from.start());
+    typeText(editor, "```");
+
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(editor.state.doc.firstChild?.textContent).toBe("```suffix");
   });
 
   it("keeps a language suffix when Shift-Enter opens the code block", () => {

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
@@ -1,0 +1,212 @@
+import "../../../../../__tests__/test-browser-apis";
+import { fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { jsonContentToMarkdown } from "@traycer/protocol/common/json-content-serializer";
+
+import { buildSubmittedChatJSONContent } from "@/lib/composer/tiptap-json-content";
+import { buildComposerExtensions } from "../editor/editor-config";
+import { createComposerPickerStore } from "../picker/composer-picker-store";
+
+const editors: Editor[] = [];
+const elements: HTMLElement[] = [];
+
+function makeFixture(): {
+  readonly editor: Editor;
+  readonly element: HTMLElement;
+  readonly submitCalls: { count: number };
+} {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  elements.push(element);
+  const submitCalls = { count: 0 };
+  const editor = new Editor({
+    element,
+    extensions: buildComposerExtensions({
+      pickerStore: createComposerPickerStore(),
+      getPlaceholder: () => "test",
+      onSubmit: {
+        current: () => {
+          submitCalls.count += 1;
+        },
+      },
+      slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
+      getIngestPastedComposerImages: () => null,
+    }),
+    content: { type: "doc", content: [{ type: "paragraph" }] },
+  });
+  editors.push(editor);
+  return { editor, element, submitCalls };
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => editor.destroy());
+  elements.splice(0).forEach((element) => element.remove());
+});
+
+describe("composer Markdown-style input", () => {
+  it("turns the third backtick into a code block immediately", () => {
+    const { editor, submitCalls } = makeFixture();
+
+    typeText(editor, "``");
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(editor.state.doc.firstChild?.textContent).toBe("``");
+
+    typeText(editor, "`");
+
+    expect(submitCalls.count).toBe(0);
+    expect(editor.getJSON().content.map((node) => node.type)).toEqual([
+      "codeBlock",
+      "paragraph",
+    ]);
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+    expect(editor.state.doc.firstChild?.attrs.language).toBeNull();
+    expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+
+    typeText(editor, "const answer = 42;");
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
+    typeText(editor, "return answer;");
+    expect(editor.state.doc.firstChild?.textContent).toBe(
+      "const answer = 42;\nreturn answer;",
+    );
+  });
+
+  it("does not show the composer placeholder inside an empty code block", () => {
+    const { editor, element } = makeFixture();
+
+    expect(element.querySelector("p")?.getAttribute("data-placeholder")).toBe(
+      "test",
+    );
+    typeText(editor, "```");
+
+    const codeBlock = element.querySelector("pre");
+    expect(codeBlock).not.toBeNull();
+    expect(codeBlock?.getAttribute("data-placeholder")).toBe("");
+  });
+
+  it("restores the literal triple backticks with Ctrl-z", () => {
+    const { editor } = makeFixture();
+
+    typeText(editor, "```");
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+
+    fireEvent.keyDown(editor.view.dom, { key: "z", ctrlKey: true });
+
+    expect(editor.getJSON().content.map((node) => node.type)).toEqual([
+      "paragraph",
+    ]);
+    expect(editor.state.doc.firstChild?.textContent).toBe("```");
+    expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
+  });
+
+  it("falls through to ordinary history undo when no input rule is active", () => {
+    const { editor } = makeFixture();
+
+    typeText(editor, "ordinary text");
+    fireEvent.keyDown(editor.view.dom, { key: "z", ctrlKey: true });
+
+    expect(editor.state.doc.textContent).toBe("");
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph");
+  });
+
+  it("formats a complete fenced block entered with Shift-Enter", () => {
+    const { editor, submitCalls } = makeFixture();
+
+    typeText(editor, "```");
+    typeText(editor, "Hello");
+    fireEvent.keyDown(editor.view.dom, { key: "Enter", shiftKey: true });
+    typeText(editor, "```");
+
+    expect(submitCalls.count).toBe(0);
+    expect(editor.getJSON().content.map((node) => node.type)).toEqual([
+      "codeBlock",
+      "paragraph",
+    ]);
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+    expect(editor.state.doc.firstChild?.textContent).toBe("Hello");
+    expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
+  });
+
+  it("keeps a language suffix when Shift-Enter opens the code block", () => {
+    const { editor, submitCalls } = makeFixture();
+
+    typeText(editor, "```");
+    fireEvent.keyDown(editor.view.dom, { key: "z", ctrlKey: true });
+    typeText(editor, "typescript");
+    fireEvent.keyDown(editor.view.dom, { key: "Enter", shiftKey: true });
+
+    expect(submitCalls.count).toBe(0);
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+    expect(editor.state.doc.firstChild?.attrs.language).toBe("typescript");
+
+    typeText(editor, "const answer: number = 42;");
+    const submitted = buildSubmittedChatJSONContent(editor.getJSON());
+    expect(
+      jsonContentToMarkdown(submitted, {
+        mentionFormat: "llm",
+        platform: "POSIX",
+      }),
+    ).toBe("```typescript\nconst answer: number = 42;\n```");
+  });
+
+  it("keeps triple backticks that are not on a new code-block line", () => {
+    const { editor } = makeFixture();
+
+    typeText(editor, "```");
+    typeText(editor, "const literal = ```;");
+
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+    expect(editor.state.doc.firstChild?.textContent).toBe(
+      "const literal = ```;",
+    );
+    expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+  });
+
+  it("still submits ordinary text ending in backticks", () => {
+    const { editor, submitCalls } = makeFixture();
+
+    typeText(editor, "Keep these ```");
+    expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+    expect(submitCalls.count).toBe(1);
+    expect(editor.state.doc.textContent).toBe("Keep these ```");
+  });
+
+  it.each([
+    { input: "**bold**", text: "bold", mark: "bold" },
+    { input: "*italic*", text: "italic", mark: "italic" },
+    { input: "~~strike~~", text: "strike", mark: "strike" },
+    { input: "`code`", text: "code", mark: "code" },
+  ])("formats $input as $mark", ({ input, text, mark }) => {
+    const { editor } = makeFixture();
+
+    typeText(editor, input);
+
+    expect(editor.getJSON()).toMatchObject({
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text, marks: [{ type: mark }] }],
+        },
+      ],
+    });
+  });
+});
+
+function typeText(editor: Editor, value: string): void {
+  Array.from(value).forEach((char) => typeChar(editor, char));
+}
+
+function typeChar(editor: Editor, char: string): void {
+  const { from, to } = editor.state.selection;
+  const defaultTransaction = () => editor.state.tr.insertText(char, from, to);
+  const handled =
+    editor.view.someProp("handleTextInput", (handler) => {
+      const result = handler(editor.view, from, to, char, defaultTransaction);
+      return result === true ? true : undefined;
+    }) === true;
+  if (!handled) {
+    editor.view.dispatch(defaultTransaction());
+  }
+}

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
@@ -1,5 +1,5 @@
 import "../../../../../__tests__/test-browser-apis";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import { jsonContentToMarkdown } from "@traycer/protocol/common/json-content-serializer";
@@ -74,13 +74,14 @@ describe("composer Markdown-style input", () => {
 
   it("does not show the composer placeholder inside an empty code block", () => {
     const { editor, element } = makeFixture();
+    const editorView = within(element);
 
-    expect(element.querySelector("p")?.getAttribute("data-placeholder")).toBe(
-      "test",
-    );
+    expect(
+      editorView.getByRole("paragraph").getAttribute("data-placeholder"),
+    ).toBe("test");
     typeText(editor, "```");
 
-    const codeBlock = element.querySelector("pre");
+    const codeBlock = editorView.getByRole("code").parentElement;
     expect(codeBlock).not.toBeNull();
     expect(codeBlock?.getAttribute("data-placeholder")).toBe("");
   });
@@ -125,6 +126,23 @@ describe("composer Markdown-style input", () => {
     ]);
     expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
     expect(editor.state.doc.firstChild?.textContent).toBe("Hello");
+    expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
+  });
+
+  it("closes an empty code block with a fence on its first line", () => {
+    const { editor, submitCalls } = makeFixture();
+
+    typeText(editor, "```");
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+
+    typeText(editor, "```");
+
+    expect(submitCalls.count).toBe(0);
+    expect(editor.getJSON().content.map((node) => node.type)).toEqual([
+      "codeBlock",
+      "paragraph",
+    ]);
+    expect(editor.state.doc.firstChild?.textContent).toBe("");
     expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
   });
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-markdown-input.test.ts
@@ -192,6 +192,69 @@ describe("composer Markdown-style input", () => {
     expect(editor.state.doc.firstChild?.textContent).toBe("```suffix");
   });
 
+  it("preserves an inline atom in an Enter fence-looking paragraph", () => {
+    const { editor, submitCalls } = makeFixture();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "slashCommand", attrs: { commandName: "plan" } },
+            { type: "text", text: "```" },
+          ],
+        },
+      ],
+    });
+    setSelectionAfterText(editor, "```");
+
+    expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+    expect(submitCalls.count).toBe(1);
+    expect(editor.getJSON()).toMatchObject({
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "slashCommand", attrs: { commandName: "plan" } },
+            { type: "text", text: "```" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("does not delete an Enter fence when a list item cannot become code", () => {
+    const { editor, submitCalls } = makeFixture();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "```" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    setSelectionAfterText(editor, "```");
+    expect(editor.can().setCodeBlock()).toBe(false);
+
+    expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+    expect(submitCalls.count).toBe(1);
+    expect(editor.state.doc.firstChild?.type.name).toBe("bulletList");
+    expect(editor.state.doc.textContent).toBe("```");
+  });
+
   it("keeps a language suffix when Shift-Enter opens the code block", () => {
     const { editor, submitCalls } = makeFixture();
 
@@ -260,6 +323,15 @@ describe("composer Markdown-style input", () => {
 
 function typeText(editor: Editor, value: string): void {
   Array.from(value).forEach((char) => typeChar(editor, char));
+}
+
+function setSelectionAfterText(editor: Editor, text: string): void {
+  let textEnd = -1;
+  editor.state.doc.descendants((node, position) => {
+    if (node.isText && node.text === text) textEnd = position + node.nodeSize;
+    return true;
+  });
+  editor.commands.setTextSelection(textEnd);
 }
 
 function typeChar(editor: Editor, char: string): void {

--- a/clients/gui-app/src/components/chat/composer/editor/editor-config.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/editor-config.ts
@@ -80,7 +80,11 @@ export function buildComposerExtensions(
       linkOnPaste: true,
     }),
     Placeholder.configure({
-      placeholder: () => args.getPlaceholder(),
+      // An empty code block is still an empty editor to Tiptap. Returning the
+      // composer hint there makes it render as monospaced code inside the new
+      // block; placeholders belong only on ordinary prompt paragraphs.
+      placeholder: ({ node }) =>
+        node.type.name === "paragraph" ? args.getPlaceholder() : "",
       includeChildren: false,
       emptyEditorClass: "is-editor-empty",
     }),

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
@@ -1,5 +1,6 @@
-import { Extension } from "@tiptap/core";
+import { Extension, InputRule } from "@tiptap/core";
 import type { Editor } from "@tiptap/core";
+import { Plugin, TextSelection } from "@tiptap/pm/state";
 import type { ChatComposerSubmitSource } from "@/lib/chats/resolve-steer-submit";
 import type { ComposerPickerStore } from "../../picker/composer-picker-store";
 
@@ -23,6 +24,9 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
   addKeyboardShortcuts() {
     const { onSubmit, pickerStore } = this.options;
     return {
+      // Undo automatic Markdown formatting before falling through to the
+      // ordinary history keymap. For the fence input rule this restores ```.
+      "Mod-z": ({ editor }) => editor.commands.undoInputRule(),
       "Mod-Enter": () => {
         // Steer chord (decision 12): with an open @mention/slash picker, commit
         // the highlighted item and then submit-as-steer in one press, rather
@@ -35,6 +39,7 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
         return true;
       },
       "Shift-Enter": ({ editor }) => {
+        if (handleOpeningCodeFence(editor)) return true;
         if (handleListEnter(editor)) return true;
         if (editor.isActive("codeBlock")) {
           // `splitBlock` would fragment one code block into two; `newlineInCode`
@@ -56,14 +61,121 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
         return editor.chain().splitBlock().scrollIntoView().run();
       },
       Backspace: ({ editor }) => handleQuoteBackspaceUnwrap(editor),
-      Enter: () => {
+      Enter: ({ editor }) => {
         if (handlePickerEnter(pickerStore)) return true;
+        if (handleOpeningCodeFence(editor)) return true;
         onSubmit.current("enter");
         return true;
       },
     };
   },
+
+  addInputRules() {
+    const codeBlockType = this.editor.schema.nodes.codeBlock;
+    const paragraphType = this.editor.schema.nodes.paragraph;
+
+    return [
+      new InputRule({
+        find: /^```$/,
+        handler: ({ state, range }) => {
+          const $start = state.doc.resolve(range.from);
+          const parent = $start.node(-1);
+          if (
+            !parent.canReplaceWith(
+              $start.index(-1),
+              $start.indexAfter(-1),
+              codeBlockType,
+            )
+          ) {
+            return null;
+          }
+
+          const tr = state.tr
+            .delete(range.from, range.to)
+            .setBlockType(range.from, range.from, codeBlockType);
+          // Keep StarterKit's trailing-paragraph invariant inside the same
+          // undoable input-rule transaction. If TrailingNode appended it in a
+          // follow-up transaction, Tiptap would discard the rule state before
+          // Mod-z had a chance to restore the literal fence.
+          if (tr.doc.lastChild?.type !== paragraphType) {
+            tr.insert(tr.doc.content.size, paragraphType.create());
+          }
+        },
+      }),
+    ];
+  },
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    return [
+      new Plugin({
+        props: {
+          handleTextInput: (_view, from, to, text) =>
+            handleClosingCodeFence(editor, from, to, text),
+        },
+      }),
+    ];
+  },
 });
+
+// The composer owns both Enter (submit) and Shift-Enter (paragraph split), so
+// Tiptap never sees the newline that completes its native fenced-code input
+// rule. Recognize the opening fence before either shortcut: a paragraph
+// containing only ``` (optionally with Tiptap's supported lowercase language
+// suffix) becomes an empty code block.
+function handleOpeningCodeFence(editor: Editor): boolean {
+  const { $from, empty } = editor.state.selection;
+  if (!empty || $from.parent.type.name !== "paragraph") return false;
+  if ($from.parentOffset !== $from.parent.content.size) return false;
+
+  const fenceText = $from.parent.textContent;
+  if (!/^```(?:[a-z]+)?$/.test(fenceText)) return false;
+
+  const fenceRange = { from: $from.start(), to: $from.end() };
+  const language = fenceText.slice(3);
+  const codeBlockAttrs = language.length === 0 ? undefined : { language };
+  return editor
+    .chain()
+    .setCodeBlock(codeBlockAttrs)
+    .deleteRange(fenceRange)
+    .scrollIntoView()
+    .run();
+}
+
+// A closing fence typed on its own line exits the rich code block immediately:
+// the incoming third backtick is absorbed, the preceding newline + two typed
+// backticks are removed, and the caret moves into the following paragraph.
+function handleClosingCodeFence(
+  editor: Editor,
+  from: number,
+  to: number,
+  text: string,
+): boolean {
+  if (text !== "`" || from !== to) return false;
+
+  const { selection } = editor.state;
+  if (!selection.empty || selection.from !== from) return false;
+  const { $from } = selection;
+  if ($from.parent.type.name !== "codeBlock") return false;
+  const textBeforeCaret = $from.parent.textContent.slice(0, $from.parentOffset);
+  if (!textBeforeCaret.endsWith("\n``")) return false;
+
+  const closingFenceFrom = from - 3;
+  const codeBlockEnd = $from.after();
+  const paragraphType = editor.schema.nodes.paragraph;
+
+  return editor.commands.command(({ tr }) => {
+    tr.delete(closingFenceFrom, to);
+    const afterCodeBlock = tr.mapping.map(codeBlockEnd);
+    const nextNode = tr.doc.nodeAt(afterCodeBlock);
+    if (nextNode?.type !== paragraphType) {
+      tr.insert(afterCodeBlock, paragraphType.create());
+    }
+    tr.setSelection(TextSelection.create(tr.doc, afterCodeBlock + 1));
+    tr.scrollIntoView();
+    return true;
+  });
+}
 
 function handlePickerEnter(pickerStore: ComposerPickerStore | null): boolean {
   if (pickerStore === null) return false;

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
@@ -1,6 +1,8 @@
 import { Extension, InputRule } from "@tiptap/core";
 import type { Editor } from "@tiptap/core";
+import { closeHistory } from "@tiptap/pm/history";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import type { ChatComposerSubmitSource } from "@/lib/chats/resolve-steer-submit";
 import type { ComposerPickerStore } from "../../picker/composer-picker-store";
 
@@ -79,6 +81,8 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
         find: /^```$/,
         handler: ({ state, range }) => {
           const $start = state.doc.resolve(range.from);
+          if (range.to !== $start.end()) return null;
+
           const parent = $start.node(-1);
           if (
             !parent.canReplaceWith(
@@ -106,12 +110,11 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
   },
 
   addProseMirrorPlugins() {
-    const editor = this.editor;
     return [
       new Plugin({
         props: {
-          handleTextInput: (_view, from, to, text) =>
-            handleClosingCodeFence(editor, from, to, text),
+          handleTextInput: (view, from, to, text) =>
+            handleClosingCodeFence(view, from, to, text),
         },
       }),
     ];
@@ -143,42 +146,47 @@ function handleOpeningCodeFence(editor: Editor): boolean {
 }
 
 // A closing fence typed on its own line exits the rich code block immediately:
-// the incoming third backtick is absorbed, the preceding newline + two typed
-// backticks are removed, and the caret moves into the following paragraph.
+// the full fence (and preceding newline on later lines) is removed, and the
+// caret moves into the following paragraph.
 function handleClosingCodeFence(
-  editor: Editor,
+  view: EditorView,
   from: number,
   to: number,
   text: string,
 ): boolean {
   if (text !== "`" || from !== to) return false;
 
-  const { selection } = editor.state;
+  const { selection } = view.state;
   if (!selection.empty || selection.from !== from) return false;
   const { $from } = selection;
   if ($from.parent.type.name !== "codeBlock") return false;
   const textBeforeCaret = $from.parent.textContent.slice(0, $from.parentOffset);
+  const isAtCodeBlockEnd = $from.parentOffset === $from.parent.content.size;
   const isFirstLineFence =
-    $from.parentOffset === 2 &&
-    textBeforeCaret === "``" &&
-    $from.parent.content.size === $from.parentOffset;
-  if (!isFirstLineFence && !textBeforeCaret.endsWith("\n``")) return false;
+    isAtCodeBlockEnd && $from.parentOffset === 2 && textBeforeCaret === "``";
+  const isLaterLineFence = isAtCodeBlockEnd && textBeforeCaret.endsWith("\n``");
+  if (!isFirstLineFence && !isLaterLineFence) return false;
 
   const closingFenceFrom = from - (isFirstLineFence ? 2 : 3);
-  const codeBlockEnd = $from.after();
-  const paragraphType = editor.schema.nodes.paragraph;
+  // Record the incoming third backtick before closing the block. Isolating the
+  // close in its own history event means undo restores the complete literal
+  // fence, even when the first two backticks belong to an older history group.
+  view.dispatch(view.state.tr.insertText(text, from, to));
+  const closingFenceTo = from + text.length;
+  const codeBlockEnd = view.state.selection.$from.after();
+  const paragraphType = view.state.schema.nodes.paragraph;
+  const tr = closeHistory(view.state.tr);
 
-  return editor.commands.command(({ tr }) => {
-    tr.delete(closingFenceFrom, to);
-    const afterCodeBlock = tr.mapping.map(codeBlockEnd);
-    const nextNode = tr.doc.nodeAt(afterCodeBlock);
-    if (nextNode?.type !== paragraphType) {
-      tr.insert(afterCodeBlock, paragraphType.create());
-    }
-    tr.setSelection(TextSelection.create(tr.doc, afterCodeBlock + 1));
-    tr.scrollIntoView();
-    return true;
-  });
+  tr.delete(closingFenceFrom, closingFenceTo);
+  const afterCodeBlock = tr.mapping.map(codeBlockEnd);
+  const nextNode = tr.doc.nodeAt(afterCodeBlock);
+  if (nextNode?.type !== paragraphType) {
+    tr.insert(afterCodeBlock, paragraphType.create());
+  }
+  tr.setSelection(TextSelection.create(tr.doc, afterCodeBlock + 1));
+  tr.scrollIntoView();
+  view.dispatch(tr);
+  return true;
 }
 
 function handlePickerEnter(pickerStore: ComposerPickerStore | null): boolean {

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
@@ -1,6 +1,7 @@
 import { Extension, InputRule } from "@tiptap/core";
 import type { Editor } from "@tiptap/core";
 import { closeHistory } from "@tiptap/pm/history";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import type { ChatComposerSubmitSource } from "@/lib/chats/resolve-steer-submit";
@@ -133,16 +134,26 @@ function handleOpeningCodeFence(editor: Editor): boolean {
 
   const fenceText = $from.parent.textContent;
   if (!/^```(?:[a-z]+)?$/.test(fenceText)) return false;
+  if (!hasOnlyTextChildren($from.parent)) return false;
 
   const fenceRange = { from: $from.start(), to: $from.end() };
   const language = fenceText.slice(3);
   const codeBlockAttrs = language.length === 0 ? undefined : { language };
+  if (!editor.can().setCodeBlock(codeBlockAttrs)) return false;
+
   return editor
     .chain()
     .setCodeBlock(codeBlockAttrs)
     .deleteRange(fenceRange)
     .scrollIntoView()
     .run();
+}
+
+function hasOnlyTextChildren(node: ProseMirrorNode): boolean {
+  for (let index = 0; index < node.childCount; index += 1) {
+    if (!node.child(index).isText) return false;
+  }
+  return true;
 }
 
 // A closing fence typed on its own line exits the rich code block immediately:

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
@@ -158,9 +158,13 @@ function handleClosingCodeFence(
   const { $from } = selection;
   if ($from.parent.type.name !== "codeBlock") return false;
   const textBeforeCaret = $from.parent.textContent.slice(0, $from.parentOffset);
-  if (!textBeforeCaret.endsWith("\n``")) return false;
+  const isFirstLineFence =
+    $from.parentOffset === 2 &&
+    textBeforeCaret === "``" &&
+    $from.parent.content.size === $from.parentOffset;
+  if (!isFirstLineFence && !textBeforeCaret.endsWith("\n``")) return false;
 
-  const closingFenceFrom = from - 3;
+  const closingFenceFrom = from - (isFirstLineFence ? 2 : 3);
   const codeBlockEnd = $from.after();
   const paragraphType = editor.schema.nodes.paragraph;
 


### PR DESCRIPTION
## Summary

- Convert three backticks typed on an empty composer line into a rich code block immediately.
- Make Ctrl+Z / Cmd+Z restore the literal fence while preserving ordinary history undo.
- Support closing fences and the language-suffix fallback, and keep the composer placeholder out of empty code blocks.

## Why

The composer already had a code-block schema, but Enter is owned by message submission and the placeholder leaked into empty non-paragraph nodes. As a result, users saw literal fences or placeholder text inside the code block instead of the Slack-style formatting interaction.

## Validation

- `bun run test src/components/chat/composer/__tests__` — 34 files, 337 tests passed
- `bun run test src/components/home/composer/__tests__` — 9 files, 46 tests passed
- Focused code-fence suite — 12 tests passed
- Pre-commit affected build, compile, lint, format, and DCO checks passed