### PR TITLE
fix(gui-app): harden minimap pane interactions

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -2632,6 +2632,8 @@ describe("ChatMessages scroll policy", () => {
     it("stays visible and interactive when an epic canvas tile is narrow", async () => {
       const messages = makeTranscript(20);
       renderChatMessages({ messages, scrollStateKey: "always-on-minimap" });
+      // Retain the narrow rect as a regression guard against reintroducing
+      // width-based minimap gating; current assertions do not derive from it.
       mockNarrowTranscriptWidth(420);
       await settleLegendList();
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -882,6 +882,7 @@ describe("ChatMessages scroll policy", () => {
     tileLiveness.live = false;
     installLegendListViewportMetrics();
     vi.useRealTimers();
+    useSettingsStore.setState({ chatTurnMinimapSide: "right" });
   });
 
   afterEach(() => {
@@ -891,6 +892,7 @@ describe("ChatMessages scroll policy", () => {
     platformMock.isMac = true;
     tileLiveness.live = false;
     setLegendListScrollContainerScrollHeightOverride(null);
+    useSettingsStore.setState({ chatTurnMinimapSide: "right" });
     // Ticket 15: dual-key durable entries survive tab-key cleanup - clear the
     // harness default epic so later tests' freshOpen paths see a true empty
     // chat-key cache rather than a leftover following-end/free-scrolling seed.
@@ -2662,6 +2664,18 @@ describe("ChatMessages scroll policy", () => {
       expect(screen.getByRole("button", { name: "Message minimap" })).toBe(
         hitStrip,
       );
+    });
+
+    it("does not mount the minimap when its placement is hidden", async () => {
+      useSettingsStore.setState({ chatTurnMinimapSide: "hide" });
+      renderChatMessages({
+        messages: makeTranscript(20),
+        scrollStateKey: "hidden-minimap",
+      });
+      await settleLegendList();
+
+      expect(screen.queryByTestId("chat-turn-minimap")).toBeNull();
+      expect(screen.queryByTestId("chat-turn-minimap-hit-strip")).toBeNull();
     });
   });
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -2607,12 +2607,7 @@ describe("ChatMessages scroll policy", () => {
     });
   });
 
-  describe("M3b minimap hit-strip is fully inert at zero gutter budget, not just visually collapsed", () => {
-    // The rail sizes its hit-strip off the PANE'S WIDTH (side gutter around
-    // the centered content column), not the composer dock height the old
-    // top-right overlay clamped against - a materially different geometry
-    // axis, so this pin targets the transcript container's own measured width
-    // instead of `composerOverlayHeight`.
+  describe("minimap rail remains available in constrained panes", () => {
     function mockNarrowTranscriptWidth(widthPx: number): void {
       const container = screen.getByTestId("chat-transcript-container");
       vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
@@ -2634,50 +2629,26 @@ describe("ChatMessages scroll policy", () => {
     // used here (see the outer `afterEach`'s own comment: it would clear the
     // file's `vi.mock` module mocks for isMac / activity store).
 
-    it("goes fully inert when the pane leaves no usable hit-strip width", async () => {
+    it("stays visible and interactive when an epic canvas tile is narrow", async () => {
       const messages = makeTranscript(20);
-      renderChatMessages({ messages, scrollStateKey: "m3b-inert-hit-strip" });
-      // 780px pane, 768px content column -> 6px side gutter, below the
-      // 12px hit-strip left offset: hitStripWidth clamps to 0.
-      mockNarrowTranscriptWidth(780);
+      renderChatMessages({ messages, scrollStateKey: "always-on-minimap" });
+      mockNarrowTranscriptWidth(420);
       await settleLegendList();
 
+      const rail = screen.getByTestId("chat-turn-minimap");
       const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
-      await waitFor(() => {
-        // jsdom does not implement the `inert` IDL property/behavior, only
-        // reflects the attribute React sets - assert on that instead of
-        // `.inert` (which reads back `undefined` here regardless of value).
-        expect(hitStrip.hasAttribute("inert")).toBe(true);
-      });
-      expect(hitStrip.getAttribute("aria-hidden")).toBe("true");
-      expect(hitStrip.classList.contains("pointer-events-none")).toBe(true);
-      expect(hitStrip.tabIndex).toBe(-1);
-      // aria-hidden removes the whole subtree from the accessibility tree -
-      // Testing Library's own role computation confirms it is unreachable,
-      // not just that we intended to hide it.
-      expect(
-        screen.queryByRole("button", { name: /Jump to message/ }),
-      ).toBeNull();
-
-      // Park in free-scrolling (a stable, non-drifting position - unlike the
-      // default following-end mode, whose own reveal-pass keeps chasing the
-      // jsdom shim's fixed large scrollHeight) so a leaking select is
-      // unambiguous: jsdom does not enforce real `inert` event-dispatch
-      // blocking, so this pins the component's OWN belt-and-suspenders guard
-      // (onClick/onKeyDown early-return on `isInert`) rather than relying
-      // solely on the browser to refuse dispatch into the subtree.
-      act(() => {
-        enterFreeScrollingAwayFromEnd();
-      });
-      await waitForPillVisible();
-      const scrollNode = getScrollNode();
-      const parkedScrollTop = scrollNode.scrollTop;
-      await selectLastChatTurnMinimapItem();
-      expect(scrollNode.scrollTop).toBe(parkedScrollTop);
-      expect(isJumpPillVisible()).toBe(true);
+      expect(rail.classList).toContain("opacity-100");
+      expect(rail.classList).not.toContain("opacity-0");
+      expect(hitStrip.hasAttribute("inert")).toBe(false);
+      expect(hitStrip.getAttribute("aria-hidden")).toBeNull();
+      expect(hitStrip.classList.contains("pointer-events-auto")).toBe(true);
+      expect(hitStrip.tabIndex).toBe(0);
+      expect(screen.getByRole("button", { name: "Message minimap" })).toBe(
+        hitStrip,
+      );
     });
 
-    it("stays interactive at the harness's default (usable) pane width", async () => {
+    it("stays interactive at the harness's default pane width", async () => {
       const messages = makeTranscript(20);
       renderChatMessages({ messages, scrollStateKey: "m3b-usable-hit-strip" });
       await settleLegendList();
@@ -2686,7 +2657,7 @@ describe("ChatMessages scroll policy", () => {
       expect(hitStrip.hasAttribute("inert")).toBe(false);
       expect(hitStrip.getAttribute("aria-hidden")).toBeNull();
       expect(hitStrip.classList.contains("pointer-events-auto")).toBe(true);
-      expect(screen.getByRole("button", { name: /Jump to message/ })).toBe(
+      expect(screen.getByRole("button", { name: "Message minimap" })).toBe(
         hitStrip,
       );
     });

--- a/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap-logic.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap-logic.test.ts
@@ -1,51 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
-  CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH,
+  CHAT_TURN_MINIMAP_END_HIT_PADDING,
   CHAT_TURN_MINIMAP_EXPANDED_HIT_STRIP_WIDTH,
-  CHAT_TURN_MINIMAP_HIT_STRIP_LEFT,
   CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
   CHAT_TURN_MINIMAP_ITEM_SPACING,
   CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS,
   CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS,
-  CHAT_TURN_MINIMAP_PERSISTENT_GUTTER,
-  resolveChatTurnMinimapHasPersistentGutter,
   resolveChatTurnMinimapHeightStyle,
-  resolveChatTurnMinimapHitStripWidth,
   resolveChatTurnMinimapIndexFromPointer,
   resolveChatTurnMinimapInteractiveWidth,
   resolveChatTurnMinimapRowHeight,
   resolveChatTurnMinimapRowInView,
   resolveChatTurnMinimapRowTop,
+  resolveChatTurnMinimapRowViewportDistance,
   resolveChatTurnMinimapTopPercent,
+  resolveChatTurnMinimapTopStyle,
 } from "@/components/chat/chat-turn-minimap-logic";
 
-/**
- * Side gutter around the centered content column for a pane of `viewportWidth`.
- * Mirrors the pure math inside the geometry helpers.
- */
-function sideGutter(viewportWidth: number): number {
-  const contentWidth = Math.min(
-    viewportWidth,
-    CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH,
-  );
-  return Math.max(0, (viewportWidth - contentWidth) / 2);
-}
-
-/** Exact viewport width that yields `sideGutter === gutterPx`. */
-function viewportForGutter(gutterPx: number): number {
-  return CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH + gutterPx * 2;
-}
-
 describe("resolveChatTurnMinimapHeightStyle", () => {
-  it("uses (itemCount-1)*spacing as the natural height, capped by the viewport and pane", () => {
+  it("adds endpoint hit padding to the visual track height, capped by the viewport and pane", () => {
     expect(resolveChatTurnMinimapHeightStyle(1)).toBe(
-      `min(1px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`,
+      `min(${1 + CHAT_TURN_MINIMAP_END_HIT_PADDING * 2}px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`,
     );
     expect(resolveChatTurnMinimapHeightStyle(2)).toBe(
-      `min(${CHAT_TURN_MINIMAP_ITEM_SPACING}px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`,
+      `min(${CHAT_TURN_MINIMAP_ITEM_SPACING + CHAT_TURN_MINIMAP_END_HIT_PADDING * 2}px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`,
     );
     expect(resolveChatTurnMinimapHeightStyle(5)).toBe(
-      `min(${4 * CHAT_TURN_MINIMAP_ITEM_SPACING}px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`,
+      `min(${4 * CHAT_TURN_MINIMAP_ITEM_SPACING + CHAT_TURN_MINIMAP_END_HIT_PADDING * 2}px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`,
     );
   });
 });
@@ -65,6 +46,18 @@ describe("resolveChatTurnMinimapTopPercent", () => {
   it("clamps out-of-range indices to the rail ends", () => {
     expect(resolveChatTurnMinimapTopPercent(-3, 4)).toBe(0);
     expect(resolveChatTurnMinimapTopPercent(99, 4)).toBe(100);
+  });
+});
+
+describe("resolveChatTurnMinimapTopStyle", () => {
+  it("insets only the two endpoint strips while preserving even track spacing", () => {
+    expect(resolveChatTurnMinimapTopStyle(0, 5)).toBe(
+      `calc(0% + ${CHAT_TURN_MINIMAP_END_HIT_PADDING}px)`,
+    );
+    expect(resolveChatTurnMinimapTopStyle(2, 5)).toBe("50%");
+    expect(resolveChatTurnMinimapTopStyle(4, 5)).toBe(
+      `calc(100% - ${CHAT_TURN_MINIMAP_END_HIT_PADDING}px)`,
+    );
   });
 });
 
@@ -150,93 +143,57 @@ describe("resolveChatTurnMinimapIndexFromPointer", () => {
       }),
     ).toBe(2);
   });
-});
 
-describe("resolveChatTurnMinimapHasPersistentGutter", () => {
-  it("is false for non-finite, zero, or negative widths", () => {
-    expect(resolveChatTurnMinimapHasPersistentGutter(Number.NaN)).toBe(false);
-    expect(resolveChatTurnMinimapHasPersistentGutter(0)).toBe(false);
-    expect(resolveChatTurnMinimapHasPersistentGutter(-10)).toBe(false);
-  });
+  it("gives the first and last items the extra endpoint padding", () => {
+    const trackHeight = base.railHeight - CHAT_TURN_MINIMAP_END_HIT_PADDING * 2;
+    const halfItemStep = trackHeight / (5 - 1) / 2;
+    const firstInteriorBoundary =
+      base.railTop + CHAT_TURN_MINIMAP_END_HIT_PADDING + halfItemStep;
+    const lastInteriorBoundary =
+      base.railTop +
+      base.railHeight -
+      CHAT_TURN_MINIMAP_END_HIT_PADDING -
+      halfItemStep;
 
-  it("is false when the pane is at or below the content max (no side gutter)", () => {
     expect(
-      resolveChatTurnMinimapHasPersistentGutter(
-        CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH,
-      ),
-    ).toBe(false);
-    expect(
-      resolveChatTurnMinimapHasPersistentGutter(
-        CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH - 100,
-      ),
-    ).toBe(false);
-  });
-
-  it("flips true exactly when side gutter reaches the 48px threshold", () => {
-    const justBelow = viewportForGutter(
-      CHAT_TURN_MINIMAP_PERSISTENT_GUTTER - 1,
-    );
-    const atThreshold = viewportForGutter(CHAT_TURN_MINIMAP_PERSISTENT_GUTTER);
-    const above = viewportForGutter(CHAT_TURN_MINIMAP_PERSISTENT_GUTTER + 1);
-
-    expect(sideGutter(justBelow)).toBe(CHAT_TURN_MINIMAP_PERSISTENT_GUTTER - 1);
-    expect(resolveChatTurnMinimapHasPersistentGutter(justBelow)).toBe(false);
-
-    expect(sideGutter(atThreshold)).toBe(CHAT_TURN_MINIMAP_PERSISTENT_GUTTER);
-    expect(resolveChatTurnMinimapHasPersistentGutter(atThreshold)).toBe(true);
-
-    expect(resolveChatTurnMinimapHasPersistentGutter(above)).toBe(true);
-  });
-});
-
-describe("resolveChatTurnMinimapHitStripWidth", () => {
-  it("is 0 for non-finite, zero, or negative widths", () => {
-    expect(resolveChatTurnMinimapHitStripWidth(Number.NaN)).toBe(0);
-    expect(resolveChatTurnMinimapHitStripWidth(0)).toBe(0);
-    expect(resolveChatTurnMinimapHitStripWidth(-1)).toBe(0);
-  });
-
-  it("is 0 at/below the content max and while gutter is still within the left offset", () => {
-    expect(
-      resolveChatTurnMinimapHitStripWidth(CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH),
+      resolveChatTurnMinimapIndexFromPointer({
+        ...base,
+        itemCount: 5,
+        pointerY: firstInteriorBoundary - 1,
+      }),
     ).toBe(0);
-    // 780px pane → 6px side gutter (M3b integration pin) → clamps to 0
-    expect(resolveChatTurnMinimapHitStripWidth(780)).toBe(0);
-    // sideGutter exactly equals the left offset → still 0 after subtraction
-    const atLeftOffset = viewportForGutter(CHAT_TURN_MINIMAP_HIT_STRIP_LEFT);
-    expect(resolveChatTurnMinimapHitStripWidth(atLeftOffset)).toBe(0);
-  });
-
-  it("scales with gutter then clamps at the 40px max", () => {
-    // First usable pixel: sideGutter = left + 1
-    const onePx = viewportForGutter(CHAT_TURN_MINIMAP_HIT_STRIP_LEFT + 1);
-    expect(resolveChatTurnMinimapHitStripWidth(onePx)).toBe(1);
-
-    // At the persistent-gutter boundary (48px): 48 - 12 = 36
-    const atPersistent = viewportForGutter(CHAT_TURN_MINIMAP_PERSISTENT_GUTTER);
-    expect(resolveChatTurnMinimapHitStripWidth(atPersistent)).toBe(
-      CHAT_TURN_MINIMAP_PERSISTENT_GUTTER - CHAT_TURN_MINIMAP_HIT_STRIP_LEFT,
-    );
-
-    // Exactly at max: left + max → sideGutter = 52 → hit = 40
-    const atMax = viewportForGutter(
-      CHAT_TURN_MINIMAP_HIT_STRIP_LEFT + CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
-    );
-    expect(resolveChatTurnMinimapHitStripWidth(atMax)).toBe(
-      CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
-    );
-
-    // Well above max stays clamped
-    expect(resolveChatTurnMinimapHitStripWidth(1200)).toBe(
-      CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
-    );
+    expect(
+      resolveChatTurnMinimapIndexFromPointer({
+        ...base,
+        itemCount: 5,
+        pointerY: firstInteriorBoundary + 1,
+      }),
+    ).toBe(1);
+    expect(
+      resolveChatTurnMinimapIndexFromPointer({
+        ...base,
+        itemCount: 5,
+        pointerY: lastInteriorBoundary - 1,
+      }),
+    ).toBe(3);
+    expect(
+      resolveChatTurnMinimapIndexFromPointer({
+        ...base,
+        itemCount: 5,
+        pointerY: lastInteriorBoundary + 1,
+      }),
+    ).toBe(4);
   });
 });
 
 describe("resolveChatTurnMinimapInteractiveWidth", () => {
   it("returns the collapsed numeric width when not expanded", () => {
-    expect(resolveChatTurnMinimapInteractiveWidth(0, false)).toBe(0);
-    expect(resolveChatTurnMinimapInteractiveWidth(36, false)).toBe(36);
+    expect(
+      resolveChatTurnMinimapInteractiveWidth(
+        CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
+        false,
+      ),
+    ).toBe(CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH);
   });
 
   it("returns the expanded rem width once the preview is open", () => {
@@ -337,5 +294,37 @@ describe("resolveChatTurnMinimapRowTop / RowHeight / RowInView", () => {
     expect(resolveChatTurnMinimapRowInView(headerState, 0)).toBe(true);
     // row 1 [200, 260) is well below the band - must read out of view.
     expect(resolveChatTurnMinimapRowInView(headerState, 1)).toBe(false);
+  });
+});
+
+describe("resolveChatTurnMinimapRowViewportDistance", () => {
+  const state = {
+    scroll: 200,
+    scrollLength: 100,
+    positionAtIndex: (index: number): number | undefined =>
+      [50, 220, 400][index],
+    sizeAtIndex: (): number => 50,
+  };
+
+  it("encodes above, intersecting, and below rows in one geometry result", () => {
+    expect(resolveChatTurnMinimapRowViewportDistance(state, 0)).toBe(100);
+    expect(resolveChatTurnMinimapRowViewportDistance(state, 1)).toBe(-1);
+    expect(resolveChatTurnMinimapRowViewportDistance(state, 2)).toBe(100);
+  });
+
+  it("keeps a touching row out of view while reporting zero proximity", () => {
+    expect(
+      resolveChatTurnMinimapRowViewportDistance(
+        {
+          ...state,
+          positionAtIndex: () => 300,
+        },
+        0,
+      ),
+    ).toBe(0);
+  });
+
+  it("returns null when row geometry is unavailable", () => {
+    expect(resolveChatTurnMinimapRowViewportDistance({}, 0)).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { createRef, type RefObject } from "react";
+import type { RefObject } from "react";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { LegendListRef } from "@legendapp/list/react";
 import { ChatTurnMinimap } from "@/components/chat/chat-turn-minimap";
@@ -88,7 +88,7 @@ function makeA2AUser(index: number, content: string): ChatMessageModel {
   };
 }
 
-/** Two human user turns (min rail) with assistant replies. */
+/** Two human user turns with assistant replies. */
 function makeTwoTurnTranscript(): ChatMessageModel[] {
   return [
     makeUser(0, "First user turn"),
@@ -301,35 +301,32 @@ function renderMinimap(options: RenderOptions): {
 }
 
 describe("ChatTurnMinimap item derivation / filtering", () => {
-  it("renders nothing with fewer than 2 human user turns", () => {
-    const { unmount } = render(
-      <ChatTurnMinimap
-        messages={[
-          makeUser(0, undefined),
-          makeAssistant(1, "only one human turn"),
-        ]}
-        inViewRefreshRef={{ current: () => undefined }}
-        listRef={createRef()}
-        topOffsetAdjustmentRef={{ current: 0 }}
-        viewportRef={createRef()}
-        bottomInset={0}
-        onSelect={vi.fn()}
-        identity={DEFAULT_MINIMAP_IDENTITY}
-        side="right"
-      />,
-    );
-    expect(screen.queryByTestId("chat-turn-minimap")).toBeNull();
-    unmount();
-
+  it("renders nothing when there are no human user queries", () => {
     renderMinimap({
       messages: [
-        makeUser(0, undefined),
-        makeAssistant(1, "a"),
-        makeA2AUser(2, "a2a"),
+        makeAssistant(0, "assistant-only transcript"),
+        makeA2AUser(1, "agent traffic is not a user query"),
+        makeMessage(2, "system"),
       ],
     });
-    // One human user + one A2A user → still below MIN_ITEMS
     expect(screen.queryByTestId("chat-turn-minimap")).toBeNull();
+  });
+
+  it("renders a usable rail for exactly one human user query", async () => {
+    renderMinimap({
+      messages: [
+        makeUser(0, "Only human query"),
+        makeAssistant(1, "Only assistant response"),
+        makeA2AUser(2, "Agent traffic must not create another marker"),
+      ],
+    });
+    await flushMinimapFrames(2);
+
+    const rail = screen.getByTestId("chat-turn-minimap");
+    const strips = rail.querySelectorAll("[data-chat-turn-minimap-strip]");
+    expect(strips).toHaveLength(1);
+    expect(strips[0].getAttribute("data-message-id")).toBe("message-0");
+    expect(screen.getByTestId("chat-turn-minimap-hit-strip")).not.toBeNull();
   });
 
   it("only human user rows become strips; A2A, assistant, and system are excluded", async () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap.test.tsx
@@ -12,14 +12,14 @@ import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { LegendListRef } from "@legendapp/list/react";
 import { ChatTurnMinimap } from "@/components/chat/chat-turn-minimap";
 import {
-  CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH,
-  CHAT_TURN_MINIMAP_HIT_STRIP_LEFT,
+  CHAT_TURN_MINIMAP_END_HIT_PADDING,
   CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
   CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE,
-  CHAT_TURN_MINIMAP_PERSISTENT_GUTTER,
 } from "@/components/chat/chat-turn-minimap-logic";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
+import type { ChatTurnMinimapSide } from "@/stores/settings/settings-store";
 import type { ChatTabPersistenceIdentity } from "@/stores/chats/chat-tab-persistence-key";
+import { isPaneActivationDeferred } from "@/components/epic-canvas/pane-activation";
 import {
   evictChatTurnMinimapActiveEntries,
   evictChatTurnMinimapActiveEntryForChat,
@@ -209,17 +209,8 @@ function mockRailGeometry(
   });
 }
 
-/** Viewport wide enough for a non-zero hit-strip (and persistent gutter). */
-const WIDE_VIEWPORT_PX =
-  CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH +
-  (CHAT_TURN_MINIMAP_HIT_STRIP_LEFT + CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH) *
-    2;
-/** 780px pane → 6px side gutter → hitStripWidth 0 (M3b pin). */
-const ZERO_BUDGET_VIEWPORT_PX = 780;
-/** Side gutter just under the 48px persistent threshold, but > 12 so the strip is live. */
-const HOVER_ONLY_VIEWPORT_PX =
-  CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH +
-  (CHAT_TURN_MINIMAP_PERSISTENT_GUTTER - 1) * 2;
+const WIDE_VIEWPORT_PX = 1200;
+const CONSTRAINED_VIEWPORT_PX = 420;
 
 interface RenderOptions {
   readonly messages: ReadonlyArray<ChatMessageModel>;
@@ -228,6 +219,7 @@ interface RenderOptions {
   readonly listState?: FakeListState;
   readonly inViewRefreshRef?: RefObject<() => void>;
   readonly onSelect?: (messageId: string) => void;
+  readonly side?: ChatTurnMinimapSide;
   /** LegendList's live measured header size (decision #18's
    *  topOffsetAdjustment) - defaults to 0 (no header) unless a scenario
    *  specifically needs to pin header-present behavior. */
@@ -275,6 +267,7 @@ function renderMinimap(options: RenderOptions): {
       bottomInset={options.bottomInset ?? 0}
       onSelect={onSelect}
       identity={DEFAULT_MINIMAP_IDENTITY}
+      side={options.side ?? "right"}
     />
   );
   const result = render(tree);
@@ -298,6 +291,7 @@ function renderMinimap(options: RenderOptions): {
           bottomInset={next.bottomInset ?? 0}
           onSelect={next.onSelect ?? onSelect}
           identity={DEFAULT_MINIMAP_IDENTITY}
+          side={next.side ?? "right"}
         />,
       );
     },
@@ -319,6 +313,7 @@ describe("ChatTurnMinimap item derivation / filtering", () => {
         bottomInset={0}
         onSelect={vi.fn()}
         identity={DEFAULT_MINIMAP_IDENTITY}
+        side="right"
       />,
     );
     expect(screen.queryByTestId("chat-turn-minimap")).toBeNull();
@@ -377,7 +372,10 @@ describe("ChatTurnMinimap preview content", () => {
     fireEvent.mouseMove(hitStrip, { clientY: 0 });
     const preview = await screen.findByText("Prompt A");
     expect(preview).toBeTruthy();
-    expect(screen.getByText("Final reply for A")).toBeTruthy();
+    const assistantPreview = screen.getByText("Final reply for A");
+    expect(assistantPreview).toBeTruthy();
+    expect(assistantPreview.classList).toContain("line-clamp-3");
+    expect(assistantPreview.classList).not.toContain("block");
     expect(screen.queryByText("Draft reply")).toBeNull();
 
     // Hover near the bottom → second human turn, no assistant line
@@ -394,7 +392,9 @@ describe("ChatTurnMinimap preview content", () => {
     );
     expect(previewPanel?.classList).not.toContain("w-80");
     expect(
-      (previewPanel as HTMLElement).querySelectorAll(".text-muted-foreground"),
+      (previewPanel as HTMLElement).querySelectorAll(
+        "[data-chat-turn-minimap-assistant]",
+      ),
     ).toHaveLength(0);
     // Exactly one text line (the user prompt) inside the card
     expect(
@@ -406,104 +406,57 @@ describe("ChatTurnMinimap preview content", () => {
     renderMinimap({ messages: makeTwoTurnTranscript() });
     await flushMinimapFrames(2);
     const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    const interactionRegion = document.querySelector<HTMLElement>(
+      "[data-chat-turn-minimap-interaction-region]",
+    );
     mockRailGeometry(hitStrip, { top: 0, height: 100 });
     fireEvent.mouseMove(hitStrip, { clientY: 0 });
     expect(await screen.findByText("First user turn")).toBeTruthy();
-    fireEvent.mouseLeave(hitStrip);
+    expect(interactionRegion).not.toBeNull();
+    fireEvent.mouseLeave(interactionRegion as HTMLElement);
     expect(
       document.querySelector("[data-chat-turn-minimap-preview]"),
     ).toBeNull();
   });
 });
 
-describe("ChatTurnMinimap gutter gating", () => {
-  it("is fully inert at zero hit-strip budget (attribute + a11y + handlers no-op)", async () => {
+describe("ChatTurnMinimap always-on rail", () => {
+  it("stays visible and interactive in a constrained or tiled pane", async () => {
     const { onSelect } = renderMinimap({
       messages: makeTwoTurnTranscript(),
-      viewportWidth: ZERO_BUDGET_VIEWPORT_PX,
+      viewportWidth: CONSTRAINED_VIEWPORT_PX,
     });
     await flushMinimapFrames(2);
 
+    const rail = screen.getByTestId("chat-turn-minimap");
     const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
-    await waitFor(() => {
-      expect(hitStrip.hasAttribute("inert")).toBe(true);
-    });
-    expect(hitStrip.getAttribute("aria-hidden")).toBe("true");
-    expect(hitStrip.classList.contains("pointer-events-none")).toBe(true);
-    expect(hitStrip.tabIndex).toBe(-1);
-    // jsdom does not enforce real inert dispatch blocking - pin the
-    // component's own isInert early-return on click/keydown.
-    fireEvent.click(hitStrip);
-    fireEvent.keyDown(hitStrip, { key: "Enter" });
-    fireEvent.keyDown(hitStrip, { key: "ArrowDown" });
-    expect(onSelect).not.toHaveBeenCalled();
-  });
-
-  it("is interactive (un-inert) above zero budget", async () => {
-    renderMinimap({
-      messages: makeTwoTurnTranscript(),
-      viewportWidth: WIDE_VIEWPORT_PX,
-    });
-    await flushMinimapFrames(2);
-
-    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
-    await waitFor(() => {
-      expect(hitStrip.hasAttribute("inert")).toBe(false);
-    });
+    expect(rail.classList).toContain("opacity-100");
+    expect(rail.classList).not.toContain("opacity-0");
+    expect(hitStrip.hasAttribute("inert")).toBe(false);
     expect(hitStrip.getAttribute("aria-hidden")).toBeNull();
     expect(hitStrip.classList.contains("pointer-events-auto")).toBe(true);
     expect(hitStrip.tabIndex).toBe(0);
+    expect(hitStrip.style.width).toBe(
+      `${CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH}px`,
+    );
     expect(
       hitStrip.hasAttribute(CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE),
     ).toBe(true);
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.click(hitStrip, { clientY: 100 });
+    expect(onSelect).toHaveBeenCalledWith("message-2");
   });
 
-  it("marks persistent gutter above the 48px side-gutter threshold and hover-reveal below it", async () => {
-    renderMinimap({
-      messages: makeTwoTurnTranscript(),
-      viewportWidth: WIDE_VIEWPORT_PX,
-    });
-    await flushMinimapFrames(2);
-    const rail = screen.getByTestId("chat-turn-minimap");
-    await waitFor(() => {
-      expect(rail.getAttribute("data-persistent-gutter")).toBe("true");
-    });
-    expect(rail.className).toContain("opacity-100");
-
-    // Re-measure at a hover-only width by swapping the rect and forcing a
-    // remount of the measure effect via a prop that still keeps 2+ items.
-    // Trigger ResizeObserver? Mock is a no-op. Re-render alone won't re-run
-    // the effect (viewportRef identity is stable). Force a remount.
-    cleanup();
-    renderMinimap({
-      messages: makeTwoTurnTranscript(),
-      viewportWidth: HOVER_ONLY_VIEWPORT_PX,
-    });
-    await flushMinimapFrames(2);
-    const hoverRail = screen.getByTestId("chat-turn-minimap");
-    await waitFor(() => {
-      expect(hoverRail.getAttribute("data-persistent-gutter")).toBe("false");
-    });
-    expect(hoverRail.className).toContain("opacity-0");
-    expect(hoverRail.className).toContain("hover:opacity-100");
-    // Still interactive (non-zero strip) even without persistent gutter
-    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
-    expect(hitStrip.hasAttribute("inert")).toBe(false);
-  });
-
-  it("sizes the collapsed hit-strip width to the gutter-clamped budget", async () => {
-    // sideGutter = 52 → hit = min(40, 52-12) = 40
+  it("uses the same fixed edge hit target in a wide pane", async () => {
     renderMinimap({
       messages: makeTwoTurnTranscript(),
       viewportWidth: WIDE_VIEWPORT_PX,
     });
     await flushMinimapFrames(2);
     const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
-    await waitFor(() => {
-      expect(hitStrip.style.width).toBe(
-        `${CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH}px`,
-      );
-    });
+    expect(hitStrip.style.width).toBe(
+      `${CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH}px`,
+    );
   });
 });
 
@@ -580,6 +533,38 @@ describe("ChatTurnMinimap keyboard navigation", () => {
 });
 
 describe("ChatTurnMinimap mouse interaction", () => {
+  it("adds invisible pointer room beyond the first and last visible strips", async () => {
+    renderMinimap({ messages: makeThreeTurnTranscript() });
+    await flushMinimapFrames(2);
+
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    const interactionRegion = document.querySelector<HTMLElement>(
+      "[data-chat-turn-minimap-interaction-region]",
+    );
+    const firstStrip = document.querySelector<HTMLElement>(
+      '[data-chat-turn-minimap-strip][data-message-id="message-0"]',
+    );
+    const lastStrip = document.querySelector<HTMLElement>(
+      '[data-chat-turn-minimap-strip][data-message-id="message-5"]',
+    );
+
+    expect(firstStrip?.style.top).toBe(
+      `calc(0% + ${CHAT_TURN_MINIMAP_END_HIT_PADDING}px)`,
+    );
+    expect(lastStrip?.style.top).toBe(
+      `calc(100% - ${CHAT_TURN_MINIMAP_END_HIT_PADDING}px)`,
+    );
+    expect(hitStrip.parentElement).toBe(interactionRegion);
+    expect(hitStrip.classList).toContain("h-full");
+    expect(hitStrip.style.height).toBe("");
+
+    mockRailGeometry(hitStrip, { top: 0, height: 40 });
+    fireEvent.mouseMove(hitStrip, { clientY: 15 });
+    expect(await screen.findByText("Turn alpha")).toBeTruthy();
+    fireEvent.mouseMove(hitStrip, { clientY: 25 });
+    expect(await screen.findByText("Turn gamma")).toBeTruthy();
+  });
+
   it("mousemove maps pointer Y to nearest index and opens the preview", async () => {
     renderMinimap({ messages: makeThreeTurnTranscript() });
     await flushMinimapFrames(2);
@@ -610,7 +595,7 @@ describe("ChatTurnMinimap mouse interaction", () => {
     expect(blurSpy).toHaveBeenCalled();
   });
 
-  it("clicking inside the preview panel does NOT trigger selection", async () => {
+  it("clicking the preview card selects its message", async () => {
     const { onSelect } = renderMinimap({
       messages: makeTwoTurnTranscript(),
     });
@@ -619,11 +604,281 @@ describe("ChatTurnMinimap mouse interaction", () => {
     mockRailGeometry(hitStrip, { top: 0, height: 100 });
     fireEvent.mouseMove(hitStrip, { clientY: 0 });
 
-    const preview = await screen.findByText("First user turn");
-    const previewRoot = preview.closest("[data-chat-turn-minimap-preview]");
-    expect(previewRoot).not.toBeNull();
-    fireEvent.click(previewRoot as HTMLElement);
-    expect(onSelect).not.toHaveBeenCalled();
+    await screen.findByText("First user turn");
+    const previewCard = document.querySelector("[data-chat-turn-minimap-card]");
+    expect(previewCard).not.toBeNull();
+    fireEvent.click(previewCard as HTMLElement);
+    expect(onSelect).toHaveBeenCalledWith("message-0");
+  });
+
+  it("explains both expand and collapse controls in keyboard-accessible tooltips", async () => {
+    renderMinimap({ messages: makeThreeTurnTranscript() });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 50 });
+
+    const expandButton = await screen.findByRole("button", {
+      name: "Expand all messages",
+    });
+    fireEvent.focus(expandButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Expand all messages",
+    );
+    fireEvent.blur(expandButton, { relatedTarget: hitStrip });
+    fireEvent.click(expandButton);
+
+    const collapseButton = screen.getByRole("button", {
+      name: "Collapse message list",
+    });
+    fireEvent.focus(collapseButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Collapse message list",
+    );
+  });
+
+  it("finishes minimap actions before an inactive canvas pane activates on the same click", async () => {
+    const order: string[] = [];
+    const onSelect = vi.fn<(messageId: string) => void>((messageId) => {
+      order.push(`select:${messageId}`);
+    });
+    renderMinimap({
+      messages: makeThreeTurnTranscript(),
+      onSelect,
+    });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 50 });
+    const expandButton = await screen.findByRole("button", {
+      name: "Expand all messages",
+    });
+    expect(isPaneActivationDeferred(expandButton)).toBe(true);
+
+    const activatePaneAfterClick = (): void => {
+      order.push("activate");
+    };
+    document.addEventListener("click", activatePaneAfterClick);
+    try {
+      fireEvent.pointerDown(expandButton);
+      fireEvent.click(expandButton);
+      expect(order).toEqual(["activate"]);
+      expect(
+        screen.getByRole("button", { name: "Collapse message list" }),
+      ).toBeTruthy();
+
+      const lastMessage = screen.getByRole("button", {
+        name: "Jump to message: Turn gamma",
+      });
+      expect(isPaneActivationDeferred(lastMessage)).toBe(true);
+      order.length = 0;
+      fireEvent.pointerDown(lastMessage);
+      fireEvent.click(lastMessage);
+      expect(order).toEqual(["select:message-5", "activate"]);
+      expect(onSelect).toHaveBeenCalledWith("message-5");
+    } finally {
+      document.removeEventListener("click", activatePaneAfterClick);
+    }
+  });
+
+  it("expands in place to a scrollable serial list and keeps every card selectable", async () => {
+    const { onSelect } = renderMinimap({
+      messages: makeThreeTurnTranscript(),
+    });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 50 });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Expand all messages" }),
+    );
+
+    const collapseButton = screen.getByRole("button", {
+      name: "Collapse message list",
+    });
+    expect(collapseButton.getAttribute("data-variant")).toBe("ghost");
+    expect(
+      collapseButton.querySelector(".lucide-fold-vertical"),
+    ).not.toBeNull();
+    const messageCards = document.querySelectorAll(
+      "[data-chat-turn-minimap-list-item]",
+    );
+    expect(messageCards).toHaveLength(3);
+    expect(screen.queryByText("User messages · 3")).toBeNull();
+    expect(screen.queryByText("Message 1")).toBeNull();
+    expect(screen.getByText("Turn alpha")).toBeTruthy();
+    expect(screen.getByText("Turn beta")).toBeTruthy();
+    expect(screen.getByText("Turn gamma")).toBeTruthy();
+    expect(messageCards[0].textContent).toBe("Turn alpha");
+    expect(messageCards[1].textContent).toBe("Turn beta");
+    expect(messageCards[2].textContent).toBe("Turn gamma");
+    expect(messageCards[0].classList).toContain("hover:bg-foreground/[0.08]");
+    expect(messageCards[1].getAttribute("data-active")).toBe("true");
+    expect(messageCards[1].getAttribute("aria-current")).toBe("true");
+    expect(messageCards[1].classList).toContain("bg-foreground/[0.13]");
+    expect(messageCards[0].getAttribute("data-active")).toBe("false");
+    expect(screen.queryByText("Reply alpha")).toBeNull();
+    expect(screen.queryByText("Reply beta final")).toBeNull();
+    const expandedPanel = document.querySelector<HTMLElement>(
+      "[data-chat-turn-minimap-preview] > div",
+    );
+    const listScroller = document.querySelector<HTMLElement>(
+      "[data-chat-turn-minimap-list-scroll]",
+    );
+    expect(expandedPanel?.classList).toContain("max-h-[60vh]");
+    expect(expandedPanel?.classList).toContain("overflow-hidden");
+    expect(listScroller?.classList).toContain("overflow-y-auto");
+
+    fireEvent.click(messageCards[2]);
+    expect(onSelect).toHaveBeenCalledWith("message-5");
+    expect(messageCards[2].getAttribute("data-active")).toBe("true");
+    expect(messageCards[1].getAttribute("data-active")).toBe("false");
+    expect(
+      screen.getByRole("button", { name: "Collapse message list" }),
+    ).toBeTruthy();
+  });
+
+  it("shows expanded user queries for up to three intrinsic lines", async () => {
+    const longQuery =
+      "Explain how the inactive pane activation contract should preserve a newly opened portalled control while route synchronization catches up";
+    renderMinimap({
+      messages: [
+        makeUser(0, longQuery),
+        makeAssistant(1, "Long query reply"),
+        makeUser(2, "Short query"),
+      ],
+    });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 0 });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Expand all messages" }),
+    );
+
+    const longText = screen
+      .getByRole("button", { name: `Jump to message: ${longQuery}` })
+      .querySelector<HTMLElement>("[data-chat-turn-minimap-user-text]");
+    const shortText = screen
+      .getByRole("button", { name: "Jump to message: Short query" })
+      .querySelector<HTMLElement>("[data-chat-turn-minimap-user-text]");
+
+    expect(longText?.classList).toContain("line-clamp-3");
+    expect(longText?.classList).toContain("whitespace-normal");
+    expect(longText?.classList).toContain("break-words");
+    expect(longText?.classList).not.toContain("whitespace-nowrap");
+    expect(shortText?.classList).toContain("line-clamp-3");
+    expect(shortText?.classList).not.toContain("min-h-[3.75rem]");
+  });
+
+  it("dismisses the expanded list when the pointer leaves the whole interaction region", async () => {
+    renderMinimap({ messages: makeThreeTurnTranscript() });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    const interactionRegion = document.querySelector<HTMLElement>(
+      "[data-chat-turn-minimap-interaction-region]",
+    );
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 50 });
+    const expandButton = await screen.findByRole("button", {
+      name: "Expand all messages",
+    });
+    expect(expandButton.getAttribute("data-variant")).toBe("ghost");
+    expect(
+      expandButton.querySelector(".lucide-unfold-vertical"),
+    ).not.toBeNull();
+    fireEvent.click(expandButton);
+
+    expect(interactionRegion).not.toBeNull();
+    fireEvent.mouseLeave(interactionRegion as HTMLElement);
+
+    expect(
+      document.querySelector("[data-chat-turn-minimap-preview]"),
+    ).toBeNull();
+    fireEvent.mouseMove(hitStrip, { clientY: 50 });
+    expect(
+      await screen.findByRole("button", { name: "Expand all messages" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the panel open while focus moves within it, then closes when focus leaves", async () => {
+    renderMinimap({ messages: makeThreeTurnTranscript() });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
+
+    fireEvent.focus(hitStrip);
+    const expandButton = await screen.findByRole("button", {
+      name: "Expand all messages",
+    });
+    fireEvent.blur(hitStrip, { relatedTarget: expandButton });
+    fireEvent.focus(expandButton);
+    expect(
+      document.querySelector("[data-chat-turn-minimap-preview]"),
+    ).not.toBeNull();
+
+    fireEvent.click(expandButton);
+    const activeMessage = screen.getByRole("button", {
+      name: "Jump to message: Turn alpha",
+    });
+    fireEvent.focus(activeMessage);
+    fireEvent.blur(activeMessage, { relatedTarget: outsideButton });
+
+    expect(
+      document.querySelector("[data-chat-turn-minimap-preview]"),
+    ).toBeNull();
+  });
+
+  it("lets Escape collapse from any expanded-list item and dismiss the compact preview", async () => {
+    renderMinimap({ messages: makeThreeTurnTranscript() });
+    await flushMinimapFrames(2);
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 50 });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Expand all messages" }),
+    );
+    const activeMessage = screen.getByRole("button", {
+      name: "Jump to message: Turn beta",
+    });
+
+    fireEvent.keyDown(activeMessage, { key: "Escape" });
+    expect(
+      screen.getByRole("button", { name: "Expand all messages" }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(hitStrip);
+
+    fireEvent.keyDown(hitStrip, { key: "Escape" });
+    expect(
+      document.querySelector("[data-chat-turn-minimap-preview]"),
+    ).toBeNull();
+  });
+});
+
+describe("ChatTurnMinimap side placement", () => {
+  it("places the rail and inward-opening preview on the configured side", async () => {
+    renderMinimap({ messages: makeTwoTurnTranscript(), side: "left" });
+    await flushMinimapFrames(2);
+    const rail = screen.getByTestId("chat-turn-minimap");
+    expect(rail.dataset.side).toBe("left");
+    expect(rail.classList).toContain("left-0");
+
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    expect(hitStrip.parentElement?.classList).toContain("left-3");
+    mockRailGeometry(hitStrip, { top: 0, height: 100 });
+    fireEvent.mouseMove(hitStrip, { clientY: 0 });
+    const preview = document.querySelector("[data-chat-turn-minimap-preview]");
+    expect(preview?.classList).toContain("left-8");
+  });
+
+  it("places the rail on the right when configured with the default side", async () => {
+    renderMinimap({ messages: makeTwoTurnTranscript() });
+    await flushMinimapFrames(2);
+    const rail = screen.getByTestId("chat-turn-minimap");
+    expect(rail.dataset.side).toBe("right");
+    expect(rail.classList).toContain("right-0");
   });
 });
 
@@ -653,6 +908,130 @@ describe("ChatTurnMinimap in-view highlighting", () => {
       expect(strip0?.getAttribute("data-in-view")).toBe("false");
       expect(strip2?.getAttribute("data-in-view")).toBe("true");
     });
+  });
+
+  it("lights the nearest user-message strip when no query is in view", async () => {
+    const messages = makeTwoTurnTranscript();
+    const listState: FakeListState = {
+      scroll: 150,
+      scrollLength: 50, // gap [150, 200): first user ends at 60, second starts at 250
+      positions: [0, 80, 250, 330],
+      sizes: [60, 60, 60, 60],
+    };
+    const { inViewRefreshRef } = renderMinimap({ messages, listState });
+    await flushMinimapFrames(3);
+
+    const firstStrip = document.querySelector(
+      '[data-chat-turn-minimap-strip][data-message-id="message-0"]',
+    );
+    const secondStrip = document.querySelector(
+      '[data-chat-turn-minimap-strip][data-message-id="message-2"]',
+    );
+    await waitFor(() => {
+      expect(firstStrip?.getAttribute("data-in-view")).toBe("false");
+      expect(secondStrip?.getAttribute("data-in-view")).toBe("false");
+      expect(firstStrip?.getAttribute("data-proximity")).toBe("false");
+      expect(secondStrip?.getAttribute("data-proximity")).toBe("true");
+    });
+
+    listState.scroll = 70;
+    act(() => inViewRefreshRef.current());
+
+    expect(firstStrip?.getAttribute("data-proximity")).toBe("true");
+    expect(secondStrip?.getAttribute("data-proximity")).toBe("false");
+
+    // Equal distance above and below: keep the earlier marker stable rather
+    // than flickering between neighbors at the exact midpoint.
+    listState.scroll = 155;
+    listState.scrollLength = 0;
+    act(() => inViewRefreshRef.current());
+    expect(firstStrip?.getAttribute("data-proximity")).toBe("true");
+    expect(secondStrip?.getAttribute("data-proximity")).toBe("false");
+
+    // Far beyond the transcript: the final real query remains the anchor.
+    listState.scroll = 1_000;
+    listState.scrollLength = 50;
+    act(() => inViewRefreshRef.current());
+    expect(firstStrip?.getAttribute("data-proximity")).toBe("false");
+    expect(secondStrip?.getAttribute("data-proximity")).toBe("true");
+  });
+
+  it("does not add a proximity highlight while real query rows are visible", async () => {
+    const messages = makeTwoTurnTranscript();
+    const listState: FakeListState = {
+      scroll: 0,
+      scrollLength: 300,
+      positions: [0, 80, 250, 330],
+      sizes: [60, 60, 60, 60],
+    };
+    renderMinimap({ messages, listState });
+    await flushMinimapFrames(3);
+
+    const strips = document.querySelectorAll("[data-chat-turn-minimap-strip]");
+    await waitFor(() => {
+      expect(
+        [...strips].filter(
+          (strip) => strip.getAttribute("data-in-view") === "true",
+        ),
+      ).toHaveLength(2);
+      expect(
+        [...strips].filter(
+          (strip) => strip.getAttribute("data-proximity") === "true",
+        ),
+      ).toHaveLength(0);
+    });
+  });
+
+  it("keeps a deterministic real marker lit while row measurements are temporarily unavailable", async () => {
+    const messages = makeTwoTurnTranscript();
+    renderMinimap({
+      messages,
+      listState: {
+        scroll: 0,
+        scrollLength: 300,
+        positions: [],
+        sizes: [],
+      },
+    });
+    await flushMinimapFrames(3);
+
+    const firstStrip = document.querySelector(
+      '[data-chat-turn-minimap-strip][data-message-id="message-0"]',
+    );
+    const secondStrip = document.querySelector(
+      '[data-chat-turn-minimap-strip][data-message-id="message-2"]',
+    );
+    await waitFor(() => {
+      expect(firstStrip?.getAttribute("data-proximity")).toBe("true");
+      expect(secondStrip?.getAttribute("data-proximity")).toBe("false");
+    });
+  });
+
+  it("does not rewrite marker attributes when repeated scroll refreshes resolve the same state", async () => {
+    const messages = makeTwoTurnTranscript();
+    const { inViewRefreshRef } = renderMinimap({
+      messages,
+      listState: {
+        scroll: 150,
+        scrollLength: 50,
+        positions: [0, 80, 250, 330],
+        sizes: [60, 60, 60, 60],
+      },
+    });
+    await flushMinimapFrames(3);
+
+    const rail = screen.getByTestId("chat-turn-minimap");
+    const observer = new MutationObserver(() => undefined);
+    observer.observe(rail, {
+      attributes: true,
+      attributeFilter: ["data-in-view", "data-proximity"],
+      subtree: true,
+    });
+
+    act(() => inViewRefreshRef.current());
+
+    expect(observer.takeRecords()).toHaveLength(0);
+    observer.disconnect();
   });
 
   it("excludes rows hidden behind the bottom overlay inset", async () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-turn-minimap.test.tsx
@@ -13,6 +13,7 @@ import type { LegendListRef } from "@legendapp/list/react";
 import { ChatTurnMinimap } from "@/components/chat/chat-turn-minimap";
 import {
   CHAT_TURN_MINIMAP_END_HIT_PADDING,
+  CHAT_TURN_MINIMAP_EXPANDED_HIT_STRIP_WIDTH,
   CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
   CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE,
 } from "@/components/chat/chat-turn-minimap-logic";
@@ -23,6 +24,7 @@ import { isPaneActivationDeferred } from "@/components/epic-canvas/pane-activati
 import {
   evictChatTurnMinimapActiveEntries,
   evictChatTurnMinimapActiveEntryForChat,
+  saveChatTurnMinimapActiveEntry,
 } from "@/stores/chats/chat-turn-minimap-active-entry-store";
 import { makeMessage } from "./chat-message-fixtures";
 
@@ -458,6 +460,29 @@ describe("ChatTurnMinimap always-on rail", () => {
       `${CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH}px`,
     );
   });
+
+  it("keeps a restored active entry collapsed until interaction", async () => {
+    saveChatTurnMinimapActiveEntry(DEFAULT_MINIMAP_IDENTITY, "message-2");
+    renderMinimap({ messages: makeTwoTurnTranscript() });
+    await flushMinimapFrames(2);
+
+    const hitStrip = screen.getByTestId("chat-turn-minimap-hit-strip");
+    expect(hitStrip.style.width).toBe(
+      `${CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH}px`,
+    );
+    expect(
+      document.querySelector("[data-chat-turn-minimap-preview]"),
+    ).toBeNull();
+
+    fireEvent.focus(hitStrip);
+
+    expect(
+      document.querySelector("[data-chat-turn-minimap-preview]"),
+    ).not.toBeNull();
+    expect(
+      hitStrip.getAttribute("data-chat-turn-minimap-interactive-width"),
+    ).toBe(CHAT_TURN_MINIMAP_EXPANDED_HIT_STRIP_WIDTH);
+  });
 });
 
 describe("ChatTurnMinimap keyboard navigation", () => {
@@ -699,6 +724,9 @@ describe("ChatTurnMinimap mouse interaction", () => {
     });
     expect(collapseButton.getAttribute("data-variant")).toBe("ghost");
     expect(
+      hitStrip.getAttribute("data-chat-turn-minimap-interactive-width"),
+    ).toBe(CHAT_TURN_MINIMAP_EXPANDED_HIT_STRIP_WIDTH);
+    expect(
       collapseButton.querySelector(".lucide-fold-vertical"),
     ).not.toBeNull();
     const messageCards = document.querySelectorAll(
@@ -726,7 +754,9 @@ describe("ChatTurnMinimap mouse interaction", () => {
     const listScroller = document.querySelector<HTMLElement>(
       "[data-chat-turn-minimap-list-scroll]",
     );
-    expect(expandedPanel?.classList).toContain("max-h-[60vh]");
+    expect(expandedPanel?.classList).toContain(
+      "max-h-[min(60vh,calc(100cqh_-_1rem))]",
+    );
     expect(expandedPanel?.classList).toContain("overflow-hidden");
     expect(listScroller?.classList).toContain("overflow-y-auto");
 

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -2396,6 +2396,9 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
   const quoteReplyEnabled = useSettingsStore(
     (state) => state.quoteReplyEnabled,
   );
+  const chatTurnMinimapSide = useSettingsStore(
+    (state) => state.chatTurnMinimapSide,
+  );
   const quoteSelection = useQuoteSelection({
     containerRef: transcriptContainerRef,
     enabled: quoteReplyEnabled && visible && !systemOverlayActive,
@@ -3059,6 +3062,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
                 bottomInset={endInset}
                 onSelect={onMinimapItemSelect}
                 identity={identity}
+                side={chatTurnMinimapSide}
               />
             ) : null}
             {hasContent ? (

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -3052,7 +3052,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
               data-testid="chat-messages-scroll"
               data-scroll-mode={scrollMode}
             />
-            {hasContent ? (
+            {hasContent && chatTurnMinimapSide !== "hide" ? (
               <ChatTurnMinimap
                 messages={messages}
                 inViewRefreshRef={minimapInViewRefreshRef}

--- a/clients/gui-app/src/components/chat/chat-turn-minimap-logic.ts
+++ b/clients/gui-app/src/components/chat/chat-turn-minimap-logic.ts
@@ -16,19 +16,20 @@ export const CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE =
 export const CHAT_TURN_MINIMAP_KEYBOARD_OWNER_SELECTOR = `[${CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE}]`;
 
 export const CHAT_TURN_MINIMAP_ITEM_SPACING = 8;
+/** Extra invisible pointer room above the first strip and below the last. */
+export const CHAT_TURN_MINIMAP_END_HIT_PADDING = 12;
 export const CHAT_TURN_MINIMAP_MIN_ITEMS = 2;
 export const CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
 export const CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS =
   "max(1px, calc(100% - 1rem))";
-/** Matches `chat-timeline.tsx`'s row `max-w-3xl` (48rem = 768px). */
-export const CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH = 768;
-export const CHAT_TURN_MINIMAP_PERSISTENT_GUTTER = 48;
 
 export function resolveChatTurnMinimapHeightStyle(itemCount: number): string {
-  const naturalHeight = Math.max(
+  const naturalTrackHeight = Math.max(
     1,
     (itemCount - 1) * CHAT_TURN_MINIMAP_ITEM_SPACING,
   );
+  const naturalHeight =
+    naturalTrackHeight + CHAT_TURN_MINIMAP_END_HIT_PADDING * 2;
   return `min(${naturalHeight}px, ${CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS}, ${CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS})`;
 }
 
@@ -40,6 +41,22 @@ export function resolveChatTurnMinimapTopPercent(
     return 0;
   }
   return (Math.max(0, Math.min(index, itemCount - 1)) / (itemCount - 1)) * 100;
+}
+
+/**
+ * Keeps the visible strips on their original evenly spaced track while the
+ * button extends beyond both ends to make the endpoint targets easier to hit.
+ */
+export function resolveChatTurnMinimapTopStyle(
+  index: number,
+  itemCount: number,
+): string {
+  const percent = resolveChatTurnMinimapTopPercent(index, itemCount);
+  const pixelOffset =
+    CHAT_TURN_MINIMAP_END_HIT_PADDING * (1 - (percent * 2) / 100);
+  if (pixelOffset === 0) return `${percent}%`;
+  const operator = pixelOffset > 0 ? "+" : "-";
+  return `calc(${percent}% ${operator} ${Math.abs(pixelOffset)}px)`;
 }
 
 export function resolveChatTurnMinimapIndexFromPointer(input: {
@@ -55,9 +72,15 @@ export function resolveChatTurnMinimapIndexFromPointer(input: {
     return 0;
   }
 
+  const endPadding = Math.min(
+    CHAT_TURN_MINIMAP_END_HIT_PADDING,
+    Math.max(0, (input.railHeight - 1) / 2),
+  );
+  const trackTop = input.railTop + endPadding;
+  const trackHeight = input.railHeight - endPadding * 2;
   const progress = Math.max(
     0,
-    Math.min(1, (input.pointerY - input.railTop) / input.railHeight),
+    Math.min(1, (input.pointerY - trackTop) / trackHeight),
   );
   return Math.max(
     0,
@@ -65,58 +88,15 @@ export function resolveChatTurnMinimapIndexFromPointer(input: {
   );
 }
 
-export function resolveChatTurnMinimapHasPersistentGutter(
-  viewportWidth: number,
-): boolean {
-  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
-    return false;
-  }
-
-  const contentWidth = Math.min(
-    viewportWidth,
-    CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH,
-  );
-  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
-  return sideGutter >= CHAT_TURN_MINIMAP_PERSISTENT_GUTTER;
-}
-
-export const CHAT_TURN_MINIMAP_HIT_STRIP_LEFT = 12;
+/** Always-on edge hit target, including narrow and tiled transcript panes. */
 export const CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH = 40;
 export const CHAT_TURN_MINIMAP_EXPANDED_HIT_STRIP_WIDTH =
   "min(22rem, calc(100vw - 1rem))";
 
 /**
- * The minimap overlays the viewport's left edge while the content column is
- * centered, so the side gutter between them shrinks under browser zoom or a
- * narrow pane. A fixed-width hover strip would then sit on top of the message
- * text and swallow its pointer events. Cap the strip's width so it never
- * extends past the gutter into the content column; 0 disables the strip.
- */
-export function resolveChatTurnMinimapHitStripWidth(
-  viewportWidth: number,
-): number {
-  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
-    return 0;
-  }
-
-  const contentWidth = Math.min(
-    viewportWidth,
-    CHAT_TURN_MINIMAP_CONTENT_MAX_WIDTH,
-  );
-  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
-  return Math.max(
-    0,
-    Math.min(
-      CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
-      Math.floor(sideGutter) - CHAT_TURN_MINIMAP_HIT_STRIP_LEFT,
-    ),
-  );
-}
-
-/**
  * Once the preview is open, keep the full preview and the space leading to it
- * interactive. The collapsed strip remains gutter-capped so it cannot block
- * selecting message text.
+ * interactive. The collapsed rail keeps a compact fixed edge target so it
+ * remains usable in narrow and tiled panes.
  */
 export function resolveChatTurnMinimapInteractiveWidth(
   collapsedWidth: number,
@@ -125,7 +105,7 @@ export function resolveChatTurnMinimapInteractiveWidth(
   return expanded ? CHAT_TURN_MINIMAP_EXPANDED_HIT_STRIP_WIDTH : collapsedWidth;
 }
 
-interface ChatTurnMinimapListState {
+export interface ChatTurnMinimapListState {
   readonly scroll?: number;
   readonly scrollLength?: number;
   readonly positionAtIndex?: (index: number) => number | undefined;
@@ -168,17 +148,34 @@ export function resolveChatTurnMinimapRowInView(
   state: ChatTurnMinimapListState,
   rowIndex: number,
 ): boolean {
+  const distance = resolveChatTurnMinimapRowViewportDistance(state, rowIndex);
+  return distance !== null && distance < 0;
+}
+
+/**
+ * Distance between a measured row and the usable viewport band. A negative
+ * value marks an intersection, zero marks a touching edge, and a positive
+ * value is the pixel gap. `null` means the row has no usable position.
+ *
+ * Encoding both visibility and proximity in one number lets the scroll path
+ * resolve every marker with one geometry pass and no per-row object churn.
+ */
+export function resolveChatTurnMinimapRowViewportDistance(
+  state: ChatTurnMinimapListState,
+  rowIndex: number,
+): number | null {
   const topOffset =
     typeof state.topOffsetAdjustment === "number" &&
     Number.isFinite(state.topOffsetAdjustment)
       ? state.topOffsetAdjustment
       : 0;
   const scrollTop = (state.scroll ?? 0) - topOffset;
-  const scrollBottom = scrollTop + (state.scrollLength ?? 0);
+  const scrollBottom = scrollTop + Math.max(0, state.scrollLength ?? 0);
   const rowTop = resolveChatTurnMinimapRowTop(state, rowIndex);
-  if (rowTop === null) return false;
+  if (rowTop === null) return null;
   const rowHeight = resolveChatTurnMinimapRowHeight(state, rowIndex);
-  return (
-    rowTop < scrollBottom && rowTop + Math.max(1, rowHeight ?? 1) > scrollTop
-  );
+  const rowBottom = rowTop + Math.max(1, rowHeight ?? 1);
+  if (rowTop < scrollBottom && rowBottom > scrollTop) return -1;
+  if (rowBottom <= scrollTop) return scrollTop - rowBottom;
+  return Math.max(0, rowTop - scrollBottom);
 }

--- a/clients/gui-app/src/components/chat/chat-turn-minimap-logic.ts
+++ b/clients/gui-app/src/components/chat/chat-turn-minimap-logic.ts
@@ -18,7 +18,7 @@ export const CHAT_TURN_MINIMAP_KEYBOARD_OWNER_SELECTOR = `[${CHAT_TURN_MINIMAP_K
 export const CHAT_TURN_MINIMAP_ITEM_SPACING = 8;
 /** Extra invisible pointer room above the first strip and below the last. */
 export const CHAT_TURN_MINIMAP_END_HIT_PADDING = 12;
-export const CHAT_TURN_MINIMAP_MIN_ITEMS = 2;
+export const CHAT_TURN_MINIMAP_MIN_ITEMS = 1;
 export const CHAT_TURN_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
 export const CHAT_TURN_MINIMAP_PANE_MAX_HEIGHT_CSS =
   "max(1px, calc(100% - 1rem))";

--- a/clients/gui-app/src/components/chat/chat-turn-minimap.tsx
+++ b/clients/gui-app/src/components/chat/chat-turn-minimap.tsx
@@ -4,7 +4,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type FocusEvent as ReactFocusEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
@@ -316,7 +315,7 @@ function ChatTurnMinimapPreview(props: ChatTurnMinimapPreviewProps) {
       }}
     >
       {expanded ? (
-        <div className="relative flex max-h-[60vh] flex-col overflow-hidden rounded-xl border border-border/60 bg-popover shadow-lg">
+        <div className="relative flex max-h-[min(60vh,calc(100cqh_-_1rem))] flex-col overflow-hidden rounded-xl border border-border/60 bg-popover shadow-lg">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -406,7 +405,7 @@ function ChatTurnMinimapPreview(props: ChatTurnMinimapPreviewProps) {
 
 /**
  * Configurable transcript-edge turn minimap (decision #20).
- * One evenly spaced strip per HUMAN user turn; hover/focus opens a 22rem
+ * One evenly spaced strip per HUMAN user turn; hover/focus opens a 20rem
  * viewport-capped preview (user text + the turn's last assistant text); a
  * single hit-target control maps pointer Y / arrow keys to the nearest turn.
  * Fine-pointer only; the compact edge target stays visible and interactive
@@ -433,6 +432,8 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     return index === -1 ? null : index;
   });
   const [expanded, setExpanded] = useState(false);
+  const [interactionStarted, setInteractionStarted] = useState(false);
+  const interactionRegionRef = useRef<HTMLDivElement | null>(null);
   const hitStripRef = useRef<HTMLButtonElement | null>(null);
   const proximityMessageIdRef = useRef<string | null>(null);
 
@@ -569,6 +570,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
 
   const updateActiveIndexFromPointer = useCallback(
     (event: ReactMouseEvent<HTMLElement>): void => {
+      setInteractionStarted(true);
       setActiveIndex(resolveActiveIndexFromPointer(event));
     },
     [resolveActiveIndexFromPointer],
@@ -587,6 +589,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   const handleHitStripClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>): void => {
       if (chatTurnMinimapEventTargetsPreview(event.target)) return;
+      setInteractionStarted(true);
       const nextIndex = resolveActiveIndexFromPointer(event);
       const nextItem = nextIndex === null ? null : (items[nextIndex] ?? null);
       if (nextItem) {
@@ -600,6 +603,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   const handleHitStripKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
       if (chatTurnMinimapEventTargetsPreview(event.target)) return;
+      setInteractionStarted(true);
       if (event.key === "ArrowDown") {
         event.preventDefault();
         moveActiveIndex(1);
@@ -640,14 +644,15 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
 
   const closeInteraction = useCallback((): void => {
     setExpanded(false);
+    setInteractionStarted(false);
     setActiveIndex(null);
   }, []);
 
   const handleInteractionBlur = useCallback(
-    (event: ReactFocusEvent<HTMLDivElement>): void => {
+    (event: FocusEvent): void => {
       if (
         event.relatedTarget instanceof Node &&
-        event.currentTarget.contains(event.relatedTarget)
+        interactionRegionRef.current?.contains(event.relatedTarget) === true
       ) {
         return;
       }
@@ -657,7 +662,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   );
 
   const handleInteractionKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+    (event: KeyboardEvent): void => {
       if (event.key !== "Escape") return;
       event.preventDefault();
       event.stopPropagation();
@@ -672,6 +677,22 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     [closeInteraction, expanded],
   );
 
+  useEffect(() => {
+    const interactionRegion = interactionRegionRef.current;
+    if (interactionRegion === null) return;
+    interactionRegion.addEventListener("focusout", handleInteractionBlur);
+    interactionRegion.addEventListener("keydown", handleInteractionKeyDown);
+    interactionRegion.addEventListener("mouseleave", closeInteraction);
+    return () => {
+      interactionRegion.removeEventListener("focusout", handleInteractionBlur);
+      interactionRegion.removeEventListener(
+        "keydown",
+        handleInteractionKeyDown,
+      );
+      interactionRegion.removeEventListener("mouseleave", closeInteraction);
+    };
+  }, [closeInteraction, handleInteractionBlur, handleInteractionKeyDown]);
+
   const handlePreviewSelect = useCallback(
     (messageId: string): void => {
       const index = items.findIndex((item) => item.id === messageId);
@@ -682,6 +703,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   );
 
   const toggleExpanded = useCallback((): void => {
+    setInteractionStarted(true);
     setExpanded((current) => !current);
   }, []);
 
@@ -690,11 +712,16 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   }
 
   const safeBottomInset = Math.max(0, Math.ceil(bottomInset));
+  const previewVisible = interactionStarted && activeItem !== null;
+  const interactiveWidth = resolveChatTurnMinimapInteractiveWidth(
+    CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
+    previewVisible || expanded,
+  );
 
   return (
     <div
       className={cn(
-        "group/chat-turn-minimap pointer-events-none absolute top-0 z-40 hidden w-18 opacity-100 [@media(pointer:fine)]:block",
+        "group/chat-turn-minimap pointer-events-none absolute top-0 z-40 hidden w-18 opacity-100 [container-type:size] [@media(pointer:fine)]:block",
         side === "left" ? "left-0" : "right-0",
       )}
       data-side={side}
@@ -710,19 +737,21 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
           aria-label="Message minimap controls"
           data-chat-turn-minimap-interaction-region=""
           {...paneActivationDeferProps}
-          onBlur={handleInteractionBlur}
-          onKeyDown={handleInteractionKeyDown}
-          onMouseLeave={closeInteraction}
-          role="toolbar"
+          ref={interactionRegionRef}
+          role="group"
           style={{ height: resolveChatTurnMinimapHeightStyle(items.length) }}
         >
           <button
             aria-label="Message minimap"
             className="pointer-events-auto relative block h-full cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
+            data-chat-turn-minimap-interactive-width={interactiveWidth}
             data-testid="chat-turn-minimap-hit-strip"
             {...{ [CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE]: "" }}
             onClick={handleHitStripClick}
-            onFocus={() => setActiveIndex((current) => current ?? 0)}
+            onFocus={() => {
+              setInteractionStarted(true);
+              setActiveIndex((current) => current ?? 0);
+            }}
             onKeyDown={handleHitStripKeyDown}
             onMouseDown={handleHitStripMouseDown}
             onMouseMove={(event) => {
@@ -730,10 +759,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
             }}
             ref={hitStripRef}
             style={{
-              width: resolveChatTurnMinimapInteractiveWidth(
-                CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
-                activeItem !== null || expanded,
-              ),
+              width: interactiveWidth,
             }}
             type="button"
           >
@@ -768,7 +794,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
               );
             })}
           </button>
-          {activeItem === null ? null : (
+          {!previewVisible ? null : (
             <ChatTurnMinimapPreview
               activeItem={activeItem}
               activeItemIndex={resolvedActiveIndex ?? 0}

--- a/clients/gui-app/src/components/chat/chat-turn-minimap.tsx
+++ b/clients/gui-app/src/components/chat/chat-turn-minimap.tsx
@@ -2,22 +2,25 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  type FocusEvent as ReactFocusEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
 } from "react";
 import type { LegendListRef } from "@legendapp/list/react";
+import { FoldVertical, UnfoldVertical } from "lucide-react";
 import {
   CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE,
+  CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
   CHAT_TURN_MINIMAP_MIN_ITEMS,
-  resolveChatTurnMinimapHasPersistentGutter,
   resolveChatTurnMinimapHeightStyle,
-  resolveChatTurnMinimapHitStripWidth,
   resolveChatTurnMinimapIndexFromPointer,
   resolveChatTurnMinimapInteractiveWidth,
-  resolveChatTurnMinimapRowInView,
-  resolveChatTurnMinimapTopPercent,
+  resolveChatTurnMinimapRowViewportDistance,
+  resolveChatTurnMinimapTopStyle,
+  type ChatTurnMinimapListState,
 } from "@/components/chat/chat-turn-minimap-logic";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 import { cn } from "@/lib/utils";
@@ -26,6 +29,14 @@ import {
   saveChatTurnMinimapActiveEntry,
 } from "@/stores/chats/chat-turn-minimap-active-entry-store";
 import type { ChatTabPersistenceIdentity } from "@/stores/chats/chat-tab-persistence-key";
+import type { ChatTurnMinimapSide } from "@/stores/settings/settings-store";
+import { Button } from "@/components/ui/button";
+import { paneActivationDeferProps } from "@/components/epic-canvas/pane-activation";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface ChatTurnMinimapProps {
   /** Same row array LegendList renders - rail indices key directly into it. */
@@ -38,8 +49,8 @@ export interface ChatTurnMinimapProps {
    *  (not a number prop) since it updates via LegendList's own metrics
    *  callback, independent of this component's own render cycle. */
   readonly topOffsetAdjustmentRef: RefObject<number>;
-  /** Measures the pane's full width, to size the gutter/hit-strip against
-   *  the centered content column (the transcript's clip-region wrapper). */
+  /** Observes the transcript clip-region wrapper so pane resizes refresh
+   *  in-view strip highlighting even when no scroll event fires. */
   readonly viewportRef: RefObject<HTMLElement | null>;
   /** Composer/queue dock height overlaying the bottom of the transcript
    *  (decision #3, #13) - the rail's own box shrinks by this amount rather
@@ -59,6 +70,8 @@ export interface ChatTurnMinimapProps {
    *  against - tab-key while switching away and back, chat-key across a
    *  full close/reopen. */
   readonly identity: ChatTabPersistenceIdentity;
+  /** Persisted transcript-edge preference. Right is the app default. */
+  readonly side: ChatTurnMinimapSide;
 }
 
 interface ChatTurnMinimapItem {
@@ -154,7 +167,6 @@ function resolveChatTurnMinimapStripWidthClassName(
 interface ChatTurnMinimapActiveState {
   readonly resolvedActiveIndex: number | null;
   readonly activeItem: ChatTurnMinimapItem | null;
-  readonly activeTopPercent: number;
 }
 
 /** Kept extracted for the same complexity-ceiling reason as the two
@@ -166,26 +178,239 @@ function resolveChatTurnMinimapActiveState(
   const resolvedActiveIndex =
     activeIndex !== null && activeIndex < items.length ? activeIndex : null;
   if (resolvedActiveIndex === null) {
-    return { resolvedActiveIndex: null, activeItem: null, activeTopPercent: 0 };
+    return { resolvedActiveIndex: null, activeItem: null };
   }
   return {
     resolvedActiveIndex,
     activeItem: items[resolvedActiveIndex] ?? null,
-    activeTopPercent: resolveChatTurnMinimapTopPercent(
-      resolvedActiveIndex,
-      items.length,
-    ),
   };
 }
 
+interface ChatTurnMinimapViewportHighlightResolution {
+  readonly closestMessageId: string | null;
+  readonly hasInViewItem: boolean;
+}
+
+function updateChatTurnMinimapStripDataset(
+  strip: HTMLSpanElement,
+  key: "inView" | "proximity",
+  enabled: boolean,
+): void {
+  const nextValue = enabled ? "true" : "false";
+  if (strip.dataset[key] !== nextValue) {
+    strip.dataset[key] = nextValue;
+  }
+}
+
+function refreshChatTurnMinimapViewportHighlights(
+  state: ChatTurnMinimapListState,
+  items: ReadonlyArray<ChatTurnMinimapItem>,
+  stripMap: ReadonlyMap<string, HTMLSpanElement>,
+): ChatTurnMinimapViewportHighlightResolution {
+  let hasInViewItem = false;
+  let closestMessageId: string | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const item of items) {
+    const strip = stripMap.get(item.id);
+    if (!strip) continue;
+    const distance = resolveChatTurnMinimapRowViewportDistance(
+      state,
+      item.rowIndex,
+    );
+    const inView = distance !== null && distance < 0;
+    updateChatTurnMinimapStripDataset(strip, "inView", inView);
+    if (inView) {
+      hasInViewItem = true;
+      continue;
+    }
+    if (distance === null || distance >= closestDistance) continue;
+    closestDistance = distance;
+    closestMessageId = item.id;
+  }
+  return { closestMessageId, hasInViewItem };
+}
+
+function syncChatTurnMinimapProximityHighlight(
+  stripMap: ReadonlyMap<string, HTMLSpanElement>,
+  previousMessageId: string | null,
+  nextMessageId: string | null,
+): void {
+  if (previousMessageId !== nextMessageId && previousMessageId !== null) {
+    const previousStrip = stripMap.get(previousMessageId);
+    if (previousStrip) {
+      updateChatTurnMinimapStripDataset(previousStrip, "proximity", false);
+    }
+  }
+  if (nextMessageId === null) return;
+  const nextStrip = stripMap.get(nextMessageId);
+  if (nextStrip) {
+    updateChatTurnMinimapStripDataset(nextStrip, "proximity", true);
+  }
+}
+
+interface ChatTurnMinimapPreviewProps {
+  readonly activeItem: ChatTurnMinimapItem;
+  readonly activeItemIndex: number;
+  readonly activeTooltipTranslate: string;
+  readonly expanded: boolean;
+  readonly items: ReadonlyArray<ChatTurnMinimapItem>;
+  readonly onSelect: (messageId: string) => void;
+  readonly onToggleExpanded: () => void;
+  readonly side: ChatTurnMinimapSide;
+}
+
+function ChatTurnMinimapItemText(props: {
+  readonly item: ChatTurnMinimapItem;
+  readonly mode: "list" | "preview";
+}) {
+  const { item, mode } = props;
+  return (
+    <>
+      <span
+        className={cn(
+          "block max-w-full text-ui-xs font-medium leading-5",
+          mode === "list"
+            ? "line-clamp-3 whitespace-normal break-words"
+            : "overflow-hidden text-ellipsis whitespace-nowrap",
+        )}
+        data-chat-turn-minimap-user-text=""
+      >
+        {item.userText ?? "User message"}
+      </span>
+      {mode === "preview" && item.assistantText !== null ? (
+        <span
+          className="mt-1 line-clamp-3 text-muted-foreground text-ui-xs leading-5"
+          data-chat-turn-minimap-assistant=""
+        >
+          {item.assistantText}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+function ChatTurnMinimapPreview(props: ChatTurnMinimapPreviewProps) {
+  const {
+    activeItem,
+    activeItemIndex,
+    activeTooltipTranslate,
+    expanded,
+    items,
+    onSelect,
+    onToggleExpanded,
+    side,
+  } = props;
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto absolute w-[min(20rem,calc(100vw-3rem))] select-none text-left text-popover-foreground",
+        side === "left" ? "left-8" : "right-8",
+      )}
+      data-chat-turn-minimap-preview=""
+      onMouseMove={(event) => event.stopPropagation()}
+      style={{
+        top: expanded
+          ? "50%"
+          : resolveChatTurnMinimapTopStyle(activeItemIndex, items.length),
+        transform: `translateY(${expanded ? "-50%" : activeTooltipTranslate})`,
+      }}
+    >
+      {expanded ? (
+        <div className="relative flex max-h-[60vh] flex-col overflow-hidden rounded-xl border border-border/60 bg-popover shadow-lg">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label="Collapse message list"
+                className="absolute top-2 right-2 z-10 text-muted-foreground/60 hover:text-foreground active:bg-muted/80 active:text-foreground"
+                onClick={() => {
+                  onToggleExpanded();
+                }}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <FoldVertical aria-hidden="true" className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              Collapse message list
+            </TooltipContent>
+          </Tooltip>
+          <div
+            className="min-h-0 overflow-y-auto p-2"
+            data-chat-turn-minimap-list-scroll=""
+          >
+            <div className="flex flex-col gap-0.5">
+              {items.map((item, index) => (
+                <button
+                  aria-label={`Jump to message: ${item.userText ?? "User message"}`}
+                  aria-current={index === activeItemIndex ? "true" : undefined}
+                  className={cn(
+                    "w-full cursor-pointer rounded-lg px-3 py-2.5 text-left transition-[background-color,color,box-shadow] duration-100 first:pr-11 hover:bg-foreground/[0.08] focus-visible:bg-foreground/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+                    index === activeItemIndex
+                      ? "bg-foreground/[0.13] text-foreground ring-1 ring-inset ring-foreground/[0.08] hover:bg-foreground/[0.16]"
+                      : "bg-transparent text-popover-foreground",
+                  )}
+                  data-active={index === activeItemIndex ? "true" : "false"}
+                  data-chat-turn-minimap-list-item=""
+                  data-message-id={item.id}
+                  key={item.id}
+                  onClick={() => {
+                    onSelect(item.id);
+                  }}
+                  type="button"
+                >
+                  <ChatTurnMinimapItemText item={item} mode="list" />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="relative overflow-hidden rounded-xl border border-border/60 bg-popover shadow-lg">
+          <button
+            aria-label={`Jump to message: ${activeItem.userText ?? "User message"}`}
+            className="block w-full cursor-pointer select-none p-3 pr-11 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+            data-chat-turn-minimap-card=""
+            onClick={() => {
+              onSelect(activeItem.id);
+            }}
+            type="button"
+          >
+            <ChatTurnMinimapItemText item={activeItem} mode="preview" />
+          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label="Expand all messages"
+                className="absolute top-2 right-2 text-muted-foreground/60 hover:text-foreground active:bg-muted/80 active:text-foreground"
+                onClick={() => {
+                  onToggleExpanded();
+                }}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <UnfoldVertical aria-hidden="true" className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              Expand all messages
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
- * Left-rail turn minimap (decision #20).
+ * Configurable transcript-edge turn minimap (decision #20).
  * One evenly spaced strip per HUMAN user turn; hover/focus opens a 22rem
  * viewport-capped preview (user text + the turn's last assistant text); a
- * single hit-target button maps pointer Y / arrow keys to the nearest turn.
- * Fine-pointer only; the collapsed strip is capped to the actual side
- * gutter and goes fully inert (not just visually collapsed) at 0px so it
- * never intercepts clicks over the centered content column.
+ * single hit-target control maps pointer Y / arrow keys to the nearest turn.
+ * Fine-pointer only; the compact edge target stays visible and interactive
+ * at every pane width, including tiled epic-canvas layouts.
  */
 export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   const {
@@ -195,6 +420,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     listRef,
     messages,
     onSelect,
+    side,
     topOffsetAdjustmentRef,
     viewportRef,
   } = props;
@@ -206,11 +432,12 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     const index = items.findIndex((item) => item.id === savedActiveMessageId);
     return index === -1 ? null : index;
   });
-  const [hasPersistentGutter, setHasPersistentGutter] = useState(false);
-  const [hitStripWidth, setHitStripWidth] = useState(0);
+  const [expanded, setExpanded] = useState(false);
+  const hitStripRef = useRef<HTMLButtonElement | null>(null);
+  const proximityMessageIdRef = useRef<string | null>(null);
 
-  // Gutter/hit-strip geometry and in-view highlighting: recomputed on mount
-  // and whenever the pane's own box changes (zoom or split resize). A
+  // In-view highlighting is refreshed on mount and whenever the pane's own
+  // box changes (zoom or split resize). A
   // height-only resize changes LegendList's scrollLength without necessarily
   // producing either a scroll event or a row remeasurement.
   useEffect(() => {
@@ -218,12 +445,6 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     if (viewportElement === null) return;
 
     const measure = (): void => {
-      const viewportWidth = viewportElement.getBoundingClientRect().width;
-      setHasPersistentGutter((current) => {
-        const next = resolveChatTurnMinimapHasPersistentGutter(viewportWidth);
-        return current === next ? current : next;
-      });
-      setHitStripWidth(resolveChatTurnMinimapHitStripWidth(viewportWidth));
       inViewRefreshRef.current();
     };
 
@@ -238,8 +459,10 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
 
   // In-view strip highlighting from LegendList's own measured positions - no
   // DOM rect probing (jsdom/perf lesson; the old reading-line probe died on
-  // exactly this). Written directly to each strip's dataset, bypassing React
-  // state, so a scroll tick never triggers a re-render of the whole rail. O2
+  // exactly this). One O(items) geometry pass with no per-item allocation
+  // handles both visibility and proximity. Dataset writes are diffed and
+  // bypass React state, so a scroll tick never re-renders the rail or repeats
+  // style work for unchanged markers. O2
   // (ticket 16 listener consolidation): this used to run off a second scroll listener
   // this component attached to the scrollable node itself (rAF-polling
   // attach + native listener + detach, duplicating a lifecycle ChatTimeline
@@ -266,15 +489,25 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
       ),
       topOffsetAdjustment: topOffsetAdjustmentRef.current,
     };
-    for (const item of items) {
-      const strip = stripMap.get(item.id);
-      if (!strip) continue;
-      strip.dataset.inView = resolveChatTurnMinimapRowInView(
-        state,
-        item.rowIndex,
-      )
-        ? "true"
-        : "false";
+    const resolution = refreshChatTurnMinimapViewportHighlights(
+      state,
+      items,
+      stripMap,
+    );
+    const fallbackMessageId = items.length === 0 ? null : items[0].id;
+    const nextProximityMessageId = resolution.hasInViewItem
+      ? null
+      : (resolution.closestMessageId ??
+        proximityMessageIdRef.current ??
+        fallbackMessageId);
+    const previousProximityMessageId = proximityMessageIdRef.current;
+    syncChatTurnMinimapProximityHighlight(
+      stripMap,
+      previousProximityMessageId,
+      nextProximityMessageId,
+    );
+    if (previousProximityMessageId !== nextProximityMessageId) {
+      proximityMessageIdRef.current = nextProximityMessageId;
     }
   }, [bottomInset, items, listRef, stripMap, topOffsetAdjustmentRef]);
 
@@ -296,8 +529,10 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   // ceiling. Inlining this 3-branch resolution pushed it over, so it stays
   // extracted; the true one-liners (aria-label, wrapper opacity) below ARE
   // inlined.
-  const { resolvedActiveIndex, activeItem, activeTopPercent } =
-    resolveChatTurnMinimapActiveState(items, activeIndex);
+  const { resolvedActiveIndex, activeItem } = resolveChatTurnMinimapActiveState(
+    items,
+    activeIndex,
+  );
   const activeTooltipTranslate = resolveChatTurnMinimapTooltipTranslate(
     resolvedActiveIndex,
     items.length,
@@ -349,15 +584,8 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     [items.length],
   );
 
-  const isInert = hitStripWidth <= 0;
-
   const handleHitStripClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>): void => {
-      // Real browsers already refuse focus/pointer/keyboard dispatch into an
-      // `inert` subtree; this guard makes that non-negotiable rather than
-      // relying solely on the attribute (M3b - the old minimap's hard-won
-      // zero-budget fix went the same belt-and-suspenders route).
-      if (isInert) return;
       if (chatTurnMinimapEventTargetsPreview(event.target)) return;
       const nextIndex = resolveActiveIndexFromPointer(event);
       const nextItem = nextIndex === null ? null : (items[nextIndex] ?? null);
@@ -366,12 +594,12 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
       }
       event.currentTarget.blur();
     },
-    [isInert, items, onSelect, resolveActiveIndexFromPointer],
+    [items, onSelect, resolveActiveIndexFromPointer],
   );
 
   const handleHitStripKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
-      if (isInert) return;
+      if (chatTurnMinimapEventTargetsPreview(event.target)) return;
       if (event.key === "ArrowDown") {
         event.preventDefault();
         moveActiveIndex(1);
@@ -399,7 +627,7 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
         }
       }
     },
-    [activeItem, isInert, items.length, moveActiveIndex, onSelect],
+    [activeItem, items.length, moveActiveIndex, onSelect],
   );
 
   const handleHitStripMouseDown = useCallback(
@@ -410,6 +638,53 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
     [],
   );
 
+  const closeInteraction = useCallback((): void => {
+    setExpanded(false);
+    setActiveIndex(null);
+  }, []);
+
+  const handleInteractionBlur = useCallback(
+    (event: ReactFocusEvent<HTMLDivElement>): void => {
+      if (
+        event.relatedTarget instanceof Node &&
+        event.currentTarget.contains(event.relatedTarget)
+      ) {
+        return;
+      }
+      closeInteraction();
+    },
+    [closeInteraction],
+  );
+
+  const handleInteractionKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (expanded) {
+        setExpanded(false);
+        hitStripRef.current?.focus();
+        return;
+      }
+      closeInteraction();
+      hitStripRef.current?.blur();
+    },
+    [closeInteraction, expanded],
+  );
+
+  const handlePreviewSelect = useCallback(
+    (messageId: string): void => {
+      const index = items.findIndex((item) => item.id === messageId);
+      if (index !== -1) setActiveIndex(index);
+      onSelect(messageId);
+    },
+    [items, onSelect],
+  );
+
+  const toggleExpanded = useCallback((): void => {
+    setExpanded((current) => !current);
+  }, []);
+
   if (items.length < CHAT_TURN_MINIMAP_MIN_ITEMS) {
     return null;
   }
@@ -419,99 +694,93 @@ export function ChatTurnMinimap(props: ChatTurnMinimapProps) {
   return (
     <div
       className={cn(
-        "group/chat-turn-minimap pointer-events-none absolute top-0 left-0 z-40 hidden w-18 [@media(pointer:fine)]:block",
-        hasPersistentGutter
-          ? "opacity-100"
-          : "opacity-0 transition-opacity duration-150 hover:opacity-100 focus-within:opacity-100",
+        "group/chat-turn-minimap pointer-events-none absolute top-0 z-40 hidden w-18 opacity-100 [@media(pointer:fine)]:block",
+        side === "left" ? "left-0" : "right-0",
       )}
+      data-side={side}
       data-testid="chat-turn-minimap"
-      data-persistent-gutter={hasPersistentGutter ? "true" : "false"}
       style={{ bottom: safeBottomInset }}
     >
       <div className="relative h-full w-full select-none">
-        <button
-          aria-hidden={isInert ? "true" : undefined}
-          aria-label={`Jump to message: ${activeItem?.userText ?? "User message"}`}
+        <div
           className={cn(
-            "absolute top-1/2 left-3 -translate-y-1/2 cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
-            // The strip is width-capped to the side gutter so it never
-            // overlays the centered content column; with no usable gutter
-            // it goes fully inert, not just visually collapsed (M3b - the
-            // old minimap's hard-won zero-budget fix).
-            isInert ? "pointer-events-none" : "pointer-events-auto",
+            "pointer-events-auto absolute top-1/2 -translate-y-1/2 cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+            side === "left" ? "left-3" : "right-3",
           )}
-          data-testid="chat-turn-minimap-hit-strip"
-          {...{ [CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE]: "" }}
-          inert={isInert}
-          onBlur={() => setActiveIndex(null)}
-          onClick={handleHitStripClick}
-          onFocus={() => setActiveIndex((current) => current ?? 0)}
-          onKeyDown={handleHitStripKeyDown}
-          onMouseDown={handleHitStripMouseDown}
-          onMouseLeave={() => setActiveIndex(null)}
-          onMouseMove={updateActiveIndexFromPointer}
-          style={{
-            height: resolveChatTurnMinimapHeightStyle(items.length),
-            width: resolveChatTurnMinimapInteractiveWidth(
-              hitStripWidth,
-              activeItem !== null,
-            ),
-          }}
-          tabIndex={isInert ? -1 : 0}
-          type="button"
+          aria-label="Message minimap controls"
+          data-chat-turn-minimap-interaction-region=""
+          {...paneActivationDeferProps}
+          onBlur={handleInteractionBlur}
+          onKeyDown={handleInteractionKeyDown}
+          onMouseLeave={closeInteraction}
+          role="toolbar"
+          style={{ height: resolveChatTurnMinimapHeightStyle(items.length) }}
         >
-          <div className="absolute top-0 left-3 h-full w-px bg-border/15" />
-          {items.map((item, index) => {
-            const top = `${resolveChatTurnMinimapTopPercent(index, items.length)}%`;
-            const activeDistance =
-              resolvedActiveIndex === null
-                ? null
-                : Math.abs(index - resolvedActiveIndex);
-            return (
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "pointer-events-none absolute left-0 h-0.5 -translate-y-1/2 rounded-full bg-muted-foreground/35 transition-[background-color,width] duration-150 data-[in-view=true]:bg-foreground/90",
-                  resolveChatTurnMinimapStripWidthClassName(activeDistance),
-                )}
-                data-chat-turn-minimap-strip=""
-                data-in-view="false"
-                data-message-id={item.id}
-                key={item.id}
-                ref={(node) => {
-                  if (node) {
-                    stripMap.set(item.id, node);
-                  } else {
-                    stripMap.delete(item.id);
-                  }
-                }}
-                style={{ top }}
-              />
-            );
-          })}
+          <button
+            aria-label="Message minimap"
+            className="pointer-events-auto relative block h-full cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
+            data-testid="chat-turn-minimap-hit-strip"
+            {...{ [CHAT_TURN_MINIMAP_KEYBOARD_OWNER_ATTRIBUTE]: "" }}
+            onClick={handleHitStripClick}
+            onFocus={() => setActiveIndex((current) => current ?? 0)}
+            onKeyDown={handleHitStripKeyDown}
+            onMouseDown={handleHitStripMouseDown}
+            onMouseMove={(event) => {
+              if (!expanded) updateActiveIndexFromPointer(event);
+            }}
+            ref={hitStripRef}
+            style={{
+              width: resolveChatTurnMinimapInteractiveWidth(
+                CHAT_TURN_MINIMAP_HIT_STRIP_MAX_WIDTH,
+                activeItem !== null || expanded,
+              ),
+            }}
+            type="button"
+          >
+            {items.map((item, index) => {
+              const top = resolveChatTurnMinimapTopStyle(index, items.length);
+              const activeDistance =
+                resolvedActiveIndex === null
+                  ? null
+                  : Math.abs(index - resolvedActiveIndex);
+              return (
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "pointer-events-none absolute h-0.5 -translate-y-1/2 rounded-full bg-muted-foreground/35 transition-[background-color,width] duration-150 data-[in-view=true]:bg-foreground/90 data-[proximity=true]:bg-foreground/90",
+                    side === "left" ? "left-0" : "right-0",
+                    resolveChatTurnMinimapStripWidthClassName(activeDistance),
+                  )}
+                  data-chat-turn-minimap-strip=""
+                  data-in-view="false"
+                  data-message-id={item.id}
+                  data-proximity="false"
+                  key={item.id}
+                  ref={(node) => {
+                    if (node) {
+                      stripMap.set(item.id, node);
+                    } else {
+                      stripMap.delete(item.id);
+                    }
+                  }}
+                  style={{ top }}
+                />
+              );
+            })}
+          </button>
           {activeItem === null ? null : (
-            <span
-              className="pointer-events-auto absolute left-8 w-[min(20rem,calc(100vw-3rem))] cursor-text select-text"
-              data-chat-turn-minimap-preview=""
-              onMouseMove={(event) => event.stopPropagation()}
-              style={{
-                top: `${activeTopPercent}%`,
-                transform: `translateY(${activeTooltipTranslate})`,
-              }}
-            >
-              <span className="block rounded-xl border border-border/60 bg-popover p-3 text-left text-popover-foreground shadow-lg">
-                <span className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-ui-xs font-medium leading-5">
-                  {activeItem.userText ?? "User message"}
-                </span>
-                {activeItem.assistantText === null ? null : (
-                  <span className="mt-1 line-clamp-3 text-muted-foreground text-ui-xs leading-5">
-                    {activeItem.assistantText}
-                  </span>
-                )}
-              </span>
-            </span>
+            <ChatTurnMinimapPreview
+              activeItem={activeItem}
+              activeItemIndex={resolvedActiveIndex ?? 0}
+              activeTooltipTranslate={activeTooltipTranslate}
+              expanded={expanded}
+              items={items}
+              onSelect={handlePreviewSelect}
+              onToggleExpanded={toggleExpanded}
+              side={side}
+            />
           )}
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
@@ -13,6 +13,10 @@ import {
   createComposerPickerStore,
   type ComposerPickerStore,
 } from "../picker/composer-picker-store";
+import {
+  PaneActivationFocusIntentContext,
+  type PaneActivationFocusIntent,
+} from "@/components/epic-canvas/pane-activation";
 
 afterEach(() => {
   cleanup();
@@ -72,6 +76,79 @@ function Harness({
 }
 
 describe("ComposerPromptEditor render isolation", () => {
+  it("does not steal focus from the control that activated its pane", async () => {
+    const handleRef: { current: ComposerPromptEditorHandle | null } = {
+      current: null,
+    };
+    const pickerStore = createComposerPickerStore();
+    let yieldCheckCount = 0;
+    const focusIntent: PaneActivationFocusIntent = {
+      mark: () => undefined,
+      shouldYieldAutoFocus: () => {
+        yieldCheckCount += 1;
+        return true;
+      },
+    };
+    const initialContent = emptyContent();
+    const renderEditor = (isActive: boolean) => (
+      <PaneActivationFocusIntentContext.Provider value={focusIntent}>
+        <ComposerPromptEditor
+          ref={(instance) => {
+            handleRef.current = instance;
+          }}
+          initialContent={initialContent}
+          initialSelection={null}
+          pickerStore={pickerStore}
+          placeholder="test"
+          editorClassName={undefined}
+          isActive={isActive}
+          disabled={false}
+          slashProviderId="claude"
+          hasPastedImageBytes={null}
+          ingestPastedComposerImages={null}
+          stabilizeImageAttachmentCaret={false}
+          onSnapshot={() => undefined}
+          onSubmit={() => undefined}
+          onPaste={() => undefined}
+          onDragOver={() => undefined}
+          onDrop={() => undefined}
+          onKeyDown={undefined}
+          onFocus={() => undefined}
+          onBlur={() => undefined}
+          onEditorReady={null}
+        />
+      </PaneActivationFocusIntentContext.Provider>
+    );
+    const view = render(renderEditor(false));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(handleRef.current?.isReady()).toBe(true);
+
+    const control = document.createElement("button");
+    view.container.append(control);
+    control.focus();
+    view.rerender(renderEditor(true));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(yieldCheckCount).toBe(1);
+    expect(document.activeElement).toBe(control);
+
+    // Nested route synchronization can briefly reapply the previous pane and
+    // then this pane again. The same activation intent must cover both active
+    // edges instead of being consumed by the first one.
+    view.rerender(renderEditor(false));
+    view.rerender(renderEditor(true));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(yieldCheckCount).toBe(2);
+    expect(document.activeElement).toBe(control);
+  });
+
   it("does not re-render the editor wrapper on focus / typing", async () => {
     const phases: string[] = [];
     const profileRender: ProfilerOnRenderCallback = (_id, phase) => {

--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import { registerComposerFocus } from "@/lib/composer/composer-focus-registry";
 import { normalizeComposerContentWithSelection } from "@/lib/composer/composer-content-normalizer";
 import { hasClaimableFileTransfer } from "@/lib/files/file-transfer-paths";
+import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
 
 import { buildComposerExtensions } from "./editor/editor-config";
 import type {
@@ -225,6 +226,7 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     onEditorReady,
     ref,
   } = props;
+  const paneActivationFocusIntent = usePaneActivationFocusIntent();
 
   // Tiptap's `useEditor` extension chain is built once (`buildComposerExtensions`
   // is memoized with empty editor deps). The plugin closure inside calls
@@ -338,8 +340,9 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     if (editor === null) return;
     if (!isActive) return;
     if (editor.isFocused) return;
+    if (paneActivationFocusIntent.shouldYieldAutoFocus()) return;
     editor.commands.focus();
-  }, [editor, isActive]);
+  }, [editor, isActive, paneActivationFocusIntent]);
 
   useEffect(() => {
     if (editor === null) return;

--- a/clients/gui-app/src/components/epic-canvas/__tests__/pane-activation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/pane-activation.test.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PaneActivationFocusIntentContext,
+  paneActivationDeferProps,
+  usePaneActivationFocusIntent,
+  usePaneActivationOwnership,
+} from "@/components/epic-canvas/pane-activation";
+
+afterEach(() => cleanup());
+
+function ActivationBoundary(props: {
+  readonly active: boolean;
+  readonly id: string;
+  readonly onActivate: () => void;
+  readonly children: ReactNode;
+}) {
+  const activation = usePaneActivationOwnership({
+    active: props.active,
+    activate: props.onActivate,
+  });
+  return (
+    <PaneActivationFocusIntentContext.Provider value={activation.focusIntent}>
+      <div
+        data-testid={`pane-${props.id}`}
+        onFocusCapture={activation.onFocusCapture}
+        onPointerCancelCapture={activation.onPointerCancelCapture}
+        onPointerDownCapture={activation.onPointerDownCapture}
+      >
+        {props.children}
+      </div>
+    </PaneActivationFocusIntentContext.Provider>
+  );
+}
+
+function PortalledDeferredAction(props: { readonly onClick: () => void }) {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+  return createPortal(
+    <button
+      type="button"
+      {...paneActivationDeferProps}
+      onClick={(event) => {
+        props.onClick();
+        event.stopPropagation();
+        setVisible(false);
+      }}
+    >
+      Portal action
+    </button>,
+    document.body,
+  );
+}
+
+function AutoFocusProbe(props: {
+  readonly active: boolean;
+  readonly onDecision: (yieldFocus: boolean) => void;
+}) {
+  const { active, onDecision } = props;
+  const focusIntent = usePaneActivationFocusIntent();
+  useEffect(() => {
+    if (!active) return;
+    onDecision(focusIntent.shouldYieldAutoFocus());
+  }, [active, focusIntent, onDecision]);
+  return null;
+}
+
+function FocusIntentHarness(props: {
+  readonly target: "blank" | "control";
+  readonly onDecision: (yieldFocus: boolean) => void;
+}) {
+  const [active, setActive] = useState(false);
+  return (
+    <ActivationBoundary
+      active={active}
+      id={props.target}
+      onActivate={() => setActive(true)}
+    >
+      {props.target === "control" ? (
+        <button type="button">Control</button>
+      ) : (
+        <div data-testid="blank-target">Blank surface</div>
+      )}
+      <AutoFocusProbe active={active} onDecision={props.onDecision} />
+    </ActivationBoundary>
+  );
+}
+
+describe("pane activation ownership", () => {
+  it("completes a deferred action whose click stops propagation", async () => {
+    const activate = vi.fn();
+    const action = vi.fn();
+    render(
+      <ActivationBoundary active={false} id="stopped" onActivate={activate}>
+        <button
+          type="button"
+          {...paneActivationDeferProps}
+          onClick={(event) => {
+            action();
+            event.stopPropagation();
+          }}
+        >
+          Stopped action
+        </button>
+      </ActivationBoundary>,
+    );
+
+    const button = screen.getByRole("button", { name: "Stopped action" });
+    fireEvent.pointerDown(button);
+    expect(activate).not.toHaveBeenCalled();
+    fireEvent.click(button);
+
+    expect(action).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(activate).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps ownership when a portalled deferred action stops and removes itself", async () => {
+    const activate = vi.fn();
+    const action = vi.fn();
+    render(
+      <ActivationBoundary active={false} id="portal" onActivate={activate}>
+        <PortalledDeferredAction onClick={action} />
+      </ActivationBoundary>,
+    );
+
+    const button = screen.getByRole("button", { name: "Portal action" });
+    fireEvent.pointerDown(button);
+    fireEvent.click(button);
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(button.isConnected).toBe(false);
+    await waitFor(() => expect(activate).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not complete a stale pane token after a sibling gesture starts", async () => {
+    const activateLeft = vi.fn();
+    const activateRight = vi.fn();
+    render(
+      <>
+        <ActivationBoundary active={false} id="left" onActivate={activateLeft}>
+          <button type="button" {...paneActivationDeferProps}>
+            Left action
+          </button>
+        </ActivationBoundary>
+        <ActivationBoundary
+          active={false}
+          id="right"
+          onActivate={activateRight}
+        >
+          <button type="button" {...paneActivationDeferProps}>
+            Right action
+          </button>
+        </ActivationBoundary>
+      </>,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Left action" }));
+    const right = screen.getByRole("button", { name: "Right action" });
+    fireEvent.pointerDown(right);
+    fireEvent.click(right);
+
+    await waitFor(() => expect(activateRight).toHaveBeenCalledTimes(1));
+    expect(activateLeft).not.toHaveBeenCalled();
+  });
+
+  it("cancels deferred ownership on pointer cancellation", async () => {
+    const activate = vi.fn();
+    render(
+      <ActivationBoundary active={false} id="cancel" onActivate={activate}>
+        <button type="button" {...paneActivationDeferProps}>
+          Cancelled action
+        </button>
+      </ActivationBoundary>,
+    );
+
+    const button = screen.getByRole("button", { name: "Cancelled action" });
+    fireEvent.pointerDown(button);
+    fireEvent.pointerCancel(button);
+    fireEvent.click(button);
+    await Promise.resolve();
+
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  it("activates on keyboard focus without stealing the control's focus intent", async () => {
+    const decision = vi.fn();
+    render(<FocusIntentHarness target="control" onDecision={decision} />);
+
+    screen.getByRole("button", { name: "Control" }).focus();
+
+    await waitFor(() => expect(decision).toHaveBeenCalledWith(true));
+  });
+
+  it("preserves primary autofocus for blank-surface pointer activation", async () => {
+    const decision = vi.fn();
+    render(<FocusIntentHarness target="blank" onDecision={decision} />);
+
+    fireEvent.pointerDown(screen.getByTestId("blank-target"));
+
+    await waitFor(() => expect(decision).toHaveBeenCalledWith(false));
+  });
+
+  it("does not let pointer focus activate a deferred action before its click", async () => {
+    const activate = vi.fn();
+    render(
+      <ActivationBoundary active={false} id="focus" onActivate={activate}>
+        <button type="button" {...paneActivationDeferProps}>
+          Deferred focus
+        </button>
+      </ActivationBoundary>,
+    );
+
+    const button = screen.getByRole("button", { name: "Deferred focus" });
+    fireEvent.pointerDown(button);
+    button.focus();
+    expect(activate).not.toHaveBeenCalled();
+    fireEvent.click(button);
+
+    await waitFor(() => expect(activate).toHaveBeenCalledTimes(1));
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/__tests__/pane-activation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/pane-activation.test.tsx
@@ -99,6 +99,31 @@ function FocusIntentHarness(props: {
   );
 }
 
+function SelfRemovingFocusIntentHarness(props: {
+  readonly onDecision: (yieldFocus: boolean) => void;
+}) {
+  const [active, setActive] = useState(false);
+  const [visible, setVisible] = useState(true);
+  return (
+    <ActivationBoundary
+      active={active}
+      id="self-removing"
+      onActivate={() => setActive(true)}
+    >
+      {visible ? (
+        <button
+          type="button"
+          {...paneActivationDeferProps}
+          onClick={() => setVisible(false)}
+        >
+          Remove and activate
+        </button>
+      ) : null}
+      <AutoFocusProbe active={active} onDecision={props.onDecision} />
+    </ActivationBoundary>
+  );
+}
+
 describe("pane activation ownership", () => {
   it("completes a deferred action whose click stops propagation", async () => {
     const activate = vi.fn();
@@ -143,6 +168,20 @@ describe("pane activation ownership", () => {
     expect(action).toHaveBeenCalledTimes(1);
     expect(button.isConnected).toBe(false);
     await waitFor(() => expect(activate).toHaveBeenCalledTimes(1));
+  });
+
+  it("stops yielding autofocus when the initiating control removes itself", async () => {
+    const decision = vi.fn();
+    render(<SelfRemovingFocusIntentHarness onDecision={decision} />);
+
+    const button = screen.getByRole("button", {
+      name: "Remove and activate",
+    });
+    fireEvent.pointerDown(button);
+    fireEvent.click(button);
+
+    expect(button.isConnected).toBe(false);
+    await waitFor(() => expect(decision).toHaveBeenCalledWith(false));
   });
 
   it("does not complete a stale pane token after a sibling gesture starts", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/pane-activation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/pane-activation.test.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -11,11 +12,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   PaneActivationFocusIntentContext,
   paneActivationDeferProps,
+  resetPaneActivationFocusIntentsForTests,
   usePaneActivationFocusIntent,
   usePaneActivationOwnership,
 } from "@/components/epic-canvas/pane-activation";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  resetPaneActivationFocusIntentsForTests();
+});
 
 function ActivationBoundary(props: {
   readonly active: boolean;
@@ -185,7 +190,9 @@ describe("pane activation ownership", () => {
     fireEvent.pointerDown(button);
     fireEvent.pointerCancel(button);
     fireEvent.click(button);
-    await Promise.resolve();
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
 
     expect(activate).not.toHaveBeenCalled();
   });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -15,12 +15,16 @@ interface TestState {
   readonly mounts: Map<string, number>;
   readonly unmounts: Map<string, number>;
   readonly deferredClicks: Map<string, number>;
+  readonly deferredRemovalClicks: Map<string, number>;
+  readonly closeAutoFocusGuards: Map<string, (event: Event) => void>;
 }
 
 const testState = vi.hoisted((): TestState => ({
   mounts: new Map(),
   unmounts: new Map(),
   deferredClicks: new Map(),
+  deferredRemovalClicks: new Map(),
+  closeAutoFocusGuards: new Map(),
 }));
 
 vi.mock("@dnd-kit/core", () => ({
@@ -71,16 +75,21 @@ vi.mock("@/lib/epic-selectors", () => ({
 
 vi.mock("@/components/epic-canvas/renderers/epic-node-tile", async () => {
   const React = await import("react");
+  const { usePaneCloseAutoFocusGuard } =
+    await import("@/components/epic-tabs/pane-visibility-context");
   function MockTile(props: { readonly id: string }) {
+    const closeAutoFocusGuard = usePaneCloseAutoFocusGuard(undefined);
     React.useEffect(() => {
       testState.mounts.set(props.id, (testState.mounts.get(props.id) ?? 0) + 1);
+      testState.closeAutoFocusGuards.set(props.id, closeAutoFocusGuard);
       return () => {
         testState.unmounts.set(
           props.id,
           (testState.unmounts.get(props.id) ?? 0) + 1,
         );
+        testState.closeAutoFocusGuards.delete(props.id);
       };
-    }, [props.id]);
+    }, [closeAutoFocusGuard, props.id]);
 
     return (
       <div data-testid={`tile-${props.id}`}>
@@ -96,6 +105,20 @@ vi.mock("@/components/epic-canvas/renderers/epic-node-tile", async () => {
           }}
         >
           Deferred action
+        </button>
+        <button
+          type="button"
+          {...paneActivationDeferProps}
+          data-testid={`deferred-removal-${props.id}`}
+          onClick={(event) => {
+            testState.deferredRemovalClicks.set(
+              props.id,
+              (testState.deferredRemovalClicks.get(props.id) ?? 0) + 1,
+            );
+            event.currentTarget.remove();
+          }}
+        >
+          Deferred action that replaces itself
         </button>
       </div>
     );
@@ -204,6 +227,8 @@ describe("<TabGroupView />", () => {
     testState.mounts.clear();
     testState.unmounts.clear();
     testState.deferredClicks.clear();
+    testState.deferredRemovalClicks.clear();
+    testState.closeAutoFocusGuards.clear();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   });
 
@@ -250,9 +275,86 @@ describe("<TabGroupView />", () => {
     fireEvent.click(deferredButton);
 
     expect(testState.deferredClicks.get(SPEC.id)).toBe(1);
+    await waitFor(() => {
+      expect(
+        useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+      ).toBe("group-1");
+    });
+  });
+
+  it("activates after a deferred child removes itself during its click action", async () => {
+    const tabs = [SPEC];
+    seedCanvasWithActivePane(tabs, SPEC.instanceId, "other-group");
+    render(groupView(tabs, SPEC.instanceId, true));
+
+    await waitFor(() => {
+      expect(testState.mounts.get(SPEC.id)).toBe(1);
+    });
+
+    const deferredButton = document.querySelector(
+      `[data-testid="deferred-removal-${SPEC.id}"]`,
+    );
+    if (!(deferredButton instanceof HTMLButtonElement)) {
+      throw new Error("Expected self-removing deferred button");
+    }
+
+    fireEvent.pointerDown(deferredButton);
     expect(
       useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
-    ).toBe("group-1");
+    ).toBe("other-group");
+
+    fireEvent.click(deferredButton);
+
+    expect(testState.deferredRemovalClicks.get(SPEC.id)).toBe(1);
+    expect(deferredButton.isConnected).toBe(false);
+    await waitFor(() => {
+      expect(
+        useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+      ).toBe("group-1");
+    });
+  });
+
+  it("gives keyboard focus ownership to the inactive inner pane", async () => {
+    const tabs = [SPEC];
+    seedCanvasWithActivePane(tabs, SPEC.instanceId, "other-group");
+    render(groupView(tabs, SPEC.instanceId, true));
+
+    const button = document.querySelector(
+      `[data-testid="deferred-activation-${SPEC.id}"]`,
+    );
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("Expected focusable action");
+    }
+    button.focus();
+
+    await waitFor(() => {
+      expect(
+        useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+      ).toBe("group-1");
+    });
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("prevents close-autofocus from bouncing ownership to an inactive inner pane", async () => {
+    const tabs = [SPEC];
+    seedCanvas(tabs, SPEC.instanceId);
+    const view = render(groupView(tabs, SPEC.instanceId, true));
+
+    await waitFor(() => {
+      expect(testState.closeAutoFocusGuards.get(SPEC.id)).toBeDefined();
+    });
+    seedCanvasWithActivePane(tabs, SPEC.instanceId, "other-group");
+    view.rerender(groupView(tabs, SPEC.instanceId, true));
+    await waitFor(() => {
+      expect(view.getByTestId("tab-group").dataset.active).toBe("false");
+    });
+
+    const closeAutoFocusEvent = new Event("closeAutoFocus", {
+      cancelable: true,
+    });
+    testState.closeAutoFocusGuards.get(SPEC.id)?.(closeAutoFocusEvent);
+
+    expect(closeAutoFocusEvent.defaultPrevented).toBe(true);
   });
 
   it("keeps recently active tabs mounted under display:none and evicts past the LRU cap", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -1,5 +1,11 @@
 import "../../../../__tests__/test-browser-apis";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import { TabGroupView } from "@/components/epic-canvas/canvas/tab-group-view";
@@ -259,12 +265,9 @@ describe("<TabGroupView />", () => {
       expect(testState.mounts.get(SPEC.id)).toBe(1);
     });
 
-    const deferredButton = document.querySelector(
-      `[data-testid="deferred-activation-${SPEC.id}"]`,
-    );
-    if (!(deferredButton instanceof HTMLButtonElement)) {
-      throw new Error("Expected deferred button");
-    }
+    const deferredButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Deferred action",
+    });
 
     fireEvent.pointerDown(deferredButton);
 
@@ -291,12 +294,9 @@ describe("<TabGroupView />", () => {
       expect(testState.mounts.get(SPEC.id)).toBe(1);
     });
 
-    const deferredButton = document.querySelector(
-      `[data-testid="deferred-removal-${SPEC.id}"]`,
-    );
-    if (!(deferredButton instanceof HTMLButtonElement)) {
-      throw new Error("Expected self-removing deferred button");
-    }
+    const deferredButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Deferred action that replaces itself",
+    });
 
     fireEvent.pointerDown(deferredButton);
     expect(
@@ -319,12 +319,9 @@ describe("<TabGroupView />", () => {
     seedCanvasWithActivePane(tabs, SPEC.instanceId, "other-group");
     render(groupView(tabs, SPEC.instanceId, true));
 
-    const button = document.querySelector(
-      `[data-testid="deferred-activation-${SPEC.id}"]`,
-    );
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error("Expected focusable action");
-    }
+    const button = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Deferred action",
+    });
     button.focus();
 
     await waitFor(() => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -1,5 +1,13 @@
 import "../../../../__tests__/test-browser-apis";
-import { act, renderHook, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import {
@@ -19,6 +27,15 @@ import {
   requestNestedRoutePrimaryEditorFocus,
   resetNestedRouteDomFocusForTests,
 } from "@/lib/nested-route-dom-focus";
+import {
+  beginNestedFocusNavigation,
+  resetNestedFocusNavigationIntentsForTests,
+  shouldDeferNestedRouteApplication,
+} from "@/lib/nested-focus-navigation-intent";
+import {
+  resetPaneActivationFocusIntentsForTests,
+  usePaneActivationOwnership,
+} from "@/components/epic-canvas/pane-activation";
 
 interface CanvasStoreSlice {
   readonly renameTab: Mock;
@@ -126,6 +143,8 @@ const THREAD_FOCUS_INTENT: EpicRouteFocusIntent = {
 
 function resetStores(): void {
   resetNestedRouteDomFocusForTests();
+  resetNestedFocusNavigationIntentsForTests();
+  resetPaneActivationFocusIntentsForTests();
   window.localStorage.clear();
   useLeftPanelStore.setState({
     activePanelIdByTabId: {},
@@ -161,6 +180,22 @@ function resetStores(): void {
   testState.canvasStore.closeCanvasTab.mockClear();
   testState.openEpicState.setLastFocusedArtifactId.mockClear();
   testState.openEpicState.setLastFocusedThreadId.mockClear();
+}
+
+function PaneActivationOriginBoundary(props: { readonly children: ReactNode }) {
+  const activation = usePaneActivationOwnership({
+    active: false,
+    activate: () => undefined,
+  });
+  return (
+    <div
+      onFocusCapture={activation.onFocusCapture}
+      onPointerCancelCapture={activation.onPointerCancelCapture}
+      onPointerDownCapture={activation.onPointerDownCapture}
+    >
+      {props.children}
+    </div>
+  );
 }
 
 function specTile(
@@ -397,6 +432,57 @@ describe("useEpicRouteSynchronization", () => {
     });
     expect(testState.navigate).not.toHaveBeenCalled();
     expect(testState.canvasStore.openTileInTab).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale route target undo an in-flight local pane navigation", () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [
+        specTile("artifact-a", "tile-a", "Artifact A"),
+        specTile("artifact-b", "tile-b", "Artifact B"),
+      ],
+      "tile-b",
+    );
+    beginNestedFocusNavigation(EPIC_ID, TAB_ID, {
+      paneId: "pane-current",
+      tileInstanceId: "tile-b",
+    });
+
+    const view = renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          focusedAt: undefined,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          focusPaneId: "pane-current",
+          focusTileInstanceId: "tile-a",
+        },
+      },
+    );
+
+    expect(testState.canvasStore.applyNestedRouteFocus).not.toHaveBeenCalled();
+
+    view.rerender({
+      epicId: EPIC_ID,
+      tabId: TAB_ID,
+      focusedAt: undefined,
+      focusArtifactId: undefined,
+      focusThreadId: undefined,
+      focusPaneId: "pane-current",
+      focusTileInstanceId: "tile-b",
+    });
+
+    expect(
+      shouldDeferNestedRouteApplication(EPIC_ID, TAB_ID, {
+        paneId: "pane-current",
+        tileInstanceId: "tile-b",
+      }),
+    ).toBe(false);
+    expect(testState.canvasStore.applyNestedRouteFocus).not.toHaveBeenCalled();
   });
 
   it("treats a pane-only route as applied when the active pane contains a tile", async () => {
@@ -800,6 +886,65 @@ describe("useEpicRouteSynchronization", () => {
 
       expect(document.activeElement).toBe(editorEl);
     } finally {
+      paneEl.remove();
+    }
+  });
+
+  it("preserves a newly opened portalled control while applying its pane route focus", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    const paneEl = document.createElement("div");
+    paneEl.setAttribute("data-group-id", "pane-current");
+    paneEl.setAttribute("data-active", "true");
+    paneEl.tabIndex = -1;
+    const tileEl = document.createElement("div");
+    tileEl.setAttribute("data-tab-instance-id", "tile-current");
+    tileEl.setAttribute("data-selected", "true");
+    tileEl.tabIndex = -1;
+    paneEl.appendChild(tileEl);
+    document.body.appendChild(paneEl);
+
+    const portalInput = document.createElement("input");
+    portalInput.setAttribute("aria-label", "Portalled picker search");
+    document.body.appendChild(portalInput);
+    const activationView = render(
+      <PaneActivationOriginBoundary>
+        <button type="button">Open model picker</button>
+      </PaneActivationOriginBoundary>,
+      { container: tileEl },
+    );
+
+    try {
+      fireEvent.pointerDown(
+        screen.getByRole("button", { name: "Open model picker" }),
+      );
+      portalInput.focus();
+
+      renderHook(
+        (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+        {
+          initialProps: {
+            epicId: EPIC_ID,
+            tabId: TAB_ID,
+            focusedAt: undefined,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            focusPaneId: "pane-current",
+            focusTileInstanceId: "tile-current",
+          },
+        },
+      );
+
+      await flushFocusRestore();
+      expect(document.activeElement).toBe(portalInput);
+    } finally {
+      activationView.unmount();
+      portalInput.remove();
       paneEl.remove();
     }
   });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -18,6 +18,8 @@ import type {
   EpicCanvasTileRef,
   TileLayoutNode,
 } from "@/stores/epics/canvas/types";
+import type { EpicCanvasStore } from "@/stores/epics/canvas/store";
+import { getCurrentNestedFocusTarget } from "@/lib/epic-nested-focus-route";
 import { useCommentThreadsStore } from "@/stores/comments/comment-threads-store";
 import {
   DEFAULT_LEFT_PANEL_GROUPS,
@@ -37,13 +39,14 @@ import {
   usePaneActivationOwnership,
 } from "@/components/epic-canvas/pane-activation";
 
-interface CanvasStoreSlice {
-  readonly renameTab: Mock;
-  readonly openTileInTab: Mock;
-  readonly applyNestedRouteFocus: Mock;
-  readonly closeCanvasTab: Mock;
-  readonly pendingCreateArtifactIds: ReadonlySet<string>;
-}
+type CanvasStoreSlice = Pick<
+  EpicCanvasStore,
+  | "renameTab"
+  | "openTileInTab"
+  | "applyNestedRouteFocus"
+  | "closeCanvasTab"
+  | "pendingCreateArtifactIds"
+>;
 
 interface TestState {
   activeArtifactId: string | null;
@@ -53,6 +56,7 @@ interface TestState {
     readonly name: string;
   } | null;
   nestedFocusEnabled: boolean;
+  useRealCanvasStore: boolean;
   navigate: Mock;
   canvasActivePaneId: string | null;
   canvasRoot: TileLayoutNode | null;
@@ -69,6 +73,7 @@ const testState = vi.hoisted<TestState>(() => ({
   activeArtifactId: null,
   autoOpenTarget: null,
   nestedFocusEnabled: false,
+  useRealCanvasStore: false,
   navigate: vi.fn(),
   canvasActivePaneId: null,
   canvasRoot: null,
@@ -105,18 +110,32 @@ vi.mock("@/providers/use-open-epic-handle", () => ({
   }),
 }));
 
-vi.mock("@/stores/epics/canvas/store", () => ({
-  useActiveEpicArtifactId: () => testState.activeArtifactId,
-  useEpicCanvas: () => ({
-    root: testState.canvasRoot,
-    activePaneId: testState.canvasActivePaneId,
-    tilesByInstanceId: testState.canvasTiles,
-    sizesByGroupId: {},
-  }),
-  useEpicCanvasStore: <T,>(selector: (store: CanvasStoreSlice) => T): T =>
-    selector(testState.canvasStore),
-  useEpicTab: () => null,
-}));
+vi.mock("@/stores/epics/canvas/store", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/stores/epics/canvas/store")>();
+  return {
+    ...actual,
+    useActiveEpicArtifactId: (tabId: string) =>
+      testState.useRealCanvasStore
+        ? actual.useActiveEpicArtifactId(tabId)
+        : testState.activeArtifactId,
+    useEpicCanvas: (tabId: string) =>
+      testState.useRealCanvasStore
+        ? actual.useEpicCanvas(tabId)
+        : {
+            root: testState.canvasRoot,
+            activePaneId: testState.canvasActivePaneId,
+            tilesByInstanceId: testState.canvasTiles,
+            sizesByGroupId: {},
+          },
+    useEpicCanvasStore: <T,>(selector: (store: CanvasStoreSlice) => T): T =>
+      testState.useRealCanvasStore
+        ? actual.useEpicCanvasStore(selector)
+        : selector(testState.canvasStore),
+    useEpicTab: (tabId: string) =>
+      testState.useRealCanvasStore ? actual.useEpicTab(tabId) : null,
+  };
+});
 
 vi.mock("@/lib/epic-selectors", () => ({
   useEpicArtifactRecords: () => testState.records,
@@ -164,6 +183,7 @@ function resetStores(): void {
   });
   testState.activeArtifactId = null;
   testState.nestedFocusEnabled = false;
+  testState.useRealCanvasStore = false;
   testState.navigate.mockClear();
   testState.canvasActivePaneId = null;
   testState.autoOpenTarget = {
@@ -174,10 +194,10 @@ function resetStores(): void {
   testState.canvasRoot = null;
   testState.canvasTiles = {};
   testState.records = [];
-  testState.canvasStore.renameTab.mockClear();
-  testState.canvasStore.openTileInTab.mockClear();
-  testState.canvasStore.applyNestedRouteFocus.mockClear();
-  testState.canvasStore.closeCanvasTab.mockClear();
+  vi.mocked(testState.canvasStore.renameTab).mockClear();
+  vi.mocked(testState.canvasStore.openTileInTab).mockClear();
+  vi.mocked(testState.canvasStore.applyNestedRouteFocus).mockClear();
+  vi.mocked(testState.canvasStore.closeCanvasTab).mockClear();
   testState.openEpicState.setLastFocusedArtifactId.mockClear();
   testState.openEpicState.setLastFocusedThreadId.mockClear();
 }
@@ -487,52 +507,75 @@ describe("useEpicRouteSynchronization", () => {
 
   it("reapplies the route target when an optimistic navigation never commits", async () => {
     vi.useFakeTimers();
+    let unmountHook: (() => void) | null = null;
+    const { useEpicCanvasStore: realCanvasStore } = await vi.importActual<
+      typeof import("@/stores/epics/canvas/store")
+    >("@/stores/epics/canvas/store");
     try {
       testState.nestedFocusEnabled = true;
-      setSinglePaneCanvas(
-        "pane-current",
-        [
-          specTile("artifact-a", "tile-a", "Artifact A"),
-          specTile("artifact-b", "tile-b", "Artifact B"),
-        ],
-        "tile-b",
+      testState.useRealCanvasStore = true;
+      testState.records = [{ id: "artifact-a" }, { id: "artifact-b" }];
+      realCanvasStore.setState(realCanvasStore.getInitialState(), true);
+      const realStore = realCanvasStore.getState();
+      const realTabId = realStore.openEpicTab(EPIC_ID, "Route retry");
+      realStore.openTileInTab(
+        realTabId,
+        specTile("artifact-a", "tile-a", "Artifact A"),
       );
-      beginNestedFocusNavigation(EPIC_ID, TAB_ID, {
-        paneId: "pane-current",
+      realStore.openTileInTab(
+        realTabId,
+        specTile("artifact-b", "tile-b", "Artifact B"),
+      );
+      const before = realCanvasStore.getState().canvasByTabId[realTabId];
+      if (before === undefined) throw new Error("Expected seeded canvas");
+      const paneId = before.activePaneId;
+      if (paneId === null) throw new Error("Expected seeded active pane");
+      expect(getCurrentNestedFocusTarget(before)).toEqual({
+        paneId,
+        tileInstanceId: "tile-b",
+      });
+      beginNestedFocusNavigation(EPIC_ID, realTabId, {
+        paneId,
         tileInstanceId: "tile-b",
       });
 
-      renderHook(
+      const view = renderHook(
         (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
         {
           initialProps: {
             epicId: EPIC_ID,
-            tabId: TAB_ID,
+            tabId: realTabId,
             focusedAt: undefined,
             focusArtifactId: undefined,
             focusThreadId: undefined,
-            focusPaneId: "pane-current",
+            focusPaneId: paneId,
             focusTileInstanceId: "tile-a",
           },
         },
       );
+      unmountHook = view.unmount;
 
-      expect(
-        testState.canvasStore.applyNestedRouteFocus,
-      ).not.toHaveBeenCalled();
+      const deferred = realCanvasStore.getState().canvasByTabId[realTabId];
+      if (deferred === undefined) throw new Error("Expected deferred canvas");
+      expect(getCurrentNestedFocusTarget(deferred)).toEqual({
+        paneId,
+        tileInstanceId: "tile-b",
+      });
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2_000);
       });
 
-      expect(testState.canvasStore.applyNestedRouteFocus).toHaveBeenCalledWith(
-        TAB_ID,
-        {
-          paneId: "pane-current",
-          tileInstanceId: "tile-a",
-        },
-      );
+      const applied = realCanvasStore.getState().canvasByTabId[realTabId];
+      if (applied === undefined) throw new Error("Expected applied canvas");
+      expect(getCurrentNestedFocusTarget(applied)).toEqual({
+        paneId,
+        tileInstanceId: "tile-a",
+      });
     } finally {
+      unmountHook?.();
+      testState.useRealCanvasStore = false;
+      realCanvasStore.setState(realCanvasStore.getInitialState(), true);
       vi.useRealTimers();
     }
   });
@@ -774,7 +817,7 @@ describe("useEpicRouteSynchronization", () => {
       );
     });
 
-    testState.canvasStore.openTileInTab.mockClear();
+    vi.mocked(testState.canvasStore.openTileInTab).mockClear();
     hook.rerender({
       ...THREAD_FOCUS_INTENT,
       epicId: "route-sync-epic-b",

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -485,6 +485,58 @@ describe("useEpicRouteSynchronization", () => {
     expect(testState.canvasStore.applyNestedRouteFocus).not.toHaveBeenCalled();
   });
 
+  it("reapplies the route target when an optimistic navigation never commits", async () => {
+    vi.useFakeTimers();
+    try {
+      testState.nestedFocusEnabled = true;
+      setSinglePaneCanvas(
+        "pane-current",
+        [
+          specTile("artifact-a", "tile-a", "Artifact A"),
+          specTile("artifact-b", "tile-b", "Artifact B"),
+        ],
+        "tile-b",
+      );
+      beginNestedFocusNavigation(EPIC_ID, TAB_ID, {
+        paneId: "pane-current",
+        tileInstanceId: "tile-b",
+      });
+
+      renderHook(
+        (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+        {
+          initialProps: {
+            epicId: EPIC_ID,
+            tabId: TAB_ID,
+            focusedAt: undefined,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            focusPaneId: "pane-current",
+            focusTileInstanceId: "tile-a",
+          },
+        },
+      );
+
+      expect(
+        testState.canvasStore.applyNestedRouteFocus,
+      ).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+
+      expect(testState.canvasStore.applyNestedRouteFocus).toHaveBeenCalledWith(
+        TAB_ID,
+        {
+          paneId: "pane-current",
+          tileInstanceId: "tile-a",
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("treats a pane-only route as applied when the active pane contains a tile", async () => {
     testState.nestedFocusEnabled = true;
     setSinglePaneCanvas(

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -1,14 +1,9 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  type PointerEvent,
-  type ReactNode,
-} from "react";
+import { memo, useCallback, useMemo, useRef, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { isPaneActivationDeferred } from "@/components/epic-canvas/pane-activation";
+import {
+  PaneActivationFocusIntentContext,
+  usePaneActivationOwnership,
+} from "@/components/epic-canvas/pane-activation";
 import { cn } from "@/lib/utils";
 import {
   useEpicCanvasStore,
@@ -30,7 +25,11 @@ import {
   isPersistentTerminalSurface,
   useMountedPaneTabs,
 } from "@/components/epic-canvas/canvas/use-mounted-pane-tabs";
-import { usePaneVisible } from "@/components/epic-tabs/pane-visibility-context";
+import {
+  PaneFocusProbeContext,
+  usePaneFocusProbe,
+  usePaneVisible,
+} from "@/components/epic-tabs/pane-visibility-context";
 import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
 import type {
   EpicCanvasTileRef,
@@ -222,44 +221,17 @@ export const TabGroupView = memo(function TabGroupView(
     prepareSetActiveTilePaneFocusTarget,
     tabId,
   ]);
-  const deferredPaneActivationRef = useRef(false);
   const paneRootRef = useRef<HTMLDivElement | null>(null);
-
-  const handlePointerDownCapture = useCallback(
-    (event: PointerEvent<HTMLDivElement>) => {
-      if (isPaneActivationDeferred(event.target)) {
-        deferredPaneActivationRef.current = true;
-        return;
-      }
-      deferredPaneActivationRef.current = false;
-      activatePane();
-    },
-    [activatePane],
+  const paneActivation = usePaneActivationOwnership({
+    active: globallyActive,
+    activate: activatePane,
+  });
+  const parentPaneFocusProbe = usePaneFocusProbe();
+  const isPaneFocused = useCallback(
+    () =>
+      parentPaneFocusProbe() && paneRootRef.current?.dataset.active === "true",
+    [parentPaneFocusProbe],
   );
-
-  useEffect(() => {
-    const handleDocumentClick = (event: globalThis.MouseEvent): void => {
-      if (!deferredPaneActivationRef.current) return;
-      deferredPaneActivationRef.current = false;
-      // The listener is document-level, so a deferred click in a SIBLING split
-      // pane reaches here too. Only complete the activation when the click
-      // lands inside THIS pane's subtree - otherwise a stale flag could
-      // activate the wrong pane on a deferred click elsewhere.
-      const { target } = event;
-      if (!(target instanceof Element)) return;
-      if (paneRootRef.current?.contains(target) !== true) return;
-      if (!isPaneActivationDeferred(target)) return;
-      activatePane();
-    };
-    document.addEventListener("click", handleDocumentClick);
-    return () => {
-      document.removeEventListener("click", handleDocumentClick);
-    };
-  }, [activatePane]);
-
-  const handlePointerCancelCapture = useCallback(() => {
-    deferredPaneActivationRef.current = false;
-  }, []);
 
   const handleSplitFromMenu = useCallback(
     (
@@ -325,106 +297,115 @@ export const TabGroupView = memo(function TabGroupView(
 
   return (
     <div className="relative h-full min-h-0 w-full bg-canvas">
-      <div
-        ref={paneRootRef}
-        data-testid="tab-group"
-        data-group-id={pane.id}
-        data-active={globallyActive ? "true" : "false"}
-        tabIndex={-1}
-        className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-canvas"
-        onPointerDownCapture={handlePointerDownCapture}
-        onPointerCancelCapture={handlePointerCancelCapture}
+      <PaneActivationFocusIntentContext.Provider
+        value={paneActivation.focusIntent}
       >
-        {showTabStrip ? (
-          <TabStrip
-            epicId={epicId}
-            tabId={tabId}
-            groupId={pane.id}
-            tabs={tabs}
-            activeTabId={pane.activeTabId}
-            onSelectTab={handleSelectTab}
-            onCloseTab={handleCloseTab}
-            onPromotePreview={handlePromotePreview}
-            onSplit={handleSplit}
-            onCloseGroup={handleCloseGroup}
-            onOpenBlankTab={handleOpenBlankTab}
-            canRenameTabs={canRenameTabs}
-            menuHandlers={{
-              onClose: handleCloseTab,
-              onCloseOthers: (gid, tid) =>
-                navigateNested(epicId, tabId, () =>
-                  prepareCloseOtherCanvasTabsFocusTarget(tabId, gid, tid),
-                ),
-              onCloseRight: (gid, tid) =>
-                navigateNested(epicId, tabId, () =>
-                  prepareCloseRightCanvasTabsFocusTarget(tabId, gid, tid),
-                ),
-              onCloseAll: (gid) =>
-                navigateNested(epicId, tabId, () =>
-                  prepareCloseAllCanvasTabsFocusTarget(tabId, gid),
-                ),
-              onSplit: handleSplitFromMenu,
-              onRevealInSidebar: handleRevealInSidebar,
-              onRename: handleRename,
-            }}
-          />
-        ) : null}
-        <div
-          data-testid="tab-group-body"
-          className="relative flex min-h-0 flex-1 flex-col"
-        >
-          {activeTab === null ? (
-            <PaneOpener
-              epicId={epicId}
-              tabId={tabId}
-              groupId={pane.id}
-              active={globallyActive}
-            />
-          ) : null}
-          {activeTab !== null
-            ? mountedTabs.map((tab) => {
-                const selected = activeTab.instanceId === tab.instanceId;
-                // Hidden terminals conceal via `visibility` so xterm keeps
-                // its box dimensions; hidden LRU keep-alives use
-                // `display:none` so concealed heavy bodies cost no layout
-                // or paint.
-                const terminal = isPersistentTerminalSurface(tab);
-                return (
-                  <div
-                    key={tab.instanceId}
-                    data-testid="pane-tab-layer"
-                    data-tab-instance-id={tab.instanceId}
-                    data-selected={selected ? "true" : "false"}
-                    tabIndex={-1}
-                    className={cn(
-                      "absolute inset-0 min-h-0",
-                      selected && "visible pointer-events-auto",
-                      !selected && terminal && "invisible pointer-events-none",
-                      !selected && !terminal && "hidden",
-                    )}
-                    aria-hidden={selected ? undefined : true}
-                  >
-                    <TabBodySelectedContext.Provider value={selected}>
-                      <ActiveTabBody
-                        activeTab={tab}
-                        epicId={epicId}
-                        groupId={pane.id}
-                        tabId={tabId}
-                        selected={selected}
-                        globallyActive={globallyActive}
-                      />
-                    </TabBodySelectedContext.Provider>
-                  </div>
-                );
-              })
-            : null}
-          <PaneDropZone
-            paneId={pane.id}
-            viewTabId={tabId}
-            tabCount={pane.tabInstanceIds.length}
-          />
-        </div>
-      </div>
+        <PaneFocusProbeContext.Provider value={isPaneFocused}>
+          <div
+            ref={paneRootRef}
+            data-testid="tab-group"
+            data-group-id={pane.id}
+            data-active={globallyActive ? "true" : "false"}
+            tabIndex={-1}
+            className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-canvas"
+            onFocusCapture={paneActivation.onFocusCapture}
+            onPointerDownCapture={paneActivation.onPointerDownCapture}
+            onPointerCancelCapture={paneActivation.onPointerCancelCapture}
+          >
+            {showTabStrip ? (
+              <TabStrip
+                epicId={epicId}
+                tabId={tabId}
+                groupId={pane.id}
+                tabs={tabs}
+                activeTabId={pane.activeTabId}
+                onSelectTab={handleSelectTab}
+                onCloseTab={handleCloseTab}
+                onPromotePreview={handlePromotePreview}
+                onSplit={handleSplit}
+                onCloseGroup={handleCloseGroup}
+                onOpenBlankTab={handleOpenBlankTab}
+                canRenameTabs={canRenameTabs}
+                menuHandlers={{
+                  onClose: handleCloseTab,
+                  onCloseOthers: (gid, tid) =>
+                    navigateNested(epicId, tabId, () =>
+                      prepareCloseOtherCanvasTabsFocusTarget(tabId, gid, tid),
+                    ),
+                  onCloseRight: (gid, tid) =>
+                    navigateNested(epicId, tabId, () =>
+                      prepareCloseRightCanvasTabsFocusTarget(tabId, gid, tid),
+                    ),
+                  onCloseAll: (gid) =>
+                    navigateNested(epicId, tabId, () =>
+                      prepareCloseAllCanvasTabsFocusTarget(tabId, gid),
+                    ),
+                  onSplit: handleSplitFromMenu,
+                  onRevealInSidebar: handleRevealInSidebar,
+                  onRename: handleRename,
+                }}
+              />
+            ) : null}
+            <div
+              data-testid="tab-group-body"
+              className="relative flex min-h-0 flex-1 flex-col"
+            >
+              {activeTab === null ? (
+                <PaneOpener
+                  epicId={epicId}
+                  tabId={tabId}
+                  groupId={pane.id}
+                  active={globallyActive}
+                />
+              ) : null}
+              {activeTab !== null
+                ? mountedTabs.map((tab) => {
+                    const selected = activeTab.instanceId === tab.instanceId;
+                    // Hidden terminals conceal via `visibility` so xterm keeps
+                    // its box dimensions; hidden LRU keep-alives use
+                    // `display:none` so concealed heavy bodies cost no layout
+                    // or paint.
+                    const terminal = isPersistentTerminalSurface(tab);
+                    return (
+                      <div
+                        key={tab.instanceId}
+                        data-testid="pane-tab-layer"
+                        data-tab-instance-id={tab.instanceId}
+                        data-selected={selected ? "true" : "false"}
+                        tabIndex={-1}
+                        className={cn(
+                          "absolute inset-0 min-h-0",
+                          selected && "visible pointer-events-auto",
+                          !selected &&
+                            terminal &&
+                            "invisible pointer-events-none",
+                          !selected && !terminal && "hidden",
+                        )}
+                        aria-hidden={selected ? undefined : true}
+                      >
+                        <TabBodySelectedContext.Provider value={selected}>
+                          <ActiveTabBody
+                            activeTab={tab}
+                            epicId={epicId}
+                            groupId={pane.id}
+                            tabId={tabId}
+                            selected={selected}
+                            globallyActive={globallyActive}
+                          />
+                        </TabBodySelectedContext.Provider>
+                      </div>
+                    );
+                  })
+                : null}
+              <PaneDropZone
+                paneId={pane.id}
+                viewTabId={tabId}
+                tabCount={pane.tabInstanceIds.length}
+              />
+            </div>
+          </div>
+        </PaneFocusProbeContext.Provider>
+      </PaneActivationFocusIntentContext.Provider>
     </div>
   );
 });

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   useNavigate,
   useRouter,
@@ -33,7 +33,7 @@ import {
   type NestedFocusTarget,
 } from "@/lib/epic-nested-focus-route";
 import { consumeNestedRoutePrimaryEditorFocus } from "@/lib/nested-route-dom-focus";
-import { shouldDeferNestedRouteApplication } from "@/lib/nested-focus-navigation-intent";
+import { getNestedRouteApplicationDeferralMs } from "@/lib/nested-focus-navigation-intent";
 import { shouldYieldPaneActivationRouteFocus } from "@/components/epic-canvas/pane-activation";
 
 const PRIMARY_CHAT_COMPOSER_SELECTOR =
@@ -84,6 +84,7 @@ export function useEpicRouteSynchronization(
     (s) => s.applyNestedRouteFocus,
   );
   const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const [nestedRouteRetryToken, setNestedRouteRetryToken] = useState(0);
   const pendingCreateArtifactIds = useEpicCanvasStore(
     (s) => s.pendingCreateArtifactIds,
   );
@@ -139,8 +140,16 @@ export function useEpicRouteSynchronization(
     if (!hasRestoredCanvas) {
       return;
     }
-    if (shouldDeferNestedRouteApplication(epicId, tabId, nestedRouteTarget)) {
-      return;
+    const deferralMs = getNestedRouteApplicationDeferralMs(
+      epicId,
+      tabId,
+      nestedRouteTarget,
+    );
+    if (deferralMs !== null) {
+      const timeout = window.setTimeout(() => {
+        setNestedRouteRetryToken((token) => token + 1);
+      }, deferralMs);
+      return () => window.clearTimeout(timeout);
     }
 
     if (nestedRouteTarget === null) {
@@ -186,6 +195,7 @@ export function useEpicRouteSynchronization(
     tabId,
     currentNestedTarget,
     applyNestedRouteFocus,
+    nestedRouteRetryToken,
   ]);
 
   // The nested-route target we last moved DOM focus to. This effect re-runs on

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -33,6 +33,8 @@ import {
   type NestedFocusTarget,
 } from "@/lib/epic-nested-focus-route";
 import { consumeNestedRoutePrimaryEditorFocus } from "@/lib/nested-route-dom-focus";
+import { shouldDeferNestedRouteApplication } from "@/lib/nested-focus-navigation-intent";
+import { shouldYieldPaneActivationRouteFocus } from "@/components/epic-canvas/pane-activation";
 
 const PRIMARY_CHAT_COMPOSER_SELECTOR =
   "[data-chat-composer] [data-composer-editor]";
@@ -135,6 +137,9 @@ export function useEpicRouteSynchronization(
       return;
     }
     if (!hasRestoredCanvas) {
+      return;
+    }
+    if (shouldDeferNestedRouteApplication(epicId, tabId, nestedRouteTarget)) {
       return;
     }
 
@@ -506,6 +511,9 @@ function focusNestedRouteTarget(
       ? findActivePaneElement(target.paneId)
       : findSelectedTileElement(target.tileInstanceId);
   if (element === null) {
+    return;
+  }
+  if (!focusPrimaryEditor && shouldYieldPaneActivationRouteFocus(element)) {
     return;
   }
   if (focusPrimaryEditor) {

--- a/clients/gui-app/src/components/epic-canvas/pane-activation.ts
+++ b/clients/gui-app/src/components/epic-canvas/pane-activation.ts
@@ -119,7 +119,11 @@ export function shouldYieldPaneActivationRouteFocus(
 ): boolean {
   const origin = paneActivationControlFocusOrigin;
   if (origin === null) return false;
-  if (Date.now() > origin.expiresAt || !origin.scope.isConnected) {
+  if (
+    Date.now() > origin.expiresAt ||
+    !origin.element.isConnected ||
+    !origin.scope.isConnected
+  ) {
     clearPaneActivationControlFocusOrigin();
     return false;
   }
@@ -249,6 +253,7 @@ export function usePaneActivationOwnership(input: {
   const activateRef = useRef(activate);
   const parentFocusIntent = usePaneActivationFocusIntent();
   const localFocusIntentExpiresAtRef = useRef(0);
+  const localFocusIntentElementRef = useRef<Element | null>(null);
   const gestureEpochRef = useRef(0);
   const deferredGestureRef = useRef<number | null>(null);
 
@@ -260,12 +265,20 @@ export function usePaneActivationOwnership(input: {
     (target: EventTarget | null, scope: EventTarget | null) => {
       const expiresAt = Date.now() + PANE_ACTIVATION_FOCUS_INTENT_TTL_MS;
       localFocusIntentExpiresAtRef.current = expiresAt;
+      localFocusIntentElementRef.current =
+        target instanceof Element ? target : null;
       markPaneActivationControlFocusOrigin(target, scope, expiresAt);
     },
     [],
   );
   const shouldYieldAutoFocus = useCallback(() => {
-    const localIntent = Date.now() <= localFocusIntentExpiresAtRef.current;
+    const localIntent =
+      Date.now() <= localFocusIntentExpiresAtRef.current &&
+      localFocusIntentElementRef.current?.isConnected === true;
+    if (!localIntent) {
+      localFocusIntentExpiresAtRef.current = 0;
+      localFocusIntentElementRef.current = null;
+    }
     const parentIntent = parentFocusIntent.shouldYieldAutoFocus();
     return localIntent || parentIntent;
   }, [parentFocusIntent]);

--- a/clients/gui-app/src/components/epic-canvas/pane-activation.ts
+++ b/clients/gui-app/src/components/epic-canvas/pane-activation.ts
@@ -1,14 +1,26 @@
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type FocusEvent,
+  type PointerEvent,
+} from "react";
+
 /**
  * Pane activation deferral contract.
  *
- * `TabGroupView` claims pane focus on `pointerdowncapture` (capture phase,
- * before any child handler runs) so clicking anywhere in a pane activates it.
- * That is wrong for subtrees whose own click must run first: activating a pane
- * triggers a synchronous re-render that can reorder/remount sibling tiles and
- * disrupt the in-flight click (e.g. a chat minimap jump landing on the wrong
- * row). Such subtrees opt out by spreading {@link paneActivationDeferProps};
- * `TabGroupView` then defers their activation to the bubble-phase `click`,
- * which fires after the child's own handler.
+ * Pane roots normally claim ownership on `pointerdowncapture`. Subtrees whose
+ * action must finish against the old layout opt out by spreading
+ * {@link paneActivationDeferProps}. The owning pane records that gesture, sees
+ * its click from native document capture, then activates in the next task after
+ * all child click handlers. A microtask is deliberately insufficient here:
+ * browsers may run its checkpoint between capture listeners, before the click
+ * reaches its target. The task boundary survives stopped propagation, React
+ * portals, and a child replacing/removing itself during the action.
  *
  * Both the producer (the marker) and the consumer (the selector) derive from
  * the single attribute name below, so the contract cannot silently drift.
@@ -24,4 +36,316 @@ const PANE_ACTIVATION_DEFER_SELECTOR = `[${PANE_ACTIVATION_DEFER_ATTRIBUTE}="tru
 export function isPaneActivationDeferred(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return target.closest(PANE_ACTIVATION_DEFER_SELECTOR) !== null;
+}
+
+const FOCUS_OWNING_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[tabindex]:not([tabindex='-1'])",
+  "[role='button']",
+  "[role='checkbox']",
+  "[role='combobox']",
+  "[role='link']",
+  "[role='menuitem']",
+  "[role='option']",
+  "[role='radio']",
+  "[role='slider']",
+  "[role='switch']",
+  "[role='tab']",
+  "[role='textbox']",
+].join(",");
+
+export function ownsPaneActivationFocus(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return target.closest(FOCUS_OWNING_SELECTOR) !== null;
+}
+
+export interface PaneActivationFocusIntent {
+  readonly mark: (
+    target: EventTarget | null,
+    scope: EventTarget | null,
+  ) => void;
+  readonly shouldYieldAutoFocus: () => boolean;
+}
+
+const DEFAULT_FOCUS_INTENT: PaneActivationFocusIntent = {
+  mark: () => undefined,
+  shouldYieldAutoFocus: () => false,
+};
+
+// Covers the complete pointer/focus/route stabilization window without making
+// the intent sticky across a later non-pointer navigation. A new pointer
+// gesture clears it immediately; this is only the keyboard/programmatic
+// fallback for an activation whose route commit resolves asynchronously.
+const PANE_ACTIVATION_FOCUS_INTENT_TTL_MS = 2_000;
+
+interface PaneActivationControlFocusOrigin {
+  readonly element: Element;
+  readonly scope: Element;
+  readonly expiresAt: number;
+}
+
+let paneActivationControlFocusOrigin: PaneActivationControlFocusOrigin | null =
+  null;
+
+function clearPaneActivationControlFocusOrigin(): void {
+  paneActivationControlFocusOrigin = null;
+}
+
+function markPaneActivationControlFocusOrigin(
+  target: EventTarget | null,
+  scope: EventTarget | null,
+  expiresAt: number,
+): void {
+  if (!(target instanceof Element) || !(scope instanceof Element)) return;
+  paneActivationControlFocusOrigin = { element: target, scope, expiresAt };
+}
+
+/**
+ * Route synchronization normally focuses the newly selected tile container.
+ * During a control-initiated activation, doing so would pull focus out of a
+ * freshly opened portalled surface (Radix popover/menu) and dismiss it. The
+ * pointer origin remains inside the target tile even when the active element
+ * is in a document portal, so it is the durable ownership proof for this short
+ * window.
+ */
+export function shouldYieldPaneActivationRouteFocus(
+  routeTarget: Element,
+): boolean {
+  const origin = paneActivationControlFocusOrigin;
+  if (origin === null) return false;
+  if (Date.now() > origin.expiresAt || !origin.scope.isConnected) {
+    clearPaneActivationControlFocusOrigin();
+    return false;
+  }
+  return (
+    routeTarget.contains(origin.scope) ||
+    origin.scope.contains(routeTarget) ||
+    routeTarget.contains(origin.element)
+  );
+}
+
+export function resetPaneActivationFocusIntentsForTests(): void {
+  clearPaneActivationControlFocusOrigin();
+}
+
+export const PaneActivationFocusIntentContext =
+  createContext<PaneActivationFocusIntent>(DEFAULT_FOCUS_INTENT);
+
+export function usePaneActivationFocusIntent(): PaneActivationFocusIntent {
+  return use(PaneActivationFocusIntentContext);
+}
+
+/**
+ * Runs a cleanup only after an in-flight pane-control activation has had its
+ * bounded route/focus stabilization window. Consumers use this when their
+ * ordinary inactive-state cleanup would otherwise erase the child action that
+ * initiated activation (for example, opening a controlled popover in an
+ * inactive pane). A genuine later pane deactivation has no focus intent and
+ * therefore runs the cleanup immediately.
+ */
+export function runAfterPaneActivationFocusIntent(
+  focusIntent: PaneActivationFocusIntent,
+  callback: () => void,
+): () => void {
+  let cancelled = false;
+  let timeout: number | null = null;
+
+  const runWhenSettled = (): void => {
+    if (cancelled) return;
+    if (!focusIntent.shouldYieldAutoFocus()) {
+      callback();
+      return;
+    }
+    timeout = window.setTimeout(
+      runWhenSettled,
+      PANE_ACTIVATION_FOCUS_INTENT_TTL_MS,
+    );
+  };
+
+  runWhenSettled();
+  return () => {
+    cancelled = true;
+    if (timeout !== null) window.clearTimeout(timeout);
+  };
+}
+
+export interface PaneActivationOwnership {
+  readonly focusIntent: PaneActivationFocusIntent;
+  readonly onFocusCapture: (event: FocusEvent<HTMLElement>) => void;
+  readonly onPointerCancelCapture: () => void;
+  readonly onPointerDownCapture: (event: PointerEvent<HTMLElement>) => void;
+}
+
+interface PaneGestureSubscriber {
+  readonly onClickCapture: () => void;
+  readonly onPointerCancelCapture: () => void;
+  readonly onPointerDownCapture: () => void;
+}
+
+const paneGestureSubscribers = new Set<PaneGestureSubscriber>();
+
+function notifyPointerDownCapture(): void {
+  clearPaneActivationControlFocusOrigin();
+  paneGestureSubscribers.forEach((subscriber) =>
+    subscriber.onPointerDownCapture(),
+  );
+}
+
+function notifyPointerCancelCapture(): void {
+  clearPaneActivationControlFocusOrigin();
+  paneGestureSubscribers.forEach((subscriber) =>
+    subscriber.onPointerCancelCapture(),
+  );
+}
+
+function notifyClickCapture(): void {
+  paneGestureSubscribers.forEach((subscriber) => subscriber.onClickCapture());
+}
+
+function subscribeToPaneGestures(
+  subscriber: PaneGestureSubscriber,
+): () => void {
+  paneGestureSubscribers.add(subscriber);
+  if (paneGestureSubscribers.size === 1) {
+    document.addEventListener("pointerdown", notifyPointerDownCapture, true);
+    document.addEventListener(
+      "pointercancel",
+      notifyPointerCancelCapture,
+      true,
+    );
+    document.addEventListener("click", notifyClickCapture, true);
+  }
+  return () => {
+    paneGestureSubscribers.delete(subscriber);
+    if (paneGestureSubscribers.size !== 0) return;
+    document.removeEventListener("pointerdown", notifyPointerDownCapture, true);
+    document.removeEventListener(
+      "pointercancel",
+      notifyPointerCancelCapture,
+      true,
+    );
+    document.removeEventListener("click", notifyClickCapture, true);
+  };
+}
+
+/**
+ * Owns one pane's activation gesture and composes with an enclosing pane (an
+ * inner Epic canvas pane inside a top-level split surface). Automatic primary
+ * focus yields throughout the activation's route-stabilization window, so a
+ * control/portal keeps focus across transient pane bounces while a
+ * blank-surface click retains editor/xterm focus.
+ */
+export function usePaneActivationOwnership(input: {
+  readonly active: boolean;
+  readonly activate: () => void;
+}): PaneActivationOwnership {
+  const { active, activate } = input;
+  const activateRef = useRef(activate);
+  const parentFocusIntent = usePaneActivationFocusIntent();
+  const localFocusIntentExpiresAtRef = useRef(0);
+  const gestureEpochRef = useRef(0);
+  const deferredGestureRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    activateRef.current = activate;
+  }, [activate]);
+
+  const mark = useCallback(
+    (target: EventTarget | null, scope: EventTarget | null) => {
+      const expiresAt = Date.now() + PANE_ACTIVATION_FOCUS_INTENT_TTL_MS;
+      localFocusIntentExpiresAtRef.current = expiresAt;
+      markPaneActivationControlFocusOrigin(target, scope, expiresAt);
+    },
+    [],
+  );
+  const shouldYieldAutoFocus = useCallback(() => {
+    const localIntent = Date.now() <= localFocusIntentExpiresAtRef.current;
+    const parentIntent = parentFocusIntent.shouldYieldAutoFocus();
+    return localIntent || parentIntent;
+  }, [parentFocusIntent]);
+  const focusIntent = useMemo(
+    () => ({ mark, shouldYieldAutoFocus }),
+    [mark, shouldYieldAutoFocus],
+  );
+
+  const clearDeferredGesture = useCallback(() => {
+    deferredGestureRef.current = null;
+  }, []);
+
+  const onPointerDownCapture = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      if (active || event.defaultPrevented) return;
+      if (ownsPaneActivationFocus(event.target)) {
+        mark(event.target, event.currentTarget);
+      }
+      if (isPaneActivationDeferred(event.target)) {
+        deferredGestureRef.current = gestureEpochRef.current;
+        return;
+      }
+      clearDeferredGesture();
+      activate();
+    },
+    [activate, active, clearDeferredGesture, mark],
+  );
+
+  const onFocusCapture = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      if (active || event.defaultPrevented) return;
+      // Mouse focus inside a deferred subtree belongs to the in-flight action;
+      // activation completes after its click, not midway through the gesture.
+      if (deferredGestureRef.current !== null) return;
+      mark(event.target, event.currentTarget);
+      activate();
+    },
+    [activate, active, mark],
+  );
+
+  useEffect(() => {
+    const handleDocumentPointerDown = (): void => {
+      // Native document capture runs before any pane's React capture handler,
+      // so a new gesture clears stale ownership before its real pane can arm.
+      gestureEpochRef.current += 1;
+      localFocusIntentExpiresAtRef.current = 0;
+      clearDeferredGesture();
+    };
+    const handleDocumentPointerCancel = (): void => {
+      gestureEpochRef.current += 1;
+      localFocusIntentExpiresAtRef.current = 0;
+      clearDeferredGesture();
+    };
+    const handleDocumentClick = (): void => {
+      const gestureEpoch = deferredGestureRef.current;
+      if (gestureEpoch === null) return;
+      deferredGestureRef.current = null;
+      window.setTimeout(() => {
+        // A later pointer gesture supersedes this one before its completion.
+        if (gestureEpochRef.current !== gestureEpoch) return;
+        activateRef.current();
+      }, 0);
+    };
+    const unsubscribe = subscribeToPaneGestures({
+      onClickCapture: handleDocumentClick,
+      onPointerCancelCapture: handleDocumentPointerCancel,
+      onPointerDownCapture: handleDocumentPointerDown,
+    });
+    return () => {
+      gestureEpochRef.current += 1;
+      localFocusIntentExpiresAtRef.current = 0;
+      clearDeferredGesture();
+      unsubscribe();
+    };
+  }, [clearDeferredGesture]);
+
+  return {
+    focusIntent,
+    onFocusCapture,
+    onPointerCancelCapture: clearDeferredGesture,
+    onPointerDownCapture,
+  };
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-find.test.tsx
@@ -30,6 +30,7 @@ import {
   focusTerminalInstance,
   resetTerminalFocusRegistryForTests,
 } from "@/lib/terminals/terminal-focus-registry";
+import { PaneActivationFocusIntentContext } from "@/components/epic-canvas/pane-activation";
 
 type Disposable = {
   readonly dispose: () => void;
@@ -1428,6 +1429,57 @@ describe("<TerminalXtermHost /> terminal find", () => {
     });
 
     expect(focusOrder).toEqual(["tab", "terminal"]);
+  });
+
+  it("does not steal focus from the control that activated the terminal pane", async () => {
+    vi.useFakeTimers();
+    const shouldYieldAutoFocus = vi.fn(() => true);
+
+    function ActivationHarness() {
+      const [active, setActive] = useState(false);
+      return (
+        <PaneActivationFocusIntentContext.Provider
+          value={{
+            mark: () => undefined,
+            shouldYieldAutoFocus,
+          }}
+        >
+          <button type="button" onClick={() => setActive(true)}>
+            Open terminal control
+          </button>
+          <TerminalXtermHost
+            sessionId="test-session"
+            tileKind="terminal"
+            instanceId="test-instance"
+            effectiveCols={80}
+            effectiveRows={24}
+            onUserInput={vi.fn()}
+            onContainerResize={vi.fn()}
+            onWriterReady={vi.fn()}
+            shouldFocusOnActivePane={active}
+            registerImperativeFocus
+            findTargetId={active ? "terminal:test" : null}
+            keepAlive={false}
+            chrome="padded"
+          />
+        </PaneActivationFocusIntentContext.Provider>
+      );
+    }
+
+    render(<ActivationHarness />);
+    const button = screen.getByRole("button", {
+      name: "Open terminal control",
+    });
+    button.focus();
+    fireEvent.click(button);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(shouldYieldAutoFocus).toHaveBeenCalledTimes(1);
+    expect(xtermMocks.terminals[0].focus).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(button);
   });
 
   it("pastes dropped file paths through xterm's paste path", async () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -55,6 +55,7 @@ import {
   useVisiblePaneEffect,
 } from "@/components/epic-tabs/pane-visibility-context";
 import { markTerminalLoad } from "@/lib/perf/terminal-load-perf";
+import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
 import { registerTerminalFocus } from "@/lib/terminals/terminal-focus-registry";
 import {
   acquireXtermHost,
@@ -1288,15 +1289,17 @@ function useActiveTerminalFocus(
   termRef: RefObject<Terminal | null>,
   shouldFocusOnActivePane: boolean,
 ): void {
+  const paneActivationFocusIntent = usePaneActivationFocusIntent();
   const focusVisibleTerminal = useCallback(() => {
     if (!shouldFocusOnActivePane) return;
+    if (paneActivationFocusIntent.shouldYieldAutoFocus()) return;
     const focusTimer = window.setTimeout(() => {
       termRef.current?.focus();
     }, 0);
     return () => {
       clearTimeout(focusTimer);
     };
-  }, [shouldFocusOnActivePane, termRef]);
+  }, [paneActivationFocusIntent, shouldFocusOnActivePane, termRef]);
   useActivePaneEffect(focusVisibleTerminal);
 }
 

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -114,7 +114,7 @@ import {
   type ProviderCliState,
   type ProviderProfile,
 } from "@traycer/protocol/host/provider-schemas";
-import type { Key, KeyboardEvent, ReactNode } from "react";
+import { useState, type Key, type KeyboardEvent, type ReactNode } from "react";
 
 interface CatalogHarness extends HarnessOption {
   readonly models: ReadonlyArray<ModelOption>;
@@ -469,6 +469,11 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
 
 import { HarnessModelPicker } from "@/components/home/pickers/harness-model-picker";
 import { SurfaceActivityProvider } from "@/components/home/composer/surface-activity-context";
+import {
+  PaneActivationFocusIntentContext,
+  usePaneActivationOwnership,
+} from "@/components/epic-canvas/pane-activation";
+import { PaneSurfaceActivityContext } from "@/components/epic-tabs/pane-visibility-context";
 import type { ProfileRowAdmission } from "@/components/providers/provider-profile-model";
 import {
   createComposerToolbarStore,
@@ -791,7 +796,10 @@ interface PickerHarness {
   readonly selections: HarnessModelSelection[];
   readonly reasoningChanges: ReasoningLevel[];
   readonly serviceTierChanges: ServiceTier[];
-  readonly element: (disabled: boolean) => ReactNode;
+  readonly element: (
+    disabled: boolean,
+    activityEnabled: boolean | undefined,
+  ) => ReactNode;
 }
 
 function pickerHarness(input: RenderPickerInput | undefined): PickerHarness {
@@ -832,8 +840,13 @@ function pickerHarness(input: RenderPickerInput | undefined): PickerHarness {
       serviceTierChanges.push(state.serviceTier);
     }
   });
-  const element = (disabled: boolean): ReactNode => (
-    <SurfaceActivityProvider active={resolvedInput.activityEnabled ?? true}>
+  const element = (
+    disabled: boolean,
+    activityEnabled: boolean | undefined,
+  ): ReactNode => (
+    <SurfaceActivityProvider
+      active={activityEnabled ?? resolvedInput.activityEnabled ?? true}
+    >
       <TooltipProvider delayDuration={0}>
         <HarnessModelPicker
           store={store}
@@ -852,9 +865,34 @@ function pickerHarness(input: RenderPickerInput | undefined): PickerHarness {
   return { store, selections, reasoningChanges, serviceTierChanges, element };
 }
 
+function ColdInactivePanePicker(props: { readonly harness: PickerHarness }) {
+  const [active, setActive] = useState(false);
+  const activation = usePaneActivationOwnership({
+    active,
+    activate: () => setActive(true),
+  });
+  return (
+    <PaneActivationFocusIntentContext.Provider value={activation.focusIntent}>
+      <PaneSurfaceActivityContext.Provider
+        value={{ visible: true, focused: active }}
+      >
+        <div
+          data-testid="cold-inactive-pane"
+          data-active={active ? "true" : "false"}
+          onFocusCapture={activation.onFocusCapture}
+          onPointerCancelCapture={activation.onPointerCancelCapture}
+          onPointerDownCapture={activation.onPointerDownCapture}
+        >
+          {props.harness.element(false, active)}
+        </div>
+      </PaneSurfaceActivityContext.Provider>
+    </PaneActivationFocusIntentContext.Provider>
+  );
+}
+
 function renderPicker(input: RenderPickerInput | undefined): PickerHarness {
   const harness = pickerHarness(input);
-  render(harness.element(input?.disabled ?? false));
+  render(harness.element(input?.disabled ?? false, undefined));
   return harness;
 }
 
@@ -1359,15 +1397,15 @@ describe("<HarnessModelPicker />", () => {
 
   it("closes and blocks selection when disabled while already open", async () => {
     const harness = pickerHarness(undefined);
-    const view = render(harness.element(false));
+    const view = render(harness.element(false, undefined));
 
     await openPicker();
-    view.rerender(harness.element(true));
+    view.rerender(harness.element(true, undefined));
 
     await waitFor(() => {
       expect(screen.queryByRole("textbox", { name: /^Search/ })).toBeNull();
     });
-    view.rerender(harness.element(false));
+    view.rerender(harness.element(false, undefined));
 
     expect(screen.queryByRole("textbox", { name: /^Search/ })).toBeNull();
     expect(harness.selections).toEqual([]);
@@ -1395,6 +1433,28 @@ describe("<HarnessModelPicker />", () => {
       enabled: false,
       subscribed: false,
     });
+  });
+
+  it("opens on the first click when both pickers are closed and its pane is inactive", async () => {
+    const harness = pickerHarness(undefined);
+    render(<ColdInactivePanePicker harness={harness} />);
+
+    const trigger = screen.getByRole("button", { name: "Select model" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("cold-inactive-pane").dataset.active).toBe(
+      "false",
+    );
+
+    fireEvent.pointerDown(trigger);
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const input = await screen.findByRole("textbox", { name: /^Search/ });
+    expect(input).toBe(document.activeElement);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByTestId("cold-inactive-pane").dataset.active).toBe(
+      "true",
+    );
   });
 
   it("keeps provider state warm before opening the picker", () => {
@@ -2128,7 +2188,7 @@ describe("<HarnessModelPicker />", () => {
         profileId: "work-profile",
       },
     });
-    const { container, rerender } = render(harness.element(false));
+    const { container, rerender } = render(harness.element(false, undefined));
 
     expect(screen.getByRole("button", { name: "GPT-5.5, Work" })).toBeDefined();
     await openPickerByTriggerName("GPT-5.5, Work");
@@ -2145,7 +2205,7 @@ describe("<HarnessModelPicker />", () => {
     act(() => {
       harness.store.getState().setReasoning("medium");
     });
-    rerender(harness.element(false));
+    rerender(harness.element(false, undefined));
 
     expect(
       screen.getByRole("button", { name: "GPT-5.5, Personal" }),

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -1,5 +1,6 @@
 import "../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetPaneActivationFocusIntentsForTests } from "@/components/epic-canvas/pane-activation";
 
 // The picker's provider-settings gear opens the settings modal through router
 // actions. This unit test renders the picker bare (no RouterProvider), so stub
@@ -940,6 +941,7 @@ describe("<HarnessModelPicker />", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     cleanup();
+    resetPaneActivationFocusIntentsForTests();
     useKeybindingStore.getState().resetAll();
     useComposerHarnessMemoryStore.getState().resetForTests();
     useProviderProfileAddFlowStore.getState().close();

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -98,6 +98,11 @@ import {
 } from "@/lib/provider-ordering";
 import { isProviderAmbientSignedOut } from "@/lib/providers/provider-ambient-auth";
 import type { ProfileRowAdmission } from "@/components/providers/provider-profile-model";
+import {
+  paneActivationDeferProps,
+  runAfterPaneActivationFocusIntent,
+  usePaneActivationFocusIntent,
+} from "@/components/epic-canvas/pane-activation";
 
 export type { ReasoningFooterConfig, ServiceTierFooterConfig };
 
@@ -174,6 +179,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     profileAdmission,
   } = props;
   const activityEnabled = useSurfaceActivity();
+  const paneActivationFocusIntent = usePaneActivationFocusIntent();
   const selection = useStore(store, (s) => s.selection);
   const selectedModel = useStore(store, (s) => s.selectedModel);
   const reasoning = useStore(store, (s) => s.reasoning);
@@ -246,8 +252,11 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
 
   useEffect(() => {
     if (activityEnabled || !visibleOpen) return;
-    closeOnly();
-  }, [activityEnabled, closeOnly, visibleOpen]);
+    return runAfterPaneActivationFocusIntent(
+      paneActivationFocusIntent,
+      closeOnly,
+    );
+  }, [activityEnabled, closeOnly, paneActivationFocusIntent, visibleOpen]);
 
   const harnessesQuery = useGuiHarnessesQuery({
     enabled: activityEnabled,
@@ -856,6 +865,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
           align={undefined}
         >
           <HarnessModelTrigger
+            {...paneActivationDeferProps}
             selection={selection}
             label={presentation.label}
             reasoningLabel={presentation.reasoningLabel}

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
@@ -14,16 +14,47 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { useTabsStore } from "@/stores/tabs/store";
 import type { TabRef } from "@/stores/tabs/types";
+import { TopLevelSurfaceActivationContext } from "@/components/layout/top-level-surface-activation-context";
 
-vi.mock("@/components/epic-tabs/epic-surface", () => ({
-  EpicSurface: (props: { readonly epicId: string; readonly tabId: string }) => (
-    <input
-      data-epic-id={props.epicId}
-      data-testid={`epic-surface-body-${props.tabId}`}
-      defaultValue={props.tabId}
-    />
-  ),
-}));
+vi.mock("@/components/epic-tabs/epic-surface", async () => {
+  const React = await import("react");
+  const { usePaneActivationFocusIntent } =
+    await import("@/components/epic-canvas/pane-activation");
+  const { usePaneFocused } =
+    await import("@/components/epic-tabs/pane-visibility-context");
+
+  function MockEpicSurface(props: {
+    readonly epicId: string;
+    readonly tabId: string;
+  }) {
+    const focused = usePaneFocused();
+    const focusIntent = usePaneActivationFocusIntent();
+    const primaryRef = React.useRef<HTMLInputElement | null>(null);
+    const previouslyFocusedRef = React.useRef(false);
+    React.useEffect(() => {
+      const newlyFocused = focused && !previouslyFocusedRef.current;
+      previouslyFocusedRef.current = focused;
+      if (!newlyFocused) return;
+      if (focusIntent.shouldYieldAutoFocus()) return;
+      primaryRef.current?.focus();
+    }, [focusIntent, focused]);
+
+    return (
+      <div data-testid={`epic-surface-content-${props.tabId}`}>
+        <input
+          aria-label={`Action ${props.tabId}`}
+          data-epic-id={props.epicId}
+          data-testid={`epic-surface-body-${props.tabId}`}
+          defaultValue={props.tabId}
+        />
+        <input aria-label={`Primary ${props.tabId}`} ref={primaryRef} />
+        <div data-testid={`blank-surface-${props.tabId}`} />
+      </div>
+    );
+  }
+
+  return { EpicSurface: MockEpicSurface };
+});
 
 vi.mock("@/components/home/landing-draft-surface", () => ({
   LandingDraftSurface: () => <div data-testid="draft-surface-body" />,
@@ -66,6 +97,18 @@ const SETTINGS: TabRef = { kind: "settings", id: "settings" };
 
 function surfaceRef(key: TabRef): HTMLElement {
   return screen.getByTestId(`top-level-surface-${key.kind}-${key.id}`);
+}
+
+function activatingHost(left: TabRef, right: TabRef): ReactNode {
+  return (
+    <TopLevelSurfaceActivationContext.Provider
+      value={(tab) => {
+        setSplit(left, right, tab.id === right.id ? "right" : "left");
+      }}
+    >
+      <TopLevelTabHost />
+    </TopLevelSurfaceActivationContext.Provider>
+  );
 }
 
 function seedSources(refs: ReadonlyArray<TabRef>): void {
@@ -215,6 +258,48 @@ describe("<TopLevelTabHost />", () => {
     expect(surfaceRef(EPIC_A)).toBe(epicBefore);
     expect(surfaceRef(DRAFT_A)).toBe(draftBefore);
     expect(surfaceRef(EPIC_A).dataset.focused).toBe("true");
+  });
+
+  it("keeps pointer and keyboard focus on the control that activates a split partner", () => {
+    seedSources([EPIC_A, EPIC_B]);
+    setSplit(EPIC_A, EPIC_B, "left");
+    render(activatingHost(EPIC_A, EPIC_B));
+
+    const action = screen.getByRole("textbox", { name: "Action epic-b" });
+    act(() => {
+      action.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, composed: true }),
+      );
+      action.focus();
+    });
+
+    expect(surfaceRef(EPIC_B).dataset.focused).toBe("true");
+    expect(document.activeElement).toBe(action);
+
+    act(() => setSplit(EPIC_A, EPIC_B, "left"));
+    act(() => action.focus());
+
+    expect(surfaceRef(EPIC_B).dataset.focused).toBe("true");
+    expect(document.activeElement).toBe(action);
+  });
+
+  it("retains primary autofocus for blank top-level surface activation", () => {
+    seedSources([EPIC_A, EPIC_B]);
+    setSplit(EPIC_A, EPIC_B, "left");
+    render(activatingHost(EPIC_A, EPIC_B));
+
+    act(() => {
+      screen
+        .getByTestId("blank-surface-epic-b")
+        .dispatchEvent(
+          new PointerEvent("pointerdown", { bubbles: true, composed: true }),
+        );
+    });
+
+    expect(surfaceRef(EPIC_B).dataset.focused).toBe("true");
+    expect(document.activeElement).toBe(
+      screen.getByRole("textbox", { name: "Primary epic-b" }),
+    );
   });
 
   it("keeps a body instance and its local value across single-to-split-to-swap", async () => {

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -1,5 +1,6 @@
 import {
   Suspense,
+  useCallback,
   useMemo,
   useRef,
   useState,
@@ -7,7 +8,6 @@ import {
   type CSSProperties,
   type ReactNode,
 } from "react";
-import type { FocusEvent, PointerEvent } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
@@ -45,12 +45,15 @@ import {
 } from "@/components/epic-canvas/dnd/dnd-store";
 import { PhaseMigrationControllerHost } from "@/components/epic-tabs/phase-migration-controller-host";
 import { PhaseMigrationSurface } from "@/components/epic-tabs/phase-migration-surface";
+import {
+  PaneActivationFocusIntentContext,
+  usePaneActivationOwnership,
+} from "@/components/epic-canvas/pane-activation";
 import { TabSurfaceActivityProvider } from "./tab-surface-activity";
 import { SurfaceReadinessBoundary } from "./host-readiness-controller";
 import { SurfacePresentationBoundary } from "./surface-presentation-boundary";
 import {
-  activateTopLevelSurfaceFromFocus,
-  activateTopLevelSurfaceFromPointer,
+  type TopLevelSurfaceActivator,
   useTopLevelSurfaceActivator,
 } from "./top-level-surface-activation-context";
 
@@ -133,51 +136,11 @@ export function TopLevelTabHost() {
     >
       <PhaseMigrationControllerHost />
       {mounts.map((mount) => (
-        <div
+        <TopLevelSurfaceMount
           key={tabRefKey(mount.tab)}
-          aria-hidden={!mount.activity.visible}
-          className={surfaceClassName(mount.placement)}
-          data-focused={mount.activity.focused ? "true" : "false"}
-          data-surface-kind={mount.tab.kind}
-          data-surface-ref={tabRefKey(mount.tab)}
-          data-testid={`top-level-surface-${mount.tab.kind}-${mount.tab.id}`}
-          data-visible={mount.activity.visible ? "true" : "false"}
-          onFocusCapture={(event: FocusEvent<HTMLDivElement>) => {
-            activateTopLevelSurfaceFromFocus(
-              event,
-              mount.activity.focused,
-              mount.tab,
-              activateSurface,
-            );
-          }}
-          onPointerDownCapture={(event: PointerEvent<HTMLDivElement>) => {
-            activateTopLevelSurfaceFromPointer(
-              event,
-              mount.activity.focused,
-              mount.tab,
-              activateSurface,
-            );
-          }}
-          style={surfaceStyle(mount.placement)}
-        >
-          <TabSurfaceActivityProvider activity={mount.activity}>
-            <SurfacePresentationBoundary
-              visible={mount.activity.visible}
-              focused={mount.activity.focused}
-            >
-              <SurfaceReadinessBoundary
-                scope={tabSurfaceDescriptor(mount.tab.kind).readinessScope}
-                // T11 supplies a durable per-Epic host id. Current top-level
-                // members deliberately use their descriptor's default/none key.
-                tabHostId={null}
-              >
-                <Suspense fallback={null}>
-                  <TabSurface tab={mount.tab} />
-                </Suspense>
-              </SurfaceReadinessBoundary>
-            </SurfacePresentationBoundary>
-          </TabSurfaceActivityProvider>
-        </div>
+          mount={mount}
+          activateSurface={activateSurface}
+        />
       ))}
       {renderedActiveItem?.kind === "tab" ? (
         <TopLevelEdgeSplitTargets targetRef={renderedActiveItem.ref} />
@@ -194,6 +157,67 @@ export function TopLevelTabHost() {
         </>
       ) : null}
     </div>
+  );
+}
+
+interface MountedTopLevelSurface {
+  readonly tab: HeaderTab;
+  readonly placement: SurfacePlacement;
+  readonly activity: {
+    readonly visible: boolean;
+    readonly focused: boolean;
+  };
+}
+
+function TopLevelSurfaceMount(props: {
+  readonly mount: MountedTopLevelSurface;
+  readonly activateSurface: TopLevelSurfaceActivator | null;
+}): ReactNode {
+  const { mount, activateSurface } = props;
+  const activate = useCallback(() => {
+    activateSurface?.(mount.tab);
+  }, [activateSurface, mount.tab]);
+  const paneActivation = usePaneActivationOwnership({
+    active: mount.activity.focused,
+    activate,
+  });
+
+  return (
+    <PaneActivationFocusIntentContext.Provider
+      value={paneActivation.focusIntent}
+    >
+      <div
+        aria-hidden={!mount.activity.visible}
+        className={surfaceClassName(mount.placement)}
+        data-focused={mount.activity.focused ? "true" : "false"}
+        data-surface-kind={mount.tab.kind}
+        data-surface-ref={tabRefKey(mount.tab)}
+        data-testid={`top-level-surface-${mount.tab.kind}-${mount.tab.id}`}
+        data-visible={mount.activity.visible ? "true" : "false"}
+        onFocusCapture={paneActivation.onFocusCapture}
+        onPointerDownCapture={paneActivation.onPointerDownCapture}
+        onPointerCancelCapture={paneActivation.onPointerCancelCapture}
+        style={surfaceStyle(mount.placement)}
+      >
+        <TabSurfaceActivityProvider activity={mount.activity}>
+          <SurfacePresentationBoundary
+            visible={mount.activity.visible}
+            focused={mount.activity.focused}
+          >
+            <SurfaceReadinessBoundary
+              scope={tabSurfaceDescriptor(mount.tab.kind).readinessScope}
+              // T11 supplies a durable per-Epic host id. Current top-level
+              // members deliberately use their descriptor's default/none key.
+              tabHostId={null}
+            >
+              <Suspense fallback={null}>
+                <TabSurface tab={mount.tab} />
+              </Suspense>
+            </SurfaceReadinessBoundary>
+          </SurfacePresentationBoundary>
+        </TabSurfaceActivityProvider>
+      </div>
+    </PaneActivationFocusIntentContext.Provider>
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/appearance-settings-panel-groups.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/appearance-settings-panel-groups.test.tsx
@@ -29,6 +29,7 @@ function resetAppearanceSettings(): void {
     artifactIconColorMode: "byType",
     artifactIconColors: DEFAULT_EPIC_NODE_ICON_COLORS,
     pointerCursors: true,
+    chatTurnMinimapSide: "right",
     codeFontFamily: null,
     codeFontSize: DEFAULT_CODE_FONT_SIZE,
     terminalFontFamily: null,
@@ -75,6 +76,17 @@ describe("<AppearanceSettingsPanel /> groups", () => {
     expect(documentPosition(iface, typography)).toBe("before");
     expect(documentPosition(typography, terminal)).toBe("before");
     expect(documentPosition(terminal, artifactIcons)).toBe("before");
+  });
+
+  it("offers a hide option for the message minimap", () => {
+    renderPanel(queryClient);
+
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Message minimap side" }),
+    );
+    fireEvent.click(screen.getByRole("option", { name: "Hide" }));
+
+    expect(useSettingsStore.getState().chatTurnMinimapSide).toBe("hide");
   });
 
   it("renders named sections as h2 headings outside separate bordered cards", () => {

--- a/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
@@ -18,6 +18,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
 import { useDesktopZoomBridge } from "@/hooks/runner/use-desktop-zoom-bridge";
 import {
@@ -202,9 +203,7 @@ export function AppearanceSettingsPanel() {
                   aria-label="Message minimap side"
                   className="w-[min(40vw,8rem)]"
                 >
-                  <span data-slot="select-value">
-                    {chatTurnMinimapSide === "right" ? "Right" : "Left"}
-                  </span>
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="right">Right</SelectItem>

--- a/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
@@ -66,6 +66,12 @@ export function AppearanceSettingsPanel() {
   const setPointerCursors = useSettingsStore(
     (state) => state.setPointerCursors,
   );
+  const chatTurnMinimapSide = useSettingsStore(
+    (state) => state.chatTurnMinimapSide,
+  );
+  const setChatTurnMinimapSide = useSettingsStore(
+    (state) => state.setChatTurnMinimapSide,
+  );
   const uiFontSize = useSettingsStore((state) => state.uiFontSize);
   const setUiFontSize = useSettingsStore((state) => state.setUiFontSize);
   const codeFontSize = useSettingsStore((state) => state.codeFontSize);
@@ -177,6 +183,34 @@ export function AppearanceSettingsPanel() {
                 )}
                 aria-label="Use pointer cursors"
               />
+            }
+          />
+          <SettingsRow
+            label="Message minimap side"
+            description="Place the chat turn minimap on the left or right edge of the transcript."
+            control={
+              <Select
+                value={chatTurnMinimapSide}
+                onValueChange={(value) => {
+                  if (value !== "left" && value !== "right") return;
+                  trackAppearanceSetting("chatTurnMinimapSide");
+                  setChatTurnMinimapSide(value);
+                }}
+              >
+                <SelectTrigger
+                  size="sm"
+                  aria-label="Message minimap side"
+                  className="w-[min(40vw,8rem)]"
+                >
+                  <span data-slot="select-value">
+                    {chatTurnMinimapSide === "right" ? "Right" : "Left"}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="right">Right</SelectItem>
+                  <SelectItem value="left">Left</SelectItem>
+                </SelectContent>
+              </Select>
             }
           />
         </SettingsGroup>

--- a/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
@@ -188,12 +188,18 @@ export function AppearanceSettingsPanel() {
           />
           <SettingsRow
             label="Message minimap side"
-            description="Place the chat turn minimap on the left or right edge of the transcript."
+            description="Place the chat turn minimap on either transcript edge, or hide it entirely."
             control={
               <Select
                 value={chatTurnMinimapSide}
                 onValueChange={(value) => {
-                  if (value !== "left" && value !== "right") return;
+                  if (
+                    value !== "left" &&
+                    value !== "right" &&
+                    value !== "hide"
+                  ) {
+                    return;
+                  }
                   trackAppearanceSetting("chatTurnMinimapSide");
                   setChatTurnMinimapSide(value);
                 }}
@@ -208,6 +214,7 @@ export function AppearanceSettingsPanel() {
                 <SelectContent>
                   <SelectItem value="right">Right</SelectItem>
                   <SelectItem value="left">Left</SelectItem>
+                  <SelectItem value="hide">Hide</SelectItem>
                 </SelectContent>
               </Select>
             }

--- a/clients/gui-app/src/lib/__tests__/epic-nested-focus-navigation.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-nested-focus-navigation.test.ts
@@ -10,6 +10,10 @@ import {
   consumeNestedRoutePrimaryEditorFocus,
   resetNestedRouteDomFocusForTests,
 } from "@/lib/nested-route-dom-focus";
+import {
+  resetNestedFocusNavigationIntentsForTests,
+  shouldDeferNestedRouteApplication,
+} from "@/lib/nested-focus-navigation-intent";
 
 interface CapturedNavigateOptions {
   readonly search: (prev: Record<string, unknown>) => unknown;
@@ -38,7 +42,10 @@ function firstNavigateOptions(
 }
 
 describe("navigateNestedFocus", () => {
-  beforeEach(resetNestedRouteDomFocusForTests);
+  beforeEach(() => {
+    resetNestedRouteDomFocusForTests();
+    resetNestedFocusNavigationIntentsForTests();
+  });
 
   it("pushes a nested search patch for persistent desktop history", () => {
     const history = createPersistentMemoryHistory(
@@ -67,6 +74,15 @@ describe("navigateNestedFocus", () => {
       focusPaneId: "pane-1",
       focusTileInstanceId: "tile-1",
     });
+    expect(shouldDeferNestedRouteApplication("epic-1", "tab-1", null)).toBe(
+      true,
+    );
+    expect(
+      shouldDeferNestedRouteApplication("epic-1", "tab-1", {
+        paneId: "pane-1",
+        tileInstanceId: "tile-1",
+      }),
+    ).toBe(false);
   });
 
   it("does not navigate duplicate focus targets", () => {

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -179,6 +179,7 @@ export type AnalyticsSetting =
   | "allowPrereleaseUpdates"
   | "artifactIconColorMode"
   | "artifactIconColors"
+  | "chatTurnMinimapSide"
   | "codeFontFamily"
   | "codeFontSize"
   | "composerMode"

--- a/clients/gui-app/src/lib/epic-nested-focus-navigation.ts
+++ b/clients/gui-app/src/lib/epic-nested-focus-navigation.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/epic-nested-focus-route";
 import { getHistoryController } from "@/lib/persistent-history";
 import { requestNestedRoutePrimaryEditorFocus } from "@/lib/nested-route-dom-focus";
+import { beginNestedFocusNavigation } from "@/lib/nested-focus-navigation-intent";
 
 export interface NestedFocusLocation {
   readonly pathname: string;
@@ -75,6 +76,7 @@ function navigateNestedFocusWithDomRestore(
   if (restorePrimaryEditor) {
     requestNestedRoutePrimaryEditorFocus(epicId, tabId, target);
   }
+  beginNestedFocusNavigation(epicId, tabId, target);
 
   void router.navigate({
     to: "/epics/$epicId/$tabId",

--- a/clients/gui-app/src/lib/nested-focus-navigation-intent.ts
+++ b/clients/gui-app/src/lib/nested-focus-navigation-intent.ts
@@ -1,0 +1,60 @@
+import {
+  areNestedFocusTargetsEqual,
+  type NestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
+
+interface PendingNestedFocusNavigation {
+  readonly target: NestedFocusTarget;
+  readonly expiresAt: number;
+}
+
+const PENDING_NAVIGATION_TTL_MS = 2_000;
+const pendingByTab = new Map<string, PendingNestedFocusNavigation>();
+
+function pendingKey(epicId: string, tabId: string): string {
+  return `${epicId}\u001f${tabId}`;
+}
+
+/**
+ * Records the locally prepared target before its async router navigation can
+ * commit. Route synchronization must not reapply the old URL target during
+ * this short optimistic window or it will bounce focus back to the old pane.
+ */
+export function beginNestedFocusNavigation(
+  epicId: string,
+  tabId: string,
+  target: NestedFocusTarget,
+): void {
+  pendingByTab.set(pendingKey(epicId, tabId), {
+    target,
+    expiresAt: Date.now() + PENDING_NAVIGATION_TTL_MS,
+  });
+}
+
+/**
+ * Returns true only while the route still exposes the stale pre-navigation
+ * target. Seeing the pending target means the router caught up and clears the
+ * optimistic guard; expiration keeps a failed navigation from becoming sticky.
+ */
+export function shouldDeferNestedRouteApplication(
+  epicId: string,
+  tabId: string,
+  routeTarget: NestedFocusTarget | null,
+): boolean {
+  const key = pendingKey(epicId, tabId);
+  const pending = pendingByTab.get(key);
+  if (pending === undefined) return false;
+  if (Date.now() > pending.expiresAt) {
+    pendingByTab.delete(key);
+    return false;
+  }
+  if (areNestedFocusTargetsEqual(pending.target, routeTarget)) {
+    pendingByTab.delete(key);
+    return false;
+  }
+  return true;
+}
+
+export function resetNestedFocusNavigationIntentsForTests(): void {
+  pendingByTab.clear();
+}

--- a/clients/gui-app/src/lib/nested-focus-navigation-intent.ts
+++ b/clients/gui-app/src/lib/nested-focus-navigation-intent.ts
@@ -41,18 +41,33 @@ export function shouldDeferNestedRouteApplication(
   tabId: string,
   routeTarget: NestedFocusTarget | null,
 ): boolean {
+  return (
+    getNestedRouteApplicationDeferralMs(epicId, tabId, routeTarget) !== null
+  );
+}
+
+/**
+ * Returns the remaining optimistic window so route synchronization can wake
+ * itself when a router navigation never commits its target.
+ */
+export function getNestedRouteApplicationDeferralMs(
+  epicId: string,
+  tabId: string,
+  routeTarget: NestedFocusTarget | null,
+): number | null {
   const key = pendingKey(epicId, tabId);
   const pending = pendingByTab.get(key);
-  if (pending === undefined) return false;
-  if (Date.now() > pending.expiresAt) {
+  if (pending === undefined) return null;
+  const remainingMs = pending.expiresAt - Date.now();
+  if (remainingMs <= 0) {
     pendingByTab.delete(key);
-    return false;
+    return null;
   }
   if (areNestedFocusTargetsEqual(pending.target, routeTarget)) {
     pendingByTab.delete(key);
-    return false;
+    return null;
   }
-  return true;
+  return remainingMs;
 }
 
 export function resetNestedFocusNavigationIntentsForTests(): void {

--- a/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
+++ b/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
@@ -58,6 +58,7 @@ describe("useSettingsStore", () => {
   });
 
   it("repairs an invalid persisted chat turn minimap side to right", async () => {
+    useSettingsStore.setState({ chatTurnMinimapSide: "left" });
     window.localStorage.setItem(
       "traycer-gui-app:settings",
       JSON.stringify({

--- a/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
+++ b/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
@@ -57,6 +57,19 @@ describe("useSettingsStore", () => {
     expect(useSettingsStore.getState().chatTurnMinimapSide).toBe("left");
   });
 
+  it("persists and rehydrates a hidden chat turn minimap", async () => {
+    useSettingsStore.getState().setChatTurnMinimapSide("hide");
+    const persisted = window.localStorage.getItem("traycer-gui-app:settings");
+    expect(persisted ?? "").toContain('"chatTurnMinimapSide":"hide"');
+
+    useSettingsStore.setState({ chatTurnMinimapSide: "right" });
+    if (persisted === null) throw new Error("expected persisted settings");
+    window.localStorage.setItem("traycer-gui-app:settings", persisted);
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().chatTurnMinimapSide).toBe("hide");
+  });
+
   it("repairs an invalid persisted chat turn minimap side to right", async () => {
     useSettingsStore.setState({ chatTurnMinimapSide: "left" });
     window.localStorage.setItem(

--- a/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
+++ b/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
@@ -22,6 +22,7 @@ function resetSettingsStore(): void {
     showGlobalResourceMonitor: true,
     showNavigatorResourceStats: false,
     pinContextUsageBreakdown: false,
+    chatTurnMinimapSide: "right",
     quoteReplyEnabled: true,
     worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
@@ -37,6 +38,37 @@ describe("useSettingsStore", () => {
     expect(useSettingsStore.getState().artifactIconColors).toEqual(
       DEFAULT_EPIC_NODE_ICON_COLORS,
     );
+  });
+
+  it("defaults the chat turn minimap to the right side", () => {
+    expect(useSettingsStore.getState().chatTurnMinimapSide).toBe("right");
+  });
+
+  it("persists and rehydrates the chat turn minimap side", async () => {
+    useSettingsStore.getState().setChatTurnMinimapSide("left");
+    const persisted = window.localStorage.getItem("traycer-gui-app:settings");
+    expect(persisted ?? "").toContain('"chatTurnMinimapSide":"left"');
+
+    useSettingsStore.setState({ chatTurnMinimapSide: "right" });
+    if (persisted === null) throw new Error("expected persisted settings");
+    window.localStorage.setItem("traycer-gui-app:settings", persisted);
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().chatTurnMinimapSide).toBe("left");
+  });
+
+  it("repairs an invalid persisted chat turn minimap side to right", async () => {
+    window.localStorage.setItem(
+      "traycer-gui-app:settings",
+      JSON.stringify({
+        state: { chatTurnMinimapSide: "top" },
+        version: 1,
+      }),
+    );
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().chatTurnMinimapSide).toBe("right");
   });
 
   it("updates the global artifact icon color mode", () => {

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -32,6 +32,7 @@ import { worktreeBranchPrefixError } from "@/lib/worktree/worktree-branch-prefix
 
 export type ThemeMode = "system" | "light" | "dark";
 export type EpicNodeIconColorMode = "byType" | "none";
+export type ChatTurnMinimapSide = "left" | "right";
 // Mirrors xterm's `cursorStyle` union; kept as our own type so the settings
 // surface doesn't take a value import from `@xterm/xterm`.
 export type TerminalCursorStyle = "block" | "bar" | "underline";
@@ -86,6 +87,8 @@ export interface SettingsState {
    * reliable context-window data still render nothing.
    */
   pinContextUsageBreakdown: boolean;
+  /** Side of the transcript used by the turn minimap. */
+  chatTurnMinimapSide: ChatTurnMinimapSide;
   pointerCursors: boolean;
   uiFontSize: number;
   codeFontSize: number;
@@ -149,6 +152,7 @@ export interface SettingsState {
   setShowGlobalResourceMonitor: (value: boolean) => void;
   setShowNavigatorResourceStats: (value: boolean) => void;
   setPinContextUsageBreakdown: (value: boolean) => void;
+  setChatTurnMinimapSide: (value: ChatTurnMinimapSide) => void;
   setPointerCursors: (value: boolean) => void;
   setUiFontSize: (value: number) => void;
   setCodeFontSize: (value: number) => void;
@@ -185,6 +189,7 @@ type PersistedSettingsState = Pick<
   | "showGlobalResourceMonitor"
   | "showNavigatorResourceStats"
   | "pinContextUsageBreakdown"
+  | "chatTurnMinimapSide"
   | "pointerCursors"
   | "uiFontSize"
   | "codeFontSize"
@@ -253,6 +258,7 @@ function partializeSettingsState(state: SettingsState): PersistedSettingsState {
     showGlobalResourceMonitor: state.showGlobalResourceMonitor,
     showNavigatorResourceStats: state.showNavigatorResourceStats,
     pinContextUsageBreakdown: state.pinContextUsageBreakdown,
+    chatTurnMinimapSide: state.chatTurnMinimapSide,
     pointerCursors: state.pointerCursors,
     uiFontSize: state.uiFontSize,
     codeFontSize: state.codeFontSize,
@@ -289,6 +295,7 @@ export const useSettingsStore = create<SettingsState>()(
       showGlobalResourceMonitor: true,
       showNavigatorResourceStats: false,
       pinContextUsageBreakdown: false,
+      chatTurnMinimapSide: "right",
       pointerCursors: true,
       uiFontSize: DEFAULT_UI_FONT_SIZE,
       codeFontSize: DEFAULT_CODE_FONT_SIZE,
@@ -321,6 +328,7 @@ export const useSettingsStore = create<SettingsState>()(
         "showNavigatorResourceStats",
       ),
       setPinContextUsageBreakdown: makeSetter(set, "pinContextUsageBreakdown"),
+      setChatTurnMinimapSide: makeSetter(set, "chatTurnMinimapSide"),
       setPointerCursors: makeSetter(set, "pointerCursors"),
       setUiFontSize: makeClampedFontSizeSetter(
         set,
@@ -397,6 +405,7 @@ export const useSettingsStore = create<SettingsState>()(
         const persisted: Record<string, unknown> = isRecord(persistedState)
           ? persistedState
           : {};
+        const persistedMinimapSide = persisted.chatTurnMinimapSide;
         const merged: SettingsState = { ...currentState, ...persisted };
         return {
           ...merged,
@@ -405,6 +414,10 @@ export const useSettingsStore = create<SettingsState>()(
             worktreeBranchPrefixError(merged.worktreeBranchPrefix) === null
               ? merged.worktreeBranchPrefix
               : DEFAULT_WORKTREE_BRANCH_PREFIX,
+          chatTurnMinimapSide:
+            persistedMinimapSide === "left" || persistedMinimapSide === "right"
+              ? persistedMinimapSide
+              : currentState.chatTurnMinimapSide,
         };
       },
     },

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -39,6 +39,7 @@ export type TerminalCursorStyle = "block" | "bar" | "underline";
 
 export const DEFAULT_TERMINAL_CURSOR_STYLE: TerminalCursorStyle = "block";
 export const DEFAULT_TERMINAL_CURSOR_BLINK = true;
+export const DEFAULT_CHAT_TURN_MINIMAP_SIDE: ChatTurnMinimapSide = "right";
 
 // Shape drawn when the terminal loses focus (xterm's `cursorInactiveStyle`,
 // which never blinks). Bar/underline mirror the chosen shape so the cursor
@@ -295,7 +296,7 @@ export const useSettingsStore = create<SettingsState>()(
       showGlobalResourceMonitor: true,
       showNavigatorResourceStats: false,
       pinContextUsageBreakdown: false,
-      chatTurnMinimapSide: "right",
+      chatTurnMinimapSide: DEFAULT_CHAT_TURN_MINIMAP_SIDE,
       pointerCursors: true,
       uiFontSize: DEFAULT_UI_FONT_SIZE,
       codeFontSize: DEFAULT_CODE_FONT_SIZE,
@@ -417,7 +418,7 @@ export const useSettingsStore = create<SettingsState>()(
           chatTurnMinimapSide:
             persistedMinimapSide === "left" || persistedMinimapSide === "right"
               ? persistedMinimapSide
-              : currentState.chatTurnMinimapSide,
+              : DEFAULT_CHAT_TURN_MINIMAP_SIDE,
         };
       },
     },

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -33,13 +33,14 @@ import { worktreeBranchPrefixError } from "@/lib/worktree/worktree-branch-prefix
 export type ThemeMode = "system" | "light" | "dark";
 export type EpicNodeIconColorMode = "byType" | "none";
 export type ChatTurnMinimapSide = "left" | "right";
+export type ChatTurnMinimapPlacement = ChatTurnMinimapSide | "hide";
 // Mirrors xterm's `cursorStyle` union; kept as our own type so the settings
 // surface doesn't take a value import from `@xterm/xterm`.
 export type TerminalCursorStyle = "block" | "bar" | "underline";
 
 export const DEFAULT_TERMINAL_CURSOR_STYLE: TerminalCursorStyle = "block";
 export const DEFAULT_TERMINAL_CURSOR_BLINK = true;
-export const DEFAULT_CHAT_TURN_MINIMAP_SIDE: ChatTurnMinimapSide = "right";
+export const DEFAULT_CHAT_TURN_MINIMAP_SIDE: ChatTurnMinimapPlacement = "right";
 
 // Shape drawn when the terminal loses focus (xterm's `cursorInactiveStyle`,
 // which never blinks). Bar/underline mirror the chosen shape so the cursor
@@ -88,8 +89,8 @@ export interface SettingsState {
    * reliable context-window data still render nothing.
    */
   pinContextUsageBreakdown: boolean;
-  /** Side of the transcript used by the turn minimap. */
-  chatTurnMinimapSide: ChatTurnMinimapSide;
+  /** Transcript edge used by the turn minimap, or `hide` to disable it. */
+  chatTurnMinimapSide: ChatTurnMinimapPlacement;
   pointerCursors: boolean;
   uiFontSize: number;
   codeFontSize: number;
@@ -153,7 +154,7 @@ export interface SettingsState {
   setShowGlobalResourceMonitor: (value: boolean) => void;
   setShowNavigatorResourceStats: (value: boolean) => void;
   setPinContextUsageBreakdown: (value: boolean) => void;
-  setChatTurnMinimapSide: (value: ChatTurnMinimapSide) => void;
+  setChatTurnMinimapSide: (value: ChatTurnMinimapPlacement) => void;
   setPointerCursors: (value: boolean) => void;
   setUiFontSize: (value: number) => void;
   setCodeFontSize: (value: number) => void;
@@ -416,7 +417,9 @@ export const useSettingsStore = create<SettingsState>()(
               ? merged.worktreeBranchPrefix
               : DEFAULT_WORKTREE_BRANCH_PREFIX,
           chatTurnMinimapSide:
-            persistedMinimapSide === "left" || persistedMinimapSide === "right"
+            persistedMinimapSide === "left" ||
+            persistedMinimapSide === "right" ||
+            persistedMinimapSide === "hide"
               ? persistedMinimapSide
               : DEFAULT_CHAT_TURN_MINIMAP_SIDE,
         };


### PR DESCRIPTION
## Summary

- restore and refine the chat turn minimap with configurable side placement, compact activation targets, expanded previews, and accessible fold controls
- highlight the nearest query on the proximity rail without React rerenders or per-item allocations
- harden inactive-pane focus ownership, portal click handling, terminal find, and model-picker interactions
- add regression coverage for minimap behavior and pane activation flows

## Related issue

None.

## Checklist

- [x] Affected build, lint, format, and compile checks pass through pre-commit
- [ ] Full tests pass in CI
- [x] Tests added/updated where it makes sense
- [x] Commit is signed off for DCO