### PR TITLE
fix(desktop): relay foreground notifications safely

### DIFF
--- a/clients/desktop/src/electron-main/__tests__/notifications.test.ts
+++ b/clients/desktop/src/electron-main/__tests__/notifications.test.ts
@@ -35,7 +35,22 @@ class FakeNotification {
   }
 }
 
+class FakeBrowserWindow {
+  static windows: Array<{
+    readonly destroyed: boolean;
+    readonly focused: boolean;
+  }> = [];
+
+  static getAllWindows() {
+    return FakeBrowserWindow.windows.map((window) => ({
+      isDestroyed: () => window.destroyed,
+      isFocused: () => window.focused,
+    }));
+  }
+}
+
 vi.mock("electron", () => ({
+  BrowserWindow: FakeBrowserWindow,
   Notification: FakeNotification,
 }));
 
@@ -47,6 +62,7 @@ vi.mock("../app/logger", () => ({
 }));
 
 beforeEach(() => {
+  FakeBrowserWindow.windows = [];
   FakeNotification.supported = true;
   FakeNotification.instances = [];
   vi.useFakeTimers();
@@ -69,10 +85,93 @@ function showOptions(replaceKey: string) {
     replaceKey,
     deliveryKey: null,
     onClick: null,
+    onForegroundSuppressed: null,
   };
 }
 
 describe("showNativeNotification", () => {
+  it("suppresses the OS notification when any live Traycer window is focused", async () => {
+    const { showNativeNotification } = await loadNotifications();
+    const onForegroundSuppressed = vi.fn();
+    FakeBrowserWindow.windows = [
+      { destroyed: false, focused: false },
+      { destroyed: false, focused: true },
+    ];
+
+    showNativeNotification({
+      ...showOptions("host:chat:chat-1"),
+      onForegroundSuppressed,
+    });
+
+    expect(FakeNotification.instances).toHaveLength(0);
+    expect(onForegroundSuppressed).toHaveBeenCalledOnce();
+  });
+
+  it("does not replay a foreground-suppressed delivery after the app loses focus", async () => {
+    const { showNativeNotification } = await loadNotifications();
+    const options = {
+      ...showOptions("host:chat:chat-1"),
+      deliveryKey: "user-1:notification-1:10",
+    };
+    FakeBrowserWindow.windows = [{ destroyed: false, focused: true }];
+    showNativeNotification(options);
+
+    FakeBrowserWindow.windows = [{ destroyed: false, focused: false }];
+    showNativeNotification(options);
+
+    expect(FakeNotification.instances).toHaveLength(0);
+  });
+
+  it("does not commit an exact delivery key when the foreground relay fails", async () => {
+    const { showNativeNotification } = await loadNotifications();
+    const options = {
+      ...showOptions("host:chat:chat-1"),
+      deliveryKey: "user-1:notification-1:10",
+      onForegroundSuppressed: () => {
+        throw new Error("focused renderer unavailable");
+      },
+    };
+    FakeBrowserWindow.windows = [{ destroyed: false, focused: true }];
+
+    expect(() => showNativeNotification(options)).toThrow(
+      "focused renderer unavailable",
+    );
+
+    FakeBrowserWindow.windows = [{ destroyed: false, focused: false }];
+    showNativeNotification({
+      ...options,
+      onForegroundSuppressed: null,
+    });
+
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0]?.show).toHaveBeenCalledOnce();
+  });
+
+  it("closes a stale same-key notification when its replacement is foreground-suppressed", async () => {
+    const { showNativeNotification } = await loadNotifications();
+    showNativeNotification(showOptions("host:chat:chat-1"));
+    const stale = FakeNotification.instances[0];
+
+    FakeBrowserWindow.windows = [{ destroyed: false, focused: true }];
+    showNativeNotification(showOptions("host:chat:chat-1"));
+
+    expect(stale.close).toHaveBeenCalledOnce();
+    expect(FakeNotification.instances).toHaveLength(1);
+  });
+
+  it("shows the OS notification when no live Traycer window is focused", async () => {
+    const { showNativeNotification } = await loadNotifications();
+    FakeBrowserWindow.windows = [
+      { destroyed: false, focused: false },
+      { destroyed: true, focused: true },
+    ];
+
+    showNativeNotification(showOptions("host:chat:chat-1"));
+
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0]?.show).toHaveBeenCalledOnce();
+  });
+
   it("closes the prior notification before showing a same-key replacement", async () => {
     const { showNativeNotification } = await loadNotifications();
 
@@ -113,16 +212,17 @@ describe("showNativeNotification", () => {
     expect(second.close).toHaveBeenCalledOnce();
   });
 
-  it("evicts a replacement mapping after its TTL without closing the notification", async () => {
-    const { NOTIFICATION_REPLACE_TTL_MS, showNativeNotification } =
-      await loadNotifications();
+  it("closes an aged notification when its same-key replacement is foreground-suppressed", async () => {
+    const { showNativeNotification } = await loadNotifications();
 
     showNativeNotification(showOptions("host:chat:chat-1"));
     const first = FakeNotification.instances[0];
-    vi.advanceTimersByTime(NOTIFICATION_REPLACE_TTL_MS);
+    vi.advanceTimersByTime(10 * 60_000);
+    FakeBrowserWindow.windows = [{ destroyed: false, focused: true }];
     showNativeNotification(showOptions("host:chat:chat-1"));
 
-    expect(first.close).not.toHaveBeenCalled();
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(FakeNotification.instances).toHaveLength(1);
   });
 
   it("evicts capacity bookkeeping without closing unrelated notifications", async () => {

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -3047,6 +3047,64 @@ describe("RunnerIpcBridge", () => {
     bridge.dispose();
   });
 
+  it("relays a background renderer notification to the focused renderer only", async () => {
+    const mod = await import("../register-runner-ipc");
+    const registry = new FakeWindowRegistry();
+    const focusedWindow = buildWindow();
+    const backgroundWindow = buildWindow();
+    registry.add("window-focused", 101, focusedWindow);
+    registry.add("window-background", 202, backgroundWindow);
+    focusedWindow.setFocused(true);
+    const bridge = new mod.RunnerIpcBridge({
+      host: new FakeHost(),
+      hostController: new FakeHostController(),
+      authnBaseUrl: "http://localhost:5005",
+      authRedirectUri: null,
+      tray: null,
+      zoomController: undefined,
+      authTokenStore: undefined,
+      windowRegistry: registry,
+      ownership: new EpicWindowOwnership(null),
+      perWindowState: new PerWindowState(null),
+      authSession: new DesktopAuthSession(),
+      quitState: undefined,
+    });
+    const display = {
+      title: "Traycer",
+      body: "Background agent failed",
+      payload: null,
+      replaceKey: "app-local:host.error:failure-1",
+      deliveryKey: "user-1:host.error:failure-1:40",
+      foregroundAppLocal: {
+        userId: "user-1",
+        entry: { id: "host.error:failure-1", updatedAt: 40 },
+      },
+    };
+
+    expect(bridge.deliverForegroundNotificationDisplay(202, display)).toBe(
+      true,
+    );
+
+    expect(focusedWindow.sentMessages).toEqual([
+      {
+        channel: RunnerHostEvent.notificationForegroundDisplay,
+        payload: display,
+      },
+    ]);
+    expect(backgroundWindow.sentMessages).toEqual([]);
+
+    expect(bridge.deliverForegroundNotificationDisplay(101, display)).toBe(
+      true,
+    );
+    expect(focusedWindow.sentMessages).toHaveLength(1);
+
+    focusedWindow.setFocused(false);
+    expect(bridge.deliverForegroundNotificationDisplay(202, display)).toBe(
+      false,
+    );
+    bridge.dispose();
+  });
+
   it("routes a chat notification click to the window that already has the chat open, not MRU", async () => {
     const mod = await import("../register-runner-ipc");
     const registry = new FakeWindowRegistry();

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -3102,6 +3102,15 @@ describe("RunnerIpcBridge", () => {
     expect(bridge.deliverForegroundNotificationDisplay(202, display)).toBe(
       false,
     );
+
+    const destroyedFocusedWindow = buildWindowWithDestroyed(true);
+    destroyedFocusedWindow.setFocused(true);
+    registry.add("window-destroyed", 303, destroyedFocusedWindow);
+
+    expect(bridge.deliverForegroundNotificationDisplay(202, display)).toBe(
+      false,
+    );
+    expect(destroyedFocusedWindow.sentMessages).toEqual([]);
     bridge.dispose();
   });
 

--- a/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
+++ b/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
@@ -36,6 +36,7 @@ import type {
   SupportSubmitReportResult,
   WindowSummary,
 } from "../../ipc-contracts/window-types";
+import type { DesktopNotificationForegroundDisplay } from "../../ipc-contracts/notification-types";
 import type {
   CredentialsMigrationOutcome,
   StoredAuthTokens,
@@ -597,6 +598,35 @@ export class RunnerIpcBridge {
       RunnerHostEvent.notificationClick,
       payload,
     );
+  }
+
+  /**
+   * Relays a renderer-owned notification to the focused renderer when the
+   * emitter lives in another window. The originating renderer already drew
+   * its own toast, so same-window focus needs no duplicate delivery.
+   */
+  deliverForegroundNotificationDisplay(
+    senderWebContentsId: number | null,
+    display: DesktopNotificationForegroundDisplay,
+  ): boolean {
+    const focused = this.windowRegistry
+      .records()
+      .find(
+        (record) => !record.window.isDestroyed() && record.window.isFocused(),
+      );
+    if (focused === undefined) return false;
+    if (focused.webContentsId === senderWebContentsId) return true;
+    const delivered = this.safeSendToWindow(
+      focused.windowId,
+      RunnerHostEvent.notificationForegroundDisplay,
+      display,
+    );
+    if (!delivered) {
+      log.warn("[runner-ipc] foreground notification relay failed", {
+        windowId: focused.windowId,
+      });
+    }
+    return delivered;
   }
 
   /**

--- a/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
+++ b/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
@@ -609,12 +609,8 @@ export class RunnerIpcBridge {
     senderWebContentsId: number | null,
     display: DesktopNotificationForegroundDisplay,
   ): boolean {
-    const focused = this.windowRegistry
-      .records()
-      .find(
-        (record) => !record.window.isDestroyed() && record.window.isFocused(),
-      );
-    if (focused === undefined) return false;
+    const focused = this.findFocusedLiveRecord();
+    if (focused === null) return false;
     if (focused.webContentsId === senderWebContentsId) return true;
     const delivered = this.safeSendToWindow(
       focused.windowId,
@@ -1063,18 +1059,24 @@ export class RunnerIpcBridge {
   private resolveRendererHostedCommandTarget(
     command: MenuCommandId,
   ): IpcWindowRecord | null {
-    const focused = this.windowRegistry
-      .records()
-      .find(
-        (record) => record.window.isFocused() && !record.window.isDestroyed(),
-      );
-    if (focused !== undefined) {
+    const focused = this.findFocusedLiveRecord();
+    if (focused !== null) {
       return focused;
     }
     if (isMruFallbackMenuCommand(command)) {
       return this.windowRegistry.getMruRecord();
     }
     return null;
+  }
+
+  private findFocusedLiveRecord(): IpcWindowRecord | null {
+    return (
+      this.windowRegistry
+        .records()
+        .find(
+          (record) => !record.window.isDestroyed() && record.window.isFocused(),
+        ) ?? null
+    );
   }
 
   pruneClosedWindowState(): void {

--- a/clients/desktop/src/electron-main/ipc/support-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/support-ipc.ts
@@ -26,6 +26,10 @@ import type {
   SupportReportType,
   SupportSubmitReportRequest,
 } from "../../ipc-contracts/window-types";
+import type {
+  DesktopNotificationForegroundAppLocal,
+  DesktopNotificationForegroundDisplay,
+} from "../../ipc-contracts/notification-types";
 import {
   MAX_REPORT_IMAGE_BYTES,
   MAX_REPORT_IMAGES,
@@ -104,12 +108,13 @@ export function registerSupportIpc(bridge: RunnerIpcBridge): void {
   bridge.handleInvoke(
     RunnerHostInvoke.notificationShow,
     async (
-      _event,
+      event,
       title: unknown,
       body: unknown,
       payload: unknown,
       replaceKey: unknown,
       deliveryKey: unknown,
+      foregroundAppLocal: unknown,
     ) => {
       assertString(title, "notifications.show");
       assertString(body, "notifications.show");
@@ -121,12 +126,33 @@ export function registerSupportIpc(bridge: RunnerIpcBridge): void {
       if (deliveryKey !== null && typeof deliveryKey !== "string") {
         throw new Error("notifications.show requires a delivery key or null");
       }
+      const parsedForegroundAppLocal =
+        parseForegroundAppLocal(foregroundAppLocal);
+      const foregroundDisplay: DesktopNotificationForegroundDisplay = {
+        title,
+        body,
+        payload,
+        replaceKey,
+        deliveryKey,
+        foregroundAppLocal: parsedForegroundAppLocal,
+      };
       showNativeNotification({
         title,
         body,
         replaceKey,
         deliveryKey,
         onClick: () => bridge.deliverNotificationClick(payload),
+        onForegroundSuppressed: () => {
+          const delivered = bridge.deliverForegroundNotificationDisplay(
+            readSenderWebContentsId(event),
+            foregroundDisplay,
+          );
+          if (!delivered) {
+            throw new Error(
+              "notifications.show could not reach the focused renderer",
+            );
+          }
+        },
       });
     },
   );
@@ -230,6 +256,27 @@ export function registerSupportIpc(bridge: RunnerIpcBridge): void {
       );
     },
   );
+}
+
+function parseForegroundAppLocal(
+  value: unknown,
+): DesktopNotificationForegroundAppLocal | null {
+  if (value === null) return null;
+  if (
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !("userId" in value) ||
+    typeof value.userId !== "string" ||
+    !("entry" in value)
+  ) {
+    throw new Error(
+      "notifications.show requires foreground app-local context or null",
+    );
+  }
+  return {
+    userId: value.userId,
+    entry: value.entry,
+  };
 }
 
 // A draftId is only unique within one renderer realm (`desktop-dialog-store`

--- a/clients/desktop/src/electron-main/notifications.ts
+++ b/clients/desktop/src/electron-main/notifications.ts
@@ -1,7 +1,6 @@
-import { Notification } from "electron";
+import { BrowserWindow, Notification } from "electron";
 import { log } from "./app/logger";
 
-export const NOTIFICATION_REPLACE_TTL_MS = 60_000;
 const MAX_REPLACEABLE_NOTIFICATIONS = 100;
 const MAX_DELIVERED_NOTIFICATION_KEYS = 5_000;
 const replaceableNotifications = new Map<string, Notification>();
@@ -13,12 +12,14 @@ export interface NativeNotificationOptions {
   readonly replaceKey: string | null;
   readonly deliveryKey: string | null;
   readonly onClick: (() => void) | null;
+  readonly onForegroundSuppressed: (() => void) | null;
 }
 
 /**
- * Shows a native notification. A replacement key groups notifications that
- * describe the same entity: a newer notification closes and re-alerts over
- * the prior one instead of leaving a stack in the OS notification center.
+ * Shows a native notification when every Traycer window is unfocused. A
+ * replacement key groups notifications that describe the same entity: a newer
+ * notification closes and re-alerts over the prior one instead of leaving a
+ * stack in the OS notification center.
  */
 export function showNativeNotification(
   options: NativeNotificationOptions,
@@ -27,6 +28,19 @@ export function showNativeNotification(
     options.deliveryKey !== null &&
     deliveredNotificationKeys.has(options.deliveryKey)
   ) {
+    return;
+  }
+  if (
+    BrowserWindow.getAllWindows().some(
+      (window) => !window.isDestroyed() && window.isFocused(),
+    )
+  ) {
+    closeReplacement(options.replaceKey);
+    options.onForegroundSuppressed?.();
+    // Foreground suppression is an intentional delivery outcome. Remember an
+    // exact key so another renderer cannot replay the same event after focus
+    // changes; the suppression callback relays it to the foreground renderer.
+    rememberDeliveredNotificationKey(options.deliveryKey);
     return;
   }
   if (!Notification.isSupported()) {
@@ -54,10 +68,6 @@ export function showNativeNotification(
     notification.on("click", () => {
       deleteReplacementIfCurrent(replaceKey, notification);
     });
-    setTimeout(() => {
-      if (replaceableNotifications.get(replaceKey) !== notification) return;
-      replaceableNotifications.delete(replaceKey);
-    }, NOTIFICATION_REPLACE_TTL_MS);
   }
 
   if (options.onClick !== null) {
@@ -65,6 +75,14 @@ export function showNativeNotification(
   }
   notification.show();
   rememberDeliveredNotificationKey(options.deliveryKey);
+}
+
+function closeReplacement(replaceKey: string | null): void {
+  if (replaceKey === null) return;
+  const priorNotification = replaceableNotifications.get(replaceKey);
+  if (priorNotification === undefined) return;
+  replaceableNotifications.delete(replaceKey);
+  priorNotification.close();
 }
 
 function rememberDeliveredNotificationKey(deliveryKey: string | null): void {
@@ -80,9 +98,10 @@ function rememberDeliveredNotificationKey(deliveryKey: string | null): void {
 }
 
 /**
- * Releases bookkeeping for platforms that do not report notification closes.
- * It deliberately does not dismiss native notifications; once an entry ages
- * out, a later same-key notification may stack rather than replace it.
+ * Bounds bookkeeping for platforms that do not report notification closes.
+ * It deliberately does not dismiss native notifications; once capacity is
+ * reached, a later same-key notification may stack rather than replace the
+ * oldest forgotten entry.
  */
 function evictReplaceableNotifications(): void {
   while (replaceableNotifications.size >= MAX_REPLACEABLE_NOTIFICATIONS) {
@@ -119,6 +138,7 @@ export function showSimpleNotification(
     replaceKey: null,
     deliveryKey: null,
     onClick,
+    onForegroundSuppressed: null,
   });
 }
 

--- a/clients/desktop/src/electron-preload/__tests__/preload-bridge.test.ts
+++ b/clients/desktop/src/electron-preload/__tests__/preload-bridge.test.ts
@@ -5,6 +5,7 @@ import {
   RunnerHostSync,
 } from "../../ipc-contracts/ipc-channels";
 import type { AuthIdentityValidationResult } from "@traycer-clients/shared/auth/auth-validation-types";
+import type { DesktopNotificationForegroundDisplay } from "../../ipc-contracts/notification-types";
 
 /**
  * Preload replay-safety tests. The preload module wires `ipcRenderer.on` and
@@ -141,6 +142,11 @@ interface PreloadBridge {
   verifyStepUpChallenge(bearerToken: string, code: string): Promise<unknown>;
   onAuthCallback(handler: () => void): {
     dispose: () => void;
+  };
+  notifications: {
+    onForegroundDisplay(
+      handler: (display: DesktopNotificationForegroundDisplay) => void,
+    ): { dispose: () => void };
   };
   tokenStore: {
     get(): Promise<string | null>;
@@ -321,6 +327,55 @@ describe("preload auth-callback replay", () => {
 
     fakeElectron.emit(RunnerHostEvent.authCallback, undefined);
     expect(observed).toBe(1);
+  });
+});
+
+describe("preload foreground-notification buffering", () => {
+  beforeEach(() => {
+    fakeElectron.reset();
+  });
+
+  afterEach(() => {
+    fakeElectron.reset();
+  });
+
+  it("delivers a notification received before GUI subscription exactly once", async () => {
+    const bridge = await loadPreload({
+      authnApiUrl: undefined,
+      desktopDev: undefined,
+      initialRouteArg: undefined,
+      invokeFn: undefined,
+      sendSyncFn: undefined,
+    });
+    const display: DesktopNotificationForegroundDisplay = {
+      title: "Traycer",
+      body: "Background agent failed",
+      payload: null,
+      replaceKey: "app-local:host.error:failure-1",
+      deliveryKey: "user-1:host.error:failure-1:40",
+      foregroundAppLocal: {
+        userId: "user-1",
+        entry: { id: "host.error:failure-1", updatedAt: 40 },
+      },
+    };
+
+    fakeElectron.emit(RunnerHostEvent.notificationForegroundDisplay, display);
+
+    const observed: DesktopNotificationForegroundDisplay[] = [];
+    const first = bridge.notifications.onForegroundDisplay((value) => {
+      observed.push(value);
+    });
+    expect(observed).toEqual([display]);
+    first.dispose();
+
+    const second = bridge.notifications.onForegroundDisplay((value) => {
+      observed.push(value);
+    });
+    expect(observed).toEqual([display]);
+
+    fakeElectron.emit(RunnerHostEvent.notificationForegroundDisplay, display);
+    expect(observed).toEqual([display, display]);
+    second.dispose();
   });
 });
 

--- a/clients/desktop/src/electron-preload/__tests__/preload-bridge.test.ts
+++ b/clients/desktop/src/electron-preload/__tests__/preload-bridge.test.ts
@@ -377,6 +377,42 @@ describe("preload foreground-notification buffering", () => {
     expect(observed).toEqual([display, display]);
     second.dispose();
   });
+
+  it("logs each oldest display dropped when the preload buffer is full", async () => {
+    const bridge = await loadPreload({
+      authnApiUrl: undefined,
+      desktopDev: undefined,
+      initialRouteArg: undefined,
+      invokeFn: undefined,
+      sendSyncFn: undefined,
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    for (let index = 0; index < 21; index++) {
+      fakeElectron.emit(RunnerHostEvent.notificationForegroundDisplay, {
+        title: "Traycer",
+        body: `Background agent ${index} failed`,
+        payload: null,
+        replaceKey: null,
+        deliveryKey: `user-1:failure-${index}`,
+        foregroundAppLocal: null,
+      });
+    }
+
+    expect(warn).toHaveBeenCalledWith(
+      "[preload] dropped buffered foreground notification display",
+      { deliveryKey: "user-1:failure-0" },
+    );
+    warn.mockRestore();
+
+    const observed: DesktopNotificationForegroundDisplay[] = [];
+    const subscription = bridge.notifications.onForegroundDisplay((display) => {
+      observed.push(display);
+    });
+    expect(observed).toHaveLength(20);
+    expect(observed[0]?.deliveryKey).toBe("user-1:failure-1");
+    subscription.dispose();
+  });
 });
 
 describe("preload host-management mutation invokes", () => {

--- a/clients/desktop/src/electron-preload/support-bridge.ts
+++ b/clients/desktop/src/electron-preload/support-bridge.ts
@@ -46,7 +46,11 @@ function createForegroundNotificationDisplayChannel(): ForegroundNotificationDis
       const display = payload as DesktopNotificationForegroundDisplay;
       if (handlers.size === 0) {
         if (buffered.length >= MAX_BUFFERED_FOREGROUND_NOTIFICATION_DISPLAYS) {
-          buffered.shift();
+          const dropped = buffered.shift();
+          console.warn(
+            "[preload] dropped buffered foreground notification display",
+            { deliveryKey: dropped?.deliveryKey ?? null },
+          );
         }
         buffered.push(display);
         return;

--- a/clients/desktop/src/electron-preload/support-bridge.ts
+++ b/clients/desktop/src/electron-preload/support-bridge.ts
@@ -17,7 +17,61 @@ import type {
   SupportSubmitReportRequest,
   SupportSubmitReportResult,
 } from "../ipc-contracts/window-types";
+import type {
+  DesktopNotificationForegroundAppLocal,
+  DesktopNotificationForegroundDisplay,
+} from "../ipc-contracts/notification-types";
 import { subscribe, type Disposable, type Listener } from "./subscribe";
+
+const MAX_BUFFERED_FOREGROUND_NOTIFICATION_DISPLAYS = 20;
+
+interface ForegroundNotificationDisplayChannel {
+  subscribe(
+    handler: Listener<DesktopNotificationForegroundDisplay>,
+  ): Disposable;
+}
+
+/**
+ * Installs the main -> preload listener as soon as the bridge is built, before
+ * React can mount. Events that arrive during renderer startup/reload are kept
+ * until the first GUI subscriber is ready, then delivered exactly once.
+ */
+function createForegroundNotificationDisplayChannel(): ForegroundNotificationDisplayChannel {
+  const handlers = new Set<Listener<DesktopNotificationForegroundDisplay>>();
+  const buffered: DesktopNotificationForegroundDisplay[] = [];
+
+  ipcRenderer.on(
+    RunnerHostEvent.notificationForegroundDisplay,
+    (_event: unknown, payload: unknown): void => {
+      const display = payload as DesktopNotificationForegroundDisplay;
+      if (handlers.size === 0) {
+        if (buffered.length >= MAX_BUFFERED_FOREGROUND_NOTIFICATION_DISPLAYS) {
+          buffered.shift();
+        }
+        buffered.push(display);
+        return;
+      }
+      for (const handler of handlers) {
+        handler(display);
+      }
+    },
+  );
+
+  return {
+    subscribe: (handler) => {
+      handlers.add(handler);
+      const pending = buffered.splice(0);
+      for (const display of pending) {
+        handler(display);
+      }
+      return {
+        dispose: () => {
+          handlers.delete(handler);
+        },
+      };
+    },
+  };
+}
 
 export interface SupportBridgeSurface {
   openExternalLink(url: string): Promise<void>;
@@ -33,8 +87,12 @@ export interface SupportBridgeSurface {
       payload: unknown,
       replaceKey: string | null,
       deliveryKey: string | null,
+      foregroundAppLocal: DesktopNotificationForegroundAppLocal | null,
     ): Promise<void>;
     onClick(handler: Listener<unknown>): Disposable;
+    onForegroundDisplay(
+      handler: Listener<DesktopNotificationForegroundDisplay>,
+    ): Disposable;
   };
   workspaceFolders: {
     pickFolders(): Promise<readonly string[]>;
@@ -69,6 +127,8 @@ export interface SupportBridgeSurface {
 }
 
 export function buildSupportBridge(): SupportBridgeSurface {
+  const foregroundNotificationDisplays =
+    createForegroundNotificationDisplayChannel();
   return {
     openExternalLink: (url) =>
       ipcRenderer.invoke(RunnerHostInvoke.openExternalLink, url),
@@ -88,7 +148,14 @@ export function buildSupportBridge(): SupportBridgeSurface {
       ipcRenderer.invoke(RunnerHostInvoke.openMicrophoneSettings),
 
     notifications: {
-      show: (title, body, payload, replaceKey, deliveryKey) =>
+      show: (
+        title,
+        body,
+        payload,
+        replaceKey,
+        deliveryKey,
+        foregroundAppLocal,
+      ) =>
         ipcRenderer.invoke(
           RunnerHostInvoke.notificationShow,
           title,
@@ -96,9 +163,12 @@ export function buildSupportBridge(): SupportBridgeSurface {
           payload,
           replaceKey,
           deliveryKey,
+          foregroundAppLocal,
         ),
       onClick: (handler) =>
         subscribe<unknown>(RunnerHostEvent.notificationClick, handler),
+      onForegroundDisplay: (handler) =>
+        foregroundNotificationDisplays.subscribe(handler),
     },
 
     workspaceFolders: {

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -256,6 +256,8 @@ export const RunnerHostEvent = {
   // ~60s heartbeat. No payload: it is a pure "the machine just woke" signal.
   systemResumed: "runnerHost:event:systemResumed",
   notificationClick: "runnerHost:event:notificationClick",
+  notificationForegroundDisplay:
+    "runnerHost:event:notificationForegroundDisplay",
   trayEpicSelected: "runnerHost:event:trayEpicSelected",
   hostPickerChange: "runnerHost:event:hostPickerChange",
   quitRequested: "runnerHost:event:quitRequested",

--- a/clients/desktop/src/ipc-contracts/notification-types.ts
+++ b/clients/desktop/src/ipc-contracts/notification-types.ts
@@ -1,0 +1,14 @@
+/** Plain-data notification projection relayed main -> focused renderer. */
+export interface DesktopNotificationForegroundAppLocal {
+  readonly userId: string;
+  readonly entry: unknown;
+}
+
+export interface DesktopNotificationForegroundDisplay {
+  readonly title: string;
+  readonly body: string;
+  readonly payload: unknown;
+  readonly replaceKey: string | null;
+  readonly deliveryKey: string | null;
+  readonly foregroundAppLocal: DesktopNotificationForegroundAppLocal | null;
+}

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -116,6 +116,7 @@ function buildFakeBridge(
     },
     notifications: {
       show: async () => undefined,
+      onForegroundDisplay: () => ({ dispose: () => undefined }),
       onClick: (_handler: (payload: unknown) => void) => ({
         dispose: () => undefined,
       }),

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -20,6 +20,8 @@ import type {
   HostRestartRequestResult,
   InstallVersionOk,
   MutationOutcome,
+  NotificationForegroundAppLocal,
+  NotificationForegroundDisplay,
   ServiceRegistrationOk,
   TraycerUninstallResult,
   FreePortAndRestartInput,
@@ -174,8 +176,12 @@ export interface DesktopPreloadBridge {
       payload: unknown,
       replaceKey: string | null,
       deliveryKey: string | null,
+      foregroundAppLocal: NotificationForegroundAppLocal | null,
     ): Promise<void>;
     onClick(handler: (payload: unknown) => void): { dispose: () => void };
+    onForegroundDisplay(
+      handler: (display: NotificationForegroundDisplay) => void,
+    ): { dispose: () => void };
   };
   onLocalHostChange(handler: (snapshot: LocalHostSnapshot | null) => void): {
     dispose: () => void;
@@ -624,16 +630,26 @@ export class DesktopRunnerHost implements IRunnerHost {
     this.tokenStore = options.bridge.tokenStore;
 
     this.notifications = {
-      show: (title, body, payload, replaceKey, deliveryKey) =>
+      show: (
+        title,
+        body,
+        payload,
+        replaceKey,
+        deliveryKey,
+        foregroundAppLocal,
+      ) =>
         this.bridge.notifications.show(
           title,
           body,
           payload,
           replaceKey,
           deliveryKey,
+          foregroundAppLocal,
         ),
       onClick: (handler) =>
         toDisposable(this.bridge.notifications.onClick(handler)),
+      onForegroundDisplay: (handler) =>
+        toDisposable(this.bridge.notifications.onForegroundDisplay(handler)),
     };
 
     this.tray = {

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -320,6 +320,7 @@ function createBaseRunnerHost(): IRunnerHost {
     },
     notifications: {
       show: () => Promise.resolve(),
+      onForegroundDisplay: () => ({ dispose: () => undefined }),
       onClick: () => ({ dispose: () => undefined }),
     },
     tray: {

--- a/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
@@ -227,6 +227,7 @@ function makeHost(tray: IHostTray, management: IHostManagement): IRunnerHost {
     },
     notifications: {
       show: () => Promise.resolve(),
+      onForegroundDisplay: () => ({ dispose: () => undefined }),
       onClick: () => ({ dispose: () => undefined }),
     },
     tray: {

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -182,6 +182,7 @@ function createRunnerHost(menu: FakeDesktopMenu): FakeRunnerHost {
       },
       notifications: {
         show: () => Promise.resolve(),
+        onForegroundDisplay: () => ({ dispose: () => undefined }),
         onClick: () => ({ dispose: () => undefined }),
       },
       tray: {

--- a/clients/gui-app/src/components/layout/__tests__/notification-emission-controller.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-emission-controller.test.tsx
@@ -343,6 +343,113 @@ describe("NotificationEmissionController", () => {
     expect(runnerHost.notificationsSent[0]?.body).toBe("Details");
   });
 
+  it("displays and records a background renderer notification relayed to this focused renderer", async () => {
+    const runnerHost = createRunnerHost();
+    renderController(runnerHost);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const backgroundEntry = {
+      ...persistedAppLocalEntry(null),
+      id: "host.error:background-renderer",
+      sourceRef: "background-renderer",
+      message: "Background renderer failed",
+      detail: "Terminal stream ended unexpectedly",
+    };
+    const version = {
+      userId: "user-1",
+      notificationId: backgroundEntry.id,
+      updatedAt: backgroundEntry.updatedAt,
+    };
+
+    act(() => {
+      runnerHost.emitForegroundNotificationDisplay({
+        title: backgroundEntry.message,
+        body: backgroundEntry.detail,
+        payload: null,
+        replaceKey: `app-local:${backgroundEntry.id}`,
+        deliveryKey: `${version.userId}:${version.notificationId}:${version.updatedAt}`,
+        foregroundAppLocal: {
+          userId: version.userId,
+          entry: backgroundEntry,
+        },
+      });
+    });
+
+    expect(toastCalls).toHaveLength(1);
+    expect(toastCalls[0]?.title).toBe(backgroundEntry.message);
+    expect(
+      useAppLocalNotificationsStore.getState().byId[backgroundEntry.id]
+        .displayedUpdatedAt,
+    ).toBe(backgroundEntry.updatedAt);
+    expect(hasAppLocalDisplayReceipt(version)).toBe(true);
+    expect(runnerHost.notificationsSent).toEqual([]);
+
+    act(() => {
+      useAppLocalNotificationsStore.getState().upsert(backgroundEntry);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(runnerHost.notificationsSent).toEqual([]);
+    expect(toastCalls).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "another user is active",
+      () => useAppLocalNotificationsStore.getState().activateIdentity("user-2"),
+    ],
+    [
+      "no user is active",
+      () => useAppLocalNotificationsStore.getState().deactivateIdentity(),
+    ],
+  ])(
+    "rejects a relayed app-local notification when %s",
+    async (_scenario, setIdentity) => {
+      setIdentity();
+      const runnerHost = createRunnerHost();
+      renderController(runnerHost);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const foreignEntry = {
+        ...persistedAppLocalEntry(null),
+        id: "host.error:foreign-user",
+        sourceRef: "foreign-user",
+      };
+      const version = {
+        userId: "user-1",
+        notificationId: foreignEntry.id,
+        updatedAt: foreignEntry.updatedAt,
+      };
+
+      act(() => {
+        runnerHost.emitForegroundNotificationDisplay({
+          title: foreignEntry.message,
+          body: foreignEntry.detail ?? "",
+          payload: null,
+          replaceKey: `app-local:${foreignEntry.id}`,
+          deliveryKey: `${version.userId}:${version.notificationId}:${version.updatedAt}`,
+          foregroundAppLocal: {
+            userId: version.userId,
+            entry: foreignEntry,
+          },
+        });
+      });
+
+      expect(toastCalls).toEqual([]);
+      expect(hasAppLocalDisplayReceipt(version)).toBe(false);
+      expect(
+        Object.hasOwn(
+          useAppLocalNotificationsStore.getState().byId,
+          foreignEntry.id,
+        ),
+      ).toBe(false);
+      expect(runnerHost.notificationsSent).toEqual([]);
+    },
+  );
+
   it("does not replay persisted unread notifications during reload hydration", async () => {
     const persisted = persistedAppLocalEntry(undefined);
     const runnerHost = renderPersistedController([persisted]);

--- a/clients/gui-app/src/components/layout/bridges/notification-emission-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/notification-emission-controller.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import {
   displayAppLocalNotification,
+  displayForwardedForegroundNotification,
   playNotificationChime,
 } from "@/lib/notifications/notification-display";
 import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
@@ -8,8 +9,16 @@ import {
   useMergedNotificationsActions,
   type MergedNotificationRow,
 } from "@/stores/notifications/merged-notifications";
-import { useNotificationShow } from "@/hooks/notifications/use-notifications";
-import { useAppLocalNotificationsStore } from "@/stores/notifications/app-local-notifications-store";
+import {
+  useNotificationForegroundDisplay,
+  useNotificationShow,
+} from "@/hooks/notifications/use-notifications";
+import {
+  parseForegroundAppLocalNotificationEntry,
+  useAppLocalNotificationsStore,
+} from "@/stores/notifications/app-local-notifications-store";
+import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
+import type { NotificationForegroundDisplay } from "@traycer-clients/shared/platform/runner-host";
 import {
   appLocalDisplayDeliveryKey,
   captureAppLocalDisplayReceiptSession,
@@ -26,6 +35,39 @@ export function NotificationEmissionController(): null {
   const actions = useMergedNotificationsActions();
   const inFlightVersionsRef = useRef(new Set<string>());
   const drainScheduledRef = useRef(false);
+  const onForegroundDisplay = useCallback(
+    (display: NotificationForegroundDisplay): void => {
+      const foregroundAppLocal = display.foregroundAppLocal;
+      if (foregroundAppLocal !== null) {
+        const state = useAppLocalNotificationsStore.getState();
+        const entry = parseForegroundAppLocalNotificationEntry(
+          foregroundAppLocal.entry,
+        );
+        if (
+          entry === null ||
+          state.activeUserId !== foregroundAppLocal.userId
+        ) {
+          return;
+        }
+        const version: AppLocalDisplayReceiptVersion = {
+          userId: foregroundAppLocal.userId,
+          notificationId: entry.id,
+          updatedAt: entry.updatedAt,
+        };
+        recordAppLocalDisplayReceipt(version);
+        state.mergeForegroundDisplayed(entry);
+      }
+      displayForwardedForegroundNotification(display, {
+        playChime: playNotificationChime,
+        onToastClick: (payload) =>
+          useNotificationEventsStore
+            .getState()
+            .recordInAppClick(payload, Date.now()),
+      });
+    },
+    [],
+  );
+  useNotificationForegroundDisplay(onForegroundDisplay);
   const onToastClick = useCallback(
     (row: MergedNotificationRow): void => {
       if (row.payload === null) return;
@@ -82,6 +124,7 @@ export function NotificationEmissionController(): null {
             onToastClick,
           },
           deliveryKey,
+          userId,
         )
           .then(() => {
             if (!isAppLocalDisplayReceiptSessionCurrent(receiptSession)) return;

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-capture-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-capture-dialog.test.tsx
@@ -233,6 +233,7 @@ function createBaseRunnerHost(): IRunnerHost {
     },
     notifications: {
       show: () => Promise.resolve(),
+      onForegroundDisplay: () => ({ dispose: () => undefined }),
       onClick: () => ({ dispose: () => undefined }),
     },
     tray: {

--- a/clients/gui-app/src/hooks/notifications/use-notifications.ts
+++ b/clients/gui-app/src/hooks/notifications/use-notifications.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect } from "react";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import type {
+  NotificationForegroundAppLocal,
+  NotificationForegroundDisplay,
+} from "@traycer-clients/shared/platform/runner-host";
 
 export interface NotificationShowRequest {
   readonly title: string;
@@ -7,6 +11,7 @@ export interface NotificationShowRequest {
   readonly payload: unknown;
   readonly replaceKey: string | null;
   readonly deliveryKey: string | null;
+  readonly foregroundAppLocal: NotificationForegroundAppLocal | null;
 }
 
 export type NotificationShow = (
@@ -20,17 +25,37 @@ export type NotificationShow = (
 export function useNotificationShow(): NotificationShow {
   const runnerHost = useRunnerHost();
   return useCallback<NotificationShow>(
-    async ({ title, body, payload, replaceKey, deliveryKey }) => {
+    async ({
+      title,
+      body,
+      payload,
+      replaceKey,
+      deliveryKey,
+      foregroundAppLocal,
+    }) => {
       await runnerHost.notifications.show(
         title,
         body,
         payload,
         replaceKey,
         deliveryKey,
+        foregroundAppLocal,
       );
     },
     [runnerHost],
   );
+}
+
+export function useNotificationForegroundDisplay(
+  handler: (display: NotificationForegroundDisplay) => void,
+): void {
+  const runnerHost = useRunnerHost();
+  useEffect(() => {
+    const subscription = runnerHost.notifications.onForegroundDisplay(handler);
+    return () => {
+      subscription.dispose();
+    };
+  }, [runnerHost, handler]);
 }
 
 /**

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
@@ -90,6 +90,7 @@ describe("notification display", () => {
       }),
       replaceKey: "host:chat:chat-1",
       deliveryKey: null,
+      foregroundAppLocal: null,
     });
     expect(toastCalls).toHaveLength(1);
     expect(toastCalls[0]?.options.id).toBe("host:chat:chat-1");
@@ -186,6 +187,7 @@ describe("notification display", () => {
       }),
       replaceKey: "notification-batch",
       deliveryKey: null,
+      foregroundAppLocal: null,
     });
 
     renderActionableToast();
@@ -263,6 +265,7 @@ describe("notification display", () => {
       payload: null,
       replaceKey: "host:id:n-1",
       deliveryKey: null,
+      foregroundAppLocal: null,
     });
   });
 

--- a/clients/gui-app/src/lib/notifications/notification-display.ts
+++ b/clients/gui-app/src/lib/notifications/notification-display.ts
@@ -1,4 +1,8 @@
 import type { NotificationShow } from "@/hooks/notifications/use-notifications";
+import type {
+  NotificationForegroundAppLocal,
+  NotificationForegroundDisplay,
+} from "@traycer-clients/shared/platform/runner-host";
 import { createElement } from "react";
 import { toast } from "sonner";
 import {
@@ -26,17 +30,62 @@ export interface NotificationDisplayTarget {
   readonly onToastClick: (row: MergedNotificationRow) => void;
 }
 
+interface NativeNotificationDisplayOptions {
+  readonly deliveryKey: string | null;
+  readonly originHostId: string | null;
+  readonly foregroundAppLocal: NotificationForegroundAppLocal | null;
+}
+
+export function displayForwardedForegroundNotification(
+  display: NotificationForegroundDisplay,
+  target: {
+    readonly playChime: () => void;
+    readonly onToastClick: (payload: unknown) => void;
+  },
+): void {
+  const actionable = display.payload !== null;
+  const title = actionable
+    ? createElement(
+        "button",
+        {
+          type: "button",
+          "aria-label": `${display.title} ${display.body}`,
+          "data-notification-toast-action": "",
+          className: "min-w-0 text-left",
+          onClick: () => target.onToastClick(display.payload),
+        },
+        createElement(
+          "span",
+          { className: "block font-medium leading-normal" },
+          display.title,
+        ),
+        createElement(
+          "span",
+          {
+            className:
+              "mt-0.5 block text-sm leading-snug text-muted-foreground",
+          },
+          display.body,
+        ),
+      )
+    : display.title;
+  toast(title, {
+    description: actionable ? undefined : display.body,
+    id: display.replaceKey ?? undefined,
+  });
+  target.playChime();
+}
+
 export function displayNotificationRows(
   rows: ReadonlyArray<MergedNotificationRow>,
   target: NotificationDisplayTarget,
   originHostId: string | null,
 ): void {
-  void displayNotificationRowsAwaitNative(
-    rows,
-    target,
-    null,
+  void displayNotificationRowsAwaitNative(rows, target, {
+    deliveryKey: null,
     originHostId,
-  ).catch(() => {
+    foregroundAppLocal: null,
+  }).catch(() => {
     // The feed remains authoritative; a failed native toast is non-critical.
   });
 }
@@ -44,8 +93,7 @@ export function displayNotificationRows(
 async function displayNotificationRowsAwaitNative(
   rows: ReadonlyArray<MergedNotificationRow>,
   target: NotificationDisplayTarget,
-  deliveryKey: string | null,
-  originHostId: string | null,
+  options: NativeNotificationDisplayOptions,
 ): Promise<void> {
   if (rows.length === 0) return;
   const content = buildNotificationToastContent(rows);
@@ -55,7 +103,7 @@ async function displayNotificationRowsAwaitNative(
       : buildNotificationActivationEnvelope({
           route: content.payload,
           feed: { source: content.row.source, id: content.row.sourceId },
-          originHostId,
+          originHostId: options.originHostId,
         });
   let nativeDisplay: Promise<void>;
   try {
@@ -64,7 +112,8 @@ async function displayNotificationRowsAwaitNative(
       body: content.body,
       payload: nativePayload,
       replaceKey: content.replaceKey,
-      deliveryKey,
+      deliveryKey: options.deliveryKey,
+      foregroundAppLocal: options.foregroundAppLocal,
     });
   } catch (error) {
     renderNotificationToast(content, target);
@@ -172,12 +221,16 @@ export function displayAppLocalNotification(
   entry: AppLocalNotificationEntry,
   target: NotificationDisplayTarget,
   deliveryKey: string,
+  userId: string,
 ): Promise<void> {
   return displayNotificationRowsAwaitNative(
     [rowFromAppLocalEntry(entry)],
     target,
-    deliveryKey,
-    null,
+    {
+      deliveryKey,
+      originHostId: null,
+      foregroundAppLocal: { userId, entry },
+    },
   );
 }
 

--- a/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
@@ -181,6 +181,7 @@ function createBaseRunnerHost(): IRunnerHost {
     },
     notifications: {
       show: () => Promise.resolve(),
+      onForegroundDisplay: () => ({ dispose: () => undefined }),
       onClick: () => ({ dispose: () => undefined }),
     },
     tray: {

--- a/clients/gui-app/src/stores/notifications/__tests__/app-local-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/app-local-notifications-store.test.ts
@@ -88,6 +88,24 @@ describe("app-local notifications store", () => {
     expect(second.getState().byId.displayed.displayedUpdatedAt).toBe(10);
   });
 
+  it("keeps a newer row and its local display state when a stale foreground relay arrives", () => {
+    const store = createAppLocalNotificationsStore(
+      appLocalNotificationsKey("user-a"),
+    );
+    store.getState().activateIdentity("user-a");
+    store.getState().upsert(entry("target", 20, null));
+    store.getState().markAsRead("target", 30);
+    store.getState().markAsDisplayed("target", 20);
+
+    store.getState().mergeForegroundDisplayed(entry("target", 10, null));
+
+    expect(store.getState().byId.target).toMatchObject({
+      updatedAt: 20,
+      readAt: 30,
+      displayedUpdatedAt: 20,
+    });
+  });
+
   it("cannot lose the monotonic receipt when a stale window writes another row", () => {
     const key = appLocalNotificationsKey("user-a");
     const seed = createAppLocalNotificationsStore(key);

--- a/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
@@ -83,6 +83,7 @@ export interface AppLocalNotificationsState {
   ) => void;
   markAllAsRead: (readAt: number) => void;
   markAsDisplayed: (id: string, updatedAt: number) => void;
+  mergeForegroundDisplayed: (entry: AppLocalNotificationInput) => void;
   clearAll: () => void;
   resetForTests: () => void;
 }
@@ -197,6 +198,24 @@ function parsePersistedAppLocalEntry(
     message: value.message,
     detail: value.detail,
     displayedUpdatedAt: value.displayedUpdatedAt,
+  };
+}
+
+export function parseForegroundAppLocalNotificationEntry(
+  value: unknown,
+): AppLocalNotificationInput | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  const parsed = parsePersistedAppLocalEntry(value.id, value);
+  if (parsed === null) return null;
+  return {
+    id: parsed.id,
+    updatedAt: parsed.updatedAt,
+    readAt: parsed.readAt,
+    kind: parsed.kind,
+    sourceRef: parsed.sourceRef,
+    payload: parsed.payload,
+    message: parsed.message,
+    detail: parsed.detail,
   };
 }
 
@@ -412,6 +431,33 @@ export function createAppLocalNotificationsStore(initialName: string) {
                 ...state.byId,
                 [id]: { ...entry, displayedUpdatedAt: updatedAt },
               },
+            };
+          });
+        },
+
+        mergeForegroundDisplayed: (entry) => {
+          if (get().activeUserId === null) return;
+          set((state) => {
+            const existing = Object.hasOwn(state.byId, entry.id)
+              ? state.byId[entry.id]
+              : null;
+            if (existing !== null && existing.updatedAt > entry.updatedAt) {
+              return state;
+            }
+            const displayedEntry: AppLocalNotificationEntry = {
+              ...entry,
+              readAt: existing === null ? entry.readAt : existing.readAt,
+              displayedUpdatedAt: entry.updatedAt,
+            };
+            const byId = cappedAppLocalEntries({
+              ...state.byId,
+              [entry.id]: displayedEntry,
+            });
+            const projection = projectAppLocalNotifications(byId);
+            return {
+              byId,
+              orderedIds: projection.orderedIds,
+              unreadCount: projection.unreadCount,
             };
           });
         },

--- a/clients/shared/host-client/__tests__/runner-host.test.ts
+++ b/clients/shared/host-client/__tests__/runner-host.test.ts
@@ -181,6 +181,7 @@ describe("MockRunnerHost - IRunnerHost contract", () => {
       { kind: "info" },
       null,
       "delivery-1",
+      null,
     );
 
     expect(host.tray.indicator).toBe("attention");
@@ -192,6 +193,7 @@ describe("MockRunnerHost - IRunnerHost contract", () => {
         payload: { kind: "info" },
         replaceKey: null,
         deliveryKey: "delivery-1",
+        foregroundAppLocal: null,
       },
     ]);
     expect(traySelection).not.toHaveBeenCalled();

--- a/clients/shared/host-client/mock/mock-runner-host.ts
+++ b/clients/shared/host-client/mock/mock-runner-host.ts
@@ -9,6 +9,8 @@ import type {
   IHostPicker,
   IHostManagement,
   INotificationHost,
+  NotificationForegroundDisplay,
+  NotificationForegroundAppLocal,
   IRunnerHost,
   ISecureStorage,
   ITokenStore,
@@ -113,6 +115,7 @@ export class MockRunnerHost implements IRunnerHost {
     readonly payload: unknown;
     readonly replaceKey: string | null;
     readonly deliveryKey: string | null;
+    readonly foregroundAppLocal: NotificationForegroundAppLocal | null;
   }> = [];
   readonly secureStorageEntries: Map<string, string> = new Map();
   readonly tokenStoreEntries: Map<string, StoredCredentials> = new Map();
@@ -132,6 +135,9 @@ export class MockRunnerHost implements IRunnerHost {
   >();
   private readonly notificationClickHandlers = new Set<
     (payload: unknown) => void
+  >();
+  private readonly notificationForegroundDisplayHandlers = new Set<
+    (display: NotificationForegroundDisplay) => void
   >();
   private readonly systemResumedHandlers = new Set<() => void>();
   private localHost: LocalHostSnapshot | null;
@@ -495,6 +501,7 @@ export class MockRunnerHost implements IRunnerHost {
       payload: unknown,
       replaceKey: string | null,
       deliveryKey: string | null,
+      foregroundAppLocal: NotificationForegroundAppLocal | null,
     ): Promise<void> => {
       this.notificationsSent.push({
         title,
@@ -502,6 +509,7 @@ export class MockRunnerHost implements IRunnerHost {
         payload,
         replaceKey,
         deliveryKey,
+        foregroundAppLocal,
       });
     },
     onClick: (handler: (payload: unknown) => void): Disposable => {
@@ -512,7 +520,25 @@ export class MockRunnerHost implements IRunnerHost {
         },
       };
     },
+    onForegroundDisplay: (
+      handler: (display: NotificationForegroundDisplay) => void,
+    ): Disposable => {
+      this.notificationForegroundDisplayHandlers.add(handler);
+      return {
+        dispose: () => {
+          this.notificationForegroundDisplayHandlers.delete(handler);
+        },
+      };
+    },
   };
+
+  emitForegroundNotificationDisplay(
+    display: NotificationForegroundDisplay,
+  ): void {
+    for (const handler of this.notificationForegroundDisplayHandlers) {
+      handler(display);
+    }
+  }
 
   onLocalHostChange(
     handler: (snapshot: LocalHostSnapshot | null) => void,

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -850,8 +850,33 @@ export interface INotificationHost {
     payload: unknown,
     replaceKey: string | null,
     deliveryKey: string | null,
+    foregroundAppLocal: NotificationForegroundAppLocal | null,
   ): Promise<void>;
   onClick(handler: (payload: unknown) => void): Disposable;
+  onForegroundDisplay(
+    handler: (display: NotificationForegroundDisplay) => void,
+  ): Disposable;
+}
+
+/**
+ * App-local data that must cross renderer realms when another Traycer window
+ * owns the foreground. `entry` stays unknown at the shell boundary; gui-app
+ * validates it before merging it into the focused renderer's store.
+ */
+export interface NotificationForegroundAppLocal {
+  readonly userId: string;
+  readonly entry: unknown;
+}
+
+/** Plain-data main -> renderer relay used instead of an OS notification while
+ * another Traycer window is focused. */
+export interface NotificationForegroundDisplay {
+  readonly title: string;
+  readonly body: string;
+  readonly payload: unknown;
+  readonly replaceKey: string | null;
+  readonly deliveryKey: string | null;
+  readonly foregroundAppLocal: NotificationForegroundAppLocal | null;
 }
 
 export interface ITrayState {


### PR DESCRIPTION
## Summary

- suppress native notifications whenever a Traycer window is focused, while relaying app-local foreground events to the focused renderer
- buffer preload relay events until GUI subscribers attach and enforce the active-user boundary before displaying them
- clean up stale replacement notifications, including aged entries, without expiring active Notification Center items

## Verification

- `bunx vitest run src/electron-main/__tests__/notifications.test.ts` (103 passed)
- focused GUI notification suites (27 passed)
- desktop and GUI compile
- commit hook: affected build, compile, lint, and format