### PR TITLE
fix(gui-app): size the PR owner popover to its content

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-owner-label.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-owner-label.test.tsx
@@ -404,6 +404,35 @@ describe("PrOwnerBadges overflow hierarchy", () => {
     expect(heightCap).not.toContain("rem");
   });
 
+  /**
+   * Same jsdom caveat as the height cap above: this pins the class contract, not
+   * an observed layout. The width used to be SET (`w-[min(80vw,20rem)]`), so a
+   * two-row list painted a mostly-empty column and a deep lineage - whose indent
+   * eats the title column that IS the reason to open this list - got no more
+   * room on a display with plenty. It is now sized by content and only capped.
+   */
+  it("sizes the popover to its content and caps the width rather than setting it", () => {
+    renderBadges(chatOwners(12));
+    fireEvent.click(screen.getByTestId("pr-owner-overflow"));
+
+    const content = screen.getByTestId("pr-owner-overflow-list").parentElement;
+    expect(content).not.toBeNull();
+    const className = content?.className ?? "";
+    // Content-sized, not a fixed column: no `w-<size>` utility survives.
+    expect(className).toContain("w-max");
+    expect(/(?:^|\s)w-(?!max\b)[^\s]+/.test(className)).toBe(false);
+
+    const widthCap = /max-w-\[[^\]]*\]/.exec(className)?.[0];
+    expect(widthCap).toBeDefined();
+    // Never wider than the space Radix measured, nor than the viewport - and
+    // each var needs a fallback, since an unmeasured one invalidates `min()`
+    // and drops the cap entirely.
+    expect(widthCap).toContain(
+      "var(--radix-popover-content-available-width,100vw)",
+    );
+    expect(widthCap).toContain("vw");
+  });
+
   it("lists every owner exactly once however the tree nests them", () => {
     parentByNodeId = Object.fromEntries(
       Array.from({ length: 12 }, (_unused, index) => [

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-owner-label.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-owner-label.tsx
@@ -297,15 +297,27 @@ function PrOwnerOverflow(props: {
         // own handler and opens the PR tile as well as the chat.
         onClick={(event) => event.stopPropagation()}
         onKeyDown={(event) => event.stopPropagation()}
-        // Capped by the space Radix measured between the trigger and the
-        // viewport edge, not by a row count: the same popover serves the narrow
+        // Both axes are CAPPED, never SIZED: the same popover serves the narrow
         // sidebar row and the wider detail card, and a PR on a large epic can
-        // list dozens of owners. The second term is `60vh`, not a rem: a fixed
-        // height would hold a long list to the same few rows on a display with
-        // room for twice as many, and layout surfaces here size fluidly
-        // (clients/gui-app/AGENTS.md). `overflow-hidden` is what makes the cap
-        // bite - without it the list paints straight past the popover's box.
-        className="max-h-[min(var(--radix-popover-content-available-height,100vh),60vh)] w-[min(80vw,20rem)] max-w-[var(--radix-popover-content-available-width)] gap-0 overflow-hidden p-0"
+        // list dozens of owners at several levels of nesting.
+        //
+        // Height: the space Radix measured between the trigger and the viewport
+        // edge, floored against `60vh` - not a rem, which would hold a long list
+        // to the same few rows on a display with room for twice as many.
+        //
+        // Width: `w-max` so the box tracks its widest row instead of painting a
+        // fixed column. A short list of short titles stops being a mostly-empty
+        // 20rem panel, and a deep lineage - whose indent eats the title column
+        // that IS the reason to open this list - gets the room a wide display
+        // already has. The rem survives only as the last term of a `max-w`,
+        // which is the fluid pattern (clients/gui-app/AGENTS.md), not a width.
+        // Each var carries a fallback: an unmeasured var invalidates the whole
+        // `min()`, and a dropped `max-w` would let a long title size the popover
+        // off-screen.
+        //
+        // `overflow-hidden` is what makes the height cap bite - without it the
+        // list paints straight past the popover's box.
+        className="max-h-[min(var(--radix-popover-content-available-height,100vh),60vh)] w-max max-w-[min(80vw,var(--radix-popover-content-available-width,100vw),28rem)] gap-0 overflow-hidden p-0"
       >
         <p className="shrink-0 border-b px-3 py-2 text-ui-xs text-muted-foreground">
           {`${nouns.capitalized} this PR came from`}
@@ -444,10 +456,12 @@ function PrOwnerBadge(props: {
 /**
  * How deep the popover keeps indenting before levels start sharing a column.
  *
- * The popover is capped at 20rem, so an unbounded indent would eventually leave
+ * The popover's width is capped, so an unbounded indent would eventually leave
  * a lineage's deepest rows with no room for their own title - the thing the
- * reader opened this list to read. A spawn chain this deep is already past what
- * indentation alone can disambiguate; the guide rails still stack.
+ * reader opened this list to read. Sizing to content buys those rows width up
+ * to the cap but cannot buy them more than the cap. A spawn chain this deep is
+ * already past what indentation alone can disambiguate; the guide rails still
+ * stack.
  */
 const MAX_OWNER_TREE_INDENT_DEPTH = 5;
 

--- a/clients/gui-app/src/hooks/pr/use-present-pr-owners.ts
+++ b/clients/gui-app/src/hooks/pr/use-present-pr-owners.ts
@@ -5,11 +5,14 @@ import { useEpicAgentNodeIds } from "@/lib/epic-selectors";
 /**
  * The owners this epic can still resolve, dropping any whose node is gone.
  *
- * A PR's owner set is host-side state that OUTLIVES its nodes: worktree
- * bindings cascade on epic delete but not on chat delete, so a PR keeps naming
- * chats the user removed months ago. Those used to render as bare "Removed
- * chat" text wedged between pills - a row that reads as broken, for an entry
- * with no title, no tile, and nothing to click.
+ * A PR's owner set is host-side state that can OUTLIVE its nodes: it is
+ * projected from persisted worktree-binding rows, and whether a given host
+ * cascades those rows on every node delete is a host-version fact this renderer
+ * cannot assume - so a PR may keep naming chats the user removed months ago.
+ * Those used to render as bare "Removed chat" text wedged between pills - a row
+ * that reads as broken, for an entry with no title, no tile, and nothing to
+ * click. Tightening the producer does not retire this filter: the rows a host
+ * already wrote are still on disk.
  *
  * Filtered HERE rather than by having each chip render null, so everything
  * derived from the list stays true: the visible chips are real ones, `+N`


### PR DESCRIPTION
## What

The PR-owner overflow popover **set** its width (`w-[min(80vw,20rem)]`) instead of capping it, so the box was the same 20rem column whatever it held:

- two short titles painted a mostly-empty panel;
- a deep spawn lineage — whose indent eats the title column that *is* the reason to open this list — got no more room on a display with plenty to spare.

It is now `w-max`, bounded by a single `max-w` folding together the viewport, the space Radix measured between the trigger and the viewport edge, and a readability ceiling.

```diff
-w-[min(80vw,20rem)] max-w-[var(--radix-popover-content-available-width)]
+w-max max-w-[min(80vw,var(--radix-popover-content-available-width,100vw),28rem)]
```

Both vars carry a fallback: an unmeasured var invalidates the whole `min()`, and a dropped `max-w` would let one long title size the popover off-screen.

That also retires the last fixed layout dimension on this surface. The rem survives only as a term of a `max-w`, which is the fluid pattern per `clients/gui-app/AGENTS.md` ("`w-full`, `max-w-*`, viewport caps"), not a width — this is deliberately **not** a sweep of the `w-[min(80vw,Nrem)]` idiom used at ~13 other call sites, where it is still the width and still the house pattern.

## Verification

`bun run test src/components/epic-canvas/pr` — 19 files, 162 tests green. Pre-commit ran the affected build/compile/lint/format.

jsdom has no layout engine, so the new test pins the **class contract** the sizing depends on, exactly like the height cap above it. It also asserts no `w-<size>` utility survives, which proves tailwind-merge drops the primitive's own `w-72` — without that the fixed column would still be there underneath.

Mutation probe: restoring `w-[min(80vw,20rem)]` fails it with

```
AssertionError: expected 'z-50 flex origin-(--radix-popover-con…' to contain 'w-max'
```

Probe reverted; suite re-run green.

**Not verified in a running app** — this is a CSS sizing change, and I pinned it by class contract rather than by a `dev-desktop` visual pass. The load-bearing assumption is that a `width: max-content` ancestor sizes to the content of the `overflow-y-auto` list inside it (scroll containers contribute their content's max-content size). Worth a look when the popover is next open in a real build.

## Also

`usePresentPrOwners`' rationale justified the filter by what the host cascades *today*. That is a host-version fact a renderer cannot assume, and a producer-side fix would falsify it. Reworded to the reason that is actually durable: rows a host already wrote stay on disk.