### PR TITLE
feat(gui): harden chat scroller lifecycle and surface hosting

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,7 +17,7 @@ paths = [
   '''^clients/gui-app/src/components/chat/__tests__/chat-messages\.test\.tsx$''',
 ]
 regexes = [
-  '''^(?:h3-gesture-preempts-ownership|m3b-usable-hit-strip|s4b-reachability-key|t4-optimistic-anchor-key|t4-anchor-drift-key|t4-gated-follow-key|t11-e-strict-epsilon-2|t10-nav-abort-gesture|t12-anchor-drift|t12-follow-catchup|t18-pin-c-exhaust)$''',
+  '''^(?:h3-gesture-preempts-ownership|m3b-usable-hit-strip|s4b-reachability-key|t4-optimistic-anchor-key|t4-anchor-drift-key|t4-gated-follow-key|t11-e-strict-epsilon-2|t10-nav-abort-gesture|t12-anchor-drift|t12-follow-catchup|t18-pin-c-exhaust|t19-hydration-nav-key|t22-pin3-no-double-correction|t22-below-anchor-no-repair|t22-unmount-mid-repair|t22-shrink-above-anchor)$''',
 ]
 
 [[allowlists]]

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages-scroll-helpers.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages-scroll-helpers.test.ts
@@ -3,6 +3,8 @@ import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-sto
 import type { SetupCardViewModel } from "@/components/chat/segments/setup-card-segment";
 import {
   buildMessageIdToIndex,
+  chatAnchorScrollCaptureIsExactBrowserClamp,
+  chatAnchorScrollCaptureShouldCancel,
   chatTimelineAnchorShouldAnimateInitialIssue,
   chatTimelineLocationForMessage,
   chatTimelineNavigationLandedAtLocation,
@@ -16,6 +18,7 @@ import {
   CHAT_TIMELINE_NAVIGATION_VIEW_OFFSET_PX,
   selectActiveUserMessageId,
   viewportActiveUserMessageId,
+  type ChatAnchorScrollCapturePhysicalSnapshot,
 } from "@/components/chat/chat-messages-scroll-helpers";
 import { makeMessageAt } from "./chat-message-fixtures";
 
@@ -1588,6 +1591,250 @@ describe("resolveChatAnchorTargetWithSetupCard (ticket 13 / decision #28)", () =
     expect(resolveChatAnchorTargetWithSetupCard(messages, retargeted)).toBe(
       retargeted,
     );
+  });
+});
+
+describe("chatAnchorScrollCaptureIsExactBrowserClamp (Ticket 19, decision #31 binding condition b)", () => {
+  function snapshot(
+    scrollTop: number,
+    maxScrollTop: number,
+  ): ChatAnchorScrollCapturePhysicalSnapshot {
+    return { scrollTop, maxScrollTop };
+  }
+
+  it("(exact clamp) recognizes an ordinary downward clamp to a newly-smaller maximum", () => {
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(1_200, 1_200),
+        snapshot(1_000, 1_000),
+      ),
+    ).toBe(true);
+  });
+
+  it("(fractional clamp) the 1px equality tolerance absorbs sub-pixel scrollTop/max values", () => {
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(1_200.7, 1_200.25),
+        snapshot(1_000.6, 1_000.3),
+      ),
+    ).toBe(true);
+  });
+
+  it("(no prior-over-max evidence) does not guess a clamp merely from landing near a maximum", () => {
+    // previous.scrollTop (900) was never above the NEW maximum (1000) - the
+    // reader could simply have scrolled there normally. Table row: "Position
+    // at maximum without prior-over-max evidence" -> cancel, not a clamp.
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(900, 1_200),
+        snapshot(1_000, 1_000),
+      ),
+    ).toBe(false);
+  });
+
+  it("(maximum did not shrink) a same-position report with an unchanged or grown maximum is not a clamp", () => {
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(1_200, 1_000),
+        snapshot(1_000, 1_000),
+      ),
+    ).toBe(false);
+  });
+
+  it("(current top not at the new maximum) a large drop that overshoots past the new max is not a clamp", () => {
+    // Same shrink, but current.scrollTop lands well short of the new max -
+    // a real clamp always lands (near) exactly at the new maximum.
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(1_200, 1_200),
+        snapshot(500, 1_000),
+      ),
+    ).toBe(false);
+  });
+
+  it("is exclusive at the exact 1px boundary of 'previous over new max'", () => {
+    // previous.scrollTop must EXCEED currentMax + 1px, not merely equal it.
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(1_001, 1_200), // exactly currentMax(1000) + 1, not > it
+        snapshot(1_000, 1_000),
+      ),
+    ).toBe(false);
+    expect(
+      chatAnchorScrollCaptureIsExactBrowserClamp(
+        snapshot(1_001.01, 1_200),
+        snapshot(1_000, 1_000),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("chatAnchorScrollCaptureShouldCancel (Ticket 19, decision #31)", () => {
+  const OWNED_NO_MOTION = {
+    isAnchoringSessionOwned: true,
+    activeAnchorMotionOwnsGeneration: false,
+  };
+
+  it("(truth table: mismatch while owned) cancels an unexplained departure while anchoring + generation owned", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 900,
+        listStateScroll: 100,
+        previousSnapshot: null,
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("(truth table: following/free mode) stays silent whenever the session is not anchoring-owned", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        isAnchoringSessionOwned: false,
+        activeAnchorMotionOwnsGeneration: false,
+        domScrollTop: 900,
+        listStateScroll: 100,
+        previousSnapshot: null,
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("(truth table: generation unowned) stays silent - `isAnchoringSessionOwned` already folds in the generation-ownership gate", () => {
+    // The caller computes `isAnchoringSessionOwned` as `mode ===
+    // "anchoring-new-turn" && generationOwned` - a mode-matched but
+    // generation-stale report reaches this classifier as `false` here.
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        isAnchoringSessionOwned: false,
+        activeAnchorMotionOwnsGeneration: false,
+        domScrollTop: 5_000,
+        listStateScroll: 0,
+        previousSnapshot: null,
+        currentMaxScrollTop: 6_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("(truth table: active anchor imperative motion) defers silently regardless of how far DOM/list state diverge", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        isAnchoringSessionOwned: true,
+        activeAnchorMotionOwnsGeneration: true,
+        domScrollTop: 50,
+        listStateScroll: 4_000,
+        previousSnapshot: null,
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("(truth table: stale active-motion generation does not exempt) a caller-computed `false` for an older generation's motion is evaluated normally, not exempted", () => {
+    // Design: "activeAnchorImperativeMotionGenerationRef must be compared
+    // with the CURRENT generation - a stale completion from an older anchor
+    // cannot exempt a newer session." The comparison itself is the caller's
+    // job (chat-messages.tsx); this classifier only ever sees the resulting
+    // boolean. A stale generation must therefore resolve to `false` here,
+    // which - unlike the true case above - does NOT defer, and the mismatch
+    // is classified as a real departure.
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        isAnchoringSessionOwned: true,
+        activeAnchorMotionOwnsGeneration: false,
+        domScrollTop: 50,
+        listStateScroll: 4_000,
+        previousSnapshot: null,
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("(truth table: DOM/list equal within 1px) a sub-pixel difference is read as a library/app-owned correction, not a departure", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 500.4,
+        listStateScroll: 500.0,
+        previousSnapshot: null,
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("(truth table: exact downward clamp) a browser clamp to a newly-smaller maximum stays silent even though DOM/list state diverge", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 1_000,
+        listStateScroll: 1_200, // library state never told about the clamp
+        previousSnapshot: { scrollTop: 1_200, maxScrollTop: 1_200 },
+        currentMaxScrollTop: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("(truth table: position at maximum without prior-over-max evidence) cancels rather than guessing a clamp", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 1_000,
+        listStateScroll: 400,
+        previousSnapshot: { scrollTop: 900, maxScrollTop: 1_200 },
+        currentMaxScrollTop: 1_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("(truth table: large library-owned correction) exact state equality stays silent no matter how large the jump", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 4_800,
+        listStateScroll: 4_800, // MVCP/non-animated scrollToOffset pre-wrote this
+        previousSnapshot: { scrollTop: 50, maxScrollTop: 5_000 },
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("(truth table: small real mismatch above 1px) cancels with no anchor-distance threshold - a 2px unexplained move is as real as a 2000px one", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 502,
+        listStateScroll: 500,
+        previousSnapshot: { scrollTop: 500, maxScrollTop: 5_000 },
+        currentMaxScrollTop: 5_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("(no previous snapshot) an owned mismatch with nothing to compare against for a clamp still cancels - unsure biases toward cancel, not silence", () => {
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 990,
+        listStateScroll: 0,
+        previousSnapshot: null,
+        currentMaxScrollTop: 990,
+      }),
+    ).toBe(true);
+  });
+
+  it("(same-window max shrink ambiguity, review finding 3) a user move ending exactly at a shrunk maximum is indistinguishable from a clamp - documented, not a bug", () => {
+    // The design-review's own accepted ambiguity table: "User thumb ends at
+    // the new max in the same delivery window as a max shrink" -> silent.
+    // This pin exists to make that acceptance explicit and mutation-visible,
+    // not to assert a distinguishing capability that does not exist.
+    expect(
+      chatAnchorScrollCaptureShouldCancel({
+        ...OWNED_NO_MOTION,
+        domScrollTop: 1_000,
+        listStateScroll: 1_200,
+        previousSnapshot: { scrollTop: 1_200, maxScrollTop: 1_200 },
+        currentMaxScrollTop: 1_000,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -153,6 +153,42 @@ vi.mock("@legendapp/list/react", async (importOriginal) => {
   return { ...actual, LegendList: TeedLegendList };
 });
 
+// Ticket 22 (review round 1, finding 4): a thin, behavior-preserving
+// pass-through around the REAL `applyChatAnchorDriftRepair` - re-exports
+// everything else unchanged, wraps only this one function to tee its call
+// count into a module-scope counter. Zero production delta; the wrapped
+// function still does exactly what the real one does, including its return
+// value. This exists because "one `scrollToOffset` call" is not the same
+// invariant as "one scheduled repair pass" - a missing coalescing guard lets
+// several independent two-rAF chains run, but only the FIRST observes
+// non-zero drift and writes, so a write-count oracle alone survives the
+// guard's removal (review round 1, finding 4). Counting actual invocations
+// of the shared repair function is deterministic (no rAF-timing noise,
+// unlike spying on `window.requestAnimationFrame`, which also picks up
+// LegendList's own unrelated internal rAF usage).
+const applyChatAnchorDriftRepairCallCountRef = vi.hoisted(() => ({
+  current: 0,
+}));
+
+vi.mock(
+  "@/components/chat/chat-messages-scroll-helpers",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/components/chat/chat-messages-scroll-helpers")
+      >();
+    return {
+      ...actual,
+      applyChatAnchorDriftRepair: (
+        ...args: Parameters<typeof actual.applyChatAnchorDriftRepair>
+      ): ReturnType<typeof actual.applyChatAnchorDriftRepair> => {
+        applyChatAnchorDriftRepairCallCountRef.current += 1;
+        return actual.applyChatAnchorDriftRepair(...args);
+      },
+    };
+  },
+);
+
 // Ticket 17 (review round 3, finding 2 residual): LegendList's per-element
 // size/layout notifications (row remeasure AND scroll-container resize) both
 // route through ONE module-cached `ResizeObserver` singleton
@@ -7769,6 +7805,932 @@ describe("ChatMessages scroll policy", () => {
       expect(
         callsOnScrollNode.every((call) => call.behavior === "smooth"),
       ).toBe(true);
+    });
+  });
+
+
+  // ---------------------------------------------------------------------
+  // Ticket 22 (painted-chat lifecycle audit, finding 3): the two-rAF anchor
+  // repair (ticket 18's drift re-assert) is keyed to `messages` - a
+  // divider/split/join/header/disclosure geometry change under the SAME
+  // `messages` array reports through `onItemSizeChanged`/`onLayout` but
+  // nothing schedules a repair for it. Row(s) above the anchor moving height
+  // shifts the anchored turn's content position with scrollTop unchanged.
+  //
+  // All four pins settle into an OVERFLOWING anchored turn first (same
+  // recipe as ticket 18's pin E) rather than a short, non-overflowing one:
+  // `anchoredEndSpace` pins a non-overflowing anchor at the maximum
+  // REACHABLE scroll, and LegendList's own internal reserve tracking for
+  // that config does not know about a raw `setItemSize` call on a row it
+  // isn't watching - it silently re-clamps scrollTop back to its own
+  // believed-correct position on the next settle, which would make a
+  // perfectly-landed real repair look like a no-op. Once the turn overflows,
+  // there is no such natural boundary to fight the repair's write.
+  // ---------------------------------------------------------------------
+  describe("ticket 22: geometry-only changes repair the anchored turn", () => {
+    const T22_GEOMETRY_DELTA_PX = 220;
+
+    /** Sends, then streams chunks until the turn genuinely overflows the
+     *  usable viewport (mirrors ticket 18 pin E's own recipe exactly). */
+    async function sendAndOverflowAnchor(
+      rerenderMessages: (
+        messages: ReadonlyArray<ChatMessageModel>,
+      ) => void,
+      history: ReadonlyArray<ChatMessageModel>,
+      sendId: string,
+      createdAt: number,
+    ): Promise<ReadonlyArray<ChatMessageModel>> {
+      const afterSend = appendOptimisticUserSend(history, sendId, createdAt);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+      let current = afterSend;
+      let overflowed = false;
+      for (let chunkIndex = 0; chunkIndex < 20; chunkIndex += 1) {
+        current = appendOneStreamingChunk(current, chunkIndex, createdAt);
+        rerenderMessages(current);
+        await waitForRevealPassTick();
+        if (isJumpPillVisible()) {
+          overflowed = true;
+          break;
+        }
+      }
+      expect(overflowed).toBe(true);
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      return current;
+    }
+
+    it("(pin 1) a same-messages row-remeasure above a settled anchor re-asserts the anchor offset", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-pin1-geometry-repair";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-pin1-geometry-repair",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 810_000);
+      const scrollBefore = getScrollNode().scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+
+      // Grow a row strictly ABOVE the anchor - SAME `messages` array, no
+      // scroll, no rerender. Driven via the real LegendList `setItemSize`
+      // ref method (teed through the pass-through mock) - the one lever
+      // that fires a genuine, no-scroll `onItemSizeChanged`, matching how a
+      // disclosure collapse/expand or a rewrap from a divider/pane resize
+      // would move rows under the anchor in a real browser.
+      act(() => {
+        legendListRefHolder.current?.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+
+      await waitForRevealPassTick();
+
+      // The anchor must hold its EXACT offset from the viewport top - the
+      // grown row pushed content above it down by exactly this much, so
+      // scroll must grow by the same amount to compensate. A flat (zero)
+      // delta here is the ticket-22 defect: the anchor silently drifts.
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(getScrollNode().scrollTop - scrollBefore).toBe(
+        T22_GEOMETRY_DELTA_PX,
+      );
+      // Review round 1 (finding 3, CONFIRMED MEDIUM): decision #31's
+      // non-animated departure classifier depends on every anchor
+      // correction being instant - assert the exact `scrollToOffset`
+      // params, not just the resulting position.
+      expect(scrollToOffsetSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: false }),
+      );
+    });
+
+    it("(pin 2) a viewport resize coalesces with a coincident item-size change into exactly one repair", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-pin2-viewport-resize";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-pin2-viewport-resize",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 820_000);
+      const scrollBefore = getScrollNode().scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+
+      // A pure viewport-length change alone (no row remeasure) never moves
+      // `positionAtIndex` for a single-column vertical list - it changes
+      // what's REVEALED, not the anchor's own content-relative position.
+      // Fired here to prove the new wiring is inert (no spurious
+      // correction) when there is genuinely nothing to repair.
+      act(() => {
+        triggerLegendListResizeObserverEntry(getScrollNode(), {
+          width: VIEWPORT_WIDTH_PX + 200,
+          height: VIEWPORT_HEIGHT_PX,
+        });
+      });
+      await waitForRevealPassTick();
+      expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      expect(getScrollNode().scrollTop).toBe(scrollBefore);
+
+      // Now pair the SAME resize signal with the real-browser consequence
+      // it would cause (a rewrapped row above the anchor growing) - jsdom's
+      // shim never rewraps text on its own, so the row-height change is
+      // driven explicitly alongside the resize event. Both signals land in
+      // the same coalescing window; the repair must fire exactly ONCE, not
+      // once per trigger. Review round 1 (finding 4): a single
+      // `scrollToOffset` call alone survives a missing coalescing guard (a
+      // second scheduled pass can settle at zero drift and never write), so
+      // also assert the shared repair function itself ran exactly once -
+      // two independent triggers (resize + item-size) collapsing to ONE
+      // scheduled pass, not two.
+      const repairCallsBefore = applyChatAnchorDriftRepairCallCountRef.current;
+      act(() => {
+        triggerLegendListResizeObserverEntry(getScrollNode(), {
+          width: VIEWPORT_WIDTH_PX + 400,
+          height: VIEWPORT_HEIGHT_PX,
+        });
+        legendListRefHolder.current?.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX + 400,
+        });
+      });
+      await waitForRevealPassTick();
+
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(getScrollNode().scrollTop - scrollBefore).toBe(
+        T22_GEOMETRY_DELTA_PX,
+      );
+      expect(scrollToOffsetSpy).toHaveBeenCalledOnce();
+      expect(
+        applyChatAnchorDriftRepairCallCountRef.current - repairCallsBefore,
+      ).toBe(1);
+    });
+
+    it("(pin 3) no double-correction with the disclosure helper's own manual correction during anchoring", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-pin3-no-double-correction";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-pin3-no-double-correction",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 830_000);
+      const scrollBefore = getScrollNode().scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+
+      // Simulates a disclosure toggle whose own trigger row sits above the
+      // anchor and genuinely shifts on-screen by the SAME delta the real
+      // row growth below produces - `correctionOwnedByMvcp: false` matches
+      // production's own `timelineScrollModeRef.current === "free-scrolling"`
+      // computation while anchoring (M2, tickets 10-12): the disclosure
+      // helper owns and applies the correction synchronously.
+      const anchorElement = document.createElement("div");
+      const rectSpy = vi.spyOn(anchorElement, "getBoundingClientRect");
+      rectSpy.mockReturnValueOnce({
+        x: 0,
+        y: 100,
+        width: 100,
+        height: 20,
+        top: 100,
+        left: 0,
+        right: 100,
+        bottom: 120,
+        toJSON: () => ({}),
+      });
+      rectSpy.mockReturnValueOnce({
+        x: 0,
+        y: 100 + T22_GEOMETRY_DELTA_PX,
+        width: 100,
+        height: 20,
+        top: 100 + T22_GEOMETRY_DELTA_PX,
+        left: 0,
+        right: 100,
+        bottom: 120 + T22_GEOMETRY_DELTA_PX,
+        toJSON: () => ({}),
+      });
+
+      act(() => {
+        preserveChatScrollAcrossDisclosureChange({
+          list: legendListRefHolder.current,
+          anchorElement,
+          mutate: () => {
+            legendListRefHolder.current?.setItemSize("message-2", {
+              height: 90 + T22_GEOMETRY_DELTA_PX,
+              width: VIEWPORT_WIDTH_PX,
+            });
+          },
+          correctionOwnedByMvcp: false,
+        });
+      });
+
+      // The disclosure helper's own delta-based correction issues
+      // synchronously; the real `setItemSize` call inside `mutate` also
+      // fires a genuine `onItemSizeChanged` - ticket 22's new coalesced
+      // geometry scheduler reacts to it independently. Let BOTH settle
+      // (LegendList's own geometry bookkeeping is not guaranteed to reflect
+      // a `scrollToOffset` call within the same act() it was issued in, and
+      // the scheduler's own pass needs its two-rAF window) before checking
+      // where the anchor landed.
+      await waitForRevealPassTick();
+      await waitForRevealPassTick();
+
+      // Exactly the delta the row growth produced - not double-applied by
+      // two independent correctors racing the same shift.
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(getScrollNode().scrollTop - scrollBefore).toBe(
+        T22_GEOMETRY_DELTA_PX,
+      );
+
+      // Idempotence: with both correctors already settled and drift at
+      // zero, a further settle window must not move it again - the
+      // regression this pin guards is a SECOND correction stacking a
+      // further +220 on top (landing at +440), not merely "some correction
+      // happened".
+      await waitForRevealPassTick();
+      expect(getScrollNode().scrollTop - scrollBefore).toBe(
+        T22_GEOMETRY_DELTA_PX,
+      );
+    });
+
+    it("(pin 4) a departed/cancelled session gets no geometry repair", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-pin4-departure-guard";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-pin4-departure-guard",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 840_000);
+
+      const scrollNode = getScrollNode();
+      // A real downward-wheel departure gesture cancels the anchoring
+      // session unconditionally (decision #14/ticket 14) - bumps the
+      // generation the same way any other real-gesture cancel does.
+      fireEvent.wheel(scrollNode, { deltaY: 40 });
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      const departedScrollTop = scrollNode.scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+
+      // The exact same geometry change pin 1 proves DOES repair while
+      // still anchoring - here the session has already departed, so this
+      // must be a pure no-op.
+      act(() => {
+        legendListRefHolder.current?.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+
+      await waitForRevealPassTick();
+
+      expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      expect(scrollNode.scrollTop).toBe(departedScrollTop);
+    });
+
+    it("(pin 4b) departure DURING the deferred two-rAF window still blocks the repair", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-pin4b-mid-window-departure";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-pin4b-mid-window-departure",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 845_000);
+      const scrollNode = getScrollNode();
+      const scrollBefore = scrollNode.scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+
+      // Review round 1 (finding 2, CONFIRMED MEDIUM): pin 4 departs BEFORE
+      // scheduling, so it only exercises the schedule-time mode guard - the
+      // deferred callback's OWN fire-time mode/generation checks never run
+      // in that pin at all. Schedule a real repair here (the same
+      // setItemSize trigger pin 1 uses), let only the FIRST of the two rAFs
+      // elapse - arms the second frame, does not run it yet, the
+      // scheduler's own pending window - THEN depart with a real
+      // downward-wheel gesture, THEN let the deferred frame actually fire.
+      act(() => {
+        list.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+      expect(scrollNode.dataset.scrollMode).toBe("anchoring-new-turn");
+
+      await act(async () => {
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve()),
+        );
+      });
+
+      fireEvent.wheel(scrollNode, { deltaY: 40 });
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+
+      await waitForRevealPassTick();
+
+      // The already-scheduled pass must see the departure at fire time and
+      // yield - pin 1's repair signature (+T22_GEOMETRY_DELTA_PX via
+      // `scrollToOffset`) must never land for this departed session.
+      expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      expect(scrollNode.scrollTop).toBe(scrollBefore);
+    });
+
+    it("geometry repair does not fire while following-end", async () => {
+      // Pure following-end (never entered anchoring-new-turn). The scheduler
+      // mode-gates at schedule time and again inside the deferred frame -
+      // pin 1's +T22_GEOMETRY_DELTA_PX signature is the anchoring-only path.
+      const history = makeCompletedTranscript(12);
+      renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-mode-following-end",
+      });
+      await settleLegendList();
+
+      const scrollNode = getScrollNode();
+      expect(scrollNode.dataset.scrollMode).toBe("following-end");
+      const scrollBefore = scrollNode.scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+
+      act(() => {
+        legendListRefHolder.current?.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+      await waitForRevealPassTick();
+
+      // following-end may still move for maintainScrollAtEnd end-stick; the
+      // load-bearing contract is mode stays non-anchoring and we never see
+      // the anchor-hold repair signature from pin 1.
+      expect(scrollNode.dataset.scrollMode).toBe("following-end");
+      expect(scrollNode.scrollTop - scrollBefore).not.toBe(
+        T22_GEOMETRY_DELTA_PX,
+      );
+    });
+
+    it("geometry repair does not fire while free-scrolling", async () => {
+      // Pure free-scrolling seed (not a post-departure pin-4 shape): park
+      // away from the end, grow a history row, confirm the geometry
+      // scheduler does not apply the anchoring-new-turn repair signature.
+      // MVCP size-preservation may adjust scrollTop for reading stability -
+      // that is a different mechanism; pin 4 already pins zero
+      // scrollToOffset for a departed overflowing session.
+      const history = makeCompletedTranscript(12);
+      const scrollStateKey = "t22-mode-free-scrolling";
+      saveChatTabState({
+        identity: makeDefaultTestIdentity(scrollStateKey),
+        mode: "free-scrolling",
+        anchorMessageId: history[0]?.id ?? null,
+        anchorIndex: 0,
+        offset: 0,
+      });
+      renderChatMessages({
+        messages: history,
+        scrollStateKey,
+      });
+      await settleLegendList();
+
+      const scrollNode = getScrollNode();
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      const scrollBefore = scrollNode.scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const freeScrollingList = legendListRefHolder.current;
+      if (!freeScrollingList) {
+        throw new Error("expected LegendListRef to be attached");
+      }
+      const scrollToOffsetSpy = vi.spyOn(freeScrollingList, "scrollToOffset");
+
+      act(() => {
+        legendListRefHolder.current?.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+      await waitForRevealPassTick();
+
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      expect(scrollNode.scrollTop - scrollBefore).not.toBe(
+        T22_GEOMETRY_DELTA_PX,
+      );
+      // Mirror pin 4 when MVCP has nothing to compensate at scrollTop=0:
+      // the geometry scheduler itself must not have called scrollToOffset.
+      // If MVCP did compensate via another path, scrollTop would move but
+      // still must not land on the pure anchor-repair signature above.
+      if (scrollNode.scrollTop === scrollBefore) {
+        expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      }
+    });
+
+    it("a row growing BELOW the anchor produces no geometry correction", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-below-anchor-no-repair";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-below-anchor-no-repair",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      const overflowing = await sendAndOverflowAnchor(
+        rerenderMessages,
+        history,
+        sendId,
+        850_000,
+      );
+      const scrollBefore = getScrollNode().scrollTop;
+
+      // Streaming reply rows sit AFTER the anchored user send - growing one
+      // of those changes content below the anchor only. positionAtIndex for
+      // the anchor is unchanged, so the repair must see zero drift.
+      const belowAnchorId = overflowing.find(
+        (message) => message.id === "incremental-chunk-0",
+      )?.id;
+      expect(belowAnchorId).toBe("incremental-chunk-0");
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const belowAnchorList = legendListRefHolder.current;
+      if (!belowAnchorList) {
+        throw new Error("expected LegendListRef to be attached");
+      }
+      const scrollToOffsetSpy = vi.spyOn(belowAnchorList, "scrollToOffset");
+
+      act(() => {
+        legendListRefHolder.current?.setItemSize("incremental-chunk-0", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+      await waitForRevealPassTick();
+
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(getScrollNode().scrollTop).toBe(scrollBefore);
+      expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+    });
+
+    it("multiple same-frame item-size changes above the anchor coalesce into one repair", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-coalesce-multi-item-size";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-coalesce-multi-item-size",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 860_000);
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const coalesceList = legendListRefHolder.current;
+      if (!coalesceList) {
+        throw new Error("expected LegendListRef to be attached");
+      }
+      const scrollToOffsetSpy = vi.spyOn(coalesceList, "scrollToOffset");
+      const scrollBefore = getScrollNode().scrollTop;
+
+      // Review round 1 (finding 4, CONFIRMED LOW): a single `scrollToOffset`
+      // call proves idempotence, not "one scheduled pass" - if the
+      // coalescing ref were missing, several independent two-rAF chains
+      // would run, but only the FIRST observes non-zero drift and writes;
+      // the rest settle at zero and never call `scrollToOffset`, so that
+      // oracle alone survives the guard's removal. Count invocations of the
+      // shared repair function itself instead (via the module-level
+      // call-count tee above) - deterministic, unlike spying on
+      // `window.requestAnimationFrame`, which also picks up LegendList's own
+      // unrelated internal rAF usage.
+      const repairCallsBefore = applyChatAnchorDriftRepairCallCountRef.current;
+
+      // Four separate setItemSize notifications in one act() - each would
+      // schedule its OWN two-rAF chain if the coalescing ref were missing;
+      // the scheduler must collapse them into a single repair pass.
+      const rowsAboveAnchor = [
+        "message-0",
+        "message-2",
+        "message-4",
+        "message-6",
+      ] as const;
+      act(() => {
+        for (const rowId of rowsAboveAnchor) {
+          legendListRefHolder.current?.setItemSize(rowId, {
+            height: 90 + T22_GEOMETRY_DELTA_PX,
+            width: VIEWPORT_WIDTH_PX,
+          });
+        }
+      });
+      await waitForRevealPassTick();
+
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(getScrollNode().scrollTop - scrollBefore).toBe(
+        T22_GEOMETRY_DELTA_PX * rowsAboveAnchor.length,
+      );
+      expect(scrollToOffsetSpy).toHaveBeenCalledOnce();
+      expect(
+        applyChatAnchorDriftRepairCallCountRef.current - repairCallsBefore,
+      ).toBe(1);
+    });
+
+    it("unmount while a geometry repair is scheduled cancels cleanly (no throw, no late scrollToOffset)", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-unmount-mid-repair";
+      const { rerenderMessages, unmount } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-unmount-mid-repair",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 870_000);
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      try {
+        // Schedule the two-rAF geometry repair, then unmount before the
+        // deferred frame runs - the cleanup effect must cancel the pending
+        // frame so the callback never touches an unmounted list.
+        act(() => {
+          list.setItemSize("message-2", {
+            height: 90 + T22_GEOMETRY_DELTA_PX,
+            width: VIEWPORT_WIDTH_PX,
+          });
+          unmount();
+        });
+
+        await waitForRevealPassTick();
+
+        expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+      } finally {
+        consoleErrorSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("(pin 1b) survives a StrictMode setup->cleanup->setup replay while already anchoring at mount (finding 1)", async () => {
+      // Fresh-open (decision #15): no saved scroll state + a transcript
+      // ending in a user send, so this mounts DIRECTLY into
+      // `anchoring-new-turn` - the exact shape the review flagged (LegendList's
+      // initial `onLayout` arms the coalescing sentinel during the FIRST
+      // StrictMode setup; the dev-only cleanup->setup replay must not leave
+      // it poisoned).
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-strict-fresh-open-anchor";
+      const baseCreatedAt = 895_000;
+      const messages = appendOptimisticUserSend(history, sendId, baseCreatedAt);
+      const instanceId = `t22-strict-fresh-open-${Math.random().toString(36).slice(2)}`;
+      const epicId = "epic-1";
+      const taskId = "task-1";
+      const identity = makeTestIdentity(instanceId, epicId, taskId);
+      expect(hasSavedChatTabState(identity)).toBe(false);
+
+      const { unmount } = render(
+        <StrictMode>
+          <div
+            data-chat-keyboard-scroll-scope
+            data-active="true"
+            style={{ height: VIEWPORT_HEIGHT_PX, width: VIEWPORT_WIDTH_PX }}
+          >
+            <ChatMessages
+              taskTitle="Test chat"
+              taskId={taskId}
+              epicId={epicId}
+              messages={messages}
+              localProvenanceMessageIds={new Set()}
+              consumeLocalProvenance={() => undefined}
+              backgroundItems={undefined}
+              getMessageActions={() => null}
+              nextStepActions={null}
+              instanceId={instanceId}
+              visible
+              systemOverlayActive={false}
+              isChatStreaming={false}
+              scrollRequest={null}
+              composerOverlayHeight={80}
+            />
+          </div>
+        </StrictMode>,
+      );
+
+      // Mode seed is synchronous at construction (decision #15) - already
+      // anchoring before StrictMode's dev-only setup->cleanup->setup replay
+      // has even finished. This is the exact commit the review flagged:
+      // LegendList's initial `onLayout` arms the coalescing sentinel WHILE
+      // mode is already `anchoring-new-turn`, then StrictMode's replay
+      // cancels those frames.
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      await settleLegendList();
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+
+      // The replay is long over by now - this is an ORDINARY later trigger,
+      // identical to pin 1's own recipe. Pre-fix, the sentinel armed during
+      // the first StrictMode setup stays non-null forever (the cleanup
+      // cancels those frames without clearing it), so every later trigger
+      // for the lifetime of this mount silently no-ops here.
+      //
+      // Signal choice: neither `scrollTop` nor the `applyChatAnchorDriftRepair`
+      // call-count tee (finding 4's signal) work for THIS specific
+      // construction - a SEPARATE, pre-existing harness limitation (fresh-
+      // open's own `scrollToIndex` bootstrap never converges `scrollTop` for
+      // a raw-StrictMode mount in this jsdom setup, so the anchor reaches
+      // "positioned" but never "settled" - unrelated to ticket 22, flagged
+      // to the reviewer rather than worked around here) means the deferred
+      // callback's OWN unsettled-anchor guard always blocks it BEFORE
+      // reaching the repair function, on both healthy and poisoned code.
+      // Count synchronous `requestAnimationFrame` registrations instead,
+      // scoped tightly to this one `act()`: `scheduleChatAnchorGeometryRepair`
+      // returns at its entry guard (`pendingGeometryRepairCancelRef.current
+      // !== null`) BEFORE calling `scheduleChatTimelineDoubleRaf` - which
+      // itself always registers exactly one synchronous rAF per call - so a
+      // poisoned sentinel drops the count by exactly one relative to a
+      // healthy one. Mutation-verified directly against this exact test: 2
+      // calls with the cleanup fix in place, 1 with it reverted (the `1` is
+      // LegendList's own unrelated internal rAF usage for this `setItemSize`
+      // call, present either way).
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+      rafSpy.mockClear();
+      act(() => {
+        list.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(rafSpy.mock.calls.length).toBeGreaterThan(1);
+
+      unmount();
+    });
+
+    it("geometry repair does not run while a new anchor is still pending/positioning (not yet settled)", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-mid-flight-anchor-guard";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-mid-flight-anchor-guard",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+
+      // Hang the library's scroll promise so the engine stays in
+      // positioned-but-not-settled (pendingTimelineAnchorRef cleared on
+      // onAnchorReady, settledTimelineAnchorRef still null) - the same
+      // mid-flight window the scheduler's "no anchor navigation currently
+      // mid-flight" guard is meant to refuse.
+      const originalScrollToIndex = list.scrollToIndex.bind(list);
+      const hangingScrollToIndex = vi
+        .spyOn(list, "scrollToIndex")
+        .mockImplementation((params) => {
+          void originalScrollToIndex(params);
+          return new Promise<void>(() => {});
+        });
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+
+      try {
+        const afterSend = appendOptimisticUserSend(history, sendId, 880_000);
+        rerenderMessages(afterSend);
+        await waitFor(() => {
+          expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+        });
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+        // Wait until the hang is engaged (positioning issued) but well
+        // before the settle watchdog fails safe out of anchoring-new-turn.
+        await waitFor(() => {
+          expect(hangingScrollToIndex).toHaveBeenCalled();
+        });
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+        scrollToOffsetSpy.mockClear();
+        const scrollBefore = getScrollNode().scrollTop;
+
+        act(() => {
+          list.setItemSize("message-2", {
+            height: 90 + T22_GEOMETRY_DELTA_PX,
+            width: VIEWPORT_WIDTH_PX,
+          });
+        });
+        await waitForRevealPassTick();
+
+        // Still mid-flight - must not apply the settled-session repair
+        // signature (+T22_GEOMETRY_DELTA_PX via scrollToOffset).
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        expect(getScrollNode().scrollTop - scrollBefore).not.toBe(
+          T22_GEOMETRY_DELTA_PX,
+        );
+        expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      } finally {
+        hangingScrollToIndex.mockRestore();
+      }
+    });
+
+    it("a genuine shrink of a row above the anchor repairs with negative drift", async () => {
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-shrink-above-anchor";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-shrink-above-anchor",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 890_000);
+      const scrollBefore = getScrollNode().scrollTop;
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+
+      // Shrink, not grow - all four required pins only exercise positive
+      // delta. The repair math is signed; a shorter row above the anchor
+      // must pull scrollTop down by the same amount.
+      const shrinkPx = 50;
+      act(() => {
+        legendListRefHolder.current?.setItemSize("message-2", {
+          height: 90 - shrinkPx,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+      await waitForRevealPassTick();
+
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(getScrollNode().scrollTop - scrollBefore).toBe(-shrinkPx);
+    });
+
+    it("(pin 4c) a scroll-only departure through following-end still blocks a pending repair (review round 2, finding 2 residual)", async () => {
+      // Review round 2 (finding 2 residual): pin 4b's wheel departure nulls
+      // `activeTimelineAnchorIndexRef` (via `cancelTimelineLiveFollowFor
+      // UserNavigation`), so `getActiveTimelineTurnMetrics` independently
+      // returns null there and backstops a deleted mode/generation check -
+      // pin 4b stays green even if those checks are removed. A REAL
+      // reachable route does not null that ref at all: a scroll-only
+      // reconcile (ticket 11 fix #1, `chat-messages.tsx` ~1915-1929) takes
+      // an overflowing anchoring session to `following-end` purely from
+      // reaching the true content edge - no wheel/touchmove/pointerdown ever
+      // fires - and a SUBSEQUENT native-OS-scrollbar-style decrease (the
+      // equality fast-path's else branch, ~1931-1941) then takes it to
+      // `free-scrolling`. Neither transition touches
+      // `activeTimelineAnchorIndexRef`/`positionedTimelineAnchorRef`/
+      // `settledTimelineAnchorRef` (only `cancelTimelineLiveFollowForUser
+      // Navigation` - the wheel/touch/pointerdown path - does). On this
+      // route the fire-time mode/generation checks are the SOLE barrier.
+      const history = makeCompletedTranscript(10);
+      const sendId = "t22-pin4c-scroll-only-departure";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t22-pin4c-scroll-only-departure",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      await sendAndOverflowAnchor(rerenderMessages, history, sendId, 900_000);
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+
+      const scrollNode = getScrollNode();
+      // Learn the REAL "true end" offset from LegendList's own
+      // `getMaxScrollOffset()` via the public `scrollToEnd` imperative API -
+      // NOT jsdom's shimmed `scrollHeight - clientHeight` (memory:
+      // legendlist-jsdom-shim-scrollheight-trap - the fake scrollHeight sits
+      // nowhere near LegendList's own tracked content size, and any offset
+      // derived from it reads as permanently "past the end"). This call
+      // alone does not report through `onIsAtEndChange` in this harness (no
+      // synthetic 'scroll' event follows it), so mode stays untouched.
+      act(() => {
+        list.scrollToEnd({ animated: false });
+      });
+      const trueEnd = scrollNode.scrollTop;
+
+      // Schedule the two-rAF geometry repair while still anchoring (arms
+      // the entry guard's cancel function) - same trigger pin 1/4b use.
+      act(() => {
+        list.setItemSize("message-2", {
+          height: 90 + T22_GEOMETRY_DELTA_PX,
+          width: VIEWPORT_WIDTH_PX,
+        });
+      });
+      expect(scrollNode.dataset.scrollMode).toBe("anchoring-new-turn");
+
+      // First scroll-only report: reaching the true end reconciles mode to
+      // `following-end` (ticket 11 fix #1) without touching the anchor refs.
+      await act(async () => {
+        scrollNode.scrollTop = trueEnd;
+        fireEvent.scroll(scrollNode);
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+      expect(scrollNode.dataset.scrollMode).toBe("following-end");
+
+      // Second scroll-only report: a real decrease (an OS-scrollbar drag
+      // away from the tail, no gesture event) takes `following-end` to
+      // `free-scrolling` via the equality fast-path's else branch - nulling
+      // `liveFollowUserScrollGenerationRef` but NOT `activeTimelineAnchor
+      // IndexRef`. This is where the still-pending geometry repair's
+      // deferred frame actually fires (confirmed empirically: this second
+      // report flushes synchronously - `following-end`'s own MVCP-active
+      // state short-circuits the scroll coalescer - so the already-armed
+      // second rAF from the schedule above elapses after this transition
+      // has already landed, not before it).
+      await act(async () => {
+        scrollNode.scrollTop = trueEnd - 900;
+        fireEvent.scroll(scrollNode);
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+
+      await waitForRevealPassTick();
+
+      // The already-scheduled repair must see the departure at fire time and
+      // yield, exactly like pin 4b - but here `getActiveTimelineTurnMetrics`
+      // would NOT independently return null (the anchor refs were never
+      // cleared), so this is a genuine, isolated proof that the mode/
+      // generation checks alone are load-bearing on this route.
+      expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      expect(scrollNode.scrollTop).toBe(trueEnd - 900);
     });
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -37,7 +37,6 @@ import {
 import {
   captureChatFreeScrollingOffset,
   CHAT_LIST_ANCHOR_OFFSET,
-  getChatNaturalMaxScrollWithoutAnchorReserve,
 } from "@/components/chat/chat-scroll-anchoring";
 import { appLogger } from "@/lib/logger";
 import { preserveChatScrollAcrossDisclosureChange } from "@/components/chat/chat-scroll-disclosure";
@@ -680,6 +679,105 @@ function fireScrollTopWithoutFlush(scrollTop: number): void {
     scrollNode.scrollTop = scrollTop;
     fireEvent.scroll(scrollNode);
   });
+}
+
+/**
+ * Ticket 19: repositions the scroll node through the REAL LegendList
+ * imperative API (`scrollToOffset`, non-animated) instead of a bare
+ * `scrollTop` write. The installed library pre-writes its own internal
+ * `getState().scroll` synchronously, before this jsdom harness's `scrollTo`
+ * shim ever touches the DOM `scrollTop` (verified against installed
+ * `@legendapp/list@3.2.0`: `react.mjs:2104-2110`) - so the capture-
+ * provenance classifier (chat-messages-scroll-helpers.ts) correctly reads
+ * this as a library-owned correction and stays silent, unlike
+ * `fireScrollTopAndFlush`/`fireScrollOnlyTo`, which (correctly, post-
+ * ticket-19) now cancels an owned anchoring-new-turn session on first use.
+ *
+ * Use this whenever a test needs to move the scroll node while remaining
+ * inside whatever mode/generation currently owns it - the same shape
+ * production code itself produces via the reveal pass / geometry repair -
+ * NOT to simulate a reader gesture (that is exactly what
+ * `fireScrollTopAndFlush` is for, and what should now correctly cancel).
+ */
+async function fireLibraryOwnedScrollTo(offset: number): Promise<void> {
+  const list = legendListRefHolder.current;
+  if (!list) throw new Error("expected LegendListRef to be attached");
+  const scrollNode = getScrollNode();
+  await act(async () => {
+    void list.scrollToOffset({ offset, animated: false });
+    fireEvent.scroll(scrollNode);
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+/**
+ * Ticket 19 silence pins: the jsdom harness's `scrollTop` setter and
+ * `scrollTo` shim never `dispatchEvent` (legend-list-test-environment.ts),
+ * so production's capture-phase classifier never runs unless a test fires
+ * `scroll` explicitly. Call this after a library-owned write
+ * (`scrollToOffset`/`scrollToIndex`/MVCP/`setItemSize` correction) so the
+ * classifier actually observes the post-write DOM - same shape the hard-
+ * gate pins and `fireLibraryOwnedScrollTo` use. Without it, a "silence"
+ * pin can stay green under a maximally-broken classifier that always
+ * cancels while owned.
+ */
+async function fireCaptureScrollAfterLibraryWrite(): Promise<void> {
+  const scrollNode = getScrollNode();
+  await act(async () => {
+    fireEvent.scroll(scrollNode);
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+/**
+ * Ticket 19: wrap LegendList imperative scroll APIs so every call also
+ * delivers a capture-phase `scroll` event (the harness never auto-fires
+ * one). Used for anchor-engine issue/reissue paths that call
+ * `scrollToIndex` from rAF inside production - without the wrap those
+ * writes are invisible to `chatAnchorScrollCaptureShouldCancel`.
+ * Fires scroll synchronously after the real method returns so the
+ * capture listener runs while `activeAnchorImperativeMotionGenerationRef`
+ * is still armed (guard 2) for in-flight anchor issues.
+ */
+function installLibraryScrollCaptureDispatch(): {
+  dispose: () => void;
+  scrollToIndexCallCount: () => number;
+  scrollToOffsetCallCount: () => number;
+} {
+  const list = legendListRefHolder.current;
+  if (!list) throw new Error("expected LegendListRef to be attached");
+  let scrollToIndexCalls = 0;
+  let scrollToOffsetCalls = 0;
+  const originalScrollToIndex = list.scrollToIndex.bind(list);
+  const originalScrollToOffset = list.scrollToOffset.bind(list);
+  const indexSpy = vi
+    .spyOn(list, "scrollToIndex")
+    .mockImplementation((opts) => {
+      scrollToIndexCalls += 1;
+      const result = originalScrollToIndex(opts);
+      fireEvent.scroll(getScrollNode());
+      return result;
+    });
+  const offsetSpy = vi
+    .spyOn(list, "scrollToOffset")
+    .mockImplementation((opts) => {
+      scrollToOffsetCalls += 1;
+      const result = originalScrollToOffset(opts);
+      fireEvent.scroll(getScrollNode());
+      return result;
+    });
+  return {
+    dispose: () => {
+      indexSpy.mockRestore();
+      offsetSpy.mockRestore();
+    },
+    scrollToIndexCallCount: () => scrollToIndexCalls,
+    scrollToOffsetCallCount: () => scrollToOffsetCalls,
+  };
 }
 
 /** Dispatch a keydown with target inside the keyboard-scroll scope. */
@@ -1753,7 +1851,7 @@ describe("ChatMessages scroll policy", () => {
     // Deleting a user message above the parked position (a real suffix
     // removal) was then expected to land at the new live edge
     // (`following-end`) but did not move.
-    it("(reachability) a programmatic scrollTop write during anchoring-new-turn does not cancel the session - documents current behavior, not a fix", async () => {
+    it("(ticket 19 pin) a settled anchoring session cedes ownership on a scroll-only DOM departure - the scrollbar-thumb gesture the reachability pin above used to document as undetected", async () => {
       const sendId = "s4b-reachability-send";
       const messages = makeCompletedTranscript(30);
       const { rerenderMessages } = renderChatMessages({
@@ -1772,22 +1870,53 @@ describe("ChatMessages scroll policy", () => {
       await waitForAnchorEngineSettle();
       expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
 
-      // Programmatic scrollTop write, no gesture event of any kind - the
-      // live harness's exact entry mechanism. A real user parking mid-history
-      // uses wheel/minimap/keys, all of which cancel or suppress the
-      // anchoring session; this path is reachable only through a
-      // non-gesture, script-driven scroll.
+      // Same scroll-only departure the old (pre-ticket-19) reachability pin
+      // documented as undetected: a direct DOM `scrollTop` write with no
+      // wheel/touch/pointerdown event of its own - the live harness's exact
+      // native-thumb-drag shape. Critically, this is also NOT a library
+      // call of any kind, so `list.getState().scroll` never advances to
+      // match - the capture-provenance classifier's state-equality check
+      // (chat-messages-scroll-helpers.ts) sees the mismatch and cancels on
+      // the very first captured event, before LegendList's own non-capture
+      // target listener ever consumes it.
       const scrollNode = getScrollNode();
       act(() => {
         scrollNode.scrollTop = 900;
         fireEvent.scroll(scrollNode);
       });
 
-      expect(scrollNode.dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
+      expect(scrollNode.scrollTop).toBe(900);
+
+      // Ownership oracle (design's integrated pin, item 3): the departed
+      // generation must never again receive a reveal/follow correction.
+      // Spying on the REAL LegendList instance's own imperative API is the
+      // strongest available negative - it is the exact surface the reveal
+      // pass and anchor engine would call to pull a still-owned reader back.
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const scrollToOffsetSpy = vi.spyOn(list, "scrollToOffset");
+      const scrollToIndexSpy = vi.spyOn(list, "scrollToIndex");
+      const withReply: ReadonlyArray<ChatMessageModel> = [
+        ...afterSend,
+        {
+          ...makeMessageAt(0, "assistant", 700_001),
+          id: "s4b-reachability-reply-1",
+          content: "chunk",
+          completedAt: null,
+          runState: "running",
+        },
+      ];
+      rerenderMessages(withReply);
+      await settleLegendList();
+
+      expect(scrollToOffsetSpy).not.toHaveBeenCalled();
+      expect(scrollToIndexSpy).not.toHaveBeenCalled();
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
       expect(scrollNode.scrollTop).toBe(900);
     });
 
-    it("(delete pin) a suffix delete that sweeps a programmatically-parked anchoring session lands at the new live edge", async () => {
+    it("(delete pin) a suffix delete that sweeps a scroll-only-departed (now free-scrolling) reader lands at the new live edge", async () => {
       const sendId = "s4b-delete-send";
       const ROW_COUNT = 30;
       const KEEP_COUNT = 10;
@@ -1808,16 +1937,22 @@ describe("ChatMessages scroll policy", () => {
       await waitForAnchorEngineSettle();
       expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
 
-      // Same programmatic park as the reachability pin above - lands well
+      // Same scroll-only departure as the ticket-19 pin above - lands well
       // past KEEP_COUNT (10), so the reader's current viewport (and the
       // anchored send itself, at index ROW_COUNT=30) both fall inside the
-      // to-be-deleted suffix.
+      // to-be-deleted suffix. Post-ticket-19, the capture-provenance
+      // classifier cancels anchoring ownership on this SAME event (mode
+      // transitions to `free-scrolling` immediately, not merely at delete
+      // time) - the delete below now exercises `classifySuffixRemoval`'s
+      // ordinary free-scrolling-viewport-touched branch, not the old
+      // anchoring-reserve teardown this pin originally targeted; the
+      // observable outcome (lands at the new live edge) is unchanged.
       const scrollNode = getScrollNode();
       act(() => {
         scrollNode.scrollTop = 900;
         fireEvent.scroll(scrollNode);
       });
-      expect(scrollNode.dataset.scrollMode).toBe("anchoring-new-turn");
+      expect(scrollNode.dataset.scrollMode).toBe("free-scrolling");
 
       // Real suffix delete: a user message above the parked viewport is
       // removed, taking everything after it (including the parked position
@@ -1892,6 +2027,768 @@ describe("ChatMessages scroll policy", () => {
       // cleared, `anchoredEndSpace` undefined, no reserve), it lands at the
       // true natural end, 2290 - a 474px gap matching the reserve exactly.
       expect(getScrollNode().scrollTop).toBe(2290);
+    });
+  });
+
+  // Ticket 19 (decision #31 binding condition c): these two pins are a HARD
+  // dependency-upgrade gate against the INSTALLED @legendapp/list@3.2.0, not
+  // ordinary behavior coverage. `chatAnchorScrollCaptureShouldCancel`'s
+  // entire state-equality/clamp classification (chat-messages-scroll-
+  // helpers.ts) depends on the library's OWN listener-ordering and pre-write
+  // contract - these pins assert THAT contract directly, against a REAL
+  // mounted LegendList instance, independent of the classifier's own logic.
+  // A future @legendapp/list bump can break this contract in two OPPOSITE
+  // directions - triage a red pin here by which one actually broke, they
+  // are not interchangeable:
+  //
+  // (a) Losing the imperative/MVCP PRE-WRITE (the non-animated-scrollToOffset
+  //     pin, or the MVCP pin below, goes red): a legitimate library-owned
+  //     correction no longer advances `state.scroll` before its DOM event
+  //     reaches ancestor capture, so it now mismatches the state-equality
+  //     check. Effect: FALSE CANCELS - the classifier treats a real
+  //     library-owned scroll as a departure. Reader-safe (the fail-safe bias
+  //     is unsure -> cancel), degrades send UX with an extra unwanted
+  //     free-scrolling transition. This is the safety net working exactly as
+  //     designed - do NOT "fix" this direction by loosening the classifier;
+  //     re-audit and restore the dependency contract instead.
+  //
+  // (b) Losing CAPTURE-BEFORE-CONSUMPTION ordering (the direct-DOM-write pin
+  //     goes red): if the library's own consuming listener ever runs before
+  //     this ancestor's capture-phase listener, then by the time capture
+  //     observes an event, LegendList has ALREADY consumed and often
+  //     resynchronized `state.scroll` to match DOM - including for a genuine
+  //     native thumb-drag departure. Effect: FALSE SILENCE - a real reader
+  //     departure now looks state-equal and slips past the classifier
+  //     un-cancelled, recreating the exact intent violation ticket 19 exists
+  //     to fix. This is the dangerous direction: it cannot be caught by
+  //     "make the classifier stricter," because the classifier never even
+  //     sees a mismatch to act on - only re-establishing capture-phase
+  //     ordering (or an entirely different detection mechanism) fixes it.
+  //
+  // (See the module doc comment on chat-messages-scroll-helpers.ts for the
+  // full writer-site table these pins are drawn from.)
+  describe("ticket 19: installed @legendapp/list 3.2.0 contract pins (hard upgrade gate)", () => {
+    it("a direct DOM scrollTop move is STALE at ancestor capture - react.mjs:5663-5671 installs the consuming listener on the scroll node with no capture flag", async () => {
+      const sendId = "t19-contract-direct-send";
+      const messages = makeCompletedTranscript(30);
+      const { rerenderMessages } = renderChatMessages({
+        messages,
+        scrollStateKey: "t19-contract-direct-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(messages, sendId, 700_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const wrapper = screen.getByTestId("chat-transcript-container");
+      const scrollNode = getScrollNode();
+      const observedListStateAtCapture: Array<number> = [];
+      const observer = (event: Event): void => {
+        if (event.target !== scrollNode) return;
+        observedListStateAtCapture.push(list.getState().scroll);
+      };
+      wrapper.addEventListener("scroll", observer, { capture: true });
+      try {
+        const domScrollTopBeforeWrite = scrollNode.scrollTop;
+        act(() => {
+          scrollNode.scrollTop = domScrollTopBeforeWrite + 300;
+          fireEvent.scroll(scrollNode);
+        });
+        expect(observedListStateAtCapture).toHaveLength(1);
+        expect(observedListStateAtCapture[0]).toBe(domScrollTopBeforeWrite);
+        expect(observedListStateAtCapture[0]).not.toBe(
+          domScrollTopBeforeWrite + 300,
+        );
+      } finally {
+        wrapper.removeEventListener("scroll", observer, { capture: true });
+      }
+    });
+
+    it("a non-animated scrollToOffset call is ALREADY SYNCHRONIZED at ancestor capture - react.mjs:2104-2110 calls updateScroll before doScrollTo", async () => {
+      const sendId = "t19-contract-scrollto-send";
+      const messages = makeCompletedTranscript(30);
+      const { rerenderMessages } = renderChatMessages({
+        messages,
+        scrollStateKey: "t19-contract-scrollto-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(messages, sendId, 700_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const wrapper = screen.getByTestId("chat-transcript-container");
+      const scrollNode = getScrollNode();
+      const observedListStateAtCapture: Array<number> = [];
+      const observer = (event: Event): void => {
+        if (event.target !== scrollNode) return;
+        observedListStateAtCapture.push(list.getState().scroll);
+      };
+      wrapper.addEventListener("scroll", observer, { capture: true });
+      try {
+        await act(async () => {
+          void list.scrollToOffset({
+            offset: scrollNode.scrollTop + 40,
+            animated: false,
+          });
+          fireEvent.scroll(scrollNode);
+          await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => resolve());
+          });
+        });
+        expect(observedListStateAtCapture).toHaveLength(1);
+        // Whatever position the (possibly clamped) call actually landed at,
+        // the library's internal state must already equal it BEFORE this
+        // ancestor capture listener ever runs - the load-bearing property
+        // `chatAnchorScrollCaptureShouldCancel`'s state-equality check
+        // depends on, proven here independent of that classifier's own code.
+        expect(observedListStateAtCapture[0]).toBe(scrollNode.scrollTop);
+      } finally {
+        wrapper.removeEventListener("scroll", observer, { capture: true });
+      }
+    });
+
+    // Decision #31 binding condition (c), third writer site: MVCP
+    // `requestAdjust` (react.mjs:1611-1629) advances `state.scroll` before
+    // the deferred web `ScrollAdjust` path issues DOM `scrollBy`
+    // (:5849-5899,6456-6467). A future @legendapp/list bump that stops
+    // pre-writing for data adjustments would break the state-equality
+    // silence path for every above-anchor weave during anchoring - this
+    // pin is the hard upgrade gate for that writer, same observation
+    // shape as the two pins above.
+    it("an MVCP data adjustment (row insertion above the anchor) is ALREADY SYNCHRONIZED at ancestor capture - react.mjs:1611-1629 requestAdjust pre-writes state.scroll before scrollBy", async () => {
+      const sendId = "t19-contract-mvcp-send";
+      const earlierUserId = "message-2";
+      const initial = makeCompletedTranscript(12);
+      const { rerenderMessages } = renderChatMessages({
+        messages: initial,
+        scrollStateKey: "t19-contract-mvcp-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(initial, sendId, 700_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      const scrollBeforeWeave = getScrollNode().scrollTop;
+
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      const wrapper = screen.getByTestId("chat-transcript-container");
+      const scrollNode = getScrollNode();
+      const observedAtCapture: Array<{
+        listScroll: number;
+        domScroll: number;
+      }> = [];
+      const observer = (event: Event): void => {
+        if (event.target !== scrollNode) return;
+        observedAtCapture.push({
+          listScroll: list.getState().scroll,
+          domScroll: scrollNode.scrollTop,
+        });
+      };
+      wrapper.addEventListener("scroll", observer, { capture: true });
+
+      // jsdom does not fire `scroll` on Element.scrollBy (LegendList's web
+      // MVCP path: react.mjs:5840). Polyfill on THIS node only so the
+      // capture-phase observation actually runs for the library's own
+      // scrollBy - without inventing a second production listener. The
+      // load-bearing property is still "list state already matches DOM at
+      // ancestor capture", not the polyfill itself.
+      const originalScrollBy = scrollNode.scrollBy.bind(scrollNode);
+      scrollNode.scrollBy = ((
+        options?: ScrollToOptions | number,
+        yArg?: number,
+      ): void => {
+        if (typeof options === "number") {
+          scrollNode.scrollLeft += options;
+          scrollNode.scrollTop += typeof yArg === "number" ? yArg : 0;
+        } else if (options && typeof options === "object") {
+          if (typeof options.left === "number") {
+            scrollNode.scrollLeft += options.left;
+          }
+          if (typeof options.top === "number") {
+            scrollNode.scrollTop += options.top;
+          }
+        }
+        fireEvent.scroll(scrollNode);
+      }) as typeof scrollNode.scrollBy;
+
+      try {
+        // Same natural MVCP trigger as ticket 13 pin (e): a non-retarget
+        // setup-card weave ABOVE an earlier (non-anchored) row - classify
+        // as `none`, so the only scroll motion is LegendList's own data
+        // MVCP adjustment keeping the anchored send pixel-stable
+        // (+1 row height). Not a messages-array tail append (which would
+        // not shift content above the viewport).
+        const earlierIndex = afterSend.findIndex(
+          (message) => message.id === earlierUserId,
+        );
+        expect(earlierIndex).toBeGreaterThanOrEqual(0);
+        const foreignCard = setupCardRow(
+          `setup-card:owner-1:0:${earlierUserId}`,
+          100,
+          earlierUserId,
+        );
+        const afterForeignCard: ReadonlyArray<ChatMessageModel> = [
+          ...afterSend.slice(0, earlierIndex),
+          foreignCard,
+          ...afterSend.slice(earlierIndex),
+        ];
+        rerenderMessages(afterForeignCard);
+        await waitForAnchorEngineSettle();
+
+        // Behavioral ownership: mode + generation still owned across the
+        // weave (classifier stayed silent for every library-owned event).
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        expect(getScrollNode().scrollTop).toBe(
+          scrollBeforeWeave + TICKET_13_ROW_HEIGHT_PX,
+        );
+
+        // Hard-gate observation: at least one capture-phase event during
+        // the MVCP path must already show list state equal to DOM (the
+        // pre-write). If the library never issued scrollBy for this
+        // weave in this harness, fall through is impossible - the
+        // behavioral +1-row assert above would have failed first.
+        const synchronizedCaptures = observedAtCapture.filter(
+          (sample) =>
+            Math.abs(sample.listScroll - sample.domScroll) <= 1,
+        );
+        expect(synchronizedCaptures.length).toBeGreaterThan(0);
+        for (const sample of synchronizedCaptures) {
+          expect(sample.listScroll).toBe(sample.domScroll);
+        }
+      } finally {
+        scrollNode.scrollBy = originalScrollBy;
+        wrapper.removeEventListener("scroll", observer, { capture: true });
+      }
+    });
+  });
+
+  // Ticket 19 (decision #31): remaining non-gesture sources from the
+  // design's audit table. Each pin settles an `anchoring-new-turn`
+  // session, drives ONE library/app/browser-owned scroll source, and
+  // asserts the capture-provenance classifier stays SILENT (mode remains
+  // `anchoring-new-turn`, session still owned). The core defect pin and
+  // pure truth-table live elsewhere; these are the silence side of the
+  // audit. Do NOT add production machinery to make a pin possible - if a
+  // source cannot be expressed in jsdom, fall back to a behavioral mode/
+  // generation-owned assertion and document the proof shape.
+  describe("ticket 19: non-gesture sources stay silent during settled anchoring", () => {
+    it("(browser-clamp integration) a content-height shrink that clamps scrollTop to the new max does not cancel anchoring", async () => {
+      // Pure clamp-predicate unit tests already cover the math
+      // (chat-messages-scroll-helpers.test.ts). This pin is the DOM-level
+      // integration: settle anchoring, shrink the scroller's reported
+      // scrollHeight so the new max falls BELOW the parked scrollTop
+      // (previous.scrollTop > currentMax + 1 AND currentMax < previousMax),
+      // then write scrollTop to the new max exactly as a real browser clamp
+      // would - no library scroll call, no wheel/touch/pointer. The
+      // classifier must recognize the exact clamp signature and stay silent
+      // (design audit table: "Browser clamping after content/reserve/
+      // viewport shrink"). A bare write that is NOT this signature is
+      // exactly what the S4B defect pin proves DOES cancel.
+      const sendId = "t19-clamp-integration-send";
+      const messages = makeCompletedTranscript(30);
+      const { rerenderMessages } = renderChatMessages({
+        messages,
+        scrollStateKey: "t19-clamp-integration-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(messages, sendId, 700_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+      const scrollNode = getScrollNode();
+      const parkedTop = scrollNode.scrollTop;
+      expect(parkedTop).toBeGreaterThan(100);
+      // Seed the capture listener's previousSnapshot at the parked
+      // position against the (still-large) default max - one library-owned
+      // no-op re-write so the next event has a real "previous" to compare.
+      await fireLibraryOwnedScrollTo(parkedTop);
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+      // Shrink content so the new max is well below the parked top. New
+      // max = scrollHeight - clientHeight. Pick scrollHeight so
+      // max = parkedTop - 120 (prior-over-max evidence with room for the
+      // 1px exclusivity boundary).
+      const clientHeight = scrollNode.clientHeight;
+      const newMax = parkedTop - 120;
+      expect(newMax).toBeGreaterThan(0);
+      setLegendListScrollContainerScrollHeightOverride(newMax + clientHeight);
+      try {
+        act(() => {
+          // Bare DOM write landing within 1px of the new max - the exact
+          // browser-clamp shape (list state still at parkedTop → mismatch,
+          // so state-equality does NOT silence; the clamp predicate must).
+          scrollNode.scrollTop = newMax;
+          fireEvent.scroll(scrollNode);
+        });
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        expect(getScrollNode().scrollTop).toBe(newMax);
+      } finally {
+        setLegendListScrollContainerScrollHeightOverride(null);
+      }
+    });
+
+    it("(fresh-open / settle re-issue) undershoot-then-reissue during anchor settle never leaves anchoring-new-turn", async () => {
+      // Ticket 10/18 F2-style: force the first large programmatic jumps
+      // short of target so the settle loop re-issues. Ticket 19's capture
+      // classifier must treat those issue/reissue DOM moves as
+      // library-owned (guard 2: active-motion ref armed across the
+      // scrollToIndex call; and/or state pre-write on non-animated path),
+      // never as a scroll-only departure.
+      //
+      // Load-bearing shape: wrap list.scrollToIndex/scrollToOffset so each
+      // real LegendList call also fires a capture-phase `scroll` event
+      // (jsdom never auto-dispatches). Without that wrap the classifier is
+      // dead code and this pin stays green under a maximally-broken
+      // "cancel every owned scroll" mutation. F2 undershoot stays in place
+      // so issue/reissue actually cycles; the fire happens inside the spy
+      // while activeAnchorImperativeMotionGenerationRef is still armed.
+      const history = makeCompletedTranscript(40);
+      const sendId = "t19-reissue-silence-send";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t19-reissue-silence-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+
+      const scrollNode = getScrollNode();
+      const modesAtCapture: Array<string | undefined> = [];
+      const wrapper = screen.getByTestId("chat-transcript-container");
+      const captureObserver = (event: Event): void => {
+        if (event.target !== scrollNode) return;
+        modesAtCapture.push(scrollNode.dataset.scrollMode);
+      };
+      wrapper.addEventListener("scroll", captureObserver, { capture: true });
+
+      // Local F2-style undershoot (same shape as ticket 18's helper).
+      let remainingCorrupt = 2;
+      let stored = scrollNode.scrollTop;
+      const undershootPx = 500;
+      Object.defineProperty(scrollNode, "scrollTop", {
+        configurable: true,
+        get() {
+          return stored;
+        },
+        set(value: number) {
+          const numeric = Number(value);
+          if (!Number.isFinite(numeric)) {
+            stored = 0;
+            return;
+          }
+          if (remainingCorrupt > 0 && Math.abs(numeric - stored) > 80) {
+            remainingCorrupt -= 1;
+            stored =
+              numeric > stored
+                ? Math.max(0, numeric - undershootPx)
+                : numeric + undershootPx;
+            return;
+          }
+          stored = numeric;
+        },
+      });
+
+      const dispatch = installLibraryScrollCaptureDispatch();
+      try {
+        const afterSend = appendOptimisticUserSend(history, sendId, 700_000);
+        rerenderMessages(afterSend);
+        await waitFor(() => {
+          expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+        });
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        await act(async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(
+              resolve,
+              (CHAT_TIMELINE_ANCHOR_SCROLL_PROMISE_TIMEOUT_MS + 100) * 5,
+            );
+          });
+        });
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        // Classifier actually ran: at least one capture-phase sample from
+        // the scrollToIndex wrap, all while still anchoring.
+        expect(dispatch.scrollToIndexCallCount()).toBeGreaterThan(0);
+        expect(modesAtCapture.length).toBeGreaterThan(0);
+        for (const mode of modesAtCapture) {
+          expect(mode).toBe("anchoring-new-turn");
+        }
+      } finally {
+        dispatch.dispose();
+        wrapper.removeEventListener("scroll", captureObserver, {
+          capture: true,
+        });
+        Reflect.deleteProperty(scrollNode, "scrollTop");
+        scrollNode.scrollTop = stored;
+      }
+    });
+
+    it("(fresh-open instant positioning) mount-time freshOpen seed never cancels itself via the capture classifier", async () => {
+      // Decision #15: fresh-open with no saved scroll state seeds
+      // anchoring-new-turn and positions non-animated at mount. That
+      // initial positioning (and any settle re-issue it triggers) must not
+      // be misclassified as a scroll-only departure.
+      //
+      // After settle, explicitly fire a capture-phase scroll at the
+      // post-position DOM (library state already synchronized) so the
+      // classifier runs. A "cancel every owned scroll" mutation must
+      // redden this pin; without the fire it stayed green vacuously.
+      const messages = makeCompletedTranscript(24);
+      const scrollStateKey = `t19-fresh-open-silence-${Math.random().toString(36).slice(2)}`;
+      expect(
+        hasSavedChatTabState(makeDefaultTestIdentity(scrollStateKey)),
+      ).toBe(false);
+
+      renderChatMessages({
+        messages,
+        scrollStateKey,
+        freshOpen: true,
+      });
+      // Mode seed is sync; capture listener is mounted via layout effect.
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      await settleLegendList();
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      await waitFor(() => {
+        expect(screen.getByTestId("mock-message-message-22")).toBeTruthy();
+      });
+
+      // Deliver the capture event the harness never auto-fires after the
+      // bootstrap scroll path. List state matches DOM → healthy silence;
+      // a broken always-cancel classifier trips free-scrolling here.
+      await fireCaptureScrollAfterLibraryWrite();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+    });
+
+    it("(hydration-retry navigation) navigateToMessage cancels anchoring before its own scroll - capture does not misclassify the landing", async () => {
+      // Design audit: "Hydration-retry navigation" - navigateToMessage
+      // cancels ownership BEFORE issuing its own scroll (chat-messages.tsx),
+      // so the capture classifier sees an unowned session for that landing.
+      //
+      // Load-bearing proof is cancel-first ordering observed AT CAPTURE:
+      // wrap scrollToOffset/scrollToIndex so the landing write fires a
+      // real capture-phase scroll, and assert mode is already
+      // free-scrolling when that event is observed (not still
+      // anchoring-new-turn). Ending free-scrolling alone is not enough -
+      // without a capture fire the classifier never runs.
+      //
+      // Note on mutation shape: a "cancel every owned scroll" mutation
+      // does NOT redden this pin by design - the landing event is already
+      // unowned (`isAnchoringSessionOwned=false`). The capture-phase mode
+      // sample is the load-bearing assertion for cancel-first ordering.
+      const messages = makeCompletedTranscript(20);
+      const sendId = "t19-hydration-nav-send";
+      const targetId = messages[4]?.id;
+      expect(targetId).toBeTruthy();
+      const { rerenderMessages, rerenderWith } = renderChatMessages({
+        messages,
+        scrollStateKey: "t19-hydration-nav-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(messages, sendId, 700_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+      const scrollNode = getScrollNode();
+      const modesAtCapture: Array<string | undefined> = [];
+      const wrapper = screen.getByTestId("chat-transcript-container");
+      const captureObserver = (event: Event): void => {
+        if (event.target !== scrollNode) return;
+        modesAtCapture.push(scrollNode.dataset.scrollMode);
+      };
+      wrapper.addEventListener("scroll", captureObserver, { capture: true });
+      const dispatch = installLibraryScrollCaptureDispatch();
+      try {
+        rerenderWith({
+          scrollRequest: {
+            messageId: targetId!,
+            blockId: null,
+            requestId: 19_001,
+          },
+        });
+        await waitForNavigationSettle();
+        // Also flush one explicit capture in case the nav path used a
+        // route that did not go through the wrapped list methods.
+        await fireCaptureScrollAfterLibraryWrite();
+
+        expect(getScrollNode().dataset.scrollMode).toBe("free-scrolling");
+        expect(getScrollNode().dataset.scrollMode).not.toBe(
+          "anchoring-new-turn",
+        );
+        // Capture-phase evidence: the classifier ran (at least one scroll
+        // event reached the wrapper). dataset.scrollMode can lag one React
+        // paint behind the ref cancel (cancel sets timelineScrollModeRef
+        // synchronously but setScrollMode is async), so samples taken
+        // mid-navigateToMessage may still read anchoring-new-turn on the
+        // DOM attribute even though the classifier already saw unowned via
+        // the ref. After settle the attribute is free-scrolling; the final
+        // fire above must stay free-scrolling (classifier silent for
+        // unowned). That post-settle capture is the cancel-first proof
+        // that does not race React paint.
+        expect(modesAtCapture.length).toBeGreaterThan(0);
+        expect(modesAtCapture[modesAtCapture.length - 1]).toBe(
+          "free-scrolling",
+        );
+      } finally {
+        dispatch.dispose();
+        wrapper.removeEventListener("scroll", captureObserver, {
+          capture: true,
+        });
+      }
+    });
+
+    it("(disclosure preservation) a disclosure helper correction during settled anchoring does not cancel the session", async () => {
+      // Design audit: "Disclosure preservation correction" - non-animated
+      // scrollToOffset advances list state before DOM, so the classifier's
+      // state-equality path silences it. After the helper writes, explicitly
+      // fire capture-phase scroll (jsdom never does) so a broken always-
+      // cancel classifier would free-scroll and redden this pin.
+      const history = makeCompletedTranscript(10);
+      const sendId = "t19-disclosure-silence-send";
+      const { rerenderMessages } = renderChatMessages({
+        messages: history,
+        scrollStateKey: "t19-disclosure-silence-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(history, sendId, 830_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+
+      await waitFor(() => {
+        expect(legendListRefHolder.current).not.toBeNull();
+      });
+      const list = legendListRefHolder.current;
+      if (!list) throw new Error("expected LegendListRef to be attached");
+      // Auto-fire capture scroll on every library scroll write the helper
+      // or geometry-repair path issues during mutate.
+      const dispatch = installLibraryScrollCaptureDispatch();
+
+      const DISCLOSURE_DELTA_PX = 180;
+      const anchorElement = document.createElement("div");
+      const rectSpy = vi.spyOn(anchorElement, "getBoundingClientRect");
+      rectSpy.mockReturnValueOnce({
+        x: 0,
+        y: 100,
+        width: 100,
+        height: 20,
+        top: 100,
+        left: 0,
+        right: 100,
+        bottom: 120,
+        toJSON: () => ({}),
+      });
+      rectSpy.mockReturnValueOnce({
+        x: 0,
+        y: 100 + DISCLOSURE_DELTA_PX,
+        width: 100,
+        height: 20,
+        top: 100 + DISCLOSURE_DELTA_PX,
+        left: 0,
+        right: 100,
+        bottom: 120 + DISCLOSURE_DELTA_PX,
+        toJSON: () => ({}),
+      });
+
+      try {
+        act(() => {
+          preserveChatScrollAcrossDisclosureChange({
+            list,
+            anchorElement,
+            mutate: () => {
+              legendListRefHolder.current?.setItemSize("message-2", {
+                height: 90 + DISCLOSURE_DELTA_PX,
+                width: VIEWPORT_WIDTH_PX,
+              });
+            },
+            correctionOwnedByMvcp: false,
+          });
+        });
+        await waitForRevealPassTick();
+        await waitForRevealPassTick();
+        // Final capture flush: covers any write that bypassed the wrap and
+        // ensures at least one classifier invocation while still owned.
+        await fireCaptureScrollAfterLibraryWrite();
+
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        expect(
+          dispatch.scrollToOffsetCallCount() +
+            dispatch.scrollToIndexCallCount(),
+        ).toBeGreaterThan(0);
+      } finally {
+        dispatch.dispose();
+        rectSpy.mockRestore();
+      }
+    });
+
+    it("(setup-card weave) mid-anchoring setup-card retarget does not cancel via the capture classifier", async () => {
+      // Design audit: "Setup-card weave/anchor retarget" is the composition
+      // of MVCP data adjustment + a new anchor issue under the current
+      // settle generation. Wrap list scroll APIs (and polyfill scrollBy for
+      // MVCP) so every library-owned DOM write delivers a capture-phase
+      // scroll - without that the classifier is never invoked and a
+      // broken always-cancel mutation would leave this pin green.
+      const initial = makeCompletedTranscript(6);
+      const sendId = "t19-setup-card-weave-send";
+      const { rerenderMessages } = renderChatMessages({
+        messages: initial,
+        scrollStateKey: "t19-setup-card-weave-key",
+        localProvenanceMessageIds: new Set([sendId]),
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(initial, sendId, 500_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      const scrollBeforeCard = getScrollNode().scrollTop;
+
+      const scrollNode = getScrollNode();
+      const originalScrollBy = scrollNode.scrollBy.bind(scrollNode);
+      scrollNode.scrollBy = ((
+        options?: ScrollToOptions | number,
+        yArg?: number,
+      ): void => {
+        if (typeof options === "number") {
+          scrollNode.scrollLeft += options;
+          scrollNode.scrollTop += typeof yArg === "number" ? yArg : 0;
+        } else if (options && typeof options === "object") {
+          if (typeof options.left === "number") {
+            scrollNode.scrollLeft += options.left;
+          }
+          if (typeof options.top === "number") {
+            scrollNode.scrollTop += options.top;
+          }
+        }
+        fireEvent.scroll(scrollNode);
+      }) as typeof scrollNode.scrollBy;
+
+      const dispatch = installLibraryScrollCaptureDispatch();
+      try {
+        const sendIndex = afterSend.findIndex(
+          (message) => message.id === sendId,
+        );
+        const card = setupCardRow(
+          `setup-card:owner-1:0:${sendId}`,
+          499_999,
+          sendId,
+        );
+        const afterCard: ReadonlyArray<ChatMessageModel> = [
+          ...afterSend.slice(0, sendIndex),
+          card,
+          ...afterSend.slice(sendIndex),
+        ];
+        rerenderMessages(afterCard);
+        await waitForAnchorEngineSettle();
+        // Explicit capture flush after settle so a retarget path that
+        // only repositioned via already-fired wraps still has a final
+        // owned event for the classifier to silence.
+        await fireCaptureScrollAfterLibraryWrite();
+
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        expect(screen.getByTestId(`mock-message-${card.id}`)).toBeTruthy();
+        // Uniform 90px rows: card takes the send's prior slot → same
+        // scrollTop after a correct retarget (ticket 13 pin d geometry).
+        expect(getScrollNode().scrollTop).toBe(scrollBeforeCard);
+      } finally {
+        dispatch.dispose();
+        scrollNode.scrollBy = originalScrollBy;
+      }
+    });
+
+    it("(endInset / lower-dock resize) composerOverlayHeight change while anchoring does not cancel the session", async () => {
+      // Design audit: "endInset / lower-dock resize" - LegendList may
+      // reprocess or requestAdjust on contentInsetEndAdjustment changes;
+      // a pure max shrink uses the clamp predicate. Either path must stay
+      // silent. After the prop change, fire a capture-phase scroll so the
+      // classifier actually runs (library state equals DOM → silence;
+      // broken always-cancel while owned → free-scrolling).
+      const sendId = "t19-endinset-silence-send";
+      const messages = makeCompletedTranscript(20);
+      const { rerenderMessages, rerenderWith } = renderChatMessages({
+        messages,
+        scrollStateKey: "t19-endinset-silence-key",
+        localProvenanceMessageIds: new Set([sendId]),
+        composerOverlayHeight: 80,
+      });
+      await settleLegendList();
+      const afterSend = appendOptimisticUserSend(messages, sendId, 700_000);
+      rerenderMessages(afterSend);
+      await waitFor(() => {
+        expect(screen.getByTestId(`mock-message-${sendId}`)).toBeTruthy();
+      });
+      await waitForAnchorEngineSettle();
+      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+      const scrollBefore = getScrollNode().scrollTop;
+
+      const scrollNode = getScrollNode();
+      const originalScrollBy = scrollNode.scrollBy.bind(scrollNode);
+      scrollNode.scrollBy = ((
+        options?: ScrollToOptions | number,
+        yArg?: number,
+      ): void => {
+        if (typeof options === "number") {
+          scrollNode.scrollLeft += options;
+          scrollNode.scrollTop += typeof yArg === "number" ? yArg : 0;
+        } else if (options && typeof options === "object") {
+          if (typeof options.left === "number") {
+            scrollNode.scrollLeft += options.left;
+          }
+          if (typeof options.top === "number") {
+            scrollNode.scrollTop += options.top;
+          }
+        }
+        fireEvent.scroll(scrollNode);
+      }) as typeof scrollNode.scrollBy;
+      const dispatch = installLibraryScrollCaptureDispatch();
+      try {
+        rerenderWith({ composerOverlayHeight: 240 });
+        await settleLegendList();
+        await waitForRevealPassTick();
+        // Ensure the classifier sees at least one event while still owned
+        // even if inset change produced no library write in this harness.
+        await fireCaptureScrollAfterLibraryWrite();
+
+        expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
+        expect(getScrollNode().dataset.scrollMode).not.toBe("free-scrolling");
+        expect(
+          Math.abs(getScrollNode().scrollTop - scrollBefore),
+        ).toBeLessThan(500);
+      } finally {
+        dispatch.dispose();
+        scrollNode.scrollBy = originalScrollBy;
+      }
     });
   });
 
@@ -3929,7 +4826,15 @@ describe("ChatMessages scroll policy", () => {
       const scrollNode = getScrollNode();
       const departedScrollTop = scrollNode.scrollTop - 180;
       expect(departedScrollTop).toBeGreaterThan(0);
-      await fireScrollTopAndFlush(departedScrollTop);
+      // Ticket 19: `anchorMoverShouldYieldToReader`'s yield check is a pure
+      // position comparison - it does not care HOW `scrollTop` ended up
+      // below the expected anchor position, only that it did. Using the
+      // real library API to set up that precondition (instead of a bare
+      // `scrollTop` write, which the capture-provenance classifier now
+      // correctly cancels as an unexplained departure) keeps this test
+      // inside `anchoring-new-turn` so it still reaches the SAME reveal-
+      // pass yield branch it always exercised.
+      await fireLibraryOwnedScrollTo(departedScrollTop);
       expect(scrollNode.dataset.scrollMode).toBe("anchoring-new-turn");
 
       const anchorIndex = afterSend.length - 1;
@@ -4621,14 +5526,6 @@ describe("ChatMessages scroll policy", () => {
       const sendId = "t5-mid-anchor-send";
       const scrollStateKey = `t5-mid-anchor-${Math.random().toString(36).slice(2)}`;
       const instanceId = `t5-mid-anchor-inst-${Math.random().toString(36).slice(2)}`;
-      // Matches legend-list-test-environment's fixed SPACER_HEIGHT_PX for any
-      // aria-hidden header/footer shell (the harness measures every spacer
-      // the same regardless of its real Tailwind height class, so this is
-      // independent of the production chat-timeline.tsx sizes - ticket 16/M4
-      // changed those to h-3/h-4 sm:h-4/h-12, not 40px).
-      const HARNESS_HEADER_PX = 40;
-      const HARNESS_FOOTER_PX = 40;
-      const HARNESS_ITEM_PX = 90;
       const composerOverlayHeight = 80;
 
       tileLiveness.live = true;
@@ -4654,46 +5551,42 @@ describe("ChatMessages scroll policy", () => {
       });
       expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
 
-      // Content-relative last-row bottom: N items of fixed harness height
-      // (positions start at 0; last bottom = N * itemHeight).
-      const lastBottom = afterSend.length * HARNESS_ITEM_PX;
-      const naturalMax = getChatNaturalMaxScrollWithoutAnchorReserve({
-        headerSize: HARNESS_HEADER_PX,
-        footerSize: HARNESS_FOOTER_PX,
-        lastBottom,
-        endInset: composerOverlayHeight,
-        viewportLength: VIEWPORT_HEIGHT_PX,
-      });
-      // Old (wrong) bound for mutation contrast - under-clamps by
-      // header+footer-anchorOffset (= 64 in this harness).
-      const oldRevealBound = Math.max(
-        0,
-        lastBottom -
-          (VIEWPORT_HEIGHT_PX -
-            composerOverlayHeight -
-            CHAT_LIST_ANCHOR_OFFSET),
-      );
-      expect(naturalMax - oldRevealBound).toBe(
-        HARNESS_HEADER_PX + HARNESS_FOOTER_PX - CHAT_LIST_ANCHOR_OFFSET,
-      );
-      expect(naturalMax).toBeGreaterThan(oldRevealBound);
-
-      // Force a reserve-inflated park ABOVE both bounds while still in
-      // anchoring-new-turn (bare scrollTop write is not a cancel gesture).
-      // F3 must clamp to naturalMax on save; the old reveal bound would clamp
-      // 64px lower - restored geometry distinguishes them.
-      await fireScrollTopAndFlush(naturalMax + 200);
-      expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
-      expect(getScrollNode().scrollTop).toBeGreaterThan(naturalMax);
-
-      // Unmount while still mid-anchor - do NOT wait for settle.
+      // Ticket 19 finding (investigated, confirmed unrelated to the capture
+      // classifier): in THIS fixture the anchor engine's own `scrollToIndex`
+      // is never issued at all - `list.scrollToIndex` stays at zero calls
+      // for several seconds past `waitForAnchorEngineSettle()`, and
+      // `list.getState().scroll` never leaves 0, even though the target row
+      // is fully measured (`positionAtIndex(16)` resolves). That means
+      // `onAnchorReady` (and with it, LegendList's own `anchoredEndSpace`
+      // reserve) never fires for this specific fixture - a pre-existing gap
+      // unrelated to this ticket's classifier (there is no departure event
+      // of any kind between the send and this point for the classifier to
+      // even act on). The original version of this test never surfaced that
+      // gap because it forced the DOM `scrollTop` directly - a technique
+      // ticket 19 now correctly reads as an unexplained departure, and
+      // through LegendList's own `scrollToOffset` API the reserve-dependent
+      // clamp caps any requested offset at `naturalMax` regardless (since
+      // the reserve is stuck at zero here), making the ABOVE-natural-max
+      // park this test used to construct unreachable through any real
+      // mechanism in this fixture. Flagged to the ticket-19 orchestrator
+      // rather than papered over; F3's underlying clamp FORMULA keeps its
+      // own dedicated coverage in chat-scroll-anchoring.test.ts
+      // (`describe("getChatNaturalMaxScrollWithoutAnchorReserve")`) - only
+      // THIS specific "unmount while genuinely parked above naturalMax"
+      // integration shape is untestable here until that separate gap is
+      // fixed.
+      //
+      // What remains fully testable, and is ticket 5's actual core claim:
+      // an unmount that catches a session GENUINELY still in
+      // `anchoring-new-turn` (no departure, no cheat) must still collapse to
+      // `free-scrolling` on save - `anchoring-new-turn` never round-trips
+      // through the cache, regardless of where `scrollTop` happens to sit.
       first.unmount();
 
       const saved = restoreChatTabState(
         makeDefaultTestIdentity(instanceId),
         afterSend,
       );
-      // anchoring-new-turn never round-trips through the cache.
       expect(saved.mode).toBe("free-scrolling");
       expect(saved.mode).not.toBe("following-end");
       // Active minimap/reading-line row (not necessarily the anchored send).
@@ -4711,19 +5604,6 @@ describe("ChatMessages scroll policy", () => {
 
       expect(getScrollNode().dataset.scrollMode).toBe("free-scrolling");
       expect(getScrollNode().dataset.scrollMode).not.toBe("anchoring-new-turn");
-      // Ticket 11 fix #3: the restore lands exactly at the true content end
-      // (naturalMax, asserted below) - decision #16's "out of view" semantic
-      // correctly keeps the pill HIDDEN here even though mode is
-      // free-scrolling, not following-end (the no-follow contract -
-      // decision #14/#21 - is about MODE, not pill visibility).
-      expect(isJumpPillVisible()).toBe(false);
-
-      // F3 geometry: restore lands on the true no-reserve max, not the
-      // under-clamped reveal target (oldRevealBound = naturalMax - 64 here).
-      const restoredScrollTop = getScrollNode().scrollTop;
-      expect(restoredScrollTop).toBe(naturalMax);
-      expect(restoredScrollTop).not.toBe(oldRevealBound);
-      expect(restoredScrollTop).toBeGreaterThan(oldRevealBound);
 
       second.unmount();
     });
@@ -5295,10 +6175,20 @@ describe("ChatMessages scroll policy", () => {
       // Find the minimal content-end scroll that flips to following-end via
       // the Ticket 11 reconciliation (scrollDeltaToRevealEnd <= 1), walking
       // from the parked anchor rather than the shim's fixed max scroll.
+      //
+      // Ticket 19: this probe walk must stay OWNED (still `anchoring-new-
+      // turn`) at every intermediate step so the boundary it finds is the
+      // ONE `onIsAtEndChange`'s strict-epsilon gate itself produces, not an
+      // earlier capture-classifier cancellation. `fireScrollOnlyTo` (a bare
+      // `scrollTop` write) is now correctly read as an unexplained reader
+      // departure and cancels on the very first divergent step - the same
+      // false-input class this ticket's classifier exists to police, which
+      // is exactly why probing the boundary now needs the real library API
+      // (pre-writes internal state, so the classifier stays silent) instead.
       const parkedAtAnchor = getScrollNode().scrollTop;
       let contentEndScroll: number | null = null;
       for (let top = parkedAtAnchor; top <= parkedAtAnchor + 4_000; top += 40) {
-        await fireScrollOnlyTo(top);
+        await fireLibraryOwnedScrollTo(top);
         if (getScrollNode().dataset.scrollMode === "following-end") {
           contentEndScroll = getScrollNode().scrollTop;
           break;
@@ -5328,7 +6218,9 @@ describe("ChatMessages scroll policy", () => {
 
       // ~200px short of the true content end: scrollDeltaToRevealEnd >> 1,
       // so even if isNearEnd is true the strict gate must keep anchoring.
-      await fireScrollOnlyTo(Math.max(0, end - 200));
+      // Library-owned (see above) - a bare write would cancel before the
+      // strict-epsilon branch is even reached.
+      await fireLibraryOwnedScrollTo(Math.max(0, end - 200));
       await act(async () => {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, 50);
@@ -5337,7 +6229,7 @@ describe("ChatMessages scroll policy", () => {
       expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
 
       // True live edge: strict epsilon satisfied → following-end.
-      await fireScrollOnlyTo(end);
+      await fireLibraryOwnedScrollTo(end);
       await waitFor(
         () => {
           expect(getScrollNode().dataset.scrollMode).toBe("following-end");
@@ -5360,10 +6252,15 @@ describe("ChatMessages scroll policy", () => {
       // Row positions are content-relative, while scrollTop includes the
       // measured 40px LegendList header. The old mixed-coordinate gate
       // declared following-end here, one whole header before the real edge.
-      await fireScrollOnlyTo(oldEarlyThreshold);
+      //
+      // Ticket 19: library-owned (not a bare `scrollTop` write) - see the
+      // matching comment on test (e) above. A bare write would cancel the
+      // session on this very first probe, before the header-pad gate this
+      // test targets is ever reached.
+      await fireLibraryOwnedScrollTo(oldEarlyThreshold);
       expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
 
-      await fireScrollOnlyTo(oldEarlyThreshold + LEGEND_LIST_HEADER_PX);
+      await fireLibraryOwnedScrollTo(oldEarlyThreshold + LEGEND_LIST_HEADER_PX);
       await waitFor(
         () => {
           expect(getScrollNode().dataset.scrollMode).toBe("following-end");

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -33,6 +33,7 @@ import {
   CHAT_ARROW_SCROLL_STEP_PX,
   CHAT_TIMELINE_NAVIGATION_VIEW_OFFSET_PX,
   chatTimelineGetItemType,
+  type ChatAnchorDriftRepairOutcome,
 } from "@/components/chat/chat-messages-scroll-helpers";
 import {
   captureChatFreeScrollingOffset,
@@ -185,7 +186,7 @@ vi.mock(
       ...actual,
       applyChatAnchorDriftRepair: (
         ...args: Parameters<typeof actual.applyChatAnchorDriftRepair>
-      ): ReturnType<typeof actual.applyChatAnchorDriftRepair> => {
+      ): ChatAnchorDriftRepairOutcome["kind"] => {
         applyChatAnchorDriftRepairCallCountRef.current += 1;
         return actual.applyChatAnchorDriftRepair(...args);
       },
@@ -2240,9 +2241,17 @@ describe("ChatMessages scroll policy", () => {
       // load-bearing property is still "list state already matches DOM at
       // ancestor capture", not the polyfill itself.
       const originalScrollBy = scrollNode.scrollBy.bind(scrollNode);
+      // `Element.scrollBy`'s overloaded native signature (`(options?)` /
+      // `(x, y)`) genuinely permits fewer arguments than this polyfill
+      // declares - house style bans `?:` (a caller-omittable parameter),
+      // but the caller here is jsdom/LegendList's own internal invocation,
+      // not code this file controls, so the params stay required-typed
+      // (`| undefined`) and the assignment cast documents the real,
+      // load-bearing arity gap instead of a redundant one: every code path
+      // already treats a missing value as `undefined` correctly.
       scrollNode.scrollBy = ((
-        options?: ScrollToOptions | number,
-        yArg?: number,
+        options: ScrollToOptions | number | undefined,
+        yArg: number | undefined,
       ): void => {
         if (typeof options === "number") {
           scrollNode.scrollLeft += options;
@@ -2295,8 +2304,7 @@ describe("ChatMessages scroll policy", () => {
         // weave in this harness, fall through is impossible - the
         // behavioral +1-row assert above would have failed first.
         const synchronizedCaptures = observedAtCapture.filter(
-          (sample) =>
-            Math.abs(sample.listScroll - sample.domScroll) <= 1,
+          (sample) => Math.abs(sample.listScroll - sample.domScroll) <= 1,
         );
         expect(synchronizedCaptures.length).toBeGreaterThan(0);
         for (const sample of synchronizedCaptures) {
@@ -2556,7 +2564,7 @@ describe("ChatMessages scroll policy", () => {
       try {
         rerenderWith({
           scrollRequest: {
-            messageId: targetId!,
+            messageId: targetId,
             blockId: null,
             requestId: 19_001,
           },
@@ -2706,9 +2714,17 @@ describe("ChatMessages scroll policy", () => {
 
       const scrollNode = getScrollNode();
       const originalScrollBy = scrollNode.scrollBy.bind(scrollNode);
+      // `Element.scrollBy`'s overloaded native signature (`(options?)` /
+      // `(x, y)`) genuinely permits fewer arguments than this polyfill
+      // declares - house style bans `?:` (a caller-omittable parameter),
+      // but the caller here is jsdom/LegendList's own internal invocation,
+      // not code this file controls, so the params stay required-typed
+      // (`| undefined`) and the assignment cast documents the real,
+      // load-bearing arity gap instead of a redundant one: every code path
+      // already treats a missing value as `undefined` correctly.
       scrollNode.scrollBy = ((
-        options?: ScrollToOptions | number,
-        yArg?: number,
+        options: ScrollToOptions | number | undefined,
+        yArg: number | undefined,
       ): void => {
         if (typeof options === "number") {
           scrollNode.scrollLeft += options;
@@ -2784,9 +2800,17 @@ describe("ChatMessages scroll policy", () => {
 
       const scrollNode = getScrollNode();
       const originalScrollBy = scrollNode.scrollBy.bind(scrollNode);
+      // `Element.scrollBy`'s overloaded native signature (`(options?)` /
+      // `(x, y)`) genuinely permits fewer arguments than this polyfill
+      // declares - house style bans `?:` (a caller-omittable parameter),
+      // but the caller here is jsdom/LegendList's own internal invocation,
+      // not code this file controls, so the params stay required-typed
+      // (`| undefined`) and the assignment cast documents the real,
+      // load-bearing arity gap instead of a redundant one: every code path
+      // already treats a missing value as `undefined` correctly.
       scrollNode.scrollBy = ((
-        options?: ScrollToOptions | number,
-        yArg?: number,
+        options: ScrollToOptions | number | undefined,
+        yArg: number | undefined,
       ): void => {
         if (typeof options === "number") {
           scrollNode.scrollLeft += options;
@@ -2812,9 +2836,9 @@ describe("ChatMessages scroll policy", () => {
 
         expect(getScrollNode().dataset.scrollMode).toBe("anchoring-new-turn");
         expect(getScrollNode().dataset.scrollMode).not.toBe("free-scrolling");
-        expect(
-          Math.abs(getScrollNode().scrollTop - scrollBefore),
-        ).toBeLessThan(500);
+        expect(Math.abs(getScrollNode().scrollTop - scrollBefore)).toBeLessThan(
+          500,
+        );
       } finally {
         dispatch.dispose();
         scrollNode.scrollBy = originalScrollBy;
@@ -8666,45 +8690,57 @@ describe("ChatMessages scroll policy", () => {
         top?: number;
         left?: number;
       }> = [];
-      const scrollTopSetter = Object.getOwnPropertyDescriptor(
+      const scrollTopDescriptor = Object.getOwnPropertyDescriptor(
         HTMLElement.prototype,
         "scrollTop",
-      )?.set;
-      const scrollLeftSetter = Object.getOwnPropertyDescriptor(
+      );
+      const scrollLeftDescriptor = Object.getOwnPropertyDescriptor(
         HTMLElement.prototype,
         "scrollLeft",
-      )?.set;
-      if (scrollTopSetter === undefined || scrollLeftSetter === undefined) {
+      );
+      if (
+        scrollTopDescriptor?.set === undefined ||
+        scrollLeftDescriptor?.set === undefined
+      ) {
         throw new Error("expected scrollTop/scrollLeft setters");
       }
-      vi.spyOn(HTMLElement.prototype, "scrollTo").mockImplementation(
-        function (
-          this: HTMLElement,
-          ...args: Array<number | ScrollToOptions | undefined>
-        ): void {
-          const first = args[0];
-          if (typeof first === "number") {
-            const second = args[1];
-            scrollLeftSetter.call(this, first);
-            scrollTopSetter.call(this, typeof second === "number" ? second : 0);
-            return;
-          }
-          if (typeof first !== "object" || first === null) return;
-          if (this === scrollNode) {
-            calls.push({
-              behavior: first.behavior,
-              top: first.top,
-              left: first.left,
-            });
-          }
-          if (typeof first.left === "number") {
-            scrollLeftSetter.call(this, first.left);
-          }
-          if (typeof first.top === "number") {
-            scrollTopSetter.call(this, first.top);
-          }
-        },
-      );
+      // The setter is called on a DIFFERENT element each invocation
+      // (whichever node `scrollTo` fires on), so it cannot be bound to one
+      // fixed `this` up front. Keep the descriptor itself as the stored
+      // reference and reach `.set` only immediately before `.call` inside
+      // these wrappers - never as a standalone extracted method reference.
+      const setScrollTop = (target: HTMLElement, value: number): void => {
+        scrollTopDescriptor.set?.call(target, value);
+      };
+      const setScrollLeft = (target: HTMLElement, value: number): void => {
+        scrollLeftDescriptor.set?.call(target, value);
+      };
+      vi.spyOn(HTMLElement.prototype, "scrollTo").mockImplementation(function (
+        this: HTMLElement,
+        ...args: Array<number | ScrollToOptions | undefined>
+      ): void {
+        const first = args[0];
+        if (typeof first === "number") {
+          const second = args[1];
+          setScrollLeft(this, first);
+          setScrollTop(this, typeof second === "number" ? second : 0);
+          return;
+        }
+        if (typeof first !== "object") return;
+        if (this === scrollNode) {
+          calls.push({
+            behavior: first.behavior,
+            top: first.top,
+            left: first.left,
+          });
+        }
+        if (typeof first.left === "number") {
+          setScrollLeft(this, first.left);
+        }
+        if (typeof first.top === "number") {
+          setScrollTop(this, first.top);
+        }
+      });
       return calls;
     }
 
@@ -8787,7 +8823,6 @@ describe("ChatMessages scroll policy", () => {
     });
   });
 
-
   // ---------------------------------------------------------------------
   // Ticket 22 (painted-chat lifecycle audit, finding 3): the two-rAF anchor
   // repair (ticket 18's drift re-assert) is keyed to `messages` - a
@@ -8812,9 +8847,7 @@ describe("ChatMessages scroll policy", () => {
     /** Sends, then streams chunks until the turn genuinely overflows the
      *  usable viewport (mirrors ticket 18 pin E's own recipe exactly). */
     async function sendAndOverflowAnchor(
-      rerenderMessages: (
-        messages: ReadonlyArray<ChatMessageModel>,
-      ) => void,
+      rerenderMessages: (messages: ReadonlyArray<ChatMessageModel>) => void,
       history: ReadonlyArray<ChatMessageModel>,
       sendId: string,
       createdAt: number,
@@ -9656,7 +9689,11 @@ describe("ChatMessages scroll policy", () => {
       // alone does not report through `onIsAtEndChange` in this harness (no
       // synthetic 'scroll' event follows it), so mode stays untouched.
       act(() => {
-        list.scrollToEnd({ animated: false });
+        // Intentionally not awaited: this call alone does not report
+        // through `onIsAtEndChange` in this harness (see comment above), so
+        // nothing here depends on its resolution - the very next line reads
+        // the synchronous DOM side effect it already produced.
+        void list.scrollToEnd({ animated: false });
       });
       const trueEnd = scrollNode.scrollTop;
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -49,6 +49,7 @@ import {
   saveChatTabState,
 } from "@/stores/chats/chat-tab-state-cache";
 import type { ChatTabPersistenceIdentity } from "@/stores/chats/chat-tab-persistence-key";
+import { flushChatTabViewportHandoff } from "@/stores/chats/chat-tab-viewport-handoff";
 import { evictChatTabPersistenceForEpic } from "@/stores/chats/chat-tab-persistence-eviction";
 import { getOrCreateActivityGroupOpenStore } from "@/stores/chats/activity-group-open-store-core";
 import type { ActivityGroupOpenState } from "@/stores/chats/activity-group-open-store-context";
@@ -7430,6 +7431,344 @@ describe("ChatMessages scroll policy", () => {
       await settleLegendList();
 
       expect(hasSavedChatTabState(identity)).toBe(false);
+    });
+  });
+
+  describe("ticket 20: pre-structural-mutation viewport handoff", () => {
+    /**
+     * Review round 1, finding 3: the same-commit pin below must actually
+     * force React to unmount the old fiber and mount the replacement in ONE
+     * commit - `unmount()` followed by a separate `render()` call is two
+     * commits, and cannot catch a cleanup-clobber. Swapping the wrapping
+     * host element's TYPE (div -> section) between rerenders makes React
+     * tear down and rebuild the whole subtree - old fiber deletion, new
+     * fiber placement, both commit-phase - inside a single `rerender` call,
+     * the same one-store-update shape a real drag/split/dissolve/tear-off
+     * produces (retained `instanceId`, replaced fiber).
+     */
+    function KeyedParentChatMessages({
+      parentTag,
+      instanceId,
+      messages,
+    }: {
+      parentTag: "div" | "section";
+      instanceId: string;
+      messages: ReadonlyArray<ChatMessageModel>;
+    }): ReactElement {
+      const Parent = parentTag;
+      return (
+        <Parent
+          data-chat-keyboard-scroll-scope
+          data-active="true"
+          style={{ height: VIEWPORT_HEIGHT_PX, width: VIEWPORT_WIDTH_PX }}
+        >
+          <ChatMessages
+            taskTitle="Test chat"
+            taskId="task-1"
+            epicId="epic-1"
+            messages={messages}
+            localProvenanceMessageIds={new Set()}
+            consumeLocalProvenance={() => undefined}
+            backgroundItems={undefined}
+            getMessageActions={() => null}
+            nextStepActions={null}
+            instanceId={instanceId}
+            visible
+            systemOverlayActive={false}
+            isChatStreaming={false}
+            scrollRequest={null}
+            composerOverlayHeight={80}
+          />
+        </Parent>
+      );
+    }
+
+    it(
+      "same-commit remount reads the pre-move position only when the action " +
+        "creator flushes before the replacement mounts (red without the flush)",
+      async () => {
+        const messages = makeCompletedTranscript(20);
+        const instanceId = `t20-same-commit-${Math.random().toString(36).slice(2)}`;
+        const identity = makeDefaultTestIdentity(instanceId);
+
+        tileLiveness.live = true;
+        const { rerender } = render(
+          <KeyedParentChatMessages
+            parentTag="div"
+            instanceId={instanceId}
+            messages={messages}
+          />,
+        );
+        await settleLegendList();
+
+        act(() => {
+          enterFreeScrollingAwayFromEnd();
+        });
+        await fireScrollTopAndFlush(360);
+        expect(getScrollNode().dataset.scrollMode).toBe("free-scrolling");
+        const preMoveScrollTop = getScrollNode().scrollTop;
+        expect(preMoveScrollTop).toBe(360);
+
+        // RED-ON-BASELINE: `restoreChatTabState` is exactly what a
+        // same-commit replacement's render-time state initializer calls
+        // (`ChatMessagesInner`'s `restoredTabState` useState initializer) -
+        // React runs it during render, which happens BEFORE ANY commit-phase
+        // effect, including the currently-mounted fiber's own unmount
+        // cleanup. Nothing has unmounted yet here, so whatever
+        // `restoreChatTabState` returns right now is exactly what the
+        // type-swap rerender below will read. Without a pre-mutation flush,
+        // that is still the harness/cache-miss default following-end seed,
+        // not the live 360px position currently on screen - the audit's own
+        // `initialize:stale` probe finding, reproduced directly.
+        const staleRestore = restoreChatTabState(identity, messages);
+        expect(staleRestore.mode).toBe("following-end");
+
+        // The fix: a structural-mutation action creator (drag/split-wrap/
+        // dissolve/tear-off) calls this exact primitive, synchronously,
+        // BEFORE its own `set()` - simulated here immediately before the
+        // type-swap rerender that stands in for that `set()`.
+        flushChatTabViewportHandoff([instanceId]);
+        const freshRestore = restoreChatTabState(identity, messages);
+        expect(freshRestore.mode).toBe("free-scrolling");
+        expect(freshRestore.anchorMessageId).not.toBeNull();
+
+        // A REAL same-commit remount: the div -> section type change and the
+        // replacement's render-time restore both happen inside this one
+        // `rerender` call - React never lets the old fiber's commit-phase
+        // cleanup run before this call's render phase (including the new
+        // fiber's state initializer) has already completed.
+        rerender(
+          <KeyedParentChatMessages
+            parentTag="section"
+            instanceId={instanceId}
+            messages={messages}
+          />,
+        );
+        await settleLegendList();
+        await settleLegendList();
+
+        // Confirm it actually paints directly at the pre-move position - no
+        // stale/default jump.
+        expect(getScrollNode().scrollTop).toBe(preMoveScrollTop);
+        expect(getScrollNode().dataset.scrollMode).toBe("free-scrolling");
+      },
+    );
+
+    it(
+      "the pre-mutation flush captures a coherent live-DOM snapshot, not a " +
+        "stale rAF-throttled mirror (review round 1, finding 2: rebuilt - " +
+        "the prior version raced a scrollRequest, but navigateToMessage " +
+        "synchronously freshens the mirror before it scrolls, so that " +
+        "construction could never actually desync it)",
+      async () => {
+        const rowCount = 100;
+        const targetRow = 50;
+        const targetScrollTop =
+          targetRow * TICKET_13_ROW_HEIGHT_PX + LEGEND_LIST_HEADER_PX;
+        const messages = makeCompletedTranscript(rowCount);
+        const instanceId = `t20-coherent-flush-${Math.random().toString(36).slice(2)}`;
+        const identity = makeDefaultTestIdentity(instanceId);
+
+        tileLiveness.live = true;
+        const first = renderChatMessages({ messages, instanceId });
+        await settleLegendList();
+        act(() => {
+          enterFreeScrollingAwayFromEnd();
+        });
+        // Ticket 15 review (live pass S5 round 3)'s exact race, reused here
+        // for the still-mounted flush path instead of that pin's non-live
+        // unmount path: sets scrollTop and fires the scroll event WITHOUT
+        // yielding a frame afterward, so `scheduleActiveViewportUpdate`'s
+        // rAF-throttled reading-line mirror (`scrolledActiveUserMessageIdRef`)
+        // never catches up to this position. Critically, nothing in this
+        // window is a navigation (`navigateToMessage` is not called - no
+        // scrollRequest, no minimap/find jump) - only `navigateToMessage`
+        // synchronously writes that ref before scrolling, so a
+        // navigation-driven jump can never desync the mirror from the DOM in
+        // the first place. That is exactly why the prior version of this
+        // pin (a scrollRequest-driven jump) was vacuous.
+        fireScrollTopWithoutFlush(targetScrollTop);
+        expect(getScrollNode().dataset.scrollMode).toBe("free-scrolling");
+
+        // Flush with `first` STILL MOUNTED, exactly as a real structural
+        // mutation's pre-`set()` flush runs. Reading `restoreChatTabState`
+        // BEFORE `first.unmount()` (same ordering proof as the same-commit
+        // pin above) is load-bearing: unmounting first would trigger
+        // `first`'s OWN unmount-cleanup save too, masking a disabled/broken
+        // flush behind the pre-existing unmount path and silently degrading
+        // this into an ordinary unmount-capture check that stays green
+        // either way.
+        flushChatTabViewportHandoff([instanceId]);
+        const saved = restoreChatTabState(identity, messages);
+        expect(saved.mode).toBe("free-scrolling");
+        expect(saved.anchorMessageId).not.toBeNull();
+        // The stale mirror (unserviced since before this scroll) points at
+        // a different row entirely - a poisoned capture would land well
+        // outside this window, not just off by a row or two.
+        expect(saved.anchorIndex).toBeGreaterThan(targetRow - 2);
+        expect(saved.anchorIndex).toBeLessThan(targetRow + 2);
+
+        first.unmount();
+
+        const replacement = renderChatMessages({ messages, instanceId });
+        await settleLegendList();
+        await settleLegendList();
+        expect(getScrollNode().scrollTop).toBe(targetScrollTop);
+
+        replacement.unmount();
+      },
+    );
+
+    it("flushing an instanceId with no live/mounted tile is a harmless no-op", () => {
+      const instanceId = `t20-no-live-mount-${Math.random().toString(36).slice(2)}`;
+      expect(() => flushChatTabViewportHandoff([instanceId])).not.toThrow();
+      expect(hasSavedChatTabState(makeDefaultTestIdentity(instanceId))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("ticket 20: restore-driven navigation never visibly traverses", () => {
+    /**
+     * Records every `scrollTo({behavior, top, left})` LegendList issues
+     * against `scrollNode`. Does NOT re-spy `HTMLElement.prototype.scrollTo`
+     * by wrapping its CURRENT value as a "call through to prior" fallback -
+     * `installLegendListViewportMetrics` already replaced it with a mock
+     * once per test, and `vi.spyOn` on an already-spied method returns that
+     * SAME mock instance rather than a fresh wrapper, so a captured
+     * "prior" reference is actually the mock being reconfigured -
+     * `mockImplementation` on it recurses into itself (stack overflow).
+     * Reimplements the shim's own minimal numeric/options handling directly
+     * against the real `scrollTop`/`scrollLeft` property setters instead.
+     */
+    function recordScrollToCallsOnNode(scrollNode: HTMLElement): ReadonlyArray<{
+      readonly behavior?: ScrollBehavior;
+      readonly top?: number;
+      readonly left?: number;
+    }> {
+      const calls: Array<{
+        behavior?: ScrollBehavior;
+        top?: number;
+        left?: number;
+      }> = [];
+      const scrollTopSetter = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "scrollTop",
+      )?.set;
+      const scrollLeftSetter = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "scrollLeft",
+      )?.set;
+      if (scrollTopSetter === undefined || scrollLeftSetter === undefined) {
+        throw new Error("expected scrollTop/scrollLeft setters");
+      }
+      vi.spyOn(HTMLElement.prototype, "scrollTo").mockImplementation(
+        function (
+          this: HTMLElement,
+          ...args: Array<number | ScrollToOptions | undefined>
+        ): void {
+          const first = args[0];
+          if (typeof first === "number") {
+            const second = args[1];
+            scrollLeftSetter.call(this, first);
+            scrollTopSetter.call(this, typeof second === "number" ? second : 0);
+            return;
+          }
+          if (typeof first !== "object" || first === null) return;
+          if (this === scrollNode) {
+            calls.push({
+              behavior: first.behavior,
+              top: first.top,
+              left: first.left,
+            });
+          }
+          if (typeof first.left === "number") {
+            scrollLeftSetter.call(this, first.left);
+          }
+          if (typeof first.top === "number") {
+            scrollTopSetter.call(this, first.top);
+          }
+        },
+      );
+      return calls;
+    }
+
+    it(
+      "late-hydration catch-up requests a non-animated (behavior: auto) jump, " +
+        "never the animated (behavior: smooth) path minimap/deep-link use " +
+        "(find is unrelated - it independently stays non-animated)",
+      async () => {
+        const fullMessages = makeCompletedTranscript(200);
+        const anchorIndex = 20;
+        const anchorId = fullMessages[anchorIndex]?.id ?? null;
+        expect(anchorId).toBeTruthy();
+        const expectedScrollTop =
+          anchorIndex * TICKET_13_ROW_HEIGHT_PX +
+          LEGEND_LIST_HEADER_PX -
+          CHAT_TIMELINE_NAVIGATION_VIEW_OFFSET_PX;
+
+        const catchupKey = `t20-hydration-single-frame-${Math.random().toString(36).slice(2)}`;
+        saveChatTabState({
+          identity: makeDefaultTestIdentity(catchupKey),
+          mode: "free-scrolling",
+          anchorMessageId: anchorId,
+          anchorIndex,
+          offset: 24,
+        });
+        const partialMessages = fullMessages.slice(180);
+        const { rerenderMessages } = renderChatMessages({
+          messages: partialMessages,
+          scrollStateKey: catchupKey,
+        });
+        await settleLegendList();
+        expect(getScrollNode().scrollTop).not.toBe(expectedScrollTop);
+
+        const scrollNode = getScrollNode();
+        const callsOnScrollNode = recordScrollToCallsOnNode(scrollNode);
+
+        // The rest of the transcript arrives (a later onSnapshot/backfill
+        // commit) - triggers the hydration-retry effect's `navigateToMessage`
+        // call.
+        rerenderMessages(fullMessages);
+        await settleLegendList();
+
+        expect(getScrollNode().scrollTop).toBe(expectedScrollTop);
+        // RED-ON-BASELINE: before threading an explicit `animated` param
+        // through `navigateToMessage`, this call hardcoded `animated: true`,
+        // which LegendList translates to `behavior: "smooth"` - a reader
+        // would see the transcript visibly scroll to the resolved anchor
+        // instead of painting there directly. A restore is not a user
+        // navigation; every call this retry produced must request
+        // `behavior: "auto"` (LegendList's instant/non-animated path).
+        expect(callsOnScrollNode.length).toBeGreaterThan(0);
+        expect(
+          callsOnScrollNode.every((call) => call.behavior === "auto"),
+        ).toBe(true);
+      },
+    );
+
+    it("minimap navigation (a real, user-triggered jump) still requests the animated path, unchanged", async () => {
+      const messages = makeTranscript(24);
+      renderChatMessages({
+        messages,
+        scrollStateKey: `t20-minimap-still-animated-${Math.random().toString(36).slice(2)}`,
+      });
+      await settleLegendList();
+
+      act(() => {
+        enterFreeScrollingAwayFromEnd();
+      });
+      await waitForPillVisible();
+
+      const scrollNode = getScrollNode();
+      const callsOnScrollNode = recordScrollToCallsOnNode(scrollNode);
+
+      await selectLastChatTurnMinimapItem();
+
+      expect(callsOnScrollNode.length).toBeGreaterThan(0);
+      expect(
+        callsOnScrollNode.every((call) => call.behavior === "smooth"),
+      ).toBe(true);
     });
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -49,6 +49,11 @@ import {
 } from "@/stores/chats/chat-tab-state-cache";
 import type { ChatTabPersistenceIdentity } from "@/stores/chats/chat-tab-persistence-key";
 import { flushChatTabViewportHandoff } from "@/stores/chats/chat-tab-viewport-handoff";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+  HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 import { evictChatTabPersistenceForEpic } from "@/stores/chats/chat-tab-persistence-eviction";
 import { getOrCreateActivityGroupOpenStore } from "@/stores/chats/activity-group-open-store-core";
 import type { ActivityGroupOpenState } from "@/stores/chats/activity-group-open-store-context";
@@ -846,6 +851,15 @@ interface RenderChatMessagesOptions {
   readonly groupId?: string;
   readonly withSiblingChrome?: boolean;
   /**
+   * Ticket 21 slice 4: models a HOSTED chat's DOM shape - the tile's own
+   * wrapper carries the hosted-record identity attributes instead of a
+   * physical `data-group-id` ancestor, while `withSiblingChrome`'s sibling
+   * (the pane's own tab strip, which never moves) stays under a real
+   * `data-group-id={hostedPaneId}`, exactly mirroring `StableTileSurfaceHost`
+   * vs `TabGroupView`'s split DOM subtrees.
+   */
+  readonly hostedPaneId?: string;
+  /**
    * Opts into decision #15's fresh-open policy (anchor the last user message
    * near the top) by leaving the scroll-state cache empty for this key. Most
    * tests here exercise following/free-scrolling/edge-mutation behavior, not
@@ -931,15 +945,35 @@ function renderChatMessages(options: RenderChatMessagesOptions) {
     isChatStreaming: options.isChatStreaming ?? false,
   };
 
+  const hostedPaneId = options.hostedPaneId;
+  const scopeAttributes: Record<string, string> =
+    hostedPaneId === undefined
+      ? { "data-group-id": groupId }
+      : {
+          [HOSTED_TILE_INSTANCE_ID_ATTRIBUTE]: instanceId,
+          [HOSTED_TILE_PANE_ID_ATTRIBUTE]: hostedPaneId,
+          [HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE]: "tab-1",
+        };
+
+  function siblingChrome(): ReactNode {
+    const button = (
+      <button type="button" data-testid="pane-sibling-chrome">
+        Sibling chrome
+      </button>
+    );
+    if (hostedPaneId === undefined) return button;
+    return <div data-group-id={hostedPaneId}>{button}</div>;
+  }
+
   const jsx = (): ReactNode => (
     <div
-      data-group-id={groupId}
+      data-group-id={hostedPaneId === undefined ? groupId : undefined}
       style={{ height: VIEWPORT_HEIGHT_PX, width: VIEWPORT_WIDTH_PX }}
     >
       <div
         data-chat-keyboard-scroll-scope
         data-active={state.tileActive ? "true" : "false"}
-        data-group-id={groupId}
+        {...scopeAttributes}
         style={{ height: VIEWPORT_HEIGHT_PX, width: VIEWPORT_WIDTH_PX }}
       >
         <ChatMessages
@@ -966,11 +1000,7 @@ function renderChatMessages(options: RenderChatMessagesOptions) {
           composerOverlayHeight={state.composerOverlayHeight}
         />
       </div>
-      {options.withSiblingChrome === true ? (
-        <button type="button" data-testid="pane-sibling-chrome">
-          Sibling chrome
-        </button>
-      ) : null}
+      {options.withSiblingChrome === true ? siblingChrome() : null}
     </div>
   );
 
@@ -4328,6 +4358,58 @@ describe("ChatMessages scroll policy", () => {
       rerenderMessages(appendAssistant(messages, "sibling-stream", 130_000));
       await settleLegendList();
       expect(getScrollNode().scrollTop).toBe(parked);
+    });
+
+    it("ticket 21 slice 4: claims keys from a pane sibling even when the tile itself is hosted (no physical data-group-id ancestor)", async () => {
+      const messages = makeTranscript(16);
+      renderChatMessages({
+        messages,
+        scrollStateKey: "kbd-hosted-sibling",
+        withSiblingChrome: true,
+        tileActive: true,
+        hostedPaneId: "pane-hosted-1",
+      });
+      await settleLegendList();
+
+      const sibling = screen.getByTestId("pane-sibling-chrome");
+      const event = new KeyboardEvent("keydown", {
+        key: "ArrowDown",
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => {
+        sibling.dispatchEvent(event);
+      });
+      // `handleKeyDownCapture` synchronously `preventDefault`s only when it
+      // claims the key (`chat-messages.tsx`) - the direct, gesture-heuristic-
+      // free signal that the hosted-record pane-id fallback matched.
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("ticket 21 slice 4: does NOT claim keys from an unrelated pane's chrome when the tile is hosted", async () => {
+      const messages = makeTranscript(16);
+      renderChatMessages({
+        messages,
+        scrollStateKey: "kbd-hosted-unrelated",
+        tileActive: true,
+        hostedPaneId: "pane-hosted-1",
+      });
+      await settleLegendList();
+
+      const unrelated = document.createElement("div");
+      unrelated.setAttribute("data-group-id", "pane-hosted-2");
+      document.body.appendChild(unrelated);
+
+      const event = new KeyboardEvent("keydown", {
+        key: "ArrowDown",
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => {
+        unrelated.dispatchEvent(event);
+      });
+      expect(event.defaultPrevented).toBe(false);
+      unrelated.remove();
     });
 
     it("on macOS, plain Home is claimed even from an editable target", async () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline-panel-resize-snapshot.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline-panel-resize-snapshot.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  captureChatTimelineVisibleRows,
+  clearChatTimelineVisibleRows,
+  PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE,
+} from "@/components/chat/chat-timeline-panel-resize-snapshot";
+import {
+  beginPanelResizeInteraction,
+  registerPanelResizeParticipant,
+} from "@/lib/layout/panel-resizing-class";
+
+const PANEL_RESIZING_CLASS = "traycer-panel-resizing";
+
+/** Pure DOM, no LegendList/React involved - deliberately sidesteps the
+ *  shared `installLegendListViewportMetrics()` shim, which stubs every
+ *  element's `getBoundingClientRect` to the SAME `(0, 0)`-origin rect (see
+ *  `legend-list-test-environment.ts`), so it cannot distinguish visible from
+ *  off-screen rows. Per-element rect overrides here give each row/scroller a
+ *  distinct, real position instead. */
+function rectOf(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 100,
+    width: 100,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+function makeRow(id: string, top: number, height: number): HTMLElement {
+  const row = document.createElement("div");
+  row.setAttribute("data-message-id", id);
+  row.getBoundingClientRect = () => rectOf(top, height);
+  return row;
+}
+
+function makeScroller(viewportHeight: number): HTMLElement {
+  const scroller = document.createElement("div");
+  scroller.getBoundingClientRect = () => rectOf(0, viewportHeight);
+  document.body.appendChild(scroller);
+  return scroller;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("captureChatTimelineVisibleRows", () => {
+  it("marks only rows whose rect intersects the scrollable node's viewport, boundary-inclusive", () => {
+    const scroller = makeScroller(300); // viewport 0..300
+    const above = makeRow("above", -150, 100); // -150..-50, fully above
+    const straddleTop = makeRow("straddle-top", -50, 100); // -50..50, straddles top edge
+    const visible = makeRow("visible", 100, 80); // 100..180, fully inside
+    const straddleBottom = makeRow("straddle-bottom", 280, 100); // 280..380, straddles bottom edge
+    const below = makeRow("below", 400, 100); // 400..500, fully below
+    for (const row of [above, straddleTop, visible, straddleBottom, below]) {
+      scroller.appendChild(row);
+    }
+
+    captureChatTimelineVisibleRows(scroller);
+
+    expect(above.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      false,
+    );
+    expect(
+      straddleTop.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE),
+    ).toBe(true);
+    expect(visible.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      true,
+    );
+    expect(
+      straddleBottom.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE),
+    ).toBe(true);
+    expect(below.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      false,
+    );
+  });
+
+  it("only marks rows within the given scrollable node's own subtree", () => {
+    const scrollerA = makeScroller(300);
+    const scrollerB = makeScroller(300);
+    const rowA = makeRow("a", 0, 100);
+    const rowB = makeRow("b", 0, 100);
+    scrollerA.appendChild(rowA);
+    scrollerB.appendChild(rowB);
+
+    captureChatTimelineVisibleRows(scrollerA);
+
+    expect(rowA.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+    expect(rowB.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+  });
+
+  it("is synchronous (no observer/subscription indirection to await)", () => {
+    const scroller = makeScroller(300);
+    const row = makeRow("sync", 0, 100);
+    scroller.appendChild(row);
+
+    captureChatTimelineVisibleRows(scroller);
+
+    // No await/flush between the call above and this assertion - a real
+    // subscription (ResizeObserver, rAF, timer) would not have fired yet.
+    expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+  });
+
+  it("is self-healing: a stale marker on a row that has since scrolled offscreen is removed by the next capture, with no clear in between (review F1)", () => {
+    const scroller = makeScroller(300); // viewport 0..300
+    const row = makeRow("row", 0, 100); // starts visible
+    scroller.appendChild(row);
+
+    captureChatTimelineVisibleRows(scroller);
+    expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+
+    // Row scrolls below the viewport; nothing ever clears its marker.
+    row.getBoundingClientRect = () => rectOf(1000, 100);
+
+    captureChatTimelineVisibleRows(scroller);
+
+    expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+  });
+});
+
+describe("clearChatTimelineVisibleRows", () => {
+  it("removes every marker set within the node's subtree, nothing more", () => {
+    const scroller = makeScroller(300);
+    const marked1 = makeRow("m1", 0, 100);
+    const marked2 = makeRow("m2", 50, 100);
+    scroller.appendChild(marked1);
+    scroller.appendChild(marked2);
+    captureChatTimelineVisibleRows(scroller);
+    expect(marked1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      true,
+    );
+    expect(marked2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      true,
+    );
+
+    clearChatTimelineVisibleRows(scroller);
+
+    expect(marked1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      false,
+    );
+    expect(marked2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+      false,
+    );
+  });
+
+  it("does not touch markers outside the given scrollable node", () => {
+    const scrollerA = makeScroller(300);
+    const scrollerB = makeScroller(300);
+    const rowA = makeRow("a", 0, 100);
+    const rowB = makeRow("b", 0, 100);
+    scrollerA.appendChild(rowA);
+    scrollerB.appendChild(rowB);
+    captureChatTimelineVisibleRows(scrollerA);
+    captureChatTimelineVisibleRows(scrollerB);
+
+    clearChatTimelineVisibleRows(scrollerA);
+
+    expect(rowA.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+    expect(rowB.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+  });
+});
+
+describe("end-to-end recovery through the real registry (review F1)", () => {
+  afterEach(() => {
+    document.documentElement.classList.remove(PANEL_RESIZING_CLASS);
+  });
+
+  it("a marker surviving a participant's thrown clear does not survive the NEXT capture", () => {
+    const scroller = makeScroller(300); // viewport 0..300
+    const row = makeRow("row", 0, 100); // starts visible
+    scroller.appendChild(row);
+
+    let clearCallCount = 0;
+    const unregister = registerPanelResizeParticipant({
+      capture: () => captureChatTimelineVisibleRows(scroller),
+      clear: () => {
+        clearCallCount += 1;
+        if (clearCallCount === 1) {
+          // Simulates the exact failure the registry is designed to
+          // isolate - this drag's clear never actually runs.
+          throw new Error("clear boom (simulated failure)");
+        }
+        clearChatTimelineVisibleRows(scroller);
+      },
+    });
+
+    // Drag 1: row visible -> marked. Its clear() throws; the registry
+    // isolates the failure (class lifecycle still completes normally, per
+    // the existing isolation pins) but the marker is never actually
+    // cleared as a side effect.
+    const stop1 = beginPanelResizeInteraction(1, () => undefined);
+    expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+    stop1();
+    expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+
+    // Row scrolls below the viewport before the next drag starts.
+    row.getBoundingClientRect = () => rectOf(1000, 100);
+
+    // Drag 2: recapture. The stale marker must not survive into this
+    // drag's freeze - self-healing capture removes it even though nothing
+    // ever successfully cleared it.
+    const stop2 = beginPanelResizeInteraction(2, () => undefined);
+    expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+    stop2();
+
+    unregister();
+  });
+});

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline-panel-resize-snapshot.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline-panel-resize-snapshot.test.ts
@@ -63,21 +63,15 @@ describe("captureChatTimelineVisibleRows", () => {
 
     captureChatTimelineVisibleRows(scroller);
 
-    expect(above.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-      false,
-    );
-    expect(
-      straddleTop.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE),
-    ).toBe(true);
-    expect(visible.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+    expect(above.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+    expect(straddleTop.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
       true,
     );
+    expect(visible.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
     expect(
       straddleBottom.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE),
     ).toBe(true);
-    expect(below.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-      false,
-    );
+    expect(below.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
   });
 
   it("only marks rows within the given scrollable node's own subtree", () => {
@@ -131,12 +125,8 @@ describe("clearChatTimelineVisibleRows", () => {
     scroller.appendChild(marked1);
     scroller.appendChild(marked2);
     captureChatTimelineVisibleRows(scroller);
-    expect(marked1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-      true,
-    );
-    expect(marked2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-      true,
-    );
+    expect(marked1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
+    expect(marked2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(true);
 
     clearChatTimelineVisibleRows(scroller);
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline-panel-resize-snapshot.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline-panel-resize-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
 import {
   captureChatTimelineVisibleRows,
   clearChatTimelineVisibleRows,
@@ -178,6 +178,7 @@ describe("end-to-end recovery through the real registry (review F1)", () => {
         clearChatTimelineVisibleRows(scroller);
       },
     });
+    onTestFinished(unregister);
 
     // Drag 1: row visible -> marked. Its clear() throws; the registry
     // isolates the failure (class lifecycle still completes normally, per
@@ -197,7 +198,5 @@ describe("end-to-end recovery through the real registry (review F1)", () => {
     const stop2 = beginPanelResizeInteraction(2, () => undefined);
     expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
     stop2();
-
-    unregister();
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -607,9 +607,7 @@ describe("ChatTimeline", () => {
     readonly initialMessages: ReadonlyArray<ChatMessageModel>;
     readonly initialHighlight: string | null;
     readonly onExposeSetters: (setters: {
-      readonly setMessages: (
-        messages: ReadonlyArray<ChatMessageModel>,
-      ) => void;
+      readonly setMessages: (messages: ReadonlyArray<ChatMessageModel>) => void;
       readonly setHighlight: (id: string | null) => void;
     }) => void;
   }): ReactElement {
@@ -789,7 +787,9 @@ describe("ChatTimeline", () => {
     );
     expect(rowHasHighlightRing(highlighted)).toBe(true);
 
-    for (const id of messages.map((m) => m.id).filter((id) => id !== "message-2")) {
+    for (const id of messages
+      .map((m) => m.id)
+      .filter((id) => id !== "message-2")) {
       const row = container.querySelector(`[data-message-id="${id}"]`);
       expect(row?.getAttribute("data-navigation-highlighted")).toBeNull();
       expect(rowHasHighlightRing(row)).toBe(false);
@@ -944,9 +944,7 @@ describe("ChatTimeline", () => {
       await flushFrame();
 
       const expected =
-        previousHighlight === null
-          ? [nextId]
-          : [previousHighlight, nextId];
+        previousHighlight === null ? [nextId] : [previousHighlight, nextId];
       expect(new Set(renderedSince(messages, before))).toEqual(
         new Set(expected),
       );
@@ -1121,24 +1119,16 @@ describe("ChatTimeline", () => {
       expect(row1.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
         "true",
       );
-      expect(row2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        false,
-      );
+      expect(row2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
 
       stop();
 
       expect(
         document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
       ).toBe(false);
-      expect(row0.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        false,
-      );
-      expect(row1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        false,
-      );
-      expect(row2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        false,
-      );
+      expect(row0.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+      expect(row1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
+      expect(row2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
     });
 
     it("clears this timeline's own markers on unmount, even mid-drag", async () => {
@@ -1159,17 +1149,13 @@ describe("ChatTimeline", () => {
       row.getBoundingClientRect = () => rectOf(0, 100);
 
       const stop = beginPanelResizeInteraction(1, () => undefined);
-      expect(row.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        "true",
-      );
+      expect(row.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe("true");
 
       expect(() => {
         unmount();
       }).not.toThrow();
 
-      expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        false,
-      );
+      expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(false);
 
       // The now-unregistered participant must not be invoked (and must not
       // throw) when the drag ends afterward.
@@ -1206,9 +1192,7 @@ describe("ChatTimeline", () => {
       // Only ONE capture ran for the currently-mounted timeline - the first
       // (unmounted) instance's participant was unregistered, not left
       // dangling to double-mark or throw against detached DOM.
-      expect(row.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
-        "true",
-      );
+      expect(row.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe("true");
       stop();
     });
   });

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -100,6 +100,8 @@ interface RenderTimelineOptions {
   readonly topFadeEnabled?: boolean;
   readonly followEnabled?: boolean;
   readonly onItemSizeChanged?: () => void;
+  /** Ticket 22: forwarded to LegendList for viewport-length changes. */
+  readonly onLayout?: () => void;
   readonly navigationHighlightedMessageId?: string | null;
 }
 
@@ -133,6 +135,7 @@ function renderTimeline(options: RenderTimelineOptions) {
         topFadeEnabled={options.topFadeEnabled}
         followEnabled={options.followEnabled}
         onItemSizeChanged={options.onItemSizeChanged}
+        onLayout={options.onLayout}
         navigationHighlightedMessageId={navigationHighlightedMessageId}
       />
     </div>
@@ -431,6 +434,26 @@ describe("ChatTimeline", () => {
     });
 
     expect(onItemSizeChanged).toHaveBeenCalled();
+  });
+
+  // Ticket 22: ChatTimeline forwards `onLayout` to LegendList so a
+  // viewport-length change (divider/pane resize) can schedule geometry
+  // repair under the same messages array. Lower-level than the
+  // chat-messages integration pins - just the prop wiring + library
+  // callback. Initial mount layout is enough; no controllable
+  // ResizeObserver needed here.
+  it("onLayout fires when LegendList reports a layout change", async () => {
+    const messages: ChatMessageModel[] = [
+      makeMessage(0, "user"),
+      makeMessage(1, "assistant"),
+    ];
+    const onLayout = vi.fn();
+    renderTimeline({ messages, onLayout });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(onLayout).toHaveBeenCalled();
+    });
   });
 
   // M1 (ticket 16 gutter alignment): `scrollbar-gutter-both` reserves the

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import {
   createRef,
   useEffect,
+  useState,
   type ReactElement,
   type ReactNode,
   type RefObject,
@@ -24,6 +25,19 @@ import {
 const MESSAGE_ROW_SELECTOR = "[data-message-id]";
 const LARGE_MESSAGE_COUNT = 400;
 
+/**
+ * Review round 1, finding 2: counts ROW-BOUNDARY renders - i.e. how many
+ * times `ChatTimelineRow` re-entered this child boundary - NOT executions of
+ * the real memoized `ChatMessageImpl` body. This wrapper is intentionally
+ * un-memoized, so it always re-runs (and increments the counter) whenever
+ * its parent `ChatTimelineRow` re-renders; the wrapped `actual.ChatMessage`
+ * (still the real `memo(ChatMessageImpl)`) could in principle still bail
+ * internally even when this wrapper re-runs. That's the right granularity
+ * for pinning the context-propagation/external-store fanout bug (a
+ * `ChatTimelineRow`-level defect), but it does NOT prove anything about
+ * `ChatMessageImpl`'s own render cost - see the `getMessageActions`-based
+ * assertions elsewhere in this file for independent row-boundary evidence.
+ */
 const renderCounts = new Map<string, number>();
 
 vi.mock("@/components/chat/chat-message", async (importOriginal) => {
@@ -86,6 +100,7 @@ interface RenderTimelineOptions {
   readonly topFadeEnabled?: boolean;
   readonly followEnabled?: boolean;
   readonly onItemSizeChanged?: () => void;
+  readonly navigationHighlightedMessageId?: string | null;
 }
 
 function renderTimeline(options: RenderTimelineOptions) {
@@ -96,7 +111,10 @@ function renderTimeline(options: RenderTimelineOptions) {
   const backgroundToolBlockIds =
     options.backgroundToolBlockIds ?? new Set<string>();
 
-  const jsx = (messages: ReadonlyArray<ChatMessageModel>): ReactNode => (
+  const jsx = (
+    messages: ReadonlyArray<ChatMessageModel>,
+    navigationHighlightedMessageId: string | null | undefined,
+  ): ReactNode => (
     <div
       style={{
         height: VIEWPORT_HEIGHT_PX,
@@ -115,18 +133,51 @@ function renderTimeline(options: RenderTimelineOptions) {
         topFadeEnabled={options.topFadeEnabled}
         followEnabled={options.followEnabled}
         onItemSizeChanged={options.onItemSizeChanged}
+        navigationHighlightedMessageId={navigationHighlightedMessageId}
       />
     </div>
   );
 
-  const result = render(jsx(options.messages));
+  const result = render(
+    jsx(options.messages, options.navigationHighlightedMessageId),
+  );
   return {
     ...result,
     listRef,
-    rerenderMessages: (messages: ReadonlyArray<ChatMessageModel>) => {
-      result.rerender(jsx(messages));
+    rerenderMessages: (
+      messages: ReadonlyArray<ChatMessageModel>,
+      navigationHighlightedMessageId: string | null | undefined,
+    ) => {
+      result.rerender(jsx(messages, navigationHighlightedMessageId));
     },
   };
+}
+
+/** Render counts (from the `ChatMessage` probe above) for every id in
+ *  `messages`, snapshotted as a plain map so two snapshots can be diffed by
+ *  value without aliasing the live `renderCounts` map. */
+function snapshotRenderCounts(
+  messages: ReadonlyArray<ChatMessageModel>,
+): Map<string, number> {
+  return new Map(messages.map((m) => [m.id, renderCounts.get(m.id) ?? 0]));
+}
+
+/** Message ids whose render count changed between two snapshots. */
+function renderedSince(
+  messages: ReadonlyArray<ChatMessageModel>,
+  before: Map<string, number>,
+): ReadonlyArray<string> {
+  return messages
+    .map((m) => m.id)
+    .filter((id) => (renderCounts.get(id) ?? 0) !== (before.get(id) ?? 0));
+}
+
+async function flushFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
 }
 
 describe("ChatTimeline", () => {
@@ -223,7 +274,7 @@ describe("ChatTimeline", () => {
       },
     ];
 
-    rerenderMessages(nextMessages);
+    rerenderMessages(nextMessages, undefined);
 
     await act(async () => {
       await new Promise<void>((resolve) => {
@@ -424,5 +475,538 @@ describe("ChatTimeline", () => {
       "h-10 sm:h-12",
       "h-3 sm:h-4",
     ]);
+  });
+
+  // Ticket 24 (painted-chat lifecycle audit, finding 5): the shared row
+  // context previously carried `navigationHighlightedMessageId` directly, so
+  // React's context propagation re-rendered EVERY mounted row - bypassing
+  // each row's own `memo` bailout entirely (see the render-count probe's own
+  // doc comment above for exactly what "renders" measures here: row-
+  // boundary commits, not `ChatMessageImpl` body executions specifically).
+  // Pin: moving the highlight renders only the old and new highlighted
+  // rows; clearing it renders only the previously highlighted row.
+  it("isolates navigation-highlight changes to only the affected rows", async () => {
+    const messageCount = 8;
+    const messages = makeMessages(messageCount);
+
+    const { container, rerenderMessages } = renderTimeline({
+      messages,
+      navigationHighlightedMessageId: null,
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(messageCount);
+    });
+
+    const baseline = snapshotRenderCounts(messages);
+
+    // Move the highlight onto message-3: only that row should render.
+    rerenderMessages(messages, "message-3");
+    await flushFrame();
+    expect(renderedSince(messages, baseline)).toEqual(["message-3"]);
+
+    const afterFirstMove = snapshotRenderCounts(messages);
+
+    // Move the highlight from message-3 to message-5: exactly the old and
+    // new highlighted rows should render - not the other 6 mounted rows.
+    rerenderMessages(messages, "message-5");
+    await flushFrame();
+    expect(new Set(renderedSince(messages, afterFirstMove))).toEqual(
+      new Set(["message-3", "message-5"]),
+    );
+
+    const afterSecondMove = snapshotRenderCounts(messages);
+
+    // Clear the highlight: only the previously highlighted row should render.
+    rerenderMessages(messages, null);
+    await flushFrame();
+    expect(renderedSince(messages, afterSecondMove)).toEqual(["message-5"]);
+  });
+
+  const NAVIGATION_HIGHLIGHT_RING_CLASS =
+    "bg-primary/15 ring-2 ring-inset ring-primary/80 motion-safe:animate-pulse";
+
+  function highlightedRowIds(container: HTMLElement): ReadonlyArray<string> {
+    return Array.from(
+      container.querySelectorAll('[data-navigation-highlighted="true"]'),
+    ).map((row) => row.getAttribute("data-message-id") ?? "");
+  }
+
+  function rowHasHighlightRing(row: Element | null): boolean {
+    if (row === null) return false;
+    const className = row.getAttribute("class") ?? "";
+    return NAVIGATION_HIGHLIGHT_RING_CLASS.split(" ").every((token) =>
+      className.includes(token),
+    );
+  }
+
+  /**
+   * Review round 1, finding 1: owns messages/highlight as REAL React state
+   * (mirroring how chat-messages.tsx drives `ChatTimeline`) and exposes the
+   * raw setters, so timing-sensitive tests can trigger updates WITHOUT going
+   * through Testing Library's `rerender` - `rerender`'s internal `act()`
+   * (confirmed empirically, including with `IS_REACT_ACT_ENVIRONMENT`
+   * disabled and with `flushSync`) fully settles BOTH `useLayoutEffect` AND
+   * `useEffect` synchronously in this React version, which hides the exact
+   * regression finding 1 covers. Calling the exposed setters directly, with
+   * the act-environment flag OFF (see `withActEnvironmentDisabled`), lets a
+   * PLAIN state update go through React's ordinary (non-test) scheduling,
+   * where a passive effect's flush is a real, separately-scheduled task
+   * instead of something `act()` eagerly drains for you.
+   */
+  function HighlightTimingHarness({
+    initialMessages,
+    initialHighlight,
+    onExposeSetters,
+  }: {
+    readonly initialMessages: ReadonlyArray<ChatMessageModel>;
+    readonly initialHighlight: string | null;
+    readonly onExposeSetters: (setters: {
+      readonly setMessages: (
+        messages: ReadonlyArray<ChatMessageModel>,
+      ) => void;
+      readonly setHighlight: (id: string | null) => void;
+    }) => void;
+  }): ReactElement {
+    const [messages, setMessages] = useState(initialMessages);
+    const [highlight, setHighlight] = useState(initialHighlight);
+    const [listRef] = useState(() => createRef<LegendListRef | null>());
+
+    useEffect(() => {
+      onExposeSetters({ setMessages, setHighlight });
+      // Setter identities from useState never change - registering once is
+      // enough, and re-running on every render would re-expose (harmlessly)
+      // identical functions anyway.
+    }, [onExposeSetters]);
+
+    return (
+      <div style={{ height: VIEWPORT_HEIGHT_PX, width: VIEWPORT_WIDTH_PX }}>
+        <ChatTimeline
+          messages={messages}
+          taskTitle="Test transcript"
+          backgroundToolBlockIds={new Set<string>()}
+          getMessageActions={() => null}
+          nextStepActions={null}
+          listRef={listRef}
+          className="h-full"
+          navigationHighlightedMessageId={highlight}
+        />
+      </div>
+    );
+  }
+
+  interface HighlightTimingSetters {
+    readonly setMessages: (messages: ReadonlyArray<ChatMessageModel>) => void;
+    readonly setHighlight: (id: string | null) => void;
+  }
+
+  /** Runs `fn` with React's act-environment detection OFF, so a plain state
+   *  update inside `fn` is scheduled the way it would be in production, not
+   *  the eagerly-flushed way `act()` schedules it for test determinism. */
+  async function withActEnvironmentDisabled(
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    const globalWithActFlag = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    const previous = globalWithActFlag.IS_REACT_ACT_ENVIRONMENT;
+    globalWithActFlag.IS_REACT_ACT_ENVIRONMENT = false;
+    try {
+      await fn();
+    } finally {
+      globalWithActFlag.IS_REACT_ACT_ENVIRONMENT = previous;
+    }
+  }
+
+  /** One real macrotask tick - empirically the exact window where a
+   *  `useLayoutEffect`-published store settles (verified against a toy
+   *  two-component external-store harness) but a `useEffect`-published one
+   *  has not yet, when act-environment is off. */
+  async function tickOneMacrotask(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  // Finding 1's "row mounting in the stale window" sub-case was investigated
+  // specifically for a row that mounts because `messages` GROWS (a new
+  // message arrives) in the same update as a highlight change. Empirically
+  // (verified with fine-grained per-tick polling, both against this fix and
+  // against a reverted `useEffect` mutation), LegendList's OWN settling work
+  // for a newly-added data item takes at least one macrotask regardless of
+  // which effect type publishes the highlight - by the time the new row's
+  // component renders for the first time, the store has already settled
+  // either way, so that specific construction cannot discriminate the two
+  // implementations in this component. The setter-direction pin below
+  // exercises the same underlying mechanism (a real, non-`rerender`-routed
+  // update publishing a NEW highlight id) on already-mounted rows, which the
+  // clear-direction pin right after it confirms DOES discriminate.
+  it("(finding 1) setting a highlight via a real update settles within one macrotask - no stale un-highlighted paint", async () => {
+    const messages = makeMessages(3);
+    let setters: HighlightTimingSetters | null = null;
+
+    const { container } = render(
+      <HighlightTimingHarness
+        initialMessages={messages}
+        initialHighlight={null}
+        onExposeSetters={(s) => {
+          setters = s;
+        }}
+      />,
+    );
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(3);
+    });
+    expect(highlightedRowIds(container)).toEqual([]);
+
+    await withActEnvironmentDisabled(async () => {
+      // Mirrors the external-jump activation shape: a plain setState call,
+      // not a Testing-Library `rerender`.
+      setters?.setHighlight("message-1");
+      await tickOneMacrotask();
+    });
+
+    expect(highlightedRowIds(container)).toEqual(["message-1"]);
+    const highlightedRow = container.querySelector(
+      '[data-message-id="message-1"]',
+    );
+    expect(rowHasHighlightRing(highlightedRow)).toBe(true);
+  });
+
+  it("(finding 1) clearing the highlight via a real update settles within one macrotask - no stale painted ring", async () => {
+    const messages = makeMessages(3);
+    let setters: HighlightTimingSetters | null = null;
+
+    const { container } = render(
+      <HighlightTimingHarness
+        initialMessages={messages}
+        initialHighlight="message-1"
+        onExposeSetters={(s) => {
+          setters = s;
+        }}
+      />,
+    );
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(3);
+    });
+    expect(highlightedRowIds(container)).toEqual(["message-1"]);
+
+    await withActEnvironmentDisabled(async () => {
+      // Mirrors the 3s-timeout / real-gesture clear shape: a plain setState
+      // call, not a Testing-Library `rerender`.
+      setters?.setHighlight(null);
+      await tickOneMacrotask();
+    });
+
+    expect(highlightedRowIds(container)).toEqual([]);
+    const previouslyHighlighted = container.querySelector(
+      '[data-message-id="message-1"]',
+    );
+    expect(rowHasHighlightRing(previouslyHighlighted)).toBe(false);
+  });
+
+  it("sets data-navigation-highlighted and the ring className only on the highlighted row", async () => {
+    const messageCount = 6;
+    const messages = makeMessages(messageCount);
+
+    const { container, rerenderMessages } = renderTimeline({
+      messages,
+      navigationHighlightedMessageId: null,
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(messageCount);
+    });
+
+    // No highlight: attribute absent on every mounted row, ring classes absent.
+    expect(highlightedRowIds(container)).toEqual([]);
+    for (const id of messages.map((m) => m.id)) {
+      const row = container.querySelector(`[data-message-id="${id}"]`);
+      expect(row).not.toBeNull();
+      expect(row?.getAttribute("data-navigation-highlighted")).toBeNull();
+      expect(rowHasHighlightRing(row)).toBe(false);
+    }
+
+    rerenderMessages(messages, "message-2");
+    await flushFrame();
+
+    expect(highlightedRowIds(container)).toEqual(["message-2"]);
+    const highlighted = container.querySelector(
+      '[data-message-id="message-2"]',
+    );
+    expect(highlighted?.getAttribute("data-navigation-highlighted")).toBe(
+      "true",
+    );
+    expect(rowHasHighlightRing(highlighted)).toBe(true);
+
+    for (const id of messages.map((m) => m.id).filter((id) => id !== "message-2")) {
+      const row = container.querySelector(`[data-message-id="${id}"]`);
+      expect(row?.getAttribute("data-navigation-highlighted")).toBeNull();
+      expect(rowHasHighlightRing(row)).toBe(false);
+    }
+
+    // Move highlight: previous loses attribute + ring; new gains both.
+    rerenderMessages(messages, "message-4");
+    await flushFrame();
+
+    expect(highlightedRowIds(container)).toEqual(["message-4"]);
+    expect(
+      container
+        .querySelector('[data-message-id="message-2"]')
+        ?.getAttribute("data-navigation-highlighted"),
+    ).toBeNull();
+    expect(
+      rowHasHighlightRing(
+        container.querySelector('[data-message-id="message-2"]'),
+      ),
+    ).toBe(false);
+    expect(
+      container
+        .querySelector('[data-message-id="message-4"]')
+        ?.getAttribute("data-navigation-highlighted"),
+    ).toBe("true");
+    expect(
+      rowHasHighlightRing(
+        container.querySelector('[data-message-id="message-4"]'),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not throw or highlight any row when navigationHighlightedMessageId is a stale/missing id", async () => {
+    const messageCount = 5;
+    const messages = makeMessages(messageCount);
+
+    const { container, rerenderMessages } = renderTimeline({
+      messages,
+      navigationHighlightedMessageId: null,
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(messageCount);
+    });
+
+    expect(() => {
+      rerenderMessages(messages, "message-not-in-list");
+    }).not.toThrow();
+    await flushFrame();
+
+    expect(highlightedRowIds(container)).toEqual([]);
+    for (const id of messages.map((m) => m.id)) {
+      const row = container.querySelector(`[data-message-id="${id}"]`);
+      expect(row?.getAttribute("data-navigation-highlighted")).toBeNull();
+      expect(rowHasHighlightRing(row)).toBe(false);
+    }
+
+    // Still healthy after a real highlight: stale id must clear any prior ring.
+    rerenderMessages(messages, "message-1");
+    await flushFrame();
+    expect(highlightedRowIds(container)).toEqual(["message-1"]);
+
+    expect(() => {
+      rerenderMessages(messages, "message-removed-earlier");
+    }).not.toThrow();
+    await flushFrame();
+    expect(highlightedRowIds(container)).toEqual([]);
+  });
+
+  it("scopes navigation-highlight state per ChatTimeline mount, not module-wide", async () => {
+    const messagesA = makeMessages(4);
+    const messagesB = makeMessages(4).map((m, index) => ({
+      ...m,
+      // Distinct ids so the two lists do not collide in the shared render probe.
+      id: `b-message-${index}`,
+      content: `B user message ${index}`,
+    }));
+
+    const timelineA = renderTimeline({
+      messages: messagesA,
+      navigationHighlightedMessageId: null,
+      "data-testid": "timeline-a",
+    });
+    const timelineB = renderTimeline({
+      messages: messagesB,
+      navigationHighlightedMessageId: null,
+      "data-testid": "timeline-b",
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(timelineA.container).length).toBe(4);
+      expect(mountedMessageRows(timelineB.container).length).toBe(4);
+    });
+
+    // Highlight only A: B must stay completely unhighlighted and not throw.
+    expect(() => {
+      timelineA.rerenderMessages(messagesA, "message-1");
+    }).not.toThrow();
+    await flushFrame();
+
+    expect(highlightedRowIds(timelineA.container)).toEqual(["message-1"]);
+    expect(highlightedRowIds(timelineB.container)).toEqual([]);
+    expect(
+      rowHasHighlightRing(
+        timelineB.container.querySelector('[data-message-id="b-message-1"]'),
+      ),
+    ).toBe(false);
+
+    // Highlight only B to a different row: A keeps its own highlight.
+    expect(() => {
+      timelineB.rerenderMessages(messagesB, "b-message-2");
+    }).not.toThrow();
+    await flushFrame();
+
+    expect(highlightedRowIds(timelineA.container)).toEqual(["message-1"]);
+    expect(highlightedRowIds(timelineB.container)).toEqual(["b-message-2"]);
+
+    // Clear A: B's highlight is untouched.
+    timelineA.rerenderMessages(messagesA, null);
+    await flushFrame();
+    expect(highlightedRowIds(timelineA.container)).toEqual([]);
+    expect(highlightedRowIds(timelineB.container)).toEqual(["b-message-2"]);
+  });
+
+  it("rapid sequential highlight moves still re-render only the previous and next rows each step", async () => {
+    const messageCount = 8;
+    const messages = makeMessages(messageCount);
+    const sequence = [
+      "message-0",
+      "message-2",
+      "message-5",
+      "message-7",
+      "message-1",
+    ] as const;
+
+    const { container, rerenderMessages } = renderTimeline({
+      messages,
+      navigationHighlightedMessageId: null,
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(messageCount);
+    });
+
+    let previousHighlight: string | null = null;
+    for (const nextId of sequence) {
+      const before = snapshotRenderCounts(messages);
+      rerenderMessages(messages, nextId);
+      await flushFrame();
+
+      const expected =
+        previousHighlight === null
+          ? [nextId]
+          : [previousHighlight, nextId];
+      expect(new Set(renderedSince(messages, before))).toEqual(
+        new Set(expected),
+      );
+      expect(highlightedRowIds(container)).toEqual([nextId]);
+      previousHighlight = nextId;
+    }
+  });
+
+  it("does not re-invoke getMessageActions for unrelated rows when only the highlight changes", async () => {
+    const messageCount = 6;
+    const messages = makeMessages(messageCount);
+    const getMessageActions = vi.fn(
+      (_message: ChatMessageModel): ChatMessageActions | null => null,
+    );
+
+    const { container, rerenderMessages } = renderTimeline({
+      messages,
+      getMessageActions,
+      navigationHighlightedMessageId: null,
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(messageCount);
+    });
+
+    function callCountByMessageId(): Map<string, number> {
+      const counts = new Map<string, number>();
+      for (const call of getMessageActions.mock.calls) {
+        const id = call[0].id;
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+      }
+      return counts;
+    }
+
+    // Mount settled: every row has been rendered at least once through the
+    // shared-context path (getMessageActions is invoked from ChatTimelineRow
+    // during render). Snapshot those counts before the highlight-only prop
+    // change so we can prove unrelated rows do not re-enter that path.
+    const baselineCalls = callCountByMessageId();
+    for (const message of messages) {
+      expect(baselineCalls.get(message.id) ?? 0).toBeGreaterThan(0);
+    }
+    getMessageActions.mockClear();
+
+    // Same messages array reference; only the highlight prop changes. The
+    // ChatTimelineRowCtx object must stay identity-stable (store is
+    // useState-stable), so non-highlighted rows must not re-render and
+    // therefore must not re-invoke getMessageActions.
+    rerenderMessages(messages, "message-3");
+    await flushFrame();
+
+    const afterFirstMove = callCountByMessageId();
+    expect(afterFirstMove.get("message-3") ?? 0).toBeGreaterThan(0);
+    for (const message of messages) {
+      if (message.id === "message-3") continue;
+      expect(afterFirstMove.get(message.id) ?? 0).toBe(0);
+    }
+
+    getMessageActions.mockClear();
+    rerenderMessages(messages, "message-0");
+    await flushFrame();
+
+    const afterSecondMove = callCountByMessageId();
+    // Old + new highlighted rows re-render; everyone else stays quiet.
+    expect(afterSecondMove.get("message-3") ?? 0).toBeGreaterThan(0);
+    expect(afterSecondMove.get("message-0") ?? 0).toBeGreaterThan(0);
+    for (const message of messages) {
+      if (message.id === "message-3" || message.id === "message-0") continue;
+      expect(afterSecondMove.get(message.id) ?? 0).toBe(0);
+    }
+  });
+
+  it("unmounts cleanly while a navigation highlight is active", async () => {
+    const messages = makeMessages(4);
+    const { container, unmount, rerenderMessages } = renderTimeline({
+      messages,
+      navigationHighlightedMessageId: null,
+    });
+
+    await settleLegendList();
+    await waitFor(() => {
+      expect(mountedMessageRows(container).length).toBe(4);
+    });
+
+    rerenderMessages(messages, "message-2");
+    await flushFrame();
+    expect(highlightedRowIds(container)).toEqual(["message-2"]);
+
+    // Defensive: unmount with an active store subscription must not throw,
+    // and post-unmount work must remain safe (no listener fire crash).
+    expect(() => {
+      unmount();
+    }).not.toThrow();
+
+    expect(mountedMessageRows(container).length).toBe(0);
+    expect(() => {
+      // After unmount the store is unreachable from React; this only asserts
+      // the unmount itself left the test environment intact for subsequent
+      // mounts (covered by later tests / afterEach cleanup).
+      renderTimeline({
+        messages,
+        navigationHighlightedMessageId: "message-0",
+      });
+    }).not.toThrow();
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -14,7 +14,9 @@ import type {
   ChatMessageUserActions,
 } from "@/components/chat/chat-message";
 import { ChatTimeline } from "@/components/chat/chat-timeline";
+import { PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE } from "@/components/chat/chat-timeline-panel-resize-snapshot";
 import type { NextStepActionHandler } from "@/components/chat/segments/next-steps-action-group";
+import { beginPanelResizeInteraction } from "@/lib/layout/panel-resizing-class";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 import { makeMessage, makeMessages } from "./chat-message-fixtures";
 import {
@@ -65,6 +67,25 @@ const VIEWPORT_WIDTH_PX = 800;
 
 function mountedMessageRows(container: HTMLElement): NodeListOf<Element> {
   return container.querySelectorAll(MESSAGE_ROW_SELECTOR);
+}
+
+/** Ticket 23 panel-resize tests: a distinct-position rect, overriding the
+ *  shared `installLegendListViewportMetrics()` shim's uniform (0,0)-origin
+ *  stub on a specific element so visible vs. off-screen rows are
+ *  distinguishable (see `chat-timeline-panel-resize-snapshot.test.ts` for
+ *  the same rationale on the pure module). */
+function rectOf(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: VIEWPORT_WIDTH_PX,
+    width: VIEWPORT_WIDTH_PX,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
 }
 
 function rowIds(container: HTMLElement): ReadonlyArray<string> {
@@ -1031,5 +1052,164 @@ describe("ChatTimeline", () => {
         navigationHighlightedMessageId: "message-0",
       });
     }).not.toThrow();
+  });
+
+  describe("panel-resize freeze (ticket 23 D20 port)", () => {
+    const PANEL_RESIZING_CLASS = "traycer-panel-resizing";
+
+    afterEach(() => {
+      // Defensive: a test that throws before its own stop() must not leak
+      // the class/markers into a later test.
+      document.documentElement.classList.remove(PANEL_RESIZING_CLASS);
+    });
+
+    it("every row carries the marker-scoped freeze selector targeting only unmarked rows", async () => {
+      const messages = [makeMessage(0, "user")];
+      const { container } = renderTimeline({ messages });
+      await settleLegendList();
+      await waitFor(() => {
+        expect(mountedMessageRows(container).length).toBe(1);
+      });
+
+      const row = container.querySelector<HTMLElement>(
+        '[data-message-id="message-0"]',
+      );
+      expect(row?.className).toContain(
+        "[.traycer-panel-resizing_&:not([data-panel-resize-visible])]:[content-visibility:hidden]",
+      );
+    });
+
+    it("marks exactly the geometrically visible rows at drag start and clears every marker at drag end", async () => {
+      const messages = [
+        makeMessage(0, "user"),
+        makeMessage(1, "assistant"),
+        makeMessage(2, "user"),
+      ];
+      const { container, listRef } = renderTimeline({ messages });
+      await settleLegendList();
+      await waitFor(() => {
+        expect(mountedMessageRows(container).length).toBe(messages.length);
+      });
+
+      const scrollNode = listRef.current?.getScrollableNode();
+      if (!scrollNode) throw new Error("scroll node not mounted");
+      // Viewport 0..300; row 0 fully inside, row 1 straddles the bottom
+      // edge (counts as visible), row 2 fully below.
+      scrollNode.getBoundingClientRect = () => rectOf(0, 300);
+      const row0 = container.querySelector<HTMLElement>(
+        '[data-message-id="message-0"]',
+      );
+      const row1 = container.querySelector<HTMLElement>(
+        '[data-message-id="message-1"]',
+      );
+      const row2 = container.querySelector<HTMLElement>(
+        '[data-message-id="message-2"]',
+      );
+      if (!row0 || !row1 || !row2) throw new Error("rows not found");
+      row0.getBoundingClientRect = () => rectOf(0, 100);
+      row1.getBoundingClientRect = () => rectOf(250, 100);
+      row2.getBoundingClientRect = () => rectOf(1000, 100);
+
+      const stop = beginPanelResizeInteraction(1, () => undefined);
+
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(true);
+      expect(row0.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        "true",
+      );
+      expect(row1.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        "true",
+      );
+      expect(row2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        false,
+      );
+
+      stop();
+
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(false);
+      expect(row0.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        false,
+      );
+      expect(row1.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        false,
+      );
+      expect(row2.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        false,
+      );
+    });
+
+    it("clears this timeline's own markers on unmount, even mid-drag", async () => {
+      const messages = [makeMessage(0, "user"), makeMessage(1, "assistant")];
+      const { container, listRef, unmount } = renderTimeline({ messages });
+      await settleLegendList();
+      await waitFor(() => {
+        expect(mountedMessageRows(container).length).toBe(messages.length);
+      });
+
+      const scrollNode = listRef.current?.getScrollableNode();
+      if (!scrollNode) throw new Error("scroll node not mounted");
+      scrollNode.getBoundingClientRect = () => rectOf(0, 300);
+      const row = container.querySelector<HTMLElement>(
+        '[data-message-id="message-0"]',
+      );
+      if (!row) throw new Error("row not found");
+      row.getBoundingClientRect = () => rectOf(0, 100);
+
+      const stop = beginPanelResizeInteraction(1, () => undefined);
+      expect(row.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        "true",
+      );
+
+      expect(() => {
+        unmount();
+      }).not.toThrow();
+
+      expect(row.hasAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        false,
+      );
+
+      // The now-unregistered participant must not be invoked (and must not
+      // throw) when the drag ends afterward.
+      expect(() => {
+        stop();
+      }).not.toThrow();
+    });
+
+    it("registers a fresh timeline as a NEW participant across remounts (no stale registration)", async () => {
+      const messages = [makeMessage(0, "user")];
+      const first = renderTimeline({ messages });
+      await settleLegendList();
+      await waitFor(() => {
+        expect(mountedMessageRows(first.container).length).toBe(1);
+      });
+      first.unmount();
+
+      const second = renderTimeline({ messages });
+      await settleLegendList();
+      await waitFor(() => {
+        expect(mountedMessageRows(second.container).length).toBe(1);
+      });
+
+      const scrollNode = second.listRef.current?.getScrollableNode();
+      if (!scrollNode) throw new Error("scroll node not mounted");
+      scrollNode.getBoundingClientRect = () => rectOf(0, 300);
+      const row = second.container.querySelector<HTMLElement>(
+        '[data-message-id="message-0"]',
+      );
+      if (!row) throw new Error("row not found");
+      row.getBoundingClientRect = () => rectOf(0, 100);
+
+      const stop = beginPanelResizeInteraction(1, () => undefined);
+      // Only ONE capture ran for the currently-mounted timeline - the first
+      // (unmounted) instance's participant was unregistered, not left
+      // dangling to double-mark or throw against detached DOM.
+      expect(row.getAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE)).toBe(
+        "true",
+      );
+      stop();
+    });
   });
 });

--- a/clients/gui-app/src/components/chat/chat-messages-scroll-helpers.ts
+++ b/clients/gui-app/src/components/chat/chat-messages-scroll-helpers.ts
@@ -109,7 +109,10 @@ export function applyChatAnchorDriftRepair(input: {
   }
   expectedAnchorScrollTopRef.current = currentExpectedScrollTop;
   if (outcome.kind === "corrected") {
-    void list.scrollToOffset({ offset: outcome.nextScrollTop, animated: false });
+    void list.scrollToOffset({
+      offset: outcome.nextScrollTop,
+      animated: false,
+    });
     return "corrected";
   }
   return "settled";

--- a/clients/gui-app/src/components/chat/chat-messages-scroll-helpers.ts
+++ b/clients/gui-app/src/components/chat/chat-messages-scroll-helpers.ts
@@ -115,6 +115,189 @@ export function applyChatAnchorDriftRepair(input: {
   return "settled";
 }
 
+/**
+ * Ticket 19 (adversarially-reviewed design, decision #31): the capture-
+ * provenance classifier for the anchoring-scrollbar-departure gap. A native
+ * OS scrollbar-thumb drag fires ONLY `scroll` events - no wheel/touchmove/
+ * pointerdown - so none of the intent listeners above ever see it, and a
+ * reader parked deep in history via a thumb drag leaves a settled
+ * `anchoring-new-turn` session live with full generation ownership.
+ * `resolveOwnedAtEndReport`'s `following-end` departure branch cannot be
+ * widened to cover this: `isAtEnd=false` is anchoring's NORMAL parked state
+ * (the anchor row sits near the viewport top with reserved space below), so
+ * widening would self-cancel every anchoring session on its own first
+ * report.
+ *
+ * The caller (`chat-messages.tsx`) installs ONE native CAPTURE-phase
+ * `scroll` listener on the stable transcript wrapper - an ancestor of
+ * LegendList's own scroll node. A capture listener on an ancestor runs
+ * BEFORE any listener on the target, for every event type, regardless of
+ * whether that event type bubbles (`scroll` does not bubble, but capturing
+ * phase does not depend on bubbling - only on reaching the target from the
+ * root). Verified against installed `@legendapp/list@3.2.0`
+ * (`react.mjs:5663-5671`): the web adapter installs its own consuming
+ * listener with `target.addEventListener("scroll", handleScroll, {
+ * passive: true })` - directly on the scroll node, no capture flag - so an
+ * ancestor capture listener always observes the raw DOM state first.
+ *
+ * At that moment `domScrollTop` may already reflect the move, while
+ * `listStateScroll` (`list.getState().scroll`) reflects the PREVIOUS
+ * position UNLESS a library-owned write already advanced it ahead of the
+ * DOM event. Three writer sites matter, all verified against the installed
+ * 3.2.0 source:
+ *
+ * | Writer | Site | Pre-writes before DOM event? |
+ * | --- | --- | --- |
+ * | Non-animated imperative `scrollToOffset`/`scrollToIndex` | `updateScroll` call at `react.mjs:2107`, inside the same synchronous call that later invokes `doScrollTo` at `:2110` | Yes - `state.scroll` is set before `scroller.scrollTo()` is even called |
+ * | MVCP data/size/inset adjustment | `requestAdjust` at `react.mjs:1611-1629` - `state.scroll += positionDiff` at `:1622`, before the deferred `scrollAdjustHandler.requestAdjust` call (`:1626`) that eventually issues a DOM `scrollBy` | Yes |
+ * | Direct DOM `scrollTop` write (native thumb, or anything else that never went through the library's own API) | none - nothing in the library ever runs | No - this is exactly the signal this classifier exists to catch |
+ *
+ * Governing invariant (decision #31, binding): a scroll-only reader
+ * departure cancels anchoring ownership, but no browser-, library-,
+ * geometry-, hydration-, or app-owned scroll may ever be classified as
+ * reader intent. `chatAnchorScrollCaptureShouldCancel` is biased toward
+ * CANCEL when unrecognized (review finding 4, binding): every case this
+ * classifier cannot positively explain as library/app/browser-owned falls
+ * through to `true`. A false cancel only costs an extra following-end/
+ * free-scrolling transition; a false silence can strand a departed reader
+ * under live anchor ownership, or worse let the next reveal pass snap them
+ * back (design-review finding 2) - never the acceptable direction.
+ *
+ * These are LegendList 3.2.0 dependency contracts, not browser folklore. A
+ * future `@legendapp/list` bump that reorders listener installation or stops
+ * pre-writing `state.scroll` for either writer above must FAIL this
+ * module's dedicated library-contract pins (`chat-messages.test.tsx`) - that
+ * failure is the safety net working, not a regression to chase: on this
+ * classifier's fail-safe bias, losing the pre-write proof only pushes
+ * legitimate library-owned corrections into more false cancels (degrades
+ * anchoring UX), it can never turn a real departure invisible again. Do not
+ * "fix" a red library-contract pin by loosening the classifier itself -
+ * re-audit the dependency contract instead.
+ */
+export interface ChatAnchorScrollCapturePhysicalSnapshot {
+  readonly scrollTop: number;
+  readonly maxScrollTop: number;
+}
+
+const CHAT_ANCHOR_CAPTURE_STATE_EQUALITY_EPSILON_PX = 1;
+const CHAT_ANCHOR_CAPTURE_CLAMP_EPSILON_PX = 1;
+
+/**
+ * Design-review finding 3 (PLAUSIBLE MEDIUM, decision #31 binding condition
+ * b): the exact browser-clamp signature - not a guessed distance or timing
+ * window. A content/reserve/viewport shrink can pull an anchored reader's
+ * `scrollTop` DOWN to the new (smaller) maximum with no app scroll call at
+ * all, producing the exact same DOM shape as a thumb drag landing near the
+ * max. This three-part signature is the tightest predicate that separates
+ * them without a grace window - a grace window would recreate the exact
+ * clamp-vs-intent ambiguity this ticket exists to resolve (design's
+ * "failure policy": do not add one).
+ *
+ * Accepted ambiguity envelope (irreducible - not a bug, do not try to widen
+ * the epsilon to close it):
+ *
+ * | Case | Result |
+ * | --- | --- |
+ * | Pure content/viewport shrink clamps a fractional prior top to the new max | Silent (expected) |
+ * | Real thumb movement of at most 1px from list state | Silent (blind zone) |
+ * | User move + MVCP/app correction net to list state within 1px | Silent (false negative) |
+ * | User thumb ends at the new max in the same delivery window as a max shrink | Indistinguishable from clamp; silent |
+ * | Browser emits an intermediate event before the new max is observable | Possible false cancel |
+ * | User ends merely near the max without prior-over-max evidence | Cancel (expected - not a guessed clamp) |
+ */
+export function chatAnchorScrollCaptureIsExactBrowserClamp(
+  previous: ChatAnchorScrollCapturePhysicalSnapshot,
+  current: ChatAnchorScrollCapturePhysicalSnapshot,
+): boolean {
+  return (
+    previous.scrollTop >
+      current.maxScrollTop + CHAT_ANCHOR_CAPTURE_CLAMP_EPSILON_PX &&
+    current.maxScrollTop < previous.maxScrollTop &&
+    Math.abs(current.scrollTop - current.maxScrollTop) <=
+      CHAT_ANCHOR_CAPTURE_CLAMP_EPSILON_PX
+  );
+}
+
+export interface ChatAnchorScrollCaptureInput {
+  /** `mode === "anchoring-new-turn"` AND the live-follow generation still
+   *  matches the current user-scroll generation - the caller's own
+   *  ownership gate (same shape `resolveOwnedAtEndReport` uses). `false`
+   *  means this capture is not this classifier's session to police at all
+   *  (following-end, free-scrolling, or an already-departed generation). */
+  readonly isAnchoringSessionOwned: boolean;
+  /**
+   * Ticket 18's settle lifecycle owns THIS generation's animated anchor
+   * `scrollToIndex` issue/reissue window right now (armed immediately
+   * before the command is issued, cleared on valid/invalid/cancel - see
+   * `chat-messages.tsx`'s `positionAnchor`).
+   *
+   * Design-review finding 1 (CONFIRMED HIGH, binding condition a): this
+   * exemption is DELIBERATELY BROADER than what ticket 18's own
+   * `anchorMoverShouldYieldToReader` can actually protect - that predicate
+   * only detects an UPWARD departure. A downward or intermediate thumb
+   * drag arriving during this exact window is silently deferred here (not
+   * classified as departure) even though ticket 18's settle loop will not
+   * yield to it either - the settle loop can re-issue/snap back once this
+   * window closes (review finding 2). This is an ACCEPTED, EXPLICITLY-
+   * TRACKED residual, not a claimed fix: jsdom cannot express the real-time
+   * race between an in-flight animated scroll and a native thumb drag, so
+   * BOTH directions during active motion are live-checklist-only items,
+   * never simulated as a passing jsdom pin.
+   */
+  readonly activeAnchorMotionOwnsGeneration: boolean;
+  /** The scroll node's live `scrollTop`, read synchronously inside the
+   *  capture-phase handler - i.e. AFTER the DOM already moved but BEFORE
+   *  LegendList's own target listener has run. */
+  readonly domScrollTop: number;
+  /** `list.getState().scroll` read at the SAME synchronous moment - still
+   *  describes the PREVIOUS position unless a library-owned write already
+   *  advanced it ahead of the DOM event (see the module doc comment above
+   *  for the three writer sites this depends on). */
+  readonly listStateScroll: number;
+  /** The physical snapshot captured on the PREVIOUS captured event (or
+   *  `null` when no scroll has been observed yet this session - in which
+   *  case the clamp predicate cannot fire, since there is nothing to
+   *  compare against, and an otherwise-unexplained event still cancels). */
+  readonly previousSnapshot: ChatAnchorScrollCapturePhysicalSnapshot | null;
+  readonly currentMaxScrollTop: number;
+}
+
+/**
+ * Top-level classifier (design's numbered steps 3-7; steps 1-2 - "read
+ * fresh, refresh the snapshot regardless of outcome" - are the caller's own
+ * imperative bookkeeping around this pure decision, not part of it).
+ * Returns `true` only for the one case this ticket exists to catch: a
+ * settled `anchoring-new-turn` session's `scrollTop` moved by a route this
+ * classifier cannot explain as library-, app-, or browser-owned. See the
+ * module doc comment above for the unsure-cancels fail-safe bias.
+ */
+export function chatAnchorScrollCaptureShouldCancel(
+  input: ChatAnchorScrollCaptureInput,
+): boolean {
+  if (!input.isAnchoringSessionOwned) return false;
+  if (input.activeAnchorMotionOwnsGeneration) return false;
+  if (
+    Math.abs(input.domScrollTop - input.listStateScroll) <=
+    CHAT_ANCHOR_CAPTURE_STATE_EQUALITY_EPSILON_PX
+  ) {
+    // Library/app-owned correction: non-animated imperative scrollTo*/
+    // scrollToOffset and MVCP requestAdjust both advance `state.scroll`
+    // before their DOM write reaches this capture listener - see the
+    // module doc comment's writer table.
+    return false;
+  }
+  if (
+    input.previousSnapshot !== null &&
+    chatAnchorScrollCaptureIsExactBrowserClamp(input.previousSnapshot, {
+      scrollTop: input.domScrollTop,
+      maxScrollTop: input.currentMaxScrollTop,
+    })
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export type ChatWheelVerticalDirection = "down" | "up" | "ambiguous";
 
 /**

--- a/clients/gui-app/src/components/chat/chat-messages-scroll-helpers.ts
+++ b/clients/gui-app/src/components/chat/chat-messages-scroll-helpers.ts
@@ -1,3 +1,4 @@
+import type { LegendListRef } from "@legendapp/list/react";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 
 /**
@@ -27,6 +28,91 @@ export function anchorMoverShouldYieldToReader(
     Math.min(previousExpectedScrollTop, currentExpectedScrollTop) -
       CHAT_ANCHOR_MOVER_DEPARTURE_EPSILON_PX
   );
+}
+
+/**
+ * Ticket 22 (painted-chat lifecycle audit, finding 3): the anchoring-new-turn
+ * drift re-assert, pulled out of the two-rAF reveal-pass effect so it can
+ * also be invoked from a geometry-only trigger (row remeasure / viewport
+ * resize under the SAME `messages` array - the effect only re-runs on a
+ * `messages` change). Pure math only; the caller owns reading/writing
+ * `scrollTop` and `expectedAnchorScrollTopRef`.
+ */
+export type ChatAnchorDriftRepairOutcome =
+  | { readonly kind: "yielded" }
+  | { readonly kind: "corrected"; readonly nextScrollTop: number }
+  | { readonly kind: "settled" };
+
+export function computeChatAnchorDriftRepair(input: {
+  readonly currentScrollTop: number;
+  readonly currentExpectedScrollTop: number;
+  readonly previousExpectedScrollTop: number | null;
+}): ChatAnchorDriftRepairOutcome {
+  const {
+    currentScrollTop,
+    currentExpectedScrollTop,
+    previousExpectedScrollTop,
+  } = input;
+  if (
+    anchorMoverShouldYieldToReader(
+      currentScrollTop,
+      previousExpectedScrollTop,
+      currentExpectedScrollTop,
+    )
+  ) {
+    return { kind: "yielded" };
+  }
+  const anchorPositionDrift = currentExpectedScrollTop - currentScrollTop;
+  if (Math.abs(anchorPositionDrift) > 1) {
+    return {
+      kind: "corrected",
+      nextScrollTop: currentScrollTop + anchorPositionDrift,
+    };
+  }
+  return { kind: "settled" };
+}
+
+/**
+ * Imperative wrapper around `computeChatAnchorDriftRepair`: reads the live
+ * scroll position + anchor metrics, applies the correction (if any), and
+ * keeps `expectedAnchorScrollTopRef` in sync exactly as the reveal pass
+ * always has (updated on both "corrected" and "settled", left untouched on
+ * "yielded" - a departed reader's baseline must not be overwritten by the
+ * drift it declined).
+ */
+export function applyChatAnchorDriftRepair(input: {
+  readonly list: Pick<LegendListRef, "getScrollableNode" | "scrollToOffset">;
+  readonly anchorTop: number;
+  readonly listTopOffsetAdjustment: number;
+  readonly anchorOffset: number;
+  readonly expectedAnchorScrollTopRef: {
+    current: number | null;
+  };
+}): ChatAnchorDriftRepairOutcome["kind"] {
+  const {
+    list,
+    anchorTop,
+    listTopOffsetAdjustment,
+    anchorOffset,
+    expectedAnchorScrollTopRef,
+  } = input;
+  const currentScrollTop = list.getScrollableNode().scrollTop;
+  const currentExpectedScrollTop =
+    anchorTop + listTopOffsetAdjustment - anchorOffset;
+  const outcome = computeChatAnchorDriftRepair({
+    currentScrollTop,
+    currentExpectedScrollTop,
+    previousExpectedScrollTop: expectedAnchorScrollTopRef.current,
+  });
+  if (outcome.kind === "yielded") {
+    return "yielded";
+  }
+  expectedAnchorScrollTopRef.current = currentExpectedScrollTop;
+  if (outcome.kind === "corrected") {
+    void list.scrollToOffset({ offset: outcome.nextScrollTop, animated: false });
+    return "corrected";
+  }
+  return "settled";
 }
 
 export type ChatWheelVerticalDirection = "down" | "up" | "ambiguous";

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -12,6 +12,7 @@ import {
   applyChatAnchorDriftRepair,
   buildMessageIdToIndex,
   CHAT_ARROW_SCROLL_STEP_PX,
+  chatAnchorScrollCaptureShouldCancel,
   chatTimelineAnchorShouldAnimateInitialIssue,
   chatTimelineLocationForMessage,
   chatTimelineNavigationLandedAtLocation,
@@ -21,6 +22,7 @@ import {
   resolveChatAnchorTargetWithSetupCard,
   selectActiveUserMessageId,
   viewportActiveUserMessageId,
+  type ChatAnchorScrollCapturePhysicalSnapshot,
   type ChatTimelineNavigationLocation,
   type ChatViewportAnchorListState,
 } from "@/components/chat/chat-messages-scroll-helpers";
@@ -969,6 +971,23 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
   // comparing against both prevents either geometry change from looking like
   // user intent.
   const expectedAnchorScrollTopRef = useRef<number | null>(null);
+  // Ticket 19 (decision #31, capture-provenance classifier): the physical
+  // DOM snapshot the capture-phase scroll listener compares each new event
+  // against (browser-clamp signature) - refreshed on every captured event
+  // regardless of mode/ownership, and reseeded at `beginAnchoringNewTurn` so
+  // the FIRST captured event of a session always has a same-session
+  // baseline. See `chatAnchorScrollCaptureShouldCancel`'s doc comment.
+  const anchoringPhysicalSnapshotRef =
+    useRef<ChatAnchorScrollCapturePhysicalSnapshot | null>(null);
+  // Ticket 19: the ONE generation-scoped in-flight ref the design/decision
+  // #31 machinery cap allows - non-null (holding the owning generation)
+  // only while the anchor engine's `scrollToIndex` issue/reissue is inside
+  // ticket 18's settle lifecycle (`positionAnchor` below). Armed
+  // immediately before each issue, cleared symmetrically in
+  // begin/retarget/cancel/valid/invalid - see each site's own comment.
+  const activeAnchorImperativeMotionGenerationRef = useRef<number | null>(
+    null,
+  );
   // Ticket 22: coalesces item-size/viewport-layout triggers into ONE pending
   // two-rAF geometry-repair pass at a time - `scheduleChatAnchorGeometryRepair`'s
   // own doc comment covers why.
@@ -1201,6 +1220,11 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
       settledTimelineAnchorRef.current = null;
       activeTimelineAnchorIndexRef.current = null;
       pendingAnchorScrollRestoreRef.current = null;
+      // Ticket 19: a cancel (real gesture or superseding navigation) ends
+      // whatever anchor motion window was in flight for the OLD generation -
+      // symmetric with the arm sites in `positionAnchor` below.
+      activeAnchorImperativeMotionGenerationRef.current = null;
+      anchoringPhysicalSnapshotRef.current = null;
       // A real gesture (or a fresh navigation, which calls this first) wins
       // immediately over a still-in-flight programmatic-scroll operation,
       // regardless of what that operation was in the middle of doing.
@@ -1385,6 +1409,24 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
         cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
         anchorScrollRestoreFrameRef.current = null;
       }
+      // Ticket 19: fresh session, fresh motion/physical bookkeeping - a
+      // stale active-motion generation from a superseded session must not
+      // exempt this one, and the physical snapshot needs a same-session
+      // baseline for the capture listener's clamp check (design's "seeded
+      // on entry to an anchoring generation"). Reading the scroll node here
+      // (not deferring to the first captured event) means a session with no
+      // natural scroll before its own positioning still has a baseline.
+      activeAnchorImperativeMotionGenerationRef.current = null;
+      const scrollNodeAtBegin = chatTimelineRef.current?.getScrollableNode();
+      anchoringPhysicalSnapshotRef.current = scrollNodeAtBegin
+        ? {
+            scrollTop: scrollNodeAtBegin.scrollTop,
+            maxScrollTop: Math.max(
+              0,
+              scrollNodeAtBegin.scrollHeight - scrollNodeAtBegin.clientHeight,
+            ),
+          }
+        : null;
       suppressFollowRestoreRef.current = false;
       anchorAnimatedRef.current = animated;
       cancelPillShow();
@@ -1449,6 +1491,10 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
       cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
       anchorScrollRestoreFrameRef.current = null;
     }
+    // Ticket 19: the OLD target's settle window (if any) is being
+    // superseded the same way `positionedTimelineAnchorRef` above is - the
+    // new target's own positioning re-arms this fresh, same generation.
+    activeAnchorImperativeMotionGenerationRef.current = null;
     timelineAnchorMessageIdRef.current = messageId;
     setTimelineAnchorMessageId(messageId);
   }, []);
@@ -1541,6 +1587,75 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
       detach();
     };
   }, [hasContent]);
+
+  // Ticket 19 (decision #31): the capture-provenance classifier's ONE
+  // native listener - installed on the STABLE transcript wrapper (unlike
+  // the wheel/touch listeners above, it never needs to track scroll-node
+  // replacement across an empty/repopulate cycle; it simply filters each
+  // captured event to whichever scroll node is current right now). Capture
+  // phase (`{ capture: true }`) is load-bearing - it is what lets this
+  // listener observe the raw DOM state before LegendList's own non-capture
+  // target listener consumes the event; see
+  // `chatAnchorScrollCaptureShouldCancel`'s doc comment (chat-messages-
+  // scroll-helpers.ts) for the full library-ordering proof this depends on,
+  // and the dedicated library-contract pins that gate a future
+  // `@legendapp/list` upgrade.
+  useLayoutEffect(() => {
+    const container = transcriptContainerRef.current;
+    if (!container) return;
+    const handleCapturedScroll = (event: Event): void => {
+      const list = chatTimelineRef.current;
+      if (!list) return;
+      const scrollNode = list.getScrollableNode();
+      // Any nested scrollable region (a code block, a horizontally
+      // overflowing table) also dispatches `scroll` events this ancestor
+      // capture listener observes - `scroll` never bubbles, but capturing
+      // phase runs regardless, for EVERY descendant's own scroll, not just
+      // the transcript's. Only the transcript's own scroll node is this
+      // classifier's concern.
+      if (event.target !== scrollNode) return;
+      const domScrollTop = scrollNode.scrollTop;
+      const currentMaxScrollTop = Math.max(
+        0,
+        scrollNode.scrollHeight - scrollNode.clientHeight,
+      );
+      const generationOwned =
+        liveFollowUserScrollGenerationRef.current ===
+        anchorUserScrollGenerationRef.current;
+      const shouldCancel = chatAnchorScrollCaptureShouldCancel({
+        isAnchoringSessionOwned:
+          timelineScrollModeRef.current === "anchoring-new-turn" &&
+          generationOwned,
+        activeAnchorMotionOwnsGeneration:
+          activeAnchorImperativeMotionGenerationRef.current ===
+          anchorUserScrollGenerationRef.current,
+        domScrollTop,
+        listStateScroll: list.getState().scroll,
+        previousSnapshot: anchoringPhysicalSnapshotRef.current,
+        currentMaxScrollTop,
+      });
+      // Design step 2: refresh regardless of outcome, so the NEXT captured
+      // event - in any mode - always compares against the last real
+      // physical position, not a stale one from several mode transitions
+      // ago. Refreshed AFTER classifying this event (which needs the OLD
+      // snapshot as its "previous" input), BEFORE acting on the result.
+      anchoringPhysicalSnapshotRef.current = {
+        scrollTop: domScrollTop,
+        maxScrollTop: currentMaxScrollTop,
+      };
+      if (shouldCancel) {
+        cancelTimelineLiveFollowForUserNavigationRef.current(false);
+      }
+    };
+    container.addEventListener("scroll", handleCapturedScroll, {
+      capture: true,
+    });
+    return () => {
+      container.removeEventListener("scroll", handleCapturedScroll, {
+        capture: true,
+      });
+    };
+  }, []);
 
   // --- Anchor engine --------------------------------------------------------
 
@@ -1675,6 +1790,13 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
             }
           };
 
+          // Ticket 19: arm immediately before issuing the command - the
+          // ONE generation-scoped in-flight ref the machinery cap allows
+          // (decision #31d). Every guard above this point has already
+          // confirmed `generationAtReady` is still current, so arming to it
+          // here (not `anchorUserScrollGenerationRef.current` - same value,
+          // but this documents which one this closure owns) is safe.
+          activeAnchorImperativeMotionGenerationRef.current = generationAtReady;
           let pendingAnchorScrollPromise = list.scrollToIndex({
             index: currentAnchorIndex,
             animated: shouldAnimateInitialIssue,
@@ -1715,6 +1837,12 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
               // offset) self-corrects both an estimate-drift undershoot and
               // a still-resolving `anchoredEndSpace` reserve clamp.
               reissue: () => {
+                // Ticket 19: retained across the re-issue - still the same
+                // generation, still the same anchor-issue closure (design's
+                // "retain across settle re-issues"). Re-set (not just left
+                // alone) so a reissue is defensively self-arming too.
+                activeAnchorImperativeMotionGenerationRef.current =
+                  generationAtReady;
                 pendingAnchorScrollPromise = list.scrollToIndex({
                   index: anchorSettleTargetIndex(),
                   animated: false,
@@ -1723,6 +1851,14 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
                 });
               },
               onSettledValid: () => {
+                // Ticket 19: the motion window this session owned is over -
+                // symmetric with the arm sites above.
+                if (
+                  activeAnchorImperativeMotionGenerationRef.current ===
+                  generationAtReady
+                ) {
+                  activeAnchorImperativeMotionGenerationRef.current = null;
+                }
                 expectedAnchorScrollTopRef.current = expectedAnchorScrollTop(
                   list,
                   anchorSettleTargetIndex(),
@@ -1739,6 +1875,15 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
                 measureSettledOverflow();
               },
               onSettledInvalid: () => {
+                // Ticket 19: same symmetric clear as onSettledValid - a
+                // corrective operation that gives up must not leave the
+                // capture classifier believing motion is still in flight.
+                if (
+                  activeAnchorImperativeMotionGenerationRef.current ===
+                  generationAtReady
+                ) {
+                  activeAnchorImperativeMotionGenerationRef.current = null;
+                }
                 // Ticket 18 safety cap: a corrective operation that cannot
                 // safely land must never claim settled. Log only the
                 // genuine non-convergence case, not the (expected, correct)

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -43,7 +43,9 @@ import {
   saveChatTabState,
   type ChatTabScrollMode,
   type SavedChatTabScrollState,
+  type SaveChatTabStateInput,
 } from "@/stores/chats/chat-tab-state-cache";
+import { registerChatTabViewportCapture } from "@/stores/chats/chat-tab-viewport-handoff";
 import { ChatTurnMinimap } from "@/components/chat/chat-turn-minimap";
 import { CHAT_TURN_MINIMAP_KEYBOARD_OWNER_SELECTOR } from "@/components/chat/chat-turn-minimap-logic";
 import { buildChatActivityTimeline } from "@/components/chat/chat-activity-groups";
@@ -2208,6 +2210,135 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     endInsetRef.current = endInset;
   }, [endInset]);
 
+  // Ticket 20: the coherent-snapshot capture used by BOTH this component's
+  // own unmount-cleanup save below AND the pre-structural-mutation viewport
+  // handoff (`chat-tab-viewport-handoff.ts`) a canvas-store action creator
+  // flushes just before a drag/split-wrap/dissolve/tear-off commits a move
+  // that retains this SAME instanceId under a NEW React parent. Without the
+  // proactive flush, React would mount the replacement fiber's
+  // `restoreChatTabState` render-time state initializer BEFORE this
+  // component's own unmount cleanup ever runs - render happens before ANY
+  // commit-phase effect, including a removed fiber's layout-effect cleanup
+  // (painted-chat lifecycle audit finding 1: a disposable probe recorded
+  // `initialize:stale` then `cleanup:fresh`). One function backs both call
+  // sites so the coherent-snapshot invariant below can never drift into two
+  // independently maintained copies.
+  const captureLiveChatTabScrollSnapshot = useCallback((): Omit<
+    SaveChatTabStateInput,
+    "identity"
+  > => {
+    // `anchoring-new-turn` never persists as its own mode (see
+    // `chat-tab-state-cache.ts`): a remount mid-anchor has no live
+    // anchor/settle sequence left to resume, so it collapses to
+    // `free-scrolling` at wherever it had settled - same as any other
+    // unpinned reading position.
+    const wasAnchoring =
+      timelineScrollModeRef.current === "anchoring-new-turn";
+    const mode: ChatTabScrollMode =
+      timelineScrollModeRef.current === "following-end"
+        ? "following-end"
+        : "free-scrolling";
+    const list = chatTimelineRef.current;
+    // Ticket 15 review (live pass S5 round 3, confirmed regression):
+    // `scrolledActiveUserMessageIdRef` is an rAF-throttled mirror
+    // (`scheduleActiveViewportUpdate`) of "which row is at the reading
+    // line" - it can lag a scroll that happened in the same tick as this
+    // capture (rAF never runs for a backgrounded/closing tab, but the race
+    // exists in a visible renderer too: scroll then close/move before the
+    // pending frame). The offset captured below reads the CURRENT live
+    // `scroll` unconditionally - pairing that with a STALE anchor row
+    // produces an internally-inconsistent {anchorMessageId, anchorIndex,
+    // offset} triple (a huge/negative offset relative to the wrong row),
+    // which restore then clamps to nonsense. Recompute the anchor row
+    // SYNCHRONOUSLY from the SAME live list snapshot the offset capture
+    // below reads, so both halves of the pair are drawn from one
+    // coherent, never-mixed-time snapshot - restoring the invariant the
+    // pre-LegendList `chat-scroll-state-cache.ts` `saveChatScrollState`
+    // documented ("captures any reading position the last animation-frame
+    // update had not yet committed"). The rAF mirror is only a fallback
+    // for when the list itself is unmeasurable (never mounted a real
+    // LegendList instance, or genuinely reports nothing yet).
+    //
+    // `list.getState().scroll` is ITSELF a candidate for the same class
+    // of lag (its own doc comment two blocks below: "LegendList's tracked
+    // scroll can lag the DOM while an animated navigation is still
+    // settling") - overridden here with `getScrollableNode().scrollTop`
+    // (the RAW, always-current DOM value, same source the offset capture
+    // below uses) so the anchor computation cannot reintroduce a mismatch
+    // through LegendList's own internal state lagging instead of React's.
+    const liveActiveUserMessageId =
+      list === null
+        ? null
+        : viewportActiveUserMessageId(
+            {
+              ...list.getState(),
+              scroll: list.getScrollableNode().scrollTop,
+              topOffsetAdjustment: listTopOffsetAdjustmentRef.current,
+            },
+            messagesRef.current,
+          );
+    const anchorMessageId =
+      mode === "free-scrolling"
+        ? (liveActiveUserMessageId ?? scrolledActiveUserMessageIdRef.current)
+        : null;
+    const anchorIndex =
+      anchorMessageId === null
+        ? undefined
+        : messageIndexByIdRef.current.get(anchorMessageId);
+    // F3: while still anchoring, `anchoredEndSpace` reserves trailing blank
+    // space below the anchor for a still-streaming reply - the live
+    // `scroll` may only be reachable because of that reserve. Clamp the
+    // captured offset to LegendList's true no-reserve max scroll (header +
+    // footer + last-row bottom + endInset - viewport) so the saved position
+    // stays valid once restored without the reserve. Do NOT use
+    // `targetScrollToRevealEnd` here - that is the reveal-pass target and
+    // under-clamps by header+footer-anchorOffset.
+    let naturalMaxScroll: number | null = null;
+    if (wasAnchoring && list !== null) {
+      const listState = list.getState();
+      const lastBottom = getChatRowBottom(
+        listState,
+        listState.data.length - 1,
+      );
+      if (lastBottom !== null) {
+        naturalMaxScroll = getChatNaturalMaxScrollWithoutAnchorReserve({
+          headerSize: listTopOffsetAdjustmentRef.current,
+          footerSize: listFooterSizeRef.current,
+          lastBottom,
+          endInset: endInsetRef.current,
+          viewportLength: listState.scrollLength,
+        });
+      }
+    }
+    // Narrow measurement source so capture can fold in the live header pad
+    // (list.getState() does not expose headerSize; metrics keep it current).
+    const measurementSource =
+      list === null
+        ? null
+        : {
+            getState: () => ({
+              positionAtIndex: (index: number) =>
+                list.getState().positionAtIndex(index),
+              // LegendList's tracked scroll can lag the DOM while an
+              // animated navigation is still settling. Persist the pixels
+              // the reader can actually see right now; row positions still
+              // come from the library's measured state.
+              scroll: list.getScrollableNode().scrollTop,
+              topOffsetAdjustment: listTopOffsetAdjustmentRef.current,
+            }),
+          };
+    return {
+      mode,
+      anchorMessageId,
+      anchorIndex: anchorIndex ?? null,
+      offset: captureChatFreeScrollingOffset(
+        measurementSource,
+        anchorIndex,
+        naturalMaxScroll,
+      ),
+    };
+  }, []);
+
   // Persist the reading position on unmount (chat tiles fully remount per tab
   // switch - decision #17 - so this is the sole persistence path; the
   // display:none keep-alive `useScrollRestoration` machinery other tile kinds
@@ -2232,120 +2363,30 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
   useLayoutEffect(
     () => () => {
       const isLive = isEpicCanvasTileInstanceLive(instanceId);
-      // `anchoring-new-turn` never persists as its own mode (see
-      // `chat-tab-state-cache.ts`): a remount mid-anchor has no live
-      // anchor/settle sequence left to resume, so it collapses to
-      // `free-scrolling` at wherever it had settled - same as any other
-      // unpinned reading position.
-      const wasAnchoring =
-        timelineScrollModeRef.current === "anchoring-new-turn";
-      const mode: ChatTabScrollMode =
-        timelineScrollModeRef.current === "following-end"
-          ? "following-end"
-          : "free-scrolling";
-      const list = chatTimelineRef.current;
-      // Ticket 15 review (live pass S5 round 3, confirmed regression):
-      // `scrolledActiveUserMessageIdRef` is an rAF-throttled mirror
-      // (`scheduleActiveViewportUpdate`) of "which row is at the reading
-      // line" - it can lag a scroll that happened in the same tick as this
-      // unmount (rAF never runs for a backgrounded/closing tab, but the
-      // race exists in a visible renderer too: scroll then close before the
-      // pending frame). The offset captured below reads the CURRENT live
-      // `scroll` unconditionally - pairing that with a STALE anchor row
-      // produces an internally-inconsistent {anchorMessageId, anchorIndex,
-      // offset} triple (a huge/negative offset relative to the wrong row),
-      // which restore then clamps to nonsense. Recompute the anchor row
-      // SYNCHRONOUSLY from the SAME live list snapshot the offset capture
-      // below reads, so both halves of the pair are drawn from one
-      // coherent, never-mixed-time snapshot - restoring the invariant the
-      // pre-LegendList `chat-scroll-state-cache.ts` `saveChatScrollState`
-      // documented ("captures any reading position the last animation-frame
-      // update had not yet committed"). The rAF mirror is only a fallback
-      // for when the list itself is unmeasurable (never mounted a real
-      // LegendList instance, or genuinely reports nothing yet).
-      //
-      // `list.getState().scroll` is ITSELF a candidate for the same class
-      // of lag (its own doc comment two blocks below: "LegendList's tracked
-      // scroll can lag the DOM while an animated navigation is still
-      // settling") - overridden here with `getScrollableNode().scrollTop`
-      // (the RAW, always-current DOM value, same source the offset capture
-      // below uses) so the anchor computation cannot reintroduce a mismatch
-      // through LegendList's own internal state lagging instead of React's.
-      const liveActiveUserMessageId =
-        list === null
-          ? null
-          : viewportActiveUserMessageId(
-              {
-                ...list.getState(),
-                scroll: list.getScrollableNode().scrollTop,
-                topOffsetAdjustment: listTopOffsetAdjustmentRef.current,
-              },
-              messagesRef.current,
-            );
-      const anchorMessageId =
-        mode === "free-scrolling"
-          ? (liveActiveUserMessageId ?? scrolledActiveUserMessageIdRef.current)
-          : null;
-      const anchorIndex =
-        anchorMessageId === null
-          ? undefined
-          : messageIndexByIdRef.current.get(anchorMessageId);
-      // F3: while still anchoring, `anchoredEndSpace` reserves trailing blank
-      // space below the anchor for a still-streaming reply - the live
-      // `scroll` may only be reachable because of that reserve. Clamp the
-      // captured offset to LegendList's true no-reserve max scroll (header +
-      // footer + last-row bottom + endInset - viewport) so the saved position
-      // stays valid once restored without the reserve. Do NOT use
-      // `targetScrollToRevealEnd` here - that is the reveal-pass target and
-      // under-clamps by header+footer-anchorOffset.
-      let naturalMaxScroll: number | null = null;
-      if (wasAnchoring && list !== null) {
-        const listState = list.getState();
-        const lastBottom = getChatRowBottom(
-          listState,
-          listState.data.length - 1,
-        );
-        if (lastBottom !== null) {
-          naturalMaxScroll = getChatNaturalMaxScrollWithoutAnchorReserve({
-            headerSize: listTopOffsetAdjustmentRef.current,
-            footerSize: listFooterSizeRef.current,
-            lastBottom,
-            endInset: endInsetRef.current,
-            viewportLength: listState.scrollLength,
-          });
-        }
-      }
-      // Narrow measurement source so capture can fold in the live header pad
-      // (list.getState() does not expose headerSize; metrics keep it current).
-      const measurementSource =
-        list === null
-          ? null
-          : {
-              getState: () => ({
-                positionAtIndex: (index: number) =>
-                  list.getState().positionAtIndex(index),
-                // LegendList's tracked scroll can lag the DOM while an
-                // animated navigation is still settling. Persist the pixels
-                // the reader can actually see at unmount; row positions still
-                // come from the library's measured state.
-                scroll: list.getScrollableNode().scrollTop,
-                topOffsetAdjustment: listTopOffsetAdjustmentRef.current,
-              }),
-            };
       const commit = isLive ? saveChatTabState : commitChatTabStateToDurable;
-      commit({
-        identity,
-        mode,
-        anchorMessageId,
-        anchorIndex: anchorIndex ?? null,
-        offset: captureChatFreeScrollingOffset(
-          measurementSource,
-          anchorIndex,
-          naturalMaxScroll,
-        ),
-      });
+      commit({ identity, ...captureLiveChatTabScrollSnapshot() });
     },
-    [identity, instanceId],
+    [identity, instanceId, captureLiveChatTabScrollSnapshot],
+  );
+
+  // Ticket 20: register the SAME capture for the canvas store's pre-
+  // structural-mutation viewport handoff (`chat-tab-viewport-handoff.ts`) - a
+  // drag/split-wrap/dissolve/tear-off action creator flushes this
+  // synchronously just BEFORE it commits a move that retains `instanceId`
+  // under a new React parent, so the replacement mount's `restoreChatTabState`
+  // initializer reads the fresh position instead of whatever was already
+  // cached. Registered live-only (only a currently-mounted tile has any DOM
+  // viewport worth capturing) - a background/never-mounted-yet tab is simply
+  // absent from the registry, same shape as the close-sweep promotion
+  // (`promoteChatTabPersistenceToDurable`) this pattern reuses. Always
+  // `saveChatTabState` (never the durable-only commit): this component is by
+  // construction live for the whole window it stays registered.
+  useLayoutEffect(
+    () =>
+      registerChatTabViewportCapture(instanceId, () => {
+        saveChatTabState({ identity, ...captureLiveChatTabScrollSnapshot() });
+      }),
+    [identity, instanceId, captureLiveChatTabScrollSnapshot],
   );
 
   const onListMetricsChange = useCallback(
@@ -2605,8 +2646,22 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     [scrollToTimelineLocation],
   );
 
+  // Ticket 20 (no-visible-traversal requirement): `animated` is an explicit
+  // caller intent, not a hardcoded constant - minimap/deep-link navigation
+  // (this function's other two callers below) are real (if programmatic)
+  // user-triggered jumps, animated by design (decision #21's "manual-
+  // navigation cancellation" framing already treats them as navigations the
+  // reader should perceive happening). Find does NOT go through this
+  // function at all - `use-chat-find-controller.ts`'s own
+  // `scrollToMessageForFind` independently builds its location with
+  // `animated: false` already, unchanged by this ticket. The late-hydration
+  // catch-up effect below is different from either: it is a RESTORE landing
+  // where the transcript simply grew to finally contain a position already
+  // decided at mount, not a fresh navigation the reader initiated - it must
+  // reposition in a single frame like any other mount-time restore, never
+  // visibly scroll/animate to get there.
   const navigateToMessage = useCallback(
-    (messageId: string, highlight: boolean): void => {
+    (messageId: string, highlight: boolean, animated: boolean): void => {
       // Decision #21: minimap/find/deep-link navigation all perform
       // manual-navigation cancellation first. Not a real gesture - a plain
       // release, no freeze: the navigation's own scroll (right below, via
@@ -2617,7 +2672,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
       const location = chatTimelineLocationForMessage(
         messageId,
         messageIndexByIdRef.current,
-        true,
+        animated,
       );
       if (location === null) return;
       if (highlight) {
@@ -2674,12 +2729,14 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     // through (minimap/find/deep-link), rather than hand-driving
     // `scrollToIndex`'s own `viewOffset` outside its one established
     // caller (`chatTimelineLocationForMessage`'s fixed navigation
-    // padding).
-    navigateToMessage(anchorId, false);
+    // padding). Non-animated (ticket 20): this is a restore finally
+    // resolving, not a fresh navigation - the reader must never see it
+    // visibly scroll to land.
+    navigateToMessage(anchorId, false, false);
   }, [messages, navigateToMessage]);
 
   const onMinimapItemSelect = useCallback(
-    (messageId: string): void => navigateToMessage(messageId, false),
+    (messageId: string): void => navigateToMessage(messageId, false, true),
     [navigateToMessage],
   );
 
@@ -2924,7 +2981,10 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     // Cross-tile jumps use the same programmatic-navigation choke point as
     // every in-tile navigation: suppression, settle validation, and bounded
     // re-issue are all armed before the scroll. The highlight is visual only.
-    navigateToMessage(request.messageId, true);
+    // Animated (ticket 20 does not change minimap/deep-link semantics - find
+    // is unrelated to this call site, see navigateToMessage's own comment):
+    // a cross-tile jump is a real navigation the reader triggered elsewhere.
+    navigateToMessage(request.messageId, true, true);
     scrollRequestRef.current = null;
   }, [activityGroupOpenStore, navigateToMessage, scrollRequest?.requestId]);
 

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -998,9 +998,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
   // ticket 18's settle lifecycle (`positionAnchor` below). Armed
   // immediately before each issue, cleared symmetrically in
   // begin/retarget/cancel/valid/invalid - see each site's own comment.
-  const activeAnchorImperativeMotionGenerationRef = useRef<number | null>(
-    null,
-  );
+  const activeAnchorImperativeMotionGenerationRef = useRef<number | null>(null);
   // Ticket 22: coalesces item-size/viewport-layout triggers into ONE pending
   // two-rAF geometry-repair pass at a time - `scheduleChatAnchorGeometryRepair`'s
   // own doc comment covers why.
@@ -2389,8 +2387,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     // anchor/settle sequence left to resume, so it collapses to
     // `free-scrolling` at wherever it had settled - same as any other
     // unpinned reading position.
-    const wasAnchoring =
-      timelineScrollModeRef.current === "anchoring-new-turn";
+    const wasAnchoring = timelineScrollModeRef.current === "anchoring-new-turn";
     const mode: ChatTabScrollMode =
       timelineScrollModeRef.current === "following-end"
         ? "following-end"
@@ -2453,10 +2450,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     let naturalMaxScroll: number | null = null;
     if (wasAnchoring && list !== null) {
       const listState = list.getState();
-      const lastBottom = getChatRowBottom(
-        listState,
-        listState.data.length - 1,
-      );
+      const lastBottom = getChatRowBottom(listState, listState.data.length - 1);
       if (lastBottom !== null) {
         naturalMaxScroll = getChatNaturalMaxScrollWithoutAnchorReserve({
           headerSize: listTopOffsetAdjustmentRef.current,

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -93,6 +93,7 @@ import {
 } from "@/stores/chats/subagent-open-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import { isEpicCanvasTileInstanceLive } from "@/stores/epics/canvas/tile-instance-liveness";
+import { resolveHostedTileOwnership } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
 import type {
   ChatMessage as ChatMessageModel,
   MessageSegment,
@@ -344,11 +345,23 @@ function ownsBoundaryKeys(target: EventTarget | null): boolean {
   return target.closest(CHAT_TURN_MINIMAP_KEYBOARD_OWNER_SELECTOR) !== null;
 }
 
+/**
+ * A hosted chat's own DOM lives in `StableTileSurfaceHost`'s plane, not
+ * inside its canvas pane's `[data-group-id]` subtree - the physical
+ * ancestry lookup misses for it (and for any target inside it), so a miss
+ * falls back to the hosted resolver, which walks the SAME node up to its
+ * hosted-record ancestor's stamped pane id instead.
+ */
 function canvasPaneIdOf(node: Node | null): string | null {
   const element = node instanceof Element ? node : node?.parentElement;
-  return (
-    element?.closest("[data-group-id]")?.getAttribute("data-group-id") ?? null
-  );
+  if (element === undefined || element === null) return null;
+  const physicalPaneId = element
+    .closest("[data-group-id]")
+    ?.getAttribute("data-group-id");
+  if (physicalPaneId !== undefined && physicalPaneId !== null) {
+    return physicalPaneId;
+  }
+  return resolveHostedTileOwnership(element)?.paneId ?? null;
 }
 
 /**

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/chat/chat-timeline";
 import {
   anchorMoverShouldYieldToReader,
+  applyChatAnchorDriftRepair,
   buildMessageIdToIndex,
   CHAT_ARROW_SCROLL_STEP_PX,
   chatTimelineAnchorShouldAnimateInitialIssue,
@@ -968,6 +969,10 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
   // comparing against both prevents either geometry change from looking like
   // user intent.
   const expectedAnchorScrollTopRef = useRef<number | null>(null);
+  // Ticket 22: coalesces item-size/viewport-layout triggers into ONE pending
+  // two-rAF geometry-repair pass at a time - `scheduleChatAnchorGeometryRepair`'s
+  // own doc comment covers why.
+  const pendingGeometryRepairCancelRef = useRef<(() => void) | null>(null);
   const pendingAnchorScrollRestoreRef = useRef<{
     readonly offset: number;
     readonly userScrollGeneration: number;
@@ -2038,30 +2043,24 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
           // callback above already guards against: a content-above change
           // can update LegendList's internal tracked position ahead of (or
           // independent of) the real DOM value actually moving.
-          const currentScrollTop = list.getScrollableNode().scrollTop;
-          const currentExpectedScrollTop =
-            metrics.anchorTop +
-            listTopOffsetAdjustmentRef.current -
-            anchorOffsetRef.current;
-          if (
-            anchorMoverShouldYieldToReader(
-              currentScrollTop,
-              expectedAnchorScrollTopRef.current,
-              currentExpectedScrollTop,
-            )
-          ) {
-            // A scroll-only upward departure leaves mode ownership intact,
-            // but the corrective mover must not pull the reader back.
-            return;
-          }
-          expectedAnchorScrollTopRef.current = currentExpectedScrollTop;
-          const anchorPositionDrift =
-            currentExpectedScrollTop - currentScrollTop;
-          if (Math.abs(anchorPositionDrift) > 1) {
-            void list.scrollToOffset({
-              offset: currentScrollTop + anchorPositionDrift,
-              animated: false,
-            });
+          //
+          // Ticket 22: this repair is shared with the geometry-only
+          // scheduler below (`scheduleChatAnchorGeometryRepair`) - same
+          // computation, same generation/departure guards, invoked here
+          // unchanged for a `messages` change and there for a coalesced
+          // item-size/viewport-length change under the SAME `messages`.
+          const repairOutcome = applyChatAnchorDriftRepair({
+            list,
+            anchorTop: metrics.anchorTop,
+            listTopOffsetAdjustment: listTopOffsetAdjustmentRef.current,
+            anchorOffset: anchorOffsetRef.current,
+            expectedAnchorScrollTopRef,
+          });
+          if (repairOutcome !== "settled") {
+            // A scroll-only upward departure ("yielded") leaves mode
+            // ownership intact, but the corrective mover must not pull the
+            // reader back; a "corrected" pass already issued this frame's
+            // scroll write.
             return;
           }
           // Deliberate live-E2E merge-blocker fix: revealing the minimum delta
@@ -2418,6 +2417,77 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     },
     [],
   );
+  // Ticket 22 (painted-chat lifecycle audit, finding 3): the two-rAF reveal
+  // pass's anchor-drift repair only re-runs on a `messages` change - a
+  // divider drag/pane split-join/header resize/disclosure toggle can rewrap
+  // rows under the SAME `messages` array, and nothing schedules a repair for
+  // that today. Reuses `applyChatAnchorDriftRepair` (the same computation the
+  // reveal pass calls) behind an independent two-rAF coalescing window, so
+  // several item-size/viewport-layout notifications inside one resize/toggle
+  // collapse into a single repair pass instead of one per notification.
+  //
+  // Guarded exactly like the reveal pass's own anchoring-new-turn branch:
+  // mode, generation ownership, "no anchor navigation currently mid-flight",
+  // then the shared repair's own departure (`anchorMoverShouldYieldToReader`)
+  // check - a departed/cancelled session gets no correction (base rule:
+  // never move the reader against their intent). Re-checked fresh INSIDE the
+  // deferred frame (not just at schedule time), same convention as
+  // `onTimelineAnchorSizeChanged` above - either can change between the
+  // triggering call and the frame actually running.
+  const scheduleChatAnchorGeometryRepair = useCallback((): void => {
+    if (timelineScrollModeRef.current !== "anchoring-new-turn") return;
+    if (pendingGeometryRepairCancelRef.current !== null) return;
+    pendingGeometryRepairCancelRef.current = scheduleChatTimelineDoubleRaf(
+      () => {
+        pendingGeometryRepairCancelRef.current = null;
+        if (timelineScrollModeRef.current !== "anchoring-new-turn") return;
+        if (
+          liveFollowUserScrollGenerationRef.current !==
+          anchorUserScrollGenerationRef.current
+        ) {
+          return;
+        }
+        if (pendingTimelineAnchorRef.current !== null) return;
+        if (
+          positionedTimelineAnchorRef.current !== null &&
+          settledTimelineAnchorRef.current !==
+            positionedTimelineAnchorRef.current
+        ) {
+          return;
+        }
+        const list = chatTimelineRef.current;
+        if (!list) return;
+        const metrics = getActiveTimelineTurnMetrics(list);
+        if (!metrics) return;
+        applyChatAnchorDriftRepair({
+          list,
+          anchorTop: metrics.anchorTop,
+          listTopOffsetAdjustment: listTopOffsetAdjustmentRef.current,
+          anchorOffset: anchorOffsetRef.current,
+          expectedAnchorScrollTopRef,
+        });
+      },
+    );
+  }, [getActiveTimelineTurnMetrics]);
+
+  useEffect(() => {
+    return () => {
+      // Review round 1 (finding 1, CONFIRMED HIGH): cancelling without
+      // clearing the sentinel leaves it permanently non-null after a
+      // StrictMode setup->cleanup->setup replay (the deferred callback that
+      // would have cleared it never runs, since `cancel()` cancels the rAFs
+      // it was scheduled in) - every later trigger then exits at the
+      // `!== null` guard above for the rest of the mount's lifetime. Read
+      // once and clear before invoking, so a schedule call made from the
+      // replayed setup (or any later mount) is never blocked by a dead
+      // cancel function from a cleanup that already ran.
+      const cancel = pendingGeometryRepairCancelRef.current;
+      if (cancel === null) return;
+      pendingGeometryRepairCancelRef.current = null;
+      cancel();
+    };
+  }, []);
+
   const onTimelineItemSizeChanged = useCallback((): void => {
     minimapInViewRefreshRef.current();
     // Ticket 17 (review round 2, finding 2 residual, CONFIRMED HIGH): a row's
@@ -2429,7 +2499,17 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
     // whose geometry may have shifted underneath it; unknown -> case (b), the
     // same safe default as an un-observed snapshot.
     viewportLastVisibleSnapshotRef.current = null;
-  }, []);
+    // Ticket 22: the same real, no-scroll size change can also move an
+    // anchoring-new-turn session's already-settled anchor.
+    scheduleChatAnchorGeometryRepair();
+  }, [scheduleChatAnchorGeometryRepair]);
+
+  // Ticket 22: viewport-length changes (divider drag/pane resize) - unlike
+  // item-size changes, LegendList never reports these as a scroll, a data
+  // change, or an item resize; nothing else in this file observes them.
+  const onTimelineViewportLayoutChanged = useCallback((): void => {
+    scheduleChatAnchorGeometryRepair();
+  }, [scheduleChatAnchorGeometryRepair]);
 
   // Quote-to-composer: track selections inside the transcript wrapper below and
   // surface the floating quote button. The hook attaches no listeners while the
@@ -3109,6 +3189,7 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
               navigationHighlightedMessageId={navigationHighlightedMessageId}
               onItemSizeChanged={onTimelineItemSizeChanged}
               onListMetricsChange={onListMetricsChange}
+              onLayout={onTimelineViewportLayoutChanged}
               data-testid="chat-messages-scroll"
               data-scroll-mode={scrollMode}
             />

--- a/clients/gui-app/src/components/chat/chat-timeline-panel-resize-snapshot.ts
+++ b/clients/gui-app/src/components/chat/chat-timeline-panel-resize-snapshot.ts
@@ -1,0 +1,57 @@
+/**
+ * Ticket 23 (D20 port): the marker-scoped panel-resize freeze's imperative
+ * visible-row snapshot. Pure DOM, no React and no LegendList API surface -
+ * `chat-timeline.tsx` calls these from a `registerPanelResizeParticipant`
+ * capture/clear pair (see `lib/layout/panel-resizing-class.ts`), once per
+ * drag. `ChatTimelineRow`'s own freeze selector targets everything WITHOUT
+ * this attribute, so marking is exact: only rows marked here stay live.
+ */
+export const PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE = "data-panel-resize-visible";
+
+const MESSAGE_ROW_SELECTOR = "[data-message-id]";
+
+/**
+ * One-shot, bounded geometry walk over `scrollableNode`'s OWN mounted rows -
+ * never the whole document, so each mounted `ChatTimeline` only ever marks
+ * its own rows. A row is marked "visible" when its rect vertically
+ * intersects the scrollable node's own viewport rect, boundary-inclusive (a
+ * row straddling the edge counts as visible, so a reader never sees a hidden
+ * sliver mid-drag). Rows are always full-width within the scroller, so only
+ * the vertical axis matters.
+ *
+ * Self-healing: every row is explicitly set OR unset on every call, so this
+ * fully replaces the marker set relative to the currently mounted rows -
+ * regardless of what markers were left over from an earlier call. This
+ * matters because the registry (`lib/layout/panel-resizing-class.ts`)
+ * isolates a participant's `clear` failure rather than letting it block the
+ * drag lifecycle; without the explicit unset branch, a marker surviving a
+ * failed clear would persist through every later capture too, silently
+ * keeping an offscreen row live.
+ */
+export function captureChatTimelineVisibleRows(
+  scrollableNode: HTMLElement,
+): void {
+  const viewport = scrollableNode.getBoundingClientRect();
+  const rows =
+    scrollableNode.querySelectorAll<HTMLElement>(MESSAGE_ROW_SELECTOR);
+  for (const row of rows) {
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom >= viewport.top && rect.top <= viewport.bottom) {
+      row.setAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE, "true");
+    } else {
+      row.removeAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE);
+    }
+  }
+}
+
+/** Clears only markers this same scrollable node's capture could have set. */
+export function clearChatTimelineVisibleRows(
+  scrollableNode: HTMLElement,
+): void {
+  const marked = scrollableNode.querySelectorAll<HTMLElement>(
+    `[${PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE}]`,
+  );
+  for (const row of marked) {
+    row.removeAttribute(PANEL_RESIZE_VISIBLE_ROW_ATTRIBUTE);
+  }
+}

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -80,8 +80,9 @@ function useIsNavigationHighlighted(
   store: NavigationHighlightStore,
   messageId: string,
 ): boolean {
-  return useSyncExternalStore(store.subscribe, () =>
-    store.getSnapshot() === messageId,
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot() === messageId,
   );
 }
 

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -24,6 +24,11 @@ import {
   resolveChatTimelineIsAtEnd,
 } from "@/components/chat/chat-scroll-anchoring";
 import { chatTimelineGetItemType } from "@/components/chat/chat-messages-scroll-helpers";
+import { registerPanelResizeParticipant } from "@/lib/layout/panel-resizing-class";
+import {
+  captureChatTimelineVisibleRows,
+  clearChatTimelineVisibleRows,
+} from "@/components/chat/chat-timeline-panel-resize-snapshot";
 import {
   computeStableChatTimelineRows,
   EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE,
@@ -379,6 +384,32 @@ export const ChatTimeline = memo(function ChatTimeline({
     onScroll?.();
   }, [listRef, onIsAtEndChange, onScroll]);
 
+  // Ticket 23 (D20 port): registers this mounted timeline as a panel-resize
+  // participant so a divider drag's capture pass (see
+  // `lib/layout/panel-resizing-class.ts`) can mark ITS OWN currently visible
+  // rows right before the freeze class lands - see `ChatTimelineRow`'s own
+  // doc comment for the freeze mechanism. `useLayoutEffect`, not `useEffect`:
+  // registration must be live before the browser can paint a state where a
+  // drag could start. Cleared defensively on unmount (in addition to
+  // unregistering) even though the unmounted DOM is about to be discarded
+  // anyway - matches the ticket's explicit "cleared ... at end/unmount"
+  // contract.
+  useLayoutEffect(() => {
+    const capture = (): void => {
+      const node = listRef.current?.getScrollableNode();
+      if (node) captureChatTimelineVisibleRows(node);
+    };
+    const clear = (): void => {
+      const node = listRef.current?.getScrollableNode();
+      if (node) clearChatTimelineVisibleRows(node);
+    };
+    const unregister = registerPanelResizeParticipant({ capture, clear });
+    return () => {
+      clear();
+      unregister();
+    };
+  }, [listRef]);
+
   if (rows.length === 0) {
     return <ChatEmptyState />;
   }
@@ -554,14 +585,25 @@ function useStableChatTimelineRows(
 }
 
 /**
- * One transcript row. During a panel-resize drag (`traycer-panel-resizing`
- * on `<html>`) every row flips to `content-visibility: hidden`: each
- * pointermove reflows all visible panes, and live rows would re-wrap and
- * re-rasterize every transcript at every intermediate width - a
- * multi-hundred-MB transient spike in the GPU process's tile pool. Hidden
- * rows keep their remembered size (the `auto` intrinsic-size keyword), so
- * LegendList's measurement sees stable heights for the whole drag; one
- * reflow on pointer-up restores content at the final width.
+ * One transcript row. Ticket 23's live profile measured a divider drag
+ * across two heavy transcripts at ~2x the idle frame budget (19.5-24% of
+ * frames over 1.5x budget, 50-75ms long tasks); a count-only ResizeObserver
+ * pass recorded substantial multi-row churn per pointermove (~22 entries in
+ * a typical callback - not literally every mounted row on every event).
+ * During a panel-resize drag (`traycer-panel-resizing` on `<html>`),
+ * `ChatTimeline`'s capture pass (D20 port, wired through
+ * `registerPanelResizeParticipant`) marks each row that was on-screen at
+ * drag START with `data-panel-resize-visible`; only UNMARKED rows flip to
+ * `content-visibility: hidden` below - marked rows stay live and can still
+ * re-render/remeasure normally. The `auto` keyword in the per-role
+ * `contain-intrinsic-size` hints below means a row that was already laid out
+ * before the drag keeps its own last-remembered size once hidden; the
+ * accompanying role length (8rem/4rem/14rem) is only the fallback for a row
+ * that mounts already-frozen, i.e. has no remembered size to fall back on
+ * (CSS Sizing Level 4's "last remembered size" - `auto` prefers it when one
+ * exists, the length is the no-memory fallback, not the other way around).
+ * So LegendList's measured heights survive the freeze untouched and one
+ * reflow on release restores content at the final width.
  */
 const ChatTimelineRow = memo(function ChatTimelineRow({
   message,
@@ -582,7 +624,7 @@ const ChatTimelineRow = memo(function ChatTimelineRow({
       data-message-id={message.id}
       data-navigation-highlighted={isNavigationHighlighted ? "true" : undefined}
       className={cn(
-        "mx-auto w-full max-w-3xl rounded-lg px-6 pb-6 transition-[background-color,box-shadow] duration-300 [contain:layout_paint_style]",
+        "mx-auto w-full max-w-3xl rounded-lg px-6 pb-6 transition-[background-color,box-shadow] duration-300 [contain:layout_paint_style] [.traycer-panel-resizing_&:not([data-panel-resize-visible])]:[content-visibility:hidden]",
         isNavigationHighlighted &&
           "bg-primary/15 ring-2 ring-inset ring-primary/80 motion-safe:animate-pulse",
         chatTimelineRowSizeHintClassName(message.role),

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -3,7 +3,10 @@ import {
   memo,
   use,
   useCallback,
+  useLayoutEffect,
   useMemo,
+  useState,
+  useSyncExternalStore,
   type RefObject,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -28,6 +31,86 @@ import {
 } from "./chat-stable-rows";
 
 /**
+ * Ticket 24 (painted-chat lifecycle audit, finding 5): a row-local
+ * subscription for the navigation highlight, kept OUT of
+ * `ChatTimelineRowSharedState`. That context's value is a single object
+ * shared by every mounted row - React forces every context consumer to
+ * re-render whenever the value changes, bypassing each row's own `memo`
+ * bailout entirely (a probe confirmed 8/8 mounted rows re-rendering on one
+ * highlight move). `useSyncExternalStore` lets each row subscribe with its
+ * own selector (`id === message.id`); React re-renders a given subscriber
+ * only when ITS boolean actually flips, so a highlight move re-renders
+ * exactly the old and new highlighted rows.
+ */
+interface NavigationHighlightStore {
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly getSnapshot: () => string | null;
+  readonly setHighlightedId: (id: string | null) => void;
+}
+
+function createNavigationHighlightStore(
+  initialHighlightedId: string | null,
+): NavigationHighlightStore {
+  let highlightedId = initialHighlightedId;
+  const listeners = new Set<() => void>();
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot() {
+      return highlightedId;
+    },
+    setHighlightedId(next) {
+      if (next === highlightedId) return;
+      highlightedId = next;
+      for (const listener of listeners) listener();
+    },
+  };
+}
+
+function useIsNavigationHighlighted(
+  store: NavigationHighlightStore,
+  messageId: string,
+): boolean {
+  return useSyncExternalStore(store.subscribe, () =>
+    store.getSnapshot() === messageId,
+  );
+}
+
+/** Owns the store's lifetime and keeps it synced with the latest prop -
+ *  pulled out of `ChatTimeline`'s own body (alongside
+ *  `resolveChatTimelineSizePreservationEnabled` below) to keep that
+ *  component's cyclomatic complexity under the lint limit. */
+function useNavigationHighlightStore(
+  navigationHighlightedMessageId: string | null | undefined,
+): NavigationHighlightStore {
+  const [store] = useState<NavigationHighlightStore>(() =>
+    createNavigationHighlightStore(navigationHighlightedMessageId ?? null),
+  );
+
+  // Review round 1, finding 1: a PASSIVE effect here runs after paint unless
+  // the update happens to originate inside a parent `useLayoutEffect` (the
+  // external-jump activation path) - the 3s highlight-timeout clear
+  // (`setTimeout`) and the real-gesture clear (a plain callback, not a
+  // layout effect) have no such guarantee, so a paint could commit the new
+  // prop while the store - and therefore every row's boolean - still holds
+  // the old id, and a row mounting in that window would read the stale
+  // snapshot. `useLayoutEffect` publishes synchronously before the browser
+  // paints on EVERY producer path uniformly, not just the ones that happen
+  // to chain off another layout effect. The mutation itself is still
+  // outside render (it runs in the commit/layout phase, not the render
+  // phase), so `useSyncExternalStore`'s purity contract is unaffected.
+  useLayoutEffect(() => {
+    store.setHighlightedId(navigationHighlightedMessageId ?? null);
+  }, [store, navigationHighlightedMessageId]);
+
+  return store;
+}
+
+/**
  * Shared, closure-free row context. Row components read business-logic
  * callbacks from context instead of a per-item closure, so `renderItem`
  * stays referentially stable and LegendList's own memo boundary is never
@@ -40,7 +123,7 @@ interface ChatTimelineRowSharedState {
     message: ChatMessageModel,
   ) => ChatMessageActions | null;
   readonly nextStepActions: NextStepActionHandler | null;
-  readonly navigationHighlightedMessageId: string | null | undefined;
+  readonly navigationHighlightStore: NavigationHighlightStore;
 }
 
 const ChatTimelineRowCtx = createContext<ChatTimelineRowSharedState | null>(
@@ -208,20 +291,24 @@ export const ChatTimeline = memo(function ChatTimeline({
 }: ChatTimelineProps) {
   const rows = useStableChatTimelineRows(listRef, messages);
 
+  const navigationHighlightStore = useNavigationHighlightStore(
+    navigationHighlightedMessageId,
+  );
+
   const sharedState = useMemo<ChatTimelineRowSharedState>(
     () => ({
       taskTitle,
       backgroundToolBlockIds,
       getMessageActions,
       nextStepActions,
-      navigationHighlightedMessageId,
+      navigationHighlightStore,
     }),
     [
       taskTitle,
       backgroundToolBlockIds,
       getMessageActions,
       nextStepActions,
-      navigationHighlightedMessageId,
+      navigationHighlightStore,
     ],
   );
 
@@ -473,16 +560,18 @@ const ChatTimelineRow = memo(function ChatTimelineRow({
   if (ctx === null) {
     throw new Error("ChatTimelineRow must render inside ChatTimeline");
   }
+  const isNavigationHighlighted = useIsNavigationHighlighted(
+    ctx.navigationHighlightStore,
+    message.id,
+  );
 
   return (
     <div
       data-message-id={message.id}
-      data-navigation-highlighted={
-        ctx.navigationHighlightedMessageId === message.id ? "true" : undefined
-      }
+      data-navigation-highlighted={isNavigationHighlighted ? "true" : undefined}
       className={cn(
         "mx-auto w-full max-w-3xl rounded-lg px-6 pb-6 transition-[background-color,box-shadow] duration-300 [contain:layout_paint_style]",
-        ctx.navigationHighlightedMessageId === message.id &&
+        isNavigationHighlighted &&
           "bg-primary/15 ring-2 ring-inset ring-primary/80 motion-safe:animate-pulse",
         chatTimelineRowSizeHintClassName(message.role),
       )}

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -235,10 +235,12 @@ export interface ChatTimelineProps {
    * when a later measurement pass corrects an earlier row's position from
    * under them). `false` in `following-end` (end-stick governs via
    * `maintainScrollAtEnd`) and `anchoring-new-turn` (the anchor engine owns
-   * motion; its own reveal-pass drift re-assert already handles above-anchor
-   * growth under `size:false` - enabling this too would double-correct the
-   * same shift). `false` by default so ticket-2/3-era callers keep today's
-   * `size:false` semantics unless they opt in.
+   * motion; its own drift re-assert - the reveal pass for a `messages`
+   * change, ticket 22's coalesced scheduler for a geometry-only change under
+   * the same `messages` - already handles above-anchor growth under
+   * `size:false`; enabling this too would double-correct the same shift).
+   * `false` by default so ticket-2/3-era callers keep today's `size:false`
+   * semantics unless they opt in.
    */
   readonly sizePreservationEnabled?: boolean;
   /** Message row receiving the temporary external-navigation highlight. */
@@ -256,6 +258,14 @@ export interface ChatTimelineProps {
     readonly headerSize: number;
     readonly footerSize: number;
   }) => void;
+  /**
+   * Ticket 22: the scroll container's own layout (width/height) changing -
+   * a divider drag/pane resize. Unlike `onItemSizeChanged`, LegendList never
+   * routes this through a data/scroll/item-size callback; it is the ONLY
+   * signal for a viewport-length change that leaves every row's own
+   * measured size untouched.
+   */
+  readonly onLayout?: () => void;
 }
 
 /**
@@ -287,6 +297,7 @@ export const ChatTimeline = memo(function ChatTimeline({
   navigationHighlightedMessageId,
   onItemSizeChanged,
   onListMetricsChange,
+  onLayout,
   ...rest
 }: ChatTimelineProps) {
   const rows = useStableChatTimelineRows(listRef, messages);
@@ -417,6 +428,7 @@ export const ChatTimeline = memo(function ChatTimeline({
         maintainVisibleContentPosition={maintainVisibleContentPosition}
         onItemSizeChanged={onItemSizeChanged}
         onScroll={handleScroll}
+        onLayout={onLayout}
         {...(onListMetricsChange !== undefined
           ? { onMetricsChange: onListMetricsChange }
           : {})}

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { useLayoutEffect, type ReactNode } from "react";
 import { TabGroupView } from "@/components/epic-canvas/canvas/tab-group-view";
 import { paneActivationDeferProps } from "@/components/epic-canvas/pane-activation";
@@ -23,7 +23,10 @@ import {
   HOSTED_TILE_PANE_ID_ATTRIBUTE,
   HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
 } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
-import { isChatRemoteDeleted } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import {
+  isChatRemoteDeleted,
+  resetChatRemoteDeletionRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
 import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
 import {
   getTileSurfaceMembership,
@@ -617,6 +620,7 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useTabsStore.setState(useTabsStore.getInitialState(), true);
     tabCommandCoordinator.resetReconciliationForTesting();
+    resetChatRemoteDeletionRegistryForTesting();
     resetTileSurfaceMembershipForTesting();
     resetTileSurfaceEnvironmentRegistryForTesting();
   });
@@ -844,6 +848,7 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "group-1");
     hostedRecord.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, VIEW_TAB_ID);
     document.body.appendChild(hostedRecord);
+    onTestFinished(() => hostedRecord.remove());
     const hostedDeferred = document.createElement("button");
     hostedDeferred.type = "button";
     hostedDeferred.setAttribute("data-pane-activation-defer", "true");
@@ -868,8 +873,6 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
         useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
       ).toBe("group-1");
     });
-
-    hostedRecord.remove();
   });
 
   it("design-review F3: activates the pane immediately on a non-deferred pointerdown on a hosted record", async () => {
@@ -892,6 +895,7 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "group-1");
     hostedRecord.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, VIEW_TAB_ID);
     document.body.appendChild(hostedRecord);
+    onTestFinished(() => hostedRecord.remove());
     const hostedBody = document.createElement("div");
     hostedBody.setAttribute("data-testid", "hosted-non-deferred-body");
     hostedRecord.appendChild(hostedBody);
@@ -904,8 +908,6 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     expect(
       useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
     ).toBe("group-1");
-
-    hostedRecord.remove();
   });
 
   it("does not activate this pane when a hosted pointerdown belongs to a different paneId", async () => {
@@ -931,6 +933,7 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
       "other-view-tab",
     );
     document.body.appendChild(foreignHosted);
+    onTestFinished(() => foreignHosted.remove());
     const foreignBody = document.createElement("div");
     foreignBody.setAttribute("data-testid", "foreign-hosted-body");
     foreignHosted.appendChild(foreignBody);
@@ -940,7 +943,5 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     expect(
       useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
     ).toBe("other-group");
-
-    foreignHosted.remove();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -165,7 +165,7 @@ function specTab(n: number): EpicCanvasTileRef {
 
 function pane(
   tabs: ReadonlyArray<EpicCanvasTileRef>,
-  activeTabId: string,
+  activeTabId: string | null,
 ): TilePane {
   return {
     kind: "pane",
@@ -173,7 +173,7 @@ function pane(
     tabInstanceIds: tabs.map((tab) => tab.instanceId),
     activeTabId,
     previewTabId: null,
-    activationHistory: [activeTabId],
+    activationHistory: activeTabId === null ? [] : [activeTabId],
   };
 }
 
@@ -182,14 +182,14 @@ function pane(
 // instanceIds resolve to the given refs.
 function seedCanvas(
   tabs: ReadonlyArray<EpicCanvasTileRef>,
-  activeTabId: string,
+  activeTabId: string | null,
 ): void {
   seedCanvasWithActivePane(tabs, activeTabId, "group-1");
 }
 
 function seedCanvasWithActivePane(
   tabs: ReadonlyArray<EpicCanvasTileRef>,
-  activeTabId: string,
+  activeTabId: string | null,
   activePaneId: string,
 ): void {
   useEpicCanvasStore.setState({
@@ -211,7 +211,7 @@ function seedCanvasWithActivePane(
 
 function groupView(
   tabs: ReadonlyArray<EpicCanvasTileRef>,
-  activeTabId: string,
+  activeTabId: string | null,
   paneVisible: boolean,
 ): ReactNode {
   return (
@@ -419,5 +419,51 @@ describe("<TabGroupView />", () => {
     expect(testState.unmounts.get("spec-1")).toBe(1);
     expect(testState.unmounts.get("spec-2")).toBeUndefined();
     expect(testState.unmounts.get("agent-1")).toBeUndefined();
+  });
+
+  it("falls back to the first tab when pane.activeTabId is null (resolveActivePaneTab wiring)", async () => {
+    // Byte-equivalence pin for Ticket 21 slice 1: TabGroupView delegates
+    // body active-tab resolution to `resolveActivePaneTab`. A null
+    // activeTabId must still mount/select the first strip tab - same as the
+    // previous inline fallback. Inactive never-visited tabs stay unmounted
+    // under the keep-alive policy (not display:none).
+    const tabs = [specTab(1), specTab(2)];
+    seedCanvas(tabs, null);
+    const { container } = render(groupView(tabs, null, true));
+
+    await waitFor(() => {
+      expect(testState.mounts.get("spec-1")).toBe(1);
+    });
+    const firstLayer = container.querySelector(
+      '[data-tab-instance-id="inst-spec-1"]',
+    );
+    expect(firstLayer).not.toBeNull();
+    expect(firstLayer?.getAttribute("data-selected")).toBe("true");
+    expect(firstLayer?.classList.contains("hidden")).toBe(false);
+    expect(
+      container.querySelector('[data-tab-instance-id="inst-spec-2"]'),
+    ).toBeNull();
+    expect(testState.mounts.get("spec-2")).toBeUndefined();
+  });
+
+  it("falls back to the first tab when pane.activeTabId is stale (resolveActivePaneTab wiring)", async () => {
+    const tabs = [specTab(1), specTab(2)];
+    const staleActiveId = "inst-spec-gone";
+    seedCanvas(tabs, staleActiveId);
+    const { container } = render(groupView(tabs, staleActiveId, true));
+
+    await waitFor(() => {
+      expect(testState.mounts.get("spec-1")).toBe(1);
+    });
+    const firstLayer = container.querySelector(
+      '[data-tab-instance-id="inst-spec-1"]',
+    );
+    expect(firstLayer).not.toBeNull();
+    expect(firstLayer?.getAttribute("data-selected")).toBe("true");
+    expect(firstLayer?.classList.contains("hidden")).toBe(false);
+    expect(
+      container.querySelector('[data-tab-instance-id="inst-spec-2"]'),
+    ).toBeNull();
+    expect(testState.mounts.get("spec-2")).toBeUndefined();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -1058,16 +1058,14 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     resetTileSurfaceEnvironmentRegistryForTesting();
     render(
       hostedGroupView(
-        () => (
-          <button type="button" data-testid="hosted-focus-owner">
-            Hosted action
-          </button>
-        ),
+        () => <button type="button">Hosted action</button>,
         undefined,
       ),
     );
 
-    const hostedControl = await screen.findByTestId("hosted-focus-owner");
+    const hostedControl = await screen.findByRole("button", {
+      name: "Hosted action",
+    });
     expect(
       getTileSurfaceEnvironment(
         CHAT.instanceId,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -1,5 +1,6 @@
 import "../../../../__tests__/test-browser-apis";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -7,13 +8,32 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
+import { useLayoutEffect, type ReactNode } from "react";
 import { TabGroupView } from "@/components/epic-canvas/canvas/tab-group-view";
 import { paneActivationDeferProps } from "@/components/epic-canvas/pane-activation";
 import { PaneVisibilityContext } from "@/components/epic-tabs/pane-visibility-context";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicCanvasTileRef, TilePane } from "@/stores/epics/canvas/types";
+import { useTabsStore } from "@/stores/tabs/store";
+import type { TabRef } from "@/stores/tabs/types";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+  HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import { isChatRemoteDeleted } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
+import {
+  getTileSurfaceMembership,
+  resetTileSurfaceMembershipForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import {
+  publishTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
 
 const VIEW_TAB_ID = "view-tab-1";
 
@@ -23,6 +43,18 @@ interface TestState {
   readonly deferredClicks: Map<string, number>;
   readonly deferredRemovalClicks: Map<string, number>;
   readonly closeAutoFocusGuards: Map<string, (event: Event) => void>;
+  /**
+   * When an artifact id is listed here, `useEpicArtifact` returns `null` so
+   * `computeIsRemoteDeleted` can fire (snapshot loaded + no live projection).
+   */
+  readonly missingArtifactIds: Set<string>;
+  /**
+   * Controllable stand-in for `STABLE_TILE_SURFACE_HOST_ENABLED`. A getter
+   * mock keeps the live ESM binding fresh on every `surfaceOwnerFor` call
+   * without `vi.resetModules()` (which would re-instantiate the canvas store
+   * and desync the static `useEpicCanvasStore` import this file seeds).
+   */
+  stableTileSurfaceHostEnabled: boolean;
 }
 
 const testState = vi.hoisted((): TestState => ({
@@ -31,7 +63,18 @@ const testState = vi.hoisted((): TestState => ({
   deferredClicks: new Map(),
   deferredRemovalClicks: new Map(),
   closeAutoFocusGuards: new Map(),
+  missingArtifactIds: new Set(),
+  stableTileSurfaceHostEnabled: false,
 }));
+
+vi.mock(
+  "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch",
+  () => ({
+    get STABLE_TILE_SURFACE_HOST_ENABLED() {
+      return testState.stableTileSurfaceHostEnabled;
+    },
+  }),
+);
 
 vi.mock("@dnd-kit/core", () => ({
   useDraggable: () => ({
@@ -70,13 +113,22 @@ vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
 }));
 
 vi.mock("@/lib/epic-selectors", () => ({
-  useEpicArtifact: (id: string) => ({ id }),
+  useEpicArtifact: (id: string) =>
+    testState.missingArtifactIds.has(id) ? null : { id },
   useEpicTabDisplayTitle: (node: { readonly name: string }) => node.name,
   useEpicLiveArtifactTitleGenerating: () => false,
   useEpicPermissionRole: () => "owner",
   useEpicSnapshotLoaded: () => true,
   useMaybeEpicTuiAgentHarnessId: () => null,
   useRegisteredEpicActiveAgentIds: () => new Set<string>(),
+  // Chat tab strip icons (ChatProgressIcon) need activity tiers when a chat
+  // tile is the active tab - not exercised by the older spec/terminal-only
+  // fixtures in this file.
+  useEpicAgentActivityTiers: () => new Map<string, false>(),
+}));
+
+vi.mock("@/lib/registries/chat-session-registry", () => ({
+  useExistingChatSessionHandle: () => null,
 }));
 
 vi.mock("@/components/epic-canvas/renderers/epic-node-tile", async () => {
@@ -150,6 +202,14 @@ const SPEC: EpicCanvasTileRef = {
   instanceId: "inst-spec-1",
   type: "spec",
   name: "Spec",
+  hostId: "host-A",
+};
+
+const CHAT: EpicCanvasTileRef = {
+  id: "chat-1",
+  instanceId: "inst-chat-1",
+  type: "chat",
+  name: "Chat",
   hostId: "host-A",
 };
 
@@ -227,6 +287,75 @@ function groupView(
   );
 }
 
+/**
+ * Design-review slice-4 F2 residual: the four-way ownership shape the
+ * reviewer's own probe used, resampled on demand.
+ */
+interface OwnershipSnapshot {
+  readonly deleted: boolean;
+  readonly member: boolean;
+  readonly inline: boolean;
+  readonly hosted: boolean;
+}
+
+function ownershipSnapshot(instanceId: string): OwnershipSnapshot {
+  return {
+    deleted: isChatRemoteDeleted(instanceId),
+    member: getTileSurfaceMembership().has(instanceId),
+    inline:
+      document.querySelector('[data-testid="deleted-node-body"]') !== null,
+    hosted:
+      document.querySelector(
+        `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${instanceId}"]`,
+      ) !== null,
+  };
+}
+
+/**
+ * Design-review slice-4 F2 residual: a genuine sibling `useLayoutEffect`
+ * (no deps array - it re-samples on EVERY commit that touches this tree)
+ * captures the four-way ownership shape the reviewer's own probe used.
+ * Rendered as the LAST sibling after `TabGroupView` and
+ * `StableTileSurfaceHost`, its layout effect only runs once React has
+ * finished processing every earlier sibling's own layout effects for the
+ * SAME commit - so it observes exactly what has settled by the end of the
+ * layout phase, strictly before any passive effect (a `useEffect`-based
+ * report, if the fix regresses) gets a chance to run.
+ *
+ * This reliably discriminates `deleted`/`member`/`inline` (all three are
+ * driven by plain, synchronous function calls in the report's own reaction
+ * chain - see `tab-group-view.tsx`'s doc comment on
+ * `reportChatRemoteDeletionState`). `hosted` is NOT part of what this probe
+ * can prove: `StableTileSurfaceHost` reacts to membership through
+ * `useSyncExternalStore`, a SEPARATE component whose consequential
+ * re-render is necessarily a LATER React commit than the one containing
+ * `TabGroupView`'s own layout effect - still synchronous and still strictly
+ * pre-paint (nothing yields to the browser in between), but after this
+ * probe's own same-commit vantage point has already sampled. Three other
+ * techniques were tried to also pin `hosted` at this exact vantage point and
+ * rejected, each confirmed empirically rather than assumed: an `act()`-
+ * wrapped `rerender()`, a raw non-act `setState` plus a `setTimeout`
+ * macrotask tick, and `react-dom`'s `flushSync` ALL settle to the fully
+ * "fixed" shape even under the reverted `useEffect` mutation - in this
+ * environment none of them stop short of also draining the passive effect,
+ * so none can tell "resolved without ever yielding to a paint" apart from
+ * "resolved, but only after yielding once" (a stricter case of the
+ * established React-19 act-environment lesson - see
+ * `chat-timeline.test.tsx` - which this component's simpler, unvirtualized
+ * effect chain leaves no natural gap for even the raw-non-act/macrotask
+ * variant to exploit). `hosted` clearing is instead covered by the
+ * post-flip `waitFor` below, which confirms real eventual settlement.
+ */
+function LayoutPhaseOwnershipProbe(props: {
+  readonly instanceId: string;
+  readonly onSnapshot: (snapshot: OwnershipSnapshot) => void;
+}): ReactNode {
+  useLayoutEffect(() => {
+    props.onSnapshot(ownershipSnapshot(props.instanceId));
+  });
+  return null;
+}
+
 describe("<TabGroupView />", () => {
   afterEach(() => {
     cleanup();
@@ -235,6 +364,8 @@ describe("<TabGroupView />", () => {
     testState.deferredClicks.clear();
     testState.deferredRemovalClicks.clear();
     testState.closeAutoFocusGuards.clear();
+    testState.missingArtifactIds.clear();
+    testState.stableTileSurfaceHostEnabled = false;
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   });
 
@@ -465,5 +596,351 @@ describe("<TabGroupView />", () => {
       container.querySelector('[data-tab-instance-id="inst-spec-2"]'),
     ).toBeNull();
     expect(testState.mounts.get("spec-2")).toBeUndefined();
+  });
+});
+
+/**
+ * Ticket 21 slice 4: with the stable-tile-surface-host switch ON, ActiveTabBody
+ * routes live chats through `TileSurfaceSlot` instead of the inline
+ * EpicNodeTile body. The switch module is mocked with a live getter (see
+ * `testState.stableTileSurfaceHostEnabled`) so these pins can flip it without
+ * `vi.resetModules()` / re-importing TabGroupView.
+ */
+describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => {
+  afterEach(() => {
+    cleanup();
+    testState.mounts.clear();
+    testState.unmounts.clear();
+    testState.deferredClicks.clear();
+    testState.missingArtifactIds.clear();
+    testState.stableTileSurfaceHostEnabled = false;
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+  });
+
+  it("renders TileSurfaceSlot for a live chat instead of the inline EpicNodeTile body", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    seedCanvas(tabs, CHAT.instanceId);
+    const { container } = render(groupView(tabs, CHAT.instanceId, true));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="tile-surface-slot"]'),
+      ).not.toBeNull();
+    });
+    const slot = container.querySelector('[data-testid="tile-surface-slot"]');
+    expect(slot?.getAttribute("data-tile-instance-id")).toBe(CHAT.instanceId);
+    // Inline EpicNodeTile body must NOT mount for a hosted chat.
+    expect(
+      container.querySelector(`[data-testid="tile-${CHAT.id}"]`),
+    ).toBeNull();
+    expect(testState.mounts.get(CHAT.id)).toBeUndefined();
+  });
+
+  it("keeps a remote-deleted chat on DeletedArtifactBody (not hosted) even with the switch ON", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    testState.missingArtifactIds.add(CHAT.id);
+    seedCanvas(tabs, CHAT.instanceId);
+    const { container } = render(groupView(tabs, CHAT.instanceId, true));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="deleted-node-body"]'),
+      ).not.toBeNull();
+    });
+    expect(
+      container.querySelector('[data-testid="tile-surface-slot"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector(`[data-testid="tile-${CHAT.id}"]`),
+    ).toBeNull();
+  });
+
+  it("reports the remote-deletion transition into the shared registry so membership can react", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    seedCanvas(tabs, CHAT.instanceId);
+    const { container, rerender } = render(
+      groupView(tabs, CHAT.instanceId, true),
+    );
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="tile-surface-slot"]'),
+      ).not.toBeNull();
+    });
+    expect(isChatRemoteDeleted(CHAT.instanceId)).toBe(false);
+
+    // Same chat, still hosted going in - now becomes remote-deleted mid-session
+    // (a Y.Doc sync event), not deleted from the start.
+    testState.missingArtifactIds.add(CHAT.id);
+    rerender(groupView(tabs, CHAT.instanceId, true));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="deleted-node-body"]'),
+      ).not.toBeNull();
+    });
+    expect(
+      container.querySelector('[data-testid="tile-surface-slot"]'),
+    ).toBeNull();
+    // `tile-surface-membership.ts`'s and `remote-deleted-chat-registry.ts`'s own
+    // pure-function pins cover the membership-drop/registry-clear consequence
+    // of this report (both are unreachable from this React-mounted harness:
+    // `TileSurfaceSlot` never publishes here without a real epic session
+    // handle, and no `StableTileSurfaceHost` sibling is mounted to observe).
+    expect(isChatRemoteDeleted(CHAT.instanceId)).toBe(true);
+  });
+
+  it("design-review F2 residual: a real StableTileSurfaceHost sibling loses the hosted owner in the SAME pre-paint commit as the inline flip", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    seedCanvas(tabs, CHAT.instanceId);
+    // `seedCanvas` does not set `openTabOrder`; `getHeaderTabs()` (the
+    // top-level retention layer's source of truth) resolves this view tab
+    // only through `openTabOrder`, not `tabsById` alone.
+    useEpicCanvasStore.setState((state) => ({
+      ...state,
+      openTabOrder: [VIEW_TAB_ID],
+    }));
+    const ref: TabRef = { kind: "epic", id: VIEW_TAB_ID };
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
+      activeItemId: `tab:${ref.kind}:${ref.id}`,
+      stripOrder: [ref],
+    }));
+    resetTileSurfaceEnvironmentRegistryForTesting();
+
+    const snapshots: OwnershipSnapshot[] = [];
+    const tree = (): ReactNode => (
+      <TooltipProvider>
+        <PaneVisibilityContext.Provider value>
+          <TabGroupView
+            epicId="epic-1"
+            tabId={VIEW_TAB_ID}
+            pane={pane(tabs, CHAT.instanceId)}
+          />
+          <StableTileSurfaceHost
+            renderRecordBody={() => <div data-testid="hosted-body-stub" />}
+          />
+          <LayoutPhaseOwnershipProbe
+            instanceId={CHAT.instanceId}
+            onSnapshot={(snapshot) => snapshots.push(snapshot)}
+          />
+        </PaneVisibilityContext.Provider>
+      </TooltipProvider>
+    );
+
+    const { rerender } = render(tree());
+    await waitFor(() => {
+      expect(getTileSurfaceMembership().has(CHAT.instanceId)).toBe(true);
+    });
+
+    // A real published environment - not a manufactured DOM node - so a real
+    // `StableTileSurfaceHost` record is genuinely mounted before the flip.
+    // `publishTileSurfaceEnvironment` synchronously notifies its
+    // `useSyncExternalStore` subscribers outside any RTL-driven update, so
+    // wrap it the same way the transfer-gap test wraps its store mutation.
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment(CHAT.instanceId, {
+          placement: {
+            epicId: "epic-1",
+            viewTabId: VIEW_TAB_ID,
+            paneId: "group-1",
+            hostId: "host-A",
+          },
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="hosted-body-stub"]'),
+      ).not.toBeNull();
+    });
+
+    // Discard every snapshot the setup steps above produced - only the
+    // deletion-triggering commit's samples matter.
+    snapshots.length = 0;
+
+    testState.missingArtifactIds.add(CHAT.id);
+    rerender(tree());
+
+    await waitFor(() => {
+      // Confirms real eventual settlement - including `StableTileSurfaceHost`
+      // actually dropping the stale record - so a genuinely broken
+      // transition doesn't silently pass this test. See
+      // `LayoutPhaseOwnershipProbe`'s doc comment for why `hosted`'s exact
+      // pre-paint timing isn't independently provable in this environment,
+      // even though it's provably synchronous by construction (a plain,
+      // uninterrupted `useSyncExternalStore` cascade from the same report).
+      expect(isChatRemoteDeleted(CHAT.instanceId)).toBe(true);
+      expect(
+        document.querySelector(
+          `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${CHAT.instanceId}"]`,
+        ),
+      ).toBeNull();
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    // The FIRST post-trigger commit's layout-phase snapshot is the one that
+    // discriminates the report's own effect type: `LayoutPhaseOwnershipProbe`
+    // is the LAST sibling, so by the time ITS layout effect runs,
+    // `TabGroupView`'s own layout effect (and the synchronous registry/
+    // membership chain it calls directly) has already completed for that
+    // same commit - a passive-effect report would not have run yet at this
+    // point, reproducing the reviewer's exact `{ deleted: false, member:
+    // true, inline: true, hosted: true }` red shape under the useEffect
+    // mutation below.
+    expect(snapshots[0].deleted).toBe(true);
+    expect(snapshots[0].member).toBe(false);
+    expect(snapshots[0].inline).toBe(true);
+  });
+
+  it("keeps a non-chat tile inline even with the switch ON", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [SPEC];
+    seedCanvas(tabs, SPEC.instanceId);
+    const { container } = render(groupView(tabs, SPEC.instanceId, true));
+
+    await waitFor(() => {
+      expect(testState.mounts.get(SPEC.id)).toBe(1);
+    });
+    expect(
+      container.querySelector(`[data-testid="tile-${SPEC.id}"]`),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="tile-surface-slot"]'),
+    ).toBeNull();
+  });
+
+  it("design-review F3: completes a deferred hosted activation on a real pointerdown+click on the hosted record itself", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    // Pane is not the active canvas pane - activation should flip activePaneId.
+    seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
+    const { container } = render(groupView(tabs, CHAT.instanceId, true));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="tile-surface-slot"]'),
+      ).not.toBeNull();
+    });
+
+    // Hosted chat body lives outside the physical pane (StableTileSurfaceHost
+    // plane, a sibling of paneRootRef's subtree). Build that sibling DOM by
+    // hand, stamped exactly as `TileSurfaceRecord` stamps a ready record.
+    const hostedRecord = document.createElement("div");
+    hostedRecord.setAttribute(
+      HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+      CHAT.instanceId,
+    );
+    hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "group-1");
+    hostedRecord.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, VIEW_TAB_ID);
+    document.body.appendChild(hostedRecord);
+    const hostedDeferred = document.createElement("button");
+    hostedDeferred.type = "button";
+    hostedDeferred.setAttribute("data-pane-activation-defer", "true");
+    hostedDeferred.setAttribute("data-testid", "hosted-deferred-activation");
+    hostedRecord.appendChild(hostedDeferred);
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("other-group");
+
+    // A real pointerdown directly on the hosted deferred marker - no
+    // physical-pane pointerdown involved - arms the deferred flag; the
+    // subsequent click on the same hosted element completes it.
+    fireEvent.pointerDown(hostedDeferred);
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("other-group");
+    fireEvent.click(hostedDeferred);
+
+    await waitFor(() => {
+      expect(
+        useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+      ).toBe("group-1");
+    });
+
+    hostedRecord.remove();
+  });
+
+  it("design-review F3: activates the pane immediately on a non-deferred pointerdown on a hosted record", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
+    const { container } = render(groupView(tabs, CHAT.instanceId, true));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="tile-surface-slot"]'),
+      ).not.toBeNull();
+    });
+
+    const hostedRecord = document.createElement("div");
+    hostedRecord.setAttribute(
+      HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+      CHAT.instanceId,
+    );
+    hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "group-1");
+    hostedRecord.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, VIEW_TAB_ID);
+    document.body.appendChild(hostedRecord);
+    const hostedBody = document.createElement("div");
+    hostedBody.setAttribute("data-testid", "hosted-non-deferred-body");
+    hostedRecord.appendChild(hostedBody);
+
+    // No `data-pane-activation-defer` anywhere on this target - ordinary
+    // hosted clicks must activate on pointerdown itself, same as an ordinary
+    // physical-pane pointerdown does via `handlePointerDownCapture`.
+    fireEvent.pointerDown(hostedBody);
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("group-1");
+
+    hostedRecord.remove();
+  });
+
+  it("does not activate this pane when a hosted pointerdown belongs to a different paneId", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
+    const { container } = render(groupView(tabs, CHAT.instanceId, true));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="tile-surface-slot"]'),
+      ).not.toBeNull();
+    });
+
+    const foreignHosted = document.createElement("div");
+    foreignHosted.setAttribute(
+      HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+      "inst-other-chat",
+    );
+    foreignHosted.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "sibling-pane");
+    foreignHosted.setAttribute(
+      HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
+      "other-view-tab",
+    );
+    document.body.appendChild(foreignHosted);
+    const foreignBody = document.createElement("div");
+    foreignBody.setAttribute("data-testid", "foreign-hosted-body");
+    foreignHosted.appendChild(foreignBody);
+
+    fireEvent.pointerDown(foreignBody);
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("other-group");
+
+    foreignHosted.remove();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -33,10 +33,13 @@ import {
   resetTileSurfaceMembershipForTesting,
 } from "@/components/epic-canvas/surface-host/tile-surface-membership";
 import {
+  getTileSurfaceEnvironment,
   publishTileSurfaceEnvironment,
   resetTileSurfaceEnvironmentRegistryForTesting,
 } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
 import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 
 const VIEW_TAB_ID = "view-tab-1";
 
@@ -908,6 +911,64 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     expect(
       useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
     ).toBe("group-1");
+  });
+
+  it("publishes the hosted control's pane activation focus intent through the real slot", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const tabs = [CHAT];
+    seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
+    useEpicCanvasStore.setState((state) => ({
+      ...state,
+      openTabOrder: [VIEW_TAB_ID],
+    }));
+    const ref: TabRef = { kind: "epic", id: VIEW_TAB_ID };
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
+      activeItemId: `tab:${ref.kind}:${ref.id}`,
+      stripOrder: [ref],
+    }));
+    resetTileSurfaceEnvironmentRegistryForTesting();
+    const openEpicHandle = {} as OpenEpicStoreHandle;
+
+    render(
+      <EpicSessionContext.Provider value={openEpicHandle}>
+        <TooltipProvider>
+          <PaneVisibilityContext.Provider value>
+            <TabGroupView
+              epicId="epic-1"
+              tabId={VIEW_TAB_ID}
+              pane={pane(tabs, CHAT.instanceId)}
+            />
+            <StableTileSurfaceHost
+              renderRecordBody={() => (
+                <button type="button" data-testid="hosted-focus-owner">
+                  Hosted action
+                </button>
+              )}
+            />
+          </PaneVisibilityContext.Provider>
+        </TooltipProvider>
+      </EpicSessionContext.Provider>,
+    );
+
+    const hostedControl = await screen.findByTestId("hosted-focus-owner");
+    expect(
+      getTileSurfaceEnvironment(
+        CHAT.instanceId,
+      )?.paneActivation.focusIntent.shouldYieldAutoFocus(),
+    ).toBe(false);
+
+    fireEvent.pointerDown(hostedControl);
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("group-1");
+    expect(
+      getTileSurfaceEnvironment(
+        CHAT.instanceId,
+      )?.paneActivation.focusIntent.shouldYieldAutoFocus(),
+    ).toBe(true);
   });
 
   it("does not activate this pane when a hosted pointerdown belongs to a different paneId", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -184,6 +184,13 @@ vi.mock("@/components/epic-canvas/renderers/epic-node-tile", async () => {
         >
           Deferred action that replaces itself
         </button>
+        <button
+          type="button"
+          data-testid={`stopped-pointer-activation-${props.id}`}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          Stopped pointer action
+        </button>
       </div>
     );
   }
@@ -290,6 +297,44 @@ function groupView(
         />
       </PaneVisibilityContext.Provider>
     </TooltipProvider>
+  );
+}
+
+const OPEN_EPIC_HANDLE = {} as OpenEpicStoreHandle;
+
+function seedHostedTopLevelTab(): void {
+  useEpicCanvasStore.setState((state) => ({
+    ...state,
+    openTabOrder: [VIEW_TAB_ID],
+  }));
+  const ref: TabRef = { kind: "epic", id: VIEW_TAB_ID };
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
+    activeItemId: `tab:${ref.kind}:${ref.id}`,
+    stripOrder: [ref],
+  }));
+}
+
+function hostedGroupView(
+  renderRecordBody: () => ReactNode,
+  onPointerDownCapture: (() => void) | undefined,
+): ReactNode {
+  return (
+    <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+      <TooltipProvider>
+        <PaneVisibilityContext.Provider value>
+          <div onPointerDownCapture={onPointerDownCapture}>
+            <TabGroupView
+              epicId="epic-1"
+              tabId={VIEW_TAB_ID}
+              pane={pane([CHAT], CHAT.instanceId)}
+            />
+            <StableTileSurfaceHost renderRecordBody={renderRecordBody} />
+          </div>
+        </PaneVisibilityContext.Provider>
+      </TooltipProvider>
+    </EpicSessionContext.Provider>
   );
 }
 
@@ -420,6 +465,21 @@ describe("<TabGroupView />", () => {
         useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
       ).toBe("group-1");
     });
+  });
+
+  it("activates a physical pane before a descendant stops pointerdown propagation", async () => {
+    const tabs = [SPEC];
+    seedCanvasWithActivePane(tabs, SPEC.instanceId, "other-group");
+    render(groupView(tabs, SPEC.instanceId, true));
+
+    const stoppedPointer = await screen.findByTestId(
+      `stopped-pointer-activation-${SPEC.id}`,
+    );
+    fireEvent.pointerDown(stoppedPointer);
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("group-1");
   });
 
   it("activates after a deferred child removes itself during its click action", async () => {
@@ -832,31 +892,24 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     const tabs = [CHAT];
     // Pane is not the active canvas pane - activation should flip activePaneId.
     seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
-    const { container } = render(groupView(tabs, CHAT.instanceId, true));
-
-    await waitFor(() => {
-      expect(
-        container.querySelector('[data-testid="tile-surface-slot"]'),
-      ).not.toBeNull();
-    });
-
-    // Hosted chat body lives outside the physical pane (StableTileSurfaceHost
-    // plane, a sibling of paneRootRef's subtree). Build that sibling DOM by
-    // hand, stamped exactly as `TileSurfaceRecord` stamps a ready record.
-    const hostedRecord = document.createElement("div");
-    hostedRecord.setAttribute(
-      HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
-      CHAT.instanceId,
+    seedHostedTopLevelTab();
+    render(
+      hostedGroupView(
+        () => (
+          <button
+            type="button"
+            {...paneActivationDeferProps}
+            data-testid="hosted-deferred-activation"
+          >
+            Deferred hosted action
+          </button>
+        ),
+        undefined,
+      ),
     );
-    hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "group-1");
-    hostedRecord.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, VIEW_TAB_ID);
-    document.body.appendChild(hostedRecord);
-    onTestFinished(() => hostedRecord.remove());
-    const hostedDeferred = document.createElement("button");
-    hostedDeferred.type = "button";
-    hostedDeferred.setAttribute("data-pane-activation-defer", "true");
-    hostedDeferred.setAttribute("data-testid", "hosted-deferred-activation");
-    hostedRecord.appendChild(hostedDeferred);
+    const hostedDeferred = await screen.findByTestId(
+      "hosted-deferred-activation",
+    );
 
     expect(
       useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
@@ -882,26 +935,14 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     testState.stableTileSurfaceHostEnabled = true;
     const tabs = [CHAT];
     seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
-    const { container } = render(groupView(tabs, CHAT.instanceId, true));
-
-    await waitFor(() => {
-      expect(
-        container.querySelector('[data-testid="tile-surface-slot"]'),
-      ).not.toBeNull();
-    });
-
-    const hostedRecord = document.createElement("div");
-    hostedRecord.setAttribute(
-      HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
-      CHAT.instanceId,
+    seedHostedTopLevelTab();
+    render(
+      hostedGroupView(
+        () => <div data-testid="hosted-non-deferred-body" />,
+        undefined,
+      ),
     );
-    hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "group-1");
-    hostedRecord.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, VIEW_TAB_ID);
-    document.body.appendChild(hostedRecord);
-    onTestFinished(() => hostedRecord.remove());
-    const hostedBody = document.createElement("div");
-    hostedBody.setAttribute("data-testid", "hosted-non-deferred-body");
-    hostedRecord.appendChild(hostedBody);
+    const hostedBody = await screen.findByTestId("hosted-non-deferred-body");
 
     // No `data-pane-activation-defer` anywhere on this target - ordinary
     // hosted clicks must activate on pointerdown itself, same as an ordinary
@@ -913,43 +954,117 @@ describe("<TabGroupView /> stable tile surface host routing (switch ON)", () => 
     ).toBe("group-1");
   });
 
+  it("activates a hosted pane before a descendant stops pointerdown propagation", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    seedCanvasWithActivePane([CHAT], CHAT.instanceId, "other-group");
+    seedHostedTopLevelTab();
+    render(
+      hostedGroupView(
+        () => (
+          <button
+            type="button"
+            data-testid="hosted-stopped-pointer"
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            Hosted stopped pointer action
+          </button>
+        ),
+        undefined,
+      ),
+    );
+
+    fireEvent.pointerDown(await screen.findByTestId("hosted-stopped-pointer"));
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("group-1");
+  });
+
+  it("does not let descendant pointerdown preventDefault suppress a hosted claim", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    seedCanvasWithActivePane([CHAT], CHAT.instanceId, "other-group");
+    seedHostedTopLevelTab();
+    render(
+      hostedGroupView(
+        () => (
+          <button
+            type="button"
+            data-testid="hosted-prevented-pointer"
+            onPointerDown={(event) => event.preventDefault()}
+          >
+            Hosted prevented pointer action
+          </button>
+        ),
+        undefined,
+      ),
+    );
+
+    fireEvent.pointerDown(
+      await screen.findByTestId("hosted-prevented-pointer"),
+    );
+
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID]?.activePaneId,
+    ).toBe("group-1");
+  });
+
+  it("keeps the hosted claim structurally after document capture and before descendants across a full remount", async () => {
+    testState.stableTileSurfaceHostEnabled = true;
+    const order: string[] = [];
+    const unsubscribe = useEpicCanvasStore.subscribe((next, previous) => {
+      const nextPaneId = next.canvasByTabId[VIEW_TAB_ID]?.activePaneId ?? null;
+      const previousPaneId =
+        previous.canvasByTabId[VIEW_TAB_ID]?.activePaneId ?? null;
+      if (nextPaneId === "group-1" && previousPaneId !== "group-1") {
+        order.push("claim");
+      }
+    });
+    onTestFinished(unsubscribe);
+    // This wrapper is structurally below document but above the hosted plane.
+    // Seeing it before the claim, and the target after the claim, proves the
+    // document marker has completed before the plane dispatches ownership.
+    const renderOrderingHarness = () =>
+      hostedGroupView(
+        () => (
+          <div
+            data-testid="hosted-ordering-target"
+            onPointerDownCapture={() => order.push("descendant")}
+          />
+        ),
+        () => order.push("plane-ancestor"),
+      );
+
+    seedCanvasWithActivePane([CHAT], CHAT.instanceId, "other-group");
+    seedHostedTopLevelTab();
+    let rendered = render(renderOrderingHarness());
+    fireEvent.pointerDown(await screen.findByTestId("hosted-ordering-target"));
+    expect(order).toEqual(["plane-ancestor", "claim", "descendant"]);
+
+    rendered.unmount();
+    seedCanvasWithActivePane([CHAT], CHAT.instanceId, "other-group");
+    seedHostedTopLevelTab();
+    order.length = 0;
+    rendered = render(renderOrderingHarness());
+    fireEvent.pointerDown(await screen.findByTestId("hosted-ordering-target"));
+    expect(order).toEqual(["plane-ancestor", "claim", "descendant"]);
+    rendered.unmount();
+  });
+
   it("publishes the hosted control's pane activation focus intent through the real slot", async () => {
     testState.stableTileSurfaceHostEnabled = true;
     const tabs = [CHAT];
     seedCanvasWithActivePane(tabs, CHAT.instanceId, "other-group");
-    useEpicCanvasStore.setState((state) => ({
-      ...state,
-      openTabOrder: [VIEW_TAB_ID],
-    }));
-    const ref: TabRef = { kind: "epic", id: VIEW_TAB_ID };
-    useTabsStore.setState((state) => ({
-      ...state,
-      items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
-      activeItemId: `tab:${ref.kind}:${ref.id}`,
-      stripOrder: [ref],
-    }));
+    seedHostedTopLevelTab();
     resetTileSurfaceEnvironmentRegistryForTesting();
-    const openEpicHandle = {} as OpenEpicStoreHandle;
-
     render(
-      <EpicSessionContext.Provider value={openEpicHandle}>
-        <TooltipProvider>
-          <PaneVisibilityContext.Provider value>
-            <TabGroupView
-              epicId="epic-1"
-              tabId={VIEW_TAB_ID}
-              pane={pane(tabs, CHAT.instanceId)}
-            />
-            <StableTileSurfaceHost
-              renderRecordBody={() => (
-                <button type="button" data-testid="hosted-focus-owner">
-                  Hosted action
-                </button>
-              )}
-            />
-          </PaneVisibilityContext.Provider>
-        </TooltipProvider>
-      </EpicSessionContext.Provider>,
+      hostedGroupView(
+        () => (
+          <button type="button" data-testid="hosted-focus-owner">
+            Hosted action
+          </button>
+        ),
+        undefined,
+      ),
     );
 
     const hostedControl = await screen.findByTestId("hosted-focus-owner");

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -38,6 +38,10 @@ import {
   resetPaneActivationFocusIntentsForTests,
   usePaneActivationOwnership,
 } from "@/components/epic-canvas/pane-activation";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 
 type CanvasStoreSlice = Pick<
   EpicCanvasStore,
@@ -1175,6 +1179,121 @@ describe("useEpicRouteSynchronization", () => {
       expect(document.activeElement).toBe(renameInputEl);
     } finally {
       paneEl.remove();
+    }
+  });
+
+  it("ticket 21 slice 4: prefers the hosted record over the real selected physical wrapper (design-review F4)", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-hosted",
+      [specTile("chat-hosted", "tile-hosted", "Hosted chat")],
+      "tile-hosted",
+    );
+
+    // Physical pane AND the real selected-tab wrapper `TabGroupView` keeps
+    // mounted around `TileSurfaceSlot`'s bare geometry anchor for a hosted
+    // chat - both carry the SAME instanceId a naive physical-only query would
+    // match first. Its presence must not shadow the hosted fallback.
+    const paneEl = document.createElement("div");
+    paneEl.setAttribute("data-group-id", "pane-hosted");
+    paneEl.setAttribute("data-active", "true");
+    paneEl.tabIndex = -1;
+    document.body.appendChild(paneEl);
+
+    const selectedWrapperEl = document.createElement("div");
+    selectedWrapperEl.setAttribute("data-tab-instance-id", "tile-hosted");
+    selectedWrapperEl.setAttribute("data-selected", "true");
+    selectedWrapperEl.tabIndex = -1;
+    document.body.appendChild(selectedWrapperEl);
+
+    const hostedRecord = document.createElement("div");
+    hostedRecord.setAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE, "tile-hosted");
+    hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "pane-hosted");
+    hostedRecord.tabIndex = -1;
+    document.body.appendChild(hostedRecord);
+
+    // Park focus elsewhere so focusNestedRouteTarget will pull it onto the
+    // resolved element (rather than no-opping because focus is already inside).
+    const outside = document.createElement("button");
+    outside.type = "button";
+    document.body.appendChild(outside);
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    try {
+      renderHook(
+        (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+        {
+          initialProps: {
+            epicId: EPIC_ID,
+            tabId: TAB_ID,
+            focusedAt: undefined,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            focusPaneId: "pane-hosted",
+            focusTileInstanceId: "tile-hosted",
+          },
+        },
+      );
+
+      await flushFocusRestore();
+      // Direct signal: focus landed on the hosted record, NOT the real
+      // selected physical wrapper that is also present and would otherwise
+      // be found first by the physical query.
+      expect(document.activeElement).toBe(hostedRecord);
+      expect(document.activeElement).not.toBe(selectedWrapperEl);
+    } finally {
+      outside.remove();
+      hostedRecord.remove();
+      selectedWrapperEl.remove();
+      paneEl.remove();
+    }
+  });
+
+  it("ticket 21 slice 4: falls back to the physical selected wrapper when no hosted record exists (switch-off parity)", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-unhosted",
+      [specTile("chat-unhosted", "tile-unhosted", "Unhosted chat")],
+      "tile-unhosted",
+    );
+
+    // No hosted record anywhere - mirrors the switch-off / non-chat-tile
+    // shape, where `findHostedTileElement` always misses and the ORIGINAL
+    // physical lookup must still resolve exactly as it did before F4.
+    const selectedWrapperEl = document.createElement("div");
+    selectedWrapperEl.setAttribute("data-tab-instance-id", "tile-unhosted");
+    selectedWrapperEl.setAttribute("data-selected", "true");
+    selectedWrapperEl.tabIndex = -1;
+    document.body.appendChild(selectedWrapperEl);
+
+    const outside = document.createElement("button");
+    outside.type = "button";
+    document.body.appendChild(outside);
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    try {
+      renderHook(
+        (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+        {
+          initialProps: {
+            epicId: EPIC_ID,
+            tabId: TAB_ID,
+            focusedAt: undefined,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            focusPaneId: "pane-unhosted",
+            focusTileInstanceId: "tile-unhosted",
+          },
+        },
+      );
+
+      await flushFocusRestore();
+      expect(document.activeElement).toBe(selectedWrapperEl);
+    } finally {
+      outside.remove();
+      selectedWrapperEl.remove();
     }
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
@@ -11,7 +11,7 @@ function renderHandle(
   sizes: ReadonlyArray<number>,
   onCommitSizes: (groupId: string, sizes: ReadonlyArray<number>) => void,
 ) {
-  render(
+  const rendered = render(
     <div data-testid="split-container" className="flex">
       <div
         data-split-child
@@ -42,6 +42,7 @@ function renderHandle(
     handle: screen.getByRole("slider", { name: "Resize pane" }),
     left: screen.getByTestId("child-left"),
     right: screen.getByTestId("child-right"),
+    unmount: rendered.unmount,
   };
 }
 
@@ -144,6 +145,256 @@ describe("<SplitResizeHandle />", () => {
     expect(groupId).toBe(GROUP_ID);
     expect(committed[0]).toBeCloseTo(0.6, 10);
     expect(committed[1]).toBeCloseTo(0.4, 10);
+  });
+
+  // Ticket 21 wave-2 live pass (row 1): a live divider drag under a
+  // stacked-plane layout showed `onDragStart` succeeding (capture engaged)
+  // while every subsequent move/up event silently failed to reach the
+  // handle's own listeners - jsdom cannot reproduce the browser's real hit-
+  // testing/pointer-capture behavior (both are stubbed to inert no-ops in
+  // this repo's test setup), so this pin instead proves the actual
+  // guarantee the fix provides: once a drag starts, move/up delivery no
+  // longer depends on the event's native target being the handle at all. A
+  // "decoy" element standing in for an occluding later-DOM sibling receives
+  // the move/up events directly; the drag must still progress and commit.
+  it("continues and commits a drag even when move/up events target an unrelated overlapping element, not the handle", () => {
+    const onCommitSizes =
+      vi.fn<(groupId: string, sizes: ReadonlyArray<number>) => void>();
+    const { handle, left, right } = renderHandle([0.5, 0.5], onCommitSizes);
+    const decoy = document.createElement("div");
+    decoy.setAttribute("data-testid", "decoy-overlay");
+    document.body.appendChild(decoy);
+
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 5,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    // Simulates the browser routing this move to an occluding element
+    // instead of the handle: dispatched on `decoy`, not `handle`.
+    fireEvent(
+      decoy,
+      pointerEvent("pointermove", {
+        pointerId: 5,
+        clientX: 600,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(flexGrowOf(left)).toBeCloseTo(0.6, 10);
+    expect(flexGrowOf(right)).toBeCloseTo(0.4, 10);
+    expect(onCommitSizes).not.toHaveBeenCalled();
+
+    fireEvent(
+      decoy,
+      pointerEvent("pointerup", {
+        pointerId: 5,
+        clientX: 600,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(onCommitSizes).toHaveBeenCalledTimes(1);
+    const [groupId, committed] = onCommitSizes.mock.calls[0];
+    expect(groupId).toBe(GROUP_ID);
+    expect(committed[0]).toBeCloseTo(0.6, 10);
+    expect(committed[1]).toBeCloseTo(0.4, 10);
+
+    document.body.removeChild(decoy);
+  });
+
+  // Ticket 21 wave-2 live pass, fix round 2 (F1): moving move/up/cancel to
+  // window listeners means blur must be a terminal event this hook owns
+  // directly - `beginPanelResizeInteraction`'s own blur cleanup only clears
+  // the shared interaction id for the CSS class, it has no idea `dragRef`
+  // exists. Without the hook's own blur listener, a later window move still
+  // mutates flexGrow even though the resize-freeze lifecycle already ended.
+  it("blur cancels the drag outright: no later frames apply, nothing commits, fractions restore, and a fresh drag starts cleanly", () => {
+    const onCommitSizes =
+      vi.fn<(groupId: string, sizes: ReadonlyArray<number>) => void>();
+    const { handle, left, right } = renderHandle([0.5, 0.5], onCommitSizes);
+
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 78,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      handle,
+      pointerEvent("pointermove", {
+        pointerId: 78,
+        clientX: 600,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(flexGrowOf(left)).toBeCloseTo(0.6, 10);
+    expect(
+      document.documentElement.classList.contains("traycer-panel-resizing"),
+    ).toBe(true);
+
+    fireEvent(window, new Event("blur"));
+
+    // Terminal: the class lifecycle ends immediately, and the pair is
+    // restored to the pre-drag committed fractions (the cancel semantic),
+    // not left frozen at the mid-drag value.
+    expect(
+      document.documentElement.classList.contains("traycer-panel-resizing"),
+    ).toBe(false);
+    expect(flexGrowOf(left)).toBeCloseTo(0.5, 10);
+    expect(flexGrowOf(right)).toBeCloseTo(0.5, 10);
+    expect(onCommitSizes).not.toHaveBeenCalled();
+
+    // A later window move for the SAME pointerId must apply ZERO frames -
+    // this is F1's exact regression: before the fix, this moved 0.6 to 0.7.
+    fireEvent(
+      window,
+      pointerEvent("pointermove", {
+        pointerId: 78,
+        clientX: 700,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(flexGrowOf(left)).toBeCloseTo(0.5, 10);
+    expect(flexGrowOf(right)).toBeCloseTo(0.5, 10);
+    expect(onCommitSizes).not.toHaveBeenCalled();
+
+    // Clean re-entry: the module-global interaction id was released by the
+    // blur-cancel, so a fresh drag on the SAME handle works normally.
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 79,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      handle,
+      pointerEvent("pointermove", {
+        pointerId: 79,
+        clientX: 550,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(flexGrowOf(left)).toBeCloseTo(0.55, 10);
+    fireEvent(
+      handle,
+      pointerEvent("pointerup", {
+        pointerId: 79,
+        clientX: 550,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(onCommitSizes).toHaveBeenCalledTimes(1);
+    expect(onCommitSizes.mock.calls[0][0]).toBe(GROUP_ID);
+  });
+
+  // Ticket 21 wave-2 live pass, fix round 2 (F2): the pre-fix React-prop
+  // design died with the element on unmount for free. Once move/up/cancel
+  // are imperative window listeners, an unmount mid-drag must be an
+  // explicit teardown path, or the dead component's closures keep
+  // listening and a later release commits through them.
+  it("unmounting mid-drag detaches the window listeners: a later release commits nothing", () => {
+    const onCommitSizes =
+      vi.fn<(groupId: string, sizes: ReadonlyArray<number>) => void>();
+    const { handle, unmount } = renderHandle([0.5, 0.5], onCommitSizes);
+
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 77,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      handle,
+      pointerEvent("pointermove", {
+        pointerId: 77,
+        clientX: 600,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+
+    unmount();
+
+    // F2's exact regression: before the fix, this later release committed
+    // ("group-1", [0.6, 0.4]) through the dead component's closures.
+    fireEvent(
+      window,
+      pointerEvent("pointerup", {
+        pointerId: 77,
+        clientX: 600,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(onCommitSizes).not.toHaveBeenCalled();
+
+    // No listener residue: a later move for the same (dead) pointerId is
+    // also a no-op - nothing throws, nothing commits.
+    fireEvent(
+      window,
+      pointerEvent("pointermove", {
+        pointerId: 77,
+        clientX: 900,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(onCommitSizes).not.toHaveBeenCalled();
+    expect(
+      document.documentElement.classList.contains("traycer-panel-resizing"),
+    ).toBe(false);
+
+    // The module-global interaction id was released, so a FRESH handle's
+    // drag is not blocked by the unmounted one's teardown.
+    const second = renderHandle([0.5, 0.5], onCommitSizes);
+    fireEvent(
+      second.handle,
+      pointerEvent("pointerdown", {
+        pointerId: 81,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      second.handle,
+      pointerEvent("pointermove", {
+        pointerId: 81,
+        clientX: 560,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(flexGrowOf(second.left)).toBeCloseTo(0.56, 10);
+    fireEvent(
+      second.handle,
+      pointerEvent("pointerup", {
+        pointerId: 81,
+        clientX: 560,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(onCommitSizes).toHaveBeenCalledTimes(1);
+    expect(onCommitSizes.mock.calls[0][0]).toBe(GROUP_ID);
   });
 
   it("restores instead of committing when the drag returns to the starting fractions", () => {

--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
@@ -397,6 +397,68 @@ describe("<SplitResizeHandle />", () => {
     expect(onCommitSizes.mock.calls[0][0]).toBe(GROUP_ID);
   });
 
+  it("finishes cancellation when the browser has already released pointer capture", () => {
+    const onCommitSizes =
+      vi.fn<(groupId: string, sizes: ReadonlyArray<number>) => void>();
+    const { handle, unmount } = renderHandle([0.5, 0.5], onCommitSizes);
+    vi.spyOn(handle, "hasPointerCapture").mockReturnValue(false);
+    const releasePointerCapture = vi
+      .spyOn(handle, "releasePointerCapture")
+      .mockImplementation(() => {
+        throw new DOMException(
+          "Pointer capture was already lost",
+          "NotFoundError",
+        );
+      });
+
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 82,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+
+    expect(() => unmount()).not.toThrow();
+    expect(releasePointerCapture).not.toHaveBeenCalled();
+    expect(onCommitSizes).not.toHaveBeenCalled();
+    expect(
+      document.documentElement.classList.contains("traycer-panel-resizing"),
+    ).toBe(false);
+
+    const second = renderHandle([0.5, 0.5], onCommitSizes);
+    fireEvent(
+      second.handle,
+      pointerEvent("pointerdown", {
+        pointerId: 83,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      second.handle,
+      pointerEvent("pointermove", {
+        pointerId: 83,
+        clientX: 550,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      second.handle,
+      pointerEvent("pointerup", {
+        pointerId: 83,
+        clientX: 550,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    expect(onCommitSizes).toHaveBeenCalledTimes(1);
+  });
+
   it("restores instead of committing when the drag returns to the starting fractions", () => {
     const onCommitSizes =
       vi.fn<(groupId: string, sizes: ReadonlyArray<number>) => void>();

--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
@@ -1,5 +1,5 @@
 import "../../../../../__tests__/test-browser-apis";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { SplitResizeHandle } from "@/components/epic-canvas/canvas/resize-handle";
 import { pointerEvent } from "./test-pointer-events";
@@ -164,6 +164,7 @@ describe("<SplitResizeHandle />", () => {
     const decoy = document.createElement("div");
     decoy.setAttribute("data-testid", "decoy-overlay");
     document.body.appendChild(decoy);
+    onTestFinished(() => decoy.remove());
 
     fireEvent(
       handle,
@@ -203,8 +204,6 @@ describe("<SplitResizeHandle />", () => {
     expect(groupId).toBe(GROUP_ID);
     expect(committed[0]).toBeCloseTo(0.6, 10);
     expect(committed[1]).toBeCloseTo(0.4, 10);
-
-    document.body.removeChild(decoy);
   });
 
   // Ticket 21 wave-2 live pass, fix round 2 (F1): moving move/up/cancel to

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -45,6 +45,7 @@ import {
   isPrDetailTileRef,
   isPrDiffTileRef,
 } from "@/stores/epics/canvas/types";
+import { resolveActivePaneTab } from "@/stores/epics/canvas/tile-tree";
 import {
   TILE_KIND_GIT_DIFF,
   TILE_KIND_PR_DETAIL,
@@ -274,12 +275,16 @@ export const TabGroupView = memo(function TabGroupView(
 
   const activeTab = useMemo<EpicCanvasTileRef | null>(() => {
     if (tabs.length === 0) return null;
+    const activeInstanceId = resolveActivePaneTab(
+      pane.activeTabId,
+      pane.tabInstanceIds,
+    );
     const explicit =
-      pane.activeTabId === null
-        ? null
-        : tabs.find((t) => t.instanceId === pane.activeTabId);
+      activeInstanceId === null
+        ? undefined
+        : tabs.find((t) => t.instanceId === activeInstanceId);
     return explicit ?? tabs[0];
-  }, [pane.activeTabId, tabs]);
+  }, [pane.activeTabId, pane.tabInstanceIds, tabs]);
   // Keep-alive mounting policy: pinned terminals ∪ LRU(cap 3) of recently
   // active tabs, with the active tab as the LRU head (so at most 3
   // non-terminal bodies are mounted, INCLUDING the active one); a hidden

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useMemo, useRef, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
 import { Button } from "@/components/ui/button";
 import {
   PaneActivationFocusIntentContext,
@@ -46,6 +54,11 @@ import {
   isPrDiffTileRef,
 } from "@/stores/epics/canvas/types";
 import { resolveActivePaneTab } from "@/stores/epics/canvas/tile-tree";
+import { surfaceOwnerFor } from "@/components/epic-canvas/surface-host/surface-owner";
+import { TileSurfaceSlot } from "@/components/epic-canvas/surface-host/tile-surface-slot";
+import { reportChatRemoteDeletionState } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import { resolveHostedTileOwnership } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
+import { HOSTED_TILE_RECORD_SELECTOR } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 import {
   TILE_KIND_GIT_DIFF,
   TILE_KIND_PR_DETAIL,
@@ -227,6 +240,7 @@ export const TabGroupView = memo(function TabGroupView(
     active: globallyActive,
     activate: activatePane,
   });
+  const { claimFocus, claimPointerDown } = paneActivation;
   const parentPaneFocusProbe = usePaneFocusProbe();
   const isPaneFocused = useCallback(
     () =>
@@ -234,6 +248,41 @@ export const TabGroupView = memo(function TabGroupView(
     [parentPaneFocusProbe],
   );
 
+  useEffect(() => {
+    const claimHostedPointerDown = (event: globalThis.PointerEvent): void => {
+      const { target } = event;
+      if (!(target instanceof Element)) return;
+      const ownership = resolveHostedTileOwnership(target);
+      if (ownership?.paneId !== pane.id) return;
+      claimPointerDown({
+        defaultPrevented: event.defaultPrevented,
+        scope: target.closest(HOSTED_TILE_RECORD_SELECTOR),
+        target,
+      });
+    };
+    const claimHostedFocus = (event: globalThis.FocusEvent): void => {
+      const { target } = event;
+      if (!(target instanceof Element)) return;
+      const ownership = resolveHostedTileOwnership(target);
+      if (ownership?.paneId !== pane.id) return;
+      claimFocus({
+        defaultPrevented: event.defaultPrevented,
+        scope: target.closest(HOSTED_TILE_RECORD_SELECTOR),
+        target,
+      });
+    };
+    // Hosted records are physical siblings of the pane root, so its React
+    // capture handlers cannot see these gestures. Reuse the current pane
+    // activation owner instead of reviving the older parallel deferred-click
+    // state machine; its document gesture ledger retains stopped-propagation,
+    // pointer-cancel, focus-intent, and next-task completion behavior.
+    document.addEventListener("pointerdown", claimHostedPointerDown);
+    document.addEventListener("focusin", claimHostedFocus);
+    return () => {
+      document.removeEventListener("pointerdown", claimHostedPointerDown);
+      document.removeEventListener("focusin", claimHostedFocus);
+    };
+  }, [claimFocus, claimPointerDown, pane.id]);
   const handleSplitFromMenu = useCallback(
     (
       groupId: string,
@@ -464,6 +513,41 @@ function ActiveTabBody(props: ActiveTabBodyProps) {
         });
   const isActive = role !== null && props.selected && props.globallyActive;
 
+  // Reports the SAME isRemoteDeleted value this render already uses for the
+  // inline DeletedArtifactBody branch below, into the outside-React registry
+  // `tile-surface-membership.ts`'s eligibility check reads - see
+  // `remote-deleted-chat-registry.ts`. Chat-only: membership only ever tracks
+  // chat instanceIds. Unregisters (reports false) on unmount so a closed
+  // tab's entry never lingers.
+  //
+  // A LAYOUT effect, not a passive one (design-review slice-4 F2 residual):
+  // this render already commits to the inline `DeletedArtifactBody` branch
+  // below for a remote-deleted chat, but that alone doesn't remove the
+  // hosted owner - `tile-surface-membership.ts`, `tile-surface-environment-
+  // registry.ts`, and `StableTileSurfaceHost`'s record all only react to
+  // THIS report. Every link in that reaction chain is synchronous
+  // (`remote-deleted-chat-registry.ts`'s listener notification and
+  // `tile-surface-membership.ts`'s `recomputeMembership` both call their
+  // listeners in the same synchronous call stack this layout effect runs
+  // in; the `useSyncExternalStore` reads in `StableTileSurfaceHost`/
+  // `TileSurfaceRecord` force a synchronous re-render on notification by
+  // React's own tearing-avoidance contract). That forced re-render is its
+  // own, LATER React commit - not interleaved into this commit's own layout-
+  // effect list - but it is still fully synchronous and still resolves
+  // strictly before the browser paints, so reporting from a layout effect
+  // still closes the gap: the hosted record is gone and membership has
+  // dropped the instance before anything is painted, never visible
+  // alongside the inline deleted body (verified with a raw non-`act()`
+  // macrotask probe - a same-commit sibling layout-effect probe cannot
+  // observe this because it necessarily samples before that later commit).
+  useLayoutEffect(() => {
+    if (activeTab.type !== "chat") return undefined;
+    reportChatRemoteDeletionState(activeTab.instanceId, isRemoteDeleted);
+    return () => {
+      reportChatRemoteDeletionState(activeTab.instanceId, false);
+    };
+  }, [activeTab.type, activeTab.instanceId, isRemoteDeleted]);
+
   if (isRemoteDeleted) {
     return (
       <DeletedArtifactBody
@@ -476,6 +560,19 @@ function ActiveTabBody(props: ActiveTabBodyProps) {
             ),
           );
         }}
+      />
+    );
+  }
+
+  if (surfaceOwnerFor({ node: activeTab, isRemoteDeleted }) === "hosted") {
+    return (
+      <TileSurfaceSlot
+        node={activeTab}
+        epicId={epicId}
+        paneId={groupId}
+        viewTabId={tabId}
+        tabSelected={props.selected}
+        canvasPaneActive={props.globallyActive}
       />
     );
   }

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   PaneActivationFocusIntentContext,
+  registerHostedPaneActivationClaim,
   usePaneActivationOwnership,
 } from "@/components/epic-canvas/pane-activation";
 import { cn } from "@/lib/utils";
@@ -248,18 +249,12 @@ export const TabGroupView = memo(function TabGroupView(
     [parentPaneFocusProbe],
   );
 
+  useLayoutEffect(
+    () => registerHostedPaneActivationClaim(tabId, pane.id, claimPointerDown),
+    [claimPointerDown, pane.id, tabId],
+  );
+
   useEffect(() => {
-    const claimHostedPointerDown = (event: globalThis.PointerEvent): void => {
-      const { target } = event;
-      if (!(target instanceof Element)) return;
-      const ownership = resolveHostedTileOwnership(target);
-      if (ownership?.paneId !== pane.id) return;
-      claimPointerDown({
-        defaultPrevented: event.defaultPrevented,
-        scope: target.closest(HOSTED_TILE_RECORD_SELECTOR),
-        target,
-      });
-    };
     const claimHostedFocus = (event: globalThis.FocusEvent): void => {
       const { target } = event;
       if (!(target instanceof Element)) return;
@@ -272,17 +267,14 @@ export const TabGroupView = memo(function TabGroupView(
       });
     };
     // Hosted records are physical siblings of the pane root, so its React
-    // capture handlers cannot see these gestures. Reuse the current pane
-    // activation owner instead of reviving the older parallel deferred-click
-    // state machine; its document gesture ledger retains stopped-propagation,
-    // pointer-cancel, focus-intent, and next-task completion behavior.
-    document.addEventListener("pointerdown", claimHostedPointerDown);
+    // focus capture handler cannot see them. Pointer claims are dispatched
+    // from the surface plane's capture handler; focus keeps this document
+    // bridge because focus ownership has no gesture-ordering dependency.
     document.addEventListener("focusin", claimHostedFocus);
     return () => {
-      document.removeEventListener("pointerdown", claimHostedPointerDown);
       document.removeEventListener("focusin", claimHostedFocus);
     };
-  }, [claimFocus, claimPointerDown, pane.id]);
+  }, [claimFocus, pane.id]);
   const handleSplitFromMenu = useCallback(
     (
       groupId: string,

--- a/clients/gui-app/src/components/epic-canvas/canvas/use-pointer-drag-commit.ts
+++ b/clients/gui-app/src/components/epic-canvas/canvas/use-pointer-drag-commit.ts
@@ -15,8 +15,46 @@
  * in `onDragFrame`, and decide what commit/restore mean for their store.
  * During a drag NO React state changes - `onDragFrame` must mutate the DOM
  * directly; the single store write happens in `onDragCommit`.
+ *
+ * Ticket 21 wave-2 live pass (row 1): once `onDragStart` succeeds, move/up/
+ * cancel/blur are handled via `window`-level listeners rather than React
+ * props on the handle. `setPointerCapture` is supposed to make the handle
+ * the sole recipient of subsequent pointer events regardless of what else
+ * is under the cursor, but a live divider drag under a stacked-plane layout
+ * (a later DOM-order sibling with its own `pointer-events:auto` content
+ * abutting the handle's seam) showed `onDragStart` succeeding (capture
+ * engaged, the `traycer-panel-resizing` class active) while every
+ * subsequent move/up event silently failed to reach the handle's own
+ * listeners for the duration of the drag - not reproducible in jsdom, since
+ * this repo's test setup stubs both `setPointerCapture` and
+ * `elementFromPoint` to inert no-ops (jsdom implements neither real pointer
+ * capture nor real hit-testing). A `window` listener is reached by the
+ * native event's normal bubble phase, independent of which element the
+ * browser ends up treating as the authoritative pointer-capture target.
+ *
+ * Fix-round 2 (same live pass): moving ownership to imperative `window`
+ * listeners means THIS hook alone is responsible for every terminal path,
+ * not just pointerup/pointercancel:
+ * - Blur must be a terminal event the hook itself owns (not just observed
+ *   via `beginPanelResizeInteraction`'s own blur cleanup, which only clears
+ *   the shared interaction id - it does not know about `dragRef` and cannot
+ *   detach this hook's listeners). Without the hook's own blur listener,
+ *   `onDragFrame` keeps firing on later moves after focus loss even though
+ *   the resize-freeze lifecycle already ended.
+ * - A component can unmount mid-drag (e.g. a structural op removes the
+ *   pane). React only runs effect cleanups on unmount, and this hook had no
+ *   effect - so nothing detached the listeners, and a later release could
+ *   commit through a dead component's closures.
+ * Every handler AND the detach function are declared inside `onPointerDown`
+ * itself (`function` declarations, not top-level consts, so they can
+ * reference each other regardless of textual order) and stored together on
+ * `dragRef.current`. This makes them exact per-drag identities - the same
+ * function references used to `addEventListener` are the ones used to
+ * `removeEventListener`, and both the unmount-cleanup effect and every
+ * window listener always act through the ONE currently-active drag record,
+ * never a stale one from an earlier or later render.
  */
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 import { beginPanelResizeInteraction } from "@/lib/layout/panel-resizing-class";
 
@@ -57,24 +95,31 @@ export interface UsePointerDragCommitArgs {
  * `aria-orientation` describes the divider line, which runs perpendicular
  * to the drag axis. Consumers add `aria-valuenow/min/max`, `aria-label`,
  * test ids, and className.
+ *
+ * Move/up/cancel are NOT exposed here - once a drag starts, they are handled
+ * by `window`-level listeners attached imperatively (see module doc), not by
+ * React props on the handle itself.
  */
 export interface PointerDragSliderProps {
   readonly role: "slider";
   readonly tabIndex: 0;
   readonly "aria-orientation": PointerDragAxis;
   readonly onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  readonly onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  readonly onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  readonly onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
   readonly onDoubleClick: () => void;
   readonly onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
 }
 
 interface ActivePointerDrag {
   readonly pointerId: number;
-  readonly startCoordinate: number;
-  readonly interactionId: number;
-  readonly stopPanelResizeInteraction: () => void;
+  readonly handleElement: HTMLDivElement;
+  /**
+   * Cancels this exact drag: detaches this exact drag's window listeners,
+   * releases pointer capture, stops the panel-resize interaction, and
+   * restores via `onDragCancel` - never commits. Bound at drag-start with
+   * that render's closures, so the unmount-cleanup effect (and blur) can
+   * call it correctly regardless of how many renders happened since.
+   */
+  readonly cancel: () => void;
 }
 
 let nextPointerResizeInteractionId = 0;
@@ -111,62 +156,113 @@ export function usePointerDragCommit(
   const horizontal = axis === "horizontal";
   const dragRef = useRef<ActivePointerDrag | null>(null);
 
-  const endDrag = (
-    event: ReactPointerEvent<HTMLDivElement>,
-    commit: boolean,
-  ): void => {
-    const drag = dragRef.current;
-    if (drag === null || drag.pointerId !== event.pointerId) return;
-    dragRef.current = null;
-    event.currentTarget.releasePointerCapture(event.pointerId);
-    const active = activePointerResizeInteractionId === drag.interactionId;
-    drag.stopPanelResizeInteraction();
-    if (commit && active) {
-      onDragCommit();
-      return;
+  // Unmount safety net (fix-round 2, F2): a drag active when this component
+  // unmounts (e.g. a structural op removes the pane mid-gesture) would
+  // otherwise leak its window listeners and let a LATER pointerup commit
+  // through a dead component. `drag.cancel` was captured at drag-start with
+  // THAT render's exact closures/listener identities, so calling it here is
+  // correct no matter how many (or how few) renders happened between
+  // drag-start and unmount - this effect's own closure is never involved.
+  useEffect(() => {
+    return () => {
+      dragRef.current?.cancel();
+    };
+  }, []);
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    if (event.button !== 0) return;
+    if (activePointerResizeInteractionId !== null) return;
+    if (!onDragStart(event)) return;
+    event.preventDefault();
+    const handleElement = event.currentTarget;
+    const pointerId = event.pointerId;
+    const startCoordinate = horizontal ? event.clientX : event.clientY;
+    handleElement.setPointerCapture(pointerId);
+    const interactionId = nextPointerResizeInteractionId + 1;
+    nextPointerResizeInteractionId = interactionId;
+    activePointerResizeInteractionId = interactionId;
+
+    // Declared as hoisted function declarations (not consts) so they can
+    // reference each other regardless of textual order - `finish` needs
+    // `detach`, `detach` needs the four handlers, three of the handlers need
+    // `finish`. All close over `pointerId`/`startCoordinate`/`handleElement`/
+    // `interactionId` from THIS `onPointerDown` invocation, never a
+    // different render's.
+    function handleMove(moveEvent: PointerEvent): void {
+      if (dragRef.current === null || moveEvent.pointerId !== pointerId) {
+        return;
+      }
+      onDragFrame(
+        (horizontal ? moveEvent.clientX : moveEvent.clientY) - startCoordinate,
+      );
     }
-    onDragCancel();
+    function handleUp(upEvent: PointerEvent): void {
+      if (dragRef.current === null || upEvent.pointerId !== pointerId) return;
+      finish(true);
+    }
+    function handlePointerCancelEvent(cancelEvent: PointerEvent): void {
+      if (dragRef.current === null || cancelEvent.pointerId !== pointerId) {
+        return;
+      }
+      finish(false);
+    }
+    // Blur is a terminal event this hook owns directly (fix-round 2, F1):
+    // `beginPanelResizeInteraction`'s own blur listener only clears the
+    // shared interaction id for the panel-resize CSS class - it has no
+    // knowledge of `dragRef` and cannot stop this hook from continuing to
+    // mutate geometry on a later move. Blur always cancels, never commits;
+    // it carries no pointerId to match against.
+    function handleBlur(): void {
+      finish(false);
+    }
+    function detach(): void {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      window.removeEventListener("pointercancel", handlePointerCancelEvent);
+      window.removeEventListener("blur", handleBlur);
+    }
+    function finish(commit: boolean): void {
+      if (dragRef.current === null) return;
+      dragRef.current = null;
+      detach();
+      handleElement.releasePointerCapture(pointerId);
+      const active = activePointerResizeInteractionId === interactionId;
+      stopPanelResizeInteraction();
+      if (commit && active) {
+        onDragCommit();
+        return;
+      }
+      onDragCancel();
+    }
+
+    // Registered before `beginPanelResizeInteraction`'s own window
+    // pointerup/pointercancel/blur listeners (below) so this hook's own
+    // commit/cancel decision - and its `stopPanelResizeInteraction()` call -
+    // always runs first; `stop()` is idempotent, so the panel-resizing
+    // class's own listener is then a harmless no-op for the same event.
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    window.addEventListener("pointercancel", handlePointerCancelEvent);
+    window.addEventListener("blur", handleBlur);
+    const stopPanelResizeInteraction = beginPanelResizeInteraction(
+      pointerId,
+      () => {
+        clearActivePointerResizeInteraction(interactionId);
+      },
+    );
+
+    dragRef.current = {
+      pointerId,
+      handleElement,
+      cancel: () => finish(false),
+    };
   };
 
   return {
     role: "slider",
     tabIndex: 0,
     "aria-orientation": horizontal ? "vertical" : "horizontal",
-    onPointerDown: (event) => {
-      if (event.button !== 0) return;
-      if (activePointerResizeInteractionId !== null) return;
-      if (!onDragStart(event)) return;
-      event.preventDefault();
-      event.currentTarget.setPointerCapture(event.pointerId);
-      const interactionId = nextPointerResizeInteractionId + 1;
-      nextPointerResizeInteractionId = interactionId;
-      activePointerResizeInteractionId = interactionId;
-      const stopPanelResizeInteraction = beginPanelResizeInteraction(
-        event.pointerId,
-        () => {
-          clearActivePointerResizeInteraction(interactionId);
-        },
-      );
-      dragRef.current = {
-        pointerId: event.pointerId,
-        startCoordinate: horizontal ? event.clientX : event.clientY,
-        interactionId,
-        stopPanelResizeInteraction,
-      };
-    },
-    onPointerMove: (event) => {
-      const drag = dragRef.current;
-      if (drag === null || drag.pointerId !== event.pointerId) return;
-      onDragFrame(
-        (horizontal ? event.clientX : event.clientY) - drag.startCoordinate,
-      );
-    },
-    onPointerUp: (event) => {
-      endDrag(event, true);
-    },
-    onPointerCancel: (event) => {
-      endDrag(event, false);
-    },
+    onPointerDown,
     onDoubleClick: onReset,
     onKeyDown: (event) => {
       const grow = horizontal ? "ArrowRight" : "ArrowDown";

--- a/clients/gui-app/src/components/epic-canvas/canvas/use-pointer-drag-commit.ts
+++ b/clients/gui-app/src/components/epic-canvas/canvas/use-pointer-drag-commit.ts
@@ -225,7 +225,9 @@ export function usePointerDragCommit(
       if (dragRef.current === null) return;
       dragRef.current = null;
       detach();
-      handleElement.releasePointerCapture(pointerId);
+      if (handleElement.hasPointerCapture(pointerId)) {
+        handleElement.releasePointerCapture(pointerId);
+      }
       const active = activePointerResizeInteractionId === interactionId;
       stopPanelResizeInteraction();
       if (commit && active) {

--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
@@ -526,9 +526,11 @@ export interface HeaderStripDropResult {
 
 /**
  * Drop of a canvas source onto the header tab strip. An existing artifact
- * tab tears off into a fresh header tab (clone semantics: new instance ids,
- * copied sidebar state); every other openable source opens in a new header
- * tab at the insertion index. Returns the new header tab for navigation.
+ * tab tears off into a fresh header tab (MOVE semantics: `tearOffTabIntoNew
+ * HeaderTab` preserves the tile's own instanceId, only the new header tab
+ * record gets a fresh id; sidebar state is copied); every other openable
+ * source opens in a new header tab at the insertion index. Returns the new
+ * header tab for navigation.
  */
 export function commitHeaderStripDrop(
   source: EpicCanvasDragSourceData,

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -35,6 +35,7 @@ import {
 import { consumeNestedRoutePrimaryEditorFocus } from "@/lib/nested-route-dom-focus";
 import { getNestedRouteApplicationDeferralMs } from "@/lib/nested-focus-navigation-intent";
 import { shouldYieldPaneActivationRouteFocus } from "@/components/epic-canvas/pane-activation";
+import { findHostedTileElement } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
 
 const PRIMARY_CHAT_COMPOSER_SELECTOR =
   "[data-chat-composer] [data-composer-editor]";
@@ -558,7 +559,22 @@ function findActivePaneElement(paneId: string): HTMLElement | null {
   );
 }
 
+/**
+ * A hosted chat's body no longer sits inside a `[data-tab-instance-id]`
+ * pane-tab layer - `TabGroupView` still keeps that selected wrapper mounted
+ * around `TileSurfaceSlot`'s bare geometry anchor (it carries layout, tab
+ * strip, and DnD target duties independent of hosting), so it is always
+ * found by the physical query and would shadow the hosted fallback if tried
+ * second (design-review slice-4 finding 4). The hosted record, when one
+ * exists for this exact `tileInstanceId`, is therefore checked FIRST: its
+ * presence unambiguously means the real body lives there, never in the
+ * physical wrapper. With the stable-tile-surface-host switch off (or for a
+ * non-hosted tile kind) no hosted record ever exists, so this falls straight
+ * through to the same physical lookup as before - byte-equivalent.
+ */
 function findSelectedTileElement(tileInstanceId: string): HTMLElement | null {
+  const hosted = findHostedTileElement(document, tileInstanceId);
+  if (hosted !== null) return hosted;
   const elements = document.querySelectorAll<HTMLElement>(
     "[data-tab-instance-id][data-selected='true']",
   );

--- a/clients/gui-app/src/components/epic-canvas/pane-activation.ts
+++ b/clients/gui-app/src/components/epic-canvas/pane-activation.ts
@@ -194,6 +194,39 @@ export interface PaneActivationClaimEvent {
   readonly target: EventTarget | null;
 }
 
+type HostedPaneActivationClaim = (event: PaneActivationClaimEvent) => void;
+
+const hostedPaneActivationClaims = new Map<
+  string,
+  Map<string, HostedPaneActivationClaim>
+>();
+
+export function registerHostedPaneActivationClaim(
+  viewTabId: string,
+  paneId: string,
+  claim: HostedPaneActivationClaim,
+): () => void {
+  let claimsByPane = hostedPaneActivationClaims.get(viewTabId);
+  if (claimsByPane === undefined) {
+    claimsByPane = new Map();
+    hostedPaneActivationClaims.set(viewTabId, claimsByPane);
+  }
+  claimsByPane.set(paneId, claim);
+  return () => {
+    if (claimsByPane.get(paneId) !== claim) return;
+    claimsByPane.delete(paneId);
+    if (claimsByPane.size === 0) hostedPaneActivationClaims.delete(viewTabId);
+  };
+}
+
+export function claimHostedPaneActivation(
+  viewTabId: string,
+  paneId: string,
+  event: PaneActivationClaimEvent,
+): void {
+  hostedPaneActivationClaims.get(viewTabId)?.get(paneId)?.(event);
+}
+
 interface PaneGestureSubscriber {
   readonly onClickCapture: () => void;
   readonly onPointerCancelCapture: () => void;

--- a/clients/gui-app/src/components/epic-canvas/pane-activation.ts
+++ b/clients/gui-app/src/components/epic-canvas/pane-activation.ts
@@ -180,10 +180,18 @@ export function runAfterPaneActivationFocusIntent(
 }
 
 export interface PaneActivationOwnership {
+  readonly claimFocus: (event: PaneActivationClaimEvent) => void;
+  readonly claimPointerDown: (event: PaneActivationClaimEvent) => void;
   readonly focusIntent: PaneActivationFocusIntent;
   readonly onFocusCapture: (event: FocusEvent<HTMLElement>) => void;
   readonly onPointerCancelCapture: () => void;
   readonly onPointerDownCapture: (event: PointerEvent<HTMLElement>) => void;
+}
+
+export interface PaneActivationClaimEvent {
+  readonly defaultPrevented: boolean;
+  readonly scope: EventTarget | null;
+  readonly target: EventTarget | null;
 }
 
 interface PaneGestureSubscriber {
@@ -291,11 +299,11 @@ export function usePaneActivationOwnership(input: {
     deferredGestureRef.current = null;
   }, []);
 
-  const onPointerDownCapture = useCallback(
-    (event: PointerEvent<HTMLElement>) => {
+  const claimPointerDown = useCallback(
+    (event: PaneActivationClaimEvent) => {
       if (active || event.defaultPrevented) return;
       if (ownsPaneActivationFocus(event.target)) {
-        mark(event.target, event.currentTarget);
+        mark(event.target, event.scope);
       }
       if (isPaneActivationDeferred(event.target)) {
         deferredGestureRef.current = gestureEpochRef.current;
@@ -307,16 +315,38 @@ export function usePaneActivationOwnership(input: {
     [activate, active, clearDeferredGesture, mark],
   );
 
-  const onFocusCapture = useCallback(
-    (event: FocusEvent<HTMLElement>) => {
+  const claimFocus = useCallback(
+    (event: PaneActivationClaimEvent) => {
       if (active || event.defaultPrevented) return;
       // Mouse focus inside a deferred subtree belongs to the in-flight action;
       // activation completes after its click, not midway through the gesture.
       if (deferredGestureRef.current !== null) return;
-      mark(event.target, event.currentTarget);
+      mark(event.target, event.scope);
       activate();
     },
     [activate, active, mark],
+  );
+
+  const onPointerDownCapture = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      claimPointerDown({
+        defaultPrevented: event.defaultPrevented,
+        scope: event.currentTarget,
+        target: event.target,
+      });
+    },
+    [claimPointerDown],
+  );
+
+  const onFocusCapture = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      claimFocus({
+        defaultPrevented: event.defaultPrevented,
+        scope: event.currentTarget,
+        target: event.target,
+      });
+    },
+    [claimFocus],
   );
 
   useEffect(() => {
@@ -356,6 +386,8 @@ export function usePaneActivationOwnership(input: {
   }, [clearDeferredGesture]);
 
   return {
+    claimFocus,
+    claimPointerDown,
     focusIntent,
     onFocusCapture,
     onPointerCancelCapture: clearDeferredGesture,

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-context-bridge.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-context-bridge.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Ticket 21 slice 4: pins the environment-to-context bridge for a hosted
+ * chat. Scope note - `renderTile` is swapped for a test probe that reads the
+ * bridged contexts and surfaces the `isActive` argument the bridge body
+ * computed. The full real-`renderTile` path is exercised transitively by the
+ * switch-ON ActiveTabBody routing tests; this file's job is narrowly "are
+ * the contexts wired right + isActive mirrors ActiveTabBody".
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { use } from "react";
+import type { ReactNode } from "react";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+import type { ReadyTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import { EpicViewTabContext } from "@/components/epic-canvas/view-tab-context";
+import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { usePanePortalContainer } from "@/components/epic-tabs/pane-visibility-context";
+
+const INSTANCE_ID = "chat-bridge-1";
+const VIEW_TAB_ID = "view-tab-bridge";
+const PANE_ID = "pane-bridge";
+const EPIC_ID = "epic-bridge";
+
+const CHAT_NODE = {
+  id: INSTANCE_ID,
+  instanceId: INSTANCE_ID,
+  type: "chat" as const,
+  name: "Bridge chat",
+  hostId: TEST_HOST_ID,
+};
+
+const OPEN_EPIC_HANDLE =
+  {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"];
+
+interface CaptureState {
+  lastIsActive: boolean | null;
+  lastViewTabId: string | null;
+  lastOpenEpicHandle: OpenEpicStoreHandle | null;
+  lastPanePortalContainer: HTMLElement | null;
+}
+
+const capture = vi.hoisted(
+  (): CaptureState => ({
+    lastIsActive: null,
+    lastViewTabId: null,
+    lastOpenEpicHandle: null,
+    lastPanePortalContainer: null,
+  }),
+);
+
+interface PermissionRoleState {
+  role: string | null;
+}
+
+const permissionRole = vi.hoisted(
+  (): PermissionRoleState => ({
+    role: "owner",
+  }),
+);
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicPermissionRole: () => permissionRole.role,
+}));
+
+vi.mock("@/components/epic-canvas/renderers/tile-render", () => ({
+  renderTile: (args: {
+    readonly isActive: boolean;
+    readonly viewTabId: string;
+  }): ReactNode => {
+    capture.lastIsActive = args.isActive;
+    // Probe lives under every context the bridge re-provides; reading them
+    // here proves the provider wiring without mounting ChatTile.
+    function Probe(): ReactNode {
+      capture.lastViewTabId = use(EpicViewTabContext);
+      capture.lastOpenEpicHandle = useOpenEpicHandle();
+      capture.lastPanePortalContainer = usePanePortalContainer();
+      return (
+        <div
+          data-testid="hosted-bridge-probe"
+          data-is-active={args.isActive ? "true" : "false"}
+          data-view-tab-id={args.viewTabId}
+        />
+      );
+    }
+    return <Probe />;
+  },
+}));
+
+// Import AFTER the mocks so HostedChatSurfaceContextBridge picks them up.
+import { HostedChatSurfaceContextBridge } from "@/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge";
+
+function seedChatTile(): void {
+  useEpicCanvasStore.setState({
+    tabsById: {
+      [VIEW_TAB_ID]: {
+        tabId: VIEW_TAB_ID,
+        epicId: EPIC_ID,
+        name: "Epic",
+      },
+    },
+    canvasByTabId: {
+      [VIEW_TAB_ID]: {
+        root: pane(PANE_ID, [INSTANCE_ID]),
+        activePaneId: PANE_ID,
+        tilesByInstanceId: { [INSTANCE_ID]: CHAT_NODE },
+        sizesByGroupId: {},
+      },
+    },
+    openTabOrder: [VIEW_TAB_ID],
+    activeTabId: VIEW_TAB_ID,
+  });
+}
+
+function buildEnvironment(
+  overrides: Partial<ReadyTileSurfaceEnvironment>,
+): ReadyTileSurfaceEnvironment {
+  return buildSyntheticTileSurfaceEnvironment(INSTANCE_ID, {
+    identity: {
+      instanceId: INSTANCE_ID,
+      tileKind: "chat",
+      contentId: INSTANCE_ID,
+      epicId: EPIC_ID,
+      hostId: TEST_HOST_ID,
+    },
+    placement: {
+      epicId: EPIC_ID,
+      viewTabId: VIEW_TAB_ID,
+      paneId: PANE_ID,
+      hostId: TEST_HOST_ID,
+    },
+    services: {
+      openEpicHandle: OPEN_EPIC_HANDLE,
+      geometryAnchorElement: document.createElement("div"),
+      panePortalContainer: null,
+      isPaneFocusedNow: () => false,
+    },
+    ...overrides,
+  });
+}
+
+function resetCapture(): void {
+  capture.lastIsActive = null;
+  capture.lastViewTabId = null;
+  capture.lastOpenEpicHandle = null;
+  capture.lastPanePortalContainer = null;
+  permissionRole.role = "owner";
+}
+
+describe("HostedChatSurfaceContextBridge", () => {
+  beforeEach(() => {
+    resetCapture();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    seedChatTile();
+  });
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    resetCapture();
+  });
+
+  it("re-provides EpicViewTabContext from environment.placement.viewTabId", () => {
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(screen.getByTestId("hosted-bridge-probe")).not.toBeNull();
+    expect(capture.lastViewTabId).toBe(VIEW_TAB_ID);
+    expect(
+      screen.getByTestId("hosted-bridge-probe").getAttribute("data-view-tab-id"),
+    ).toBe(VIEW_TAB_ID);
+  });
+
+  it("re-provides the SAME openEpicHandle object reference (no second EpicSessionProvider)", () => {
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(capture.lastOpenEpicHandle).toBe(OPEN_EPIC_HANDLE);
+    expect(capture.lastOpenEpicHandle).toBe(
+      environment.services.openEpicHandle,
+    );
+  });
+
+  it("computes isActive = role!==null && tabSelected && canvasPaneActive (true case)", () => {
+    permissionRole.role = "owner";
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(capture.lastIsActive).toBe(true);
+    expect(
+      screen.getByTestId("hosted-bridge-probe").getAttribute("data-is-active"),
+    ).toBe("true");
+  });
+
+  it("computes isActive = false when canvasPaneActive is false", () => {
+    permissionRole.role = "owner";
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: false },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(capture.lastIsActive).toBe(false);
+    expect(
+      screen.getByTestId("hosted-bridge-probe").getAttribute("data-is-active"),
+    ).toBe("false");
+  });
+
+  it("computes isActive = false when role is null", () => {
+    permissionRole.role = null;
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(capture.lastIsActive).toBe(false);
+  });
+
+  it("design-review F5: re-provides the REAL panePortalContainer value, not the slot's own geometry anchor", () => {
+    const realPortalHost = document.createElement("div");
+    const geometryAnchor = document.createElement("div");
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+      services: {
+        openEpicHandle: OPEN_EPIC_HANDLE,
+        geometryAnchorElement: geometryAnchor,
+        panePortalContainer: realPortalHost,
+        isPaneFocusedNow: () => false,
+      },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(capture.lastPanePortalContainer).toBe(realPortalHost);
+    expect(capture.lastPanePortalContainer).not.toBe(geometryAnchor);
+  });
+
+  it("renders nothing when the canvas tile is missing from the store", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {},
+      canvasByTabId: {},
+      openTabOrder: [],
+      activeTabId: null,
+    });
+    const environment = buildEnvironment({
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+    });
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(screen.queryByTestId("hosted-bridge-probe")).toBeNull();
+    expect(capture.lastIsActive).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-context-bridge.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-context-bridge.test.tsx
@@ -21,6 +21,10 @@ import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 import { EpicViewTabContext } from "@/components/epic-canvas/view-tab-context";
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { usePanePortalContainer } from "@/components/epic-tabs/pane-visibility-context";
+import {
+  usePaneActivationFocusIntent,
+  type PaneActivationFocusIntent,
+} from "@/components/epic-canvas/pane-activation";
 
 const INSTANCE_ID = "chat-bridge-1";
 const VIEW_TAB_ID = "view-tab-bridge";
@@ -43,6 +47,7 @@ interface CaptureState {
   lastViewTabId: string | null;
   lastOpenEpicHandle: OpenEpicStoreHandle | null;
   lastPanePortalContainer: HTMLElement | null;
+  lastPaneActivationFocusIntent: PaneActivationFocusIntent | null;
 }
 
 const capture = vi.hoisted((): CaptureState => ({
@@ -50,6 +55,7 @@ const capture = vi.hoisted((): CaptureState => ({
   lastViewTabId: null,
   lastOpenEpicHandle: null,
   lastPanePortalContainer: null,
+  lastPaneActivationFocusIntent: null,
 }));
 
 interface PermissionRoleState {
@@ -76,6 +82,7 @@ vi.mock("@/components/epic-canvas/renderers/tile-render", () => ({
       capture.lastViewTabId = use(EpicViewTabContext);
       capture.lastOpenEpicHandle = useOpenEpicHandle();
       capture.lastPanePortalContainer = usePanePortalContainer();
+      capture.lastPaneActivationFocusIntent = usePaneActivationFocusIntent();
       return (
         <div
           data-testid="hosted-bridge-probe"
@@ -145,6 +152,7 @@ function resetCapture(): void {
   capture.lastViewTabId = null;
   capture.lastOpenEpicHandle = null;
   capture.lastPanePortalContainer = null;
+  capture.lastPaneActivationFocusIntent = null;
   permissionRole.role = "owner";
 }
 
@@ -184,6 +192,25 @@ describe("HostedChatSurfaceContextBridge", () => {
     expect(capture.lastOpenEpicHandle).toBe(OPEN_EPIC_HANDLE);
     expect(capture.lastOpenEpicHandle).toBe(
       environment.services.openEpicHandle,
+    );
+  });
+
+  it("re-provides the exact pane activation focus intent from its environment", () => {
+    const focusIntent: PaneActivationFocusIntent = {
+      mark: vi.fn(),
+      shouldYieldAutoFocus: () => true,
+    };
+    const environment = {
+      ...buildEnvironment({
+        canvasActivity: { tabSelected: true, canvasPaneActive: true },
+      }),
+      paneActivation: { focusIntent },
+    };
+    render(<HostedChatSurfaceContextBridge environment={environment} />);
+
+    expect(capture.lastPaneActivationFocusIntent).toBe(focusIntent);
+    expect(capture.lastPaneActivationFocusIntent?.shouldYieldAutoFocus()).toBe(
+      true,
     );
   });
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-context-bridge.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-context-bridge.test.tsx
@@ -45,24 +45,20 @@ interface CaptureState {
   lastPanePortalContainer: HTMLElement | null;
 }
 
-const capture = vi.hoisted(
-  (): CaptureState => ({
-    lastIsActive: null,
-    lastViewTabId: null,
-    lastOpenEpicHandle: null,
-    lastPanePortalContainer: null,
-  }),
-);
+const capture = vi.hoisted((): CaptureState => ({
+  lastIsActive: null,
+  lastViewTabId: null,
+  lastOpenEpicHandle: null,
+  lastPanePortalContainer: null,
+}));
 
 interface PermissionRoleState {
   role: string | null;
 }
 
-const permissionRole = vi.hoisted(
-  (): PermissionRoleState => ({
-    role: "owner",
-  }),
-);
+const permissionRole = vi.hoisted((): PermissionRoleState => ({
+  role: "owner",
+}));
 
 vi.mock("@/lib/epic-selectors", () => ({
   useEpicPermissionRole: () => permissionRole.role,
@@ -173,7 +169,9 @@ describe("HostedChatSurfaceContextBridge", () => {
     expect(screen.getByTestId("hosted-bridge-probe")).not.toBeNull();
     expect(capture.lastViewTabId).toBe(VIEW_TAB_ID);
     expect(
-      screen.getByTestId("hosted-bridge-probe").getAttribute("data-view-tab-id"),
+      screen
+        .getByTestId("hosted-bridge-probe")
+        .getAttribute("data-view-tab-id"),
     ).toBe(VIEW_TAB_ID);
   });
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-transfer-gap.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-chat-surface-transfer-gap.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Ticket 21 slice 4 fix round, finding 1 (BLOCKER): a header tear-off must
+ * not unmount/remount the hosted chat body. Reproduces the reviewer's exact
+ * transfer-gap discriminator - a REAL tear-off action moves the tile's
+ * canvas entry to a destination tab in one synchronous `EpicCanvasStore`
+ * write, while the environment passed to the bridge deliberately stays the
+ * SOURCE environment (no destination `TileSurfaceSlot` is rendered here to
+ * republish a fresh one - that's the gap).
+ *
+ * `renderTile` is swapped for a STABLE, module-level mount-tracking probe -
+ * defined ONCE, not recreated per call - so a false remount reading can't be
+ * an artifact of the mock itself; only `HostedChatSurfaceBody`'s own node
+ * resolution can cause one.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { useEffect, type ReactNode } from "react";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useTabsStore } from "@/stores/tabs/store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+import type { ReadyTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import type { TabRef } from "@/stores/tabs/types";
+
+const INSTANCE_ID = "chat-transfer-1";
+const SOURCE_TAB_ID = "tab-source";
+const PANE_ID = "p1";
+const EPIC_ID = "epic-1";
+
+const CHAT_NODE = {
+  id: INSTANCE_ID,
+  instanceId: INSTANCE_ID,
+  type: "chat" as const,
+  name: "Transfer chat",
+  hostId: TEST_HOST_ID,
+};
+
+interface ProbeEvent {
+  readonly kind: "mount" | "unmount";
+}
+const probeEvents = vi.hoisted((): ProbeEvent[] => []);
+
+function TransferGapProbe(): ReactNode {
+  useEffect(() => {
+    probeEvents.push({ kind: "mount" });
+    return () => {
+      probeEvents.push({ kind: "unmount" });
+    };
+  }, []);
+  return <div data-testid="transfer-gap-probe" />;
+}
+
+vi.mock("@/components/epic-canvas/renderers/tile-render", () => ({
+  renderTile: (): ReactNode => <TransferGapProbe />,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicPermissionRole: () => "owner",
+}));
+
+// Import AFTER the mocks so the bridge picks them up.
+import { HostedChatSurfaceContextBridge } from "@/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge";
+
+function seedSourceCanvas(): void {
+  useEpicCanvasStore.setState({
+    tabsById: {
+      [SOURCE_TAB_ID]: { tabId: SOURCE_TAB_ID, epicId: EPIC_ID, name: "Epic" },
+    },
+    canvasByTabId: {
+      [SOURCE_TAB_ID]: {
+        root: pane(PANE_ID, [INSTANCE_ID]),
+        activePaneId: PANE_ID,
+        tilesByInstanceId: { [INSTANCE_ID]: CHAT_NODE },
+        sizesByGroupId: {},
+      },
+    },
+    openTabOrder: [SOURCE_TAB_ID],
+    activeTabId: SOURCE_TAB_ID,
+  });
+  const ref: TabRef = { kind: "epic", id: SOURCE_TAB_ID };
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
+    activeItemId: `tab:${ref.kind}:${ref.id}`,
+    stripOrder: [ref],
+  }));
+}
+
+function sourceEnvironment(): ReadyTileSurfaceEnvironment {
+  return buildSyntheticTileSurfaceEnvironment(INSTANCE_ID, {
+    identity: {
+      instanceId: INSTANCE_ID,
+      tileKind: "chat",
+      contentId: INSTANCE_ID,
+      epicId: EPIC_ID,
+      hostId: TEST_HOST_ID,
+    },
+    placement: {
+      epicId: EPIC_ID,
+      viewTabId: SOURCE_TAB_ID,
+      paneId: PANE_ID,
+      hostId: TEST_HOST_ID,
+    },
+    canvasActivity: { tabSelected: true, canvasPaneActive: true },
+  });
+}
+
+describe("HostedChatSurfaceContextBridge transfer-gap continuity (finding 1)", () => {
+  beforeEach(() => {
+    probeEvents.length = 0;
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    seedSourceCanvas();
+  });
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+  });
+
+  it("keeps the body mounted across a real header tear-off while the environment still names the source tab", () => {
+    render(
+      <HostedChatSurfaceContextBridge environment={sourceEnvironment()} />,
+    );
+    expect(screen.getByTestId("transfer-gap-probe")).not.toBeNull();
+    expect(probeEvents.filter((e) => e.kind === "mount")).toHaveLength(1);
+    expect(probeEvents.filter((e) => e.kind === "unmount")).toHaveLength(0);
+
+    // Real tear-off: the `EpicCanvasStore` write lands synchronously inside
+    // the coordinator transaction; `useTabsStore`'s header ref lands moments
+    // later in the SAME transaction. The bridge keeps the SAME (now-stale)
+    // source environment throughout - no destination `TileSurfaceSlot`
+    // exists in this test to republish a fresh one, reproducing the gap.
+    let destinationTabId: string | null = null;
+    act(() => {
+      tabCommandCoordinator.createSourceRefAtStripIndex(0, () => {
+        destinationTabId = useEpicCanvasStore
+          .getState()
+          .tearOffTabIntoNewHeaderTab({
+            sourceTabId: SOURCE_TAB_ID,
+            sourcePaneId: PANE_ID,
+            sourceTileTabId: INSTANCE_ID,
+            insertIndex: 0,
+          });
+        return destinationTabId === null
+          ? null
+          : { kind: "epic", id: destinationTabId };
+      });
+    });
+    expect(destinationTabId).not.toBeNull();
+
+    // Confirm the tile really did move out of the source tab - this is the
+    // actual gap condition, not a no-op action.
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[SOURCE_TAB_ID]
+        ?.tilesByInstanceId[INSTANCE_ID],
+    ).toBeUndefined();
+
+    expect(screen.getByTestId("transfer-gap-probe")).not.toBeNull();
+    expect(probeEvents.filter((e) => e.kind === "mount")).toHaveLength(1);
+    expect(probeEvents.filter((e) => e.kind === "unmount")).toHaveLength(0);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-resolver.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-resolver.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
   HOSTED_TILE_PANE_ID_ATTRIBUTE,
+  HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
 } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 import {
   findHostedTileElement,
@@ -12,11 +13,13 @@ import {
 function buildHostedRecord(
   instanceId: string,
   paneId: string,
+  viewTabId: string,
   innerHtml: string,
 ): HTMLDivElement {
   const record = document.createElement("div");
   record.setAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE, instanceId);
   record.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, paneId);
+  record.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, viewTabId);
   record.innerHTML = innerHtml;
   return record;
 }
@@ -41,6 +44,7 @@ describe("findHostedTileElement (forward instanceId -> element, command-to-compo
     const record = buildHostedRecord(
       "chat-1",
       "p1",
+      "tab-1",
       '<textarea data-testid="composer"></textarea>',
     );
     const root = mount(record);
@@ -50,32 +54,33 @@ describe("findHostedTileElement (forward instanceId -> element, command-to-compo
   });
 
   it("returns null for an instanceId with no hosted record", () => {
-    const root = mount(buildHostedRecord("chat-1", "p1", ""));
+    const root = mount(buildHostedRecord("chat-1", "p1", "tab-1", ""));
     expect(findHostedTileElement(root, "chat-missing")).toBeNull();
   });
 
   it("does not cross-match a record belonging to a different, unrelated root", () => {
     const otherRoot = document.createElement("div");
-    otherRoot.appendChild(buildHostedRecord("chat-1", "p1", ""));
+    otherRoot.appendChild(buildHostedRecord("chat-1", "p1", "tab-1", ""));
     document.body.appendChild(otherRoot);
-    const root = mount(buildHostedRecord("chat-2", "p2", ""));
+    const root = mount(buildHostedRecord("chat-2", "p2", "tab-1", ""));
     expect(findHostedTileElement(root, "chat-1")).toBeNull();
     otherRoot.remove();
   });
 
   it("escapes instanceIds containing quote/backslash characters instead of producing an invalid selector", () => {
     const trickyId = 'chat-"1\\2';
-    const record = buildHostedRecord(trickyId, "p1", "");
+    const record = buildHostedRecord(trickyId, "p1", "tab-1", "");
     const root = mount(record);
     expect(findHostedTileElement(root, trickyId)).toBe(record);
   });
 });
 
-describe("resolveHostedTileOwnership (reverse target -> {instanceId, paneId}, chat-keyboard-scrolling shape)", () => {
+describe("resolveHostedTileOwnership (reverse target -> {instanceId, paneId, viewTabId}, chat-keyboard-scrolling shape)", () => {
   it("resolves ownership from a descendant several levels inside the record", () => {
     const record = buildHostedRecord(
       "chat-1",
       "p1",
+      "tab-1",
       '<div><span data-testid="row">row</span></div>',
     );
     mount(record);
@@ -84,15 +89,17 @@ describe("resolveHostedTileOwnership (reverse target -> {instanceId, paneId}, ch
     expect(resolveHostedTileOwnership(row)).toEqual({
       instanceId: "chat-1",
       paneId: "p1",
+      viewTabId: "tab-1",
     });
   });
 
   it("resolves ownership from the record element itself", () => {
-    const record = buildHostedRecord("chat-1", "p1", "");
+    const record = buildHostedRecord("chat-1", "p1", "tab-1", "");
     mount(record);
     expect(resolveHostedTileOwnership(record)).toEqual({
       instanceId: "chat-1",
       paneId: "p1",
+      viewTabId: "tab-1",
     });
   });
 
@@ -106,30 +113,54 @@ describe("resolveHostedTileOwnership (reverse target -> {instanceId, paneId}, ch
     expect(resolveHostedTileOwnership(null)).toBeNull();
   });
 
+  it("returns null for a record whose environment has not published yet (no viewTabId attribute)", () => {
+    const record = document.createElement("div");
+    record.setAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE, "chat-1");
+    record.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, "p1");
+    mount(record);
+    expect(resolveHostedTileOwnership(record)).toBeNull();
+  });
+
   it("resolves the nearest record when hosted records are nested (does not walk past the closest ancestor)", () => {
-    const inner = buildHostedRecord("chat-inner", "p-inner", "<span data-testid=\"leaf\">leaf</span>");
-    const outer = buildHostedRecord("chat-outer", "p-outer", "");
+    const inner = buildHostedRecord(
+      "chat-inner",
+      "p-inner",
+      "tab-inner",
+      '<span data-testid="leaf">leaf</span>',
+    );
+    const outer = buildHostedRecord("chat-outer", "p-outer", "tab-outer", "");
     outer.appendChild(inner);
     mount(outer);
     const leaf = inner.querySelector('[data-testid="leaf"]');
     expect(resolveHostedTileOwnership(leaf)).toEqual({
       instanceId: "chat-inner",
       paneId: "p-inner",
+      viewTabId: "tab-inner",
     });
   });
 });
 
 describe("isTargetInsideHostedTile (deferred pane-activation containment shape, paneRoot.contains(target) generalized)", () => {
   it("is true for a target inside the named instance's record", () => {
-    const record = buildHostedRecord("chat-1", "p1", '<button data-testid="btn"></button>');
+    const record = buildHostedRecord(
+      "chat-1",
+      "p1",
+      "tab-1",
+      '<button data-testid="btn"></button>',
+    );
     mount(record);
     const button = record.querySelector('[data-testid="btn"]');
     expect(isTargetInsideHostedTile("chat-1", button)).toBe(true);
   });
 
   it("is false for a target inside a DIFFERENT instance's record - the exact false-positive `paneRoot.contains` would need a hosted rewrite to avoid", () => {
-    const recordA = buildHostedRecord("chat-a", "p-a", "");
-    const recordB = buildHostedRecord("chat-b", "p-b", '<button data-testid="btn"></button>');
+    const recordA = buildHostedRecord("chat-a", "p-a", "tab-1", "");
+    const recordB = buildHostedRecord(
+      "chat-b",
+      "p-b",
+      "tab-1",
+      '<button data-testid="btn"></button>',
+    );
     mount(recordA, recordB);
     const button = recordB.querySelector('[data-testid="btn"]');
     expect(isTargetInsideHostedTile("chat-a", button)).toBe(false);

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-resolver.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-resolver.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
 import {
   HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
   HOSTED_TILE_PANE_ID_ATTRIBUTE,
@@ -62,9 +62,9 @@ describe("findHostedTileElement (forward instanceId -> element, command-to-compo
     const otherRoot = document.createElement("div");
     otherRoot.appendChild(buildHostedRecord("chat-1", "p1", "tab-1", ""));
     document.body.appendChild(otherRoot);
+    onTestFinished(() => otherRoot.remove());
     const root = mount(buildHostedRecord("chat-2", "p2", "tab-1", ""));
     expect(findHostedTileElement(root, "chat-1")).toBeNull();
-    otherRoot.remove();
   });
 
   it("escapes instanceIds containing quote/backslash characters instead of producing an invalid selector", () => {

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-resolver.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-resolver.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import {
+  findHostedTileElement,
+  isTargetInsideHostedTile,
+  resolveHostedTileOwnership,
+} from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
+
+function buildHostedRecord(
+  instanceId: string,
+  paneId: string,
+  innerHtml: string,
+): HTMLDivElement {
+  const record = document.createElement("div");
+  record.setAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE, instanceId);
+  record.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, paneId);
+  record.innerHTML = innerHtml;
+  return record;
+}
+
+let mountedRoot: HTMLElement | null = null;
+
+function mount(...elements: ReadonlyArray<HTMLElement>): HTMLElement {
+  const root = document.createElement("div");
+  for (const element of elements) root.appendChild(element);
+  document.body.appendChild(root);
+  mountedRoot = root;
+  return root;
+}
+
+afterEach(() => {
+  mountedRoot?.remove();
+  mountedRoot = null;
+});
+
+describe("findHostedTileElement (forward instanceId -> element, command-to-composer / route-focus shape)", () => {
+  it("finds the record for a given instanceId scoped to root", () => {
+    const record = buildHostedRecord(
+      "chat-1",
+      "p1",
+      '<textarea data-testid="composer"></textarea>',
+    );
+    const root = mount(record);
+    const found = findHostedTileElement(root, "chat-1");
+    expect(found).toBe(record);
+    expect(found?.querySelector('[data-testid="composer"]')).not.toBeNull();
+  });
+
+  it("returns null for an instanceId with no hosted record", () => {
+    const root = mount(buildHostedRecord("chat-1", "p1", ""));
+    expect(findHostedTileElement(root, "chat-missing")).toBeNull();
+  });
+
+  it("does not cross-match a record belonging to a different, unrelated root", () => {
+    const otherRoot = document.createElement("div");
+    otherRoot.appendChild(buildHostedRecord("chat-1", "p1", ""));
+    document.body.appendChild(otherRoot);
+    const root = mount(buildHostedRecord("chat-2", "p2", ""));
+    expect(findHostedTileElement(root, "chat-1")).toBeNull();
+    otherRoot.remove();
+  });
+
+  it("escapes instanceIds containing quote/backslash characters instead of producing an invalid selector", () => {
+    const trickyId = 'chat-"1\\2';
+    const record = buildHostedRecord(trickyId, "p1", "");
+    const root = mount(record);
+    expect(findHostedTileElement(root, trickyId)).toBe(record);
+  });
+});
+
+describe("resolveHostedTileOwnership (reverse target -> {instanceId, paneId}, chat-keyboard-scrolling shape)", () => {
+  it("resolves ownership from a descendant several levels inside the record", () => {
+    const record = buildHostedRecord(
+      "chat-1",
+      "p1",
+      '<div><span data-testid="row">row</span></div>',
+    );
+    mount(record);
+    const row = record.querySelector('[data-testid="row"]');
+    expect(row).not.toBeNull();
+    expect(resolveHostedTileOwnership(row)).toEqual({
+      instanceId: "chat-1",
+      paneId: "p1",
+    });
+  });
+
+  it("resolves ownership from the record element itself", () => {
+    const record = buildHostedRecord("chat-1", "p1", "");
+    mount(record);
+    expect(resolveHostedTileOwnership(record)).toEqual({
+      instanceId: "chat-1",
+      paneId: "p1",
+    });
+  });
+
+  it("returns null for a target outside any hosted record", () => {
+    const outside = document.createElement("div");
+    mount(outside);
+    expect(resolveHostedTileOwnership(outside)).toBeNull();
+  });
+
+  it("returns null for a null target", () => {
+    expect(resolveHostedTileOwnership(null)).toBeNull();
+  });
+
+  it("resolves the nearest record when hosted records are nested (does not walk past the closest ancestor)", () => {
+    const inner = buildHostedRecord("chat-inner", "p-inner", "<span data-testid=\"leaf\">leaf</span>");
+    const outer = buildHostedRecord("chat-outer", "p-outer", "");
+    outer.appendChild(inner);
+    mount(outer);
+    const leaf = inner.querySelector('[data-testid="leaf"]');
+    expect(resolveHostedTileOwnership(leaf)).toEqual({
+      instanceId: "chat-inner",
+      paneId: "p-inner",
+    });
+  });
+});
+
+describe("isTargetInsideHostedTile (deferred pane-activation containment shape, paneRoot.contains(target) generalized)", () => {
+  it("is true for a target inside the named instance's record", () => {
+    const record = buildHostedRecord("chat-1", "p1", '<button data-testid="btn"></button>');
+    mount(record);
+    const button = record.querySelector('[data-testid="btn"]');
+    expect(isTargetInsideHostedTile("chat-1", button)).toBe(true);
+  });
+
+  it("is false for a target inside a DIFFERENT instance's record - the exact false-positive `paneRoot.contains` would need a hosted rewrite to avoid", () => {
+    const recordA = buildHostedRecord("chat-a", "p-a", "");
+    const recordB = buildHostedRecord("chat-b", "p-b", '<button data-testid="btn"></button>');
+    mount(recordA, recordB);
+    const button = recordB.querySelector('[data-testid="btn"]');
+    expect(isTargetInsideHostedTile("chat-a", button)).toBe(false);
+    expect(isTargetInsideHostedTile("chat-b", button)).toBe(true);
+  });
+
+  it("is false for a non-Element target (e.g. a null event target, or a non-Element EventTarget like window)", () => {
+    expect(isTargetInsideHostedTile("chat-1", null)).toBe(false);
+    expect(isTargetInsideHostedTile("chat-1", window)).toBe(false);
+  });
+
+  it("is false for a target outside any hosted record", () => {
+    const outside = document.createElement("div");
+    mount(outside);
+    expect(isTargetInsideHostedTile("chat-1", outside)).toBe(false);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
@@ -1,0 +1,1275 @@
+import "../../../../../__tests__/test-browser-apis";
+import {
+  StrictMode,
+  useEffect,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as Y from "yjs";
+import { TestRouterProvider } from "@/__tests__/with-test-router";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
+import type { ChatStreamClient } from "@traycer-clients/shared/host-transport/chat-stream-client";
+import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
+import {
+  __getChatSessionRegistryForTests,
+  __setChatStreamClientFactoryForTests,
+} from "@/lib/registries/chat-session-registry";
+import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useComposerDraftStore } from "@/stores/composer/composer-draft-store";
+import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
+import { useComposerHarnessMemoryStore } from "@/stores/composer/composer-harness-memory-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import { resetFocusedComposerControlsForTests } from "@/lib/commands/composer-controls-registry";
+import {
+  installLegendListViewportMetrics,
+  settleLegendList,
+} from "@/components/chat/__tests__/legend-list-test-environment";
+import { TestEpicSessionWrapper } from "@/components/epic-canvas/__tests__/test-epic-session";
+import { createEpicSessionTestHarness } from "@/components/epic-canvas/__tests__/test-epic-session-harness";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+} from "@/stores/epics/canvas/types";
+import {
+  collectPanes,
+  findPanePath,
+  getNodeAtPath,
+  type TileLayoutNode,
+} from "@/stores/epics/canvas/tile-tree";
+import {
+  group,
+  pane,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import { useTabsStore } from "@/stores/tabs/store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import { resetTileSurfaceEnvironmentRegistryForTesting } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { resetTileSurfaceGeometryCoordinatorForTesting } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
+import { resetChatRemoteDeletionRegistryForTesting } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import { HOSTED_TILE_INSTANCE_ID_ATTRIBUTE } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
+import { renderHostedChatSurfaceBody } from "@/components/epic-canvas/surface-host/hosted-chat-surface-body";
+import { TileCanvas } from "@/components/epic-canvas/canvas/tile-canvas";
+import { SnapshotLoadingProvider } from "@/components/epic-canvas/snapshots/snapshot-loading-context";
+import { getChatsMap } from "@/stores/epics/open-epic/projection-helpers";
+import { CommandPaletteRouterContext } from "@/components/command-palette/command-palette-context";
+import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
+
+/**
+ * Ticket 21 slice 5 (jsdom half): the PERMANENT lifecycle-matrix gate for the
+ * REAL `ChatTile -> ChatMessages -> LegendList` chain, routed through the
+ * REAL production wiring (`TileCanvas` + a real `StableTileSurfaceHost`
+ * sibling using the REAL `renderHostedChatSurfaceBody` renderer), with the
+ * stable-tile-surface-host switch ON.
+ *
+ * This is deliberately the real-body companion to the composite lifecycle
+ * test in `stable-tile-surface-host.test.tsx`, which drives the same kind of
+ * structural operations but against a SYNTHETIC body and a standalone
+ * `<StableTileSurfaceHost>` (no `TabGroupView`/`TileCanvas`, no switch-ON
+ * routing, no real chat content). Extend THIS file, not that one, when a new
+ * structural canvas operation needs lifecycle coverage against real chat
+ * content.
+ */
+
+vi.mock(
+  "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch",
+  () => ({ STABLE_TILE_SURFACE_HOST_ENABLED: true }),
+);
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({
+    setNodeRef: () => undefined,
+    listeners: undefined,
+    isDragging: false,
+  }),
+  useDroppable: () => ({ setNodeRef: () => undefined }),
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-rename-for-mutation", () => ({
+  useTerminalRenameFor: () => ({ mutate: () => undefined }),
+}));
+
+vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
+  useHostNotificationIndicators: () => ({
+    data: { epics: {}, chats: {} },
+    isPending: false,
+    isFetching: false,
+    error: null,
+    refetch: () => Promise.resolve(),
+  }),
+}));
+
+vi.mock(
+  "@/components/home/host-workspace-selector/host-workspace-selector",
+  () => ({
+    HostWorkspaceSelector: (props: {
+      readonly surface: { readonly bindingResolved: boolean };
+    }) => (
+      <div
+        data-testid="host-workspace-selector"
+        data-binding-resolved={String(props.surface.bindingResolved)}
+      />
+    ),
+    ActiveHostWorkspaceControls: () => null,
+  }),
+);
+
+const MOCK_HOST_CLIENT = {
+  request: () => new Promise(() => {}),
+  getActiveHostId: () => "host-test",
+  getRequestContextUserId: () => "user-test",
+  onChange: () => () => undefined,
+};
+const MOCK_HOST_ENTRY = {
+  hostId: "host-test",
+  label: "Test host",
+  kind: "local" as const,
+  websocketUrl: "ws://127.0.0.1:1/rpc",
+  streamUrl: "ws://127.0.0.1:1/stream",
+};
+const MOCK_HOST_DIRECTORY = {
+  onChange: () => ({ dispose() {} }),
+  findById: (hostId: string) =>
+    hostId === MOCK_HOST_ENTRY.hostId ? MOCK_HOST_ENTRY : null,
+};
+
+vi.mock("@/lib/host", () => ({
+  useHostBinding: () => null,
+  useHostDirectory: () => MOCK_HOST_DIRECTORY,
+  useAuthService: () => ({
+    revalidateCurrentContext: () => Promise.resolve({ kind: "valid" as const }),
+  }),
+  useHostClient: () => MOCK_HOST_CLIENT,
+}));
+
+vi.mock("@/lib/host/runtime", () => ({
+  useHostBinding: () => null,
+  useHostDirectory: () => MOCK_HOST_DIRECTORY,
+  useAuthService: () => ({
+    revalidateCurrentContext: () => Promise.resolve({ kind: "valid" as const }),
+  }),
+  useHostClient: () => MOCK_HOST_CLIENT,
+}));
+
+vi.mock("@/hooks/host/use-tab-host-client", () => ({
+  useTabHostClient: () => MOCK_HOST_CLIENT,
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@/hooks/epic/use-epic-chat-mutations")
+  >()),
+  useEpicCreateChatForHost: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/host/use-host-stream-client-for", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@/hooks/host/use-host-stream-client-for")
+  >()),
+  useHostStreamClientFor: () => null,
+  useHostStreamClientBindingFor: () => null,
+}));
+
+vi.mock("@/lib/host/stream-runtime-context", () => ({
+  useWsStreamClient: () => null,
+  useStreamMethodSupport: () => null,
+  useStreamMethodSchemaVersion: () => null,
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-test",
+}));
+
+/**
+ * Instrumentation-only wrapper around the REAL `ChatTile` (`importOriginal`,
+ * following the `ChatMessage` render-probe precedent in
+ * `chat-timeline.test.tsx`): gives a real numeric mount/unmount counter per
+ * `instanceId` without mocking away any real rendering.
+ */
+const chatTileLifecycle = vi.hoisted(() => ({
+  mounts: new Map<string, number>(),
+  unmounts: new Map<string, number>(),
+}));
+
+vi.mock(
+  "@/components/epic-canvas/renderers/chat-tile",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/components/epic-canvas/renderers/chat-tile")
+      >();
+
+    function ChatTileWithLifecycleProbe(
+      props: Parameters<typeof actual.ChatTile>[0],
+    ): ReactElement {
+      const instanceId = props.node.instanceId;
+      useEffect(() => {
+        chatTileLifecycle.mounts.set(
+          instanceId,
+          (chatTileLifecycle.mounts.get(instanceId) ?? 0) + 1,
+        );
+        return () => {
+          chatTileLifecycle.unmounts.set(
+            instanceId,
+            (chatTileLifecycle.unmounts.get(instanceId) ?? 0) + 1,
+          );
+        };
+      }, [instanceId]);
+      return <actual.ChatTile {...props} />;
+    }
+
+    return { ...actual, ChatTile: ChatTileWithLifecycleProbe };
+  },
+);
+
+function mountCount(instanceId: string): number {
+  return chatTileLifecycle.mounts.get(instanceId) ?? 0;
+}
+function unmountCount(instanceId: string): number {
+  return chatTileLifecycle.unmounts.get(instanceId) ?? 0;
+}
+
+const EPIC_ID = "epic-lifecycle-matrix";
+const VIEW_TAB_ID = "tab-1";
+const HOST_ID = "host-test";
+
+const CHAT_TRACKED: EpicCanvasTileRef = {
+  id: "chat-tracked",
+  instanceId: "inst-tracked",
+  type: "chat",
+  name: "Tracked Chat",
+  hostId: HOST_ID,
+};
+const CHAT_SIBLING: EpicCanvasTileRef = {
+  id: "chat-sibling",
+  instanceId: "inst-sibling",
+  type: "chat",
+  name: "Sibling Chat",
+  hostId: HOST_ID,
+};
+const CHAT_WRAP_PARTNER: EpicCanvasTileRef = {
+  id: "chat-wrap-partner",
+  instanceId: "inst-wrap-partner",
+  type: "chat",
+  name: "Wrap Partner Chat",
+  hostId: HOST_ID,
+};
+const ALL_CHATS: ReadonlyArray<EpicCanvasTileRef> = [
+  CHAT_TRACKED,
+  CHAT_SIBLING,
+  CHAT_WRAP_PARTNER,
+];
+
+const CHAT_RUN_SETTINGS: ChatRunSettings = {
+  harnessId: "claude",
+  model: "claude-sonnet",
+  permissionMode: "supervised",
+  reasoningEffort: "medium",
+  serviceTier: null,
+  agentMode: "regular",
+  profileId: null,
+};
+
+function buildChatYMap(chat: EpicCanvasTileRef): Y.Map<unknown> {
+  const chatMap = new Y.Map<unknown>();
+  chatMap.set("id", chat.id);
+  chatMap.set("title", chat.name);
+  chatMap.set("parentId", null);
+  chatMap.set("createdAt", 0);
+  chatMap.set("updatedAt", 0);
+  const messages = new Y.Array<unknown>();
+  messages.push([{ role: "user", content: `${chat.name} seed`, timestamp: 1 }]);
+  chatMap.set("messages", messages);
+  return chatMap;
+}
+
+function seedDocWithChats(doc: Y.Doc): void {
+  const epic = doc.getMap("epic");
+  const chatsMap = new Y.Map<unknown>();
+  for (const chat of ALL_CHATS) {
+    chatsMap.set(chat.id, buildChatYMap(chat));
+  }
+  epic.set("title", "Lifecycle Matrix Epic");
+  epic.set("artifacts", new Y.Map<unknown>());
+  epic.set("chats", chatsMap);
+}
+
+/**
+ * Mutation-check / row 13 helper: remote-delete a chat by removing its entry
+ * from the chats map of the live epic Y.Doc.
+ */
+function deleteChatFromLiveDoc(chatId: string): void {
+  const handle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
+  if (handle === null) throw new Error("expected a live epic session handle");
+  const chatsMap = getChatsMap(handle.doc);
+  chatsMap?.delete(chatId);
+}
+
+/** Row 13 recovery: re-insert a fresh Y.Map entry for the chat. */
+function restoreChatToLiveDoc(chat: EpicCanvasTileRef): void {
+  const handle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
+  if (handle === null) throw new Error("expected a live epic session handle");
+  const chatsMap = getChatsMap(handle.doc);
+  if (chatsMap === null) throw new Error("expected a live chats map");
+  chatsMap.set(chat.id, buildChatYMap(chat));
+}
+
+function emitChatSnapshot(
+  chat: EpicCanvasTileRef,
+  callbacks: ChatStreamCallbacks,
+): void {
+  callbacks.onSnapshot({
+    kind: "snapshot",
+    hasBinaryPayload: false,
+    epicId: EPIC_ID,
+    chatId: chat.id,
+    snapshot: {
+      chat: {
+        id: chat.id,
+        parentId: null,
+        userId: "owner-1",
+        hostId: chat.hostId,
+        title: chat.name,
+        createdAt: 0,
+        updatedAt: 0,
+        archivedAt: null,
+        isTitleEditedByUser: false,
+        settings: CHAT_RUN_SETTINGS,
+        activeSessionChain: null,
+        claudePendingWakes: [],
+        messages: [
+          {
+            role: "user",
+            messageId: `${chat.id}-message-1`,
+            sender: { type: "user", userId: "owner-1" },
+            message: {
+              kind: "user",
+              content: {
+                type: "doc",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      { type: "text", text: `${chat.name} seed message` },
+                    ],
+                  },
+                ],
+              },
+            },
+            timestamp: 1,
+            sessionAnchor: null,
+          },
+        ],
+        events: [],
+      },
+      access: { role: "owner", ownerUserId: "owner-1", canAct: true },
+      queue: { status: "idle", items: [] },
+      runStatus: "idle",
+      activeTurn: null,
+      pendingApprovals: [],
+      pendingInterviews: [],
+      worktreeBinding: { entries: [] },
+      missingWorktreePaths: [],
+      pendingFileEditApprovals: [],
+      accumulatedFileChanges: [],
+    },
+  });
+}
+
+function createChatHarness(): { install(): void; teardown(): void } {
+  return {
+    install: () => {
+      __setChatStreamClientFactoryForTests((_epicId, chatId, callbacks) => {
+        setTimeout(() => {
+          callbacks.onConnectionStatus("open", null);
+          const chat = ALL_CHATS.find((candidate) => candidate.id === chatId);
+          if (chat !== undefined) emitChatSnapshot(chat, callbacks);
+        }, 0);
+        const client: Pick<
+          ChatStreamClient,
+          "sendAction" | "close" | "sameTurnSteeringProtocolSupported"
+        > = {
+          sendAction: () => undefined,
+          sameTurnSteeringProtocolSupported: () => true,
+          close: () => undefined,
+        };
+        return client;
+      });
+    },
+    teardown: () => {
+      __setChatStreamClientFactoryForTests(null);
+      __getChatSessionRegistryForTests().disposeAll();
+    },
+  };
+}
+
+const epicHarness = createEpicSessionTestHarness(EPIC_ID);
+const chatHarness = createChatHarness();
+
+function resetSurfaceHostModules(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  tabCommandCoordinator.resetReconciliationForTesting();
+  resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
+  resetTileSurfaceGeometryCoordinatorForTesting();
+  resetChatRemoteDeletionRegistryForTesting();
+}
+
+beforeEach(() => {
+  installLegendListViewportMetrics();
+  window.localStorage.clear();
+  useAuthStore.setState({
+    status: "signed-in",
+    profile: {
+      userId: "owner-1",
+      userName: "Owner",
+      email: "owner@example.com",
+    },
+    contextMetadata: { userId: "owner-1", username: "Owner" },
+  });
+  useComposerDraftStore.setState({ drafts: {} });
+  useComposerRunSettingsStore.getState().resetForTests();
+  useComposerHarnessMemoryStore.getState().resetForTests();
+  useSettingsStore.setState({
+    steerOnModEnterEnabled: true,
+    defaultSelection: {
+      harnessId: "claude",
+      modelSlug: "claude-sonnet",
+      profileId: null,
+    },
+  });
+  resetFocusedComposerControlsForTests();
+  chatTileLifecycle.mounts.clear();
+  chatTileLifecycle.unmounts.clear();
+  resetSurfaceHostModules();
+  epicHarness.install(seedDocWithChats, "editor");
+  chatHarness.install();
+});
+
+afterEach(() => {
+  cleanup();
+  chatHarness.teardown();
+  epicHarness.teardown();
+  __getOpenEpicRegistryForTests().disposeAll();
+  resetFocusedComposerControlsForTests();
+  resetSurfaceHostModules();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Canvas / tab-strip seeding
+// ---------------------------------------------------------------------------
+
+function seedCanvas(
+  root: TileLayoutNode,
+  tiles: ReadonlyArray<EpicCanvasTileRef>,
+  activePaneId: string,
+): void {
+  useEpicCanvasStore.setState({
+    tabsById: {
+      [VIEW_TAB_ID]: {
+        tabId: VIEW_TAB_ID,
+        epicId: EPIC_ID,
+        name: "Lifecycle Matrix",
+      },
+    },
+    canvasByTabId: {
+      [VIEW_TAB_ID]: {
+        root,
+        activePaneId,
+        tilesByInstanceId: Object.fromEntries(
+          tiles.map((tile) => [tile.instanceId, tile]),
+        ),
+        sizesByGroupId: {},
+      },
+    },
+    openTabOrder: [VIEW_TAB_ID],
+    activeTabId: VIEW_TAB_ID,
+  });
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: [
+      {
+        kind: "tab" as const,
+        id: `tab:epic:${VIEW_TAB_ID}`,
+        ref: { kind: "epic" as const, id: VIEW_TAB_ID },
+      },
+    ],
+    activeItemId: `tab:epic:${VIEW_TAB_ID}`,
+    stripOrder: [{ kind: "epic" as const, id: VIEW_TAB_ID }],
+  }));
+}
+
+function currentCanvas(): EpicCanvasState {
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+  if (canvas === undefined) throw new Error("expected canvas");
+  return canvas;
+}
+
+// ---------------------------------------------------------------------------
+// Render tree - the REAL production wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * A pane goes empty (and mounts the real PaneOpener, which needs a
+ * CommandPaletteRouterContext) whenever a structural op vacates a pane -
+ * the flat/wrap split rows and the tear-off row all do this. Navigation
+ * itself is irrelevant to tile-identity assertions, so this is a no-op
+ * stub matching the precedent in search-run-view.test.tsx (same
+ * epic-canvas/canvas/__tests__ directory), not a defeated real dependency.
+ */
+function noopKeybindingRouter(): KeybindingRouter {
+  return {
+    getPathname: () => "/",
+    navigateHome: () => undefined,
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+  };
+}
+
+function renderMatrix(options: { readonly strictMode: boolean } | undefined) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const tree: ReactNode = (
+    <TestRouterProvider>
+      <QueryClientProvider client={queryClient}>
+        <RunnerHostProvider
+          runnerHost={
+            new MockRunnerHost({
+              signInUrl: "https://example.com",
+              authnBaseUrl: "https://auth.example.com",
+              localHost: null,
+              hosts: [],
+              workspaceFolderPickerPaths: undefined,
+              hasLocalHost: undefined,
+              traycerCli: undefined,
+            })
+          }
+        >
+          <TooltipProvider>
+            <CommandPaletteRouterContext.Provider
+              value={noopKeybindingRouter()}
+            >
+              <TestEpicSessionWrapper epicId={EPIC_ID}>
+                <SnapshotLoadingProvider
+                  value={{ snapshotLoaded: true, snapshotFetchError: null }}
+                >
+                  <TileCanvas epicId={EPIC_ID} tabId={VIEW_TAB_ID} />
+                  <StableTileSurfaceHost
+                    renderRecordBody={renderHostedChatSurfaceBody}
+                  />
+                </SnapshotLoadingProvider>
+              </TestEpicSessionWrapper>
+            </CommandPaletteRouterContext.Provider>
+          </TooltipProvider>
+        </RunnerHostProvider>
+      </QueryClientProvider>
+    </TestRouterProvider>
+  );
+  return render(
+    options?.strictMode === true ? <StrictMode>{tree}</StrictMode> : tree,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DOM accessors, scoped to a hosted record so a query can never
+// accidentally cross into an unrelated instance subtree.
+// ---------------------------------------------------------------------------
+
+function hostedRecord(container: HTMLElement, instanceId: string): HTMLElement {
+  const element = container.querySelector(
+    `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${instanceId}"]`,
+  );
+  if (element === null) {
+    throw new Error(`expected a hosted record for ${instanceId}`);
+  }
+  return element as HTMLElement;
+}
+
+function queryHostedRecord(
+  container: HTMLElement,
+  instanceId: string,
+): HTMLElement | null {
+  return container.querySelector(
+    `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${instanceId}"]`,
+  );
+}
+
+function chatTileRoot(container: HTMLElement, instanceId: string): HTMLElement {
+  const element = hostedRecord(container, instanceId).querySelector(
+    '[data-testid="chat-tile"]',
+  );
+  if (element === null) {
+    throw new Error(`expected a loaded chat-tile root for ${instanceId}`);
+  }
+  return element as HTMLElement;
+}
+
+function messagesScroll(
+  container: HTMLElement,
+  instanceId: string,
+): HTMLElement {
+  const element = hostedRecord(container, instanceId).querySelector(
+    '[data-testid="chat-messages-scroll"]',
+  );
+  if (element === null) {
+    throw new Error(`expected a chat-messages-scroll node for ${instanceId}`);
+  }
+  return element as HTMLElement;
+}
+
+function firstMessageRow(
+  container: HTMLElement,
+  instanceId: string,
+): HTMLElement {
+  const element = hostedRecord(container, instanceId).querySelector(
+    "[data-message-id]",
+  );
+  if (element === null) {
+    throw new Error(`expected at least one message row for ${instanceId}`);
+  }
+  return element as HTMLElement;
+}
+
+/**
+ * Waits for the REAL `ChatTile -> ChatMessages -> LegendList` chain to
+ * finish loading for `instanceId`: the loading marker is gone, the real
+ * `chat-tile` wrapper has replaced it, and at least one real message row is
+ * in the DOM. Only AFTER this resolves is a captured DOM node reference
+ * meaningful (`chat-tile` also labels the pre-handle loading wrapper, a
+ * different element, so capturing before this settles would pin the wrong
+ * node identity).
+ */
+async function waitForHostedChatLoaded(
+  container: HTMLElement,
+  instanceId: string,
+): Promise<void> {
+  await waitFor(() => {
+    const record = queryHostedRecord(container, instanceId);
+    expect(record).not.toBeNull();
+    expect(
+      record?.querySelector('[data-testid="chat-tile-loading"]'),
+    ).toBeNull();
+    expect(record?.querySelector('[data-testid="chat-tile"]')).not.toBeNull();
+    expect(record?.querySelector("[data-message-id]")).not.toBeNull();
+  });
+  await settleLegendList();
+}
+
+interface TrackedRefs {
+  readonly chatTile: HTMLElement;
+  readonly messagesScroll: HTMLElement;
+  readonly firstRow: HTMLElement;
+}
+
+function captureRefs(container: HTMLElement, instanceId: string): TrackedRefs {
+  return {
+    chatTile: chatTileRoot(container, instanceId),
+    messagesScroll: messagesScroll(container, instanceId),
+    firstRow: firstMessageRow(container, instanceId),
+  };
+}
+
+function expectRefsStable(
+  container: HTMLElement,
+  instanceId: string,
+  before: TrackedRefs,
+): void {
+  expect(chatTileRoot(container, instanceId)).toBe(before.chatTile);
+  expect(messagesScroll(container, instanceId)).toBe(before.messagesScroll);
+  expect(firstMessageRow(container, instanceId)).toBe(before.firstRow);
+}
+
+// ---------------------------------------------------------------------------
+// Rows
+// ---------------------------------------------------------------------------
+
+describe("StableTileSurfaceHost permanent lifecycle matrix (real store/coordinator, real ChatTile/ChatMessages/LegendList body)", () => {
+  it("row 1 - background-tab add: an inert background tab never mounts, tracked active chat is untouched", async () => {
+    seedCanvas(pane("p1", [CHAT_TRACKED.instanceId]), [CHAT_TRACKED], "p1");
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    const before = captureRefs(container, CHAT_TRACKED.instanceId);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .openTileInBackgroundTab(VIEW_TAB_ID, CHAT_SIBLING);
+    });
+
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, before);
+    // A background-only tab never becomes the active tab of its pane, so it
+    // is never mounted at all (no keep-alive for chat tabs, see
+    // `remountsOnTabSwitch` in `use-mounted-pane-tabs.ts`).
+    expect(queryHostedRecord(container, CHAT_SIBLING.instanceId)).toBeNull();
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(0);
+  });
+
+  it("row 2 - same-pane reorder: real moveTabOnTabStrip action leaves the tracked chat mounted exactly once", async () => {
+    seedCanvas(
+      pane("p1", [CHAT_TRACKED.instanceId, CHAT_SIBLING.instanceId]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    const before = captureRefs(container, CHAT_TRACKED.instanceId);
+
+    act(() => {
+      useEpicCanvasStore.getState().moveTabOnTabStrip(VIEW_TAB_ID, {
+        sourcePaneId: "p1",
+        tabId: CHAT_TRACKED.instanceId,
+        targetPaneId: "p1",
+        targetIndex: 1,
+      });
+    });
+
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, before);
+    expect(currentCanvas().root).not.toBeNull();
+  });
+
+  it("row 3 - cross-pane move: tracked chat AND an unrelated bystander pane both survive without remounting", async () => {
+    // Three panes, not two: p2 hosts an unrelated bystander chat that is
+    // NEITHER the move source NOR the move target, so this row is a clean
+    // test of cross-pane geometry-move stability in isolation. (A two-pane
+    // version where the target pane already has an active tab conflates
+    // this with decision #17's real, INTENDED remount-on-deactivation
+    // policy - see row 11's negative control - because dropping a tab onto
+    // a pane makes the dropped tab that pane's new active tab, which
+    // legitimately unmounts whatever was active there before.)
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("p1", [CHAT_TRACKED.instanceId]),
+        pane("p2", [CHAT_SIBLING.instanceId]),
+        pane("p3", []),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    await waitForHostedChatLoaded(container, CHAT_SIBLING.instanceId);
+    const trackedBefore = captureRefs(container, CHAT_TRACKED.instanceId);
+    const siblingBefore = captureRefs(container, CHAT_SIBLING.instanceId);
+
+    act(() => {
+      useEpicCanvasStore.getState().moveTabOnTabStrip(VIEW_TAB_ID, {
+        sourcePaneId: "p1",
+        tabId: CHAT_TRACKED.instanceId,
+        targetPaneId: "p3",
+        targetIndex: 0,
+      });
+    });
+
+    // Content: zero remounts for either instance.
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, trackedBefore);
+    expectRefsStable(container, CHAT_SIBLING.instanceId, siblingBefore);
+
+    // Thin-wrapper allowance: the pane-id attribute owned by the hosted
+    // record is allowed (expected) to update, that is the geometry/env
+    // republish this whole ticket exists to make cheap. Only the CONTENT
+    // identity above is pinned to zero remounts.
+    expect(
+      hostedRecord(container, CHAT_TRACKED.instanceId).getAttribute(
+        "data-hosted-canvas-pane-id",
+      ),
+    ).toBe("p3");
+  });
+
+  it("row 3b - two-pane occupied-target move: the dragged chat survives, the displaced destination chat gets its one intended decision-17 remount, and the emptied source pane dissolves", async () => {
+    // Review finding 2: row 3 only drives an empty-target move; row 11 only
+    // drives `setActiveTileTab` (a plain in-pane switch), never
+    // `moveTabOnTabStrip` across two panes. Neither composes the real drop's
+    // three simultaneous consequences a genuine drag-onto-an-occupied-pane
+    // produces. This row does.
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("pA", [CHAT_TRACKED.instanceId]),
+        pane("pB", [CHAT_SIBLING.instanceId]),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "pA",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    await waitForHostedChatLoaded(container, CHAT_SIBLING.instanceId);
+    const draggedBefore = captureRefs(container, CHAT_TRACKED.instanceId);
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+
+    // Drag TRACKED (pA's only tab) onto pB, which already has SIBLING
+    // active. `moveTabAcrossPanes` both makes TRACKED the new active tab of
+    // pB (displacing SIBLING) and, since pA is now empty, closes pA -
+    // dissolving the 2-child root group down to pB alone.
+    act(() => {
+      useEpicCanvasStore.getState().moveTabOnTabStrip(VIEW_TAB_ID, {
+        sourcePaneId: "pA",
+        tabId: CHAT_TRACKED.instanceId,
+        targetPaneId: "pB",
+        targetIndex: 0,
+      });
+    });
+
+    // (a) The dragged chat: content continuity through the drop.
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, draggedBefore);
+
+    // (b) The displaced destination chat: exactly the ONE intended
+    // decision-17 remount (no longer pB's active tab -> chat tabs never
+    // keep-alive when inactive -> real unmount), not a leaked hosted body.
+    await waitFor(() => {
+      expect(queryHostedRecord(container, CHAT_SIBLING.instanceId)).toBeNull();
+    });
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(1);
+
+    // (c) Source-pane dissolve: pA had only TRACKED, so the move empties
+    // and closes it, collapsing the 2-child root group down to pB as the
+    // bare root pane.
+    const after = currentCanvas();
+    if (after.root === null || after.root.kind !== "pane") {
+      throw new Error(
+        "expected the emptied source pane to dissolve, promoting pB to the bare root",
+      );
+    }
+    expect(after.root.id).toBe("pB");
+    // Dropped at targetIndex 0: TRACKED lands ahead of SIBLING in the strip.
+    expect(after.root.tabInstanceIds).toEqual([
+      CHAT_TRACKED.instanceId,
+      CHAT_SIBLING.instanceId,
+    ]);
+    expect(after.root.activeTabId).toBe(CHAT_TRACKED.instanceId);
+  });
+
+  it("row 4 - edge/new-pane move: tracked chat moves into its own new pane without remounting", async () => {
+    seedCanvas(
+      pane("p1", [CHAT_TRACKED.instanceId, CHAT_SIBLING.instanceId]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    const before = captureRefs(container, CHAT_TRACKED.instanceId);
+    const rootPaneId =
+      currentCanvas().root?.kind === "pane" ? currentCanvas().root?.id : null;
+    expect(rootPaneId).toBe("p1");
+
+    act(() => {
+      useEpicCanvasStore.getState().splitPaneWithTab(VIEW_TAB_ID, {
+        sourcePaneId: "p1",
+        tabId: CHAT_TRACKED.instanceId,
+        targetPaneId: "p1",
+        position: "right",
+      });
+    });
+
+    const after = currentCanvas();
+    if (after.root === null || after.root.kind !== "group") {
+      throw new Error("expected the split to wrap the bare root pane");
+    }
+    expect(after.root.children).toHaveLength(2);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, before);
+  });
+
+  it("row 5 - same-axis flat split: the MOVED chat survives the flat insertion, with the untouched tracked chat as an additional bystander check", async () => {
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("p1", [CHAT_TRACKED.instanceId]),
+        pane("p2", [CHAT_SIBLING.instanceId]),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    await waitForHostedChatLoaded(container, CHAT_SIBLING.instanceId);
+    const trackedBefore = captureRefs(container, CHAT_TRACKED.instanceId);
+    // The chat the flat split actually MOVES - this is the row's real
+    // subject. Review finding 1: an earlier version of this row loaded and
+    // asserted only the untouched bystander (tracked), so it never proved
+    // content continuity through the same-axis insertion it claims to
+    // cover - a `Suspense` boundary keyed by `environment.placement.paneId`
+    // could silently remount the moved chat's body and this row would still
+    // pass. Capturing and re-asserting the SIBLING's own refs below is what
+    // catches that.
+    const siblingBefore = captureRefs(container, CHAT_SIBLING.instanceId);
+
+    // The parent group of p2 (root-g) is already horizontal and "right" is
+    // also horizontal, so per `insertPaneAtEdge` this is the FLAT branch:
+    // the new pane splices into root-g as a third sibling; the identity of
+    // root-g and the rest of the tree (in particular p1, tracked) stay
+    // untouched. Verified by the tree-shape assertions below; this row
+    // currently has zero existing DOM-level real-action coverage anywhere
+    // else in the suite.
+    act(() => {
+      useEpicCanvasStore.getState().splitPaneWithTab(VIEW_TAB_ID, {
+        sourcePaneId: "p2",
+        tabId: CHAT_SIBLING.instanceId,
+        targetPaneId: "p2",
+        position: "right",
+      });
+    });
+
+    const after = currentCanvas();
+    if (after.root === null || after.root.kind !== "group") {
+      throw new Error("expected the root group to survive flat");
+    }
+    expect(after.root.id).toBe("root-g");
+    expect(after.root.children).toHaveLength(3);
+    expect(
+      after.root.children.some(
+        (child) => child.kind === "pane" && child.id === "p1",
+      ),
+    ).toBe(true);
+
+    // The MOVED chat: content continuity through the flat insertion.
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_SIBLING.instanceId, siblingBefore);
+
+    // The untouched bystander, in the pane the split never touched.
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, trackedBefore);
+  });
+
+  it("row 6 + row 7 - perpendicular wrap then sibling-close dissolve/promotion: tracked chat and an unrelated real sibling both survive", async () => {
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("p1", [CHAT_TRACKED.instanceId]),
+        pane("p2", [CHAT_SIBLING.instanceId]),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    await waitForHostedChatLoaded(container, CHAT_SIBLING.instanceId);
+    const trackedBefore = captureRefs(container, CHAT_TRACKED.instanceId);
+    const siblingBefore = captureRefs(container, CHAT_SIBLING.instanceId);
+
+    // --- Row 6: perpendicular wrap around p1 (the wrap partner rides
+    // along and is never asserted on directly). ---
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .openTileInBackgroundTab(VIEW_TAB_ID, CHAT_WRAP_PARTNER);
+    });
+    act(() => {
+      useEpicCanvasStore.getState().splitPaneWithTab(VIEW_TAB_ID, {
+        sourcePaneId: "p1",
+        tabId: CHAT_WRAP_PARTNER.instanceId,
+        targetPaneId: "p1",
+        position: "bottom",
+      });
+    });
+
+    const afterWrap = currentCanvas();
+    if (afterWrap.root === null) throw new Error("expected canvas root");
+    const wrapPath = findPanePath(afterWrap.root, "p1");
+    if (wrapPath === null || wrapPath.length === 0) {
+      throw new Error("expected p1 to be nested under a fresh wrap group");
+    }
+    const wrapParent = getNodeAtPath(afterWrap.root, wrapPath.slice(0, -1));
+    if (wrapParent.kind !== "group") throw new Error("expected a group");
+    expect(wrapParent.id).not.toBe("root-g");
+    expect(wrapParent.direction).toBe("vertical");
+    expect(wrapParent.children).toHaveLength(2);
+
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, trackedBefore);
+    expectRefsStable(container, CHAT_SIBLING.instanceId, siblingBefore);
+
+    // --- Row 7: close the wrap partner pane, dissolving the wrap group
+    // and promoting p1 back into the slot under root-g. ---
+    const wrapPartnerPane = collectPanes(afterWrap.root).find((candidate) =>
+      candidate.tabInstanceIds.includes(CHAT_WRAP_PARTNER.instanceId),
+    );
+    if (wrapPartnerPane === undefined) {
+      throw new Error("expected a pane for the wrap partner");
+    }
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .closeCanvasTab(
+          VIEW_TAB_ID,
+          wrapPartnerPane.id,
+          CHAT_WRAP_PARTNER.instanceId,
+        );
+    });
+
+    const afterDissolve = currentCanvas();
+    if (afterDissolve.root === null || afterDissolve.root.kind !== "group") {
+      throw new Error("expected the outer group to survive the dissolve");
+    }
+    expect(afterDissolve.root.id).toBe("root-g");
+    expect(
+      afterDissolve.root.children.some(
+        (child) => child.kind === "pane" && child.id === "p1",
+      ),
+    ).toBe(true);
+
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, trackedBefore);
+    expectRefsStable(container, CHAT_SIBLING.instanceId, siblingBefore);
+  });
+
+  it("row 8 - divider-drag store commit (resizeSplitInTab): zero effect on either pane chat content identity", async () => {
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("p1", [CHAT_TRACKED.instanceId]),
+        pane("p2", [CHAT_SIBLING.instanceId]),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    await waitForHostedChatLoaded(container, CHAT_SIBLING.instanceId);
+    const trackedBefore = captureRefs(container, CHAT_TRACKED.instanceId);
+    const siblingBefore = captureRefs(container, CHAT_SIBLING.instanceId);
+
+    // This is literally the `onResizeGroup` callback body of `TileCanvas`,
+    // a divider-drag commit, called directly on the store the same way
+    // production calls it. Zero existing coverage of this action through
+    // the real store prior to this row.
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .resizeSplitInTab(VIEW_TAB_ID, "root-g", [0.3, 0.7]);
+    });
+
+    expect(currentCanvas().sizesByGroupId["root-g"]).toEqual([0.3, 0.7]);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, trackedBefore);
+    expectRefsStable(container, CHAT_SIBLING.instanceId, siblingBefore);
+  });
+
+  it("row 9 - header tear-off: the real two-commit coordinator transaction never remounts the tracked chat", async () => {
+    seedCanvas(pane("p1", [CHAT_TRACKED.instanceId]), [CHAT_TRACKED], "p1");
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    const before = captureRefs(container, CHAT_TRACKED.instanceId);
+
+    act(() => {
+      tabCommandCoordinator.createSourceRefAtStripIndex(0, () => {
+        const newTabId = useEpicCanvasStore
+          .getState()
+          .tearOffTabIntoNewHeaderTab({
+            sourceTabId: VIEW_TAB_ID,
+            sourcePaneId: "p1",
+            sourceTileTabId: CHAT_TRACKED.instanceId,
+            insertIndex: 0,
+          });
+        return newTabId === null ? null : { kind: "epic", id: newTabId };
+      });
+    });
+
+    // The tile moved to a BRAND NEW top-level view tab (a completely
+    // different `EpicCanvasStore` root than the one `<TileCanvas>` above is
+    // bound to). The hosted body survives this only because its content
+    // lives in the plane owned by `StableTileSurfaceHost`, decoupled from
+    // which `TileCanvas` is currently showing it.
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, before);
+  });
+
+  it("row 10 - close: the real closeCanvasTab action fully unmounts the closed instance and removes its hosted DOM record", async () => {
+    seedCanvas(pane("p1", [CHAT_TRACKED.instanceId]), [CHAT_TRACKED], "p1");
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .closeCanvasTab(VIEW_TAB_ID, "p1", CHAT_TRACKED.instanceId);
+    });
+
+    await waitFor(() => {
+      expect(queryHostedRecord(container, CHAT_TRACKED.instanceId)).toBeNull();
+    });
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(container.querySelector('[data-testid="chat-tile"]')).toBeNull();
+  });
+
+  it("row 11 - NEGATIVE CONTROL (decision #17): switching the active inner tab away then back is the ONE intentional remount", async () => {
+    seedCanvas(
+      pane("p1", [CHAT_TRACKED.instanceId, CHAT_SIBLING.instanceId]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .setActiveTileTab(VIEW_TAB_ID, "p1", CHAT_SIBLING.instanceId);
+    });
+    await waitFor(() => {
+      expect(queryHostedRecord(container, CHAT_TRACKED.instanceId)).toBeNull();
+    });
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(1);
+
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .setActiveTileTab(VIEW_TAB_ID, "p1", CHAT_TRACKED.instanceId);
+    });
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+
+    // Exactly one fresh mount, one prior unmount: proves the mount-count
+    // assertions in this matrix are meaningful (they would correctly flag a
+    // real remount) rather than vacuously always passing.
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(2);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(1);
+  });
+
+  it("row 12 - StrictMode replay: a representative move/split/resize subset settles to no net-new remount beyond the one-time double-invoke performed by StrictMode itself", async () => {
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("p1", [CHAT_TRACKED.instanceId]),
+        pane("p2", [CHAT_SIBLING.instanceId]),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix({ strictMode: true });
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+
+    // StrictMode (dev-only) double-invokes the passive effects of the
+    // initial mount (mount -> cleanup -> mount), so this counting wrapper
+    // does not necessarily start its baseline at 1/0 after initial settle;
+    // see the StrictMode test in `stable-tile-surface-host.test.tsx` for
+    // the same codebase precedent of not asserting a literal
+    // post-StrictMode count. The real invariant under test is that the
+    // STRUCTURAL OPERATIONS below add no ADDITIONAL mount/unmount beyond
+    // whatever the one-time double-invoke performed by StrictMode itself
+    // already produced, captured here as a baseline and then reasserted
+    // unchanged after each op.
+    const mountBaseline = mountCount(CHAT_TRACKED.instanceId);
+    const unmountBaseline = unmountCount(CHAT_TRACKED.instanceId);
+    const before = captureRefs(container, CHAT_TRACKED.instanceId);
+
+    act(() => {
+      useEpicCanvasStore.getState().moveTabOnTabStrip(VIEW_TAB_ID, {
+        sourcePaneId: "p1",
+        tabId: CHAT_TRACKED.instanceId,
+        targetPaneId: "p2",
+        targetIndex: 1,
+      });
+    });
+    act(() => {
+      useEpicCanvasStore.getState().splitPaneWithTab(VIEW_TAB_ID, {
+        sourcePaneId: "p2",
+        tabId: CHAT_TRACKED.instanceId,
+        targetPaneId: "p2",
+        position: "right",
+      });
+    });
+    const afterSplit = currentCanvas();
+    const trackedPane = collectPanes(afterSplit.root).find((candidate) =>
+      candidate.tabInstanceIds.includes(CHAT_TRACKED.instanceId),
+    );
+    if (trackedPane === undefined) throw new Error("expected tracked pane");
+    const rootGroupId =
+      afterSplit.root?.kind === "group" ? afterSplit.root.id : null;
+    if (rootGroupId === null) throw new Error("expected a root group");
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .resizeSplitInTab(VIEW_TAB_ID, rootGroupId, [0.4, 0.3, 0.3]);
+    });
+
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(mountBaseline);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(unmountBaseline);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, before);
+  });
+
+  it("row 13 - remote-delete ownership handoff: real artifact deletion unmounts the hosted body; recovery republishes a fresh one", async () => {
+    seedCanvas(pane("p1", [CHAT_TRACKED.instanceId]), [CHAT_TRACKED], "p1");
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+
+    act(() => {
+      deleteChatFromLiveDoc(CHAT_TRACKED.id);
+    });
+
+    await waitFor(() => {
+      expect(queryHostedRecord(container, CHAT_TRACKED.instanceId)).toBeNull();
+      expect(
+        container.querySelector('[data-testid="deleted-node-body"]'),
+      ).not.toBeNull();
+    });
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(1);
+
+    act(() => {
+      restoreChatToLiveDoc(CHAT_TRACKED);
+    });
+
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    expect(
+      container.querySelector('[data-testid="deleted-node-body"]'),
+    ).toBeNull();
+    // Recovery is a genuine fresh mount, not a no-op: the point of this row
+    // is that a real remount happens here, unlike every survives row above.
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(2);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(1);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
@@ -60,7 +60,10 @@ import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/s
 import { resetTileSurfaceEnvironmentRegistryForTesting } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
 import { resetTileSurfaceGeometryCoordinatorForTesting } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
 import { resetChatRemoteDeletionRegistryForTesting } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
-import { HOSTED_TILE_INSTANCE_ID_ATTRIBUTE } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
 import { renderHostedChatSurfaceBody } from "@/components/epic-canvas/surface-host/hosted-chat-surface-body";
 import { TileCanvas } from "@/components/epic-canvas/canvas/tile-canvas";
@@ -324,7 +327,8 @@ function deleteChatFromLiveDoc(chatId: string): void {
   const handle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
   if (handle === null) throw new Error("expected a live epic session handle");
   const chatsMap = getChatsMap(handle.doc);
-  chatsMap?.delete(chatId);
+  if (chatsMap === null) throw new Error("expected a live chats map");
+  chatsMap.delete(chatId);
 }
 
 /** Row 13 recovery: re-insert a fresh Y.Map entry for the chat. */
@@ -814,7 +818,7 @@ describe("StableTileSurfaceHost permanent lifecycle matrix (real store/coordinat
     // identity above is pinned to zero remounts.
     expect(
       hostedRecord(container, CHAT_TRACKED.instanceId).getAttribute(
-        "data-hosted-canvas-pane-id",
+        HOSTED_TILE_PANE_ID_ATTRIBUTE,
       ),
     ).toBe("p3");
   });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
@@ -6,7 +6,13 @@ import {
   type ReactNode,
 } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Y from "yjs";
 import { TestRouterProvider } from "@/__tests__/with-test-router";
@@ -62,6 +68,7 @@ import { SnapshotLoadingProvider } from "@/components/epic-canvas/snapshots/snap
 import { getChatsMap } from "@/stores/epics/open-epic/projection-helpers";
 import { CommandPaletteRouterContext } from "@/components/command-palette/command-palette-context";
 import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
+import { pointerEvent } from "@/components/epic-canvas/canvas/__tests__/test-pointer-events";
 
 /**
  * Ticket 21 slice 5 (jsdom half): the PERMANENT lifecycle-matrix gate for the
@@ -1083,6 +1090,75 @@ describe("StableTileSurfaceHost permanent lifecycle matrix (real store/coordinat
         .getState()
         .resizeSplitInTab(VIEW_TAB_ID, "root-g", [0.3, 0.7]);
     });
+
+    expect(currentCanvas().sizesByGroupId["root-g"]).toEqual([0.3, 0.7]);
+    expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_TRACKED.instanceId)).toBe(0);
+    expect(mountCount(CHAT_SIBLING.instanceId)).toBe(1);
+    expect(unmountCount(CHAT_SIBLING.instanceId)).toBe(0);
+    expectRefsStable(container, CHAT_TRACKED.instanceId, trackedBefore);
+    expectRefsStable(container, CHAT_SIBLING.instanceId, siblingBefore);
+  });
+
+  it("row 8b - divider-drag REAL pointer sequence (switch ON): the drag actually commits through usePointerDragCommit, not just the store action", async () => {
+    seedCanvas(
+      group("root-g", "horizontal", [
+        pane("p1", [CHAT_TRACKED.instanceId]),
+        pane("p2", [CHAT_SIBLING.instanceId]),
+      ]),
+      [CHAT_TRACKED, CHAT_SIBLING],
+      "p1",
+    );
+    const { container } = renderMatrix(undefined);
+    await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
+    await waitForHostedChatLoaded(container, CHAT_SIBLING.instanceId);
+    const trackedBefore = captureRefs(container, CHAT_TRACKED.instanceId);
+    const siblingBefore = captureRefs(container, CHAT_SIBLING.instanceId);
+
+    const split = container.querySelector('[data-testid="tile-split"]');
+    if (split === null) throw new Error("expected the root split container");
+    vi.spyOn(split, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(0, 0, 1000, 600),
+    );
+    const handle = container.querySelector(
+      '[data-testid="split-resize-handle"]',
+    );
+    if (handle === null) throw new Error("expected the split resize handle");
+
+    // Row 1's live-pass fix: move/up are delivered via window listeners once
+    // a drag starts, so they no longer need to target the handle itself.
+    // Dispatching them on a stand-in element proves the REAL production
+    // wiring (not just the isolated hook) tolerates that.
+    const decoy = document.createElement("div");
+    document.body.appendChild(decoy);
+    fireEvent(
+      handle,
+      pointerEvent("pointerdown", {
+        pointerId: 7,
+        clientX: 500,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      decoy,
+      pointerEvent("pointermove", {
+        pointerId: 7,
+        clientX: 300,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      decoy,
+      pointerEvent("pointerup", {
+        pointerId: 7,
+        clientX: 300,
+        clientY: 10,
+        button: 0,
+      }),
+    );
+    document.body.removeChild(decoy);
 
     expect(currentCanvas().sizesByGroupId["root-g"]).toEqual([0.3, 0.7]);
     expect(mountCount(CHAT_TRACKED.instanceId)).toBe(1);

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
@@ -461,6 +461,99 @@ describe("StableTileSurfaceHost presentation contract (design-review F1)", () =>
   });
 });
 
+describe("StableTileSurfaceHost presentation-loss blur (design-review finding 5)", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  function seedOneChat(): void {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChats("p1", ["chat-1"]) },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+  }
+
+  it("blurs a focused descendant of a record that goes top-level-hidden", () => {
+    seedOneChat();
+    render(
+      <StableTileSurfaceHost
+        renderRecordBody={() => (
+          <button type="button" data-testid="hosted-focus-target">
+            focus me
+          </button>
+        )}
+      />,
+    );
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          presentation: { topLevelVisible: true, topLevelFocused: true },
+        }),
+      );
+    });
+    const target = screen.getByTestId("hosted-focus-target");
+    act(() => {
+      target.focus();
+    });
+    expect(document.activeElement).toBe(target);
+
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          presentation: { topLevelVisible: false, topLevelFocused: false },
+        }),
+      );
+    });
+    expect(document.activeElement).not.toBe(target);
+  });
+
+  it("leaves focus alone when the newly-hidden record has no focused descendant", () => {
+    seedOneChat();
+    render(
+      <StableTileSurfaceHost
+        renderRecordBody={() => (
+          <button type="button" data-testid="hosted-focus-target">
+            focus me
+          </button>
+        )}
+      />,
+    );
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          presentation: { topLevelVisible: true, topLevelFocused: true },
+        }),
+      );
+    });
+    const outside = document.createElement("input");
+    document.body.appendChild(outside);
+    act(() => {
+      outside.focus();
+    });
+    expect(document.activeElement).toBe(outside);
+
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          presentation: { topLevelVisible: false, topLevelFocused: false },
+        }),
+      );
+    });
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
+  });
+});
+
 describe("StableTileSurfaceHost hosted DOM identity", () => {
   beforeEach(() => resetAll());
   afterEach(() => {
@@ -565,7 +658,8 @@ describe("StableTileSurfaceHost geometry under StrictMode replay", () => {
         buildSyntheticTileSurfaceEnvironment("chat-1", {
           services: {
             openEpicHandle: {} as never,
-            panePortalContainer: slot,
+            geometryAnchorElement: slot,
+            panePortalContainer: null,
             isPaneFocusedNow: () => false,
           },
         }),

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
@@ -109,10 +109,10 @@ describe("StableTileSurfaceHost lifecycle matrix (real store/coordinator, synthe
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     publishTileSurfaceEnvironment(
       buildSyntheticTileSurfaceEnvironment("chat-1", {}),
     );
@@ -193,9 +193,7 @@ describe("StableTileSurfaceHost lifecycle matrix (real store/coordinator, synthe
     const wrapRoot = afterWrap.root;
     const wrapPath = findPanePath(wrapRoot, chat1PaneId);
     if (wrapPath === null || wrapPath.length === 0) {
-      throw new Error(
-        "expected chat-1's pane to be nested under a wrap group",
-      );
+      throw new Error("expected chat-1's pane to be nested under a wrap group");
     }
     const wrapParent = getNodeAtPath(wrapRoot, wrapPath.slice(0, -1));
     if (wrapParent.kind !== "group") throw new Error("expected a group");
@@ -226,8 +224,7 @@ describe("StableTileSurfaceHost lifecycle matrix (real store/coordinator, synthe
         .getState()
         .closeCanvasTab("tab-1", chat3Pane.id, "chat-3");
     });
-    const afterDissolve =
-      useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    const afterDissolve = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
     if (afterDissolve === undefined) throw new Error("expected canvas");
     if (afterDissolve.root === null || afterDissolve.root.kind !== "group") {
       throw new Error("expected the outer group to survive");
@@ -295,10 +292,10 @@ describe("StableTileSurfaceHost lifecycle matrix (real store/coordinator, synthe
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     publishTileSurfaceEnvironment(
       buildSyntheticTileSurfaceEnvironment("chat-1", {}),
     );
@@ -389,10 +386,10 @@ describe("StableTileSurfaceHost presentation contract (design-review F1)", () =>
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
   }
 
   it("plane root carries no aria-hidden of its own", () => {
@@ -477,10 +474,10 @@ describe("StableTileSurfaceHost presentation-loss blur (design-review finding 5)
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
   }
 
   it("blurs a focused descendant of a record that goes top-level-hidden", () => {
@@ -570,10 +567,10 @@ describe("StableTileSurfaceHost hosted DOM identity", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
 
     const renderer = createSyntheticTileSurfaceBodyRenderer();
     render(
@@ -583,9 +580,9 @@ describe("StableTileSurfaceHost hosted DOM identity", () => {
     const dormantRecord = screen.getByTestId(
       "stable-tile-surface-record-chat-1",
     );
-    expect(
-      dormantRecord.getAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE),
-    ).toBe("chat-1");
+    expect(dormantRecord.getAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE)).toBe(
+      "chat-1",
+    );
     expect(dormantRecord.hasAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE)).toBe(
       false,
     );
@@ -596,12 +593,8 @@ describe("StableTileSurfaceHost hosted DOM identity", () => {
       );
     });
 
-    const readyRecord = screen.getByTestId(
-      "stable-tile-surface-record-chat-1",
-    );
-    expect(readyRecord.getAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE)).toBe(
-      "p1",
-    );
+    const readyRecord = screen.getByTestId("stable-tile-surface-record-chat-1");
+    expect(readyRecord.getAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE)).toBe("p1");
   });
 });
 
@@ -621,10 +614,10 @@ describe("StableTileSurfaceHost geometry under StrictMode replay", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
 
     const slot = document.createElement("div");
     document.body.appendChild(slot);
@@ -668,9 +661,7 @@ describe("StableTileSurfaceHost geometry under StrictMode replay", () => {
       const renderer = createSyntheticTileSurfaceBodyRenderer();
       render(
         <StrictMode>
-          <StableTileSurfaceHost
-            renderRecordBody={renderer.renderRecordBody}
-          />
+          <StableTileSurfaceHost renderRecordBody={renderer.renderRecordBody} />
         </StrictMode>,
       );
 
@@ -727,7 +718,9 @@ describe("default-on proof (slice 6)", () => {
   });
 
   it("TopLevelTabHost's render output mounts the stable-tile-surface-host plane with the switch enabled", () => {
-    useEpicCanvasStore.getState().openEpicTabWithId("epic-a", "epic-a", "Epic A");
+    useEpicCanvasStore
+      .getState()
+      .openEpicTabWithId("epic-a", "epic-a", "Epic A");
     useTabsStore.setState((state) => ({
       ...state,
       items: [
@@ -744,8 +737,6 @@ describe("default-on proof (slice 6)", () => {
     render(<TopLevelTabHost />);
 
     expect(screen.getByTestId("top-level-surface-epic-epic-a")).not.toBeNull();
-    expect(
-      screen.queryByTestId("stable-tile-surface-host"),
-    ).not.toBeNull();
+    expect(screen.queryByTestId("stable-tile-surface-host")).not.toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
@@ -710,7 +710,7 @@ function fakeDomRect(rect: {
   };
 }
 
-describe("default-off proof", () => {
+describe("default-on proof (slice 6)", () => {
   beforeEach(() => {
     window.localStorage.clear();
     useTabsStore.setState(useTabsStore.getInitialState(), true);
@@ -726,7 +726,7 @@ describe("default-off proof", () => {
     resetAll();
   });
 
-  it("TopLevelTabHost's render output contains no stable-tile-surface-host plane while the switch is off", () => {
+  it("TopLevelTabHost's render output mounts the stable-tile-surface-host plane with the switch enabled", () => {
     useEpicCanvasStore.getState().openEpicTabWithId("epic-a", "epic-a", "Epic A");
     useTabsStore.setState((state) => ({
       ...state,
@@ -746,6 +746,6 @@ describe("default-off proof", () => {
     expect(screen.getByTestId("top-level-surface-epic-epic-a")).not.toBeNull();
     expect(
       screen.queryByTestId("stable-tile-surface-host"),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
@@ -1,0 +1,657 @@
+import { StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+import {
+  collectPanes,
+  findPanePath,
+  getNodeAtPath,
+} from "@/stores/epics/canvas/tile-tree";
+import { useTabsStore } from "@/stores/tabs/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import type { TabRef } from "@/stores/tabs/types";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import {
+  publishTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { resetTileSurfaceGeometryCoordinatorForTesting } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
+import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import { TopLevelTabHost } from "@/components/layout/top-level-tab-host";
+import {
+  buildSyntheticTileSurfaceEnvironment,
+  createSyntheticTileSurfaceBodyRenderer,
+} from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+
+function chatRef(instanceId: string) {
+  return {
+    id: instanceId,
+    instanceId,
+    type: "chat" as const,
+    name: `Chat ${instanceId}`,
+    hostId: TEST_HOST_ID,
+  };
+}
+
+function terminalRef(instanceId: string) {
+  return {
+    id: instanceId,
+    instanceId,
+    type: "terminal-agent" as const,
+    name: `Terminal ${instanceId}`,
+    hostId: TEST_HOST_ID,
+  };
+}
+
+function canvasWithChats(
+  paneId: string,
+  instanceIds: ReadonlyArray<string>,
+): EpicCanvasState {
+  return {
+    root: pane(paneId, instanceIds),
+    activePaneId: paneId,
+    tilesByInstanceId: Object.fromEntries(
+      instanceIds.map((id) => [id, chatRef(id)]),
+    ),
+    sizesByGroupId: {},
+  };
+}
+
+function seedSingleTabStrip(
+  refs: ReadonlyArray<TabRef>,
+  activeRef: TabRef,
+): void {
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: refs.map((ref) => ({
+      kind: "tab" as const,
+      id: `tab:${ref.kind}:${ref.id}`,
+      ref,
+    })),
+    activeItemId: `tab:${activeRef.kind}:${activeRef.id}`,
+    stripOrder: refs,
+  }));
+}
+
+function resetAll(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+  tabCommandCoordinator.resetReconciliationForTesting();
+  resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
+  resetTileSurfaceGeometryCoordinatorForTesting();
+}
+
+describe("StableTileSurfaceHost lifecycle matrix (real store/coordinator, synthetic body)", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  it("keeps the synthetic body mounted exactly once across move / edge-split / wrap-dissolve / cross-pane-move / header tear-off", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChats("p1", ["chat-1", "chat-2"]) },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    publishTileSurfaceEnvironment(
+      buildSyntheticTileSurfaceEnvironment("chat-1", {}),
+    );
+
+    const renderer = createSyntheticTileSurfaceBodyRenderer();
+    render(
+      <StableTileSurfaceHost renderRecordBody={renderer.renderRecordBody} />,
+    );
+
+    expect(
+      screen.getByTestId("synthetic-tile-surface-body-chat-1"),
+    ).not.toBeNull();
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    // Same-pane reorder via the real action (design-review F3 - was a
+    // handcrafted setState).
+    act(() => {
+      useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
+        sourcePaneId: "p1",
+        tabId: "chat-1",
+        targetPaneId: "p1",
+        targetIndex: 2,
+      });
+    });
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    // Real edge split: chat-1 moves into its own pane, right of p1.
+    act(() => {
+      useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+        sourcePaneId: "p1",
+        tabId: "chat-1",
+        targetPaneId: "p1",
+        position: "right",
+      });
+    });
+    const afterSplit = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (afterSplit === undefined) throw new Error("expected canvas");
+    const chat1PaneAfterSplit = collectPanes(afterSplit.root).find((p) =>
+      p.tabInstanceIds.includes("chat-1"),
+    );
+    if (chat1PaneAfterSplit === undefined) {
+      throw new Error("expected chat-1's own pane");
+    }
+    const chat1PaneId = chat1PaneAfterSplit.id;
+    const rootGroupId =
+      afterSplit.root !== null && afterSplit.root.kind === "group"
+        ? afterSplit.root.id
+        : null;
+    if (rootGroupId === null) throw new Error("expected a root group");
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    // Wrap (design-review F3 - the old test's same-direction split
+    // flattened 2->3 siblings instead of wrapping): a genuinely
+    // PERPENDICULAR split ("bottom" against the root's "horizontal" group)
+    // around chat-1's OWN pane. chat-3 rides along purely as the wrap
+    // partner and is dissolved back out below; the tracked instance
+    // (chat-1) never changes pane and never remounts.
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .openTileInBackgroundTab("tab-1", chatRef("chat-3"));
+    });
+    act(() => {
+      useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+        sourcePaneId: chat1PaneId,
+        tabId: "chat-3",
+        targetPaneId: chat1PaneId,
+        position: "bottom",
+      });
+    });
+    const afterWrap = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (afterWrap === undefined || afterWrap.root === null) {
+      throw new Error("expected canvas");
+    }
+    const wrapRoot = afterWrap.root;
+    const wrapPath = findPanePath(wrapRoot, chat1PaneId);
+    if (wrapPath === null || wrapPath.length === 0) {
+      throw new Error(
+        "expected chat-1's pane to be nested under a wrap group",
+      );
+    }
+    const wrapParent = getNodeAtPath(wrapRoot, wrapPath.slice(0, -1));
+    if (wrapParent.kind !== "group") throw new Error("expected a group");
+    // The wrap genuinely nests chat-1's pane under a FRESH group, distinct
+    // from the original root group - proof this is a real wrap, not a flat
+    // same-direction insertion.
+    expect(wrapParent.id).not.toBe(rootGroupId);
+    expect(wrapParent.direction).toBe("vertical");
+    expect(wrapParent.children).toHaveLength(2);
+    const chat1PaneAfterWrap = collectPanes(afterWrap.root).find(
+      (p) => p.id === chat1PaneId,
+    );
+    if (chat1PaneAfterWrap === undefined) throw new Error("expected pane");
+    expect(chat1PaneAfterWrap.tabInstanceIds).toEqual(["chat-1"]);
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    // Dissolve: closing chat-3's pane (the wrap group's other child) leaves
+    // the wrap group with exactly one survivor, which the tree promotes
+    // back into the ORIGINAL group's slot - a genuine one-child-group
+    // promotion, not the old test's flat 3-to-2 sibling removal.
+    const chat3Pane = collectPanes(afterWrap.root).find((p) =>
+      p.tabInstanceIds.includes("chat-3"),
+    );
+    if (chat3Pane === undefined) throw new Error("expected chat-3's pane");
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .closeCanvasTab("tab-1", chat3Pane.id, "chat-3");
+    });
+    const afterDissolve =
+      useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (afterDissolve === undefined) throw new Error("expected canvas");
+    if (afterDissolve.root === null || afterDissolve.root.kind !== "group") {
+      throw new Error("expected the outer group to survive");
+    }
+    expect(afterDissolve.root.id).toBe(rootGroupId);
+    expect(
+      afterDissolve.root.children.some(
+        (child) => child.kind === "pane" && child.id === chat1PaneId,
+      ),
+    ).toBe(true);
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    // Cross-pane move via the real action: merge chat-1 back into p1.
+    act(() => {
+      useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
+        sourcePaneId: chat1PaneId,
+        tabId: "chat-1",
+        targetPaneId: "p1",
+        targetIndex: 0,
+      });
+    });
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    // Header tear-off: real coordinator transaction, source/destination
+    // strips split across two stores. chat-1's own pane dissolved back
+    // into p1 above, so p1 is the sole remaining pane.
+    act(() => {
+      tabCommandCoordinator.createSourceRefAtStripIndex(0, () => {
+        const newTabId = useEpicCanvasStore
+          .getState()
+          .tearOffTabIntoNewHeaderTab({
+            sourceTabId: "tab-1",
+            sourcePaneId: "p1",
+            sourceTileTabId: "chat-1",
+            insertIndex: 0,
+          });
+        return newTabId === null ? null : { kind: "epic", id: newTabId };
+      });
+    });
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+    expect(
+      screen.getByTestId("synthetic-tile-surface-body-chat-1"),
+    ).not.toBeNull();
+  });
+
+  it("decision #17: deselecting a chat's inner tab unmounts the synthetic body; selecting it again is an INTENTIONAL fresh mount after a fresh publish", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: {
+        "tab-1": {
+          root: { ...pane("p1", ["chat-1", "term-1"]), activeTabId: "chat-1" },
+          activePaneId: "p1",
+          tilesByInstanceId: {
+            "chat-1": chatRef("chat-1"),
+            "term-1": terminalRef("term-1"),
+          },
+          sizesByGroupId: {},
+        },
+      },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    publishTileSurfaceEnvironment(
+      buildSyntheticTileSurfaceEnvironment("chat-1", {}),
+    );
+
+    const renderer = createSyntheticTileSurfaceBodyRenderer();
+    render(
+      <StableTileSurfaceHost renderRecordBody={renderer.renderRecordBody} />,
+    );
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(0);
+
+    act(() => {
+      useEpicCanvasStore.setState((state) => {
+        const current = state.canvasByTabId["tab-1"];
+        if (current === undefined) throw new Error("expected canvas");
+        return {
+          canvasByTabId: {
+            ...state.canvasByTabId,
+            "tab-1": {
+              ...current,
+              root: {
+                ...pane("p1", ["chat-1", "term-1"]),
+                activeTabId: "term-1",
+              },
+            },
+          },
+        };
+      });
+    });
+    expect(
+      screen.queryByTestId("synthetic-tile-surface-body-chat-1"),
+    ).toBeNull();
+    expect(renderer.mountCount("chat-1")).toBe(1);
+    expect(renderer.unmountCount("chat-1")).toBe(1);
+
+    act(() => {
+      useEpicCanvasStore.setState((state) => {
+        const current = state.canvasByTabId["tab-1"];
+        if (current === undefined) throw new Error("expected canvas");
+        return {
+          canvasByTabId: {
+            ...state.canvasByTabId,
+            "tab-1": {
+              ...current,
+              root: {
+                ...pane("p1", ["chat-1", "term-1"]),
+                activeTabId: "chat-1",
+              },
+            },
+          },
+        };
+      });
+    });
+    // Membership re-includes chat-1, but the registry has no unregister API -
+    // it already deleted the record on loss (F2). No body without a fresh
+    // publish: this is the dormant state, not an automatic remount.
+    expect(
+      screen.queryByTestId("synthetic-tile-surface-body-chat-1"),
+    ).toBeNull();
+    expect(renderer.mountCount("chat-1")).toBe(1);
+
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {}),
+      );
+    });
+    expect(
+      screen.getByTestId("synthetic-tile-surface-body-chat-1"),
+    ).not.toBeNull();
+    expect(renderer.mountCount("chat-1")).toBe(2);
+    expect(renderer.unmountCount("chat-1")).toBe(1);
+  });
+});
+
+describe("StableTileSurfaceHost presentation contract (design-review F1)", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  function seedOneChat(): void {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChats("p1", ["chat-1"]) },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+  }
+
+  it("plane root carries no aria-hidden of its own", () => {
+    seedOneChat();
+    render(<StableTileSurfaceHost renderRecordBody={() => null} />);
+    const host = screen.getByTestId("stable-tile-surface-host");
+    expect(host.hasAttribute("aria-hidden")).toBe(false);
+  });
+
+  it("a visible record is not hidden by any ancestor and stays painted", () => {
+    seedOneChat();
+    render(<StableTileSurfaceHost renderRecordBody={() => null} />);
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          presentation: { topLevelVisible: true, topLevelFocused: false },
+        }),
+      );
+    });
+    const record = screen.getByTestId("stable-tile-surface-record-chat-1");
+    // No ancestor (including the plane root) carries aria-hidden="true" -
+    // an aria-hidden ancestor overrides a descendant's own attribute, which
+    // is exactly the F1 defect: the plane used to shroud every record.
+    expect(record.closest('[aria-hidden="true"]')).toBeNull();
+    expect(record.getAttribute("aria-hidden")).toBe("false");
+    expect(record.hasAttribute("inert")).toBe(false);
+    expect(record.classList.contains("invisible")).toBe(false);
+  });
+
+  it("a top-level-hidden record is aria-hidden, inert, AND non-painted", () => {
+    seedOneChat();
+    render(<StableTileSurfaceHost renderRecordBody={() => null} />);
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          presentation: { topLevelVisible: false, topLevelFocused: false },
+        }),
+      );
+    });
+    const record = screen.getByTestId("stable-tile-surface-record-chat-1");
+    expect(record.getAttribute("aria-hidden")).toBe("true");
+    expect(record.hasAttribute("inert")).toBe(true);
+    // The F1 gap: aria-hidden/inert alone do not stop painting - only a real
+    // non-paint rule does.
+    expect(record.classList.contains("invisible")).toBe(true);
+  });
+
+  it("pins the pointer-event split, overflow clipping, and no positive record z-index", () => {
+    seedOneChat();
+    render(<StableTileSurfaceHost renderRecordBody={() => null} />);
+    const host = screen.getByTestId("stable-tile-surface-host");
+    expect(host.classList.contains("pointer-events-none")).toBe(true);
+    expect(host.classList.contains("z-0")).toBe(true);
+
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {}),
+      );
+    });
+    const record = screen.getByTestId("stable-tile-surface-record-chat-1");
+    expect(record.classList.contains("pointer-events-auto")).toBe(true);
+    expect(record.classList.contains("overflow-hidden")).toBe(true);
+    expect(
+      [...record.classList].some((className) => /^z-[1-9]/.test(className)),
+    ).toBe(false);
+  });
+});
+
+describe("StableTileSurfaceHost hosted DOM identity", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  it("stamps the record with its instanceId always, and its paneId once ready", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChats("p1", ["chat-1"]) },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+
+    const renderer = createSyntheticTileSurfaceBodyRenderer();
+    render(
+      <StableTileSurfaceHost renderRecordBody={renderer.renderRecordBody} />,
+    );
+
+    const dormantRecord = screen.getByTestId(
+      "stable-tile-surface-record-chat-1",
+    );
+    expect(
+      dormantRecord.getAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE),
+    ).toBe("chat-1");
+    expect(dormantRecord.hasAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE)).toBe(
+      false,
+    );
+
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {}),
+      );
+    });
+
+    const readyRecord = screen.getByTestId(
+      "stable-tile-surface-record-chat-1",
+    );
+    expect(readyRecord.getAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE)).toBe(
+      "p1",
+    );
+  });
+});
+
+describe("StableTileSurfaceHost geometry under StrictMode replay", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  it("survives setup->cleanup->setup StrictMode replay and still applies the correct host-relative rect", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChats("p1", ["chat-1"]) },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+
+    const slot = document.createElement("div");
+    document.body.appendChild(slot);
+
+    // Attribute/identity-keyed rect stub, installed BEFORE render: the host
+    // element does not exist yet, so it cannot be stubbed by reference the
+    // way `slot` can - `data-testid="stable-tile-surface-host"` is a static
+    // JSX attribute already present on the node by the time its callback
+    // ref fires, so matching on it works regardless of which of StrictMode's
+    // two constructed instances ends up live. Every other element falls back
+    // to the zero rect jsdom already reports by default, so there is no need
+    // to preserve or re-invoke the original implementation.
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "getBoundingClientRect",
+    );
+    Element.prototype.getBoundingClientRect = function (
+      this: Element,
+    ): DOMRect {
+      if (this === slot) {
+        return fakeDomRect({ left: 120, top: 130, width: 200, height: 100 });
+      }
+      if (this.getAttribute("data-testid") === "stable-tile-surface-host") {
+        return fakeDomRect({ left: 20, top: 30, width: 800, height: 600 });
+      }
+      return fakeDomRect({ left: 0, top: 0, width: 0, height: 0 });
+    };
+
+    try {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          services: {
+            openEpicHandle: {} as never,
+            panePortalContainer: slot,
+            isPaneFocusedNow: () => false,
+          },
+        }),
+      );
+
+      const renderer = createSyntheticTileSurfaceBodyRenderer();
+      render(
+        <StrictMode>
+          <StableTileSurfaceHost
+            renderRecordBody={renderer.renderRecordBody}
+          />
+        </StrictMode>,
+      );
+
+      const record = screen.getByTestId("stable-tile-surface-record-chat-1");
+      expect(record.style.transform).toBe("translate(100px, 100px)");
+      expect(record.style.width).toBe("200px");
+      expect(record.style.height).toBe("100px");
+    } finally {
+      if (originalDescriptor !== undefined) {
+        Object.defineProperty(
+          Element.prototype,
+          "getBoundingClientRect",
+          originalDescriptor,
+        );
+      }
+      slot.remove();
+    }
+  });
+});
+
+function fakeDomRect(rect: {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}): DOMRect {
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+    right: rect.left + rect.width,
+    bottom: rect.top + rect.height,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => rect,
+  };
+}
+
+describe("default-off proof", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    resetAll();
+  });
+  afterEach(() => {
+    cleanup();
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    resetAll();
+  });
+
+  it("TopLevelTabHost's render output contains no stable-tile-surface-host plane while the switch is off", () => {
+    useEpicCanvasStore.getState().openEpicTabWithId("epic-a", "epic-a", "Epic A");
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: [
+        {
+          kind: "tab" as const,
+          id: "tab:epic:epic-a",
+          ref: { kind: "epic" as const, id: "epic-a" },
+        },
+      ],
+      activeItemId: "tab:epic:epic-a",
+      stripOrder: [{ kind: "epic" as const, id: "epic-a" }],
+    }));
+
+    render(<TopLevelTabHost />);
+
+    expect(screen.getByTestId("top-level-surface-epic-epic-a")).not.toBeNull();
+    expect(
+      screen.queryByTestId("stable-tile-surface-host"),
+    ).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host.test.tsx
@@ -676,6 +676,8 @@ describe("StableTileSurfaceHost geometry under StrictMode replay", () => {
           "getBoundingClientRect",
           originalDescriptor,
         );
+      } else {
+        Reflect.deleteProperty(Element.prototype, "getBoundingClientRect");
       }
       slot.remove();
     }

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/surface-owner.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/surface-owner.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
+import type { surfaceOwnerFor as SurfaceOwnerFor } from "@/components/epic-canvas/surface-host/surface-owner";
+
+const SWITCH_MODULE_PATH =
+  "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch";
+
+const CHAT_REF: EpicArtifactRef = {
+  id: "chat-1",
+  instanceId: "instance-1",
+  type: "chat",
+  name: "Chat",
+  hostId: "host-1",
+};
+
+const SPEC_REF: EpicArtifactRef = {
+  ...CHAT_REF,
+  id: "spec-1",
+  instanceId: "instance-2",
+  type: "spec",
+};
+
+async function loadSurfaceOwnerFor(
+  enabled: boolean,
+): Promise<typeof SurfaceOwnerFor> {
+  vi.resetModules();
+  vi.doMock(SWITCH_MODULE_PATH, () => ({
+    STABLE_TILE_SURFACE_HOST_ENABLED: enabled,
+  }));
+  const mod = await import(
+    "@/components/epic-canvas/surface-host/surface-owner"
+  );
+  return mod.surfaceOwnerFor;
+}
+
+afterEach(() => {
+  vi.doUnmock(SWITCH_MODULE_PATH);
+  vi.resetModules();
+});
+
+describe("surfaceOwnerFor", () => {
+  it("stays inline for a live chat while the switch is off", async () => {
+    const surfaceOwnerFor = await loadSurfaceOwnerFor(false);
+    expect(
+      surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: false }),
+    ).toBe("inline");
+  });
+
+  it("hosts a live chat once the switch is on", async () => {
+    const surfaceOwnerFor = await loadSurfaceOwnerFor(true);
+    expect(
+      surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: false }),
+    ).toBe("hosted");
+  });
+
+  it("keeps a remote-deleted chat inline even with the switch on", async () => {
+    const surfaceOwnerFor = await loadSurfaceOwnerFor(true);
+    expect(
+      surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: true }),
+    ).toBe("inline");
+  });
+
+  it("keeps a non-chat node inline even with the switch on", async () => {
+    const surfaceOwnerFor = await loadSurfaceOwnerFor(true);
+    expect(
+      surfaceOwnerFor({ node: SPEC_REF, isRemoteDeleted: false }),
+    ).toBe("inline");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/surface-owner.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/surface-owner.test.ts
@@ -27,9 +27,8 @@ async function loadSurfaceOwnerFor(
   vi.doMock(SWITCH_MODULE_PATH, () => ({
     STABLE_TILE_SURFACE_HOST_ENABLED: enabled,
   }));
-  const mod = await import(
-    "@/components/epic-canvas/surface-host/surface-owner"
-  );
+  const mod =
+    await import("@/components/epic-canvas/surface-host/surface-owner");
   return mod.surfaceOwnerFor;
 }
 
@@ -41,29 +40,29 @@ afterEach(() => {
 describe("surfaceOwnerFor", () => {
   it("stays inline for a live chat while the switch is off", async () => {
     const surfaceOwnerFor = await loadSurfaceOwnerFor(false);
-    expect(
-      surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: false }),
-    ).toBe("inline");
+    expect(surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: false })).toBe(
+      "inline",
+    );
   });
 
   it("hosts a live chat once the switch is on", async () => {
     const surfaceOwnerFor = await loadSurfaceOwnerFor(true);
-    expect(
-      surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: false }),
-    ).toBe("hosted");
+    expect(surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: false })).toBe(
+      "hosted",
+    );
   });
 
   it("keeps a remote-deleted chat inline even with the switch on", async () => {
     const surfaceOwnerFor = await loadSurfaceOwnerFor(true);
-    expect(
-      surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: true }),
-    ).toBe("inline");
+    expect(surfaceOwnerFor({ node: CHAT_REF, isRemoteDeleted: true })).toBe(
+      "inline",
+    );
   });
 
   it("keeps a non-chat node inline even with the switch on", async () => {
     const surfaceOwnerFor = await loadSurfaceOwnerFor(true);
-    expect(
-      surfaceOwnerFor({ node: SPEC_REF, isRemoteDeleted: false }),
-    ).toBe("inline");
+    expect(surfaceOwnerFor({ node: SPEC_REF, isRemoteDeleted: false })).toBe(
+      "inline",
+    );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
@@ -17,7 +17,7 @@ export function buildSyntheticTileSurfaceEnvironment(
   instanceId: string,
   overrides: Partial<ReadyTileSurfaceEnvironment>,
 ): ReadyTileSurfaceEnvironment {
-  const identity: TileSurfaceIdentity = {
+  const defaultIdentity: TileSurfaceIdentity = {
     instanceId,
     tileKind: "chat",
     contentId: instanceId,
@@ -25,7 +25,6 @@ export function buildSyntheticTileSurfaceEnvironment(
     hostId: TEST_HOST_ID,
   };
   return {
-    identity,
     placement: {
       epicId: "tab-1",
       viewTabId: "tab-1",
@@ -42,6 +41,11 @@ export function buildSyntheticTileSurfaceEnvironment(
       isPaneFocusedNow: () => false,
     },
     ...overrides,
+    identity: {
+      ...defaultIdentity,
+      ...overrides.identity,
+      instanceId,
+    },
   };
 }
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
@@ -1,0 +1,97 @@
+/**
+ * Ticket 21 slice 3's "synthetic ready slot/body seam" (design/index.md,
+ * slice-3 row): a test-only `ReadyTileSurfaceEnvironment` builder and a
+ * mount/unmount-counting body component, used to drive `StableTileSurfaceHost`
+ * with REAL membership/registry/store state but a fake body - proving the
+ * jsdom-expressible half of the lifecycle contract without claiming a real
+ * `ChatTile`/`ChatMessages` integration (that's slice 4+).
+ */
+import { useEffect, type ReactNode } from "react";
+import type {
+  ReadyTileSurfaceEnvironment,
+  TileSurfaceIdentity,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { TEST_HOST_ID } from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+
+export function buildSyntheticTileSurfaceEnvironment(
+  instanceId: string,
+  overrides: Partial<ReadyTileSurfaceEnvironment>,
+): ReadyTileSurfaceEnvironment {
+  const identity: TileSurfaceIdentity = {
+    instanceId,
+    tileKind: "chat",
+    contentId: instanceId,
+    epicId: "tab-1",
+    hostId: TEST_HOST_ID,
+  };
+  return {
+    identity,
+    placement: {
+      epicId: "tab-1",
+      viewTabId: "tab-1",
+      paneId: "p1",
+      hostId: TEST_HOST_ID,
+    },
+    presentation: { topLevelVisible: true, topLevelFocused: false },
+    canvasActivity: { tabSelected: true, canvasPaneActive: false },
+    services: {
+      openEpicHandle:
+        {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+      panePortalContainer: null,
+      isPaneFocusedNow: () => false,
+    },
+    ...overrides,
+  };
+}
+
+export interface SyntheticTileSurfaceLifecycleEvent {
+  readonly instanceId: string;
+  readonly kind: "mount" | "unmount";
+}
+
+export interface SyntheticTileSurfaceBodyRenderer {
+  readonly renderRecordBody: (
+    environment: ReadyTileSurfaceEnvironment,
+  ) => ReactNode;
+  readonly events: ReadonlyArray<SyntheticTileSurfaceLifecycleEvent>;
+  readonly mountCount: (instanceId: string) => number;
+  readonly unmountCount: (instanceId: string) => number;
+}
+
+/**
+ * A fresh renderer per test - `events` is a live array reference the caller
+ * can inspect at any point, not a snapshot taken at creation time.
+ */
+export function createSyntheticTileSurfaceBodyRenderer(): SyntheticTileSurfaceBodyRenderer {
+  const events: SyntheticTileSurfaceLifecycleEvent[] = [];
+
+  function SyntheticTileSurfaceBody(props: {
+    readonly instanceId: string;
+  }): ReactNode {
+    useEffect(() => {
+      events.push({ instanceId: props.instanceId, kind: "mount" });
+      return () => {
+        events.push({ instanceId: props.instanceId, kind: "unmount" });
+      };
+    }, [props.instanceId]);
+    return (
+      <div
+        data-synthetic-tile-surface-body="true"
+        data-testid={`synthetic-tile-surface-body-${props.instanceId}`}
+      />
+    );
+  }
+
+  return {
+    renderRecordBody: (environment) => (
+      <SyntheticTileSurfaceBody instanceId={environment.identity.instanceId} />
+    ),
+    events,
+    mountCount: (instanceId) =>
+      events.filter((e) => e.instanceId === instanceId && e.kind === "mount")
+        .length,
+    unmountCount: (instanceId) =>
+      events.filter((e) => e.instanceId === instanceId && e.kind === "unmount")
+        .length,
+  };
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
@@ -33,6 +33,12 @@ export function buildSyntheticTileSurfaceEnvironment(
     },
     presentation: { topLevelVisible: true, topLevelFocused: false },
     canvasActivity: { tabSelected: true, canvasPaneActive: false },
+    paneActivation: {
+      focusIntent: {
+        mark: () => undefined,
+        shouldYieldAutoFocus: () => false,
+      },
+    },
     services: {
       openEpicHandle:
         {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture.tsx
@@ -37,6 +37,7 @@ export function buildSyntheticTileSurfaceEnvironment(
     services: {
       openEpicHandle:
         {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+      geometryAnchorElement: document.createElement("div"),
       panePortalContainer: null,
       isPaneFocusedNow: () => false,
     },

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+} from "vitest";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicCanvasState } from "@/stores/epics/canvas/types";
 import { useTabsStore } from "@/stores/tabs/store";
@@ -20,7 +27,8 @@ import {
   subscribeTileSurfaceEnvironment,
   type ReadyTileSurfaceEnvironment,
 } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
-import { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/components/layout/top-level-tab-host";
+import { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/stores/tabs/top-level-surface-retention";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
 
 function canvasWithChat(instanceId: string): EpicCanvasState {
   return {
@@ -110,6 +118,21 @@ describe("tile surface environment registry", () => {
     expect(getTileSurfaceEnvironment("never-a-member")).toBeNull();
   });
 
+  it("keeps the requested registry key when a synthetic identity override disagrees", () => {
+    const synthetic = buildSyntheticTileSurfaceEnvironment("chat-1", {
+      identity: {
+        instanceId: "mismatched-instance",
+        tileKind: "chat",
+        contentId: "chat-content",
+        epicId: "epic-1",
+        hostId: TEST_HOST_ID,
+      },
+    });
+
+    expect(synthetic.identity.instanceId).toBe("chat-1");
+    expect(synthetic.identity.contentId).toBe("chat-content");
+  });
+
   it("publishes a ready environment for a current member and notifies its subscribers", () => {
     seedMember("chat-1", "tab-1");
     let notifications = 0;
@@ -135,6 +158,26 @@ describe("tile surface environment registry", () => {
     expect(notifications).toBe(0);
     expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
     unsubscribe();
+  });
+
+  it("a repeated stale unsubscribe cannot delete a newer listener set", () => {
+    seedMember("chat-1", "tab-1");
+    const unsubscribeStale = subscribeTileSurfaceEnvironment(
+      "chat-1",
+      () => {},
+    );
+    unsubscribeStale();
+
+    let notifications = 0;
+    const unsubscribeCurrent = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+    onTestFinished(unsubscribeCurrent);
+
+    unsubscribeStale();
+    publishTileSurfaceEnvironment(environment({}));
+
+    expect(notifications).toBe(1);
   });
 
   it("retains the last valid environment across a structural transfer (no round-trip through null)", () => {

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -1,0 +1,529 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+import { useTabsStore } from "@/stores/tabs/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import type { TabRef } from "@/stores/tabs/types";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import {
+  getTileSurfaceMembership,
+  resetTileSurfaceMembershipForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import {
+  getTileSurfaceEnvironment,
+  publishTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+  subscribeTileSurfaceEnvironment,
+  type ReadyTileSurfaceEnvironment,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/components/layout/top-level-tab-host";
+
+function canvasWithChat(instanceId: string): EpicCanvasState {
+  return {
+    root: pane("p1", [instanceId]),
+    activePaneId: "p1",
+    tilesByInstanceId: {
+      [instanceId]: {
+        id: instanceId,
+        instanceId,
+        type: "chat",
+        name: "Chat",
+        hostId: TEST_HOST_ID,
+      },
+    },
+    sizesByGroupId: {},
+  };
+}
+
+function seedMember(instanceId: string, tabId: string): void {
+  useEpicCanvasStore.setState({
+    tabsById: { [tabId]: { tabId, epicId: tabId, name: tabId } },
+    canvasByTabId: { [tabId]: canvasWithChat(instanceId) },
+    openTabOrder: [tabId],
+    activeTabId: tabId,
+  });
+  const ref: TabRef = { kind: "epic", id: tabId };
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
+    activeItemId: `tab:${ref.kind}:${ref.id}`,
+    stripOrder: [ref],
+  }));
+}
+
+function environment(
+  overrides: Partial<ReadyTileSurfaceEnvironment>,
+): ReadyTileSurfaceEnvironment {
+  return {
+    identity: {
+      instanceId: "chat-1",
+      tileKind: "chat",
+      contentId: "chat-1",
+      epicId: "tab-1",
+      hostId: TEST_HOST_ID,
+    },
+    placement: {
+      epicId: "tab-1",
+      viewTabId: "tab-1",
+      paneId: "p1",
+      hostId: TEST_HOST_ID,
+    },
+    presentation: { topLevelVisible: true, topLevelFocused: false },
+    canvasActivity: { tabSelected: true, canvasPaneActive: false },
+    services: {
+      // Slice 2 has no real session wiring yet - a synthetic handle is the
+      // deliberate fixture seam the design calls for (real host/session
+      // integration is slice 5).
+      openEpicHandle: {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+      panePortalContainer: null,
+      isPaneFocusedNow: () => false,
+    },
+    ...overrides,
+  };
+}
+
+function resetAll(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+  tabCommandCoordinator.resetReconciliationForTesting();
+  resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
+}
+
+describe("tile surface environment registry", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => resetAll());
+
+  it("reads null (dormant) for a member with no published environment yet", () => {
+    seedMember("chat-1", "tab-1");
+    expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
+  });
+
+  it("reads null for a non-member instance", () => {
+    expect(getTileSurfaceEnvironment("never-a-member")).toBeNull();
+  });
+
+  it("publishes a ready environment for a current member and notifies its subscribers", () => {
+    seedMember("chat-1", "tab-1");
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    publishTileSurfaceEnvironment(environment({}));
+
+    expect(notifications).toBe(1);
+    expect(getTileSurfaceEnvironment("chat-1")).not.toBeNull();
+    unsubscribe();
+  });
+
+  it("drops a publish for an instance that is not currently a member", () => {
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    publishTileSurfaceEnvironment(environment({}));
+
+    expect(notifications).toBe(0);
+    expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
+    unsubscribe();
+  });
+
+  it("retains the last valid environment across a structural transfer (no round-trip through null)", () => {
+    seedMember("chat-1", "tab-1");
+    const first = environment({
+      placement: {
+        epicId: "tab-1",
+        viewTabId: "tab-1",
+        paneId: "p1",
+        hostId: TEST_HOST_ID,
+      },
+    });
+    publishTileSurfaceEnvironment(first);
+    expect(getTileSurfaceEnvironment("chat-1")).toBe(first);
+
+    // Simulate a structural move: the tile stays a member (instanceId
+    // unchanged) while its owning pane changes underneath it - the source
+    // slot goes quiet (no unregister call exists; see the module doc) and
+    // the destination slot has not published yet.
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": {
+          ...canvasWithChat("chat-1"),
+          root: pane("p2", ["chat-1"]),
+          activePaneId: "p2",
+        },
+      },
+    }));
+
+    expect(getTileSurfaceEnvironment("chat-1")).toBe(first);
+
+    const second = environment({
+      placement: {
+        epicId: "tab-1",
+        viewTabId: "tab-1",
+        paneId: "p2",
+        hostId: TEST_HOST_ID,
+      },
+    });
+    publishTileSurfaceEnvironment(second);
+    expect(getTileSurfaceEnvironment("chat-1")).toBe(second);
+  });
+
+  it("removes the record and notifies only on membership loss, never mid-transfer", () => {
+    seedMember("chat-1", "tab-1");
+    publishTileSurfaceEnvironment(environment({}));
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": {
+          root: null,
+          activePaneId: null,
+          tilesByInstanceId: {},
+          sizesByGroupId: {},
+        },
+      },
+    }));
+
+    expect(notifications).toBe(1);
+    expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
+    unsubscribe();
+  });
+
+  it("isolates subscriptions per instance: publishing for B never notifies A's subscribers", () => {
+    seedMember("chat-a", "tab-a");
+    useEpicCanvasStore.setState((state) => ({
+      tabsById: { ...state.tabsById, "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "tab-b" } },
+      canvasByTabId: { ...state.canvasByTabId, "tab-b": canvasWithChat("chat-b") },
+      openTabOrder: [...state.openTabOrder, "tab-b"],
+    }));
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: [
+        ...state.items,
+        {
+          kind: "tab" as const,
+          id: "tab:epic:tab-b",
+          ref: { kind: "epic" as const, id: "tab-b" },
+        },
+      ],
+      // Becomes active so layer 2 (never-yet-active tabs are not retained;
+      // see the membership suite) treats it as an eligible member too.
+      activeItemId: "tab:epic:tab-b",
+      stripOrder: [...state.stripOrder, { kind: "epic" as const, id: "tab-b" }],
+    }));
+
+    let notificationsA = 0;
+    let notificationsB = 0;
+    const unsubA = subscribeTileSurfaceEnvironment("chat-a", () => {
+      notificationsA += 1;
+    });
+    const unsubB = subscribeTileSurfaceEnvironment("chat-b", () => {
+      notificationsB += 1;
+    });
+
+    publishTileSurfaceEnvironment(
+      environment({
+        identity: {
+          instanceId: "chat-b",
+          tileKind: "chat",
+          contentId: "chat-b",
+          epicId: "tab-b",
+          hostId: TEST_HOST_ID,
+        },
+      }),
+    );
+
+    expect(notificationsB).toBe(1);
+    expect(notificationsA).toBe(0);
+    unsubA();
+    unsubB();
+  });
+
+  it("updates in place on a second publish for the same still-a-member instanceId", () => {
+    seedMember("chat-1", "tab-1");
+    const first = environment({
+      presentation: { topLevelVisible: true, topLevelFocused: false },
+    });
+    const second = environment({
+      presentation: { topLevelVisible: true, topLevelFocused: true },
+      canvasActivity: { tabSelected: true, canvasPaneActive: true },
+    });
+
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    publishTileSurfaceEnvironment(first);
+    expect(getTileSurfaceEnvironment("chat-1")).toBe(first);
+    expect(notifications).toBe(1);
+
+    publishTileSurfaceEnvironment(second);
+    expect(getTileSurfaceEnvironment("chat-1")).toBe(second);
+    expect(notifications).toBe(2);
+    unsubscribe();
+  });
+
+  it("clears a published environment when membership drops via top-level MRU eviction", () => {
+    const ref0: TabRef = { kind: "epic", id: "epic-0" };
+    const ref1: TabRef = { kind: "epic", id: "epic-1" };
+    const ref2: TabRef = { kind: "epic", id: "epic-2" };
+    const ref3: TabRef = { kind: "epic", id: "epic-3" };
+    const ref4: TabRef = { kind: "epic", id: "epic-4" };
+    const ref5: TabRef = { kind: "epic", id: "epic-5" };
+    const refs = [ref0, ref1, ref2, ref3, ref4, ref5];
+
+    useEpicCanvasStore.setState({
+      tabsById: Object.fromEntries(
+        refs.map((ref) => [
+          ref.id,
+          { tabId: ref.id, epicId: ref.id, name: ref.id },
+        ]),
+      ),
+      canvasByTabId: Object.fromEntries(
+        refs.map((ref) => [
+          ref.id,
+          {
+            root: pane("p1", [`chat-${ref.id}`]),
+            activePaneId: "p1",
+            tilesByInstanceId: {
+              [`chat-${ref.id}`]: {
+                id: `chat-${ref.id}`,
+                instanceId: `chat-${ref.id}`,
+                type: "chat",
+                name: `Chat ${ref.id}`,
+                hostId: TEST_HOST_ID,
+              },
+            },
+            sizesByGroupId: {},
+          },
+        ]),
+      ),
+      openTabOrder: refs.map((ref) => ref.id),
+      activeTabId: ref0.id,
+    });
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: refs.map((ref) => ({
+        kind: "tab" as const,
+        id: `tab:${ref.kind}:${ref.id}`,
+        ref,
+      })),
+      activeItemId: `tab:${ref0.kind}:${ref0.id}`,
+      stripOrder: refs,
+    }));
+
+    const doomedInstanceId = `chat-${ref0.id}`;
+    expect(getTileSurfaceMembership().has(doomedInstanceId)).toBe(true);
+    publishTileSurfaceEnvironment(
+      environment({
+        identity: {
+          instanceId: doomedInstanceId,
+          tileKind: "chat",
+          contentId: doomedInstanceId,
+          epicId: ref0.id,
+          hostId: TEST_HOST_ID,
+        },
+      }),
+    );
+    expect(getTileSurfaceEnvironment(doomedInstanceId)).not.toBeNull();
+
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment(
+      doomedInstanceId,
+      () => {
+        notifications += 1;
+      },
+    );
+
+    // Walk recency through the remaining tabs so ref0 is the least-recently
+    // active and is evicted once the retained cap is exceeded (same pattern
+    // as the membership suite's eviction pin).
+    for (const ref of [ref1, ref2, ref3, ref4, ref5]) {
+      useTabsStore.setState((state) => ({
+        ...state,
+        activeItemId: `tab:${ref.kind}:${ref.id}`,
+      }));
+    }
+
+    expect(getTileSurfaceMembership().has(doomedInstanceId)).toBe(false);
+    expect(getTileSurfaceMembership().has(`chat-${ref5.id}`)).toBe(true);
+    expect(
+      refs.filter((ref) =>
+        getTileSurfaceMembership().has(`chat-${ref.id}`),
+      ).length,
+    ).toBe(MAX_RETAINED_TOP_LEVEL_SURFACES);
+    expect(getTileSurfaceEnvironment(doomedInstanceId)).toBeNull();
+    expect(notifications).toBe(1);
+    unsubscribe();
+  });
+
+  it("resetTileSurfaceEnvironmentRegistryForTesting clears environments and subscribers", () => {
+    seedMember("chat-1", "tab-1");
+    publishTileSurfaceEnvironment(environment({}));
+    expect(getTileSurfaceEnvironment("chat-1")).not.toBeNull();
+
+    let staleNotifications = 0;
+    subscribeTileSurfaceEnvironment("chat-1", () => {
+      staleNotifications += 1;
+    });
+
+    resetTileSurfaceEnvironmentRegistryForTesting();
+    expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
+
+    // Re-seed membership and publish again for the same instanceId (fake
+    // reincarnation). The pre-reset subscriber must not fire - the registry
+    // dropped its listener map on reset.
+    seedMember("chat-1", "tab-1");
+    publishTileSurfaceEnvironment(environment({}));
+    expect(getTileSurfaceEnvironment("chat-1")).not.toBeNull();
+    expect(staleNotifications).toBe(0);
+  });
+
+  it("ReadyTileSurfaceEnvironment type-shape smoke: full object round-trips publish/get", () => {
+    seedMember("chat-1", "tab-1");
+    const portal = document.createElement("div");
+    const isPaneFocusedNow = (): boolean => true;
+    const full: ReadyTileSurfaceEnvironment = {
+      identity: {
+        instanceId: "chat-1",
+        tileKind: "chat",
+        contentId: "content-chat-1",
+        epicId: "tab-1",
+        hostId: TEST_HOST_ID,
+      },
+      placement: {
+        epicId: "tab-1",
+        viewTabId: "tab-1",
+        paneId: "p1",
+        hostId: TEST_HOST_ID,
+      },
+      presentation: {
+        topLevelVisible: true,
+        topLevelFocused: true,
+      },
+      canvasActivity: {
+        tabSelected: true,
+        canvasPaneActive: true,
+      },
+      services: {
+        openEpicHandle:
+          {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+        panePortalContainer: portal,
+        isPaneFocusedNow,
+      },
+    };
+
+    publishTileSurfaceEnvironment(full);
+    const got = getTileSurfaceEnvironment("chat-1");
+    expect(got).toBe(full);
+    expect(got).toEqual(full);
+    if (got === null) throw new Error("expected published environment");
+    expect(got.presentation.topLevelFocused).toBe(true);
+    expect(got.canvasActivity.canvasPaneActive).toBe(true);
+    expect(got.services.panePortalContainer).toBe(portal);
+    expect(got.services.isPaneFocusedNow()).toBe(true);
+  });
+
+  it("design-review F2: clears an environment on its first removal even when membership was already populated at registry init", () => {
+    seedMember("chat-1", "tab-1");
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    // Simulate the registry module initializing (or being reset) while
+    // membership is already non-empty - the "normal shape" the review
+    // flagged, since the canvas/tabs stores are synchronously hydrated
+    // before this module's own module-load-time snapshot runs.
+    resetTileSurfaceEnvironmentRegistryForTesting();
+
+    publishTileSurfaceEnvironment(environment({}));
+    expect(getTileSurfaceEnvironment("chat-1")).not.toBeNull();
+
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": {
+          root: null,
+          activePaneId: null,
+          tilesByInstanceId: {},
+          sizesByGroupId: {},
+        },
+      },
+    }));
+
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
+    expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
+    expect(notifications).toBe(1);
+    unsubscribe();
+  });
+
+  it("design-review F3: the record is always keyed by the environment's own identity.instanceId - no independent key parameter exists to disagree with it", () => {
+    seedMember("chat-a", "tab-a");
+    useEpicCanvasStore.setState((state) => ({
+      tabsById: { ...state.tabsById, "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "tab-b" } },
+      canvasByTabId: { ...state.canvasByTabId, "tab-b": canvasWithChat("chat-b") },
+      openTabOrder: [...state.openTabOrder, "tab-b"],
+    }));
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: [
+        ...state.items,
+        {
+          kind: "tab" as const,
+          id: "tab:epic:tab-b",
+          ref: { kind: "epic" as const, id: "tab-b" },
+        },
+      ],
+      activeItemId: "tab:epic:tab-b",
+      stripOrder: [...state.stripOrder, { kind: "epic" as const, id: "tab-b" }],
+    }));
+
+    const envForA = environment({
+      identity: {
+        instanceId: "chat-a",
+        tileKind: "chat",
+        contentId: "chat-a",
+        epicId: "tab-a",
+        hostId: TEST_HOST_ID,
+      },
+    });
+    const envForB = environment({
+      identity: {
+        instanceId: "chat-b",
+        tileKind: "chat",
+        contentId: "chat-b",
+        epicId: "tab-b",
+        hostId: TEST_HOST_ID,
+      },
+    });
+
+    publishTileSurfaceEnvironment(envForA);
+    publishTileSurfaceEnvironment(envForB);
+
+    const gotA = getTileSurfaceEnvironment("chat-a");
+    const gotB = getTileSurfaceEnvironment("chat-b");
+    if (gotA === null || gotB === null) {
+      throw new Error("expected both instances to have a published environment");
+    }
+    expect(gotA.identity.instanceId).toBe("chat-a");
+    expect(gotB.identity.instanceId).toBe("chat-b");
+    expect(gotA).not.toBe(gotB);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -79,6 +79,7 @@ function environment(
       // deliberate fixture seam the design calls for (real host/session
       // integration is slice 5).
       openEpicHandle: {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+      geometryAnchorElement: document.createElement("div"),
       panePortalContainer: null,
       isPaneFocusedNow: () => false,
     },
@@ -422,6 +423,7 @@ describe("tile surface environment registry", () => {
       services: {
         openEpicHandle:
           {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+        geometryAnchorElement: document.createElement("div"),
         panePortalContainer: portal,
         isPaneFocusedNow,
       },

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -78,7 +78,8 @@ function environment(
       // Slice 2 has no real session wiring yet - a synthetic handle is the
       // deliberate fixture seam the design calls for (real host/session
       // integration is slice 5).
-      openEpicHandle: {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+      openEpicHandle:
+        {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
       geometryAnchorElement: document.createElement("div"),
       panePortalContainer: null,
       isPaneFocusedNow: () => false,
@@ -206,8 +207,14 @@ describe("tile surface environment registry", () => {
   it("isolates subscriptions per instance: publishing for B never notifies A's subscribers", () => {
     seedMember("chat-a", "tab-a");
     useEpicCanvasStore.setState((state) => ({
-      tabsById: { ...state.tabsById, "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "tab-b" } },
-      canvasByTabId: { ...state.canvasByTabId, "tab-b": canvasWithChat("chat-b") },
+      tabsById: {
+        ...state.tabsById,
+        "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "tab-b" },
+      },
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-b": canvasWithChat("chat-b"),
+      },
       openTabOrder: [...state.openTabOrder, "tab-b"],
     }));
     useTabsStore.setState((state) => ({
@@ -363,9 +370,8 @@ describe("tile surface environment registry", () => {
     expect(getTileSurfaceMembership().has(doomedInstanceId)).toBe(false);
     expect(getTileSurfaceMembership().has(`chat-${ref5.id}`)).toBe(true);
     expect(
-      refs.filter((ref) =>
-        getTileSurfaceMembership().has(`chat-${ref.id}`),
-      ).length,
+      refs.filter((ref) => getTileSurfaceMembership().has(`chat-${ref.id}`))
+        .length,
     ).toBe(MAX_RETAINED_TOP_LEVEL_SURFACES);
     expect(getTileSurfaceEnvironment(doomedInstanceId)).toBeNull();
     expect(notifications).toBe(1);
@@ -479,8 +485,14 @@ describe("tile surface environment registry", () => {
   it("design-review F3: the record is always keyed by the environment's own identity.instanceId - no independent key parameter exists to disagree with it", () => {
     seedMember("chat-a", "tab-a");
     useEpicCanvasStore.setState((state) => ({
-      tabsById: { ...state.tabsById, "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "tab-b" } },
-      canvasByTabId: { ...state.canvasByTabId, "tab-b": canvasWithChat("chat-b") },
+      tabsById: {
+        ...state.tabsById,
+        "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "tab-b" },
+      },
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-b": canvasWithChat("chat-b"),
+      },
       openTabOrder: [...state.openTabOrder, "tab-b"],
     }));
     useTabsStore.setState((state) => ({
@@ -522,7 +534,9 @@ describe("tile surface environment registry", () => {
     const gotA = getTileSurfaceEnvironment("chat-a");
     const gotB = getTileSurfaceEnvironment("chat-b");
     if (gotA === null || gotB === null) {
-      throw new Error("expected both instances to have a published environment");
+      throw new Error(
+        "expected both instances to have a published environment",
+      );
     }
     expect(gotA.identity.instanceId).toBe("chat-a");
     expect(gotB.identity.instanceId).toBe("chat-b");

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -82,6 +82,12 @@ function environment(
     },
     presentation: { topLevelVisible: true, topLevelFocused: false },
     canvasActivity: { tabSelected: true, canvasPaneActive: false },
+    paneActivation: {
+      focusIntent: {
+        mark: () => undefined,
+        shouldYieldAutoFocus: () => false,
+      },
+    },
     services: {
       // Slice 2 has no real session wiring yet - a synthetic handle is the
       // deliberate fixture seam the design calls for (real host/session
@@ -468,6 +474,12 @@ describe("tile surface environment registry", () => {
       canvasActivity: {
         tabSelected: true,
         canvasPaneActive: true,
+      },
+      paneActivation: {
+        focusIntent: {
+          mark: () => undefined,
+          shouldYieldAutoFocus: () => false,
+        },
       },
       services: {
         openEpicHandle:

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
@@ -150,12 +150,16 @@ describe("host-root movement invalidates every registered slot", () => {
     const slotA = document.createElement("div");
     stubRect(slotA, { left: 100, top: 100, width: 50, height: 50 });
     const rectsA: TileSurfaceRect[] = [];
-    registerTileSurfaceGeometrySlot("chat-a", slotA, (rect) => rectsA.push(rect));
+    registerTileSurfaceGeometrySlot("chat-a", slotA, (rect) =>
+      rectsA.push(rect),
+    );
 
     const slotB = document.createElement("div");
     stubRect(slotB, { left: 300, top: 300, width: 50, height: 50 });
     const rectsB: TileSurfaceRect[] = [];
-    registerTileSurfaceGeometrySlot("chat-b", slotB, (rect) => rectsB.push(rect));
+    registerTileSurfaceGeometrySlot("chat-b", slotB, (rect) =>
+      rectsB.push(rect),
+    );
 
     rectsA.length = 0;
     rectsB.length = 0;
@@ -199,11 +203,15 @@ describe("unregister and re-registration", () => {
     const slot = document.createElement("div");
     stubRect(slot, { left: 0, top: 0, width: 100, height: 100 });
     const rectsFirst: TileSurfaceRect[] = [];
-    const unregisterFirst = registerTileSurfaceGeometrySlot("chat-1", slot, (rect) =>
-      rectsFirst.push(rect),
+    const unregisterFirst = registerTileSurfaceGeometrySlot(
+      "chat-1",
+      slot,
+      (rect) => rectsFirst.push(rect),
     );
     const rectsSecond: TileSurfaceRect[] = [];
-    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rectsSecond.push(rect));
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) =>
+      rectsSecond.push(rect),
+    );
     rectsSecond.length = 0;
 
     // The first registration's own cleanup fires late, after the second

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerTileSurfaceGeometryHost,
+  registerTileSurfaceGeometrySlot,
+  resetTileSurfaceGeometryCoordinatorForTesting,
+  type TileSurfaceRect,
+} from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
+
+/**
+ * The global `MockResizeObserver` installed by `test-browser-apis.ts` is a
+ * total no-op - it never invokes its callback. Installing a controllable
+ * replacement at MODULE LOAD TIME (before any test body runs, so it is in
+ * place before this coordinator's lazily-constructed singleton observer is
+ * ever created) lets these tests fire real RO callbacks on demand. Same
+ * technique this repo already used for the ticket-17/18 stack's height-only
+ * resize pin - see [[legendlist-pass-through-mock-ref-tee]] in memory.
+ */
+class ControllableResizeObserver implements ResizeObserver {
+  readonly callback: ResizeObserverCallback;
+  readonly observed = new Set<Element>();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    controllableInstances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observed.delete(target);
+  }
+
+  disconnect(): void {
+    this.observed.clear();
+  }
+}
+
+let controllableInstances: ControllableResizeObserver[] = [];
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  configurable: true,
+  writable: true,
+  value: ControllableResizeObserver,
+});
+
+function triggerResizeObserverCallbacks(): void {
+  for (const instance of controllableInstances) {
+    instance.callback([], instance);
+  }
+}
+
+function fakeRect(rect: {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}): DOMRect {
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+    right: rect.left + rect.width,
+    bottom: rect.top + rect.height,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => rect,
+  };
+}
+
+function stubRect(
+  element: Element,
+  rect: {
+    readonly left: number;
+    readonly top: number;
+    readonly width: number;
+    readonly height: number;
+  },
+): void {
+  element.getBoundingClientRect = () => fakeRect(rect);
+}
+
+beforeEach(() => {
+  controllableInstances = [];
+  resetTileSurfaceGeometryCoordinatorForTesting();
+});
+
+afterEach(() => {
+  resetTileSurfaceGeometryCoordinatorForTesting();
+});
+
+describe("registration and direct-flush application", () => {
+  it("applies an initial rect synchronously on registration, without waiting for a RO callback", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 50, top: 40, width: 200, height: 100 });
+    const rects: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rects.push(rect));
+
+    expect(rects).toEqual([{ left: 50, top: 40, width: 200, height: 100 }]);
+  });
+
+  it("applies a slot's rect host-relative, not viewport-relative", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 20, top: 30, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 120, top: 130, width: 200, height: 100 });
+    const rects: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rects.push(rect));
+
+    expect(rects[0]).toEqual({ left: 100, top: 100, width: 200, height: 100 });
+  });
+
+  it("applies a RO callback's rect update directly and synchronously in the same task - no requestAnimationFrame dependence", () => {
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 0, top: 0, width: 100, height: 100 });
+    const rects: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rects.push(rect));
+    rects.length = 0;
+
+    stubRect(slot, { left: 0, top: 0, width: 400, height: 300 });
+    triggerResizeObserverCallbacks();
+
+    // Synchronous assertion, no await/advanceTimers/rAF flush of any kind:
+    // the new rect must already be applied by the time this line runs.
+    expect(rects).toEqual([{ left: 0, top: 0, width: 400, height: 300 }]);
+    expect(rafSpy).not.toHaveBeenCalled();
+    rafSpy.mockRestore();
+  });
+});
+
+describe("host-root movement invalidates every registered slot", () => {
+  it("re-applies every live slot's rect when the host root itself moves, not only a slot named in the triggering batch", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slotA = document.createElement("div");
+    stubRect(slotA, { left: 100, top: 100, width: 50, height: 50 });
+    const rectsA: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-a", slotA, (rect) => rectsA.push(rect));
+
+    const slotB = document.createElement("div");
+    stubRect(slotB, { left: 300, top: 300, width: 50, height: 50 });
+    const rectsB: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-b", slotB, (rect) => rectsB.push(rect));
+
+    rectsA.length = 0;
+    rectsB.length = 0;
+
+    // Simulate a real host-root resize (e.g. the sidebar toggling) - only
+    // the HOST's own observed element changed; neither slot moved.
+    stubRect(host, { left: 0, top: 0, width: 400, height: 300 });
+    triggerResizeObserverCallbacks();
+
+    expect(rectsA).toEqual([{ left: 100, top: 100, width: 50, height: 50 }]);
+    expect(rectsB).toEqual([{ left: 300, top: 300, width: 50, height: 50 }]);
+  });
+});
+
+describe("unregister and re-registration", () => {
+  it("stops delivering rect updates after unregister", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 0, top: 0, width: 100, height: 100 });
+    const rects: TileSurfaceRect[] = [];
+    const unregister = registerTileSurfaceGeometrySlot("chat-1", slot, (rect) =>
+      rects.push(rect),
+    );
+    rects.length = 0;
+    unregister();
+
+    stubRect(slot, { left: 0, top: 0, width: 999, height: 999 });
+    triggerResizeObserverCallbacks();
+
+    expect(rects).toEqual([]);
+  });
+
+  it("a stale unregister from a displaced registration cannot clobber a fresh registration under the same key", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 0, top: 0, width: 100, height: 100 });
+    const rectsFirst: TileSurfaceRect[] = [];
+    const unregisterFirst = registerTileSurfaceGeometrySlot("chat-1", slot, (rect) =>
+      rectsFirst.push(rect),
+    );
+    const rectsSecond: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rectsSecond.push(rect));
+    rectsSecond.length = 0;
+
+    // The first registration's own cleanup fires late, after the second
+    // registration has already replaced it under the identical key -
+    // exactly the StrictMode double-invoke ordering ticket 22's sentinel
+    // bug got wrong ("cleanup cancelled but didn't clear").
+    unregisterFirst();
+
+    stubRect(slot, { left: 0, top: 0, width: 250, height: 250 });
+    triggerResizeObserverCallbacks();
+
+    expect(rectsSecond).toEqual([{ left: 0, top: 0, width: 250, height: 250 }]);
+  });
+});
+
+describe("host re-registration", () => {
+  it("a later host registration replaces the coordinate origin outright", () => {
+    const hostOne = document.createElement("div");
+    stubRect(hostOne, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(hostOne);
+
+    const hostTwo = document.createElement("div");
+    stubRect(hostTwo, { left: 500, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(hostTwo);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 600, top: 0, width: 50, height: 50 });
+    const rects: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rects.push(rect));
+
+    expect(rects).toEqual([{ left: 100, top: 0, width: 50, height: 50 }]);
+  });
+});
+
+describe("displaced-element unobserve (design-review F2)", () => {
+  function soleObserver(): ControllableResizeObserver {
+    const observer = controllableInstances.at(0);
+    if (observer === undefined) {
+      throw new Error("expected the shared observer to already be constructed");
+    }
+    return observer;
+  }
+
+  it("re-registering a different slot under the same key survives AND stops observing the displaced slot element", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const oldSlot = document.createElement("div");
+    stubRect(oldSlot, { left: 0, top: 0, width: 100, height: 100 });
+    registerTileSurfaceGeometrySlot("chat-1", oldSlot, () => {});
+    expect(soleObserver().observed.has(oldSlot)).toBe(true);
+
+    const newSlot = document.createElement("div");
+    stubRect(newSlot, { left: 0, top: 0, width: 200, height: 200 });
+    registerTileSurfaceGeometrySlot("chat-1", newSlot, () => {});
+
+    // New registration survives (the reviewer's own phrasing)...
+    expect(soleObserver().observed.has(newSlot)).toBe(true);
+    // ...and the displaced target is no longer observed.
+    expect(soleObserver().observed.has(oldSlot)).toBe(false);
+  });
+
+  it("a later host registration stops observing the displaced host element", () => {
+    const hostOne = document.createElement("div");
+    stubRect(hostOne, { left: 0, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(hostOne);
+    expect(soleObserver().observed.has(hostOne)).toBe(true);
+
+    const hostTwo = document.createElement("div");
+    stubRect(hostTwo, { left: 500, top: 0, width: 800, height: 600 });
+    registerTileSurfaceGeometryHost(hostTwo);
+
+    expect(soleObserver().observed.has(hostTwo)).toBe(true);
+    expect(soleObserver().observed.has(hostOne)).toBe(false);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
@@ -163,14 +163,18 @@ describe("host-root movement invalidates every registered slot", () => {
 
     rectsA.length = 0;
     rectsB.length = 0;
+    const hostRectRead = vi.spyOn(host, "getBoundingClientRect");
 
     // Simulate a real host-root resize (e.g. the sidebar toggling) - only
     // the HOST's own observed element changed; neither slot moved.
-    stubRect(host, { left: 0, top: 0, width: 400, height: 300 });
+    hostRectRead.mockReturnValue(
+      fakeRect({ left: 0, top: 0, width: 400, height: 300 }),
+    );
     triggerResizeObserverCallbacks();
 
     expect(rectsA).toEqual([{ left: 100, top: 100, width: 50, height: 50 }]);
     expect(rectsB).toEqual([{ left: 300, top: 300, width: 50, height: 50 }]);
+    expect(hostRectRead).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -224,6 +228,46 @@ describe("unregister and re-registration", () => {
     triggerResizeObserverCallbacks();
 
     expect(rectsSecond).toEqual([{ left: 0, top: 0, width: 250, height: 250 }]);
+  });
+
+  it("stops all slot updates and unobserves the host after host unregister", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    const unregisterHost = registerTileSurfaceGeometryHost(host);
+
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 0, top: 0, width: 100, height: 100 });
+    const rects: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-1", slot, (rect) => rects.push(rect));
+    rects.length = 0;
+
+    unregisterHost();
+    const observer = controllableInstances.at(0);
+    expect(observer?.observed.has(host)).toBe(false);
+    stubRect(slot, { left: 0, top: 0, width: 250, height: 250 });
+    triggerResizeObserverCallbacks();
+
+    expect(rects).toEqual([]);
+  });
+
+  it("late cleanup after a test reset does not construct a replacement observer", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 800, height: 600 });
+    const unregisterHost = registerTileSurfaceGeometryHost(host);
+    const slot = document.createElement("div");
+    stubRect(slot, { left: 0, top: 0, width: 100, height: 100 });
+    const unregisterSlot = registerTileSurfaceGeometrySlot(
+      "chat-1",
+      slot,
+      () => {},
+    );
+    expect(controllableInstances).toHaveLength(1);
+
+    resetTileSurfaceGeometryCoordinatorForTesting();
+    unregisterHost();
+    unregisterSlot();
+
+    expect(controllableInstances).toHaveLength(1);
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+} from "vitest";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicCanvasState, EpicNodeRef } from "@/stores/epics/canvas/types";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
@@ -25,6 +32,7 @@ import {
 import {
   reportChatRemoteDeletionState,
   resetChatRemoteDeletionRegistryForTesting,
+  subscribeChatRemoteDeletion,
 } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
 import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
 
@@ -57,7 +65,10 @@ function canvasWithChat(instanceId: string, paneId: string): EpicCanvasState {
   };
 }
 
-function seedSingleTabStrip(refs: ReadonlyArray<TabRef>, activeRef: TabRef) {
+function seedSingleTabStrip(
+  refs: ReadonlyArray<TabRef>,
+  activeRef: TabRef,
+): void {
   useTabsStore.setState((state) => ({
     ...state,
     items: refs.map((ref) => ({
@@ -837,6 +848,33 @@ describe("design-review F2: shared eligibility discriminator (remote-deletion)",
     expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
 
     reportChatRemoteDeletionState("chat-1", false);
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+  });
+
+  it("reset notifies subscribers and immediately recomputes remote-deletion membership", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
+    reportChatRemoteDeletionState("chat-1", true);
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
+
+    let notifications = 0;
+    const unsubscribe = subscribeChatRemoteDeletion(() => {
+      notifications += 1;
+    });
+    onTestFinished(unsubscribe);
+    resetChatRemoteDeletionRegistryForTesting();
+
+    expect(notifications).toBe(1);
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
@@ -1,0 +1,753 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicCanvasState, EpicNodeRef } from "@/stores/epics/canvas/types";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
+import { useTabsStore } from "@/stores/tabs/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import type { TabRef } from "@/stores/tabs/types";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import {
+  collectCanvasWideSelectedChatMembership,
+  getTileSurfaceMembership,
+  resetTileSurfaceMembershipForTesting,
+  subscribeTileSurfaceMembership,
+} from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/stores/tabs/top-level-surface-retention";
+
+function chatRef(instanceId: string): EpicNodeRef {
+  return {
+    id: instanceId,
+    instanceId,
+    type: "chat",
+    name: `Chat ${instanceId}`,
+    hostId: TEST_HOST_ID,
+  };
+}
+
+function terminalRef(instanceId: string): EpicNodeRef {
+  return {
+    id: instanceId,
+    instanceId,
+    type: "terminal-agent",
+    name: `Terminal ${instanceId}`,
+    hostId: TEST_HOST_ID,
+  };
+}
+
+function canvasWithChat(instanceId: string, paneId: string): EpicCanvasState {
+  return {
+    root: pane(paneId, [instanceId]),
+    activePaneId: paneId,
+    tilesByInstanceId: { [instanceId]: chatRef(instanceId) },
+    sizesByGroupId: {},
+  };
+}
+
+function seedSingleTabStrip(refs: ReadonlyArray<TabRef>, activeRef: TabRef) {
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: refs.map((ref) => ({
+      kind: "tab" as const,
+      id: `tab:${ref.kind}:${ref.id}`,
+      ref,
+    })),
+    activeItemId: `tab:${activeRef.kind}:${activeRef.id}`,
+    stripOrder: refs,
+  }));
+}
+
+function resetAll(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+  tabCommandCoordinator.resetReconciliationForTesting();
+  resetTileSurfaceMembershipForTesting();
+}
+
+describe("collectCanvasWideSelectedChatMembership (layer 1, pure)", () => {
+  it("includes a chat tile that is its pane's active tab", () => {
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": canvasWithChat("chat-inst", "p1"),
+    });
+    expect(membership.get("chat-inst")).toBe("tab-1");
+  });
+
+  it("excludes a non-chat tile even when it is the active tab", () => {
+    const term = terminalRef("term-inst");
+    const canvas: EpicCanvasState = {
+      root: pane("p1", ["term-inst"]),
+      activePaneId: "p1",
+      tilesByInstanceId: { "term-inst": term },
+      sizesByGroupId: {},
+    };
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": canvas,
+    });
+    expect(membership.size).toBe(0);
+  });
+
+  it("excludes a chat tile that is a background (non-active) tab in its pane", () => {
+    const canvas: EpicCanvasState = {
+      root: {
+        ...pane("p1", ["chat-front", "chat-back"]),
+        activeTabId: "chat-front",
+      },
+      activePaneId: "p1",
+      tilesByInstanceId: {
+        "chat-front": chatRef("chat-front"),
+        "chat-back": chatRef("chat-back"),
+      },
+      sizesByGroupId: {},
+    };
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": canvas,
+    });
+    expect(membership.has("chat-front")).toBe(true);
+    expect(membership.has("chat-back")).toBe(false);
+  });
+
+  it("falls back to the first tab (resolveActivePaneTab wiring) when activeTabId is stale", () => {
+    const canvas: EpicCanvasState = {
+      root: { ...pane("p1", ["chat-a"]), activeTabId: "gone" },
+      activePaneId: "p1",
+      tilesByInstanceId: { "chat-a": chatRef("chat-a") },
+      sizesByGroupId: {},
+    };
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": canvas,
+    });
+    expect(membership.get("chat-a")).toBe("tab-1");
+  });
+
+  it("walks every pane across every open top-level tab", () => {
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": canvasWithChat("chat-1", "p1"),
+      "tab-2": canvasWithChat("chat-2", "p1"),
+    });
+    expect(membership.get("chat-1")).toBe("tab-1");
+    expect(membership.get("chat-2")).toBe("tab-2");
+  });
+
+  it("ignores a tab with a null (empty-shell) canvas root", () => {
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": {
+        root: null,
+        activePaneId: null,
+        tilesByInstanceId: {},
+        sizesByGroupId: {},
+      },
+    });
+    expect(membership.size).toBe(0);
+  });
+});
+
+describe("tile surface membership - live store integration", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => resetAll());
+
+  it("stays continuous across a same-pane reorder (single EpicCanvasStore commit)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    // Reorder: add a second (background) tab, then swap which is active -
+    // the tracked instance itself never structurally moves.
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": {
+          ...canvasWithChat("chat-1", "p1"),
+          root: {
+            ...pane("p1", ["chat-1", "chat-2"]),
+            activeTabId: "chat-1",
+          },
+          tilesByInstanceId: {
+            "chat-1": chatRef("chat-1"),
+            "chat-2": chatRef("chat-2"),
+          },
+        },
+      },
+    }));
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+  });
+
+  it("stays continuous across a cross-pane move (instanceId preserved, pane changes)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": canvasWithChat("chat-1", "p2"),
+      },
+    }));
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+  });
+
+  it("removes membership on close (permanent unmount)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": {
+          root: null,
+          activePaneId: null,
+          tilesByInstanceId: {},
+          sizesByGroupId: {},
+        },
+      },
+    }));
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
+  });
+
+  it("decision #17: switching a pane's active tab away from a chat removes it; switching back re-adds it", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: {
+        "tab-1": {
+          root: { ...pane("p1", ["chat-1", "term-1"]), activeTabId: "chat-1" },
+          activePaneId: "p1",
+          tilesByInstanceId: {
+            "chat-1": chatRef("chat-1"),
+            "term-1": terminalRef("term-1"),
+          },
+          sizesByGroupId: {},
+        },
+      },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    function canvasWithActiveTab(activeTabId: string): EpicCanvasState {
+      return {
+        root: { ...pane("p1", ["chat-1", "term-1"]), activeTabId },
+        activePaneId: "p1",
+        tilesByInstanceId: {
+          "chat-1": chatRef("chat-1"),
+          "term-1": terminalRef("term-1"),
+        },
+        sizesByGroupId: {},
+      };
+    }
+
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": canvasWithActiveTab("term-1"),
+      },
+    }));
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
+
+    useEpicCanvasStore.setState((state) => ({
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        "tab-1": canvasWithActiveTab("chat-1"),
+      },
+    }));
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+  });
+
+  it("evicts the least-recently-active top-level tab's chat once the retained cap is exceeded", () => {
+    const ref0: TabRef = { kind: "epic", id: "epic-0" };
+    const ref1: TabRef = { kind: "epic", id: "epic-1" };
+    const ref2: TabRef = { kind: "epic", id: "epic-2" };
+    const ref3: TabRef = { kind: "epic", id: "epic-3" };
+    const ref4: TabRef = { kind: "epic", id: "epic-4" };
+    const ref5: TabRef = { kind: "epic", id: "epic-5" };
+    const refs = [ref0, ref1, ref2, ref3, ref4, ref5];
+    useEpicCanvasStore.setState({
+      tabsById: Object.fromEntries(
+        refs.map((ref) => [
+          ref.id,
+          { tabId: ref.id, epicId: ref.id, name: ref.id },
+        ]),
+      ),
+      canvasByTabId: Object.fromEntries(
+        refs.map((ref) => [ref.id, canvasWithChat(`chat-${ref.id}`, "p1")]),
+      ),
+      openTabOrder: refs.map((ref) => ref.id),
+      activeTabId: ref0.id,
+    });
+    seedSingleTabStrip(refs, ref0);
+    for (const ref of [ref1, ref2, ref3, ref4, ref5]) {
+      seedSingleTabStrip(refs, ref);
+    }
+
+    const membership = getTileSurfaceMembership();
+    expect(membership.has("chat-epic-0")).toBe(false);
+    expect(membership.has(`chat-${ref5.id}`)).toBe(true);
+    const memberCount = refs.filter((ref) =>
+      membership.has(`chat-${ref.id}`),
+    ).length;
+    expect(memberCount).toBe(MAX_RETAINED_TOP_LEVEL_SURFACES);
+  });
+
+  it(
+    "header tear-off: membership never shows a false-absence frame across the " +
+      "two-store (EpicCanvasStore then TabsStore) transaction, sampled at " +
+      "every store/coordinator notification",
+    () => {
+      useEpicCanvasStore.setState({
+        tabsById: {
+          "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+        },
+        canvasByTabId: {
+          "tab-1": {
+            root: {
+              ...pane("p1", ["chat-1", "chat-2"]),
+              activeTabId: "chat-1",
+            },
+            activePaneId: "p1",
+            tilesByInstanceId: {
+              "chat-1": chatRef("chat-1"),
+              "chat-2": chatRef("chat-2"),
+            },
+            sizesByGroupId: {},
+          },
+        },
+        openTabOrder: ["tab-1"],
+        activeTabId: "tab-1",
+      });
+      seedSingleTabStrip(
+        [{ kind: "epic", id: "tab-1" }],
+        { kind: "epic", id: "tab-1" },
+      );
+      expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+      const samples: boolean[] = [];
+      const record = (): void => {
+        samples.push(getTileSurfaceMembership().has("chat-1"));
+      };
+      const unsubCanvas = useEpicCanvasStore.subscribe(record);
+      const unsubTabs = useTabsStore.subscribe(record);
+      const unsubCoordinator = tabCommandCoordinator.subscribe(record);
+
+      try {
+        const placedRef = tabCommandCoordinator.createSourceRefAtStripIndex(
+          0,
+          () => {
+            const newTabId = useEpicCanvasStore
+              .getState()
+              .tearOffTabIntoNewHeaderTab({
+                sourceTabId: "tab-1",
+                sourcePaneId: "p1",
+                sourceTileTabId: "chat-1",
+                insertIndex: 0,
+              });
+            return newTabId === null ? null : { kind: "epic", id: newTabId };
+          },
+        );
+        expect(placedRef).not.toBeNull();
+      } finally {
+        unsubCanvas();
+        unsubTabs();
+        unsubCoordinator();
+      }
+
+      expect(samples.length).toBeGreaterThan(0);
+      expect(samples.every((sampledMember) => sampledMember)).toBe(true);
+      expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+    },
+  );
+
+  it("stays continuous across a real edge split (splitPaneWithTab)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: {
+        "tab-1": {
+          root: {
+            ...pane("p1", ["chat-1", "chat-2"]),
+            activeTabId: "chat-1",
+          },
+          activePaneId: "p1",
+          tilesByInstanceId: {
+            "chat-1": chatRef("chat-1"),
+            "chat-2": chatRef("chat-2"),
+          },
+          sizesByGroupId: {},
+        },
+      },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    const samples: boolean[] = [];
+    const record = (): void => {
+      samples.push(getTileSurfaceMembership().has("chat-1"));
+    };
+    const unsubCanvas = useEpicCanvasStore.subscribe(record);
+    const unsubMembership = subscribeTileSurfaceMembership(record);
+
+    try {
+      // Same-pane edge split: dragged tab lands in a brand-new pane; the
+      // original pane keeps chat-2. Membership must keep chat-1 continuous.
+      useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+        sourcePaneId: "p1",
+        tabId: "chat-1",
+        targetPaneId: "p1",
+        position: "right",
+      });
+    } finally {
+      unsubCanvas();
+      unsubMembership();
+    }
+
+    const canvas = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (canvas === undefined) throw new Error("expected canvas for tab-1");
+    expect(collectPanes(canvas.root).length).toBeGreaterThan(1);
+    expect(samples.length).toBeGreaterThan(0);
+    expect(samples.every((sampledMember) => sampledMember)).toBe(true);
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+  });
+
+  it("stays continuous across wrap/dissolve (split then closeCanvasTab sibling)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: {
+        "tab-1": {
+          root: {
+            ...pane("p1", ["chat-1", "chat-2"]),
+            activeTabId: "chat-1",
+          },
+          activePaneId: "p1",
+          tilesByInstanceId: {
+            "chat-1": chatRef("chat-1"),
+            "chat-2": chatRef("chat-2"),
+          },
+          sizesByGroupId: {},
+        },
+      },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+    expect(getTileSurfaceMembership().has("chat-2")).toBe(false);
+
+    const survivorSamples: boolean[] = [];
+    const recordSurvivor = (): void => {
+      survivorSamples.push(getTileSurfaceMembership().has("chat-1"));
+    };
+    const unsubCanvas = useEpicCanvasStore.subscribe(recordSurvivor);
+    const unsubMembership = subscribeTileSurfaceMembership(recordSurvivor);
+
+    try {
+      useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+        sourcePaneId: "p1",
+        tabId: "chat-2",
+        targetPaneId: "p1",
+        position: "right",
+      });
+
+      const afterSplit = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+      if (afterSplit === undefined) {
+        throw new Error("expected canvas after split");
+      }
+      const panes = collectPanes(afterSplit.root);
+      expect(panes.length).toBe(2);
+      // chat-2 is now its own pane's active tab → also a member.
+      expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+      expect(getTileSurfaceMembership().has("chat-2")).toBe(true);
+
+      const chat2Pane = panes.find((p) =>
+        p.tabInstanceIds.includes("chat-2"),
+      );
+      if (chat2Pane === undefined) {
+        throw new Error("expected pane hosting chat-2 after split");
+      }
+
+      // Closing the sibling's only tab dissolves the split (one-child-group
+      // promotion). chat-2 must leave membership; chat-1 must stay throughout.
+      useEpicCanvasStore
+        .getState()
+        .closeCanvasTab("tab-1", chat2Pane.id, "chat-2");
+    } finally {
+      unsubCanvas();
+      unsubMembership();
+    }
+
+    const afterDissolve = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (afterDissolve === undefined) {
+      throw new Error("expected canvas after dissolve");
+    }
+    expect(collectPanes(afterDissolve.root).length).toBe(1);
+    expect(survivorSamples.length).toBeGreaterThan(0);
+    expect(survivorSamples.every((sampledMember) => sampledMember)).toBe(true);
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+    expect(getTileSurfaceMembership().has("chat-2")).toBe(false);
+  });
+
+  it("stays continuous across moveTabOnTabStrip (cross-pane move)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: {
+        "tab-1": {
+          root: {
+            ...pane("p1", ["chat-1", "chat-2"]),
+            activeTabId: "chat-1",
+          },
+          activePaneId: "p1",
+          tilesByInstanceId: {
+            "chat-1": chatRef("chat-1"),
+            "chat-2": chatRef("chat-2"),
+          },
+          sizesByGroupId: {},
+        },
+      },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+
+    // First create a real second pane via edge split, then move chat-1 onto it.
+    useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+      sourcePaneId: "p1",
+      tabId: "chat-2",
+      targetPaneId: "p1",
+      position: "right",
+    });
+    const afterSplit = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (afterSplit === undefined) throw new Error("expected canvas after split");
+    const panes = collectPanes(afterSplit.root);
+    expect(panes.length).toBe(2);
+    const chat1Pane = panes.find((p) => p.tabInstanceIds.includes("chat-1"));
+    const chat2Pane = panes.find((p) => p.tabInstanceIds.includes("chat-2"));
+    if (chat1Pane === undefined || chat2Pane === undefined) {
+      throw new Error("expected both panes after split");
+    }
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    const samples: boolean[] = [];
+    const record = (): void => {
+      samples.push(getTileSurfaceMembership().has("chat-1"));
+    };
+    const unsubCanvas = useEpicCanvasStore.subscribe(record);
+    const unsubMembership = subscribeTileSurfaceMembership(record);
+
+    try {
+      useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
+        sourcePaneId: chat1Pane.id,
+        tabId: "chat-1",
+        targetPaneId: chat2Pane.id,
+        targetIndex: 0,
+      });
+    } finally {
+      unsubCanvas();
+      unsubMembership();
+    }
+
+    const afterMove = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (afterMove === undefined) throw new Error("expected canvas after move");
+    // chat-1 left its only-tab pane → that pane dissolved; chat-1 should still
+    // be a member wherever it landed.
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+    expect(samples.length).toBeGreaterThan(0);
+    expect(samples.every((sampledMember) => sampledMember)).toBe(true);
+  });
+
+  it("add-background: openTileInBackgroundTab does not touch active-chat membership", () => {
+    // Correction vs brief: `openTileInPane` always activates the new tab
+    // (and would deselect the prior active chat under decision #17). The
+    // real "add background without switching active tab" store action is
+    // `openTileInBackgroundTab`.
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+    let membershipNotifications = 0;
+    const unsubMembership = subscribeTileSurfaceMembership(() => {
+      membershipNotifications += 1;
+    });
+
+    try {
+      useEpicCanvasStore
+        .getState()
+        .openTileInBackgroundTab("tab-1", chatRef("chat-2"));
+    } finally {
+      unsubMembership();
+    }
+
+    const canvas = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
+    if (canvas === undefined) throw new Error("expected canvas for tab-1");
+    const rootPane = canvas.root;
+    if (rootPane === null || rootPane.kind !== "pane") {
+      throw new Error("expected single root pane after background open");
+    }
+    expect(rootPane.tabInstanceIds).toContain("chat-1");
+    expect(rootPane.tabInstanceIds).toContain("chat-2");
+    expect(rootPane.activeTabId).toBe("chat-1");
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+    expect(getTileSurfaceMembership().has("chat-2")).toBe(false);
+    // Membership set is unchanged → recomputeMembership short-circuits
+    // without notifying (setsEqual).
+    expect(membershipNotifications).toBe(0);
+  });
+
+  it("two top-level tabs: each active chat is a member attributed to its own tabId", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-a": { tabId: "tab-a", epicId: "tab-a", name: "Tab A" },
+        "tab-b": { tabId: "tab-b", epicId: "tab-b", name: "Tab B" },
+      },
+      canvasByTabId: {
+        "tab-a": canvasWithChat("chat-a", "p1"),
+        "tab-b": canvasWithChat("chat-b", "p1"),
+      },
+      openTabOrder: ["tab-a", "tab-b"],
+      activeTabId: "tab-b",
+    });
+    // Activate both so layer-2 recency retains them under the cap.
+    seedSingleTabStrip(
+      [
+        { kind: "epic", id: "tab-a" },
+        { kind: "epic", id: "tab-b" },
+      ],
+      { kind: "epic", id: "tab-a" },
+    );
+    seedSingleTabStrip(
+      [
+        { kind: "epic", id: "tab-a" },
+        { kind: "epic", id: "tab-b" },
+      ],
+      { kind: "epic", id: "tab-b" },
+    );
+
+    const layer1 = collectCanvasWideSelectedChatMembership(
+      useEpicCanvasStore.getState().canvasByTabId,
+    );
+    expect(layer1.get("chat-a")).toBe("tab-a");
+    expect(layer1.get("chat-b")).toBe("tab-b");
+
+    const membership = getTileSurfaceMembership();
+    expect(membership.has("chat-a")).toBe(true);
+    expect(membership.has("chat-b")).toBe(true);
+  });
+});
+
+describe("design-review F1: global MRU cap spans every top-level kind, not just epic", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => resetAll());
+
+  it("evicts an epic chat once the global cap-5 is exceeded by mixed-kind activations (epic-old -> 4 drafts -> epic-new)", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "epic-old": { tabId: "epic-old", epicId: "epic-old", name: "Epic Old" },
+        "epic-new": { tabId: "epic-new", epicId: "epic-new", name: "Epic New" },
+      },
+      canvasByTabId: {
+        "epic-old": canvasWithChat("chat-old", "p1"),
+        "epic-new": canvasWithChat("chat-new", "p1"),
+      },
+      openTabOrder: ["epic-old", "epic-new"],
+      activeTabId: "epic-old",
+    });
+    const draftId1 = useLandingDraftStore
+      .getState()
+      .createDraftWithId("draft-1", null);
+    const draftId2 = useLandingDraftStore
+      .getState()
+      .createDraftWithId("draft-2", null);
+    const draftId3 = useLandingDraftStore
+      .getState()
+      .createDraftWithId("draft-3", null);
+    const draftId4 = useLandingDraftStore
+      .getState()
+      .createDraftWithId("draft-4", null);
+
+    const epicOldRef: TabRef = { kind: "epic", id: "epic-old" };
+    const epicNewRef: TabRef = { kind: "epic", id: "epic-new" };
+    const draftRefs: ReadonlyArray<TabRef> = [
+      { kind: "draft", id: draftId1 },
+      { kind: "draft", id: draftId2 },
+      { kind: "draft", id: draftId3 },
+      { kind: "draft", id: draftId4 },
+    ];
+    const allRefs = [epicOldRef, ...draftRefs, epicNewRef];
+
+    seedSingleTabStrip(allRefs, epicOldRef);
+    expect(getTileSurfaceMembership().has("chat-old")).toBe(true);
+
+    for (const draftRef of draftRefs) {
+      seedSingleTabStrip(allRefs, draftRef);
+    }
+    seedSingleTabStrip(allRefs, epicNewRef);
+
+    // Real global cap-5 recency: epic-old, draft-1..4, epic-new is 6 distinct
+    // activations - epic-old (least recently active) must be evicted, and
+    // its chat must leave membership with it.
+    expect(getTileSurfaceMembership().has("chat-old")).toBe(false);
+    expect(getTileSurfaceMembership().has("chat-new")).toBe(true);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
@@ -17,6 +17,16 @@ import {
   subscribeTileSurfaceMembership,
 } from "@/components/epic-canvas/surface-host/tile-surface-membership";
 import { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/stores/tabs/top-level-surface-retention";
+import {
+  getTileSurfaceEnvironment,
+  publishTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import {
+  reportChatRemoteDeletionState,
+  resetChatRemoteDeletionRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
 
 function chatRef(instanceId: string): EpicNodeRef {
   return {
@@ -65,10 +75,14 @@ function resetAll(): void {
   useTabsStore.setState(useTabsStore.getInitialState(), true);
   useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
   tabCommandCoordinator.resetReconciliationForTesting();
+  resetChatRemoteDeletionRegistryForTesting();
   resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
 }
 
 describe("collectCanvasWideSelectedChatMembership (layer 1, pure)", () => {
+  afterEach(() => resetChatRemoteDeletionRegistryForTesting());
+
   it("includes a chat tile that is its pane's active tab", () => {
     const membership = collectCanvasWideSelectedChatMembership({
       "tab-1": canvasWithChat("chat-inst", "p1"),
@@ -130,6 +144,14 @@ describe("collectCanvasWideSelectedChatMembership (layer 1, pure)", () => {
     });
     expect(membership.get("chat-1")).toBe("tab-1");
     expect(membership.get("chat-2")).toBe("tab-2");
+  });
+
+  it("design-review F2: excludes a chat that is remote-deleted even though it is the active tab", () => {
+    reportChatRemoteDeletionState("chat-deleted", true);
+    const membership = collectCanvasWideSelectedChatMembership({
+      "tab-1": canvasWithChat("chat-deleted", "p1"),
+    });
+    expect(membership.size).toBe(0);
   });
 
   it("ignores a tab with a null (empty-shell) canvas root", () => {
@@ -749,5 +771,73 @@ describe("design-review F1: global MRU cap spans every top-level kind, not just 
     // its chat must leave membership with it.
     expect(getTileSurfaceMembership().has("chat-old")).toBe(false);
     expect(getTileSurfaceMembership().has("chat-new")).toBe(true);
+  });
+});
+
+describe("design-review F2: shared eligibility discriminator (remote-deletion)", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => resetAll());
+
+  it(
+    "pin: remote-delete while hosted -> membership drops the instance and its " +
+      "published environment is cleared - exactly one owner survives",
+    () => {
+      useEpicCanvasStore.setState({
+        tabsById: {
+          "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+        },
+        canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+        openTabOrder: ["tab-1"],
+        activeTabId: "tab-1",
+      });
+      seedSingleTabStrip(
+        [{ kind: "epic", id: "tab-1" }],
+        { kind: "epic", id: "tab-1" },
+      );
+      expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+
+      // Mirrors what `TileSurfaceSlot` does once mounted for a real hosted
+      // chat - a published environment is the thing that would otherwise
+      // linger as a second, orphaned owner alongside the inline
+      // `DeletedArtifactBody` (design-review slice-4 finding 2).
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment("chat-1", {
+          placement: {
+            epicId: "epic-1",
+            viewTabId: "tab-1",
+            paneId: "p1",
+            hostId: TEST_HOST_ID,
+          },
+        }),
+      );
+      expect(getTileSurfaceEnvironment("chat-1")).not.toBeNull();
+
+      // Mirrors what `ActiveTabBody`'s effect reports the instant
+      // `computeIsRemoteDeleted` flips true for this chat.
+      reportChatRemoteDeletionState("chat-1", true);
+
+      expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
+      expect(getTileSurfaceEnvironment("chat-1")).toBeNull();
+    },
+  );
+
+  it("re-admits the chat to membership once the deletion is reverted", () => {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChat("chat-1", "p1") },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip(
+      [{ kind: "epic", id: "tab-1" }],
+      { kind: "epic", id: "tab-1" },
+    );
+    reportChatRemoteDeletionState("chat-1", true);
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
+
+    reportChatRemoteDeletionState("chat-1", false);
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-membership.test.ts
@@ -180,10 +180,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
     // Reorder: add a second (background) tab, then swap which is active -
@@ -216,10 +216,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
     useEpicCanvasStore.setState((state) => ({
@@ -240,10 +240,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
     useEpicCanvasStore.setState((state) => ({
@@ -279,10 +279,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
     function canvasWithActiveTab(activeTabId: string): EpicCanvasState {
@@ -375,10 +375,10 @@ describe("tile surface membership - live store integration", () => {
         openTabOrder: ["tab-1"],
         activeTabId: "tab-1",
       });
-      seedSingleTabStrip(
-        [{ kind: "epic", id: "tab-1" }],
-        { kind: "epic", id: "tab-1" },
-      );
+      seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+        kind: "epic",
+        id: "tab-1",
+      });
       expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
       const samples: boolean[] = [];
@@ -439,10 +439,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
     const samples: boolean[] = [];
@@ -496,10 +496,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
     expect(getTileSurfaceMembership().has("chat-2")).toBe(false);
 
@@ -528,9 +528,7 @@ describe("tile surface membership - live store integration", () => {
       expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
       expect(getTileSurfaceMembership().has("chat-2")).toBe(true);
 
-      const chat2Pane = panes.find((p) =>
-        p.tabInstanceIds.includes("chat-2"),
-      );
+      const chat2Pane = panes.find((p) => p.tabInstanceIds.includes("chat-2"));
       if (chat2Pane === undefined) {
         throw new Error("expected pane hosting chat-2 after split");
       }
@@ -578,10 +576,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
 
     // First create a real second pane via edge split, then move chat-1 onto it.
     useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
@@ -591,7 +589,8 @@ describe("tile surface membership - live store integration", () => {
       position: "right",
     });
     const afterSplit = useEpicCanvasStore.getState().canvasByTabId["tab-1"];
-    if (afterSplit === undefined) throw new Error("expected canvas after split");
+    if (afterSplit === undefined)
+      throw new Error("expected canvas after split");
     const panes = collectPanes(afterSplit.root);
     expect(panes.length).toBe(2);
     const chat1Pane = panes.find((p) => p.tabInstanceIds.includes("chat-1"));
@@ -642,10 +641,10 @@ describe("tile surface membership - live store integration", () => {
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
     let membershipNotifications = 0;
@@ -790,10 +789,10 @@ describe("design-review F2: shared eligibility discriminator (remote-deletion)",
         openTabOrder: ["tab-1"],
         activeTabId: "tab-1",
       });
-      seedSingleTabStrip(
-        [{ kind: "epic", id: "tab-1" }],
-        { kind: "epic", id: "tab-1" },
-      );
+      seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+        kind: "epic",
+        id: "tab-1",
+      });
       expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
 
       // Mirrors what `TileSurfaceSlot` does once mounted for a real hosted
@@ -830,10 +829,10 @@ describe("design-review F2: shared eligibility discriminator (remote-deletion)",
       openTabOrder: ["tab-1"],
       activeTabId: "tab-1",
     });
-    seedSingleTabStrip(
-      [{ kind: "epic", id: "tab-1" }],
-      { kind: "epic", id: "tab-1" },
-    );
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
     reportChatRemoteDeletionState("chat-1", true);
     expect(getTileSurfaceMembership().has("chat-1")).toBe(false);
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-slot.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-slot.test.tsx
@@ -1,0 +1,342 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  act,
+  cleanup,
+  render,
+  waitFor,
+  type RenderResult,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { TileSurfaceSlot } from "@/components/epic-canvas/surface-host/tile-surface-slot";
+import {
+  getTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+  subscribeTileSurfaceEnvironment,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+import { useTabsStore } from "@/stores/tabs/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import type { TabRef } from "@/stores/tabs/types";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import {
+  PaneFocusProbeContext,
+  PanePortalContainerContext,
+  PaneSurfaceActivityContext,
+  PaneVisibilityContext,
+} from "@/components/epic-tabs/pane-visibility-context";
+
+const INSTANCE_ID = "chat-slot-1";
+const VIEW_TAB_ID = "tab-1";
+const PANE_ID = "p1";
+const EPIC_ID = "epic-1";
+
+const CHAT_NODE = {
+  id: INSTANCE_ID,
+  instanceId: INSTANCE_ID,
+  type: "chat" as const,
+  name: "Chat slot",
+  hostId: TEST_HOST_ID,
+};
+
+const OPEN_EPIC_HANDLE = {} as OpenEpicStoreHandle;
+
+function canvasWithChat(): EpicCanvasState {
+  return {
+    root: pane(PANE_ID, [INSTANCE_ID]),
+    activePaneId: PANE_ID,
+    tilesByInstanceId: { [INSTANCE_ID]: CHAT_NODE },
+    sizesByGroupId: {},
+  };
+}
+
+function seedMembership(): void {
+  useEpicCanvasStore.setState({
+    tabsById: {
+      [VIEW_TAB_ID]: {
+        tabId: VIEW_TAB_ID,
+        epicId: EPIC_ID,
+        name: "Epic 1",
+      },
+    },
+    canvasByTabId: { [VIEW_TAB_ID]: canvasWithChat() },
+    openTabOrder: [VIEW_TAB_ID],
+    activeTabId: VIEW_TAB_ID,
+  });
+  const ref: TabRef = { kind: "epic", id: VIEW_TAB_ID };
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: [{ kind: "tab" as const, id: `tab:${ref.kind}:${ref.id}`, ref }],
+    activeItemId: `tab:${ref.kind}:${ref.id}`,
+    stripOrder: [ref],
+  }));
+}
+
+function resetAll(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+  tabCommandCoordinator.resetReconciliationForTesting();
+  resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
+}
+
+function renderSlot(args: {
+  readonly visible: boolean;
+  readonly focused: boolean;
+  readonly tabSelected: boolean;
+  readonly canvasPaneActive: boolean;
+}): RenderResult {
+  const tree = (providers: {
+    readonly visible: boolean;
+    readonly focused: boolean;
+  }): ReactNode => (
+    <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+      <PaneVisibilityContext.Provider value={providers.visible}>
+        <PaneSurfaceActivityContext.Provider
+          value={{ visible: providers.visible, focused: providers.focused }}
+        >
+          <PaneFocusProbeContext.Provider value={() => providers.focused}>
+            <TileSurfaceSlot
+              node={CHAT_NODE}
+              epicId={EPIC_ID}
+              paneId={PANE_ID}
+              viewTabId={VIEW_TAB_ID}
+              tabSelected={args.tabSelected}
+              canvasPaneActive={args.canvasPaneActive}
+            />
+          </PaneFocusProbeContext.Provider>
+        </PaneSurfaceActivityContext.Provider>
+      </PaneVisibilityContext.Provider>
+    </EpicSessionContext.Provider>
+  );
+
+  return render(tree({ visible: args.visible, focused: args.focused }));
+}
+
+describe("TileSurfaceSlot environment publish", () => {
+  beforeEach(() => {
+    resetAll();
+    seedMembership();
+  });
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  it("publishes a ReadyTileSurfaceEnvironment with identity/placement/canvasActivity/services", async () => {
+    renderSlot({
+      visible: true,
+      focused: false,
+      tabSelected: true,
+      canvasPaneActive: true,
+    });
+
+    await waitFor(() => {
+      expect(getTileSurfaceEnvironment(INSTANCE_ID)).not.toBeNull();
+    });
+
+    const env = getTileSurfaceEnvironment(INSTANCE_ID);
+    if (env === null) throw new Error("expected published environment");
+    expect(env.identity).toEqual({
+      instanceId: INSTANCE_ID,
+      tileKind: "chat",
+      contentId: INSTANCE_ID,
+      epicId: EPIC_ID,
+      hostId: TEST_HOST_ID,
+    });
+    expect(env.placement).toEqual({
+      epicId: EPIC_ID,
+      viewTabId: VIEW_TAB_ID,
+      paneId: PANE_ID,
+      hostId: TEST_HOST_ID,
+    });
+    expect(env.canvasActivity).toEqual({
+      tabSelected: true,
+      canvasPaneActive: true,
+    });
+    expect(env.services.openEpicHandle).toBe(OPEN_EPIC_HANDLE);
+    expect(env.services.geometryAnchorElement).toBeInstanceOf(HTMLElement);
+    // No `PanePortalContainerContext.Provider` wraps this render, so the
+    // ambient value is the context's own `null` default.
+    expect(env.services.panePortalContainer).toBeNull();
+    expect(typeof env.services.isPaneFocusedNow).toBe("function");
+  });
+
+  it("design-review F5: publishes the REAL ambient PanePortalContainerContext value as services.panePortalContainer, distinct from the slot's own geometry anchor", async () => {
+    const realPortalHost = document.createElement("div");
+    render(
+      <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+        <PaneVisibilityContext.Provider value>
+          <PaneSurfaceActivityContext.Provider
+            value={{ visible: true, focused: true }}
+          >
+            <PaneFocusProbeContext.Provider value={() => true}>
+              <PanePortalContainerContext.Provider value={realPortalHost}>
+                <TileSurfaceSlot
+                  node={CHAT_NODE}
+                  epicId={EPIC_ID}
+                  paneId={PANE_ID}
+                  viewTabId={VIEW_TAB_ID}
+                  tabSelected
+                  canvasPaneActive
+                />
+              </PanePortalContainerContext.Provider>
+            </PaneFocusProbeContext.Provider>
+          </PaneSurfaceActivityContext.Provider>
+        </PaneVisibilityContext.Provider>
+      </EpicSessionContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(getTileSurfaceEnvironment(INSTANCE_ID)).not.toBeNull();
+    });
+
+    const env = getTileSurfaceEnvironment(INSTANCE_ID);
+    if (env === null) throw new Error("expected published environment");
+    expect(env.services.panePortalContainer).toBe(realPortalHost);
+    expect(env.services.geometryAnchorElement).toBeInstanceOf(HTMLElement);
+    expect(env.services.geometryAnchorElement).not.toBe(realPortalHost);
+  });
+
+  it("publishes topLevelFocused from the RAW PaneSurfaceActivityContext.focused, not visible&&focused (design-review finding 1)", async () => {
+    // Case A: visible=true, focused=false -> collapsed (visible&&focused) is
+    // false, raw focused is false - both agree, baseline.
+    const { rerender } = renderSlot({
+      visible: true,
+      focused: false,
+      tabSelected: true,
+      canvasPaneActive: false,
+    });
+    await waitFor(() => {
+      expect(getTileSurfaceEnvironment(INSTANCE_ID)).not.toBeNull();
+    });
+    expect(getTileSurfaceEnvironment(INSTANCE_ID)?.presentation).toEqual({
+      topLevelVisible: true,
+      topLevelFocused: false,
+    });
+
+    // Case B: visible=false, focused=true -> collapsed would be false, raw
+    // focused is true. Pin that the published value is the RAW focused bit.
+    const nextTree = (
+      <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+        <PaneVisibilityContext.Provider value={false}>
+          <PaneSurfaceActivityContext.Provider
+            value={{ visible: false, focused: true }}
+          >
+            <PaneFocusProbeContext.Provider value={() => true}>
+              <TileSurfaceSlot
+                node={CHAT_NODE}
+                epicId={EPIC_ID}
+                paneId={PANE_ID}
+                viewTabId={VIEW_TAB_ID}
+                tabSelected
+                canvasPaneActive={false}
+              />
+            </PaneFocusProbeContext.Provider>
+          </PaneSurfaceActivityContext.Provider>
+        </PaneVisibilityContext.Provider>
+      </EpicSessionContext.Provider>
+    );
+    rerender(nextTree);
+
+    await waitFor(() => {
+      expect(getTileSurfaceEnvironment(INSTANCE_ID)?.presentation).toEqual({
+        topLevelVisible: false,
+        topLevelFocused: true,
+      });
+    });
+    // Collapsed form (visible && focused) would be false here - asserting the
+    // published value is true is the direct signal that the slot did NOT go
+    // through usePaneFocused().
+    const published = getTileSurfaceEnvironment(INSTANCE_ID)?.presentation;
+    if (published === undefined) {
+      throw new Error("expected published presentation");
+    }
+    const collapsedFocused = published.topLevelVisible && published.topLevelFocused;
+    expect(published.topLevelFocused).toBe(true);
+    expect(collapsedFocused).toBe(false);
+  });
+
+  it("notifies environment subscribers when presentation changes", async () => {
+    const notifications: number[] = [];
+    const unsubscribe = subscribeTileSurfaceEnvironment(INSTANCE_ID, () => {
+      notifications.push(notifications.length + 1);
+    });
+
+    const { rerender } = renderSlot({
+      visible: true,
+      focused: false,
+      tabSelected: true,
+      canvasPaneActive: false,
+    });
+    await waitFor(() => {
+      expect(getTileSurfaceEnvironment(INSTANCE_ID)).not.toBeNull();
+    });
+    const afterFirstPublish = notifications.length;
+    expect(afterFirstPublish).toBeGreaterThan(0);
+
+    act(() => {
+      rerender(
+        <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+          <PaneVisibilityContext.Provider value>
+            <PaneSurfaceActivityContext.Provider
+              value={{ visible: true, focused: true }}
+            >
+              <PaneFocusProbeContext.Provider value={() => true}>
+                <TileSurfaceSlot
+                  node={CHAT_NODE}
+                  epicId={EPIC_ID}
+                  paneId={PANE_ID}
+                  viewTabId={VIEW_TAB_ID}
+                  tabSelected
+                  canvasPaneActive={false}
+                />
+              </PaneFocusProbeContext.Provider>
+            </PaneSurfaceActivityContext.Provider>
+          </PaneVisibilityContext.Provider>
+        </EpicSessionContext.Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(notifications.length).toBeGreaterThan(afterFirstPublish);
+    });
+    expect(getTileSurfaceEnvironment(INSTANCE_ID)?.presentation).toEqual({
+      topLevelVisible: true,
+      topLevelFocused: true,
+    });
+    unsubscribe();
+  });
+
+  it("stays cold (no publish) when the epic session handle is not yet available", () => {
+    render(
+      <EpicSessionContext.Provider value={null}>
+        <PaneVisibilityContext.Provider value>
+          <PaneSurfaceActivityContext.Provider
+            value={{ visible: true, focused: true }}
+          >
+            <TileSurfaceSlot
+              node={CHAT_NODE}
+              epicId={EPIC_ID}
+              paneId={PANE_ID}
+              viewTabId={VIEW_TAB_ID}
+              tabSelected
+              canvasPaneActive
+            />
+          </PaneSurfaceActivityContext.Provider>
+        </PaneVisibilityContext.Provider>
+      </EpicSessionContext.Provider>,
+    );
+
+    // Layout effect has already run; no publish without a handle.
+    expect(getTileSurfaceEnvironment(INSTANCE_ID)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-slot.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-slot.test.tsx
@@ -260,7 +260,8 @@ describe("TileSurfaceSlot environment publish", () => {
     if (published === undefined) {
       throw new Error("expected published presentation");
     }
-    const collapsedFocused = published.topLevelVisible && published.topLevelFocused;
+    const collapsedFocused =
+      published.topLevelVisible && published.topLevelFocused;
     expect(published.topLevelFocused).toBe(true);
     expect(collapsedFocused).toBe(false);
   });

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-slot.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-slot.test.tsx
@@ -32,6 +32,10 @@ import {
   PaneSurfaceActivityContext,
   PaneVisibilityContext,
 } from "@/components/epic-tabs/pane-visibility-context";
+import {
+  PaneActivationFocusIntentContext,
+  type PaneActivationFocusIntent,
+} from "@/components/epic-canvas/pane-activation";
 
 const INSTANCE_ID = "chat-slot-1";
 const VIEW_TAB_ID = "tab-1";
@@ -314,6 +318,59 @@ describe("TileSurfaceSlot environment publish", () => {
       topLevelVisible: true,
       topLevelFocused: true,
     });
+    unsubscribe();
+  });
+
+  it("republishes the dedicated pane activation axis before paint when its context identity changes", async () => {
+    const firstIntent: PaneActivationFocusIntent = {
+      mark: () => undefined,
+      shouldYieldAutoFocus: () => false,
+    };
+    const secondIntent: PaneActivationFocusIntent = {
+      mark: () => undefined,
+      shouldYieldAutoFocus: () => true,
+    };
+    const notifications: number[] = [];
+    const unsubscribe = subscribeTileSurfaceEnvironment(INSTANCE_ID, () => {
+      notifications.push(notifications.length + 1);
+    });
+    const tree = (focusIntent: PaneActivationFocusIntent): ReactNode => (
+      <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+        <PaneVisibilityContext.Provider value>
+          <PaneSurfaceActivityContext.Provider
+            value={{ visible: true, focused: true }}
+          >
+            <PaneFocusProbeContext.Provider value={() => true}>
+              <PaneActivationFocusIntentContext.Provider value={focusIntent}>
+                <TileSurfaceSlot
+                  node={CHAT_NODE}
+                  epicId={EPIC_ID}
+                  paneId={PANE_ID}
+                  viewTabId={VIEW_TAB_ID}
+                  tabSelected
+                  canvasPaneActive
+                />
+              </PaneActivationFocusIntentContext.Provider>
+            </PaneFocusProbeContext.Provider>
+          </PaneSurfaceActivityContext.Provider>
+        </PaneVisibilityContext.Provider>
+      </EpicSessionContext.Provider>
+    );
+
+    const { rerender } = render(tree(firstIntent));
+    await waitFor(() => {
+      expect(
+        getTileSurfaceEnvironment(INSTANCE_ID)?.paneActivation.focusIntent,
+      ).toBe(firstIntent);
+    });
+    const afterFirstPublish = notifications.length;
+
+    rerender(tree(secondIntent));
+
+    expect(
+      getTileSurfaceEnvironment(INSTANCE_ID)?.paneActivation.focusIntent,
+    ).toBe(secondIntent);
+    expect(notifications.length).toBeGreaterThan(afterFirstPublish);
     unsubscribe();
   });
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-chat-surface-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-chat-surface-body.tsx
@@ -1,0 +1,25 @@
+/**
+ * Ticket 21 slice 4: the real `StableTileSurfaceHost.renderRecordBody` for a
+ * hosted chat - `TopLevelTabHost`'s only call site.
+ *
+ * `HostedChatSurfaceContextBridge` bridges the small set of ambient contexts
+ * a chat's render tree actually consumes (design-review's provider
+ * inventory), then calls the REAL `renderTile` - unmodified - so
+ * `TabHostProvider` and `TileFindScope` are reused verbatim rather than
+ * cloned. Everything else in `ChatTile`'s chain (`useEpicPermissionRole`,
+ * `useEpicSnapshotLoaded`, `useEpicArtifact`, ...) resolves through
+ * `useEpicStore`, which itself only ever reads `EpicSessionContext` -
+ * bridging that ONE context is what makes the whole chain work with no
+ * further wiring. Never mount a second `EpicSessionProvider`; the bridge
+ * only re-provides the SAME handle the real provider (still an ancestor of
+ * the publishing `TileSurfaceSlot`) already produced.
+ */
+import type { ReactNode } from "react";
+import { HostedChatSurfaceContextBridge } from "@/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge";
+import type { ReadyTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+
+export function renderHostedChatSurfaceBody(
+  environment: ReadyTileSurfaceEnvironment,
+): ReactNode {
+  return <HostedChatSurfaceContextBridge environment={environment} />;
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge.tsx
@@ -1,0 +1,108 @@
+/**
+ * Ticket 21 slice 4: the component half of
+ * `hosted-chat-surface-body.tsx`'s environment-to-context bridge, split into
+ * its own file so that file's `renderHostedChatSurfaceBody` stays the sole
+ * export (matching `tile-render.tsx`'s `renderTile` precedent) - a file
+ * mixing a lowercase JSX-returning export with real components breaks
+ * `react-refresh/only-export-components`.
+ */
+import type { ReactNode } from "react";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+import { renderTile } from "@/components/epic-canvas/renderers/tile-render";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import { EpicViewTabContext } from "@/components/epic-canvas/view-tab-context";
+import {
+  PaneFocusProbeContext,
+  PanePortalContainerContext,
+  PaneSurfaceActivityContext,
+  PaneVisibilityContext,
+} from "@/components/epic-tabs/pane-visibility-context";
+import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
+import type { ReadyTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+export function HostedChatSurfaceContextBridge(props: {
+  readonly environment: ReadyTileSurfaceEnvironment;
+}): ReactNode {
+  const { environment } = props;
+  return (
+    <EpicSessionContext.Provider value={environment.services.openEpicHandle}>
+      <EpicViewTabContext.Provider value={environment.placement.viewTabId}>
+        <PaneSurfaceActivityContext.Provider
+          value={{
+            visible: environment.presentation.topLevelVisible,
+            focused: environment.presentation.topLevelFocused,
+          }}
+        >
+          <PaneVisibilityContext.Provider
+            value={environment.presentation.topLevelVisible}
+          >
+            <PaneFocusProbeContext.Provider
+              value={environment.services.isPaneFocusedNow}
+            >
+              <PanePortalContainerContext.Provider
+                value={environment.services.panePortalContainer}
+              >
+                <TabBodySelectedContext.Provider
+                  value={environment.canvasActivity.tabSelected}
+                >
+                  <HostedChatSurfaceBody environment={environment} />
+                </TabBodySelectedContext.Provider>
+              </PanePortalContainerContext.Provider>
+            </PaneFocusProbeContext.Provider>
+          </PaneVisibilityContext.Provider>
+        </PaneSurfaceActivityContext.Provider>
+      </EpicViewTabContext.Provider>
+    </EpicSessionContext.Provider>
+  );
+}
+
+/**
+ * Header tear-off moves a tile's canvas entry to its destination top-level
+ * tab in one synchronous `EpicCanvasStore` write, before the destination
+ * `TileSurfaceSlot` mounts and republishes a fresh environment - `useTabsStore`'s
+ * header strip catches up moments later, in the same transaction (see
+ * `tile-surface-membership.ts`'s transaction-aware retention doc comment).
+ * During that gap, `environment.placement.viewTabId` still names the SOURCE
+ * tab, so looking the node up there returns `undefined` and unmounts the real
+ * `renderTile()` subtree (finding 1). Scanning every open canvas by
+ * `instanceId` instead - not just the environment's last-published tab -
+ * finds the tile immediately once the canvas write lands, regardless of
+ * which tab currently owns it. Placement/providers deliberately stay on the
+ * last-ready environment until the destination publish replaces them; only
+ * the node CONTENT needs to survive the gap.
+ */
+function useCurrentCanvasTile(
+  instanceId: string,
+): EpicCanvasTileRef | undefined {
+  return useEpicCanvasStore((s) => {
+    for (const canvas of Object.values(s.canvasByTabId)) {
+      const tile = canvas?.tilesByInstanceId[instanceId];
+      if (tile !== undefined) return tile;
+    }
+    return undefined;
+  });
+}
+
+function HostedChatSurfaceBody(props: {
+  readonly environment: ReadyTileSurfaceEnvironment;
+}): ReactNode {
+  const { environment } = props;
+  const node = useCurrentCanvasTile(environment.identity.instanceId);
+  const role = useEpicPermissionRole();
+  if (node === undefined) return null;
+  // Same rule as `ActiveTabBody`'s inline `isActive` - never a second
+  // independent active boolean.
+  const isActive =
+    role !== null &&
+    environment.canvasActivity.tabSelected &&
+    environment.canvasActivity.canvasPaneActive;
+  return renderTile({
+    node,
+    viewTabId: environment.placement.viewTabId,
+    tileId: environment.placement.paneId,
+    epicId: environment.placement.epicId,
+    isActive,
+  });
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-chat-surface-context-bridge.tsx
@@ -21,6 +21,7 @@ import {
 import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
 import type { ReadyTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
 import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+import { PaneActivationFocusIntentContext } from "@/components/epic-canvas/pane-activation";
 
 export function HostedChatSurfaceContextBridge(props: {
   readonly environment: ReadyTileSurfaceEnvironment;
@@ -38,19 +39,23 @@ export function HostedChatSurfaceContextBridge(props: {
           <PaneVisibilityContext.Provider
             value={environment.presentation.topLevelVisible}
           >
-            <PaneFocusProbeContext.Provider
-              value={environment.services.isPaneFocusedNow}
+            <PaneActivationFocusIntentContext.Provider
+              value={environment.paneActivation.focusIntent}
             >
-              <PanePortalContainerContext.Provider
-                value={environment.services.panePortalContainer}
+              <PaneFocusProbeContext.Provider
+                value={environment.services.isPaneFocusedNow}
               >
-                <TabBodySelectedContext.Provider
-                  value={environment.canvasActivity.tabSelected}
+                <PanePortalContainerContext.Provider
+                  value={environment.services.panePortalContainer}
                 >
-                  <HostedChatSurfaceBody environment={environment} />
-                </TabBodySelectedContext.Provider>
-              </PanePortalContainerContext.Provider>
-            </PaneFocusProbeContext.Provider>
+                  <TabBodySelectedContext.Provider
+                    value={environment.canvasActivity.tabSelected}
+                  >
+                    <HostedChatSurfaceBody environment={environment} />
+                  </TabBodySelectedContext.Provider>
+                </PanePortalContainerContext.Provider>
+              </PaneFocusProbeContext.Provider>
+            </PaneActivationFocusIntentContext.Provider>
           </PaneVisibilityContext.Provider>
         </PaneSurfaceActivityContext.Provider>
       </EpicViewTabContext.Provider>

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-dom.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-dom.ts
@@ -17,10 +17,13 @@
  */
 export const HOSTED_TILE_INSTANCE_ID_ATTRIBUTE = "data-hosted-tile-instance-id";
 export const HOSTED_TILE_PANE_ID_ATTRIBUTE = "data-hosted-canvas-pane-id";
+export const HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE = "data-hosted-view-tab-id";
 
 export const HOSTED_TILE_RECORD_SELECTOR = `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}]`;
 
 export interface HostedTileOwnership {
   readonly instanceId: string;
   readonly paneId: string;
+  /** The owning top-level (`"epic"` kind) tab id. */
+  readonly viewTabId: string;
 }

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-dom.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-dom.ts
@@ -1,0 +1,26 @@
+/**
+ * Ticket 21 slice 3: dedicated physical DOM identity for hosted tile
+ * surface records, per design-review finding 4.
+ *
+ * Portal events follow the React tree, not the physical pane tree, so a
+ * hosted record needs its own attributes rather than reusing
+ * `[data-group-id]` - that attribute is the pane-geometry authority
+ * (`lib/keybindings/tile-geometry.ts`), and duplicating it on a transformed
+ * record would create a second, conflicting geometry source for spatial
+ * keyboard navigation. Do not add `data-group-id` here.
+ *
+ * Wiring these attributes into the four broken lookup paths (chat keyboard
+ * ownership, command-to-composer, route focus, deferred pane-activation
+ * containment) is slice 4's "host-aware activation/focus resolution" per
+ * the design's own slice table - this module and `hosted-tile-resolver.ts`
+ * are the infrastructure slice 4 wires in, not the wiring itself.
+ */
+export const HOSTED_TILE_INSTANCE_ID_ATTRIBUTE = "data-hosted-tile-instance-id";
+export const HOSTED_TILE_PANE_ID_ATTRIBUTE = "data-hosted-canvas-pane-id";
+
+export const HOSTED_TILE_RECORD_SELECTOR = `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}]`;
+
+export interface HostedTileOwnership {
+  readonly instanceId: string;
+  readonly paneId: string;
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-resolver.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-resolver.ts
@@ -18,6 +18,7 @@ import {
   HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
   HOSTED_TILE_PANE_ID_ATTRIBUTE,
   HOSTED_TILE_RECORD_SELECTOR,
+  HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
   type HostedTileOwnership,
 } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 
@@ -49,8 +50,11 @@ export function resolveHostedTileOwnership(
   if (record === null) return null;
   const instanceId = record.getAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE);
   const paneId = record.getAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE);
-  if (instanceId === null || paneId === null) return null;
-  return { instanceId, paneId };
+  const viewTabId = record.getAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE);
+  if (instanceId === null || paneId === null || viewTabId === null) {
+    return null;
+  }
+  return { instanceId, paneId, viewTabId };
 }
 
 /**

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-resolver.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-resolver.ts
@@ -1,0 +1,79 @@
+/**
+ * Ticket 21 slice 3: the one shared resolver design-review finding 4 asks
+ * for, mapping pane/instance ownership across the hosted DOM identity
+ * (`hosted-tile-dom.ts`) instead of physical pane ancestry.
+ *
+ * Models the two lookup shapes the four broken call sites need once slice 4
+ * wires them in:
+ *
+ * - forward, instanceId -> element (command-to-composer focus, route focus:
+ *   "find `[data-group-id]`, then query its selected-tab descendant" becomes
+ *   `findHostedTileElement` then the caller's own descendant query);
+ * - reverse, event target -> owning instance/pane (chat keyboard scrolling's
+ *   "walk to `[data-group-id]`", deferred pane-activation's
+ *   `paneRoot.contains(target)` becomes `resolveHostedTileOwnership` /
+ *   `isTargetInsideHostedTile`).
+ */
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+  HOSTED_TILE_RECORD_SELECTOR,
+  type HostedTileOwnership,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+
+/**
+ * Direct instanceId -> record element lookup, scoped to `root` (the plane,
+ * or any ancestor of it) so a caller never accidentally resolves a record
+ * belonging to an unrelated host in a test fixture with multiple planes.
+ */
+export function findHostedTileElement(
+  root: ParentNode,
+  instanceId: string,
+): HTMLElement | null {
+  return root.querySelector<HTMLElement>(
+    `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${cssEscapeAttributeValue(instanceId)}"]`,
+  );
+}
+
+/**
+ * Walks up from `target` to the nearest hosted-record ancestor and returns
+ * its identity, or `null` if `target` is not inside any hosted record.
+ * Mirrors the existing `[data-group-id]`-closest idiom for physical panes,
+ * applied to the hosted plane's own identity attributes instead.
+ */
+export function resolveHostedTileOwnership(
+  target: Element | null,
+): HostedTileOwnership | null {
+  if (target === null) return null;
+  const record = target.closest<HTMLElement>(HOSTED_TILE_RECORD_SELECTOR);
+  if (record === null) return null;
+  const instanceId = record.getAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE);
+  const paneId = record.getAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE);
+  if (instanceId === null || paneId === null) return null;
+  return { instanceId, paneId };
+}
+
+/**
+ * Convenience wrapper for the deferred-activation containment shape
+ * (`paneRoot.contains(target)`, generalized to a hosted record): true only
+ * when `target` is inside the SPECIFIC instance's record, not merely inside
+ * some hosted record.
+ */
+export function isTargetInsideHostedTile(
+  instanceId: string,
+  target: EventTarget | null,
+): boolean {
+  if (!(target instanceof Element)) return false;
+  const ownership = resolveHostedTileOwnership(target);
+  return ownership !== null && ownership.instanceId === instanceId;
+}
+
+/**
+ * `CSS.escape` is not implemented in every target runtime this app ships
+ * against; instanceIds are opaque store-generated ids, never user-authored
+ * text, so escaping only the two characters that would break a `querySelector`
+ * attribute-value string (`"` and `\`) is sufficient and avoids a polyfill.
+ */
+function cssEscapeAttributeValue(value: string): string {
+  return value.replace(/[\\"]/g, (char) => `\\${char}`);
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-top-level-activation.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-top-level-activation.ts
@@ -1,0 +1,67 @@
+/**
+ * Design-review slice-4 finding 3: a hosted record's pointerdown/focus never
+ * reaches any physical top-level surface wrapper's own
+ * `onFocusCapture`/`onPointerDownCapture` (each of `TopLevelTabHost`'s
+ * `mounts.map(...)` divs) - `StableTileSurfaceHost` is a SIBLING of those
+ * wrappers, not a descendant of any one of them. This resolves the hosted
+ * record's owning `HeaderTab` from the event target itself and applies the
+ * exact same focused/defaultPrevented gate `activateTopLevelSurfaceFromPointer`/
+ * `FromFocus` already use for the physical case, so a hosted body activates
+ * its OWN owning top-level tab rather than a fixed one.
+ *
+ * A non-component module (design-review slice-4 residual): co-located with
+ * `TopLevelTabHost` until this was factored out, exporting a plain
+ * function/interface alongside a component tripped `react-refresh/only-
+ * export-components`. `refsMatch`/`refIsFocused` moved here too rather than
+ * being duplicated - `TopLevelTabHost`'s own `placementForRef` needs the
+ * exact same ref-vs-tab matching this activation path does, so this module
+ * is their single shared source, imported back into `top-level-tab-host.tsx`.
+ */
+import {
+  tabRefKey,
+  type SplitSide,
+  type StripItem,
+} from "@/stores/tabs/layout";
+import type { HeaderTab, TabRef } from "@/stores/tabs/types";
+import { resolveHostedTileOwnership } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
+import type { TopLevelSurfaceActivator } from "@/components/layout/top-level-surface-activation-context";
+
+export interface HostedTopLevelActivationContext {
+  readonly tabsByRefKey: ReadonlyMap<string, HeaderTab>;
+  readonly activeItem: StripItem | null;
+  readonly activate: TopLevelSurfaceActivator | null;
+}
+
+export function refsMatch(ref: TabRef | SplitSide, tab: HeaderTab): boolean {
+  const candidate = ref.kind === "tab" ? ref.ref : ref;
+  return (
+    candidate.kind === tab.kind && "id" in candidate && candidate.id === tab.id
+  );
+}
+
+export function refIsFocused(
+  activeItem: StripItem | null,
+  tab: HeaderTab,
+): boolean {
+  if (activeItem === null) return false;
+  if (activeItem.kind === "tab") return refsMatch(activeItem.ref, tab);
+  const focused =
+    activeItem.focusedSide === "left" ? activeItem.left : activeItem.right;
+  return refsMatch(focused, tab);
+}
+
+export function activateHostedTopLevelSurface(
+  target: EventTarget | null,
+  defaultPrevented: boolean,
+  context: HostedTopLevelActivationContext,
+): void {
+  if (defaultPrevented || context.activate === null) return;
+  if (!(target instanceof Element)) return;
+  const ownership = resolveHostedTileOwnership(target);
+  if (ownership === null) return;
+  const tab = context.tabsByRefKey.get(
+    tabRefKey({ kind: "epic", id: ownership.viewTabId }),
+  );
+  if (tab === undefined || refIsFocused(context.activeItem, tab)) return;
+  context.activate(tab);
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/remote-deleted-chat-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/remote-deleted-chat-registry.ts
@@ -49,5 +49,9 @@ export function subscribeChatRemoteDeletion(
 }
 
 export function resetChatRemoteDeletionRegistryForTesting(): void {
+  const hadDeletedInstances = remoteDeletedInstanceIds.size > 0;
   remoteDeletedInstanceIds.clear();
+  if (hadDeletedInstances) {
+    listeners.forEach((listener) => listener());
+  }
 }

--- a/clients/gui-app/src/components/epic-canvas/surface-host/remote-deleted-chat-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/remote-deleted-chat-registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Ticket 21 slice 4 fix round, finding 2: reports which chat `instanceId`s
+ * are currently remote-deleted, per `ActiveTabBody`'s own
+ * `computeIsRemoteDeleted` - an epic-session-scoped React computation
+ * (`useEpicSnapshotLoaded`/`useEpicArtifact` read the CURRENT epic's Y.Doc
+ * projection store via `EpicSessionContext`) that `tile-surface-membership.ts`'s
+ * outside-React, store-subscription-driven computation cannot reach
+ * directly. Same registry-read shape as `chat-tab-viewport-handoff.ts`'s live
+ * capture map, reused rather than reinvented.
+ *
+ * Membership subscribes to `subscribeChatRemoteDeletion` so a remote deletion
+ * arriving mid-session (a Y.Doc sync event, unrelated to any canvas/tab-strip
+ * store change) still triggers a membership recompute.
+ */
+type RemoteDeletionListener = () => void;
+
+const remoteDeletedInstanceIds = new Set<string>();
+const listeners = new Set<RemoteDeletionListener>();
+
+/**
+ * Called from `ActiveTabBody`'s own effect for chat tiles only - reports the
+ * SAME `isRemoteDeleted` value it already computed for its inline
+ * `DeletedArtifactBody` branch. A no-op unregister (`isRemoteDeleted: false`)
+ * on unmount prevents a stale `true` entry from outliving its tab.
+ */
+export function reportChatRemoteDeletionState(
+  instanceId: string,
+  isRemoteDeleted: boolean,
+): void {
+  const wasDeleted = remoteDeletedInstanceIds.has(instanceId);
+  if (wasDeleted === isRemoteDeleted) return;
+  if (isRemoteDeleted) {
+    remoteDeletedInstanceIds.add(instanceId);
+  } else {
+    remoteDeletedInstanceIds.delete(instanceId);
+  }
+  listeners.forEach((listener) => listener());
+}
+
+export function isChatRemoteDeleted(instanceId: string): boolean {
+  return remoteDeletedInstanceIds.has(instanceId);
+}
+
+export function subscribeChatRemoteDeletion(
+  listener: RemoteDeletionListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function resetChatRemoteDeletionRegistryForTesting(): void {
+  remoteDeletedInstanceIds.clear();
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host-switch.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host-switch.ts
@@ -1,16 +1,23 @@
 /**
- * Ticket 21 slice 3: the single centralized switch gating whether
+ * Ticket 21: the single centralized switch gating whether
  * `StableTileSurfaceHost` mounts inside `TopLevelTabHost` at all.
  *
- * Off by construction until slice 6 flips it: nothing publishes a real
- * `ReadyTileSurfaceEnvironment` in production yet (chat routing is slice 4),
- * so the plane would stay empty either way, but the switch keeps its DOM
- * subtree - the plane div, the shared `ResizeObserver`, the membership
- * subscription - entirely absent from the render tree until rollout, rather
- * than relying on "nothing publishes to it" as the only safeguard.
+ * Enabled since slice 6, after the full recorded dev-desktop gate cleared
+ * (lifecycle matrix, geometry/stacking/hit-testing, focus/selection/IME
+ * survival, DnD, the divider-drag re-drive, and the integrated operation
+ * pass - see the wave-2 live-pass evidence in the epic artifacts). Selected
+ * chat bodies render once in the fixed surface plane and never remount on
+ * structural canvas operations; a tab switch remains the only intentional
+ * remount (decision #17).
+ *
+ * This constant is also the ROLLBACK lever: setting it back to `false`
+ * returns selected chats to the inline pane path in one line. The ticket-20
+ * viewport handoff stays installed as the absorber for that one controlled
+ * remount, per the design's rollback contract. Any surface-host code change
+ * after enablement requires re-recording the live gate (decision #32).
  *
  * One export, one call site (`top-level-tab-host.tsx`). Do not gate any
  * other surface-host module on this - membership and the environment
  * registry (slice 2) are always live; only the host's own mount is gated.
  */
-export const STABLE_TILE_SURFACE_HOST_ENABLED: boolean = false;
+export const STABLE_TILE_SURFACE_HOST_ENABLED: boolean = true;

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host-switch.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host-switch.ts
@@ -1,0 +1,16 @@
+/**
+ * Ticket 21 slice 3: the single centralized switch gating whether
+ * `StableTileSurfaceHost` mounts inside `TopLevelTabHost` at all.
+ *
+ * Off by construction until slice 6 flips it: nothing publishes a real
+ * `ReadyTileSurfaceEnvironment` in production yet (chat routing is slice 4),
+ * so the plane would stay empty either way, but the switch keeps its DOM
+ * subtree - the plane div, the shared `ResizeObserver`, the membership
+ * subscription - entirely absent from the render tree until rollout, rather
+ * than relying on "nothing publishes to it" as the only safeguard.
+ *
+ * One export, one call site (`top-level-tab-host.tsx`). Do not gate any
+ * other surface-host module on this - membership and the environment
+ * registry (slice 2) are always live; only the host's own mount is gated.
+ */
+export const STABLE_TILE_SURFACE_HOST_ENABLED: boolean = false;

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
@@ -44,6 +44,7 @@ import {
   useRef,
   useSyncExternalStore,
   Suspense,
+  type PointerEvent,
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
@@ -63,10 +64,13 @@ import {
   type TileSurfaceRect,
 } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
 import {
+  HOSTED_TILE_RECORD_SELECTOR,
   HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
   HOSTED_TILE_PANE_ID_ATTRIBUTE,
   HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
 } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import { resolveHostedTileOwnership } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
+import { claimHostedPaneActivation } from "@/components/epic-canvas/pane-activation";
 
 export interface StableTileSurfaceHostProps {
   readonly renderRecordBody: (
@@ -89,12 +93,29 @@ export function StableTileSurfaceHost(
     },
     [],
   );
+  const claimHostedPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const { target } = event;
+      if (!(target instanceof Element)) return;
+      const ownership = resolveHostedTileOwnership(target);
+      if (ownership === null) return;
+      // Descendant preventDefault does not suppress claims, matching the
+      // physical capture path; the deferred attribute is the opt-out.
+      claimHostedPaneActivation(ownership.viewTabId, ownership.paneId, {
+        defaultPrevented: event.defaultPrevented,
+        scope: target.closest(HOSTED_TILE_RECORD_SELECTOR),
+        target,
+      });
+    },
+    [],
+  );
 
   return (
     <div
       ref={registerHostElement}
       data-testid="stable-tile-surface-host"
       className="pointer-events-none absolute inset-0 z-0"
+      onPointerDownCapture={claimHostedPointerDown}
     >
       {Array.from(memberInstanceIds, (instanceId) => (
         <TileSurfaceRecord

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
@@ -119,7 +119,8 @@ function TileSurfaceRecord(props: {
 }): ReactNode {
   const { instanceId } = props;
   const subscribe = useCallback(
-    (listener: () => void) => subscribeTileSurfaceEnvironment(instanceId, listener),
+    (listener: () => void) =>
+      subscribeTileSurfaceEnvironment(instanceId, listener),
     [instanceId],
   );
   const getSnapshot = useCallback(
@@ -173,7 +174,8 @@ function TileSurfaceRecord(props: {
       {...(environment !== null
         ? {
             [HOSTED_TILE_PANE_ID_ATTRIBUTE]: environment.placement.paneId,
-            [HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE]: environment.placement.viewTabId,
+            [HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE]:
+              environment.placement.viewTabId,
           }
         : {})}
     >

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
@@ -1,0 +1,161 @@
+/**
+ * Ticket 21 slice 3: the fixed connected overlay plane itself.
+ *
+ * One flat host, keyed by `instanceId`, above every retained top-level
+ * surface and below the app-wide `DndContext` (mounted inside
+ * `TopLevelTabHost`, itself inside `RootDndProvider`). A member's record is
+ * a stable, permanently connected DOM container; structural moves reassign
+ * its rect/environment, never its React parent or DOM parent - see
+ * `design/index.md`'s "Why the host must be above EpicSurface".
+ *
+ * `renderRecordBody` is the seam the design calls a "synthetic ready
+ * slot/body seam": nothing in production supplies a real one yet (slice 4
+ * routes chats through it), so `TopLevelTabHost` passes a no-op and only
+ * the permanent jsdom lifecycle suite - and a future dev-desktop
+ * synthetic-body check - ever supply a real renderer.
+ *
+ * Layer contract (`design/index.md` "Permanent surface plane and geometry",
+ * design-review finding 9): the plane is `pointer-events:none` at the root
+ * auto/zero stacking layer; each record is `pointer-events:auto`,
+ * `overflow:hidden`, and gets NO positive z-index of its own, so pane
+ * drag shields/drop previews and document portals (which DO carry positive
+ * z-index) always paint above every record without depending on DOM order.
+ *
+ * Presentation contract (slice-3 review finding 1): the PLANE ROOT carries
+ * no `aria-hidden` of its own - an aria-hidden ancestor hides every
+ * descendant regardless of the descendant's own `aria-hidden` value, which
+ * would erase every future visible hosted body from the accessibility tree.
+ * Visibility is a per-RECORD concern only. A record whose environment
+ * reports `presentation.topLevelVisible: false` is `aria-hidden`, `inert`,
+ * AND non-painted via `visibility:hidden` (Tailwind's `invisible`) rather
+ * than `display:none`: `visibility:hidden` keeps the box's layout - and
+ * this module's own geometry-coordinator-applied `transform`/`width`/
+ * `height` - intact while hidden, so a later re-show needs no re-measure or
+ * reflow; `display:none` would collapse the box out of layout entirely and
+ * force one on re-show. The explicit focus-relinquishment protocol
+ * (`runPresentationLossBlur`, design-review finding 5) is slice 4's
+ * "presentation-loss blur" - `inert` alone does not reliably force a browser
+ * to blur a focused descendant, so this module does not claim it does.
+ */
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useSyncExternalStore,
+  Suspense,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+import {
+  getTileSurfaceMembership,
+  subscribeTileSurfaceMembership,
+} from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import {
+  getTileSurfaceEnvironment,
+  subscribeTileSurfaceEnvironment,
+  type ReadyTileSurfaceEnvironment,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import {
+  registerTileSurfaceGeometryHost,
+  registerTileSurfaceGeometrySlot,
+  type TileSurfaceRect,
+} from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+
+export interface StableTileSurfaceHostProps {
+  readonly renderRecordBody: (
+    environment: ReadyTileSurfaceEnvironment,
+  ) => ReactNode;
+}
+
+export function StableTileSurfaceHost(
+  props: StableTileSurfaceHostProps,
+): ReactNode {
+  const memberInstanceIds = useSyncExternalStore(
+    subscribeTileSurfaceMembership,
+    getTileSurfaceMembership,
+    getTileSurfaceMembership,
+  );
+  const registerHostElement = useCallback(
+    (element: HTMLDivElement | null): (() => void) | undefined => {
+      if (element === null) return undefined;
+      return registerTileSurfaceGeometryHost(element);
+    },
+    [],
+  );
+
+  return (
+    <div
+      ref={registerHostElement}
+      data-testid="stable-tile-surface-host"
+      className="pointer-events-none absolute inset-0 z-0"
+    >
+      {Array.from(memberInstanceIds, (instanceId) => (
+        <TileSurfaceRecord
+          key={instanceId}
+          instanceId={instanceId}
+          renderBody={props.renderRecordBody}
+        />
+      ))}
+    </div>
+  );
+}
+
+function applyRectToElement(element: HTMLElement, rect: TileSurfaceRect): void {
+  element.style.transform = `translate(${rect.left}px, ${rect.top}px)`;
+  element.style.width = `${rect.width}px`;
+  element.style.height = `${rect.height}px`;
+}
+
+function TileSurfaceRecord(props: {
+  readonly instanceId: string;
+  readonly renderBody: (environment: ReadyTileSurfaceEnvironment) => ReactNode;
+}): ReactNode {
+  const { instanceId } = props;
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeTileSurfaceEnvironment(instanceId, listener),
+    [instanceId],
+  );
+  const getSnapshot = useCallback(
+    () => getTileSurfaceEnvironment(instanceId),
+    [instanceId],
+  );
+  const environment = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const slotElement = environment?.services.panePortalContainer ?? null;
+
+  useLayoutEffect(() => {
+    if (slotElement === null) return undefined;
+    const element = elementRef.current;
+    if (element === null) return undefined;
+    return registerTileSurfaceGeometrySlot(instanceId, slotElement, (rect) => {
+      applyRectToElement(element, rect);
+    });
+  }, [instanceId, slotElement]);
+
+  const visible = environment?.presentation.topLevelVisible ?? false;
+
+  return (
+    <div
+      ref={elementRef}
+      aria-hidden={!visible}
+      inert={!visible}
+      className={cn(
+        "pointer-events-auto absolute left-0 top-0 overflow-hidden",
+        !visible && "invisible",
+      )}
+      data-testid={`stable-tile-surface-record-${instanceId}`}
+      {...{ [HOSTED_TILE_INSTANCE_ID_ATTRIBUTE]: instanceId }}
+      {...(environment !== null
+        ? { [HOSTED_TILE_PANE_ID_ATTRIBUTE]: environment.placement.paneId }
+        : {})}
+    >
+      {environment !== null ? (
+        <Suspense fallback={null}>{props.renderBody(environment)}</Suspense>
+      ) : null}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
@@ -39,6 +39,7 @@
  */
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useSyncExternalStore,
@@ -46,6 +47,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
+import { runPresentationLossBlur } from "@/components/epic-tabs/pane-visibility-context";
 import {
   getTileSurfaceMembership,
   subscribeTileSurfaceMembership,
@@ -63,6 +65,7 @@ import {
 import {
   HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
   HOSTED_TILE_PANE_ID_ATTRIBUTE,
+  HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
 } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 
 export interface StableTileSurfaceHostProps {
@@ -125,7 +128,7 @@ function TileSurfaceRecord(props: {
   );
   const environment = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   const elementRef = useRef<HTMLDivElement | null>(null);
-  const slotElement = environment?.services.panePortalContainer ?? null;
+  const slotElement = environment?.services.geometryAnchorElement ?? null;
 
   useLayoutEffect(() => {
     if (slotElement === null) return undefined;
@@ -137,6 +140,24 @@ function TileSurfaceRecord(props: {
   }, [instanceId, slotElement]);
 
   const visible = environment?.presentation.topLevelVisible ?? false;
+
+  // A hosted record going hidden is a physically distant sibling of
+  // `SurfacePresentationBoundary`'s own portal container, so that
+  // boundary's own presentation-loss blur (scoped to ITS container) never
+  // reaches a focused descendant here. Reuse the same protocol directly
+  // rather than reimplementing it - see design-review finding 5.
+  useEffect(() => {
+    if (visible) return;
+    const element = elementRef.current;
+    const active = document.activeElement;
+    if (
+      element !== null &&
+      active instanceof HTMLElement &&
+      element.contains(active)
+    ) {
+      runPresentationLossBlur(() => active.blur());
+    }
+  }, [visible]);
 
   return (
     <div
@@ -150,7 +171,10 @@ function TileSurfaceRecord(props: {
       data-testid={`stable-tile-surface-record-${instanceId}`}
       {...{ [HOSTED_TILE_INSTANCE_ID_ATTRIBUTE]: instanceId }}
       {...(environment !== null
-        ? { [HOSTED_TILE_PANE_ID_ATTRIBUTE]: environment.placement.paneId }
+        ? {
+            [HOSTED_TILE_PANE_ID_ATTRIBUTE]: environment.placement.paneId,
+            [HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE]: environment.placement.viewTabId,
+          }
         : {})}
     >
       {environment !== null ? (

--- a/clients/gui-app/src/components/epic-canvas/surface-host/surface-owner.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/surface-owner.ts
@@ -1,0 +1,43 @@
+/**
+ * Ticket 21 slice 4: the single centralized discriminator deciding whether a
+ * pane's active tab renders through `StableTileSurfaceHost` (a `TileSurfaceSlot`
+ * geometry anchor, real body painted elsewhere) or inline (`ActiveTabBody`'s
+ * existing `EpicNodeTile` path), per the design's "chat-first migration with
+ * one temporary ownership discriminator."
+ *
+ * Chat-only for this slice: pinned terminals and non-chat LRU surfaces stay
+ * inline until a later, separately justified cut. A remote-deleted chat also
+ * stays inline - `ActiveTabBody` already renders `DeletedArtifactBody` for it,
+ * and hosting a chat that's about to disappear would need the hosted body to
+ * duplicate that deletion detection for no behavioral gain.
+ *
+ * `isHostedSurfaceEligible` is the shared candidate rule extracted so
+ * `tile-surface-membership.ts`'s canvas-wide membership derivation and this
+ * module's render-routing decision are structurally incapable of disagreeing
+ * (design-review slice-4 finding 2: they used to drift on remote-deletion,
+ * producing two simultaneous owners for the same instance). `surfaceOwnerFor`
+ * layers the switch check on top - membership itself is switch-independent
+ * by design (see `stable-tile-surface-host-switch.ts`: "membership and the
+ * environment registry are always live; only the host's own mount is gated").
+ */
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+import { STABLE_TILE_SURFACE_HOST_ENABLED } from "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch";
+
+export type TileSurfaceOwner = "hosted" | "inline";
+
+export function isHostedSurfaceEligible(args: {
+  readonly node: EpicCanvasTileRef;
+  readonly isRemoteDeleted: boolean;
+}): boolean {
+  if (args.isRemoteDeleted) return false;
+  if (args.node.type !== "chat") return false;
+  return true;
+}
+
+export function surfaceOwnerFor(args: {
+  readonly node: EpicCanvasTileRef;
+  readonly isRemoteDeleted: boolean;
+}): TileSurfaceOwner {
+  if (!STABLE_TILE_SURFACE_HOST_ENABLED) return "inline";
+  return isHostedSurfaceEligible(args) ? "hosted" : "inline";
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
@@ -65,6 +65,7 @@ import {
 } from "@/components/epic-canvas/surface-host/tile-surface-membership";
 import type { TileKindId } from "@/stores/epics/canvas/tile-kinds";
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import type { PaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
 
 export interface TileSurfaceIdentity {
   readonly instanceId: string;
@@ -89,6 +90,10 @@ export interface TileSurfacePresentation {
 export interface TileSurfaceCanvasActivity {
   readonly tabSelected: boolean;
   readonly canvasPaneActive: boolean;
+}
+
+export interface TileSurfacePaneActivation {
+  readonly focusIntent: PaneActivationFocusIntent;
 }
 
 export interface TileSurfaceServices {
@@ -130,6 +135,7 @@ export interface ReadyTileSurfaceEnvironment {
   readonly placement: TileSurfacePlacement;
   readonly presentation: TileSurfacePresentation;
   readonly canvasActivity: TileSurfaceCanvasActivity;
+  readonly paneActivation: TileSurfacePaneActivation;
   readonly services: TileSurfaceServices;
 }
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
@@ -1,0 +1,186 @@
+/**
+ * Ticket 21 slice 2: the cold/ready environment registry for hosted tile
+ * surfaces.
+ *
+ * A store-selected chat may be a stable-tile-surface-host member before
+ * `EpicSessionGate` opens or a slot has measured/registered it (`useOpenEpicHandle`
+ * throws on a null handle, so readiness cannot be assumed at membership time).
+ * The registry therefore stores `ReadyTileSurfaceEnvironment | null` per
+ * `instanceId`: a member with no published environment yet reads as `null`
+ * (dormant) rather than failing.
+ *
+ * Two invariants the design calls out explicitly:
+ *
+ * - Retain last valid environment across a structural transfer. There is
+ *   deliberately no "unregister"/"retract" write path: the ONLY way an
+ *   environment changes is a fresh publish (source slot -> destination slot
+ *   overwrites in place, never round-tripping through `null`) or membership
+ *   itself removing the record. A transient gap between a source slot going
+ *   quiet and a destination slot publishing must not surface as `null`.
+ * - Removal only by membership. The registry subscribes to
+ *   `subscribeTileSurfaceMembership` and deletes a record (notifying its
+ *   subscribers) only when the instance actually leaves membership - close,
+ *   deselect (decision #17), or settled MRU eviction. Nothing else clears it.
+ *
+ * Subscriptions are isolated per instance (`Map<instanceId, Set<listener>>`):
+ * publishing or updating pane B's environment must not notify pane A's
+ * subscribers.
+ *
+ * ## The transfer-gap contract (design-review finding 4)
+ *
+ * "Retained" is a continuity guarantee, not a current-readiness guarantee.
+ * During the gap between a source slot going quiet and a destination slot's
+ * first publish, `getTileSurfaceEnvironment` keeps returning the SAME object
+ * the source slot last published - including its `services` handles, which
+ * were only ever proven valid for the source slot:
+ *
+ * - `services.panePortalContainer` may already be a disconnected DOM node
+ *   (the source slot unmounted it).
+ * - `services.isPaneFocusedNow` is still the source pane's own focus probe;
+ *   calling it during the gap answers "was the OLD pane focused", not
+ *   "is the tile focused now".
+ *
+ * This registry does not - and, without an additional attachment/ownership
+ * signal from the slot/geometry layer, cannot - distinguish a genuinely
+ * current environment from a retained continuity snapshot. Any consumer that
+ * takes a placement-sensitive action (portal-mounting into
+ * `panePortalContainer`, routing a focus request through `isPaneFocusedNow`)
+ * MUST NOT do so purely because `getTileSurfaceEnvironment` returned
+ * non-null. Slice 3+ is responsible for either (a) proving current
+ * attachment via a separate slot/geometry signal before acting, or (b)
+ * gating placement-sensitive actions until the destination slot's own
+ * publish lands. This module intentionally does not add that gating itself -
+ * doing so here would require the very unregister/retract path the no-null
+ * design rejects.
+ */
+import {
+  getTileSurfaceMembership,
+  subscribeTileSurfaceMembership,
+} from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import type { TileKindId } from "@/stores/epics/canvas/tile-kinds";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+
+export interface TileSurfaceIdentity {
+  readonly instanceId: string;
+  readonly tileKind: TileKindId;
+  readonly contentId: string;
+  readonly epicId: string;
+  readonly hostId: string;
+}
+
+export interface TileSurfacePlacement {
+  readonly epicId: string;
+  readonly viewTabId: string;
+  readonly paneId: string;
+  readonly hostId: string;
+}
+
+export interface TileSurfacePresentation {
+  readonly topLevelVisible: boolean;
+  readonly topLevelFocused: boolean;
+}
+
+export interface TileSurfaceCanvasActivity {
+  readonly tabSelected: boolean;
+  readonly canvasPaneActive: boolean;
+}
+
+export interface TileSurfaceServices {
+  readonly openEpicHandle: OpenEpicStoreHandle;
+  /**
+   * The publishing slot's portal container at publish time. During a
+   * transfer gap (see the module doc's "transfer-gap contract") this can be
+   * a disconnected node left behind by a since-unmounted source slot -
+   * verify current attachment before portal-mounting into it.
+   */
+  readonly panePortalContainer: HTMLElement | null;
+  /**
+   * The publishing slot's own focus probe. During a transfer gap this still
+   * answers for the source slot, not the tile's current pane - do not treat
+   * a retained `true`/`false` as the tile's live focus state.
+   */
+  readonly isPaneFocusedNow: () => boolean;
+}
+
+export interface ReadyTileSurfaceEnvironment {
+  readonly identity: TileSurfaceIdentity;
+  readonly placement: TileSurfacePlacement;
+  readonly presentation: TileSurfacePresentation;
+  readonly canvasActivity: TileSurfaceCanvasActivity;
+  readonly services: TileSurfaceServices;
+}
+
+export type TileSurfaceEnvironment = ReadyTileSurfaceEnvironment | null;
+
+export type TileSurfaceEnvironmentListener = () => void;
+
+const environments = new Map<string, ReadyTileSurfaceEnvironment>();
+const listenersByInstance = new Map<
+  string,
+  Set<TileSurfaceEnvironmentListener>
+>();
+let previousMembers: ReadonlySet<string> = getTileSurfaceMembership();
+
+function notify(instanceId: string): void {
+  const listeners = listenersByInstance.get(instanceId);
+  if (listeners === undefined) return;
+  listeners.forEach((listener) => listener());
+}
+
+/**
+ * Publishes (or replaces) the ready environment for
+ * `environment.identity.instanceId` - the record is always keyed by the
+ * environment's own immutable identity, never an independently passed id
+ * that could disagree with it. A publish for an instance that is not
+ * currently a member is dropped - membership is the sole authority over
+ * which records exist, so a stale/late publish cannot resurrect a record
+ * membership has already removed.
+ */
+export function publishTileSurfaceEnvironment(
+  environment: ReadyTileSurfaceEnvironment,
+): void {
+  const { instanceId } = environment.identity;
+  if (!getTileSurfaceMembership().has(instanceId)) return;
+  environments.set(instanceId, environment);
+  notify(instanceId);
+}
+
+/** `null` for a member with no published environment yet, or a non-member. */
+export function getTileSurfaceEnvironment(
+  instanceId: string,
+): TileSurfaceEnvironment {
+  return environments.get(instanceId) ?? null;
+}
+
+export function subscribeTileSurfaceEnvironment(
+  instanceId: string,
+  listener: TileSurfaceEnvironmentListener,
+): () => void {
+  let listeners = listenersByInstance.get(instanceId);
+  if (listeners === undefined) {
+    listeners = new Set();
+    listenersByInstance.set(instanceId, listeners);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) listenersByInstance.delete(instanceId);
+  };
+}
+
+function reconcileAgainstMembership(): void {
+  const members = getTileSurfaceMembership();
+  for (const instanceId of previousMembers) {
+    if (members.has(instanceId)) continue;
+    if (environments.delete(instanceId)) notify(instanceId);
+  }
+  previousMembers = members;
+}
+
+export function resetTileSurfaceEnvironmentRegistryForTesting(): void {
+  environments.clear();
+  listenersByInstance.clear();
+  previousMembers = getTileSurfaceMembership();
+}
+
+subscribeTileSurfaceMembership(reconcileAgainstMembership);

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
@@ -187,7 +187,12 @@ export function subscribeTileSurfaceEnvironment(
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
-    if (listeners.size === 0) listenersByInstance.delete(instanceId);
+    if (
+      listeners.size === 0 &&
+      listenersByInstance.get(instanceId) === listeners
+    ) {
+      listenersByInstance.delete(instanceId);
+    }
   };
 }
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
@@ -34,8 +34,14 @@
  * the source slot last published - including its `services` handles, which
  * were only ever proven valid for the source slot:
  *
- * - `services.panePortalContainer` may already be a disconnected DOM node
- *   (the source slot unmounted it).
+ * - `services.geometryAnchorElement` may already be a disconnected DOM node
+ *   (the source slot unmounted it) - it is per-slot, unlike the shared
+ *   per-top-level-surface `panePortalContainer` below.
+ * - `services.panePortalContainer` is `SurfacePresentationBoundary`'s
+ *   container, shared by every pane of the source top-level tab, so it stays
+ *   attached across any canvas-only structural move; it goes stale only
+ *   across a header tear-off, where it is still the SOURCE tab's container
+ *   until the destination publish replaces it.
  * - `services.isPaneFocusedNow` is still the source pane's own focus probe;
  *   calling it during the gap answers "was the OLD pane focused", not
  *   "is the tile focused now".
@@ -88,10 +94,27 @@ export interface TileSurfaceCanvasActivity {
 export interface TileSurfaceServices {
   readonly openEpicHandle: OpenEpicStoreHandle;
   /**
-   * The publishing slot's portal container at publish time. During a
-   * transfer gap (see the module doc's "transfer-gap contract") this can be
-   * a disconnected node left behind by a since-unmounted source slot -
-   * verify current attachment before portal-mounting into it.
+   * The publishing slot's OWN plain placeholder element - the geometry
+   * coordinator's `ResizeObserver`-observed anchor, positioned/sized exactly
+   * where the hosted record should paint. During a transfer gap (see the
+   * module doc's "transfer-gap contract") this can be a disconnected node
+   * left behind by a since-unmounted source slot - verify current attachment
+   * before relying on its geometry. Distinct from `panePortalContainer`
+   * below (design-review slice-4 finding 5): this element exists purely to
+   * be measured, never to host portaled content.
+   */
+  readonly geometryAnchorElement: HTMLElement;
+  /**
+   * The REAL `PanePortalContainerContext` value ambient at the publishing
+   * slot's location - `SurfacePresentationBoundary`'s per-top-level-surface
+   * portal host, the same node every other pane-local kept-mounted portal
+   * (comment composer, artifact-link editor, mention/hover popovers) renders
+   * into. That boundary wraps one entire top-level surface (every pane of
+   * one Epic tab shares it), so this stays current across any canvas-only
+   * structural move; it only changes across a header tear-off, and during
+   * that gap it is still the SOURCE tab's container until the destination
+   * publish replaces it - the same retained-until-replaced caveat as every
+   * other service here.
    */
   readonly panePortalContainer: HTMLElement | null;
   /**

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
@@ -69,9 +69,10 @@ function ensureSharedObserver(): ResizeObserver {
   return sharedObserver;
 }
 
-function applyRect(registration: SlotRegistration): void {
-  if (hostRegistration === null) return;
-  const hostRect = hostRegistration.element.getBoundingClientRect();
+function applyRectAgainstHost(
+  registration: SlotRegistration,
+  hostRect: DOMRect,
+): void {
   const slotRect = registration.slotElement.getBoundingClientRect();
   registration.onRect({
     left: slotRect.left - hostRect.left,
@@ -81,9 +82,19 @@ function applyRect(registration: SlotRegistration): void {
   });
 }
 
+function applyRect(registration: SlotRegistration): void {
+  if (hostRegistration === null) return;
+  applyRectAgainstHost(
+    registration,
+    hostRegistration.element.getBoundingClientRect(),
+  );
+}
+
 function applyAllRegisteredRects(): void {
+  if (hostRegistration === null) return;
+  const hostRect = hostRegistration.element.getBoundingClientRect();
   for (const registration of slotRegistrations.values()) {
-    applyRect(registration);
+    applyRectAgainstHost(registration, hostRect);
   }
 }
 
@@ -103,7 +114,7 @@ export function registerTileSurfaceGeometryHost(element: Element): () => void {
   applyAllRegisteredRects();
   return () => {
     if (hostRegistration === registration) {
-      ensureSharedObserver().unobserve(element);
+      sharedObserver?.unobserve(element);
       hostRegistration = null;
     }
   };
@@ -133,7 +144,7 @@ export function registerTileSurfaceGeometrySlot(
   applyRect(registration);
   return () => {
     if (slotRegistrations.get(key) === registration) {
-      ensureSharedObserver().unobserve(slotElement);
+      sharedObserver?.unobserve(slotElement);
       slotRegistrations.delete(key);
     }
   };

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
@@ -110,7 +110,7 @@ export function registerTileSurfaceGeometryHost(element: Element): () => void {
 }
 
 /**
- * Registers a slot element (a `ReadyTileSurfaceEnvironment.services.panePortalContainer`)
+ * Registers a slot element (a `ReadyTileSurfaceEnvironment.services.geometryAnchorElement`)
  * to report its host-relative rect to `onRect` - synchronously once on
  * registration, then on every subsequent layout change, directly in the RO
  * callback. `key` is the owning record's stable identity (its `instanceId`)

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
@@ -1,0 +1,147 @@
+/**
+ * Ticket 21 slice 3: the direct-flush geometry coordinator design-review
+ * finding 2 requires in place of `ResizeObserver -> requestAnimationFrame`.
+ *
+ * ONE shared `ResizeObserver` for the host root and every registered slot.
+ * Its callback applies every registered rect DIRECTLY - synchronously, in
+ * the same task, no `requestAnimationFrame` hop - because `document.hidden`
+ * is `true` in the automated renderer and a prior live investigation
+ * established that rAF never services a state mirror there. Resize
+ * observation already fires after layout and before paint; scheduling rAF
+ * from that callback would push the record-box write a full rendering
+ * opportunity late during a continuous divider drag, and can stall
+ * indefinitely in that hidden renderer.
+ *
+ * The callback recomputes EVERY currently registered rect on any observed
+ * change, not only the entries in that batch: a host-root move (a real
+ * `TopLevelTabHost` resize, e.g. a sidebar toggle) must invalidate every
+ * live record's position, not just the slot that happened to report in this
+ * particular batch. `getBoundingClientRect()` is read fresh for both the
+ * host and the slot at apply time rather than trusted from the RO entry -
+ * `ResizeObserverEntry.contentRect` only carries size, never position.
+ *
+ * Writing an absolutely positioned record does not resize its OWN observed
+ * slot (the record is not a descendant of the slot), so applying rects
+ * directly here cannot re-trigger this same observer in a feedback loop.
+ *
+ * Registration is callback-ref driven (a synchronous initial measurement on
+ * attach, matching the design's structural-transfer requirement) and
+ * StrictMode-safe by construction: every register call creates a fresh
+ * registration object, and its own unregister closure only ever removes
+ * that EXACT object (`registrations.get(key) === registration`), so a stale
+ * cleanup from an earlier registration can never clobber a newer one that
+ * has already replaced it - the same compare-before-clear discipline
+ * ticket 22's geometry scheduler needed for its own StrictMode replay.
+ *
+ * A same-key re-registration (slice-3 review finding 2) unobserves the
+ * DISPLACED element before observing the new one, at replacement time -
+ * the identity-guarded cleanup above correctly refuses to remove the new
+ * mapping entry, but that guard alone left the old element observed
+ * forever (its own late cleanup skips `unobserve` along with the deletion
+ * it correctly declines). Repeated structural transfers would otherwise
+ * retain every detached source element in the shared observer's target set
+ * and pay a redundant all-record recompute pass per stale target.
+ */
+
+export interface TileSurfaceRect {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+type TileSurfaceRectListener = (rect: TileSurfaceRect) => void;
+
+interface SlotRegistration {
+  readonly key: string;
+  readonly slotElement: Element;
+  readonly onRect: TileSurfaceRectListener;
+}
+
+let hostRegistration: { readonly element: Element } | null = null;
+const slotRegistrations = new Map<string, SlotRegistration>();
+let sharedObserver: ResizeObserver | null = null;
+
+function ensureSharedObserver(): ResizeObserver {
+  if (sharedObserver === null) {
+    sharedObserver = new ResizeObserver(applyAllRegisteredRects);
+  }
+  return sharedObserver;
+}
+
+function applyRect(registration: SlotRegistration): void {
+  if (hostRegistration === null) return;
+  const hostRect = hostRegistration.element.getBoundingClientRect();
+  const slotRect = registration.slotElement.getBoundingClientRect();
+  registration.onRect({
+    left: slotRect.left - hostRect.left,
+    top: slotRect.top - hostRect.top,
+    width: slotRect.width,
+    height: slotRect.height,
+  });
+}
+
+function applyAllRegisteredRects(): void {
+  for (const registration of slotRegistrations.values()) {
+    applyRect(registration);
+  }
+}
+
+/**
+ * Registers the plane's own root element as the coordinate origin every
+ * slot rect is reported relative to. Exactly one host element is expected
+ * live at a time; a later register replaces the origin outright (the
+ * unregister closure only clears it if it is still the one that set it).
+ */
+export function registerTileSurfaceGeometryHost(element: Element): () => void {
+  if (hostRegistration !== null) {
+    ensureSharedObserver().unobserve(hostRegistration.element);
+  }
+  const registration = { element };
+  hostRegistration = registration;
+  ensureSharedObserver().observe(element);
+  applyAllRegisteredRects();
+  return () => {
+    if (hostRegistration === registration) {
+      ensureSharedObserver().unobserve(element);
+      hostRegistration = null;
+    }
+  };
+}
+
+/**
+ * Registers a slot element (a `ReadyTileSurfaceEnvironment.services.panePortalContainer`)
+ * to report its host-relative rect to `onRect` - synchronously once on
+ * registration, then on every subsequent layout change, directly in the RO
+ * callback. `key` is the owning record's stable identity (its `instanceId`)
+ * so a structural transfer's destination-slot registration cannot be
+ * confused with a still-draining source-slot registration for a different
+ * record.
+ */
+export function registerTileSurfaceGeometrySlot(
+  key: string,
+  slotElement: Element,
+  onRect: TileSurfaceRectListener,
+): () => void {
+  const previous = slotRegistrations.get(key);
+  if (previous !== undefined) {
+    ensureSharedObserver().unobserve(previous.slotElement);
+  }
+  const registration: SlotRegistration = { key, slotElement, onRect };
+  slotRegistrations.set(key, registration);
+  ensureSharedObserver().observe(slotElement);
+  applyRect(registration);
+  return () => {
+    if (slotRegistrations.get(key) === registration) {
+      ensureSharedObserver().unobserve(slotElement);
+      slotRegistrations.delete(key);
+    }
+  };
+}
+
+export function resetTileSurfaceGeometryCoordinatorForTesting(): void {
+  if (sharedObserver !== null) sharedObserver.disconnect();
+  sharedObserver = null;
+  hostRegistration = null;
+  slotRegistrations.clear();
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-membership.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-membership.ts
@@ -29,11 +29,18 @@
  *    coordinator's own settle notification.
  *
  * Membership is recomputed and diffed on every notification from
- * `useEpicCanvasStore`, `useTabsStore`, and `tabCommandCoordinator` -
- * deriving from observed state at each checkpoint rather than trusting any
- * one store's change to imply the others are consistent (the same
- * observation-over-claim lesson slice 1's identity machinery learned the
- * hard way).
+ * `useEpicCanvasStore`, `useTabsStore`, `tabCommandCoordinator`, and
+ * `remote-deleted-chat-registry.ts` - deriving from observed state at each
+ * checkpoint rather than trusting any one store's change to imply the others
+ * are consistent (the same observation-over-claim lesson slice 1's identity
+ * machinery learned the hard way).
+ *
+ * A selected chat also has to pass `isHostedSurfaceEligible` (shared with
+ * `surface-owner.ts`'s render-routing decision - design-review slice-4
+ * finding 2) - a remote-deleted chat leaves membership the same instant
+ * `ActiveTabBody` reports it, so the registry entry it's holding gets cleared
+ * by slice 2's existing membership-loss subscription instead of lingering
+ * alongside the inline `DeletedArtifactBody`.
  */
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicCanvasState } from "@/stores/epics/canvas/types";
@@ -47,6 +54,11 @@ import {
   advanceTopLevelSurfaceRecency,
   retainedTopLevelSurfaceKeys,
 } from "@/stores/tabs/top-level-surface-retention";
+import { isHostedSurfaceEligible } from "@/components/epic-canvas/surface-host/surface-owner";
+import {
+  isChatRemoteDeleted,
+  subscribeChatRemoteDeletion,
+} from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
 
 export type SurfaceMembershipListener = () => void;
 
@@ -68,7 +80,13 @@ export function collectCanvasWideSelectedChatMembership(
       );
       if (activeInstanceId === null) continue;
       const tile = canvas.tilesByInstanceId[activeInstanceId];
-      if (tile?.type === "chat") {
+      if (
+        tile !== undefined &&
+        isHostedSurfaceEligible({
+          node: tile,
+          isRemoteDeleted: isChatRemoteDeleted(activeInstanceId),
+        })
+      ) {
         instanceIdToTabId.set(activeInstanceId, tabId);
       }
     }
@@ -176,4 +194,5 @@ useEpicCanvasStore.subscribe(recomputeMembership);
 useTabsStore.subscribe(recomputeMembership);
 useLandingDraftStore.subscribe(recomputeMembership);
 tabCommandCoordinator.subscribe(recomputeMembership);
+subscribeChatRemoteDeletion(recomputeMembership);
 recomputeMembership();

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-membership.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-membership.ts
@@ -44,7 +44,10 @@
  */
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicCanvasState } from "@/stores/epics/canvas/types";
-import { collectPanes, resolveActivePaneTab } from "@/stores/epics/canvas/tile-tree";
+import {
+  collectPanes,
+  resolveActivePaneTab,
+} from "@/stores/epics/canvas/tile-tree";
 import { useTabsStore } from "@/stores/tabs/store";
 import { flattenStripItemRefs, tabRefKey } from "@/stores/tabs/layout";
 import { getHeaderTabs } from "@/stores/tabs/use-header-tabs";

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-membership.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-membership.ts
@@ -1,0 +1,179 @@
+/**
+ * Ticket 21 slice 2: the canvas-wide, transaction-aware set of chat
+ * `instanceId`s a stable tile surface host must keep painted.
+ *
+ * Three layers, matching the design (`ticket-21-stable-tile-surface-identity`,
+ * "Host membership and lifecycle"):
+ *
+ * 1. Canvas-wide selected identity - the chat tile each pane, across every
+ *    open top-level tab's canvas, currently shows as its active tab. Uses the
+ *    same `resolveActivePaneTab` fallback the renderer uses, so a chat
+ *    `TabGroupView` paints is never omitted from membership.
+ * 2. Top-level retained-surface/MRU eligibility - a chat's owning top-level
+ *    tab must also be one of the retained top-level surfaces. This reuses
+ *    `TopLevelTabHost`'s actual recency/cap algorithm, extracted into
+ *    `stores/tabs/top-level-surface-retention.ts` as a shared pure module, so
+ *    both the render-time host and this store-driven mirror apply exactly
+ *    one global cap across every top-level kind (epic, draft, history,
+ *    settings) - never a per-kind cap.
+ * 3. Transaction-aware retention - header tear-off is not one-store atomic
+ *    (`tearOffTabIntoNewHeaderTab` commits `EpicCanvasStore` synchronously;
+ *    `tabCommandCoordinator` places the new header ref in `useTabsStore`
+ *    moments later, in the same transaction). Mid-transaction, the tile's new
+ *    owning top-level tab id can exist in `EpicCanvasStore` before it exists
+ *    in `useTabsStore`'s header strip - recomputing at that instant would
+ *    read a real but momentarily inconsistent cross-store snapshot and could
+ *    evict it. So membership is entirely FROZEN (not recomputed at all)
+ *    while the coordinator's ledger shows an in-flight transaction, and
+ *    reconciles - additions and MRU eviction alike - exactly once, from the
+ *    coordinator's own settle notification.
+ *
+ * Membership is recomputed and diffed on every notification from
+ * `useEpicCanvasStore`, `useTabsStore`, and `tabCommandCoordinator` -
+ * deriving from observed state at each checkpoint rather than trusting any
+ * one store's change to imply the others are consistent (the same
+ * observation-over-claim lesson slice 1's identity machinery learned the
+ * hard way).
+ */
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+import { collectPanes, resolveActivePaneTab } from "@/stores/epics/canvas/tile-tree";
+import { useTabsStore } from "@/stores/tabs/store";
+import { flattenStripItemRefs, tabRefKey } from "@/stores/tabs/layout";
+import { getHeaderTabs } from "@/stores/tabs/use-header-tabs";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import {
+  advanceTopLevelSurfaceRecency,
+  retainedTopLevelSurfaceKeys,
+} from "@/stores/tabs/top-level-surface-retention";
+
+export type SurfaceMembershipListener = () => void;
+
+/**
+ * Layer 1 (pure, standalone-testable): every chat `instanceId` a pane
+ * currently shows as its active tab, across the complete `canvasByTabId`
+ * snapshot, mapped to the top-level tab id that owns it.
+ */
+export function collectCanvasWideSelectedChatMembership(
+  canvasByTabId: Readonly<Record<string, EpicCanvasState | undefined>>,
+): ReadonlyMap<string, string> {
+  const instanceIdToTabId = new Map<string, string>();
+  for (const [tabId, canvas] of Object.entries(canvasByTabId)) {
+    if (canvas === undefined) continue;
+    for (const pane of collectPanes(canvas.root)) {
+      const activeInstanceId = resolveActivePaneTab(
+        pane.activeTabId,
+        pane.tabInstanceIds,
+      );
+      if (activeInstanceId === null) continue;
+      const tile = canvas.tilesByInstanceId[activeInstanceId];
+      if (tile?.type === "chat") {
+        instanceIdToTabId.set(activeInstanceId, tabId);
+      }
+    }
+  }
+  return instanceIdToTabId;
+}
+
+/**
+ * Layer 2: the kind-qualified `TabRef` keys (the same `"<kind>:<id>"` format
+ * `tabRefKey` produces) currently eligible to retain a hosted surface, given
+ * every open top-level tab strip and which refs are presently active.
+ * Recomputed with the exact same shared algorithm `TopLevelTabHost` uses -
+ * one global MRU/cap decision across every kind, never a per-kind one.
+ */
+function computeRetainedTopLevelRefKeys(): ReadonlyArray<string> {
+  const { items, activeItemId } = useTabsStore.getState();
+  const headerTabs = getHeaderTabs();
+  const knownRefKeys = new Set(headerTabs.map(tabRefKey));
+  const availableRefKeys = items
+    .flatMap(flattenStripItemRefs)
+    .map(tabRefKey)
+    .filter((key, index, keys) => keys.indexOf(key) === index)
+    .filter((key) => knownRefKeys.has(key));
+  const activeItem = items.find((item) => item.id === activeItemId) ?? null;
+  const activeRefKeys =
+    activeItem === null
+      ? []
+      : flattenStripItemRefs(activeItem)
+          .map(tabRefKey)
+          .filter((key) => knownRefKeys.has(key));
+
+  topLevelRecency = advanceTopLevelSurfaceRecency(
+    activeRefKeys,
+    topLevelRecency,
+  );
+  return retainedTopLevelSurfaceKeys(
+    availableRefKeys,
+    activeRefKeys,
+    topLevelRecency,
+  );
+}
+
+let topLevelRecency: ReadonlyArray<string> = [];
+let currentMembership: ReadonlySet<string> = new Set();
+const listeners = new Set<SurfaceMembershipListener>();
+
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * While the coordinator has an in-flight transaction, membership is left
+ * exactly as it was at the last settled snapshot - not recomputed at all.
+ * Header tear-off's canvas write (which moves a tile to a brand-new,
+ * not-yet-in-the-header-strip top-level tab id) synchronously notifies both
+ * `useEpicCanvasStore` and, later in the same transaction, `useTabsStore`;
+ * recomputing mid-transaction would read a real but momentarily
+ * inconsistent snapshot (the tile's new owner exists in one store and not
+ * yet the other) and could evict it. Freezing avoids that by construction -
+ * the correct post-transaction membership is derived fresh, exactly once,
+ * from the coordinator's own settle notification.
+ */
+function recomputeMembership(): void {
+  if (tabCommandCoordinator.getLedger().suppressionDepth > 0) return;
+
+  const retainedRefKeys = new Set(computeRetainedTopLevelRefKeys());
+  const instanceIdToTabId = collectCanvasWideSelectedChatMembership(
+    useEpicCanvasStore.getState().canvasByTabId,
+  );
+  const nextMembership = new Set<string>();
+  for (const [instanceId, tabId] of instanceIdToTabId) {
+    if (retainedRefKeys.has(tabRefKey({ kind: "epic", id: tabId }))) {
+      nextMembership.add(instanceId);
+    }
+  }
+
+  if (setsEqual(nextMembership, currentMembership)) return;
+  currentMembership = nextMembership;
+  listeners.forEach((listener) => listener());
+}
+
+/** The chat `instanceId`s a stable tile surface host should keep mounted. */
+export function getTileSurfaceMembership(): ReadonlySet<string> {
+  return currentMembership;
+}
+
+export function subscribeTileSurfaceMembership(
+  listener: SurfaceMembershipListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function resetTileSurfaceMembershipForTesting(): void {
+  topLevelRecency = [];
+  currentMembership = new Set();
+  recomputeMembership();
+}
+
+useEpicCanvasStore.subscribe(recomputeMembership);
+useTabsStore.subscribe(recomputeMembership);
+useLandingDraftStore.subscribe(recomputeMembership);
+tabCommandCoordinator.subscribe(recomputeMembership);
+recomputeMembership();

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-slot.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-slot.tsx
@@ -32,6 +32,7 @@ import {
 import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { publishTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
 import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
 
 export interface TileSurfaceSlotProps {
   readonly node: EpicCanvasTileRef;
@@ -50,6 +51,7 @@ export function TileSurfaceSlot(props: TileSurfaceSlotProps): ReactNode {
   const topLevelFocused = use(PaneSurfaceActivityContext).focused;
   const isPaneFocusedNow = usePaneFocusProbe();
   const panePortalContainer = usePanePortalContainer();
+  const paneActivationFocusIntent = usePaneActivationFocusIntent();
   const openEpicHandle = useMaybeOpenEpicHandle();
 
   useLayoutEffect(() => {
@@ -66,6 +68,7 @@ export function TileSurfaceSlot(props: TileSurfaceSlotProps): ReactNode {
       placement: { epicId, viewTabId, paneId, hostId: node.hostId },
       presentation: { topLevelVisible, topLevelFocused },
       canvasActivity: { tabSelected, canvasPaneActive },
+      paneActivation: { focusIntent: paneActivationFocusIntent },
       services: {
         openEpicHandle,
         geometryAnchorElement: slotElement,
@@ -87,6 +90,7 @@ export function TileSurfaceSlot(props: TileSurfaceSlotProps): ReactNode {
     topLevelFocused,
     tabSelected,
     canvasPaneActive,
+    paneActivationFocusIntent,
     panePortalContainer,
     isPaneFocusedNow,
   ]);

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-slot.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-slot.tsx
@@ -1,0 +1,102 @@
+/**
+ * Ticket 21 slice 4: `TabGroupView`'s hosted-chat counterpart to
+ * `ActiveTabBody` - a pure geometry anchor and environment publisher, no
+ * chat content of its own. The real `ChatTile`/`ChatMessages` body paints
+ * inside `StableTileSurfaceHost`'s fixed plane (slice 3); this slot only
+ * marks WHERE that body should be positioned and publishes the environment
+ * it needs to render itself correctly there.
+ *
+ * This slot's OWN plain placeholder element - occupying the exact rect the
+ * removed `ActiveTabBody` used to - publishes as `services.geometryAnchorElement`,
+ * the geometry coordinator's measurement anchor. It is NOT the same thing as
+ * `services.panePortalContainer`: that field carries the REAL ambient
+ * `PanePortalContainerContext` value (`SurfacePresentationBoundary`'s
+ * top-level portal host for kept-mounted popovers/composer overlays),
+ * captured here via `usePanePortalContainer()` and republished so a hosted
+ * chat's bridge can re-provide the genuine context value instead of this
+ * slot's own geometry element (design-review slice-4 finding 5).
+ *
+ * Cold until the real Epic session handle is available
+ * (`useMaybeOpenEpicHandle` returns `null` before `EpicSessionGate` opens):
+ * no publish happens, so `StableTileSurfaceHost` keeps the record dormant
+ * per the design's cold/ready contract - never a throwing `useOpenEpicHandle`
+ * call from a store-selected-but-not-yet-ready record.
+ */
+import { use, useLayoutEffect, useState, type ReactNode } from "react";
+import {
+  PaneSurfaceActivityContext,
+  usePaneFocusProbe,
+  usePanePortalContainer,
+  usePaneVisible,
+} from "@/components/epic-tabs/pane-visibility-context";
+import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { publishTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+export interface TileSurfaceSlotProps {
+  readonly node: EpicCanvasTileRef;
+  readonly epicId: string;
+  readonly paneId: string;
+  readonly viewTabId: string;
+  readonly tabSelected: boolean;
+  readonly canvasPaneActive: boolean;
+}
+
+export function TileSurfaceSlot(props: TileSurfaceSlotProps): ReactNode {
+  const { node, epicId, paneId, viewTabId, tabSelected, canvasPaneActive } =
+    props;
+  const [slotElement, setSlotElement] = useState<HTMLDivElement | null>(null);
+  const topLevelVisible = usePaneVisible();
+  const topLevelFocused = use(PaneSurfaceActivityContext).focused;
+  const isPaneFocusedNow = usePaneFocusProbe();
+  const panePortalContainer = usePanePortalContainer();
+  const openEpicHandle = useMaybeOpenEpicHandle();
+
+  useLayoutEffect(() => {
+    if (slotElement === null) return;
+    if (openEpicHandle === null) return;
+    publishTileSurfaceEnvironment({
+      identity: {
+        instanceId: node.instanceId,
+        tileKind: node.type,
+        contentId: node.id,
+        epicId,
+        hostId: node.hostId,
+      },
+      placement: { epicId, viewTabId, paneId, hostId: node.hostId },
+      presentation: { topLevelVisible, topLevelFocused },
+      canvasActivity: { tabSelected, canvasPaneActive },
+      services: {
+        openEpicHandle,
+        geometryAnchorElement: slotElement,
+        panePortalContainer,
+        isPaneFocusedNow,
+      },
+    });
+  }, [
+    slotElement,
+    openEpicHandle,
+    node.instanceId,
+    node.type,
+    node.id,
+    node.hostId,
+    epicId,
+    viewTabId,
+    paneId,
+    topLevelVisible,
+    topLevelFocused,
+    tabSelected,
+    canvasPaneActive,
+    panePortalContainer,
+    isPaneFocusedNow,
+  ]);
+
+  return (
+    <div
+      ref={setSlotElement}
+      data-testid="tile-surface-slot"
+      data-tile-instance-id={node.instanceId}
+      className="h-full w-full"
+    />
+  );
+}

--- a/clients/gui-app/src/components/epic-tabs/__tests__/phase-migration-controller.test.ts
+++ b/clients/gui-app/src/components/epic-tabs/__tests__/phase-migration-controller.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from "vitest";
 import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
 import {
   resolveTabEpicIdentity,
@@ -236,15 +244,16 @@ describe("PhaseMigrationController", () => {
     controller.attach(PHASE_TAB_ID, "phase-1", start);
     const unsubscribeCompletion =
       controller.subscribeCompletion(completionListener);
+    onTestFinished(unsubscribeCompletion);
     const unsubscribeRace = tabCommandCoordinator.subscribe(() => {
       const current = useEpicCanvasStore.getState().tabsById[PHASE_TAB_ID];
       if (current?.surfaceMode?.kind === "phase-migration") {
         resolveTabEpicIdentity(PHASE_TAB_ID, "phase-1", "epic-racer");
       }
     });
+    onTestFinished(unsubscribeRace);
 
     controller.succeed(PHASE_TAB_ID, "phase-1", 1, "epic-created");
-    unsubscribeRace();
 
     expect(controller.snapshot(PHASE_TAB_ID)).toMatchObject({
       status: "error",
@@ -269,7 +278,6 @@ describe("PhaseMigrationController", () => {
     });
     expect(start.mock.calls).toEqual([[1], [2]]);
     expect(completionListener).not.toHaveBeenCalled();
-    unsubscribeCompletion();
   });
 
   it("clears migration mode when the migrated Epic keeps the Phase id", () => {

--- a/clients/gui-app/src/components/epic-tabs/__tests__/phase-migration-controller.test.ts
+++ b/clients/gui-app/src/components/epic-tabs/__tests__/phase-migration-controller.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import {
+  resolveTabEpicIdentity,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import { useTabsStore } from "@/stores/tabs/store";
 import { PhaseMigrationController } from "@/components/epic-tabs/phase-migration-controller";
@@ -154,6 +157,119 @@ describe("PhaseMigrationController", () => {
       },
     ]);
     expect(useEpicCanvasStore.getState().activeTabId).toBe(PARTNER_TAB_ID);
+  });
+
+  it("completePhaseMigration returns false and leaves surfaceMode alone when a listener races the resolution to a different epic first", () => {
+    // `execute`'s listeners fire before `applySources`, so this racer wins
+    // BEFORE `completePhaseMigration`'s own resolution call ever runs - the
+    // pre-commit window (closed since round 1/2). See the pin below for a
+    // listener that races the commit itself instead.
+    const unsubscribeRace = tabCommandCoordinator.subscribe(() => {
+      const current = useEpicCanvasStore.getState().tabsById[PHASE_TAB_ID];
+      if (current?.surfaceMode?.kind === "phase-migration") {
+        resolveTabEpicIdentity(PHASE_TAB_ID, "phase-1", "epic-racer");
+      }
+    });
+
+    let completed: boolean | undefined;
+    try {
+      completed = tabCommandCoordinator.completePhaseMigration({
+        tabId: PHASE_TAB_ID,
+        phaseId: "phase-1",
+        epicId: "epic-created",
+      });
+    } finally {
+      unsubscribeRace();
+    }
+
+    expect(completed).toBe(false);
+    expect(useEpicCanvasStore.getState().tabsById[PHASE_TAB_ID]).toEqual({
+      tabId: PHASE_TAB_ID,
+      epicId: "epic-racer",
+      name: "Legacy Phase",
+      surfaceMode: { kind: "phase-migration", phaseId: "phase-1" },
+    });
+  });
+
+  it("completePhaseMigration returns false when a raw store subscriber supersedes the resolution DURING its own commit", () => {
+    // The round-3 window: `rawPublicSetState` inside `resolveTabEpicIdentity`
+    // notifies zustand subscribers SYNCHRONOUSLY, mid-commit - a listener
+    // observing the just-landed epicId can call the same authorized action
+    // AGAIN before the outer `resolveTabEpicIdentity` call returns to
+    // `completePhaseMigration`'s own closure. The precondition passes (the
+    // outer write already landed), so a claim recorded at write time would
+    // be wrong; the fix reads `getState()` back after `execute()` instead.
+    // The listener is self-limiting: it only fires while the tab's epicId
+    // still equals the outer target, which stops holding once the racer's
+    // own write lands (including on the racer's own re-entrant
+    // notification), so this terminates without a manual guard.
+    const unsubscribeRace = useEpicCanvasStore.subscribe((state) => {
+      if (state.tabsById[PHASE_TAB_ID]?.epicId === "epic-created") {
+        resolveTabEpicIdentity(PHASE_TAB_ID, "epic-created", "epic-racer");
+      }
+    });
+
+    let completed: boolean | undefined;
+    try {
+      completed = tabCommandCoordinator.completePhaseMigration({
+        tabId: PHASE_TAB_ID,
+        phaseId: "phase-1",
+        epicId: "epic-created",
+      });
+    } finally {
+      unsubscribeRace();
+    }
+
+    expect(completed).toBe(false);
+    expect(useEpicCanvasStore.getState().tabsById[PHASE_TAB_ID]).toEqual({
+      tabId: PHASE_TAB_ID,
+      epicId: "epic-racer",
+      name: "Legacy Phase",
+      surfaceMode: { kind: "phase-migration", phaseId: "phase-1" },
+    });
+  });
+
+  it("succeed() surfaces as an error (not complete) when a listener races the resolution, and retry routes sanely (no hot-loop)", () => {
+    const controller = new PhaseMigrationController();
+    const start = vi.fn();
+    const completionListener = vi.fn();
+    controller.attach(PHASE_TAB_ID, "phase-1", start);
+    const unsubscribeCompletion =
+      controller.subscribeCompletion(completionListener);
+    const unsubscribeRace = tabCommandCoordinator.subscribe(() => {
+      const current = useEpicCanvasStore.getState().tabsById[PHASE_TAB_ID];
+      if (current?.surfaceMode?.kind === "phase-migration") {
+        resolveTabEpicIdentity(PHASE_TAB_ID, "phase-1", "epic-racer");
+      }
+    });
+
+    controller.succeed(PHASE_TAB_ID, "phase-1", 1, "epic-created");
+    unsubscribeRace();
+
+    expect(controller.snapshot(PHASE_TAB_ID)).toMatchObject({
+      status: "error",
+      errorMessage: "The migrated Epic could not be attached to this tab.",
+    });
+    expect(completionListener).not.toHaveBeenCalled();
+    expect(
+      useEpicCanvasStore.getState().tabsById[PHASE_TAB_ID]?.surfaceMode,
+    ).toEqual({ kind: "phase-migration", phaseId: "phase-1" });
+
+    // The race already committed the tab to a third epic through the same
+    // authorized action, ahead of this migration's own resolution - a real
+    // caller can't retry its way back to "phase-1" against that. What
+    // matters here is that `retry()` routes into its existing pending/start
+    // cycle sanely (same "retries after an error" mechanics as the
+    // ordinary-failure pin above) instead of hot-looping or getting stuck.
+    controller.retry(PHASE_TAB_ID);
+
+    expect(controller.snapshot(PHASE_TAB_ID)).toMatchObject({
+      status: "pending",
+      errorMessage: null,
+    });
+    expect(start.mock.calls).toEqual([[1], [2]]);
+    expect(completionListener).not.toHaveBeenCalled();
+    unsubscribeCompletion();
   });
 
   it("clears migration mode when the migrated Epic keeps the Phase id", () => {

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
@@ -1,7 +1,14 @@
 import "../../../../__tests__/test-browser-apis";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import {
   LandingTerminalHost,
   LandingTerminalPaneAnchor,
@@ -10,11 +17,58 @@ import {
   MAX_RETAINED_TOP_LEVEL_SURFACES,
   TopLevelTabHost,
 } from "@/components/layout/top-level-tab-host";
+import {
+  TopLevelSurfaceActivationContext,
+  type TopLevelSurfaceActivator,
+} from "@/components/layout/top-level-surface-activation-context";
+import { activateHostedTopLevelSurface } from "@/components/epic-canvas/surface-host/hosted-top-level-activation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { useTabsStore } from "@/stores/tabs/store";
-import type { TabRef } from "@/stores/tabs/types";
-import { TopLevelSurfaceActivationContext } from "@/components/layout/top-level-surface-activation-context";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import type { HeaderTab, TabRef } from "@/stores/tabs/types";
+import { tabRefKey, type StripItem } from "@/stores/tabs/layout";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+  HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+import {
+  pane,
+  TEST_HOST_ID,
+} from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import {
+  publishTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+
+const stableTileSurfaceHostTestState = vi.hoisted(() => ({ enabled: false }));
+
+vi.mock(
+  "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch",
+  () => ({
+    get STABLE_TILE_SURFACE_HOST_ENABLED() {
+      return stableTileSurfaceHostTestState.enabled;
+    },
+  }),
+);
+
+// The wiring test below only cares whether a real pointerdown/focus event on
+// a hosted record's DOM reaches `activateHostedTopLevelSurface` - not that
+// the real ChatTile/ChatMessages chain renders (that needs a real Epic
+// session handle the synthetic environment fixture cannot supply). Stub the
+// body the same way `stable-tile-surface-host.test.tsx` uses a synthetic
+// body renderer.
+vi.mock(
+  "@/components/epic-canvas/surface-host/hosted-chat-surface-body",
+  () => ({
+    renderHostedChatSurfaceBody: () => (
+      <div data-testid="hosted-wiring-body-stub" />
+    ),
+  }),
+);
 
 vi.mock("@/components/epic-tabs/epic-surface", async () => {
   const React = await import("react");
@@ -483,5 +537,266 @@ describe("<TopLevelTabHost />", () => {
         .getByTestId(`landing-terminal-anchor-${DRAFT_B.id}`)
         .contains(screen.getByTestId("landing-terminal-panel-body")),
     ).toBe(true);
+  });
+});
+
+describe("activateHostedTopLevelSurface (design-review F3: hosted pointer/focus reaches its OWN owning top-level tab)", () => {
+  afterEach(() => cleanup());
+
+  function buildHostedRecord(
+    instanceId: string,
+    paneId: string,
+    viewTabId: string,
+  ): HTMLDivElement {
+    const record = document.createElement("div");
+    record.setAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE, instanceId);
+    record.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, paneId);
+    record.setAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE, viewTabId);
+    return record;
+  }
+
+  it("activates the hosted record's OWN owning epic tab, not a fixed one", () => {
+    const tabA: HeaderTab = {
+      kind: "epic",
+      id: "epic-a",
+      epicId: "epic-a",
+      route: "/epic/epic-a",
+      name: "Epic A",
+      icon: null,
+      canClose: true,
+      canDuplicate: true,
+      canOpenInNewWindow: true,
+    };
+    const tabB: HeaderTab = { ...tabA, id: "epic-b", epicId: "epic-b" };
+    const tabsByRefKey = new Map([
+      [tabRefKey(tabA), tabA],
+      [tabRefKey(tabB), tabB],
+    ]);
+    const activeItem: StripItem = {
+      kind: "tab",
+      id: "tab:epic:epic-a",
+      ref: { kind: "epic", id: "epic-a" },
+    };
+    const record = buildHostedRecord("inst-chat-b", "p1", "epic-b");
+    document.body.appendChild(record);
+    const activate = vi.fn();
+
+    activateHostedTopLevelSurface(record, false, {
+      tabsByRefKey,
+      activeItem,
+      activate,
+    });
+
+    expect(activate).toHaveBeenCalledTimes(1);
+    expect(activate).toHaveBeenCalledWith(tabB);
+    record.remove();
+  });
+
+  it("does not re-activate the already-focused owning tab", () => {
+    const tabA: HeaderTab = {
+      kind: "epic",
+      id: "epic-a",
+      epicId: "epic-a",
+      route: "/epic/epic-a",
+      name: "Epic A",
+      icon: null,
+      canClose: true,
+      canDuplicate: true,
+      canOpenInNewWindow: true,
+    };
+    const tabsByRefKey = new Map([[tabRefKey(tabA), tabA]]);
+    const activeItem: StripItem = {
+      kind: "tab",
+      id: "tab:epic:epic-a",
+      ref: { kind: "epic", id: "epic-a" },
+    };
+    const record = buildHostedRecord("inst-chat-a", "p1", "epic-a");
+    document.body.appendChild(record);
+    const activate = vi.fn();
+
+    activateHostedTopLevelSurface(record, false, {
+      tabsByRefKey,
+      activeItem,
+      activate,
+    });
+
+    expect(activate).not.toHaveBeenCalled();
+    record.remove();
+  });
+
+  it("respects defaultPrevented, a null activator, and a target outside any hosted record", () => {
+    const tabA: HeaderTab = {
+      kind: "epic",
+      id: "epic-a",
+      epicId: "epic-a",
+      route: "/epic/epic-a",
+      name: "Epic A",
+      icon: null,
+      canClose: true,
+      canDuplicate: true,
+      canOpenInNewWindow: true,
+    };
+    const tabsByRefKey = new Map([[tabRefKey(tabA), tabA]]);
+    const activeItem: StripItem | null = null;
+    const record = buildHostedRecord("inst-chat-a", "p1", "epic-a");
+    document.body.appendChild(record);
+    const activate = vi.fn();
+
+    activateHostedTopLevelSurface(record, true, {
+      tabsByRefKey,
+      activeItem,
+      activate,
+    });
+    expect(activate).not.toHaveBeenCalled();
+
+    activateHostedTopLevelSurface(record, false, {
+      tabsByRefKey,
+      activeItem,
+      activate: null,
+    });
+    expect(activate).not.toHaveBeenCalled();
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    activateHostedTopLevelSurface(outside, false, {
+      tabsByRefKey,
+      activeItem,
+      activate,
+    });
+    expect(activate).not.toHaveBeenCalled();
+
+    record.remove();
+    outside.remove();
+  });
+});
+
+/**
+ * Design-review F3: `activateHostedTopLevelSurface`'s own unit tests above
+ * prove its routing logic, but not that a real hosted pointerdown reaches it
+ * at all - that depends on the `onPointerDownCapture`/`onFocusCapture` JSX
+ * wiring on `TopLevelTabHost`'s hosted-plane wrapper (a sibling of every
+ * physical top-level surface wrapper, so it cannot inherit their own
+ * handlers). This renders the REAL `TopLevelTabHost` with the switch on and a
+ * REAL hosted record (real membership + registry, synthetic environment -
+ * the same fixture seam `stable-tile-surface-host.test.tsx` uses), then fires
+ * a genuine `pointerdown` on it to prove the wiring itself, not just the
+ * function it calls.
+ */
+describe("TopLevelTabHost hosted-plane wiring (design-review F3: real pointerdown reaches activateHostedTopLevelSurface)", () => {
+  const EPIC_A: TabRef = { kind: "epic", id: "epic-a" };
+  const EPIC_B: TabRef = { kind: "epic", id: "epic-b" };
+  const CHAT_INSTANCE_ID = "hosted-wiring-chat";
+  const PANE_ID = "p1";
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+    stableTileSurfaceHostTestState.enabled = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    stableTileSurfaceHostTestState.enabled = false;
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+  });
+
+  it("activates epic-b when a real pointerdown lands on its hosted record, while epic-a stays the physically focused surface", async () => {
+    useEpicCanvasStore
+      .getState()
+      .openEpicTabWithId(EPIC_A.id, EPIC_A.id, "Epic A");
+    useEpicCanvasStore
+      .getState()
+      .openEpicTabWithId(EPIC_B.id, EPIC_B.id, "Epic B");
+    const stripItems = [EPIC_A, EPIC_B].map((ref) => ({
+      kind: "tab" as const,
+      id: `tab:${ref.kind}:${ref.id}`,
+      ref,
+    }));
+    // The MRU retention policy only retains a background surface once it has
+    // been active at least once (`advanceTopLevelSurfaceRecency` only adds
+    // active keys). Visit B first so it enters recency, matching how a real
+    // "open in background then switch away" sequence would leave B eligible
+    // for the surface-host membership while A is the focused surface.
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: stripItems,
+      activeItemId: `tab:${EPIC_B.kind}:${EPIC_B.id}`,
+      stripOrder: [EPIC_A, EPIC_B],
+    }));
+    useTabsStore.setState((state) => ({
+      ...state,
+      activeItemId: `tab:${EPIC_A.kind}:${EPIC_A.id}`,
+    }));
+    useEpicCanvasStore.setState((state) => ({
+      ...state,
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        [EPIC_B.id]: {
+          root: pane(PANE_ID, [CHAT_INSTANCE_ID]),
+          activePaneId: PANE_ID,
+          tilesByInstanceId: {
+            [CHAT_INSTANCE_ID]: {
+              id: CHAT_INSTANCE_ID,
+              instanceId: CHAT_INSTANCE_ID,
+              type: "chat" as const,
+              name: "Hosted wiring chat",
+              hostId: TEST_HOST_ID,
+            },
+          },
+          sizesByGroupId: {},
+        },
+      },
+    }));
+
+    const activate = vi.fn<TopLevelSurfaceActivator>();
+    render(
+      <TopLevelSurfaceActivationContext.Provider value={activate}>
+        <TopLevelTabHost />
+      </TopLevelSurfaceActivationContext.Provider>,
+    );
+
+    expect(surfaceRef(EPIC_A).dataset.focused).toBe("true");
+
+    act(() => {
+      publishTileSurfaceEnvironment(
+        buildSyntheticTileSurfaceEnvironment(CHAT_INSTANCE_ID, {
+          placement: {
+            epicId: EPIC_B.id,
+            viewTabId: EPIC_B.id,
+            paneId: PANE_ID,
+            hostId: TEST_HOST_ID,
+          },
+        }),
+      );
+    });
+
+    const hostedRecord = await waitFor(() => {
+      const element = document.querySelector(
+        `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${CHAT_INSTANCE_ID}"]`,
+      );
+      if (element === null) throw new Error("hosted record not yet published");
+      return element;
+    });
+    expect(hostedRecord.getAttribute(HOSTED_TILE_VIEW_TAB_ID_ATTRIBUTE)).toBe(
+      EPIC_B.id,
+    );
+
+    // A real pointerdown on the hosted record - not a direct function call -
+    // must reach the wrapper's onPointerDownCapture and activate epic-b.
+    fireEvent.pointerDown(hostedRecord);
+
+    expect(activate).toHaveBeenCalledTimes(1);
+    const [activatedTab] = activate.mock.calls[0];
+    expect(activatedTab.id).toBe(EPIC_B.id);
   });
 });

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -60,6 +60,8 @@ import {
   advanceTopLevelSurfaceRecency,
   retainedTopLevelSurfaceKeys,
 } from "@/stores/tabs/top-level-surface-retention";
+import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
+import { STABLE_TILE_SURFACE_HOST_ENABLED } from "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch";
 
 export { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/stores/tabs/top-level-surface-retention";
 
@@ -146,6 +148,9 @@ export function TopLevelTabHost() {
           activateSurface={activateSurface}
         />
       ))}
+      {STABLE_TILE_SURFACE_HOST_ENABLED ? (
+        <StableTileSurfaceHost renderRecordBody={() => null} />
+      ) : null}
       {renderedActiveItem?.kind === "tab" ? (
         <TopLevelEdgeSplitTargets targetRef={renderedActiveItem.ref} />
       ) : null}

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -56,8 +56,12 @@ import {
   type TopLevelSurfaceActivator,
   useTopLevelSurfaceActivator,
 } from "./top-level-surface-activation-context";
+import {
+  advanceTopLevelSurfaceRecency,
+  retainedTopLevelSurfaceKeys,
+} from "@/stores/tabs/top-level-surface-retention";
 
-export const MAX_RETAINED_TOP_LEVEL_SURFACES = 5;
+export { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/stores/tabs/top-level-surface-retention";
 
 type SurfacePlacement =
   | { readonly kind: "hidden" }
@@ -232,23 +236,15 @@ function useMountedSurfaceKeys(
 
   if (activeSignature !== seenActiveSignature) {
     setSeenActiveSignature(activeSignature);
-    setRecency((previous) => [
-      ...activeRefKeys,
-      ...previous.filter((key) => !activeRefKeys.includes(key)),
-    ]);
+    setRecency((previous) =>
+      advanceTopLevelSurfaceRecency(activeRefKeys, previous),
+    );
   }
 
-  return useMemo(() => {
-    const available = new Set(availableRefKeys);
-    const ordered = [
-      ...activeRefKeys,
-      ...recency.filter(
-        (key) => available.has(key) && !activeRefKeys.includes(key),
-      ),
-    ];
-    const retained = new Set(ordered.slice(0, MAX_RETAINED_TOP_LEVEL_SURFACES));
-    return availableRefKeys.filter((key) => retained.has(key));
-  }, [activeRefKeys, availableRefKeys, recency]);
+  return useMemo(
+    () => retainedTopLevelSurfaceKeys(availableRefKeys, activeRefKeys, recency),
+    [activeRefKeys, availableRefKeys, recency],
+  );
 }
 
 function FillableSplitSlots(props: {

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -6,6 +6,8 @@ import {
   useState,
   useSyncExternalStore,
   type CSSProperties,
+  type FocusEvent,
+  type PointerEvent,
   type ReactNode,
 } from "react";
 import { useDroppable } from "@dnd-kit/core";
@@ -13,6 +15,7 @@ import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import {
   flattenStripItemRefs,
+  tabRefKey,
   type SplitSide,
   type SplitSideName,
   type SplitStripItem,
@@ -62,6 +65,12 @@ import {
 } from "@/stores/tabs/top-level-surface-retention";
 import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
 import { STABLE_TILE_SURFACE_HOST_ENABLED } from "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch";
+import { renderHostedChatSurfaceBody } from "@/components/epic-canvas/surface-host/hosted-chat-surface-body";
+import {
+  activateHostedTopLevelSurface,
+  refIsFocused,
+  refsMatch,
+} from "@/components/epic-canvas/surface-host/hosted-top-level-activation";
 
 export { MAX_RETAINED_TOP_LEVEL_SURFACES } from "@/stores/tabs/top-level-surface-retention";
 
@@ -149,7 +158,11 @@ export function TopLevelTabHost() {
         />
       ))}
       {STABLE_TILE_SURFACE_HOST_ENABLED ? (
-        <StableTileSurfaceHost renderRecordBody={() => null} />
+        <HostedTileSurfaceHostMount
+          tabsByRefKey={tabsByRefKey}
+          activeItem={activeItem}
+          activateSurface={activateSurface}
+        />
       ) : null}
       {renderedActiveItem?.kind === "tab" ? (
         <TopLevelEdgeSplitTargets targetRef={renderedActiveItem.ref} />
@@ -166,6 +179,82 @@ export function TopLevelTabHost() {
         </>
       ) : null}
     </div>
+  );
+}
+
+function HostedTileSurfaceHostMount(props: {
+  readonly tabsByRefKey: ReadonlyMap<string, HeaderTab>;
+  readonly activeItem: StripItem | null;
+  readonly activateSurface: TopLevelSurfaceActivator | null;
+}): ReactNode {
+  const { activateSurface, activeItem, tabsByRefKey } = props;
+  const pendingTabRef = useRef<HeaderTab | null>(null);
+  const activatePendingTab = useCallback(() => {
+    const tab = pendingTabRef.current;
+    if (tab === null) return;
+    activateSurface?.(tab);
+  }, [activateSurface]);
+  const activation = usePaneActivationOwnership({
+    active: false,
+    activate: activatePendingTab,
+  });
+  const {
+    claimFocus: claimActivationFocus,
+    claimPointerDown: claimActivationPointerDown,
+  } = activation;
+
+  const claimFocus = useCallback(
+    (event: FocusEvent<HTMLDivElement>): void => {
+      activateHostedTopLevelSurface(event.target, event.defaultPrevented, {
+        tabsByRefKey,
+        activeItem,
+        activate:
+          activateSurface === null
+            ? null
+            : (tab) => {
+                pendingTabRef.current = tab;
+                claimActivationFocus({
+                  defaultPrevented: false,
+                  scope: event.target,
+                  target: event.target,
+                });
+              },
+      });
+    },
+    [activeItem, activateSurface, claimActivationFocus, tabsByRefKey],
+  );
+  const claimPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>): void => {
+      activateHostedTopLevelSurface(event.target, event.defaultPrevented, {
+        tabsByRefKey,
+        activeItem,
+        activate:
+          activateSurface === null
+            ? null
+            : (tab) => {
+                pendingTabRef.current = tab;
+                claimActivationPointerDown({
+                  defaultPrevented: false,
+                  scope: event.target,
+                  target: event.target,
+                });
+              },
+      });
+    },
+    [activeItem, activateSurface, claimActivationPointerDown, tabsByRefKey],
+  );
+
+  return (
+    <PaneActivationFocusIntentContext.Provider value={activation.focusIntent}>
+      <div
+        className="contents"
+        onFocusCapture={claimFocus}
+        onPointerDownCapture={claimPointerDown}
+        onPointerCancelCapture={activation.onPointerCancelCapture}
+      >
+        <StableTileSurfaceHost renderRecordBody={renderHostedChatSurfaceBody} />
+      </div>
+    </PaneActivationFocusIntentContext.Provider>
   );
 }
 
@@ -506,25 +595,6 @@ function splitSidePlacement(
     left: leftWidth,
     width: `${(1 - item.leftRatio) * 100}%`,
   };
-}
-
-function refIsFocused(activeItem: StripItem | null, tab: HeaderTab): boolean {
-  if (activeItem === null) return false;
-  if (activeItem.kind === "tab") return refsMatch(activeItem.ref, tab);
-  const focused =
-    activeItem.focusedSide === "left" ? activeItem.left : activeItem.right;
-  return refsMatch(focused, tab);
-}
-
-function refsMatch(ref: TabRef | SplitSide, tab: HeaderTab): boolean {
-  const candidate = ref.kind === "tab" ? ref.ref : ref;
-  return (
-    candidate.kind === tab.kind && "id" in candidate && candidate.id === tab.id
-  );
-}
-
-function tabRefKey(ref: TabRef | HeaderTab): string {
-  return `${ref.kind}:${ref.id}`;
 }
 
 function surfaceClassName(placement: SurfacePlacement): string {

--- a/clients/gui-app/src/lib/keybindings/__tests__/dispatch-focus-editor.test.ts
+++ b/clients/gui-app/src/lib/keybindings/__tests__/dispatch-focus-editor.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  dispatchAction,
+  type KeybindingRouter,
+} from "@/lib/keybindings/dispatch";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import {
+  resetTabsStoreForTest,
+  seedActiveEpicTabInTabsStore,
+} from "@/stores/tabs/test-support/tabs-store-fixtures";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import {
+  HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+  HOSTED_TILE_PANE_ID_ATTRIBUTE,
+} from "@/components/epic-canvas/surface-host/hosted-tile-dom";
+
+const CHAT_A: EpicNodeRef = {
+  id: "chat-a",
+  instanceId: "inst-a",
+  type: "chat",
+  name: "Chat A",
+  hostId: "host-A",
+};
+
+const SEED_EPIC_ID = "epic-focus-editor";
+
+function routerForTab(tabId: string): KeybindingRouter {
+  return {
+    getPathname: () => `/epics/${SEED_EPIC_ID}/${tabId}`,
+    navigateHome: () => undefined,
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+  };
+}
+
+function seedActiveGroupTab(): {
+  readonly tabId: string;
+  readonly groupId: string;
+  readonly instanceId: string;
+} {
+  const store = useEpicCanvasStore.getState();
+  const tabId = store.openEpicTab(SEED_EPIC_ID, "Epic");
+  store.openTileInTab(tabId, CHAT_A);
+  seedActiveEpicTabInTabsStore(tabId);
+  const groupId =
+    useEpicCanvasStore.getState().canvasByTabId[tabId]?.activePaneId ?? null;
+  if (groupId === null) throw new Error("expected an active group");
+  return { tabId, groupId, instanceId: CHAT_A.instanceId };
+}
+
+/** Mirrors `TabGroupView`'s own tab-body wrapper markup - see `tab-group-view.tsx`. */
+function buildSelectedTabWrapper(
+  groupId: string,
+  instanceId: string,
+): HTMLElement {
+  const group = document.createElement("div");
+  group.setAttribute("data-group-id", groupId);
+  const selectedTab = document.createElement("div");
+  selectedTab.setAttribute("data-tab-instance-id", instanceId);
+  selectedTab.setAttribute("data-selected", "true");
+  group.appendChild(selectedTab);
+  document.body.appendChild(group);
+  return selectedTab;
+}
+
+function appendComposerEditor(parent: HTMLElement): HTMLElement {
+  const composer = document.createElement("div");
+  composer.setAttribute("data-chat-composer", "");
+  const editor = document.createElement("div");
+  editor.setAttribute("data-composer-editor", "");
+  editor.setAttribute("tabindex", "-1");
+  composer.appendChild(editor);
+  parent.appendChild(composer);
+  return editor;
+}
+
+beforeEach(() => {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  resetTabsStoreForTest();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("dispatchAction group.focus-editor (ticket 21 slice 4 hosted fallback)", () => {
+  it("focuses the physical composer when the tile is inline", () => {
+    const { tabId, groupId, instanceId } = seedActiveGroupTab();
+    const selectedTab = buildSelectedTabWrapper(groupId, instanceId);
+    const editor = appendComposerEditor(selectedTab);
+
+    const result = dispatchAction("group.focus-editor", routerForTab(tabId));
+    expect(result).toBe(true);
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("falls back to the hosted record's composer when the selected tab only holds a geometry anchor", () => {
+    const { tabId, groupId, instanceId } = seedActiveGroupTab();
+    // Empty - models `TileSurfaceSlot`'s geometry anchor with no real body.
+    buildSelectedTabWrapper(groupId, instanceId);
+
+    const hostedRecord = document.createElement("div");
+    hostedRecord.setAttribute(HOSTED_TILE_INSTANCE_ID_ATTRIBUTE, instanceId);
+    hostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, groupId);
+    document.body.appendChild(hostedRecord);
+    const editor = appendComposerEditor(hostedRecord);
+
+    const result = dispatchAction("group.focus-editor", routerForTab(tabId));
+    expect(result).toBe(true);
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("does not reach for a hosted record belonging to a different instance", () => {
+    const { tabId, groupId, instanceId } = seedActiveGroupTab();
+    buildSelectedTabWrapper(groupId, instanceId);
+
+    const unrelatedHostedRecord = document.createElement("div");
+    unrelatedHostedRecord.setAttribute(
+      HOSTED_TILE_INSTANCE_ID_ATTRIBUTE,
+      "some-other-instance",
+    );
+    unrelatedHostedRecord.setAttribute(HOSTED_TILE_PANE_ID_ATTRIBUTE, groupId);
+    document.body.appendChild(unrelatedHostedRecord);
+    appendComposerEditor(unrelatedHostedRecord);
+
+    const before = document.activeElement;
+    dispatchAction("group.focus-editor", routerForTab(tabId));
+    expect(document.activeElement).toBe(before);
+  });
+});

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -47,6 +47,7 @@ import {
   SETTINGS_SECTIONS,
   type SettingsSectionId,
 } from "@/lib/settings-sections";
+import { findHostedTileElement } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
 
 const SELECTED_GROUP_TAB_SELECTOR =
   '[data-tab-instance-id][data-selected="true"]';
@@ -737,11 +738,36 @@ function focusGroupEditor(groupId: string): boolean {
     SELECTED_GROUP_TAB_SELECTOR,
   );
   const editor =
-    selectedTab?.querySelector<HTMLElement>(PRIMARY_CHAT_COMPOSER_SELECTOR) ??
-    selectedTab?.querySelector<HTMLElement>(ARTIFACT_EDITOR_SELECTOR);
-  if (editor === undefined || editor === null) return false;
+    findComposerOrArtifactEditor(selectedTab) ??
+    findComposerOrArtifactEditor(hostedRecordForSelectedTab(selectedTab));
+  if (editor === null) return false;
   editor.focus({ preventScroll: true });
   return true;
+}
+
+function findComposerOrArtifactEditor(
+  scope: HTMLElement | null | undefined,
+): HTMLElement | null {
+  if (scope === null || scope === undefined) return null;
+  return (
+    scope.querySelector<HTMLElement>(PRIMARY_CHAT_COMPOSER_SELECTOR) ??
+    scope.querySelector<HTMLElement>(ARTIFACT_EDITOR_SELECTOR)
+  );
+}
+
+/**
+ * A hosted chat's own composer/editor lives in `StableTileSurfaceHost`'s
+ * plane - `selectedTab` (the pane's tab-body wrapper) only ever contains
+ * `TileSurfaceSlot`'s empty geometry anchor for it. `selectedTab` still
+ * carries the tab's own `data-tab-instance-id`, so no extra plumbing is
+ * needed to locate the hosted record for the same instance.
+ */
+function hostedRecordForSelectedTab(
+  selectedTab: HTMLElement | null | undefined,
+): HTMLElement | null {
+  const instanceId = selectedTab?.dataset.tabInstanceId;
+  if (instanceId === undefined) return null;
+  return findHostedTileElement(document, instanceId);
 }
 
 function focusActiveGroupEditor(router: KeybindingRouter): boolean {

--- a/clients/gui-app/src/lib/layout/__tests__/panel-resizing-class.test.ts
+++ b/clients/gui-app/src/lib/layout/__tests__/panel-resizing-class.test.ts
@@ -213,9 +213,7 @@ describe("panel-resizing-class participant registry", () => {
         document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
       ).toBe(true);
 
-      window.dispatchEvent(
-        new PointerEvent("pointercancel", { pointerId: 3 }),
-      );
+      window.dispatchEvent(new PointerEvent("pointercancel", { pointerId: 3 }));
 
       expect(
         document.documentElement.classList.contains(PANEL_RESIZING_CLASS),

--- a/clients/gui-app/src/lib/layout/__tests__/panel-resizing-class.test.ts
+++ b/clients/gui-app/src/lib/layout/__tests__/panel-resizing-class.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  beginPanelResizeInteraction,
+  registerPanelResizeParticipant,
+} from "@/lib/layout/panel-resizing-class";
+
+const PANEL_RESIZING_CLASS = "traycer-panel-resizing";
+
+type VoidMock = Mock<() => void>;
+
+interface ParticipantSpy {
+  readonly capture: VoidMock;
+  readonly clear: VoidMock;
+}
+
+function participantSpy(): ParticipantSpy {
+  return {
+    capture: vi.fn(),
+    clear: vi.fn(),
+  };
+}
+
+/**
+ * This module holds global singleton state (the participant registry, and
+ * the single "currently active interaction" slot). A test whose assertion
+ * throws before reaching its own manual `stop()`/`unregister()` calls would
+ * otherwise leak a registered participant AND an unfinished interaction into
+ * every later test in this file - track every `unregister`/`stop` returned
+ * during a test and sweep them unconditionally in `afterEach`, regardless of
+ * how the test body exits. Calling an already-unregistered `unregister` or
+ * an already-stopped `stop` a second time is a documented no-op on both, so
+ * this sweep is safe even for tests that already did their own cleanup.
+ */
+let pendingUnregisters: Array<() => void> = [];
+let pendingStops: Array<() => void> = [];
+
+function trackedRegister(participant: {
+  readonly capture: () => void;
+  readonly clear: () => void;
+}): () => void {
+  const unregister = registerPanelResizeParticipant(participant);
+  pendingUnregisters.push(unregister);
+  return unregister;
+}
+
+const NOOP_ON_STOP = (): void => undefined;
+
+function trackedBegin(pointerId: number): () => void {
+  const stop = beginPanelResizeInteraction(pointerId, NOOP_ON_STOP);
+  pendingStops.push(stop);
+  return stop;
+}
+
+afterEach(() => {
+  for (const stop of pendingStops) stop();
+  pendingStops = [];
+  for (const unregister of pendingUnregisters) unregister();
+  pendingUnregisters = [];
+  document.documentElement.classList.remove(PANEL_RESIZING_CLASS);
+});
+
+describe("panel-resizing-class participant registry", () => {
+  it("invokes every registered participant's capture BEFORE the class is added", () => {
+    const classPresentDuringCapture: boolean[] = [];
+    trackedRegister({
+      capture: () => {
+        classPresentDuringCapture.push(
+          document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+        );
+      },
+      clear: () => undefined,
+    });
+
+    trackedBegin(1);
+
+    expect(classPresentDuringCapture).toEqual([false]);
+    expect(
+      document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+    ).toBe(true);
+  });
+
+  it("removes the class BEFORE invoking clear on stop", () => {
+    const classPresentDuringClear: boolean[] = [];
+    trackedRegister({
+      capture: () => undefined,
+      clear: () => {
+        classPresentDuringClear.push(
+          document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+        );
+      },
+    });
+
+    const stop = trackedBegin(1);
+    stop();
+
+    expect(classPresentDuringClear).toEqual([false]);
+  });
+
+  it("calls capture exactly once per begin and clear exactly once per stop - no per-move re-invocation", () => {
+    const spy = participantSpy();
+    trackedRegister(spy);
+
+    const stop = trackedBegin(1);
+    expect(spy.capture).toHaveBeenCalledTimes(1);
+    expect(spy.clear).not.toHaveBeenCalled();
+
+    // The mechanism has no per-pointermove hook at all - there is nothing
+    // here that COULD re-invoke capture no matter how long/eventful the drag
+    // is. This asserts the call count stays flat across the drag's own
+    // begin->stop lifecycle, matching the "no per-scroll subscription"
+    // constraint.
+    stop();
+    expect(spy.capture).toHaveBeenCalledTimes(1);
+    expect(spy.clear).toHaveBeenCalledTimes(1);
+
+    // Calling the same stop() again is a no-op (already-stopped guard) -
+    // clear must not fire twice.
+    stop();
+    expect(spy.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates one participant's thrown capture/clear from the others and from the class lifecycle", () => {
+    const good = participantSpy();
+    trackedRegister(good);
+    trackedRegister({
+      capture: () => {
+        throw new Error("capture boom");
+      },
+      clear: () => {
+        throw new Error("clear boom");
+      },
+    });
+
+    const stop = trackedBegin(1);
+    expect(
+      document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+    ).toBe(true);
+    expect(good.capture).toHaveBeenCalledTimes(1);
+
+    stop();
+    expect(
+      document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+    ).toBe(false);
+    expect(good.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops calling a participant once it has unregistered", () => {
+    const spy = participantSpy();
+    const unregister = trackedRegister(spy);
+    unregister();
+
+    const stop = trackedBegin(1);
+    stop();
+
+    expect(spy.capture).not.toHaveBeenCalled();
+    expect(spy.clear).not.toHaveBeenCalled();
+  });
+
+  it("captures/clears every registered participant, not just one", () => {
+    const spyA = participantSpy();
+    const spyB = participantSpy();
+    trackedRegister(spyA);
+    trackedRegister(spyB);
+
+    const stop = trackedBegin(1);
+    stop();
+
+    expect(spyA.capture).toHaveBeenCalledTimes(1);
+    expect(spyB.capture).toHaveBeenCalledTimes(1);
+    expect(spyA.clear).toHaveBeenCalledTimes(1);
+    expect(spyB.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("a new interaction beginning mid-drag (finishing the prior one) still captures every live participant exactly once", () => {
+    const spy = participantSpy();
+    trackedRegister(spy);
+
+    trackedBegin(1);
+    expect(spy.capture).toHaveBeenCalledTimes(1);
+
+    // A second begin() without calling the first drag's stop() first -
+    // `beginPanelResizeInteraction` finishes the prior interaction itself.
+    const secondStop = trackedBegin(2);
+    expect(spy.clear).toHaveBeenCalledTimes(1); // prior interaction's clear
+    expect(spy.capture).toHaveBeenCalledTimes(2); // new interaction's capture
+
+    secondStop();
+    expect(spy.clear).toHaveBeenCalledTimes(2);
+  });
+
+  describe("termination routes (pointerup/pointercancel/blur)", () => {
+    it("stops on a matching pointerup dispatched through the real window listener path", () => {
+      const spy = participantSpy();
+      trackedRegister(spy);
+      trackedBegin(7);
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(true);
+
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 7 }));
+
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(false);
+      expect(spy.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops on a matching pointercancel dispatched through the real window listener path", () => {
+      const spy = participantSpy();
+      trackedRegister(spy);
+      trackedBegin(3);
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(true);
+
+      window.dispatchEvent(
+        new PointerEvent("pointercancel", { pointerId: 3 }),
+      );
+
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(false);
+      expect(spy.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops on blur regardless of pointerId", () => {
+      const spy = participantSpy();
+      trackedRegister(spy);
+      trackedBegin(9);
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(true);
+
+      window.dispatchEvent(new Event("blur"));
+
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(false);
+      expect(spy.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a pointerup from a different pointerId (foreign-pointer negative)", () => {
+      const spy = participantSpy();
+      trackedRegister(spy);
+      trackedBegin(5);
+
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 999 }));
+
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(true);
+      expect(spy.clear).not.toHaveBeenCalled();
+
+      // Prove the interaction is still genuinely live (not just "afterEach
+      // will clean it up regardless") by stopping it with the MATCHING
+      // pointerId and observing the real transition.
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 5 }));
+      expect(
+        document.documentElement.classList.contains(PANEL_RESIZING_CLASS),
+      ).toBe(false);
+      expect(spy.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves a pre-registered hook-style window pointerup listener BEFORE this module's own stop", () => {
+      const order: Array<string> = [];
+      const hookListener = (): void => {
+        order.push("hook");
+      };
+      // Registered BEFORE beginPanelResizeInteraction - models
+      // use-pointer-drag-commit.ts's own window-level pointerup listener
+      // (registered at pointerdown time, ahead of this module's, per the
+      // row-1 drag fix under parallel review). DOM listeners for the same
+      // target/event type fire in registration order, so the hook's own
+      // commit/cancel resolves before this module's `stop()` - which is
+      // exactly what makes `stop()`'s idempotent guard safe to rely on here
+      // rather than a source of double-invocation bugs.
+      window.addEventListener("pointerup", hookListener);
+
+      trackedRegister({
+        capture: () => undefined,
+        clear: () => {
+          order.push("registry-clear");
+        },
+      });
+      trackedBegin(11);
+
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 11 }));
+
+      expect(order).toEqual(["hook", "registry-clear"]);
+      window.removeEventListener("pointerup", hookListener);
+    });
+  });
+});

--- a/clients/gui-app/src/lib/layout/panel-resizing-class.ts
+++ b/clients/gui-app/src/lib/layout/panel-resizing-class.ts
@@ -1,21 +1,61 @@
 /**
  * Global "a panel resize drag is in progress" signal, expressed as the
- * `traycer-panel-resizing` class on `<html>`. Expensive surfaces opt into
- * freezing during a drag via `[.traycer-panel-resizing_&]:...` descendant
- * selectors so per-frame reflows stay cheap: overlay chrome (chat minimap,
- * scroll-to-bottom chip) hides via opacity, and transcript rows
- * (`ChatMessageRow`) flip to `content-visibility: hidden` so intermediate
- * drag widths never re-wrap and re-rasterize every visible pane. Shared by
- * every resize handle in the app - the canvas/sidebar-section
- * `SplitResizeHandle` and the hoisted sidebar's width handle - so consumers
- * never care which surface drove the drag.
+ * `traycer-panel-resizing` class on `<html>`. Before the class is added,
+ * registered transcript surfaces imperatively snapshot their currently
+ * visible rows. Descendant selectors keep those marked rows live, freeze only
+ * unmarked/off-screen rows, and suppress transient resize chrome without any
+ * per-scroll React subscription. Snapshot markers are cleared after the class
+ * is removed. The signal is shared by every resize handle, so consumers do
+ * not need to know which surface started the drag.
  */
+import { appLogger } from "@/lib/logger";
+
 const PANEL_RESIZING_CLASS_NAME = "traycer-panel-resizing";
 
 let stopPanelResizeInteraction: (() => void) | null = null;
 
 export function isPanelResizeInteractionActive(): boolean {
   return stopPanelResizeInteraction !== null;
+}
+
+interface PanelResizeParticipant {
+  /** Runs once, synchronously, right before the global class is added. */
+  readonly capture: () => void;
+  /** Runs once, synchronously, right after the global class is removed. */
+  readonly clear: () => void;
+}
+
+const panelResizeParticipants = new Set<PanelResizeParticipant>();
+
+/**
+ * Registers a surface (ticket 23's D20 port: one per mounted `ChatTimeline`)
+ * that imperatively snapshots/clears its own visible-row markers around a
+ * panel-resize drag. Returns an unregister function. A participant's own
+ * `capture`/`clear` failure is isolated (logged, not thrown) so one broken
+ * tile never blocks the drag's class lifecycle or another tile's own
+ * capture/clear.
+ */
+export function registerPanelResizeParticipant(
+  participant: PanelResizeParticipant,
+): () => void {
+  panelResizeParticipants.add(participant);
+  return () => {
+    panelResizeParticipants.delete(participant);
+  };
+}
+
+function runPanelResizeParticipants(step: "capture" | "clear"): void {
+  for (const participant of panelResizeParticipants) {
+    try {
+      participant[step]();
+    } catch (error) {
+      appLogger.errorSummary(
+        "[panel-resize] participant failed",
+        { step },
+        error,
+      );
+    }
+  }
 }
 
 export function beginPanelResizeInteraction(
@@ -27,6 +67,7 @@ export function beginPanelResizeInteraction(
   }
 
   stopPanelResizeInteraction?.();
+  runPanelResizeParticipants("capture");
   document.documentElement.classList.add(PANEL_RESIZING_CLASS_NAME);
 
   let stopped = false;
@@ -34,6 +75,7 @@ export function beginPanelResizeInteraction(
     if (stopped) return;
     stopped = true;
     document.documentElement.classList.remove(PANEL_RESIZING_CLASS_NAME);
+    runPanelResizeParticipants("clear");
     window.removeEventListener("pointerup", stopForEvent);
     window.removeEventListener("pointercancel", stopForEvent);
     window.removeEventListener("blur", stopForEvent);

--- a/clients/gui-app/src/lib/tab-navigation.ts
+++ b/clients/gui-app/src/lib/tab-navigation.ts
@@ -802,7 +802,16 @@ export class TabNavigationController {
     }
 
     const activationTarget = this.activationTarget(requestedIntent);
-    const activation = tabCommandCoordinator.activateTab(activationTarget);
+    // Same convention as `activateExternalTarget` below: `activateTab` can
+    // throw for a migrated-epic target whose identity resolution was raced
+    // out from under it (see `resolveMigratedEpicActivation` in
+    // tab-command-coordinator.ts) - treat that the same as a `null` result.
+    let activation: CoordinatedTabActivation | null;
+    try {
+      activation = tabCommandCoordinator.activateTab(activationTarget);
+    } catch {
+      return false;
+    }
     if (activation === null) return false;
     const intent = this.canonicalIntent(requestedIntent, activation.ref);
     if (intent === null) {

--- a/clients/gui-app/src/lib/tab-navigation/__tests__/t3-rev3-adversarial.test.ts
+++ b/clients/gui-app/src/lib/tab-navigation/__tests__/t3-rev3-adversarial.test.ts
@@ -25,6 +25,7 @@ import {
   describe,
   expect,
   it,
+  onTestFinished,
   vi,
   type Mock,
 } from "vitest";
@@ -1786,6 +1787,7 @@ describe("T3 rev-3 adversarial: coordinator ledger & structural restore", () => 
         resolveTabEpicIdentity(phase.tabId, "phase-race", "epic-racer");
       }
     });
+    onTestFinished(unsubscribeRace);
 
     const thrown = runAndCaptureError(() => {
       tabCommandCoordinator.activateTab({
@@ -1795,8 +1797,6 @@ describe("T3 rev-3 adversarial: coordinator ledger & structural restore", () => 
         tabId: phase.tabId,
       });
     });
-    unsubscribeRace();
-
     expect(thrown).toBeInstanceOf(Error);
     expect(useTabsStore.getState().items).toEqual(layoutBefore);
     expect(useEpicCanvasStore.getState().activeTabId).toBe(activeBefore);
@@ -1833,6 +1833,7 @@ describe("T3 rev-3 adversarial: coordinator ledger & structural restore", () => 
         resolveTabEpicIdentity(phase.tabId, "epic-canonical", "epic-racer");
       }
     });
+    onTestFinished(unsubscribeRace);
 
     const thrown = runAndCaptureError(() => {
       tabCommandCoordinator.activateTab({
@@ -1842,8 +1843,6 @@ describe("T3 rev-3 adversarial: coordinator ledger & structural restore", () => 
         tabId: phase.tabId,
       });
     });
-    unsubscribeRace();
-
     expect(thrown).toBeInstanceOf(Error);
     expect(useTabsStore.getState().items).toEqual(layoutBefore);
     expect(useEpicCanvasStore.getState().activeTabId).toBe(activeBefore);
@@ -2251,6 +2250,7 @@ describe("T3 rev-3 adversarial: Resource Monitor nested + Phase completion", () 
         resolveTabEpicIdentity(first.tabId, "epic-phase", "epic-racer");
       }
     });
+    onTestFinished(unsubscribeRace);
 
     let result: boolean | undefined;
     expect(() => {
@@ -2271,8 +2271,6 @@ describe("T3 rev-3 adversarial: Resource Monitor nested + Phase completion", () 
         { replace: true },
       );
     }).not.toThrow();
-    unsubscribeRace();
-
     expect(result).toBe(false);
     expect(nav.calls.length).toBe(0);
     expect(useEpicCanvasStore.getState().tabsById[first.tabId]?.epicId).toBe(

--- a/clients/gui-app/src/lib/tab-navigation/__tests__/t3-rev3-adversarial.test.ts
+++ b/clients/gui-app/src/lib/tab-navigation/__tests__/t3-rev3-adversarial.test.ts
@@ -49,7 +49,10 @@ import {
   __resetTabSyncCoordinatorForTesting,
   installTabSyncCoordinator,
 } from "@/lib/tab-sync/tab-sync-coordinator";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import {
+  resolveTabEpicIdentity,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import {
   flattenLayoutRefs,
@@ -1753,6 +1756,103 @@ describe("T3 rev-3 adversarial: coordinator ledger & structural restore", () => 
     expectLedgerReleased();
   });
 
+  it("migrated-epic activation throws (no focus, no placement) when a listener races the resolution to a different epic first", () => {
+    const phase = openEpic("phase-race", "Phase");
+    useEpicCanvasStore.getState().closeTab(phase.tabId);
+    seedCommittedLayout({
+      version: 2,
+      items: [],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+    });
+    const layoutBefore = useTabsStore.getState().items;
+    const activeBefore = useEpicCanvasStore.getState().activeTabId;
+    // `execute`'s listeners fire before `applySources` (see execute() in
+    // tab-command-coordinator.ts), so this racer wins BEFORE this
+    // activation's own resolution call ever runs - its own resolution then
+    // finds a stale `expectedCurrentEpicId` and rejects at that precondition.
+    // This is the pre-commit window (closed since round 1/2), not the
+    // round-3 window - see the pin below this one for a listener that races
+    // the commit itself via a raw `useEpicCanvasStore.subscribe`. Both are
+    // real, both must hold: this one still exercises "must not silently
+    // succeed" end to end. Unlike the ledger-snapshot-safety pins above
+    // (which drive a call that eventually places its source), this one
+    // deliberately throws and never places anything -
+    // `expectLedgerReleased()` below is the applicable contract here,
+    // matching "fresh source failure preserves T2 error precedence".
+    const unsubscribeRace = tabCommandCoordinator.subscribe(() => {
+      const current = useEpicCanvasStore.getState().tabsById[phase.tabId];
+      if (current?.epicId === "phase-race") {
+        resolveTabEpicIdentity(phase.tabId, "phase-race", "epic-racer");
+      }
+    });
+
+    const thrown = runAndCaptureError(() => {
+      tabCommandCoordinator.activateTab({
+        kind: "migrated-epic",
+        sourceEpicId: "phase-race",
+        epicId: "epic-canonical",
+        tabId: phase.tabId,
+      });
+    });
+    unsubscribeRace();
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(useTabsStore.getState().items).toEqual(layoutBefore);
+    expect(useEpicCanvasStore.getState().activeTabId).toBe(activeBefore);
+    expect(useEpicCanvasStore.getState().tabsById[phase.tabId]?.epicId).toBe(
+      "epic-racer",
+    );
+    expectLedgerReleased();
+  });
+
+  it("migrated-epic activation throws (no focus, no placement) when a raw store subscriber supersedes the resolution DURING its own commit", () => {
+    // The round-3 window: `rawPublicSetState` inside `resolveTabEpicIdentity`
+    // notifies zustand subscribers SYNCHRONOUSLY, mid-commit - a listener
+    // observing the just-landed epicId can call the same authorized action
+    // AGAIN before the outer `resolveTabEpicIdentity` call ever returns to
+    // its caller. The precondition passes (the outer write already landed),
+    // so a claim recorded at write time would be wrong; the fix reads
+    // `getState()` back AFTER the write instead. The listener is
+    // self-limiting: it only fires while the tab's epicId still equals the
+    // outer target, which stops being true once the racer's own write lands
+    // (including on the racer's own re-entrant notification), so this
+    // terminates without a manual guard.
+    const phase = openEpic("phase-race-commit", "Phase");
+    useEpicCanvasStore.getState().closeTab(phase.tabId);
+    seedCommittedLayout({
+      version: 2,
+      items: [],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+    });
+    const layoutBefore = useTabsStore.getState().items;
+    const activeBefore = useEpicCanvasStore.getState().activeTabId;
+    const unsubscribeRace = useEpicCanvasStore.subscribe((state) => {
+      if (state.tabsById[phase.tabId]?.epicId === "epic-canonical") {
+        resolveTabEpicIdentity(phase.tabId, "epic-canonical", "epic-racer");
+      }
+    });
+
+    const thrown = runAndCaptureError(() => {
+      tabCommandCoordinator.activateTab({
+        kind: "migrated-epic",
+        sourceEpicId: "phase-race-commit",
+        epicId: "epic-canonical",
+        tabId: phase.tabId,
+      });
+    });
+    unsubscribeRace();
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(useTabsStore.getState().items).toEqual(layoutBefore);
+    expect(useEpicCanvasStore.getState().activeTabId).toBe(activeBefore);
+    expect(useEpicCanvasStore.getState().tabsById[phase.tabId]?.epicId).toBe(
+      "epic-racer",
+    );
+    expectLedgerReleased();
+  });
+
   it("fresh source failure preserves T2 error precedence and releases the ledger", () => {
     seedCommittedLayout({
       version: 2,
@@ -2124,6 +2224,61 @@ describe("T3 rev-3 adversarial: Resource Monitor nested + Phase completion", () 
       tabId: first.tabId,
     });
     expect(nav.lastOptions().replace).toBe(true);
+  });
+
+  it("Phase completion activation returns false (no navigate, no focus change) when a listener races the resolution first", () => {
+    const first = openEpic("epic-phase", "Phase Epic");
+    const second = openEpic("epic-phase", "Phase Epic other tab");
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        { kind: "tab", id: tabItemId(first.ref), ref: first.ref },
+        { kind: "tab", id: tabItemId(second.ref), ref: second.ref },
+      ],
+      activeItemId: tabItemId(first.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const focusedBefore = focusedRefKey();
+    const nav = makeDeferredNavigate();
+    // Same interleaving as the coordinator-level pin above, driven this time
+    // through the public `activateTabIntent` entry point that a real Phase
+    // completion trigger goes through - `executeActivation`
+    // (tab-navigation.ts) must convert the coordinator's throw into a clean
+    // `false`, not an uncaught exception.
+    const unsubscribeRace = tabCommandCoordinator.subscribe(() => {
+      const current = useEpicCanvasStore.getState().tabsById[first.tabId];
+      if (current?.epicId === "epic-phase") {
+        resolveTabEpicIdentity(first.tabId, "epic-phase", "epic-racer");
+      }
+    });
+
+    let result: boolean | undefined;
+    expect(() => {
+      result = activateTabIntent(
+        nav.asNavigate,
+        completeEpicMigrationIntent({
+          sourceEpicId: "epic-phase",
+          epicId: "epic-migrated",
+          tabId: first.tabId,
+          focus: {
+            focusedAt: 123,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            migrationSource: undefined,
+          },
+          nestedFocus: null,
+        }),
+        { replace: true },
+      );
+    }).not.toThrow();
+    unsubscribeRace();
+
+    expect(result).toBe(false);
+    expect(nav.calls.length).toBe(0);
+    expect(useEpicCanvasStore.getState().tabsById[first.tabId]?.epicId).toBe(
+      "epic-racer",
+    );
+    expect(focusedRefKey()).toBe(focusedBefore);
   });
 });
 

--- a/clients/gui-app/src/stores/chats/chat-tab-state-cache.ts
+++ b/clients/gui-app/src/stores/chats/chat-tab-state-cache.ts
@@ -132,7 +132,7 @@ export function restoreChatTabState(
   };
 }
 
-interface SaveChatTabStateInput {
+export interface SaveChatTabStateInput {
   readonly identity: ChatTabPersistenceIdentity;
   readonly mode: ChatTabScrollMode;
   readonly anchorMessageId: string | null;

--- a/clients/gui-app/src/stores/chats/chat-tab-viewport-handoff.ts
+++ b/clients/gui-app/src/stores/chats/chat-tab-viewport-handoff.ts
@@ -1,0 +1,60 @@
+/**
+ * Ticket 20 (painted-chat lifecycle audit, finding 1): cross-pane drag, edge
+ * split/wrap, dissolve promotion, and header tear-off retain a chat tile's
+ * `instanceId` but delete+create its keyed layer in ONE store update. React
+ * renders the replacement fiber - including its render-time
+ * `restoreChatTabState` state initializer - BEFORE the removed fiber's
+ * `useLayoutEffect` unmount cleanup ever runs (render happens before ANY
+ * commit-phase effect), so the replacement necessarily reads whatever was
+ * ALREADY in the tab-key scroll cache instead of the position the reader
+ * actually left the transcript at.
+ *
+ * This module-scope registry lets the canvas store's structural-mutation
+ * action creators flush a chat tile's CURRENT live viewport into the cache
+ * SYNCHRONOUSLY, before the `set()` that moves it - same registry-read shape
+ * as the ticket-15 close-sweep promotion (`promoteChatTabPersistenceToDurable`
+ * in `chat-tab-persistence-eviction.ts`), reused rather than reinvented. A
+ * mounted `ChatMessages` registers its capture callback for the lifetime of
+ * the mount (`chat-messages.tsx`); the callback runs the SAME coherent-
+ * snapshot logic the component's own unmount cleanup uses, so both paths can
+ * never drift out of sync with each other.
+ */
+type ChatTabViewportCapture = () => void;
+
+const liveViewportCaptures = new Map<string, ChatTabViewportCapture>();
+
+/**
+ * Registers `capture` for `instanceId` while a `ChatMessages` tile is
+ * mounted; returns the unregister function for the component's own unmount
+ * cleanup. There is never more than one live mount per `instanceId`.
+ */
+export function registerChatTabViewportCapture(
+  instanceId: string,
+  capture: ChatTabViewportCapture,
+): () => void {
+  liveViewportCaptures.set(instanceId, capture);
+  return () => {
+    if (liveViewportCaptures.get(instanceId) === capture) {
+      liveViewportCaptures.delete(instanceId);
+    }
+  };
+}
+
+/**
+ * Calls the registered capture callback for each of `instanceIds`, if (and
+ * only if) that tile is currently mounted - a no-op for any id with no live
+ * registration (not a chat tile, or already unmounted). Defensive by design:
+ * a caller unsure whether a specific structural mutation will actually move
+ * a given tile (e.g. an edge split's target pane, which only wraps - and
+ * therefore only remounts - under some parent-direction shapes) can flush it
+ * unconditionally: capturing a tile's current position when it turns out NOT
+ * to move is harmless, since the tile stays mounted and its own later
+ * save/unmount simply overwrites the entry again.
+ */
+export function flushChatTabViewportHandoff(
+  instanceIds: ReadonlyArray<string>,
+): void {
+  for (const instanceId of instanceIds) {
+    liveViewportCaptures.get(instanceId)?.();
+  }
+}

--- a/clients/gui-app/src/stores/chats/chat-tab-viewport-handoff.ts
+++ b/clients/gui-app/src/stores/chats/chat-tab-viewport-handoff.ts
@@ -19,6 +19,8 @@
  * snapshot logic the component's own unmount cleanup uses, so both paths can
  * never drift out of sync with each other.
  */
+import { appLogger } from "@/lib/logger";
+
 type ChatTabViewportCapture = () => void;
 
 const liveViewportCaptures = new Map<string, ChatTabViewportCapture>();
@@ -55,6 +57,14 @@ export function flushChatTabViewportHandoff(
   instanceIds: ReadonlyArray<string>,
 ): void {
   for (const instanceId of instanceIds) {
-    liveViewportCaptures.get(instanceId)?.();
+    try {
+      liveViewportCaptures.get(instanceId)?.();
+    } catch (error) {
+      appLogger.error(
+        "chat tab viewport capture failed during structural handoff",
+        { instanceId },
+        error,
+      );
+    }
   }
 }

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store-tile-identity-invariant.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store-tile-identity-invariant.test.ts
@@ -1,0 +1,1321 @@
+/**
+ * Store-integration pins for the canvas-store-wide immutable tile identity
+ * invariant (Ticket 21 slice 1). `tile-identity-invariant.test.ts` pins the
+ * pure detection/policy functions in isolation; this file drives the SAME
+ * invariant through the real store wiring: the wrapped internal `set()`
+ * (every action below `updateTabCanvas` AND the handful of actions - like
+ * `tearOffTabIntoNewHeaderTab` - that write `canvasByTabId` directly),
+ * `applyEpicCanvasDesktopProjection`, and the persist `merge` hydration path.
+ *
+ * `import.meta.env.DEV` is true under Vitest, so every real ingress below
+ * throws on a violation (the production fail-closed branch is pinned
+ * directly on `enforceTileIdentityInvariant` in the pure-module test - it is
+ * not reachable through this store without stubbing Vite's static env).
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { appLogger } from "@/lib/logger";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import {
+  applyEpicCanvasDesktopProjection,
+  resolveTabEpicIdentity,
+  setEpicCanvasDesktopProjectionBridge,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
+import { collectPanes, findPaneById } from "@/stores/epics/canvas/tile-tree";
+import { serializeEpicCanvasState } from "@/stores/epics/canvas/migrate-canvas";
+import { makeBlankTileRef } from "@/stores/epics/canvas/tile-schema/blank-tile";
+import { makeCommGraphTileRef } from "@/stores/epics/canvas/tile-schema/comm-graph-tile";
+import { epicCanvasKey } from "@/lib/persist";
+import type {
+  BlankTileRef,
+  CommGraphTileRef,
+  EpicCanvasState,
+  EpicCanvasTileRef,
+  EpicNodeRef,
+  EpicTerminalRef,
+  WorkspaceFileRef,
+} from "@/stores/epics/canvas/types";
+import type {
+  DesktopPerWindowSnapshot,
+  DesktopPerWindowStatePatch,
+} from "@/lib/windows/types";
+import type { DesktopPerWindowProjectionBridge } from "@/lib/windows/per-window-projection-debounce";
+import {
+  CHAT_A,
+  GIT_FILE_A,
+  GIT_FILE_B,
+  SNAPSHOT_BUNDLE_CHANGES,
+  SPEC_A,
+  SPEC_B,
+  SPEC_C,
+  TEST_HOST_ID,
+} from "./canvas-test-fixtures";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useEpicCanvasStore.persist.setOptions({ name: epicCanvasKey(null) });
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+});
+
+function requireCanvas(tabId: string): EpicCanvasState {
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+  if (canvas === undefined) throw new Error(`Expected canvas for ${tabId}`);
+  return canvas;
+}
+
+function requireActivePaneId(tabId: string): string {
+  const paneId = requireCanvas(tabId).activePaneId;
+  if (paneId === null) throw new Error(`Expected active pane for ${tabId}`);
+  return paneId;
+}
+
+/** Fixed-instanceId fixtures for every non-spec/chat kind the pure pins skipped. */
+const TERMINAL_A: EpicTerminalRef = {
+  id: "term-a",
+  instanceId: "inst-term-a",
+  type: "terminal",
+  name: "shell-a",
+  titleSource: "manual",
+  hostId: TEST_HOST_ID,
+  cwd: "/repo",
+};
+const TERMINAL_B: EpicTerminalRef = {
+  id: "term-b",
+  instanceId: "inst-term-b",
+  type: "terminal",
+  name: "shell-b",
+  titleSource: "manual",
+  hostId: TEST_HOST_ID,
+  cwd: "/other",
+};
+const WORKSPACE_FILE_A: WorkspaceFileRef = {
+  id: "workspace-file:test-host:/repo:src/a.ts",
+  instanceId: "inst-ws-a",
+  type: "workspace-file",
+  name: "a.ts",
+  hostId: TEST_HOST_ID,
+  workspacePath: "/repo",
+  filePath: "src/a.ts",
+};
+const WORKSPACE_FILE_B: WorkspaceFileRef = {
+  id: "workspace-file:test-host:/repo:src/b.ts",
+  instanceId: "inst-ws-b",
+  type: "workspace-file",
+  name: "b.ts",
+  hostId: TEST_HOST_ID,
+  workspacePath: "/repo",
+  filePath: "src/b.ts",
+};
+const BLANK_A: BlankTileRef = {
+  ...makeBlankTileRef(),
+  id: "blank-a",
+  instanceId: "inst-blank-a",
+  hostId: UNKNOWN_HOST_PLACEHOLDER,
+};
+const BLANK_B: BlankTileRef = {
+  ...makeBlankTileRef(),
+  id: "blank-b",
+  instanceId: "inst-blank-b",
+  hostId: UNKNOWN_HOST_PLACEHOLDER,
+};
+const COMM_GRAPH_A: CommGraphTileRef = {
+  ...makeCommGraphTileRef("epic-comm-a"),
+  instanceId: "inst-comm-a",
+};
+const COMM_GRAPH_B: CommGraphTileRef = {
+  ...makeCommGraphTileRef("epic-comm-b"),
+  instanceId: "inst-comm-b",
+};
+const GIT_DIFF_A = { ...GIT_FILE_A, instanceId: "inst-git-a" };
+const GIT_DIFF_B = { ...GIT_FILE_B, instanceId: "inst-git-b" };
+const SNAPSHOT_A = {
+  ...SNAPSHOT_BUNDLE_CHANGES,
+  instanceId: "inst-snap-a",
+};
+const SNAPSHOT_B: typeof SNAPSHOT_BUNDLE_CHANGES = {
+  ...SNAPSHOT_BUNDLE_CHANGES,
+  id: `${SNAPSHOT_BUNDLE_CHANGES.id}:alt`,
+  instanceId: "inst-snap-b",
+  diff: {
+    ...SNAPSHOT_BUNDLE_CHANGES.diff,
+    chatId: "chat-2",
+  },
+};
+
+/**
+ * Open `seed` in epic-1, then try to open a same-instanceId repoint of
+ * `collidingContent` into a second epic. Every free-form open path must throw.
+ */
+function expectOpenTileInTabRejectsRepoint(
+  seed: EpicCanvasTileRef,
+  collidingContent: EpicCanvasTileRef,
+): void {
+  const store = useEpicCanvasStore.getState();
+  const tabId = store.openEpicTab("epic-seed", "Seed");
+  store.openTileInTab(tabId, seed);
+  const otherTabId = store.openEpicTab("epic-other", "Other");
+  const colliding: EpicCanvasTileRef = {
+    ...collidingContent,
+    instanceId: seed.instanceId,
+  };
+  expect(() =>
+    useEpicCanvasStore.getState().openTileInTab(otherTabId, colliding),
+  ).toThrow(/identity invariant violated/i);
+  expect(requireCanvas(tabId).tilesByInstanceId[seed.instanceId]).toEqual(seed);
+  expect(requireCanvas(otherTabId).root).toBeNull();
+}
+
+describe("canvas tile identity invariant: internal mutation ingress", () => {
+  it("throws when an internal mutation repoints an existing instanceId's content id", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-2", "Epic Bar");
+
+    // Adversarial input: a caller-constructed node that reuses SPEC_A's
+    // instanceId for a DIFFERENT content id. Nothing in the public action
+    // API mints instanceIds itself - callers always supply them - so this is
+    // exactly the shape a future bug (not today's code) could produce.
+    const colliding: EpicNodeRef = { ...SPEC_B, instanceId: SPEC_A.instanceId };
+
+    expect(() =>
+      useEpicCanvasStore.getState().openTileInTab(otherTabId, colliding),
+    ).toThrow(/identity invariant violated/i);
+
+    // Rejected: tab B's canvas never received the colliding tile.
+    expect(requireCanvas(otherTabId).root).toBeNull();
+    // Tab A's original tile is untouched.
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+  });
+
+  it("throws when an internal mutation repoints an existing instanceId's tile kind", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-2", "Epic Bar");
+    const colliding: EpicNodeRef = {
+      ...CHAT_A,
+      instanceId: SPEC_A.instanceId,
+    };
+
+    expect(() =>
+      useEpicCanvasStore.getState().openTileInTab(otherTabId, colliding),
+    ).toThrow(/identity invariant violated/i);
+  });
+
+  it.each([
+    {
+      label: "git-diff",
+      seed: GIT_DIFF_A,
+      collidingContent: GIT_DIFF_B,
+    },
+    {
+      label: "snapshot-diff",
+      seed: SNAPSHOT_A,
+      collidingContent: SNAPSHOT_B,
+    },
+    {
+      label: "comm-graph",
+      seed: COMM_GRAPH_A,
+      collidingContent: COMM_GRAPH_B,
+    },
+    {
+      label: "blank",
+      seed: BLANK_A,
+      collidingContent: BLANK_B,
+    },
+    {
+      label: "workspace-file",
+      seed: WORKSPACE_FILE_A,
+      collidingContent: WORKSPACE_FILE_B,
+    },
+    {
+      label: "terminal",
+      seed: TERMINAL_A,
+      collidingContent: TERMINAL_B,
+    },
+  ] as const)(
+    "throws on a $label repoint (same instanceId, different content tuple)",
+    ({ seed, collidingContent }) => {
+      expectOpenTileInTabRejectsRepoint(seed, collidingContent);
+    },
+  );
+
+  it("throws when restoreClosedTilePreview reopens a tampered closed-payload tuple", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+    const paneId = requireActivePaneId(tabId);
+    store.closeCanvasTab(tabId, paneId, SPEC_A.instanceId);
+
+    const closed =
+      useEpicCanvasStore.getState().closedTilePayloadsByTabId[tabId]?.[
+        SPEC_A.instanceId
+      ];
+    expect(closed?.node).toEqual(SPEC_A);
+
+    // Adversarial: closed-payload map keeps the original instanceId key, but
+    // the node tuple is rewritten to a different content id before restore.
+    const tampered: EpicNodeRef = {
+      ...SPEC_C,
+      instanceId: SPEC_A.instanceId,
+    };
+    useEpicCanvasStore.setState((state) => ({
+      closedTilePayloadsByTabId: {
+        ...state.closedTilePayloadsByTabId,
+        [tabId]: {
+          ...(state.closedTilePayloadsByTabId[tabId] ?? {}),
+          [SPEC_A.instanceId]: {
+            node: tampered,
+            pendingCreate: false,
+          },
+        },
+      },
+    }));
+
+    // SPEC_A is no longer live, but SPEC_B is. Restoring the tampered
+    // payload is fine for a free instanceId - re-open SPEC_A first so the
+    // restore would repoint a live instanceId.
+    useEpicCanvasStore.getState().openTileInTab(tabId, SPEC_A);
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .restoreClosedTilePreview(tabId, paneId, tampered),
+    ).toThrow(/identity invariant violated/i);
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+  });
+
+  it("throws when restoreClosedTilePreview collides with a live instanceId in another epic tab", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-2", "Epic Bar");
+    store.openTileInTab(otherTabId, SPEC_B);
+    const otherPaneId = requireActivePaneId(otherTabId);
+
+    const colliding: EpicNodeRef = {
+      ...SPEC_C,
+      instanceId: SPEC_A.instanceId,
+    };
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .restoreClosedTilePreview(otherTabId, otherPaneId, colliding),
+    ).toThrow(/identity invariant violated/i);
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    expect(
+      requireCanvas(otherTabId).tilesByInstanceId[SPEC_A.instanceId],
+    ).toBeUndefined();
+  });
+
+  it("throws when insertNodeOnTabStrip inserts a colliding instanceId", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-2", "Epic Bar");
+    store.openTileInTab(otherTabId, SPEC_B);
+    const otherPaneId = requireActivePaneId(otherTabId);
+    const colliding: EpicNodeRef = {
+      ...SPEC_C,
+      instanceId: SPEC_A.instanceId,
+    };
+
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .insertNodeOnTabStrip(otherTabId, otherPaneId, 0, colliding),
+    ).toThrow(/identity invariant violated/i);
+    expect(
+      requireCanvas(otherTabId).tilesByInstanceId[SPEC_A.instanceId],
+    ).toBeUndefined();
+  });
+
+  it("throws when splitPaneWithNode splits with a colliding instanceId", () => {
+    // splitPaneWithTab only relocates an already-live instanceId (tuple
+    // retained); the free-form node path that CAN introduce a colliding
+    // instanceId is splitPaneWithNode.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-2", "Epic Bar");
+    store.openTileInTab(otherTabId, SPEC_B);
+    const otherPaneId = requireActivePaneId(otherTabId);
+    const colliding: EpicNodeRef = {
+      ...SPEC_C,
+      instanceId: SPEC_A.instanceId,
+    };
+
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .splitPaneWithNode(otherTabId, otherPaneId, "right", colliding),
+    ).toThrow(/identity invariant violated/i);
+    expect(
+      requireCanvas(otherTabId).tilesByInstanceId[SPEC_A.instanceId],
+    ).toBeUndefined();
+  });
+
+  it("openTileInPane remints instanceId so a colliding input is not committed", () => {
+    // openTileInPane deliberately mints a fresh instanceId (second view of
+    // the same content is allowed). The input instanceId is ignored, so a
+    // caller-supplied collision never reaches the identity check as a
+    // repoint - pin that the action succeeds and the live seed is untouched.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-2", "Epic Bar");
+    store.openTileInTab(otherTabId, SPEC_B);
+    const otherPaneId = requireActivePaneId(otherTabId);
+    const collidingInput: EpicNodeRef = {
+      ...SPEC_C,
+      instanceId: SPEC_A.instanceId,
+    };
+
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .openTileInPane(otherTabId, otherPaneId, collidingInput),
+    ).not.toThrow();
+
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    const otherTiles = requireCanvas(otherTabId).tilesByInstanceId;
+    expect(otherTiles[SPEC_A.instanceId]).toBeUndefined();
+    const opened = Object.values(otherTiles).find(
+      (tile) => tile !== undefined && tile.id === SPEC_C.id,
+    );
+    expect(opened?.instanceId).not.toBe(SPEC_A.instanceId);
+  });
+
+  it("moveTabOnTabStrip and splitPaneWithTab retain tuples (no free-form instanceId mint)", () => {
+    // These actions only relocate an already-live instanceId; they cannot
+    // introduce a colliding free-form node. Pin that the relocates never
+    // throw and the tuple is retained - the adversarial free-form path is
+    // covered by insertNodeOnTabStrip / splitPaneWithNode above.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+    const paneId = requireActivePaneId(tabId);
+
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .splitPaneWithTab(tabId, {
+          sourcePaneId: paneId,
+          tabId: SPEC_B.instanceId,
+          targetPaneId: paneId,
+          position: "right",
+        }),
+    ).not.toThrow();
+
+    const afterSplit = requireCanvas(tabId);
+    const panes = collectPanes(afterSplit.root);
+    expect(panes.length).toBeGreaterThan(1);
+    const targetPane = panes.find((p) => p.id !== paneId);
+    if (targetPane === undefined) throw new Error("expected split pane");
+
+    expect(() =>
+      useEpicCanvasStore.getState().moveTabOnTabStrip(tabId, {
+        sourcePaneId: paneId,
+        tabId: SPEC_A.instanceId,
+        targetPaneId: targetPane.id,
+        targetIndex: 0,
+      }),
+    ).not.toThrow();
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_B.instanceId]).toEqual(
+      SPEC_B,
+    );
+  });
+});
+
+describe("canvas tile identity invariant: public setState ingress is always strict (no epicId allowance)", () => {
+  // Every generic ingress (closure `set`, this public `setState` wrapper,
+  // desktop projection, persisted hydration) is unconditionally strict - it
+  // has no parameter that could ever let an epicId-only change through.
+  // `resolveTabEpicIdentity` (its own describe block below) is the ONLY
+  // function that changes a tab's epicId, and provenance is enforced by that
+  // function being the sole caller of the module-private raw setter, not by
+  // anything this generic path has to understand. These pins call
+  // `useEpicCanvasStore.setState` directly to prove the generic path rejects
+  // the shape regardless.
+  it("rejects a pure epicId-only public setState for a genuine phase-migration tab", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openPhaseMigrationTabWithId(
+      "tab-phase",
+      "phase-1",
+      "Migrating",
+    );
+    store.openTileInTab(tabId, SPEC_A);
+    const before = requireCanvas(tabId);
+
+    expect(() =>
+      useEpicCanvasStore.setState((state) => {
+        const current = state.tabsById[tabId];
+        if (current === undefined) return state;
+        return {
+          tabsById: {
+            ...state.tabsById,
+            [tabId]: { ...current, epicId: "epic-real" },
+          },
+        };
+      }),
+    ).toThrow(/identity invariant violated/i);
+
+    // Fail-closed: the tab's epicId and canvas are both untouched.
+    expect(useEpicCanvasStore.getState().tabsById[tabId]?.epicId).toBe(
+      "phase-1",
+    );
+    expect(requireCanvas(tabId)).toBe(before);
+  });
+
+  it("throws when a public setState bundles a phase tab's epicId change with a content-id repoint", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openPhaseMigrationTabWithId(
+      "tab-phase",
+      "phase-1",
+      "Migrating",
+    );
+    store.openTileInTab(tabId, SPEC_A);
+    const before = requireCanvas(tabId);
+
+    // NOT a pure epicId-only resolution: the same setState also repoints the
+    // tile's content id, so the tab-scoped allowance must not apply.
+    expect(() =>
+      useEpicCanvasStore.setState((state) => {
+        const current = state.tabsById[tabId];
+        const currentCanvas = state.canvasByTabId[tabId];
+        if (current === undefined || currentCanvas === undefined) return state;
+        return {
+          tabsById: {
+            ...state.tabsById,
+            [tabId]: { ...current, epicId: "epic-real" },
+          },
+          canvasByTabId: {
+            ...state.canvasByTabId,
+            [tabId]: {
+              ...currentCanvas,
+              tilesByInstanceId: {
+                ...currentCanvas.tilesByInstanceId,
+                [SPEC_A.instanceId]: { ...SPEC_B, instanceId: SPEC_A.instanceId },
+              },
+            },
+          },
+        };
+      }),
+    ).toThrow(/identity invariant violated/i);
+
+    expect(requireCanvas(tabId)).toBe(before);
+    expect(useEpicCanvasStore.getState().tabsById[tabId]?.epicId).toBe(
+      "phase-1",
+    );
+  });
+
+  it("throws when a public setState moves a phase tab's tile into a DIFFERENT existing tab's canvas", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openPhaseMigrationTabWithId(
+      "tab-phase",
+      "phase-1",
+      "Migrating",
+    );
+    store.openTileInTab(tabId, SPEC_A);
+    const otherTabId = store.openEpicTab("epic-other", "Other");
+    const beforePhase = requireCanvas(tabId);
+    const beforeOther = requireCanvas(otherTabId);
+
+    // A canvas-only repoint: tabsById is untouched, but the instance now
+    // lives under a DIFFERENT tab's canvas - not the sanctioned same-tab
+    // resolution, even though tileKind/contentId/hostId all match.
+    expect(() =>
+      useEpicCanvasStore.setState((state) => {
+        const targetCanvas = state.canvasByTabId[otherTabId];
+        if (targetCanvas === undefined) return state;
+        return {
+          canvasByTabId: {
+            ...state.canvasByTabId,
+            [otherTabId]: {
+              ...targetCanvas,
+              tilesByInstanceId: {
+                ...targetCanvas.tilesByInstanceId,
+                [SPEC_A.instanceId]: SPEC_A,
+              },
+            },
+          },
+        };
+      }),
+    ).toThrow(/identity invariant violated/i);
+
+    expect(requireCanvas(tabId)).toBe(beforePhase);
+    expect(requireCanvas(otherTabId)).toBe(beforeOther);
+  });
+});
+
+describe("canvas tile identity invariant: resolveTabEpicIdentity (the sole authorized epic-resolution path)", () => {
+  // Provenance, not shape, is what authorizes an epicId-only change now -
+  // this is the ONE function permitted to commit one, and it does so by
+  // being the sole caller of the module-private raw setter, not by any
+  // parameter. Both real callers publish success from a POST-commit
+  // `getState()` read-back rather than trusting a return value from this
+  // function (see their own doc comments in tab-command-coordinator.ts) -
+  // their reentrant-race coverage lives in t3-rev3-adversarial.test.ts and
+  // phase-migration-controller.test.ts. These pins exercise
+  // `resolveTabEpicIdentity` itself: the legitimate commit and its own
+  // preconditions, observed through resulting store state (this function
+  // returns void).
+  let errorSpy: Mock<typeof appLogger.error>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(appLogger, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves a phase tab's epicId, reindexes mostRecentTabIdByEpicId, and leaves canvas untouched", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openPhaseMigrationTabWithId(
+      "tab-phase",
+      "phase-1",
+      "Migrating",
+    );
+    store.openTileInTab(tabId, SPEC_A);
+    const before = requireCanvas(tabId);
+
+    expect(() =>
+      resolveTabEpicIdentity(tabId, "phase-1", "epic-real"),
+    ).not.toThrow();
+
+    expect(useEpicCanvasStore.getState().tabsById[tabId]?.epicId).toBe(
+      "epic-real",
+    );
+    expect(
+      useEpicCanvasStore.getState().mostRecentTabIdByEpicId["epic-real"],
+    ).toBe(tabId);
+    expect(
+      useEpicCanvasStore.getState().mostRecentTabIdByEpicId["phase-1"],
+    ).toBeUndefined();
+    expect(requireCanvas(tabId)).toBe(before);
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a silent no-op when the tab does not exist", () => {
+    expect(() =>
+      resolveTabEpicIdentity("tab-missing", "phase-1", "epic-real"),
+    ).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a silent no-op when resolvedEpicId already matches the tab's current epicId (idempotent retry)", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openPhaseMigrationTabWithId(
+      "tab-phase",
+      "phase-1",
+      "Migrating",
+    );
+    resolveTabEpicIdentity(tabId, "phase-1", "epic-real");
+    errorSpy.mockClear();
+    const before = useEpicCanvasStore.getState().tabsById[tabId];
+
+    expect(() =>
+      resolveTabEpicIdentity(tabId, "epic-real", "epic-real"),
+    ).not.toThrow();
+
+    expect(useEpicCanvasStore.getState().tabsById[tabId]).toBe(before);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects and logs when the caller's expectedCurrentEpicId does not match the tab's actual current epicId", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openPhaseMigrationTabWithId(
+      "tab-phase",
+      "phase-1",
+      "Migrating",
+    );
+    const before = useEpicCanvasStore.getState().tabsById[tabId];
+
+    expect(() =>
+      resolveTabEpicIdentity(tabId, "phase-stale", "epic-real"),
+    ).not.toThrow();
+
+    expect(useEpicCanvasStore.getState().tabsById[tabId]).toBe(before);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [, fields] = errorSpy.mock.calls[0] ?? [];
+    expect(fields).toMatchObject({
+      tabId,
+      expectedCurrentEpicId: "phase-stale",
+      actualCurrentEpicId: "phase-1",
+      resolvedEpicId: "epic-real",
+    });
+  });
+});
+
+describe("canvas tile identity invariant: desktop-projection ingress", () => {
+  it("throws when an incoming desktop snapshot repoints an existing instanceId", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic One");
+    store.openTileInTab(tabId, SPEC_A);
+    const before = requireCanvas(tabId);
+
+    const repointed: EpicCanvasState = {
+      ...before,
+      tilesByInstanceId: {
+        ...before.tilesByInstanceId,
+        [SPEC_A.instanceId]: { ...SPEC_B, instanceId: SPEC_A.instanceId },
+      },
+    };
+    const snapshot: DesktopPerWindowSnapshot = {
+      epicTabs: [{ id: tabId, epicId: "epic-1", name: "Epic One" }],
+      activeTabId: tabId,
+      canvasByTabId: { [tabId]: serializeEpicCanvasState(repointed) },
+      landingDrafts: [],
+      activeLandingDraftId: null,
+    };
+
+    expect(() => applyEpicCanvasDesktopProjection(snapshot)).toThrow(
+      /identity invariant violated/i,
+    );
+    // Fail-closed: the store's committed canvas is untouched by the rejected
+    // projection (the updater threw before zustand ever assigned state).
+    expect(requireCanvas(tabId)).toBe(before);
+  });
+
+  it("accepts a desktop snapshot for a genuinely NEW instanceId in a different tab", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic One");
+    store.openTileInTab(tabId, SPEC_A);
+
+    const snapshot: DesktopPerWindowSnapshot = {
+      epicTabs: [
+        { id: tabId, epicId: "epic-1", name: "Epic One" },
+        { id: "tab-remote", epicId: "epic-remote", name: "Remote" },
+      ],
+      activeTabId: tabId,
+      canvasByTabId: {
+        [tabId]: serializeEpicCanvasState(requireCanvas(tabId)),
+      },
+      landingDrafts: [],
+      activeLandingDraftId: null,
+    };
+
+    expect(() => applyEpicCanvasDesktopProjection(snapshot)).not.toThrow();
+    expect(useEpicCanvasStore.getState().tabsById["tab-remote"]).toBeDefined();
+  });
+
+  it("throws when a projected OPEN tab collides with a HIDDEN (preserved) tab's live instanceId", () => {
+    // closeTab hides a tab without discarding its canvas. Projection only
+    // ships open tabs; preserved hidden canvases stay in memory. A projected
+    // open tab that reuses a hidden tab's instanceId under a different tuple
+    // must still trip the invariant (visible tabs alone look fine).
+    const store = useEpicCanvasStore.getState();
+    const visibleTabId = store.openEpicTab("epic-visible", "Visible");
+    store.openTileInTab(visibleTabId, SPEC_B);
+    const hiddenTabId = store.openEpicTab("epic-hidden", "Hidden");
+    store.openTileInTab(hiddenTabId, SPEC_A);
+    store.closeTab(hiddenTabId);
+
+    expect(useEpicCanvasStore.getState().openTabOrder).not.toContain(
+      hiddenTabId,
+    );
+    expect(useEpicCanvasStore.getState().tabsById[hiddenTabId]).toBeDefined();
+    expect(
+      requireCanvas(hiddenTabId).tilesByInstanceId[SPEC_A.instanceId],
+    ).toEqual(SPEC_A);
+
+    const beforeHidden = requireCanvas(hiddenTabId);
+    const beforeVisible = requireCanvas(visibleTabId);
+    const collidingCanvas: EpicCanvasState = {
+      root: {
+        kind: "pane",
+        id: "pane-projected",
+        tabInstanceIds: [SPEC_A.instanceId],
+        activeTabId: SPEC_A.instanceId,
+        previewTabId: null,
+        activationHistory: [SPEC_A.instanceId],
+      },
+      activePaneId: "pane-projected",
+      tilesByInstanceId: {
+        [SPEC_A.instanceId]: { ...SPEC_C, instanceId: SPEC_A.instanceId },
+      },
+      sizesByGroupId: {},
+    };
+    const snapshot: DesktopPerWindowSnapshot = {
+      epicTabs: [
+        { id: visibleTabId, epicId: "epic-visible", name: "Visible" },
+        { id: "tab-projected", epicId: "epic-projected", name: "Projected" },
+      ],
+      activeTabId: visibleTabId,
+      canvasByTabId: {
+        [visibleTabId]: serializeEpicCanvasState(beforeVisible),
+        "tab-projected": serializeEpicCanvasState(collidingCanvas),
+      },
+      landingDrafts: [],
+      activeLandingDraftId: null,
+    };
+
+    expect(() => applyEpicCanvasDesktopProjection(snapshot)).toThrow(
+      /identity invariant violated/i,
+    );
+    // Fail-closed: hidden tab canvas and visible tab canvas stay put; the
+    // colliding projected tab never lands.
+    expect(requireCanvas(hiddenTabId)).toBe(beforeHidden);
+    expect(requireCanvas(visibleTabId)).toBe(beforeVisible);
+    expect(
+      useEpicCanvasStore.getState().tabsById["tab-projected"],
+    ).toBeUndefined();
+  });
+
+  it("throws when a projection reopens a HIDDEN tab with a repointed canvas (visible tabs stay clean)", () => {
+    // closeTab preserves the tab + canvas. A desktop snapshot can re-list
+    // that tab id among epicTabs with a different payload under the same
+    // instanceId - visible-only data looks fine, but the reopened hidden
+    // tab is the sole source of the violation.
+    const store = useEpicCanvasStore.getState();
+    const visibleTabId = store.openEpicTab("epic-visible", "Visible");
+    store.openTileInTab(visibleTabId, SPEC_B);
+    const hiddenTabId = store.openEpicTab("epic-hidden", "Hidden");
+    store.openTileInTab(hiddenTabId, SPEC_A);
+    store.closeTab(hiddenTabId);
+
+    const beforeHidden = requireCanvas(hiddenTabId);
+    const beforeVisible = requireCanvas(visibleTabId);
+    const repointedHidden: EpicCanvasState = {
+      ...beforeHidden,
+      tilesByInstanceId: {
+        ...beforeHidden.tilesByInstanceId,
+        [SPEC_A.instanceId]: { ...SPEC_C, instanceId: SPEC_A.instanceId },
+      },
+    };
+    const snapshot: DesktopPerWindowSnapshot = {
+      epicTabs: [
+        { id: visibleTabId, epicId: "epic-visible", name: "Visible" },
+        { id: hiddenTabId, epicId: "epic-hidden", name: "Hidden" },
+      ],
+      activeTabId: visibleTabId,
+      canvasByTabId: {
+        [visibleTabId]: serializeEpicCanvasState(beforeVisible),
+        [hiddenTabId]: serializeEpicCanvasState(repointedHidden),
+      },
+      landingDrafts: [],
+      activeLandingDraftId: null,
+    };
+
+    expect(() => applyEpicCanvasDesktopProjection(snapshot)).toThrow(
+      /identity invariant violated/i,
+    );
+    expect(requireCanvas(hiddenTabId)).toBe(beforeHidden);
+    expect(requireCanvas(visibleTabId)).toBe(beforeVisible);
+    expect(requireCanvas(hiddenTabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+  });
+
+  it("releases applyingDesktopProjection after a rejected inbound projection, so the next local mutation still reaches the bridge", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic One");
+    store.openTileInTab(tabId, SPEC_A);
+
+    const updates: Array<DesktopPerWindowStatePatch> = [];
+    const bridge: DesktopPerWindowProjectionBridge = {
+      update: (patch) => {
+        updates.push(patch);
+        return Promise.resolve();
+      },
+      flush: () => Promise.resolve(),
+      dispose: () => {},
+    };
+    setEpicCanvasDesktopProjectionBridge(bridge);
+
+    const before = requireCanvas(tabId);
+    const repointed: EpicCanvasState = {
+      ...before,
+      tilesByInstanceId: {
+        ...before.tilesByInstanceId,
+        [SPEC_A.instanceId]: { ...SPEC_B, instanceId: SPEC_A.instanceId },
+      },
+    };
+    const snapshot: DesktopPerWindowSnapshot = {
+      epicTabs: [{ id: tabId, epicId: "epic-1", name: "Epic One" }],
+      activeTabId: tabId,
+      canvasByTabId: { [tabId]: serializeEpicCanvasState(repointed) },
+      landingDrafts: [],
+      activeLandingDraftId: null,
+    };
+
+    expect(() => applyEpicCanvasDesktopProjection(snapshot)).toThrow(
+      /identity invariant violated/i,
+    );
+    expect(updates).toHaveLength(0);
+
+    // If `applyingDesktopProjection` stuck `true` after the throw above,
+    // this valid local mutation would be silently suppressed too.
+    useEpicCanvasStore.getState().openTileInTab(tabId, SPEC_C);
+    expect(updates).toHaveLength(1);
+
+    setEpicCanvasDesktopProjectionBridge(null);
+  });
+
+  it("throws when a desktop projection changes only a tab's epicId while its canvas stays identical (round-2 adversarial probe)", () => {
+    // Round 1's shape-based allowance let exactly this through: same tab id,
+    // identical canvas/instanceIds, only the projected epicId differs - a
+    // stale or malformed desktop projection producing the same shape as a
+    // legitimate coordinator resolution. Desktop projection has no route to
+    // `resolveTabEpicIdentity`, so this must stay a violation.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-old", "Epic Old");
+    store.openTileInTab(tabId, SPEC_A);
+    const before = requireCanvas(tabId);
+
+    const snapshot: DesktopPerWindowSnapshot = {
+      epicTabs: [{ id: tabId, epicId: "epic-new", name: "Epic Old" }],
+      activeTabId: tabId,
+      canvasByTabId: { [tabId]: serializeEpicCanvasState(before) },
+      landingDrafts: [],
+      activeLandingDraftId: null,
+    };
+
+    expect(() => applyEpicCanvasDesktopProjection(snapshot)).toThrow(
+      /identity invariant violated/i,
+    );
+    // Fail-closed: the tab's epicId and canvas are both untouched.
+    expect(useEpicCanvasStore.getState().tabsById[tabId]?.epicId).toBe(
+      "epic-old",
+    );
+    expect(requireCanvas(tabId)).toBe(before);
+  });
+});
+
+describe("canvas tile identity invariant: persisted-migration ingress", () => {
+  let errorSpy: Mock<typeof appLogger.error>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(appLogger, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed when hydrated localStorage state repoints an instanceId already live in memory", async () => {
+    // zustand's `persist` middleware swallows a `merge` throw internally
+    // (`hydrate()` ends in a `.catch` with no configured `onRehydrateStorage`
+    // rethrow) - `rehydrate()` itself resolves either way. The diagnostic
+    // and the untouched in-memory state are what this pin actually verifies.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic One");
+    store.openTileInTab(tabId, SPEC_A);
+
+    window.localStorage.setItem(
+      epicCanvasKey(null),
+      JSON.stringify({
+        state: {
+          tabsById: {
+            "tab-persisted": {
+              tabId: "tab-persisted",
+              epicId: "epic-persisted",
+              name: "Persisted",
+            },
+          },
+          canvasByTabId: {
+            "tab-persisted": serializeEpicCanvasState({
+              root: {
+                kind: "pane",
+                id: "pane-persisted",
+                tabInstanceIds: [SPEC_A.instanceId],
+                activeTabId: SPEC_A.instanceId,
+                previewTabId: null,
+                activationHistory: [SPEC_A.instanceId],
+              },
+              activePaneId: "pane-persisted",
+              tilesByInstanceId: {
+                [SPEC_A.instanceId]: { ...SPEC_C, instanceId: SPEC_A.instanceId },
+              },
+              sizesByGroupId: {},
+            }),
+          },
+          openTabOrder: ["tab-persisted"],
+          activeTabId: "tab-persisted",
+          mostRecentTabIdByEpicId: { "epic-persisted": "tab-persisted" },
+          artifactTreeByEpicId: {},
+        },
+        version: 1,
+      }),
+    );
+
+    await useEpicCanvasStore.persist.rehydrate();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    // Fail-closed: the in-memory tile from before rehydration survives, and
+    // the colliding persisted tab was never merged in.
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    expect(useEpicCanvasStore.getState().tabsById["tab-persisted"]).toBeUndefined();
+  });
+
+  it("fails closed when a parse/migrate-shaped legacy blob repoints a live instanceId", async () => {
+    // Unlike the same-version pin above (which uses serializeEpicCanvasState),
+    // this blob is a hand-rolled legacy shape: no activationHistory, raw tile
+    // records (not schema-serialized), so sanitize → parseEpicCanvasState
+    // (migrate-canvas) must normalize it before the merge-level check runs.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic One");
+    store.openTileInTab(tabId, SPEC_A);
+
+    window.localStorage.setItem(
+      epicCanvasKey(null),
+      JSON.stringify({
+        state: {
+          tabsById: {
+            "tab-legacy-migrate": {
+              tabId: "tab-legacy-migrate",
+              epicId: "epic-legacy-migrate",
+              name: "Legacy Migrate",
+              // Legacy field ignored by sanitize (removed from EpicViewTab).
+              lastSeenAt: 1,
+            },
+          },
+          canvasByTabId: {
+            "tab-legacy-migrate": {
+              root: {
+                kind: "pane",
+                id: "pane-legacy",
+                tabInstanceIds: [SPEC_A.instanceId],
+                activeTabId: SPEC_A.instanceId,
+                previewTabId: null,
+                // activationHistory intentionally omitted - parse seeds it.
+              },
+              activePaneId: "pane-legacy",
+              tilesByInstanceId: {
+                // Raw tile record (not serializeTileRef output) that reuses
+                // the live instanceId under a different content id.
+                [SPEC_A.instanceId]: {
+                  id: SPEC_C.id,
+                  instanceId: SPEC_A.instanceId,
+                  type: SPEC_C.type,
+                  name: SPEC_C.name,
+                  hostId: SPEC_C.hostId,
+                },
+              },
+              sizesByGroupId: {},
+            },
+          },
+          openTabOrder: ["tab-legacy-migrate"],
+          activeTabId: "tab-legacy-migrate",
+          mostRecentTabIdByEpicId: {
+            "epic-legacy-migrate": "tab-legacy-migrate",
+          },
+          artifactTreeByEpicId: {},
+        },
+        // Persist version stays 1 (canvas store has no multi-version migrate
+        // fn); the "migration" here is parseEpicCanvasState's total parse /
+        // reconcile path, which is what merge runs before the identity check.
+        version: 1,
+      }),
+    );
+
+    await useEpicCanvasStore.persist.rehydrate();
+
+    expect(errorSpy).toHaveBeenCalled();
+    const [, fields] = errorSpy.mock.calls[0] ?? [];
+    expect(fields).toMatchObject({
+      ingressContext: "persisted-migration",
+      instanceId: SPEC_A.instanceId,
+    });
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    expect(
+      useEpicCanvasStore.getState().tabsById["tab-legacy-migrate"],
+    ).toBeUndefined();
+  });
+
+  it("completes hydration (hasHydrated + onFinishHydration) even when the merge is rejected", async () => {
+    // zustand's `hydrate()` resets `hasHydrated` to `false` at the start of
+    // every call and only flips it back once `merge()` returns normally and
+    // `set(stateFromStorage, true)` runs. A throwing `merge()` (the old
+    // behavior here) never reaches that point, so consumers gated on
+    // hydration completion - history-prune-provider.tsx,
+    // epic-tab-existence-reconciler.tsx - would hang forever.
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic One");
+    store.openTileInTab(tabId, SPEC_A);
+
+    window.localStorage.setItem(
+      epicCanvasKey(null),
+      JSON.stringify({
+        state: {
+          tabsById: {
+            "tab-persisted": {
+              tabId: "tab-persisted",
+              epicId: "epic-persisted",
+              name: "Persisted",
+            },
+          },
+          canvasByTabId: {
+            "tab-persisted": serializeEpicCanvasState({
+              root: {
+                kind: "pane",
+                id: "pane-persisted",
+                tabInstanceIds: [SPEC_A.instanceId],
+                activeTabId: SPEC_A.instanceId,
+                previewTabId: null,
+                activationHistory: [SPEC_A.instanceId],
+              },
+              activePaneId: "pane-persisted",
+              tilesByInstanceId: {
+                [SPEC_A.instanceId]: { ...SPEC_C, instanceId: SPEC_A.instanceId },
+              },
+              sizesByGroupId: {},
+            }),
+          },
+          openTabOrder: ["tab-persisted"],
+          activeTabId: "tab-persisted",
+          mostRecentTabIdByEpicId: { "epic-persisted": "tab-persisted" },
+          artifactTreeByEpicId: {},
+        },
+        version: 1,
+      }),
+    );
+
+    let finished = false;
+    const unsubscribe = useEpicCanvasStore.persist.onFinishHydration(() => {
+      finished = true;
+    });
+
+    await useEpicCanvasStore.persist.rehydrate();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(useEpicCanvasStore.persist.hasHydrated()).toBe(true);
+    expect(finished).toBe(true);
+    // Fail-closed still holds: the rejected persisted state never merged in.
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+    expect(useEpicCanvasStore.getState().tabsById["tab-persisted"]).toBeUndefined();
+
+    unsubscribe();
+  });
+});
+
+describe("canvas tile identity invariant: legitimate flows pass untouched", () => {
+  it("header tear-off retains the exact tuple across the two-store write", () => {
+    const store = useEpicCanvasStore.getState();
+    const sourceTabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(sourceTabId, SPEC_A);
+    const sourceGroupId = requireCanvas(sourceTabId).activePaneId;
+    if (sourceGroupId === null) throw new Error("expected active group");
+
+    expect(() =>
+      useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
+        sourceTabId,
+        sourcePaneId: sourceGroupId,
+        sourceTileTabId: SPEC_A.instanceId,
+        insertIndex: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  it("duplicateTab's freshly-minted instanceIds never collide with the source tab", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+
+    expect(() => useEpicCanvasStore.getState().duplicateTab(tabId)).not.toThrow();
+  });
+
+  it("cross-pane move and edge split retain the moved instanceId's tuple", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    const groupId = requireCanvas(tabId).activePaneId;
+    if (groupId === null) throw new Error("expected active group");
+
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .splitPaneWithNode(tabId, groupId, "right", SPEC_B),
+    ).not.toThrow();
+
+    const canvas = requireCanvas(tabId);
+    const panes = collectPanes(canvas.root);
+    expect(panes.length).toBeGreaterThan(1);
+    expect(canvas.tilesByInstanceId[SPEC_A.instanceId]).toEqual(SPEC_A);
+
+    const targetPane = panes.find((p) => p.id !== groupId);
+    if (targetPane === undefined) throw new Error("expected split pane");
+    expect(() =>
+      useEpicCanvasStore.getState().moveTabOnTabStrip(tabId, {
+        sourcePaneId: groupId,
+        tabId: SPEC_A.instanceId,
+        targetPaneId: targetPane.id,
+        targetIndex: 0,
+      }),
+    ).not.toThrow();
+    const afterMove = requireCanvas(tabId);
+    expect(afterMove.tilesByInstanceId[SPEC_A.instanceId]).toEqual(SPEC_A);
+    const movedPane = findPaneById(afterMove.root, targetPane.id);
+    expect(movedPane?.tabInstanceIds).toContain(SPEC_A.instanceId);
+  });
+
+  it("a tab switch (decision #17 unmount/remount) never touches the tuple", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+    const groupId = requireCanvas(tabId).activePaneId;
+    if (groupId === null) throw new Error("expected active group");
+
+    expect(() =>
+      useEpicCanvasStore
+        .getState()
+        .setActiveTileTab(tabId, groupId, SPEC_A.instanceId),
+    ).not.toThrow();
+    expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
+      SPEC_A,
+    );
+  });
+
+  it("chaos sequence of legitimate multi-tab/multi-epic ops never throws", () => {
+    // Strongest regression pin for ordinary usage: a long realistic sequence
+    // across several epics/tabs must never trip the identity choke point.
+    expect(() => {
+      const store = useEpicCanvasStore.getState();
+      const tab1 = store.openEpicTab("epic-chaos-1", "Chaos One");
+      const tab2 = store.openEpicTab("epic-chaos-2", "Chaos Two");
+      const tab3 = store.openEpicTab("epic-chaos-3", "Chaos Three");
+
+      for (let round = 0; round < 3; round += 1) {
+        const suffix = String(round);
+        const a: EpicNodeRef = {
+          id: `chaos-a-${suffix}`,
+          instanceId: `inst-chaos-a-${suffix}`,
+          type: "spec",
+          name: `Chaos A ${suffix}`,
+          hostId: TEST_HOST_ID,
+        };
+        const b: EpicNodeRef = {
+          id: `chaos-b-${suffix}`,
+          instanceId: `inst-chaos-b-${suffix}`,
+          type: "spec",
+          name: `Chaos B ${suffix}`,
+          hostId: TEST_HOST_ID,
+        };
+        const c: EpicNodeRef = {
+          id: `chaos-c-${suffix}`,
+          instanceId: `inst-chaos-c-${suffix}`,
+          type: "chat",
+          name: `Chaos C ${suffix}`,
+          hostId: TEST_HOST_ID,
+        };
+        const d: EpicNodeRef = {
+          id: `chaos-d-${suffix}`,
+          instanceId: `inst-chaos-d-${suffix}`,
+          type: "ticket",
+          name: `Chaos D ${suffix}`,
+          hostId: TEST_HOST_ID,
+        };
+
+        useEpicCanvasStore.getState().openTileInTab(tab1, a);
+        useEpicCanvasStore.getState().openTileInTab(tab1, b);
+        useEpicCanvasStore.getState().openTileInTab(tab2, c);
+        useEpicCanvasStore.getState().openTileInTab(tab3, d);
+        useEpicCanvasStore.getState().openTileInTab(tab2, GIT_DIFF_A);
+        useEpicCanvasStore.getState().openTileInTab(tab3, TERMINAL_A);
+        useEpicCanvasStore.getState().openTileInTab(tab1, WORKSPACE_FILE_A);
+
+        const pane1 = requireActivePaneId(tab1);
+        useEpicCanvasStore
+          .getState()
+          .splitPaneWithNode(tab1, pane1, "right", {
+            id: `chaos-split-${suffix}`,
+            instanceId: `inst-chaos-split-${suffix}`,
+            type: "spec",
+            name: `Split ${suffix}`,
+            hostId: TEST_HOST_ID,
+          });
+
+        const afterSplit = requireCanvas(tab1);
+        const panes = collectPanes(afterSplit.root);
+        if (panes.length < 2) {
+          throw new Error("expected split to create a second pane");
+        }
+        const rightPane = panes.find((p) => p.id !== pane1);
+        if (rightPane === undefined) {
+          throw new Error("expected right pane");
+        }
+
+        useEpicCanvasStore.getState().moveTabOnTabStrip(tab1, {
+          sourcePaneId: pane1,
+          tabId: a.instanceId,
+          targetPaneId: rightPane.id,
+          targetIndex: 0,
+        });
+        useEpicCanvasStore.getState().setActiveTileTab(tab1, rightPane.id, a.instanceId);
+        useEpicCanvasStore.getState().renameTab(tab1, `Chaos One renamed ${suffix}`);
+        useEpicCanvasStore.getState().renameArtifactInTab(tab1, a.id, `A renamed ${suffix}`);
+
+        useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
+          sourceTabId: tab2,
+          sourcePaneId: requireActivePaneId(tab2),
+          sourceTileTabId: c.instanceId,
+          insertIndex: 1,
+        });
+
+        useEpicCanvasStore.getState().duplicateTab(tab3);
+
+        const pane2 = requireActivePaneId(tab2);
+        const tab2Canvas = requireCanvas(tab2);
+        const closeTarget = Object.keys(tab2Canvas.tilesByInstanceId).at(0);
+        if (closeTarget !== undefined) {
+          useEpicCanvasStore
+            .getState()
+            .closeCanvasTab(tab2, pane2, closeTarget);
+          const closed =
+            useEpicCanvasStore.getState().closedTilePayloadsByTabId[tab2]?.[
+              closeTarget
+            ]?.node;
+          if (closed !== undefined) {
+            useEpicCanvasStore
+              .getState()
+              .restoreClosedTilePreview(tab2, pane2, closed);
+          }
+        }
+
+        useEpicCanvasStore.getState().openTilePreviewInTab(tab1, {
+          id: `chaos-preview-${suffix}`,
+          instanceId: `inst-chaos-preview-${suffix}`,
+          type: "review",
+          name: `Preview ${suffix}`,
+          hostId: TEST_HOST_ID,
+        });
+        useEpicCanvasStore.getState().setActiveTab(tab2);
+        useEpicCanvasStore.getState().setActiveTab(tab3);
+        useEpicCanvasStore.getState().setActiveTab(tab1);
+        useEpicCanvasStore.getState().closeTab(tab3);
+        useEpicCanvasStore.getState().setActiveTab(tab3);
+      }
+    }).not.toThrow();
+  });
+});

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store-tile-identity-invariant.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store-tile-identity-invariant.test.ts
@@ -415,14 +415,12 @@ describe("canvas tile identity invariant: internal mutation ingress", () => {
     const paneId = requireActivePaneId(tabId);
 
     expect(() =>
-      useEpicCanvasStore
-        .getState()
-        .splitPaneWithTab(tabId, {
-          sourcePaneId: paneId,
-          tabId: SPEC_B.instanceId,
-          targetPaneId: paneId,
-          position: "right",
-        }),
+      useEpicCanvasStore.getState().splitPaneWithTab(tabId, {
+        sourcePaneId: paneId,
+        tabId: SPEC_B.instanceId,
+        targetPaneId: paneId,
+        position: "right",
+      }),
     ).not.toThrow();
 
     const afterSplit = requireCanvas(tabId);
@@ -516,7 +514,10 @@ describe("canvas tile identity invariant: public setState ingress is always stri
               ...currentCanvas,
               tilesByInstanceId: {
                 ...currentCanvas.tilesByInstanceId,
-                [SPEC_A.instanceId]: { ...SPEC_B, instanceId: SPEC_A.instanceId },
+                [SPEC_A.instanceId]: {
+                  ...SPEC_B,
+                  instanceId: SPEC_A.instanceId,
+                },
               },
             },
           },
@@ -576,8 +577,8 @@ describe("canvas tile identity invariant: resolveTabEpicIdentity (the sole autho
   // parameter. Both real callers publish success from a POST-commit
   // `getState()` read-back rather than trusting a return value from this
   // function (see their own doc comments in tab-command-coordinator.ts) -
-  // their reentrant-race coverage lives in t3-rev3-adversarial.test.ts and
-  // phase-migration-controller.test.ts. These pins exercise
+  // their reentrant-race coverage lives in the tab-navigation adversarial and
+  // phase-migration controller suites. These pins exercise
   // `resolveTabEpicIdentity` itself: the legitimate commit and its own
   // preconditions, observed through resulting store state (this function
   // returns void).
@@ -826,9 +827,9 @@ describe("canvas tile identity invariant: desktop-projection ingress", () => {
     );
     expect(requireCanvas(hiddenTabId)).toBe(beforeHidden);
     expect(requireCanvas(visibleTabId)).toBe(beforeVisible);
-    expect(requireCanvas(hiddenTabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
-      SPEC_A,
-    );
+    expect(
+      requireCanvas(hiddenTabId).tilesByInstanceId[SPEC_A.instanceId],
+    ).toEqual(SPEC_A);
   });
 
   it("releases applyingDesktopProjection after a rejected inbound projection, so the next local mutation still reaches the bridge", () => {
@@ -948,7 +949,10 @@ describe("canvas tile identity invariant: persisted-migration ingress", () => {
               },
               activePaneId: "pane-persisted",
               tilesByInstanceId: {
-                [SPEC_A.instanceId]: { ...SPEC_C, instanceId: SPEC_A.instanceId },
+                [SPEC_A.instanceId]: {
+                  ...SPEC_C,
+                  instanceId: SPEC_A.instanceId,
+                },
               },
               sizesByGroupId: {},
             }),
@@ -970,7 +974,9 @@ describe("canvas tile identity invariant: persisted-migration ingress", () => {
     expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
       SPEC_A,
     );
-    expect(useEpicCanvasStore.getState().tabsById["tab-persisted"]).toBeUndefined();
+    expect(
+      useEpicCanvasStore.getState().tabsById["tab-persisted"],
+    ).toBeUndefined();
   });
 
   it("fails closed when a parse/migrate-shaped legacy blob repoints a live instanceId", async () => {
@@ -1084,7 +1090,10 @@ describe("canvas tile identity invariant: persisted-migration ingress", () => {
               },
               activePaneId: "pane-persisted",
               tilesByInstanceId: {
-                [SPEC_A.instanceId]: { ...SPEC_C, instanceId: SPEC_A.instanceId },
+                [SPEC_A.instanceId]: {
+                  ...SPEC_C,
+                  instanceId: SPEC_A.instanceId,
+                },
               },
               sizesByGroupId: {},
             }),
@@ -1112,7 +1121,9 @@ describe("canvas tile identity invariant: persisted-migration ingress", () => {
     expect(requireCanvas(tabId).tilesByInstanceId[SPEC_A.instanceId]).toEqual(
       SPEC_A,
     );
-    expect(useEpicCanvasStore.getState().tabsById["tab-persisted"]).toBeUndefined();
+    expect(
+      useEpicCanvasStore.getState().tabsById["tab-persisted"],
+    ).toBeUndefined();
 
     unsubscribe();
   });
@@ -1142,7 +1153,9 @@ describe("canvas tile identity invariant: legitimate flows pass untouched", () =
     store.openTileInTab(tabId, SPEC_A);
     store.openTileInTab(tabId, SPEC_B);
 
-    expect(() => useEpicCanvasStore.getState().duplicateTab(tabId)).not.toThrow();
+    expect(() =>
+      useEpicCanvasStore.getState().duplicateTab(tabId),
+    ).not.toThrow();
   });
 
   it("cross-pane move and edge split retain the moved instanceId's tuple", () => {
@@ -1246,15 +1259,13 @@ describe("canvas tile identity invariant: legitimate flows pass untouched", () =
         useEpicCanvasStore.getState().openTileInTab(tab1, WORKSPACE_FILE_A);
 
         const pane1 = requireActivePaneId(tab1);
-        useEpicCanvasStore
-          .getState()
-          .splitPaneWithNode(tab1, pane1, "right", {
-            id: `chaos-split-${suffix}`,
-            instanceId: `inst-chaos-split-${suffix}`,
-            type: "spec",
-            name: `Split ${suffix}`,
-            hostId: TEST_HOST_ID,
-          });
+        useEpicCanvasStore.getState().splitPaneWithNode(tab1, pane1, "right", {
+          id: `chaos-split-${suffix}`,
+          instanceId: `inst-chaos-split-${suffix}`,
+          type: "spec",
+          name: `Split ${suffix}`,
+          hostId: TEST_HOST_ID,
+        });
 
         const afterSplit = requireCanvas(tab1);
         const panes = collectPanes(afterSplit.root);
@@ -1272,9 +1283,15 @@ describe("canvas tile identity invariant: legitimate flows pass untouched", () =
           targetPaneId: rightPane.id,
           targetIndex: 0,
         });
-        useEpicCanvasStore.getState().setActiveTileTab(tab1, rightPane.id, a.instanceId);
-        useEpicCanvasStore.getState().renameTab(tab1, `Chaos One renamed ${suffix}`);
-        useEpicCanvasStore.getState().renameArtifactInTab(tab1, a.id, `A renamed ${suffix}`);
+        useEpicCanvasStore
+          .getState()
+          .setActiveTileTab(tab1, rightPane.id, a.instanceId);
+        useEpicCanvasStore
+          .getState()
+          .renameTab(tab1, `Chaos One renamed ${suffix}`);
+        useEpicCanvasStore
+          .getState()
+          .renameArtifactInTab(tab1, a.id, `A renamed ${suffix}`);
 
         useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
           sourceTabId: tab2,

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store-tile-identity-invariant.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store-tile-identity-invariant.test.ts
@@ -18,6 +18,7 @@ import {
   describe,
   expect,
   it,
+  onTestFinished,
   vi,
   type Mock,
 } from "vitest";
@@ -847,6 +848,7 @@ describe("canvas tile identity invariant: desktop-projection ingress", () => {
       dispose: () => {},
     };
     setEpicCanvasDesktopProjectionBridge(bridge);
+    onTestFinished(() => setEpicCanvasDesktopProjectionBridge(null));
 
     const before = requireCanvas(tabId);
     const repointed: EpicCanvasState = {
@@ -873,8 +875,6 @@ describe("canvas tile identity invariant: desktop-projection ingress", () => {
     // this valid local mutation would be silently suppressed too.
     useEpicCanvasStore.getState().openTileInTab(tabId, SPEC_C);
     expect(updates).toHaveLength(1);
-
-    setEpicCanvasDesktopProjectionBridge(null);
   });
 
   it("throws when a desktop projection changes only a tab's epicId while its canvas stays identical (round-2 adversarial probe)", () => {

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -19,6 +19,7 @@ import {
   makeSelectTabActivation,
   useEpicCanvasStore,
 } from "@/stores/epics/canvas/store";
+import * as chatTabViewportHandoff from "@/stores/chats/chat-tab-viewport-handoff";
 import { isBlankTileRef } from "@/stores/epics/canvas/types";
 import { epicCanvasKey } from "@/lib/persist";
 import { makePrDetailTile } from "@/lib/pr/pr-detail-tile";
@@ -33,7 +34,13 @@ import {
   getCurrentNestedFocusTarget,
   type NestedFocusTarget,
 } from "@/lib/epic-nested-focus-route";
-import { SPEC_A, SPEC_B, SPEC_C, TEST_HOST_ID } from "./canvas-test-fixtures";
+import {
+  CHAT_A,
+  SPEC_A,
+  SPEC_B,
+  SPEC_C,
+  TEST_HOST_ID,
+} from "./canvas-test-fixtures";
 
 // Resolve a pane's tab payloads in strip order via tilesByInstanceId.
 function tabRefsOfPane(
@@ -1009,6 +1016,42 @@ describe("epic canvas store header tabs", () => {
     expect(state.activeTabId).toBe(newTabId);
   });
 
+  /**
+   * Ticket 20: backs the corrected doc comment at `commitHeaderStripDrop`
+   * (`root-dnd-commits.ts`) - the tile that tears off keeps its OWN
+   * instanceId; only the new HEADER TAB record gets a fresh id
+   * (`newTabId` above, an `EpicViewTab.tabId`, not a tile instanceId). The
+   * old comment's "clone semantics: new instance ids" conflated the two.
+   * Mutation-verified: temporarily minting a fresh instanceId for the moved
+   * tile in `tearOffTabIntoNewHeaderTab` (simulating what the old comment
+   * claimed) turns this red.
+   */
+  it("ticket 20: tearing a tab off preserves the tile's own instanceId (MOVE, not clone)", () => {
+    const store = useEpicCanvasStore.getState();
+    const sourceTabId = store.openEpicTab("epic-1", "Epic Foo");
+    store.openTileInTab(sourceTabId, SPEC_A);
+    const sourceGroupId = requireCanvas(sourceTabId).activePaneId;
+    if (sourceGroupId === null) throw new Error("expected active group");
+
+    const newTabId = useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
+      sourceTabId,
+      sourcePaneId: sourceGroupId,
+      sourceTileTabId: SPEC_A.instanceId,
+      insertIndex: 1,
+    });
+    if (newTabId === null) throw new Error("expected tear-off tab");
+
+    const newCanvas = requireCanvas(newTabId);
+    const newPane = collectPanes(newCanvas.root)[0];
+    if (newPane === undefined) throw new Error("expected a promoted pane");
+
+    expect(newPane.activeTabId).toBe(SPEC_A.instanceId);
+    expect(newPane.tabInstanceIds).toEqual([SPEC_A.instanceId]);
+    expect(newCanvas.tilesByInstanceId[SPEC_A.instanceId]?.id).toBe(
+      SPEC_A.id,
+    );
+  });
+
   it("closes every header tab for a deleted epic", () => {
     const store = useEpicCanvasStore.getState();
     const firstDeletedTabId = store.openEpicTab("epic-delete", "Delete Me");
@@ -1711,5 +1754,563 @@ describe("restoreClosedTilePreview", () => {
     const canvas = requireCanvas(tabId);
     expect(canvas.tilesByInstanceId[SPEC_A.instanceId]).toBeUndefined();
     expect(canvas.tilesByInstanceId[SPEC_B.instanceId]).toEqual(SPEC_B);
+  });
+});
+
+/**
+ * Ticket 20: the 5 mechanism pins in chat-messages.test.tsx prove the
+ * handoff registry works; the tear-off instanceId pin above proves MOVE
+ * semantics. These wiring tests pin that EACH of the 9 structural action
+ * creators calls `flushChatTabViewportHandoff` with the correct instanceId
+ * set, from PRE-mutation tree state, and that the sibling paths that must
+ * NOT remount anything skip the flush (or flush `[]` for the dissolve
+ * predictor's no-op).
+ */
+function spyOnFlushChatTabViewportHandoff() {
+  return vi.spyOn(chatTabViewportHandoff, "flushChatTabViewportHandoff");
+}
+
+describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
+  let flushSpy: ReturnType<typeof spyOnFlushChatTabViewportHandoff>;
+
+  beforeEach(() => {
+    flushSpy = spyOnFlushChatTabViewportHandoff();
+  });
+
+  /** Seed a header tab with the given canvas already in place. */
+  function seedHeaderTab(
+    tabId: string,
+    canvas: EpicCanvasState,
+    epicId: string = "epic-t20",
+  ): void {
+    useEpicCanvasStore.setState({
+      tabsById: {
+        [tabId]: { tabId, epicId, name: "Ticket 20" },
+      },
+      canvasByTabId: { [tabId]: canvas },
+      openTabOrder: [tabId],
+      activeTabId: tabId,
+      mostRecentTabIdByEpicId: { [epicId]: tabId },
+    });
+  }
+
+  /** Two-pane horizontal split: left holds A+B, right holds C. */
+  function twoPaneSplitCanvas(): EpicCanvasState {
+    return {
+      activePaneId: "pane-left",
+      root: {
+        kind: "group",
+        id: "split-2",
+        direction: "horizontal",
+        children: [
+          {
+            kind: "pane",
+            id: "pane-left",
+            tabInstanceIds: [SPEC_A.instanceId, SPEC_B.instanceId],
+            activeTabId: SPEC_A.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_A.instanceId, SPEC_B.instanceId],
+          },
+          {
+            kind: "pane",
+            id: "pane-right",
+            tabInstanceIds: [SPEC_C.instanceId],
+            activeTabId: SPEC_C.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_C.instanceId],
+          },
+        ],
+      },
+      tilesByInstanceId: {
+        [SPEC_A.instanceId]: SPEC_A,
+        [SPEC_B.instanceId]: SPEC_B,
+        [SPEC_C.instanceId]: SPEC_C,
+      },
+      sizesByGroupId: { "split-2": [0.5, 0.5] },
+    };
+  }
+
+  /**
+   * Nested dissolve fixture: closing `pane-gone` promotes a 2-pane survivor
+   * group (the mounts=3/unmounts=2 case). Active tabs: B and C survive.
+   */
+  function nestedSurvivorDissolveCanvas(): EpicCanvasState {
+    return {
+      activePaneId: "pane-gone",
+      root: {
+        kind: "group",
+        id: "split-outer",
+        direction: "horizontal",
+        children: [
+          {
+            kind: "pane",
+            id: "pane-gone",
+            tabInstanceIds: [SPEC_A.instanceId],
+            activeTabId: SPEC_A.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_A.instanceId],
+          },
+          {
+            kind: "group",
+            id: "split-survivor",
+            direction: "vertical",
+            children: [
+              {
+                kind: "pane",
+                id: "pane-keep-1",
+                tabInstanceIds: [SPEC_B.instanceId],
+                activeTabId: SPEC_B.instanceId,
+                previewTabId: null,
+                activationHistory: [SPEC_B.instanceId],
+              },
+              {
+                kind: "pane",
+                id: "pane-keep-2",
+                tabInstanceIds: [SPEC_C.instanceId],
+                activeTabId: SPEC_C.instanceId,
+                previewTabId: null,
+                activationHistory: [SPEC_C.instanceId],
+              },
+            ],
+          },
+        ],
+      },
+      tilesByInstanceId: {
+        [SPEC_A.instanceId]: SPEC_A,
+        [SPEC_B.instanceId]: SPEC_B,
+        [SPEC_C.instanceId]: SPEC_C,
+      },
+      sizesByGroupId: {
+        "split-outer": [0.5, 0.5],
+        "split-survivor": [0.5, 0.5],
+      },
+    };
+  }
+
+  /** Three flat sibling panes - removing one does NOT dissolve. */
+  function threePaneFlatCanvas(): EpicCanvasState {
+    return {
+      activePaneId: "pane-a",
+      root: {
+        kind: "group",
+        id: "split-3",
+        direction: "horizontal",
+        children: [
+          {
+            kind: "pane",
+            id: "pane-a",
+            tabInstanceIds: [SPEC_A.instanceId],
+            activeTabId: SPEC_A.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_A.instanceId],
+          },
+          {
+            kind: "pane",
+            id: "pane-b",
+            tabInstanceIds: [SPEC_B.instanceId],
+            activeTabId: SPEC_B.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_B.instanceId],
+          },
+          {
+            kind: "pane",
+            id: "pane-c",
+            tabInstanceIds: [SPEC_C.instanceId],
+            activeTabId: SPEC_C.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_C.instanceId],
+          },
+        ],
+      },
+      tilesByInstanceId: {
+        [SPEC_A.instanceId]: SPEC_A,
+        [SPEC_B.instanceId]: SPEC_B,
+        [SPEC_C.instanceId]: SPEC_C,
+      },
+      sizesByGroupId: { "split-3": [1 / 3, 1 / 3, 1 / 3] },
+    };
+  }
+
+  /** Bare single-pane root with one tile (tear-off / wrap targets). */
+  function singlePaneCanvas(
+    node: EpicCanvasTileRef = SPEC_A,
+  ): EpicCanvasState {
+    return {
+      activePaneId: "pane-root",
+      root: {
+        kind: "pane",
+        id: "pane-root",
+        tabInstanceIds: [node.instanceId],
+        activeTabId: node.instanceId,
+        previewTabId: null,
+        activationHistory: [node.instanceId],
+      },
+      tilesByInstanceId: { [node.instanceId]: node },
+      sizesByGroupId: {},
+    };
+  }
+
+  /**
+   * When the flush fires, the pre-mutation tree must still be intact - i.e.
+   * the action creator called it BEFORE its own `set()`. The spy records the
+   * call either way; this implementation only asserts timing.
+   */
+  function withPreMutationCheck(
+    tabId: string,
+    paneThatMustStillExist: string,
+  ): void {
+    flushSpy.mockImplementation(() => {
+      const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+      expect(canvas).toBeDefined();
+      if (canvas === undefined) return;
+      expect(findPaneById(canvas.root, paneThatMustStillExist)).not.toBeNull();
+    });
+  }
+
+  // ---- moveTabOnTabStrip ------------------------------------------------
+
+  it("moveTabOnTabStrip: cross-pane move flushes the dragged tab (and not a no-op sibling)", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-left");
+
+    useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
+      sourcePaneId: "pane-left",
+      tabId: SPEC_B.instanceId,
+      targetPaneId: "pane-right",
+      targetIndex: 0,
+    });
+
+    // SPEC_B was not the only tab in pane-left, so no dissolve targets.
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_B.instanceId]);
+  });
+
+  it("moveTabOnTabStrip: cross-pane move of a pane's last tab also flushes dissolve survivors", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-right");
+
+    useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
+      sourcePaneId: "pane-right",
+      tabId: SPEC_C.instanceId,
+      targetPaneId: "pane-left",
+      targetIndex: 0,
+    });
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    // Dragged tab + dissolve survivor (left pane's active tab is SPEC_A).
+    expect(flushSpy.mock.calls[0]?.[0]).toEqual([
+      SPEC_C.instanceId,
+      SPEC_A.instanceId,
+    ]);
+  });
+
+  it("moveTabOnTabStrip: same-pane reorder does NOT flush (no remount)", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+
+    useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
+      sourcePaneId: "pane-left",
+      tabId: SPEC_B.instanceId,
+      targetPaneId: "pane-left",
+      targetIndex: 0,
+    });
+
+    expect(flushSpy).not.toHaveBeenCalled();
+  });
+
+  // ---- insertNodeOnTabStrip ---------------------------------------------
+
+  it("insertNodeOnTabStrip: cross-pane re-insert of an already-open node flushes it", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-right");
+
+    // SPEC_C is already open in pane-right; inserting it onto pane-left is a
+    // cross-pane move via findPaneTabByContentId.
+    useEpicCanvasStore
+      .getState()
+      .insertNodeOnTabStrip("tab-1", "pane-left", 0, SPEC_C);
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy.mock.calls[0]?.[0]).toEqual([
+      SPEC_C.instanceId,
+      SPEC_A.instanceId, // dissolve of emptied pane-right
+    ]);
+  });
+
+  it("insertNodeOnTabStrip: brand-new node does NOT flush (no existing mount to move)", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+
+    useEpicCanvasStore
+      .getState()
+      .insertNodeOnTabStrip("tab-1", "pane-left", 0, CHAT_A);
+
+    expect(flushSpy).not.toHaveBeenCalled();
+  });
+
+  // ---- splitPaneWithNode ------------------------------------------------
+
+  it("splitPaneWithNode: flushes the target pane's active tab (wrap or flat)", () => {
+    seedHeaderTab("tab-1", singlePaneCanvas(SPEC_A));
+    withPreMutationCheck("tab-1", "pane-root");
+
+    // Bare root + edge split always wraps the target.
+    useEpicCanvasStore
+      .getState()
+      .splitPaneWithNode("tab-1", "pane-root", "right", SPEC_B);
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_A.instanceId]);
+  });
+
+  /**
+   * Ticket 20 review round 1, finding 1 (CONFIRMED HIGH): `splitPaneAtEdge`
+   * resolves a `node` source whose content is ALREADY OPEN elsewhere into a
+   * `tab`-kind cross-pane MOVE before doing anything else - the same
+   * "already open" resolution `insertNodeOnTabStrip` performs - but this
+   * production creator only flushed the target pane's active tab, missing
+   * the moved instance and its source-pane dissolve survivors entirely.
+   * Mutation-verified: reverting the `existing`/dissolve branch (leaving
+   * only the target-active flush) drops `SPEC_B.instanceId` and
+   * `SPEC_C.instanceId` from the flushed set - red.
+   */
+  it(
+    "splitPaneWithNode: existing-node edge split (already open elsewhere) " +
+      "flushes the moved instance, target active, AND its source-pane dissolve survivor",
+    () => {
+      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas());
+      withPreMutationCheck("tab-1", "pane-keep-1");
+
+      // SPEC_B is already open (as the only tab) in the nested pane-keep-1,
+      // sibling to pane-keep-2 (SPEC_C) under split-survivor. Edge-splitting
+      // it onto the UNRELATED pane-gone (SPEC_A) resolves internally to a
+      // cross-pane tab move: the moved tab (B) always lands in a brand-new
+      // pane, the target (A) may wrap, and pane-keep-1 emptying dissolves
+      // split-survivor, promoting pane-keep-2 (C) to a new ancestor.
+      useEpicCanvasStore
+        .getState()
+        .splitPaneWithNode("tab-1", "pane-gone", "right", SPEC_B);
+
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+      const flushed = flushSpy.mock.calls[0]?.[0] ?? [];
+      expect(flushed).toContain(SPEC_A.instanceId); // target active
+      expect(flushed).toContain(SPEC_B.instanceId); // moved instance
+      expect(flushed).toContain(SPEC_C.instanceId); // dissolve survivor
+    },
+  );
+
+  it("splitPaneWithNode: brand-new node does NOT trigger the existing-node move flush", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+
+    useEpicCanvasStore
+      .getState()
+      .splitPaneWithNode("tab-1", "pane-left", "right", CHAT_A);
+
+    // Only the target-pane active-tab (wrap-risk) flush fires - no moved
+    // instance or dissolve survivor, since CHAT_A was not open anywhere.
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_A.instanceId]);
+  });
+
+  // ---- splitPaneWithTab -------------------------------------------------
+
+  it("splitPaneWithTab: flushes the dragged tab + target active + dissolve survivors", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-right");
+
+    // Drag SPEC_C (only tab in pane-right) onto an edge of pane-left →
+    // remounts the dragged tab, may wrap pane-left (its active is A), and
+    // dissolves pane-right's parent (survivor is pane-left → A again).
+    useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+      sourcePaneId: "pane-right",
+      tabId: SPEC_C.instanceId,
+      targetPaneId: "pane-left",
+      position: "bottom", // cross-axis wrap of pane-left
+    });
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    const flushed = flushSpy.mock.calls[0]?.[0] ?? [];
+    expect(flushed).toContain(SPEC_C.instanceId); // dragged
+    expect(flushed).toContain(SPEC_A.instanceId); // target active (+ dissolve)
+  });
+
+  it("splitPaneWithTab: same-pane edge split still flushes the dragged tab", () => {
+    // Dragging a non-last tab from pane-left onto an edge of the same pane:
+    // still creates a brand-new pane for the dragged tab → remounts it.
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+
+    useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
+      sourcePaneId: "pane-left",
+      tabId: SPEC_B.instanceId,
+      targetPaneId: "pane-left",
+      position: "bottom",
+    });
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    const flushed = flushSpy.mock.calls[0]?.[0] ?? [];
+    expect(flushed).toContain(SPEC_B.instanceId);
+    expect(flushed).toContain(SPEC_A.instanceId); // target active
+    // sourcePane was not emptied (A remains) and source===target, so no dissolve.
+    expect(flushed).toHaveLength(2);
+  });
+
+  // ---- splitPaneEmptyInTab ----------------------------------------------
+
+  it("splitPaneEmptyInTab: flushes the target pane's active tab", () => {
+    seedHeaderTab("tab-1", singlePaneCanvas(SPEC_A));
+    withPreMutationCheck("tab-1", "pane-root");
+
+    useEpicCanvasStore
+      .getState()
+      .splitPaneEmptyInTab("tab-1", "pane-root", "horizontal");
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_A.instanceId]);
+  });
+
+  // ---- closeCanvasTab ---------------------------------------------------
+
+  it("closeCanvasTab: last-tab close that dissolves flushes survivor actives", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-right");
+
+    useEpicCanvasStore
+      .getState()
+      .closeCanvasTab("tab-1", "pane-right", SPEC_C.instanceId);
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_A.instanceId]);
+  });
+
+  it("closeCanvasTab: non-last-tab close does NOT flush (pane stays, no dissolve)", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+
+    useEpicCanvasStore
+      .getState()
+      .closeCanvasTab("tab-1", "pane-left", SPEC_B.instanceId);
+
+    expect(flushSpy).not.toHaveBeenCalled();
+  });
+
+  it("closeCanvasTab: last-tab close with >2 siblings flushes [] (no dissolve remount)", () => {
+    seedHeaderTab("tab-1", threePaneFlatCanvas());
+
+    useEpicCanvasStore
+      .getState()
+      .closeCanvasTab("tab-1", "pane-a", SPEC_A.instanceId);
+
+    // Still called (last-tab path), but dissolve predictor returns [].
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([]);
+  });
+
+  // ---- closeAllCanvasTabs -----------------------------------------------
+
+  it("closeAllCanvasTabs: dissolve flushes survivor actives", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-right");
+
+    useEpicCanvasStore.getState().closeAllCanvasTabs("tab-1", "pane-right");
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_A.instanceId]);
+  });
+
+  it("closeAllCanvasTabs: >2 siblings flushes [] (no dissolve)", () => {
+    seedHeaderTab("tab-1", threePaneFlatCanvas());
+
+    useEpicCanvasStore.getState().closeAllCanvasTabs("tab-1", "pane-a");
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([]);
+  });
+
+  // ---- closeCanvasPane --------------------------------------------------
+
+  it("closeCanvasPane: dissolve flushes survivor actives", () => {
+    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-1", "pane-left");
+
+    useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-left");
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_C.instanceId]);
+  });
+
+  it("closeCanvasPane: >2 siblings flushes [] (no dissolve remount)", () => {
+    seedHeaderTab("tab-1", threePaneFlatCanvas());
+
+    useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-b");
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([]);
+  });
+
+  it(
+    "closeCanvasPane: multi-pane promoted survivor flushes EVERY descendant active tab",
+    () => {
+      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas());
+      withPreMutationCheck("tab-1", "pane-gone");
+
+      useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-gone");
+
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+      expect(flushSpy).toHaveBeenCalledWith([
+        SPEC_B.instanceId,
+        SPEC_C.instanceId,
+      ]);
+    },
+  );
+
+  // ---- tearOffTabIntoNewHeaderTab ---------------------------------------
+
+  it("tearOffTabIntoNewHeaderTab: always flushes the torn-off tile instanceId", () => {
+    // Two tabs in one pane: tear-off does not dissolve a sibling pane.
+    const canvas: EpicCanvasState = {
+      activePaneId: "pane-root",
+      root: {
+        kind: "pane",
+        id: "pane-root",
+        tabInstanceIds: [SPEC_A.instanceId, SPEC_B.instanceId],
+        activeTabId: SPEC_A.instanceId,
+        previewTabId: null,
+        activationHistory: [SPEC_A.instanceId, SPEC_B.instanceId],
+      },
+      tilesByInstanceId: {
+        [SPEC_A.instanceId]: SPEC_A,
+        [SPEC_B.instanceId]: SPEC_B,
+      },
+      sizesByGroupId: {},
+    };
+    seedHeaderTab("tab-src", canvas);
+    withPreMutationCheck("tab-src", "pane-root");
+
+    const newTabId = useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
+      sourceTabId: "tab-src",
+      sourcePaneId: "pane-root",
+      sourceTileTabId: SPEC_A.instanceId,
+      insertIndex: 1,
+    });
+    expect(newTabId).not.toBeNull();
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([SPEC_A.instanceId]);
+  });
+
+  it("tearOffTabIntoNewHeaderTab: only-tab tear-off also flushes dissolve survivors", () => {
+    seedHeaderTab("tab-src", twoPaneSplitCanvas());
+    withPreMutationCheck("tab-src", "pane-right");
+
+    const newTabId = useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
+      sourceTabId: "tab-src",
+      sourcePaneId: "pane-right",
+      sourceTileTabId: SPEC_C.instanceId,
+      insertIndex: 1,
+    });
+    expect(newTabId).not.toBeNull();
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy.mock.calls[0]?.[0]).toEqual([
+      SPEC_C.instanceId,
+      SPEC_A.instanceId,
+    ]);
   });
 });

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -1054,7 +1054,7 @@ describe("epic canvas store header tabs", () => {
     if (newTabId === null) throw new Error("expected tear-off tab");
 
     const newCanvas = requireCanvas(newTabId);
-    const newPane = collectPanes(newCanvas.root)[0];
+    const newPane = collectPanes(newCanvas.root).at(0);
     if (newPane === undefined) throw new Error("expected a promoted pane");
 
     expect(newPane.activeTabId).toBe(SPEC_A.instanceId);

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -4,6 +4,7 @@ import {
   describe,
   expect,
   it,
+  onTestFinished,
   vi,
   type Mock,
 } from "vitest";
@@ -28,6 +29,14 @@ import {
   useEpicCanvasStore,
 } from "@/stores/epics/canvas/store";
 import * as chatTabViewportHandoff from "@/stores/chats/chat-tab-viewport-handoff";
+import {
+  evictChatTabState,
+  evictChatTabStateForChat,
+  hasSavedChatTabState,
+  restoreChatTabState,
+} from "@/stores/chats/chat-tab-state-cache";
+import type { ChatTabPersistenceIdentity } from "@/stores/chats/chat-tab-persistence-key";
+import { appLogger } from "@/lib/logger";
 import { isBlankTileRef } from "@/stores/epics/canvas/types";
 import { epicCanvasKey } from "@/lib/persist";
 import { makePrDetailTile } from "@/lib/pr/pr-detail-tile";
@@ -2325,5 +2334,127 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
       SPEC_C.instanceId,
       SPEC_A.instanceId,
     ]);
+  });
+
+  it("a failed viewport capture cannot abort remaining captures or the structural mutation", () => {
+    const throwingChat: EpicCanvasTileRef = {
+      ...CHAT_A,
+      id: "chat-capture-throws",
+      instanceId: "inst-chat-capture-throws",
+      name: "Throwing capture",
+    };
+    const healthyChat: EpicCanvasTileRef = {
+      ...CHAT_A,
+      id: "chat-capture-healthy",
+      instanceId: "inst-chat-capture-healthy",
+      name: "Healthy capture",
+    };
+    const identity: ChatTabPersistenceIdentity = {
+      epicId: "epic-t20",
+      chatId: throwingChat.id,
+      tileInstanceId: throwingChat.instanceId,
+    };
+    evictChatTabState([identity.tileInstanceId]);
+    evictChatTabStateForChat(identity);
+    onTestFinished(() => {
+      evictChatTabState([identity.tileInstanceId]);
+      evictChatTabStateForChat(identity);
+    });
+
+    seedHeaderTab(
+      "tab-capture-isolation",
+      {
+        activePaneId: "pane-gone",
+        root: {
+          kind: "group",
+          id: "split-outer",
+          direction: "horizontal",
+          children: [
+            {
+              kind: "pane",
+              id: "pane-gone",
+              tabInstanceIds: [SPEC_A.instanceId],
+              activeTabId: SPEC_A.instanceId,
+              previewTabId: null,
+              activationHistory: [SPEC_A.instanceId],
+            },
+            {
+              kind: "group",
+              id: "split-survivor",
+              direction: "vertical",
+              children: [
+                {
+                  kind: "pane",
+                  id: "pane-throwing",
+                  tabInstanceIds: [throwingChat.instanceId],
+                  activeTabId: throwingChat.instanceId,
+                  previewTabId: null,
+                  activationHistory: [throwingChat.instanceId],
+                },
+                {
+                  kind: "pane",
+                  id: "pane-healthy",
+                  tabInstanceIds: [healthyChat.instanceId],
+                  activeTabId: healthyChat.instanceId,
+                  previewTabId: null,
+                  activationHistory: [healthyChat.instanceId],
+                },
+              ],
+            },
+          ],
+        },
+        tilesByInstanceId: {
+          [SPEC_A.instanceId]: SPEC_A,
+          [throwingChat.instanceId]: throwingChat,
+          [healthyChat.instanceId]: healthyChat,
+        },
+        sizesByGroupId: {
+          "split-outer": [0.5, 0.5],
+          "split-survivor": [0.5, 0.5],
+        },
+      },
+      "epic-t20",
+    );
+
+    const captureFailure = new Error("capture failed");
+    const unregisterThrowing =
+      chatTabViewportHandoff.registerChatTabViewportCapture(
+        throwingChat.instanceId,
+        () => {
+          throw captureFailure;
+        },
+      );
+    onTestFinished(unregisterThrowing);
+    const healthyCapture = vi.fn();
+    const unregisterHealthy =
+      chatTabViewportHandoff.registerChatTabViewportCapture(
+        healthyChat.instanceId,
+        healthyCapture,
+      );
+    onTestFinished(unregisterHealthy);
+    const logError = vi.spyOn(appLogger, "error").mockImplementation(() => {});
+
+    expect(() => {
+      useEpicCanvasStore
+        .getState()
+        .closeCanvasPane("tab-capture-isolation", "pane-gone");
+    }).not.toThrow();
+
+    expect(healthyCapture).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(
+      "chat tab viewport capture failed during structural handoff",
+      { instanceId: throwingChat.instanceId },
+      captureFailure,
+    );
+    expect(
+      findPaneById(requireCanvas("tab-capture-isolation").root, "pane-gone"),
+    ).toBeNull();
+    expect(hasSavedChatTabState(identity)).toBe(false);
+    expect(restoreChatTabState(identity, [])).toEqual({
+      mode: "following-end",
+      anchorMessageId: null,
+      anchorIndex: null,
+      offset: 0,
+    });
   });
 });

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { paneTabRefs, setActiveTab } from "@/stores/epics/canvas/actions";
 import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
 import {
@@ -708,15 +708,27 @@ describe("epic canvas store header tabs", () => {
       "epic-prepare-preview",
       "Prepare Preview",
     );
-    store.openTilePreviewInTab(previewTabId, SPEC_A);
+    // Same CONTENT id as `SPEC_A`, opened into a different epic tab - per the
+    // instanceId-per-tab contract (`EpicArtifactRef`'s doc comment), that
+    // gets its OWN instanceId. Reusing `SPEC_A`'s instanceId across two
+    // unrelated tabs would violate the canvas-wide immutable identity tuple
+    // (same instanceId, different epicId).
+    const specAInPreviewTab: EpicCanvasTileRef = {
+      ...SPEC_A,
+      instanceId: "inst-a-preview",
+    };
+    store.openTilePreviewInTab(previewTabId, specAInPreviewTab);
     const previewPaneId = requireCanvas(previewTabId).activePaneId;
     if (previewPaneId === null) throw new Error("expected preview pane");
     expect(
       requirePane(requireCanvas(previewTabId), previewPaneId).previewTabId,
-    ).toBe(SPEC_A.instanceId);
-    expect(store.prepareOpenTileInTabFocusTarget(previewTabId, SPEC_A)).toEqual(
-      { paneId: previewPaneId, tileInstanceId: SPEC_A.instanceId },
-    );
+    ).toBe(specAInPreviewTab.instanceId);
+    expect(
+      store.prepareOpenTileInTabFocusTarget(previewTabId, specAInPreviewTab),
+    ).toEqual({
+      paneId: previewPaneId,
+      tileInstanceId: specAInPreviewTab.instanceId,
+    });
     expect(
       requirePane(requireCanvas(previewTabId), previewPaneId).previewTabId,
     ).toBeNull();
@@ -1771,7 +1783,7 @@ function spyOnFlushChatTabViewportHandoff() {
 }
 
 describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
-  let flushSpy: ReturnType<typeof spyOnFlushChatTabViewportHandoff>;
+  let flushSpy: Mock<(instanceIds: ReadonlyArray<string>) => void>;
 
   beforeEach(() => {
     flushSpy = spyOnFlushChatTabViewportHandoff();
@@ -1781,7 +1793,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   function seedHeaderTab(
     tabId: string,
     canvas: EpicCanvasState,
-    epicId: string = "epic-t20",
+    epicId: string,
   ): void {
     useEpicCanvasStore.setState({
       tabsById: {
@@ -1932,9 +1944,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   }
 
   /** Bare single-pane root with one tile (tear-off / wrap targets). */
-  function singlePaneCanvas(
-    node: EpicCanvasTileRef = SPEC_A,
-  ): EpicCanvasState {
+  function singlePaneCanvas(node: EpicCanvasTileRef): EpicCanvasState {
     return {
       activePaneId: "pane-root",
       root: {
@@ -1970,7 +1980,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- moveTabOnTabStrip ------------------------------------------------
 
   it("moveTabOnTabStrip: cross-pane move flushes the dragged tab (and not a no-op sibling)", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-left");
 
     useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
@@ -1986,7 +1996,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("moveTabOnTabStrip: cross-pane move of a pane's last tab also flushes dissolve survivors", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-right");
 
     useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
@@ -2005,7 +2015,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("moveTabOnTabStrip: same-pane reorder does NOT flush (no remount)", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
 
     useEpicCanvasStore.getState().moveTabOnTabStrip("tab-1", {
       sourcePaneId: "pane-left",
@@ -2020,7 +2030,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- insertNodeOnTabStrip ---------------------------------------------
 
   it("insertNodeOnTabStrip: cross-pane re-insert of an already-open node flushes it", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-right");
 
     // SPEC_C is already open in pane-right; inserting it onto pane-left is a
@@ -2037,7 +2047,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("insertNodeOnTabStrip: brand-new node does NOT flush (no existing mount to move)", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
 
     useEpicCanvasStore
       .getState()
@@ -2049,7 +2059,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- splitPaneWithNode ------------------------------------------------
 
   it("splitPaneWithNode: flushes the target pane's active tab (wrap or flat)", () => {
-    seedHeaderTab("tab-1", singlePaneCanvas(SPEC_A));
+    seedHeaderTab("tab-1", singlePaneCanvas(SPEC_A), "epic-t20");
     withPreMutationCheck("tab-1", "pane-root");
 
     // Bare root + edge split always wraps the target.
@@ -2076,7 +2086,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
     "splitPaneWithNode: existing-node edge split (already open elsewhere) " +
       "flushes the moved instance, target active, AND its source-pane dissolve survivor",
     () => {
-      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas());
+      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas(), "epic-t20");
       withPreMutationCheck("tab-1", "pane-keep-1");
 
       // SPEC_B is already open (as the only tab) in the nested pane-keep-1,
@@ -2098,7 +2108,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   );
 
   it("splitPaneWithNode: brand-new node does NOT trigger the existing-node move flush", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
 
     useEpicCanvasStore
       .getState()
@@ -2113,7 +2123,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- splitPaneWithTab -------------------------------------------------
 
   it("splitPaneWithTab: flushes the dragged tab + target active + dissolve survivors", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-right");
 
     // Drag SPEC_C (only tab in pane-right) onto an edge of pane-left →
@@ -2135,7 +2145,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   it("splitPaneWithTab: same-pane edge split still flushes the dragged tab", () => {
     // Dragging a non-last tab from pane-left onto an edge of the same pane:
     // still creates a brand-new pane for the dragged tab → remounts it.
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
 
     useEpicCanvasStore.getState().splitPaneWithTab("tab-1", {
       sourcePaneId: "pane-left",
@@ -2155,7 +2165,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- splitPaneEmptyInTab ----------------------------------------------
 
   it("splitPaneEmptyInTab: flushes the target pane's active tab", () => {
-    seedHeaderTab("tab-1", singlePaneCanvas(SPEC_A));
+    seedHeaderTab("tab-1", singlePaneCanvas(SPEC_A), "epic-t20");
     withPreMutationCheck("tab-1", "pane-root");
 
     useEpicCanvasStore
@@ -2169,7 +2179,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- closeCanvasTab ---------------------------------------------------
 
   it("closeCanvasTab: last-tab close that dissolves flushes survivor actives", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-right");
 
     useEpicCanvasStore
@@ -2181,7 +2191,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("closeCanvasTab: non-last-tab close does NOT flush (pane stays, no dissolve)", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
 
     useEpicCanvasStore
       .getState()
@@ -2191,7 +2201,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("closeCanvasTab: last-tab close with >2 siblings flushes [] (no dissolve remount)", () => {
-    seedHeaderTab("tab-1", threePaneFlatCanvas());
+    seedHeaderTab("tab-1", threePaneFlatCanvas(), "epic-t20");
 
     useEpicCanvasStore
       .getState()
@@ -2205,7 +2215,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- closeAllCanvasTabs -----------------------------------------------
 
   it("closeAllCanvasTabs: dissolve flushes survivor actives", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-right");
 
     useEpicCanvasStore.getState().closeAllCanvasTabs("tab-1", "pane-right");
@@ -2215,7 +2225,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("closeAllCanvasTabs: >2 siblings flushes [] (no dissolve)", () => {
-    seedHeaderTab("tab-1", threePaneFlatCanvas());
+    seedHeaderTab("tab-1", threePaneFlatCanvas(), "epic-t20");
 
     useEpicCanvasStore.getState().closeAllCanvasTabs("tab-1", "pane-a");
 
@@ -2226,7 +2236,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   // ---- closeCanvasPane --------------------------------------------------
 
   it("closeCanvasPane: dissolve flushes survivor actives", () => {
-    seedHeaderTab("tab-1", twoPaneSplitCanvas());
+    seedHeaderTab("tab-1", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-1", "pane-left");
 
     useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-left");
@@ -2236,7 +2246,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("closeCanvasPane: >2 siblings flushes [] (no dissolve remount)", () => {
-    seedHeaderTab("tab-1", threePaneFlatCanvas());
+    seedHeaderTab("tab-1", threePaneFlatCanvas(), "epic-t20");
 
     useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-b");
 
@@ -2247,7 +2257,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   it(
     "closeCanvasPane: multi-pane promoted survivor flushes EVERY descendant active tab",
     () => {
-      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas());
+      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas(), "epic-t20");
       withPreMutationCheck("tab-1", "pane-gone");
 
       useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-gone");
@@ -2280,7 +2290,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
       },
       sizesByGroupId: {},
     };
-    seedHeaderTab("tab-src", canvas);
+    seedHeaderTab("tab-src", canvas, "epic-t20");
     withPreMutationCheck("tab-src", "pane-root");
 
     const newTabId = useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({
@@ -2296,7 +2306,7 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   });
 
   it("tearOffTabIntoNewHeaderTab: only-tab tear-off also flushes dissolve survivors", () => {
-    seedHeaderTab("tab-src", twoPaneSplitCanvas());
+    seedHeaderTab("tab-src", twoPaneSplitCanvas(), "epic-t20");
     withPreMutationCheck("tab-src", "pane-right");
 
     const newTabId = useEpicCanvasStore.getState().tearOffTabIntoNewHeaderTab({

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -1976,6 +1976,50 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
   }
 
   /**
+   * Two panes where the target's painted tab must be resolved from its first
+   * live tab because activeTabId is absent or stale. The source keeps a second
+   * tab so splitPaneWithTab does not add a dissolve-survivor target that could
+   * mask the target-pane assertion.
+   */
+  function fallbackActiveSplitCanvas(
+    targetActiveTabId: string | null,
+  ): EpicCanvasState {
+    return {
+      activePaneId: "pane-left",
+      root: {
+        kind: "group",
+        id: "split-fallback-active",
+        direction: "horizontal",
+        children: [
+          {
+            kind: "pane",
+            id: "pane-left",
+            tabInstanceIds: [SPEC_A.instanceId, SPEC_B.instanceId],
+            activeTabId: targetActiveTabId,
+            previewTabId: null,
+            activationHistory: [SPEC_A.instanceId, SPEC_B.instanceId],
+          },
+          {
+            kind: "pane",
+            id: "pane-right",
+            tabInstanceIds: [SPEC_C.instanceId, CHAT_A.instanceId],
+            activeTabId: SPEC_C.instanceId,
+            previewTabId: null,
+            activationHistory: [SPEC_C.instanceId, CHAT_A.instanceId],
+          },
+        ],
+      },
+      tilesByInstanceId: {
+        [SPEC_A.instanceId]: SPEC_A,
+        [SPEC_B.instanceId]: SPEC_B,
+        [SPEC_C.instanceId]: SPEC_C,
+        [CHAT_A.instanceId]: CHAT_A,
+      },
+      sizesByGroupId: { "split-fallback-active": [0.5, 0.5] },
+    };
+  }
+
+  /**
    * When the flush fires, the pre-mutation tree must still be intact - i.e.
    * the action creator called it BEFORE its own `set()`. The spy records the
    * call either way; this implementation only asserts timing.
@@ -2176,6 +2220,75 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
     // sourcePane was not emptied (A remains) and source===target, so no dissolve.
     expect(flushed).toHaveLength(2);
   });
+
+  const newSplitNode: EpicCanvasTileRef = {
+    ...CHAT_A,
+    id: "chat-new-split-node",
+    instanceId: "inst-chat-new-split-node",
+    name: "New split chat",
+  };
+  const fallbackActiveCases: ReadonlyArray<{
+    activeCase: string;
+    activeTabId: string | null;
+  }> = [
+    { activeCase: "null activeTabId", activeTabId: null },
+    { activeCase: "stale activeTabId", activeTabId: "inst-stale-active" },
+  ];
+  const splitTargetCases: ReadonlyArray<{
+    entryPoint: string;
+    expected: ReadonlyArray<string>;
+    invoke: (tabId: string) => void;
+  }> = [
+    {
+      entryPoint: "splitPaneWithNode",
+      expected: [SPEC_A.instanceId],
+      invoke: (tabId) => {
+        useEpicCanvasStore
+          .getState()
+          .splitPaneWithNode(tabId, "pane-left", "bottom", newSplitNode);
+      },
+    },
+    {
+      entryPoint: "splitPaneWithTab",
+      expected: [SPEC_C.instanceId, SPEC_A.instanceId],
+      invoke: (tabId) => {
+        useEpicCanvasStore.getState().splitPaneWithTab(tabId, {
+          sourcePaneId: "pane-right",
+          tabId: SPEC_C.instanceId,
+          targetPaneId: "pane-left",
+          position: "bottom",
+        });
+      },
+    },
+    {
+      entryPoint: "splitPaneEmptyInTab",
+      expected: [SPEC_A.instanceId],
+      invoke: (tabId) => {
+        useEpicCanvasStore
+          .getState()
+          .splitPaneEmptyInTab(tabId, "pane-left", "vertical");
+      },
+    },
+  ];
+  const fallbackSplitTargetCases = fallbackActiveCases.flatMap((activeCase) =>
+    splitTargetCases.map((splitCase) => ({ ...activeCase, ...splitCase })),
+  );
+
+  it.each(fallbackSplitTargetCases)(
+    "$entryPoint flushes the painted first tab for a $activeCase target",
+    ({ activeTabId, expected, invoke }) => {
+      seedHeaderTab(
+        "tab-fallback-active",
+        fallbackActiveSplitCanvas(activeTabId),
+        "epic-t20",
+      );
+
+      invoke("tab-fallback-active");
+
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+      expect(flushSpy).toHaveBeenCalledWith(expected);
+    },
+  );
 
   // ---- splitPaneEmptyInTab ----------------------------------------------
 

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
 import { paneTabRefs, setActiveTab } from "@/stores/epics/canvas/actions";
 import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
 import {
@@ -1059,9 +1067,7 @@ describe("epic canvas store header tabs", () => {
 
     expect(newPane.activeTabId).toBe(SPEC_A.instanceId);
     expect(newPane.tabInstanceIds).toEqual([SPEC_A.instanceId]);
-    expect(newCanvas.tilesByInstanceId[SPEC_A.instanceId]?.id).toBe(
-      SPEC_A.id,
-    );
+    expect(newCanvas.tilesByInstanceId[SPEC_A.instanceId]?.id).toBe(SPEC_A.id);
   });
 
   it("closes every header tab for a deleted epic", () => {
@@ -2254,21 +2260,18 @@ describe("ticket 20: pre-structural-mutation viewport handoff wiring", () => {
     expect(flushSpy).toHaveBeenCalledWith([]);
   });
 
-  it(
-    "closeCanvasPane: multi-pane promoted survivor flushes EVERY descendant active tab",
-    () => {
-      seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas(), "epic-t20");
-      withPreMutationCheck("tab-1", "pane-gone");
+  it("closeCanvasPane: multi-pane promoted survivor flushes EVERY descendant active tab", () => {
+    seedHeaderTab("tab-1", nestedSurvivorDissolveCanvas(), "epic-t20");
+    withPreMutationCheck("tab-1", "pane-gone");
 
-      useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-gone");
+    useEpicCanvasStore.getState().closeCanvasPane("tab-1", "pane-gone");
 
-      expect(flushSpy).toHaveBeenCalledTimes(1);
-      expect(flushSpy).toHaveBeenCalledWith([
-        SPEC_B.instanceId,
-        SPEC_C.instanceId,
-      ]);
-    },
-  );
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledWith([
+      SPEC_B.instanceId,
+      SPEC_C.instanceId,
+    ]);
+  });
 
   // ---- tearOffTabIntoNewHeaderTab ---------------------------------------
 

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-identity-invariant.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-identity-invariant.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Direct unit pins for the pure identity-invariant module: no store, no
+ * React - just `canvasByTabId` snapshots and epicId resolvers. The store
+ * integration pins (real actions, real desktop-projection ingress) live in
+ * `store-tile-identity-invariant.test.ts`.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { appLogger } from "@/lib/logger";
+import {
+  collectTileIdentityRegistry,
+  enforceTileIdentityInvariant,
+  findTileIdentityViolation,
+  type TileIdentityTuple,
+} from "@/stores/epics/canvas/tile-identity-invariant";
+import type { EpicCanvasState, EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+import { pane } from "./canvas-test-fixtures";
+import { CHAT_A, SPEC_A, SPEC_B, TEST_HOST_ID } from "./canvas-test-fixtures";
+
+function canvasOf(tiles: ReadonlyArray<EpicCanvasTileRef>): EpicCanvasState {
+  const p = pane(
+    "pane-1",
+    tiles.map((t) => t.instanceId),
+  );
+  return {
+    root: p,
+    activePaneId: p.id,
+    tilesByInstanceId: Object.fromEntries(
+      tiles.map((t) => [t.instanceId, t]),
+    ),
+    sizesByGroupId: {},
+  };
+}
+
+const EPIC_ID_BY_TAB_ID: Readonly<Record<string, string | undefined>> = {
+  "tab-a": "epic-a",
+  "tab-b": "epic-b",
+};
+const EPIC_A = (tabId: string): string | null =>
+  EPIC_ID_BY_TAB_ID[tabId] ?? null;
+
+describe("collectTileIdentityRegistry", () => {
+  it("builds one entry per live tile, tupled with the resolved epicId", () => {
+    const canvasByTabId = { "tab-a": canvasOf([SPEC_A]) };
+    const registry = collectTileIdentityRegistry(canvasByTabId, EPIC_A);
+    expect(registry.get(SPEC_A.instanceId)).toEqual({
+      tileKind: "spec",
+      contentId: SPEC_A.id,
+      epicId: "epic-a",
+      hostId: TEST_HOST_ID,
+    });
+  });
+
+  it("skips a tab whose epicId cannot be resolved", () => {
+    const canvasByTabId = { "tab-unknown": canvasOf([SPEC_A]) };
+    const registry = collectTileIdentityRegistry(canvasByTabId, EPIC_A);
+    expect(registry.size).toBe(0);
+  });
+
+  it("skips an undefined canvas entry", () => {
+    const canvasByTabId = { "tab-a": undefined };
+    const registry = collectTileIdentityRegistry(canvasByTabId, EPIC_A);
+    expect(registry.size).toBe(0);
+  });
+});
+
+describe("findTileIdentityViolation", () => {
+  it("returns null for a fresh mint (absent from previous)", () => {
+    const previous = new Map<string, TileIdentityTuple>();
+    const canvasByTabId = { "tab-a": canvasOf([SPEC_A]) };
+    expect(findTileIdentityViolation(previous, canvasByTabId, EPIC_A)).toBeNull();
+  });
+
+  it("returns null when an instanceId is retained with the SAME tuple", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const canvasByTabId = { "tab-a": canvasOf([SPEC_A]) };
+    expect(findTileIdentityViolation(previous, canvasByTabId, EPIC_A)).toBeNull();
+  });
+
+  it("returns null when an instanceId simply closes (absent from the candidate)", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const canvasByTabId = { "tab-a": canvasOf([]) };
+    expect(findTileIdentityViolation(previous, canvasByTabId, EPIC_A)).toBeNull();
+  });
+
+  it("detects a repoint: same instanceId, changed content id, against `previous`", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const repointed = { ...SPEC_B, instanceId: SPEC_A.instanceId };
+    const canvasByTabId = { "tab-a": canvasOf([repointed]) };
+    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    expect(violation).not.toBeNull();
+    expect(violation?.instanceId).toBe(SPEC_A.instanceId);
+    expect(violation?.previous.contentId).toBe(SPEC_A.id);
+    expect(violation?.incoming.contentId).toBe(SPEC_B.id);
+  });
+
+  it("detects a repoint that only changes tile kind", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const repointed = { ...CHAT_A, instanceId: SPEC_A.instanceId, id: SPEC_A.id };
+    const canvasByTabId = { "tab-a": canvasOf([repointed]) };
+    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    expect(violation?.previous.tileKind).toBe("spec");
+    expect(violation?.incoming.tileKind).toBe("chat");
+  });
+
+  it("detects a repoint that only changes host id", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const repointed = { ...SPEC_A, hostId: "other-host" };
+    const canvasByTabId = { "tab-a": canvasOf([repointed]) };
+    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    expect(violation?.previous.hostId).toBe(TEST_HOST_ID);
+    expect(violation?.incoming.hostId).toBe("other-host");
+  });
+
+  it("detects an intra-candidate collision across two DIFFERENT tabs with no prior history", () => {
+    const previous = new Map<string, TileIdentityTuple>();
+    const conflicting = { ...SPEC_B, instanceId: SPEC_A.instanceId };
+    const canvasByTabId = {
+      "tab-a": canvasOf([SPEC_A]),
+      "tab-b": canvasOf([conflicting]),
+    };
+    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    expect(violation).not.toBeNull();
+    expect(violation?.instanceId).toBe(SPEC_A.instanceId);
+  });
+});
+
+describe("enforceTileIdentityInvariant", () => {
+  let errorSpy: Mock<typeof appLogger.error>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(appLogger, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true and never logs when there is no violation", () => {
+    const previous = new Map<string, TileIdentityTuple>();
+    const accepted = enforceTileIdentityInvariant(
+      previous,
+      {
+        canvasByTabId: { "tab-a": canvasOf([SPEC_A]) },
+        epicIdForTabId: EPIC_A,
+        ingressContext: "test-ingress",
+      },
+      true,
+    );
+    expect(accepted).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("dev/test policy (throwOnViolation=true): throws AND emits a diagnostic first", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const repointed = { ...SPEC_B, instanceId: SPEC_A.instanceId };
+    expect(() =>
+      enforceTileIdentityInvariant(
+        previous,
+        {
+          canvasByTabId: { "tab-a": canvasOf([repointed]) },
+          epicIdForTabId: EPIC_A,
+          ingressContext: "test-ingress",
+        },
+        true,
+      ),
+    ).toThrow(/identity invariant violated/i);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [, fields] = errorSpy.mock.calls[0] ?? [];
+    expect(fields).toMatchObject({
+      ingressContext: "test-ingress",
+      instanceId: SPEC_A.instanceId,
+    });
+  });
+
+  it("production policy (throwOnViolation=false): fails closed - no throw, returns false, still emits a diagnostic", () => {
+    const previous = collectTileIdentityRegistry(
+      { "tab-a": canvasOf([SPEC_A]) },
+      EPIC_A,
+    );
+    const repointed = { ...SPEC_B, instanceId: SPEC_A.instanceId };
+    let accepted: boolean | null = null;
+    expect(() => {
+      accepted = enforceTileIdentityInvariant(
+        previous,
+        {
+          canvasByTabId: { "tab-a": canvasOf([repointed]) },
+          epicIdForTabId: EPIC_A,
+          ingressContext: "test-ingress",
+        },
+        false,
+      );
+    }).not.toThrow();
+    expect(accepted).toBe(false);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-identity-invariant.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-identity-invariant.test.ts
@@ -20,7 +20,10 @@ import {
   findTileIdentityViolation,
   type TileIdentityTuple,
 } from "@/stores/epics/canvas/tile-identity-invariant";
-import type { EpicCanvasState, EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+} from "@/stores/epics/canvas/types";
 import { pane } from "./canvas-test-fixtures";
 import { CHAT_A, SPEC_A, SPEC_B, TEST_HOST_ID } from "./canvas-test-fixtures";
 
@@ -32,9 +35,7 @@ function canvasOf(tiles: ReadonlyArray<EpicCanvasTileRef>): EpicCanvasState {
   return {
     root: p,
     activePaneId: p.id,
-    tilesByInstanceId: Object.fromEntries(
-      tiles.map((t) => [t.instanceId, t]),
-    ),
+    tilesByInstanceId: Object.fromEntries(tiles.map((t) => [t.instanceId, t])),
     sizesByGroupId: {},
   };
 }
@@ -75,7 +76,9 @@ describe("findTileIdentityViolation", () => {
   it("returns null for a fresh mint (absent from previous)", () => {
     const previous = new Map<string, TileIdentityTuple>();
     const canvasByTabId = { "tab-a": canvasOf([SPEC_A]) };
-    expect(findTileIdentityViolation(previous, canvasByTabId, EPIC_A)).toBeNull();
+    expect(
+      findTileIdentityViolation(previous, canvasByTabId, EPIC_A),
+    ).toBeNull();
   });
 
   it("returns null when an instanceId is retained with the SAME tuple", () => {
@@ -84,7 +87,9 @@ describe("findTileIdentityViolation", () => {
       EPIC_A,
     );
     const canvasByTabId = { "tab-a": canvasOf([SPEC_A]) };
-    expect(findTileIdentityViolation(previous, canvasByTabId, EPIC_A)).toBeNull();
+    expect(
+      findTileIdentityViolation(previous, canvasByTabId, EPIC_A),
+    ).toBeNull();
   });
 
   it("returns null when an instanceId simply closes (absent from the candidate)", () => {
@@ -93,7 +98,9 @@ describe("findTileIdentityViolation", () => {
       EPIC_A,
     );
     const canvasByTabId = { "tab-a": canvasOf([]) };
-    expect(findTileIdentityViolation(previous, canvasByTabId, EPIC_A)).toBeNull();
+    expect(
+      findTileIdentityViolation(previous, canvasByTabId, EPIC_A),
+    ).toBeNull();
   });
 
   it("detects a repoint: same instanceId, changed content id, against `previous`", () => {
@@ -103,7 +110,11 @@ describe("findTileIdentityViolation", () => {
     );
     const repointed = { ...SPEC_B, instanceId: SPEC_A.instanceId };
     const canvasByTabId = { "tab-a": canvasOf([repointed]) };
-    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    const violation = findTileIdentityViolation(
+      previous,
+      canvasByTabId,
+      EPIC_A,
+    );
     expect(violation).not.toBeNull();
     expect(violation?.instanceId).toBe(SPEC_A.instanceId);
     expect(violation?.previous.contentId).toBe(SPEC_A.id);
@@ -115,9 +126,17 @@ describe("findTileIdentityViolation", () => {
       { "tab-a": canvasOf([SPEC_A]) },
       EPIC_A,
     );
-    const repointed = { ...CHAT_A, instanceId: SPEC_A.instanceId, id: SPEC_A.id };
+    const repointed = {
+      ...CHAT_A,
+      instanceId: SPEC_A.instanceId,
+      id: SPEC_A.id,
+    };
     const canvasByTabId = { "tab-a": canvasOf([repointed]) };
-    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    const violation = findTileIdentityViolation(
+      previous,
+      canvasByTabId,
+      EPIC_A,
+    );
     expect(violation?.previous.tileKind).toBe("spec");
     expect(violation?.incoming.tileKind).toBe("chat");
   });
@@ -129,7 +148,11 @@ describe("findTileIdentityViolation", () => {
     );
     const repointed = { ...SPEC_A, hostId: "other-host" };
     const canvasByTabId = { "tab-a": canvasOf([repointed]) };
-    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    const violation = findTileIdentityViolation(
+      previous,
+      canvasByTabId,
+      EPIC_A,
+    );
     expect(violation?.previous.hostId).toBe(TEST_HOST_ID);
     expect(violation?.incoming.hostId).toBe("other-host");
   });
@@ -141,7 +164,11 @@ describe("findTileIdentityViolation", () => {
       "tab-a": canvasOf([SPEC_A]),
       "tab-b": canvasOf([conflicting]),
     };
-    const violation = findTileIdentityViolation(previous, canvasByTabId, EPIC_A);
+    const violation = findTileIdentityViolation(
+      previous,
+      canvasByTabId,
+      EPIC_A,
+    );
     expect(violation).not.toBeNull();
     expect(violation?.instanceId).toBe(SPEC_A.instanceId);
   });

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
@@ -503,9 +503,9 @@ describe("paneRemovalDissolveHandoffTargets", () => {
   });
 
   it("returns [] when removing the bare-pane root (no parent group to dissolve)", () => {
-    expect(paneRemovalDissolveHandoffTargets(pane("root", ["t-root"]), "root")).toEqual(
-      [],
-    );
+    expect(
+      paneRemovalDissolveHandoffTargets(pane("root", ["t-root"]), "root"),
+    ).toEqual([]);
   });
 
   it("returns [] for a null root or an absent pane id", () => {

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
@@ -4,15 +4,20 @@ import {
   collectPanes,
   findPaneById,
   findPanePath,
+  getNodeAtPath,
   getTreeDepth,
   insertPaneAtEdge,
   normalizeSizes,
+  paneRemovalDissolveHandoffTargets,
   pruneSizes,
   removePaneFromTree,
   replaceNodeAtPath,
   replacePane,
 } from "@/stores/epics/canvas/tile-tree";
-import type { SizesByGroupId } from "@/stores/epics/canvas/tile-tree";
+import type {
+  SizesByGroupId,
+  TileLayoutNode,
+} from "@/stores/epics/canvas/tile-tree";
 import {
   MAX_TREE_DEPTH,
   MIN_SPLIT_SIZE,
@@ -441,6 +446,178 @@ describe("insertPaneAtEdge - rejections", () => {
     expect(merged === null ? 0 : getTreeDepth(merged.root)).toBe(
       MAX_TREE_DEPTH,
     );
+  });
+});
+
+/**
+ * Ticket 20: read-only dissolve predictor used by close/move/tear-off action
+ * creators to know which surviving panes' painted chats remount when a pane
+ * removal dissolves its 2-child parent. Must mirror `removePaneFromTree`'s
+ * single-survivor branch exactly - a multi-pane promoted survivor remounts
+ * EVERY descendant pane, not just the direct sibling.
+ */
+describe("paneRemovalDissolveHandoffTargets", () => {
+  it("returns the survivor's active tab when the parent group has exactly 2 children", () => {
+    const tree = group("g", "horizontal", [
+      pane("a", ["t-a"]),
+      pane("b", ["t-b"]),
+    ]);
+    expect(paneRemovalDissolveHandoffTargets(tree, "a")).toEqual(["t-b"]);
+    expect(paneRemovalDissolveHandoffTargets(tree, "b")).toEqual(["t-a"]);
+  });
+
+  it("returns [] when the parent group has more than 2 children (no dissolve)", () => {
+    const tree = group("g", "horizontal", [
+      pane("a", ["t-a"]),
+      pane("b", ["t-b"]),
+      pane("c", ["t-c"]),
+    ]);
+    expect(paneRemovalDissolveHandoffTargets(tree, "a")).toEqual([]);
+    expect(paneRemovalDissolveHandoffTargets(tree, "b")).toEqual([]);
+  });
+
+  it("returns [] when removing the bare-pane root (no parent group to dissolve)", () => {
+    expect(paneRemovalDissolveHandoffTargets(pane("root", ["t-root"]), "root")).toEqual(
+      [],
+    );
+  });
+
+  it("returns [] for a null root or an absent pane id", () => {
+    expect(paneRemovalDissolveHandoffTargets(null, "a")).toEqual([]);
+    expect(
+      paneRemovalDissolveHandoffTargets(
+        group("g", "horizontal", [pane("a", ["t-a"]), pane("b", ["t-b"])]),
+        "missing",
+      ),
+    ).toEqual([]);
+  });
+
+  it(
+    "returns EVERY active tab in a multi-pane promoted survivor subtree " +
+      "(the mounts=3/unmounts=2 dissolve the audit probe found)",
+    () => {
+      // Removing `gone` dissolves the root 2-child group and promotes the
+      // nested survivor group; both of ITS panes remount under a new ancestor.
+      const tree = group("g-root", "horizontal", [
+        pane("gone", ["t-gone"]),
+        group("g-survivor", "vertical", [
+          pane("keep-1", ["t-keep-1"]),
+          pane("keep-2", ["t-keep-2"]),
+        ]),
+      ]);
+      expect(paneRemovalDissolveHandoffTargets(tree, "gone")).toEqual([
+        "t-keep-1",
+        "t-keep-2",
+      ]);
+    },
+  );
+
+  it("filters out panes whose activeTabId is null (empty survivor panes)", () => {
+    const tree = group("g", "horizontal", [
+      pane("a", ["t-a"]),
+      pane("empty", []),
+    ]);
+    expect(paneRemovalDissolveHandoffTargets(tree, "a")).toEqual([]);
+  });
+
+  /**
+   * Review round 1, finding 4: the original version of this test only
+   * checked `result.root?.kind` (pane vs group) - it would stay green even
+   * if the helper flushed the WRONG pane's tabs, or missed panes nested
+   * under a multi-pane survivor, as long as the root's shape matched.
+   * Compares the EXACT set of active-tab ids `paneRemovalDissolveHandoffTargets`
+   * predicts against `removePaneFromTree`'s REAL post-removal tree - walking
+   * to wherever the survivor actually landed (found independently via
+   * `findPanePath`/`getNodeAtPath`, not by re-deriving the helper's own
+   * `parentPath` logic) and collecting every pane grafted in there.
+   */
+  function exactSurvivorActiveTabIds(
+    root: TileLayoutNode,
+    sizesByGroupId: SizesByGroupId,
+    removedPaneId: string,
+  ): ReadonlyArray<string> {
+    const path = findPanePath(root, removedPaneId);
+    expect(path).not.toBeNull();
+    if (path === null) return [];
+    const parentPath = path.slice(0, -1);
+    const result = removePaneFromTree({ root, sizesByGroupId }, removedPaneId);
+    expect(result?.root).not.toBeNull();
+    if (result?.root === null || result?.root === undefined) return [];
+    const survivorNode = getNodeAtPath(result.root, parentPath);
+    return collectPanes(survivorNode)
+      .map((survivorPane) => survivorPane.activeTabId)
+      .filter((activeTabId): activeTabId is string => activeTabId !== null);
+  }
+
+  it("agrees with removePaneFromTree's dissolve decision on the same trees", () => {
+    const twoChild = group("g", "horizontal", [
+      pane("a", ["t-a"]),
+      pane("b", ["t-b"]),
+    ]);
+    const threeChild = group("g", "horizontal", [
+      pane("a", ["t-a"]),
+      pane("b", ["t-b"]),
+      pane("c", ["t-c"]),
+    ]);
+    // 2-child, remove index 0: dissolve happens → handoff non-empty; tree
+    // root becomes the survivor.
+    expect(paneRemovalDissolveHandoffTargets(twoChild, "a")).toEqual(
+      exactSurvivorActiveTabIds(twoChild, { g: [0.5, 0.5] }, "a"),
+    );
+    const dissolved = removePaneFromTree(
+      { root: twoChild, sizesByGroupId: { g: [0.5, 0.5] } },
+      "a",
+    );
+    expect(dissolved?.root?.kind).toBe("pane");
+    // 2-child, remove index 1 (reversed): the OTHER child is now the
+    // survivor - catches an off-by-one/reversed-index bug the index-0-only
+    // case above cannot.
+    expect(paneRemovalDissolveHandoffTargets(twoChild, "b")).toEqual(
+      exactSurvivorActiveTabIds(twoChild, { g: [0.5, 0.5] }, "b"),
+    );
+    // >2-child: no dissolve → handoff empty; parent group survives shrunk.
+    expect(paneRemovalDissolveHandoffTargets(threeChild, "a")).toEqual([]);
+    const shrunk = removePaneFromTree(
+      { root: threeChild, sizesByGroupId: { g: [0.3, 0.3, 0.4] } },
+      "a",
+    );
+    expect(shrunk?.root?.kind).toBe("group");
+  });
+
+  it("agrees with removePaneFromTree on a multi-pane nested survivor (mounts=3/unmounts=2)", () => {
+    const tree = group("g-root", "horizontal", [
+      pane("gone", ["t-gone"]),
+      group("g-survivor", "vertical", [
+        pane("keep-1", ["t-keep-1"]),
+        pane("keep-2", ["t-keep-2"]),
+      ]),
+    ]);
+    const sizesByGroupId: SizesByGroupId = {
+      "g-root": [0.5, 0.5],
+      "g-survivor": [0.5, 0.5],
+    };
+    expect(paneRemovalDissolveHandoffTargets(tree, "gone")).toEqual(
+      exactSurvivorActiveTabIds(tree, sizesByGroupId, "gone"),
+    );
+  });
+
+  it("agrees with removePaneFromTree when the dissolving group is nested (not the tree root)", () => {
+    // Removing "a" dissolves "inner" (2 -> 1 child), promoting "b" into
+    // inner's slot - but "inner" itself is a child of "outer", so the
+    // helper must locate the RIGHT parent path, not assume it is the root.
+    const tree = group("outer", "horizontal", [
+      pane("x", ["t-x"]),
+      group("inner", "vertical", [pane("a", ["t-a"]), pane("b", ["t-b"])]),
+    ]);
+    const sizesByGroupId: SizesByGroupId = {
+      outer: [0.5, 0.5],
+      inner: [0.5, 0.5],
+    };
+    expect(paneRemovalDissolveHandoffTargets(tree, "a")).toEqual(
+      exactSurvivorActiveTabIds(tree, sizesByGroupId, "a"),
+    );
+    // Sanity: this really is a nested (non-root) dissolve, not a no-op.
+    expect(paneRemovalDissolveHandoffTargets(tree, "a")).toEqual(["t-b"]);
   });
 });
 

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
@@ -13,6 +13,7 @@ import {
   removePaneFromTree,
   replaceNodeAtPath,
   replacePane,
+  resolveActivePaneTab,
 } from "@/stores/epics/canvas/tile-tree";
 import type {
   SizesByGroupId,
@@ -152,6 +153,31 @@ describe("findPaneById", () => {
     const tree = group("g", "horizontal", [pane("a", []), leaf]);
     expect(findPaneById(tree, "b")).toBe(leaf);
     expect(findPaneById(tree, "missing")).toBeNull();
+  });
+});
+
+describe("resolveActivePaneTab", () => {
+  it("returns null for an empty pane regardless of activeTabId", () => {
+    expect(resolveActivePaneTab(null, [])).toBeNull();
+    expect(resolveActivePaneTab("t-a", [])).toBeNull();
+  });
+
+  it("returns activeTabId when it names a live tab", () => {
+    expect(resolveActivePaneTab("t-b", ["t-a", "t-b", "t-c"])).toBe("t-b");
+  });
+
+  it("falls back to the first tab when activeTabId is null", () => {
+    expect(resolveActivePaneTab(null, ["t-a", "t-b"])).toBe("t-a");
+  });
+
+  it("falls back to the first tab when activeTabId names a tab no longer in the pane", () => {
+    expect(resolveActivePaneTab("stale", ["t-a", "t-b"])).toBe("t-a");
+  });
+
+  it("returns the sole tab for a single-tab pane, matching or not matching activeTabId", () => {
+    expect(resolveActivePaneTab("t-a", ["t-a"])).toBe("t-a");
+    expect(resolveActivePaneTab("stale", ["t-a"])).toBe("t-a");
+    expect(resolveActivePaneTab(null, ["t-a"])).toBe("t-a");
   });
 });
 

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-tree.test.ts
@@ -546,6 +546,27 @@ describe("paneRemovalDissolveHandoffTargets", () => {
     expect(paneRemovalDissolveHandoffTargets(tree, "a")).toEqual([]);
   });
 
+  it("captures the same fallback tab rendering paints when a survivor activeTabId is null or stale", () => {
+    const nullActive = group("g-null", "horizontal", [
+      pane("gone-null", ["t-gone"]),
+      { ...pane("keep-null", ["t-painted", "t-other"]), activeTabId: null },
+    ]);
+    const staleActive = group("g-stale", "horizontal", [
+      pane("gone-stale", ["t-gone"]),
+      {
+        ...pane("keep-stale", ["t-painted", "t-other"]),
+        activeTabId: "t-missing",
+      },
+    ]);
+
+    expect
+      .soft(paneRemovalDissolveHandoffTargets(nullActive, "gone-null"))
+      .toEqual(["t-painted"]);
+    expect
+      .soft(paneRemovalDissolveHandoffTargets(staleActive, "gone-stale"))
+      .toEqual(["t-painted"]);
+  });
+
   /**
    * Review round 1, finding 4: the original version of this test only
    * checked `result.root?.kind` (pane vs group) - it would stay green even

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -42,6 +42,7 @@ import type {
 import type { DesktopPerWindowProjectionBridge } from "@/lib/windows/per-window-projection-debounce";
 import { useTileScrollAnchorStore } from "@/stores/epics/canvas/tile-scroll-anchor-store";
 import { evictChatTabState } from "@/stores/chats/chat-tab-state-cache";
+import { flushChatTabViewportHandoff } from "@/stores/chats/chat-tab-viewport-handoff";
 import { evictActivityGroupOpenStores } from "@/stores/chats/activity-group-open-store-core";
 import { evictA2AOpenStores } from "@/stores/chats/a2a-open-store-context";
 import {
@@ -93,7 +94,10 @@ import {
   collectLiveTileInstanceIds,
   createEmptyCanvas,
 } from "@/stores/epics/canvas/canvas-state";
-import { findPaneById } from "@/stores/epics/canvas/tile-tree";
+import {
+  findPaneById,
+  paneRemovalDissolveHandoffTargets,
+} from "@/stores/epics/canvas/tile-tree";
 import {
   isOpenableEpicNodeKind,
   makeOpenableNodeRef,
@@ -1451,6 +1455,23 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             ? (sourceCanvas.tilesByInstanceId[args.sourceTileTabId] ?? null)
             : null;
         if (pane === null || node === null) return null;
+        // Ticket 20: the torn-off tile always remounts - it moves from the
+        // source header tab's canvas root into a brand-new header tab's
+        // canvas root, a completely different React parent chain (MOVE
+        // semantics, same instanceId - see the corrected comment at
+        // `commitHeaderStripDrop`'s call site). When it was its source
+        // pane's only tab, `closeTileTab` below falls through to
+        // `closePane`, which can also dissolve that pane's parent group and
+        // remount a sibling. Flush both before `set()` commits the move.
+        flushChatTabViewportHandoff([
+          args.sourceTileTabId,
+          ...(pane.tabInstanceIds.length === 1
+            ? paneRemovalDissolveHandoffTargets(
+                sourceCanvas.root,
+                args.sourcePaneId,
+              )
+            : []),
+        ]);
         const newId = uuidv4();
         const siblingNames = epicTabNames(state.tabsById, sourceTab.epicId);
         const newTab: EpicViewTab = {
@@ -1899,6 +1920,27 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       insertNodeOnTabStrip: (tabId, targetPaneId, targetIndex, node) => {
+        // Ticket 20: mirrors `dropOnTabStrip`'s own node-kind resolution -
+        // dropping a node already open in a DIFFERENT pane routes through
+        // `moveTabAcrossPanes` there, remounting that pane's painted tile
+        // exactly like an explicit cross-pane drag (and, if it empties its
+        // source pane, can also dissolve a sibling's parent group). Flush
+        // both before `set()` commits the move.
+        const before = canvasForExistingTab(get(), tabId);
+        if (before !== null) {
+          const existing = findPaneTabByContentId(before, node.id);
+          if (existing !== null && existing.pane.id !== targetPaneId) {
+            flushChatTabViewportHandoff([
+              existing.instanceId,
+              ...(existing.pane.tabInstanceIds.length === 1
+                ? paneRemovalDissolveHandoffTargets(
+                    before.root,
+                    existing.pane.id,
+                  )
+                : []),
+            ]);
+          }
+        }
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             dropOnTabStrip(
@@ -1929,6 +1971,24 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       moveTabOnTabStrip: (tabId, args) => {
         const before = canvasForExistingTab(get(), tabId);
         const node = before?.tilesByInstanceId[args.tabId];
+        // Ticket 20: a cross-pane move remounts the dragged tab's painted
+        // chat (the keyed layer moves from the source `TabGroupView` to the
+        // target one - `moveTabAcrossPanes`). When the dragged tab was its
+        // source pane's only tab, that pane also closes and can dissolve its
+        // parent group, remounting a SIBLING pane too. Flush both before
+        // `set()` commits. A same-pane reorder never remounts anything.
+        if (before !== null && args.sourcePaneId !== args.targetPaneId) {
+          const sourcePane = findPaneById(before.root, args.sourcePaneId);
+          flushChatTabViewportHandoff([
+            args.tabId,
+            ...(sourcePane !== null && sourcePane.tabInstanceIds.length === 1
+              ? paneRemovalDissolveHandoffTargets(
+                  before.root,
+                  args.sourcePaneId,
+                )
+              : []),
+          ]);
+        }
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => {
             const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
@@ -1977,6 +2037,42 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
 
       splitPaneWithNode: (tabId, targetPaneId, position, node) => {
         const before = canvasForExistingTab(get(), tabId);
+        // Ticket 20 (review round 1, finding 1): when the target pane's
+        // parent group runs perpendicular to `position` (or the target is
+        // the bare root pane), inserting beside it WRAPS the target instead
+        // of a flat insertion (`insertPaneAtEdge`) - the target's own
+        // painted chat remounts even though this call never touches its
+        // content. Flushing its active tab's viewport unconditionally is
+        // cheap and correct either way (a flat, non-wrapping insertion
+        // leaves it mounted, and the flush is simply harmless there).
+        //
+        // Separately: `splitPaneAtEdge` (actions.ts) resolves a `node`
+        // source whose content is ALREADY OPEN somewhere into a `tab`-kind
+        // move BEFORE doing anything else - the same "already open"
+        // resolution `insertNodeOnTabStrip`/`dropOnTabStrip` perform, but
+        // this call creates a BRAND NEW pane for the moved tab unconditionally
+        // (`createPaneWithTab`), regardless of whether the existing tab's
+        // source pane is the same as `targetPaneId` - so the moved instance
+        // always remounts, not just on a genuine cross-pane move. When its
+        // source pane empties (and isn't the target itself - the
+        // `splitsIntoItself` case deliberately keeps that pane alive as the
+        // split's other half instead of dissolving it), flush the promoted
+        // dissolve survivors too.
+        if (before !== null) {
+          const targetPane = findPaneById(before.root, targetPaneId);
+          const existing = findPaneTabByContentId(before, node.id);
+          flushChatTabViewportHandoff([
+            ...(targetPane !== null && targetPane.activeTabId !== null
+              ? [targetPane.activeTabId]
+              : []),
+            ...(existing !== null ? [existing.instanceId] : []),
+            ...(existing !== null &&
+            existing.pane.tabInstanceIds.length === 1 &&
+            existing.pane.id !== targetPaneId
+              ? paneRemovalDissolveHandoffTargets(before.root, existing.pane.id)
+              : []),
+          ]);
+        }
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             splitPaneAtEdge(canvas, targetPaneId, position, {
@@ -2010,6 +2106,31 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       splitPaneWithTab: (tabId, args) => {
         const before = canvasForExistingTab(get(), tabId);
         const node = before?.tilesByInstanceId[args.tabId];
+        // Ticket 20: the dragged tab always lands in a brand-new pane
+        // (`createPaneWithTab` inside `splitPaneAtEdge`) - it remounts
+        // unconditionally, unlike a same-pane/same-axis flat split of a
+        // DIFFERENT tab. The target pane can also wrap (see
+        // `splitPaneWithNode`'s comment) and, when the drag emptied its
+        // source pane, that pane's own close can dissolve a THIRD pane's
+        // parent. Flush all three defensively before `set()`.
+        if (before !== null) {
+          const targetPane = findPaneById(before.root, args.targetPaneId);
+          const sourcePane = findPaneById(before.root, args.sourcePaneId);
+          flushChatTabViewportHandoff([
+            args.tabId,
+            ...(targetPane !== null && targetPane.activeTabId !== null
+              ? [targetPane.activeTabId]
+              : []),
+            ...(sourcePane !== null &&
+            sourcePane.tabInstanceIds.length === 1 &&
+            args.sourcePaneId !== args.targetPaneId
+              ? paneRemovalDissolveHandoffTargets(
+                  before.root,
+                  args.sourcePaneId,
+                )
+              : []),
+          ]);
+        }
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => {
             const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
@@ -2045,6 +2166,16 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
 
       splitPaneEmptyInTab: (tabId, targetPaneId, direction) => {
         let newPaneId: string | null = null;
+        // Ticket 20: an empty placeholder pane can still WRAP the target
+        // (same `insertPaneAtEdge` mechanism as `splitPaneWithNode`), even
+        // though this action opens no content of its own.
+        const before = canvasForExistingTab(get(), tabId);
+        if (before !== null) {
+          const targetPane = findPaneById(before.root, targetPaneId);
+          if (targetPane !== null && targetPane.activeTabId !== null) {
+            flushChatTabViewportHandoff([targetPane.activeTabId]);
+          }
+        }
         set((state) => {
           const tab = state.tabsById[tabId];
           if (tab === undefined) return state;
@@ -2078,6 +2209,18 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
 
       closeCanvasTab: (tabId, paneId, tileTabId) => {
         const beforeCanvas = get().canvasByTabId[tabId];
+        // Ticket 20: closing a pane's LAST tab removes the pane itself
+        // (`closeTab` falls through to `closePane`), which can dissolve its
+        // parent group and remount a sibling's painted chat. Predict this
+        // BEFORE `set()`, from the state as it stands right now.
+        if (beforeCanvas !== undefined) {
+          const pane = findPaneById(beforeCanvas.root, paneId);
+          if (pane !== null && pane.tabInstanceIds.length === 1) {
+            flushChatTabViewportHandoff(
+              paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
+            );
+          }
+        }
         // `tileTabId` is a tab instanceId; pendingCreate tracking is keyed by
         // content id, so resolve the closed tab's content id before clearing.
         set((state) => {
@@ -2147,6 +2290,16 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
 
       closeAllCanvasTabs: (tabId, paneId) => {
         const beforeCanvas = get().canvasByTabId[tabId];
+        // Ticket 20: `closeAllTabs` always falls through to `closePane` for
+        // a non-empty pane - same dissolve risk as `closeCanvasTab`.
+        if (beforeCanvas !== undefined) {
+          const pane = findPaneById(beforeCanvas.root, paneId);
+          if (pane !== null && pane.tabInstanceIds.length > 0) {
+            flushChatTabViewportHandoff(
+              paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
+            );
+          }
+        }
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             closeAllTabs(canvas, paneId),
@@ -2165,6 +2318,13 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
 
       closeCanvasPane: (tabId, paneId) => {
         const beforeCanvas = get().canvasByTabId[tabId];
+        // Ticket 20: same dissolve risk as `closeCanvasTab`/`closeAllCanvasTabs`
+        // - `closePane` always removes the whole pane.
+        if (beforeCanvas !== undefined) {
+          flushChatTabViewportHandoff(
+            paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
+          );
+        }
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => closePane(canvas, paneId)),
         );

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -98,6 +98,7 @@ import {
 import {
   findPaneById,
   paneRemovalDissolveHandoffTargets,
+  resolveActivePaneTab,
 } from "@/stores/epics/canvas/tile-tree";
 import {
   isOpenableEpicNodeKind,
@@ -2145,11 +2146,16 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           // dissolve survivors too.
           if (before !== null) {
             const targetPane = findPaneById(before.root, targetPaneId);
+            const targetInstanceId =
+              targetPane === null
+                ? null
+                : resolveActivePaneTab(
+                    targetPane.activeTabId,
+                    targetPane.tabInstanceIds,
+                  );
             const existing = findPaneTabByContentId(before, node.id);
             flushChatTabViewportHandoff([
-              ...(targetPane !== null && targetPane.activeTabId !== null
-                ? [targetPane.activeTabId]
-                : []),
+              ...(targetInstanceId === null ? [] : [targetInstanceId]),
               ...(existing !== null ? [existing.instanceId] : []),
               ...(existing !== null &&
               existing.pane.tabInstanceIds.length === 1 &&
@@ -2203,12 +2209,17 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           // parent. Flush all three defensively before `set()`.
           if (before !== null) {
             const targetPane = findPaneById(before.root, args.targetPaneId);
+            const targetInstanceId =
+              targetPane === null
+                ? null
+                : resolveActivePaneTab(
+                    targetPane.activeTabId,
+                    targetPane.tabInstanceIds,
+                  );
             const sourcePane = findPaneById(before.root, args.sourcePaneId);
             flushChatTabViewportHandoff([
               args.tabId,
-              ...(targetPane !== null && targetPane.activeTabId !== null
-                ? [targetPane.activeTabId]
-                : []),
+              ...(targetInstanceId === null ? [] : [targetInstanceId]),
               ...(sourcePane !== null &&
               sourcePane.tabInstanceIds.length === 1 &&
               args.sourcePaneId !== args.targetPaneId
@@ -2260,8 +2271,15 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           const before = canvasForExistingTab(get(), tabId);
           if (before !== null) {
             const targetPane = findPaneById(before.root, targetPaneId);
-            if (targetPane !== null && targetPane.activeTabId !== null) {
-              flushChatTabViewportHandoff([targetPane.activeTabId]);
+            const targetInstanceId =
+              targetPane === null
+                ? null
+                : resolveActivePaneTab(
+                    targetPane.activeTabId,
+                    targetPane.tabInstanceIds,
+                  );
+            if (targetInstanceId !== null) {
+              flushChatTabViewportHandoff([targetInstanceId]);
             }
           }
           set((state) => {

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -1227,782 +1227,933 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         useEpicCanvasStore.setState(partial, undefined);
       };
       return {
-      tabsById: {},
-      canvasByTabId: {},
-      closedTilePayloadsByTabId: {},
-      openTabOrder: [],
-      activeTabId: null,
-      mostRecentTabIdByEpicId: {},
-      artifactTreeByEpicId: EMPTY_TREES,
-      selfDeletedArtifactIds: new Set<string>(),
-      pendingCreateArtifactIds: new Set<string>(),
-      preAckRootCreatesByEpic: {},
-      pendingRootCreatesByEpic: {},
-      pendingEpicTitles: {},
-      pendingChatTitles: {},
+        tabsById: {},
+        canvasByTabId: {},
+        closedTilePayloadsByTabId: {},
+        openTabOrder: [],
+        activeTabId: null,
+        mostRecentTabIdByEpicId: {},
+        artifactTreeByEpicId: EMPTY_TREES,
+        selfDeletedArtifactIds: new Set<string>(),
+        pendingCreateArtifactIds: new Set<string>(),
+        preAckRootCreatesByEpic: {},
+        pendingRootCreatesByEpic: {},
+        pendingEpicTitles: {},
+        pendingChatTitles: {},
 
-      openEpicTab: (epicId, name) => {
-        const tab = createEpicViewTab(epicId, name);
-        set((state) => ({
-          ...appendedEpicTabState(state, tab),
-          activeTabId: tab.tabId,
-        }));
-        return tab.tabId;
-      },
+        openEpicTab: (epicId, name) => {
+          const tab = createEpicViewTab(epicId, name);
+          set((state) => ({
+            ...appendedEpicTabState(state, tab),
+            activeTabId: tab.tabId,
+          }));
+          return tab.tabId;
+        },
 
-      openEpicTabWithId: (tabId, epicId, name) => {
-        // `closeTab` preserves the record in `tabsById` so the tab can be
-        // reopened, which means an existing record is NOT the same thing as an
-        // open tab. Returning the id without revealing it hands the caller a
-        // ref that `tabSourceRefs()` does not back, and strip reconciliation
-        // then deletes the layout item the caller just placed. `setActiveTab`
-        // re-pushes onto `openTabOrder` and no-ops when already open + active.
-        if (get().tabsById[tabId] !== undefined) {
-          get().setActiveTab(tabId);
-          return tabId;
-        }
-        const tab: EpicViewTab = {
-          tabId,
-          epicId,
-          name: name ?? UNTITLED_EPIC_TITLE,
-        };
-        set((state) => ({
-          ...appendedEpicTabState(state, tab),
-          activeTabId: tab.tabId,
-        }));
-        return tab.tabId;
-      },
-
-      openPhaseMigrationTabWithId: (tabId, phaseId, name) => {
-        const existingId = resolveTabIdForPhaseMigration(get(), phaseId);
-        if (existingId !== null) {
-          get().setActiveTab(existingId);
-          return existingId;
-        }
-        const existing = get().tabsById[tabId];
-        if (existing !== undefined) return existing.tabId;
-        const tab: EpicViewTab = {
-          tabId,
-          epicId: phaseId,
-          name: name ?? UNTITLED_EPIC_TITLE,
-          surfaceMode: { kind: "phase-migration", phaseId },
-        };
-        set((state) => ({
-          ...appendedEpicTabState(state, tab),
-          activeTabId: tab.tabId,
-        }));
-        return tab.tabId;
-      },
-
-      openEpicTabInBackground: (epicId, name) => {
-        const existing = resolveTabIdForEpic(get(), epicId);
-        if (existing !== null) {
-          // Reveal a preserved-but-hidden tab in the strip without activating
-          // it; an already-visible tab is left exactly where it is. The
-          // functional updater is the single guard - it no-ops (returns the
-          // same state, which Zustand bails on) when the tab is already shown.
-          set((current) =>
-            current.openTabOrder.includes(existing)
-              ? current
-              : { openTabOrder: [...current.openTabOrder, existing] },
-          );
-          return existing;
-        }
-        const tab = createEpicViewTab(epicId, name);
-        // activeTabId is intentionally left untouched - the tab opens behind
-        // the current surface and never steals focus.
-        set((current) => appendedEpicTabState(current, tab));
-        return tab.tabId;
-      },
-
-      closeTab: (tabId) => {
-        if (isTabCloseLocked({ kind: "epic", id: tabId })) return;
-        set((state) => {
-          const tab = state.tabsById[tabId];
-          if (tab === undefined) return state;
-          const openTabOrder = state.openTabOrder.filter((id) => id !== tabId);
-          const activeTabId =
-            state.activeTabId === tabId
-              ? nextOpenTabAfterClose(state.openTabOrder, tabId)
-              : state.activeTabId;
-          // The tab record stays untouched in `tabsById` (preserved for reopen);
-          // hiding only updates order/active/recent pointers.
-          return {
-            openTabOrder,
-            activeTabId,
-            mostRecentTabIdByEpicId: {
-              ...state.mostRecentTabIdByEpicId,
-              [tab.epicId]: tabId,
-            },
+        openEpicTabWithId: (tabId, epicId, name) => {
+          // `closeTab` preserves the record in `tabsById` so the tab can be
+          // reopened, which means an existing record is NOT the same thing as an
+          // open tab. Returning the id without revealing it hands the caller a
+          // ref that `tabSourceRefs()` does not back, and strip reconciliation
+          // then deletes the layout item the caller just placed. `setActiveTab`
+          // re-pushes onto `openTabOrder` and no-ops when already open + active.
+          if (get().tabsById[tabId] !== undefined) {
+            get().setActiveTab(tabId);
+            return tabId;
+          }
+          const tab: EpicViewTab = {
+            tabId,
+            epicId,
+            name: name ?? UNTITLED_EPIC_TITLE,
           };
-        });
-      },
+          set((state) => ({
+            ...appendedEpicTabState(state, tab),
+            activeTabId: tab.tabId,
+          }));
+          return tab.tabId;
+        },
 
-      closeTabsForEpics: (epicIds) => {
-        const targetEpicIds = new Set(epicIds);
-        if (targetEpicIds.size === 0) return;
-        // Cancel any in-flight epic-title backstop timers so a deletion
-        // can't strand a 30s no-op timer in the map.
-        for (const epicId of targetEpicIds) {
-          clearScheduledTitlePending(epicTitleTimers, epicId);
-        }
-        set((state) => {
-          const removedTabIds = new Set(
-            Object.keys(state.tabsById).filter((tabId) => {
-              const tab = state.tabsById[tabId];
-              return tab !== undefined && targetEpicIds.has(tab.epicId);
-            }),
-          );
-          if (removedTabIds.size === 0) return state;
-          const openTabOrder = state.openTabOrder.filter(
-            (tabId) => !removedTabIds.has(tabId),
-          );
-          return {
-            tabsById: withoutTabIds(state.tabsById, removedTabIds),
-            canvasByTabId: withoutCanvasByTabIds(
-              state.canvasByTabId,
-              removedTabIds,
-            ),
-            closedTilePayloadsByTabId: withoutClosedTilePayloadsByTabIds(
-              state.closedTilePayloadsByTabId,
-              removedTabIds,
-            ),
-            openTabOrder,
-            activeTabId: nextOpenTabAfterBulkClose(
-              state.openTabOrder,
-              state.activeTabId,
-              removedTabIds,
-            ),
-            mostRecentTabIdByEpicId: withoutRecentTabIds(
-              state.mostRecentTabIdByEpicId,
-              removedTabIds,
-            ),
-            artifactTreeByEpicId: Object.fromEntries(
-              Object.entries(state.artifactTreeByEpicId).filter(
-                ([epicId]) => !targetEpicIds.has(epicId),
-              ),
-            ),
-            preAckRootCreatesByEpic: Object.fromEntries(
-              Object.entries(state.preAckRootCreatesByEpic).filter(
-                ([epicId]) => !targetEpicIds.has(epicId),
-              ),
-            ),
-            pendingRootCreatesByEpic: Object.fromEntries(
-              Object.entries(state.pendingRootCreatesByEpic).filter(
-                ([epicId]) => !targetEpicIds.has(epicId),
-              ),
-            ),
-            pendingEpicTitles: Object.fromEntries(
-              Object.entries(state.pendingEpicTitles).filter(
-                ([epicId]) => !targetEpicIds.has(epicId),
-              ),
-            ),
+        openPhaseMigrationTabWithId: (tabId, phaseId, name) => {
+          const existingId = resolveTabIdForPhaseMigration(get(), phaseId);
+          if (existingId !== null) {
+            get().setActiveTab(existingId);
+            return existingId;
+          }
+          const existing = get().tabsById[tabId];
+          if (existing !== undefined) return existing.tabId;
+          const tab: EpicViewTab = {
+            tabId,
+            epicId: phaseId,
+            name: name ?? UNTITLED_EPIC_TITLE,
+            surfaceMode: { kind: "phase-migration", phaseId },
           };
-        });
-      },
+          set((state) => ({
+            ...appendedEpicTabState(state, tab),
+            activeTabId: tab.tabId,
+          }));
+          return tab.tabId;
+        },
 
-      closeOtherTabs: (tabId) => {
-        set((state) => {
-          const keep = state.tabsById[tabId];
-          if (keep === undefined) return state;
-          // Hidden tabs stay in `tabsById` untouched (preserved for reopen);
-          // only order/active/recent change.
-          return {
-            openTabOrder: [tabId],
-            activeTabId: tabId,
-            mostRecentTabIdByEpicId: {
-              ...state.mostRecentTabIdByEpicId,
-              [keep.epicId]: tabId,
-            },
-          };
-        });
-      },
+        openEpicTabInBackground: (epicId, name) => {
+          const existing = resolveTabIdForEpic(get(), epicId);
+          if (existing !== null) {
+            // Reveal a preserved-but-hidden tab in the strip without activating
+            // it; an already-visible tab is left exactly where it is. The
+            // functional updater is the single guard - it no-ops (returns the
+            // same state, which Zustand bails on) when the tab is already shown.
+            set((current) =>
+              current.openTabOrder.includes(existing)
+                ? current
+                : { openTabOrder: [...current.openTabOrder, existing] },
+            );
+            return existing;
+          }
+          const tab = createEpicViewTab(epicId, name);
+          // activeTabId is intentionally left untouched - the tab opens behind
+          // the current surface and never steals focus.
+          set((current) => appendedEpicTabState(current, tab));
+          return tab.tabId;
+        },
 
-      moveOpenTab: (tabId, targetIndex) => {
-        if (isTabStructurallyLocked({ kind: "epic", id: tabId })) return;
-        set((state) => {
-          const next = moveId(state.openTabOrder, tabId, targetIndex);
-          return next === state.openTabOrder ? state : { openTabOrder: next };
-        });
-      },
-
-      duplicateTab: (tabId) => {
-        if (isTabStructurallyLocked({ kind: "epic", id: tabId })) {
-          return null;
-        }
-        const state = get();
-        const source = state.tabsById[tabId];
-        if (source === undefined) return null;
-        if (source.surfaceMode?.kind === "phase-migration") return null;
-        const newId = uuidv4();
-        const siblingNames = epicTabNames(state.tabsById, source.epicId);
-        const sourceCanvas = state.canvasByTabId[tabId] ?? createEmptyCanvas();
-        const newTab: EpicViewTab = {
-          tabId: newId,
-          epicId: source.epicId,
-          name: nextCopyName(source.name, siblingNames),
-        };
-        set((current) => {
-          const insertAt = current.openTabOrder.indexOf(tabId) + 1;
-          return {
-            tabsById: { ...current.tabsById, [newId]: newTab },
-            canvasByTabId: {
-              ...current.canvasByTabId,
-              [newId]: cloneEpicCanvasState(sourceCanvas),
-            },
-            openTabOrder: [
-              ...current.openTabOrder.slice(0, insertAt),
-              newId,
-              ...current.openTabOrder.slice(insertAt),
-            ],
-            activeTabId: newId,
-            mostRecentTabIdByEpicId: {
-              ...current.mostRecentTabIdByEpicId,
-              [newTab.epicId]: newId,
-            },
-          };
-        });
-        return newId;
-      },
-
-      openTileInNewTab: (epicId, node, insertIndex) => {
-        const state = get();
-        const sourceTabId = resolveTabIdForEpic(state, epicId);
-        const sourceTab =
-          sourceTabId === null ? null : (state.tabsById[sourceTabId] ?? null);
-        const tabId = uuidv4();
-        const siblingNames = epicTabNames(state.tabsById, epicId);
-        const tabName =
-          sourceTab === null
-            ? node.name
-            : nextCopyName(sourceTab.name, siblingNames);
-        const tab: EpicViewTab = {
-          tabId,
-          epicId,
-          name: tabName,
-        };
-        set((current) => {
-          const insertAt =
-            insertIndex === null
-              ? current.openTabOrder.length
-              : Math.max(0, Math.min(insertIndex, current.openTabOrder.length));
-          return {
-            tabsById: { ...current.tabsById, [tabId]: tab },
-            canvasByTabId: {
-              ...current.canvasByTabId,
-              [tabId]: createSingleTileCanvas(node),
-            },
-            openTabOrder: [
-              ...current.openTabOrder.slice(0, insertAt),
-              tabId,
-              ...current.openTabOrder.slice(insertAt),
-            ],
-            activeTabId: tabId,
-            mostRecentTabIdByEpicId: {
-              ...current.mostRecentTabIdByEpicId,
-              [epicId]: tabId,
-            },
-          };
-        });
-        const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
-        if (analyticsTarget !== null) {
-          Analytics.getInstance().track(AnalyticsEvent.TabCreated, {
-            target: analyticsTarget,
-          });
-        }
-        return tabId;
-      },
-
-      tearOffTabIntoNewHeaderTab: (args) => {
-        const state = get();
-        const sourceTab = state.tabsById[args.sourceTabId];
-        if (sourceTab === undefined) return null;
-        const sourceCanvas =
-          state.canvasByTabId[args.sourceTabId] ?? EMPTY_CANVAS;
-        const pane = findPaneById(sourceCanvas.root, args.sourcePaneId);
-        const node =
-          pane !== null && pane.tabInstanceIds.includes(args.sourceTileTabId)
-            ? (sourceCanvas.tilesByInstanceId[args.sourceTileTabId] ?? null)
-            : null;
-        if (pane === null || node === null) return null;
-        // Ticket 20: the torn-off tile always remounts - it moves from the
-        // source header tab's canvas root into a brand-new header tab's
-        // canvas root, a completely different React parent chain (MOVE
-        // semantics, same instanceId - see the corrected comment at
-        // `commitHeaderStripDrop`'s call site). When it was its source
-        // pane's only tab, `closeTileTab` below falls through to
-        // `closePane`, which can also dissolve that pane's parent group and
-        // remount a sibling. Flush both before `set()` commits the move.
-        flushChatTabViewportHandoff([
-          args.sourceTileTabId,
-          ...(pane.tabInstanceIds.length === 1
-            ? paneRemovalDissolveHandoffTargets(
-                sourceCanvas.root,
-                args.sourcePaneId,
-              )
-            : []),
-        ]);
-        const newId = uuidv4();
-        const siblingNames = epicTabNames(state.tabsById, sourceTab.epicId);
-        const newTab: EpicViewTab = {
-          tabId: newId,
-          epicId: sourceTab.epicId,
-          name: nextCopyName(sourceTab.name, siblingNames),
-        };
-        set((current) => {
-          const currentSource = current.tabsById[args.sourceTabId];
-          if (currentSource === undefined) return current;
-          const currentSourceCanvas =
-            current.canvasByTabId[args.sourceTabId] ?? EMPTY_CANVAS;
-          const insertAt = Math.max(
-            0,
-            Math.min(args.insertIndex, current.openTabOrder.length),
-          );
-          return {
-            tabsById: {
-              ...current.tabsById,
-              [newId]: newTab,
-            },
-            canvasByTabId: {
-              ...current.canvasByTabId,
-              [args.sourceTabId]: closeTileTab(
-                currentSourceCanvas,
-                args.sourcePaneId,
-                args.sourceTileTabId,
-              ),
-              [newId]: createSingleTileCanvas(node),
-            },
-            openTabOrder: [
-              ...current.openTabOrder.slice(0, insertAt),
-              newId,
-              ...current.openTabOrder.slice(insertAt),
-            ],
-            activeTabId: newId,
-            mostRecentTabIdByEpicId: {
-              ...current.mostRecentTabIdByEpicId,
-              [newTab.epicId]: newId,
-            },
-          };
-        });
-        const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
-        if (analyticsTarget !== null) {
-          Analytics.getInstance().track(AnalyticsEvent.TabMoved, {
-            target: analyticsTarget,
-          });
-        }
-        return newId;
-      },
-
-      setActiveTab: (tabId) => {
-        set((state) => {
-          const tab = state.tabsById[tabId];
-          if (tab === undefined) return state;
-          const isOpen = state.openTabOrder.includes(tabId);
-          if (state.activeTabId === tabId && isOpen) return state;
-          // Activation only moves order/active/recent pointers; the tab record
-          // stays stable so header-strip / command-palette consumers (which read
-          // tab metadata) don't re-render on every tab switch.
-          return {
-            openTabOrder: isOpen
-              ? state.openTabOrder
-              : [...state.openTabOrder, tabId],
-            activeTabId: tabId,
-            mostRecentTabIdByEpicId: {
-              ...state.mostRecentTabIdByEpicId,
-              [tab.epicId]: tabId,
-            },
-          };
-        });
-      },
-
-      renameTab: (tabId, name) => {
-        const trimmed = name.trim();
-        if (trimmed.length === 0) return;
-        set((state) => {
-          const tab = state.tabsById[tabId];
-          if (tab === undefined || tab.name === trimmed) return state;
-          return {
-            tabsById: {
-              ...state.tabsById,
-              [tabId]: { ...tab, name: trimmed },
-            },
-          };
-        });
-      },
-
-      discardTabState: (tabId) => {
-        if (isTabStructurallyLocked({ kind: "epic", id: tabId })) {
-          return null;
-        }
-        const tab = get().tabsById[tabId];
-        if (tab === undefined) return null;
-        set((state) => {
-          const removed = new Set([tabId]);
-          return {
-            tabsById: withoutTabIds(state.tabsById, removed),
-            canvasByTabId: withoutCanvasByTabIds(state.canvasByTabId, removed),
-            closedTilePayloadsByTabId: withoutClosedTilePayloadsByTabIds(
-              state.closedTilePayloadsByTabId,
-              removed,
-            ),
-            openTabOrder: state.openTabOrder.filter((id) => id !== tabId),
-            activeTabId:
+        closeTab: (tabId) => {
+          if (isTabCloseLocked({ kind: "epic", id: tabId })) return;
+          set((state) => {
+            const tab = state.tabsById[tabId];
+            if (tab === undefined) return state;
+            const openTabOrder = state.openTabOrder.filter(
+              (id) => id !== tabId,
+            );
+            const activeTabId =
               state.activeTabId === tabId
                 ? nextOpenTabAfterClose(state.openTabOrder, tabId)
-                : state.activeTabId,
-            mostRecentTabIdByEpicId: withoutRecentTabIds(
-              state.mostRecentTabIdByEpicId,
-              removed,
-            ),
-          };
-        });
-        return {
-          epicTabs: projectTabsForDesktop(get()),
-          activeTabId: get().activeTabId,
-          canvasByTabId: { [tabId]: null },
-        };
-      },
+                : state.activeTabId;
+            // The tab record stays untouched in `tabsById` (preserved for reopen);
+            // hiding only updates order/active/recent pointers.
+            return {
+              openTabOrder,
+              activeTabId,
+              mostRecentTabIdByEpicId: {
+                ...state.mostRecentTabIdByEpicId,
+                [tab.epicId]: tabId,
+              },
+            };
+          });
+        },
 
-      resolveTargetTabForEpic: (epicId, name) => {
-        const state = get();
-        const existing = resolveTabIdForEpic(state, epicId);
-        if (existing !== null) {
-          if (!state.openTabOrder.includes(existing)) {
-            state.setActiveTab(existing);
+        closeTabsForEpics: (epicIds) => {
+          const targetEpicIds = new Set(epicIds);
+          if (targetEpicIds.size === 0) return;
+          // Cancel any in-flight epic-title backstop timers so a deletion
+          // can't strand a 30s no-op timer in the map.
+          for (const epicId of targetEpicIds) {
+            clearScheduledTitlePending(epicTitleTimers, epicId);
           }
-          return existing;
-        }
-        // Caller-supplied name comes from the row the user clicked on
-        // (history list, command palette, deep link). Falls back to
-        // "Untitled task" only when the caller has no title in hand.
-        return state.openEpicTab(epicId, name ?? UNTITLED_EPIC_TITLE);
-      },
-
-      resolveTabIdForEpic: (epicId) => resolveTabIdForEpic(get(), epicId),
-
-      openTileInTab: (tabId, node) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            openTile(canvas, node, false, null),
-          ),
-        );
-      },
-
-      prepareOpenTileInTabFocusTarget: (tabId, node) => {
-        get().openTileInTab(tabId, node);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        return after;
-      },
-
-      prepareOpenTileInTabFocusTargetFromSource: (tabId, node, source) => {
-        const before = canvasForExistingTab(get(), tabId);
-        get().openTileInTab(tabId, node);
-        const canvas = canvasForExistingTab(get(), tabId);
-        if (before !== canvas) trackOpenedCanvasTile(node, source);
-        return currentNestedFocusTargetForTab(get(), tabId);
-      },
-
-      openTilePreviewInTab: (tabId, node) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            openTile(canvas, node, true, null),
-          ),
-        );
-      },
-
-      prepareOpenTilePreviewInTabFocusTarget: (tabId, node) => {
-        get().openTilePreviewInTab(tabId, node);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        return after;
-      },
-
-      prepareOpenTilePreviewInTabFocusTargetFromSource: (
-        tabId,
-        node,
-        source,
-      ) => {
-        const before = canvasForExistingTab(get(), tabId);
-        get().openTilePreviewInTab(tabId, node);
-        const canvas = canvasForExistingTab(get(), tabId);
-        if (before !== canvas) trackOpenedCanvasTile(node, source);
-        return currentNestedFocusTargetForTab(get(), tabId);
-      },
-
-      restoreClosedTilePreview: (tabId, preferredPaneId, node) => {
-        set((state) => {
-          const forTab = state.closedTilePayloadsByTabId[tabId];
-          const restoredPayload = forTab?.[node.instanceId];
-          const withoutRestored =
-            forTab === undefined || restoredPayload === undefined
-              ? state.closedTilePayloadsByTabId
-              : {
-                  ...state.closedTilePayloadsByTabId,
-                  [tabId]: withoutClosedTilePayload(forTab, node.instanceId),
-                };
-          const pendingCreateArtifactIds = restoredPayload?.pendingCreate
-            ? withId(state.pendingCreateArtifactIds, node.id)
-            : state.pendingCreateArtifactIds;
-          // Strip the entry being restored BEFORE the canvas update runs its
-          // own eviction-capture: capturing against a map that still counts
-          // the restored entry can push a same-transaction preview eviction
-          // (e.g. the destination pane's prior preview) past the per-tab FIFO
-          // cap and needlessly evict an unrelated payload.
-          const baseState = {
-            ...state,
-            closedTilePayloadsByTabId: withoutRestored,
-            pendingCreateArtifactIds,
-          };
-          const canvasUpdate = updateTabCanvas(baseState, tabId, (canvas) =>
-            restoreTilePreviewCanvas(canvas, node, preferredPaneId),
-          );
-          if (canvasUpdate === baseState) {
-            return withoutRestored === state.closedTilePayloadsByTabId
-              ? state
-              : { closedTilePayloadsByTabId: withoutRestored };
-          }
-          return pendingCreateArtifactIds === state.pendingCreateArtifactIds
-            ? canvasUpdate
-            : { ...canvasUpdate, pendingCreateArtifactIds };
-        });
-      },
-
-      discardClosedTilePayload: (tabId, instanceId) => {
-        set((state) => {
-          const forTab = state.closedTilePayloadsByTabId[tabId];
-          if (forTab === undefined || forTab[instanceId] === undefined) {
-            return state;
-          }
-          return {
-            closedTilePayloadsByTabId: {
-              ...state.closedTilePayloadsByTabId,
-              [tabId]: withoutClosedTilePayload(forTab, instanceId),
-            },
-          };
-        });
-      },
-
-      openTileInBackgroundTab: (tabId, node) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            openTileInBackgroundTabCanvas(canvas, node),
-          ),
-        );
-      },
-
-      prepareOpenTileInBackgroundTabFocusTarget: (tabId, node) => {
-        get().openTileInBackgroundTab(tabId, node);
-        return null;
-      },
-
-      prepareOpenTileInBackgroundTabFocusTargetFromSource: (
-        tabId,
-        node,
-        source,
-      ) => {
-        const before = canvasForExistingTab(get(), tabId);
-        get().openTileInBackgroundTab(tabId, node);
-        const after = canvasForExistingTab(get(), tabId);
-        if (before !== after) trackOpenedCanvasTile(node, source);
-        return null;
-      },
-
-      openTileInPane: (tabId, paneId, ref) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            openTileInPaneCanvas(canvas, paneId, ref),
-          ),
-        );
-      },
-
-      prepareOpenTileInPaneFocusTarget: (tabId, paneId, ref) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const targetPane =
-          before === null ? null : findPaneById(before.root, paneId);
-        get().openTileInPane(tabId, paneId, ref);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = targetPane === null ? null : after;
-        return target;
-      },
-
-      prepareOpenSingletonTileInPaneFocusTarget: (tabId, paneId, ref) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const targetPane =
-          before === null ? null : findPaneById(before.root, paneId);
-        const existingSingleton =
-          before === null ? null : findPaneTabByContentId(before, ref.id);
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            openSingletonTileInPaneCanvas(canvas, paneId, ref),
-          ),
-        );
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        // A focus of an ALREADY-OPEN singleton is still a real focus target
-        // even when the requested pane is stale - the canvas focused the
-        // existing instance in ITS pane regardless. Null only when nothing
-        // could have happened: no pane to insert into AND no existing
-        // instance to focus.
-        return targetPane === null && existingSingleton === null ? null : after;
-      },
-
-      prepareOpenTileInPaneFocusTargetFromSource: (
-        tabId,
-        paneId,
-        ref,
-        source,
-      ) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const targetPane =
-          before === null ? null : findPaneById(before.root, paneId);
-        get().openTileInPane(tabId, paneId, ref);
-        const canvas = canvasForExistingTab(get(), tabId);
-        if (before !== canvas) trackOpenedCanvasTile(ref, source);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = targetPane === null ? null : after;
-        return target;
-      },
-
-      openBlankTabInPane: (tabId, paneId) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            openBlankTabInPaneCanvas(canvas, paneId),
-          ),
-        );
-      },
-
-      prepareOpenBlankTabInPaneFocusTarget: (tabId, paneId) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const targetPane =
-          before === null ? null : findPaneById(before.root, paneId);
-        get().openBlankTabInPane(tabId, paneId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = targetPane === null ? null : after;
-        return target;
-      },
-
-      updateGitDiffTileViewInTab: (tabId, tileId, view) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            updateGitDiffTileView(canvas, tileId, view),
-          ),
-        );
-      },
-
-      updateSnapshotDiffTileViewInTab: (tabId, tileId, view) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            updateSnapshotDiffTileView(canvas, tileId, view),
-          ),
-        );
-      },
-
-      updateCommGraphTileViewInTab: (tabId, tileId, view) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            updateCommGraphTileView(canvas, tileId, view),
-          ),
-        );
-      },
-
-      updatePrDiffTileViewInTab: (tabId, tileId, view) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            updatePrDiffTileView(canvas, tileId, view),
-          ),
-        );
-      },
-
-      togglePrDiffFileCollapsedInTab: (tabId, tileId, filePath) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            togglePrDiffFileCollapsed(canvas, tileId, filePath),
-          ),
-        );
-      },
-
-      toggleGitDiffBundleFileCollapsedInTab: (tabId, tileId, filePath) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            toggleGitDiffBundleFileCollapsed(canvas, tileId, filePath),
-          ),
-        );
-      },
-
-      toggleSnapshotDiffBundleFileCollapsedInTab: (tabId, tileId, filePath) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            toggleSnapshotDiffBundleFileCollapsed(canvas, tileId, filePath),
-          ),
-        );
-      },
-
-      promotePreviewInTab: (tabId, paneId) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            promotePreview(canvas, paneId),
-          ),
-        );
-      },
-
-      applyNestedRouteFocus: (tabId, target) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            target.tileInstanceId === undefined
-              ? setActivePane(canvas, target.paneId)
-              : setActiveTileTabCanvas(
-                  canvas,
-                  target.paneId,
-                  target.tileInstanceId,
+          set((state) => {
+            const removedTabIds = new Set(
+              Object.keys(state.tabsById).filter((tabId) => {
+                const tab = state.tabsById[tabId];
+                return tab !== undefined && targetEpicIds.has(tab.epicId);
+              }),
+            );
+            if (removedTabIds.size === 0) return state;
+            const openTabOrder = state.openTabOrder.filter(
+              (tabId) => !removedTabIds.has(tabId),
+            );
+            return {
+              tabsById: withoutTabIds(state.tabsById, removedTabIds),
+              canvasByTabId: withoutCanvasByTabIds(
+                state.canvasByTabId,
+                removedTabIds,
+              ),
+              closedTilePayloadsByTabId: withoutClosedTilePayloadsByTabIds(
+                state.closedTilePayloadsByTabId,
+                removedTabIds,
+              ),
+              openTabOrder,
+              activeTabId: nextOpenTabAfterBulkClose(
+                state.openTabOrder,
+                state.activeTabId,
+                removedTabIds,
+              ),
+              mostRecentTabIdByEpicId: withoutRecentTabIds(
+                state.mostRecentTabIdByEpicId,
+                removedTabIds,
+              ),
+              artifactTreeByEpicId: Object.fromEntries(
+                Object.entries(state.artifactTreeByEpicId).filter(
+                  ([epicId]) => !targetEpicIds.has(epicId),
                 ),
-          ),
-        );
-      },
+              ),
+              preAckRootCreatesByEpic: Object.fromEntries(
+                Object.entries(state.preAckRootCreatesByEpic).filter(
+                  ([epicId]) => !targetEpicIds.has(epicId),
+                ),
+              ),
+              pendingRootCreatesByEpic: Object.fromEntries(
+                Object.entries(state.pendingRootCreatesByEpic).filter(
+                  ([epicId]) => !targetEpicIds.has(epicId),
+                ),
+              ),
+              pendingEpicTitles: Object.fromEntries(
+                Object.entries(state.pendingEpicTitles).filter(
+                  ([epicId]) => !targetEpicIds.has(epicId),
+                ),
+              ),
+            };
+          });
+        },
 
-      setActiveTileTab: (tabId, paneId, tileTabId) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            setActiveTileTabCanvas(canvas, paneId, tileTabId),
-          ),
-        );
-      },
+        closeOtherTabs: (tabId) => {
+          set((state) => {
+            const keep = state.tabsById[tabId];
+            if (keep === undefined) return state;
+            // Hidden tabs stay in `tabsById` untouched (preserved for reopen);
+            // only order/active/recent change.
+            return {
+              openTabOrder: [tabId],
+              activeTabId: tabId,
+              mostRecentTabIdByEpicId: {
+                ...state.mostRecentTabIdByEpicId,
+                [keep.epicId]: tabId,
+              },
+            };
+          });
+        },
 
-      prepareSetActiveTileTabFocusTarget: (tabId, paneId, tileTabId) => {
-        get().setActiveTileTab(tabId, paneId, tileTabId);
-        const target = exactNestedFocusTargetForTab(get(), tabId, {
+        moveOpenTab: (tabId, targetIndex) => {
+          if (isTabStructurallyLocked({ kind: "epic", id: tabId })) return;
+          set((state) => {
+            const next = moveId(state.openTabOrder, tabId, targetIndex);
+            return next === state.openTabOrder ? state : { openTabOrder: next };
+          });
+        },
+
+        duplicateTab: (tabId) => {
+          if (isTabStructurallyLocked({ kind: "epic", id: tabId })) {
+            return null;
+          }
+          const state = get();
+          const source = state.tabsById[tabId];
+          if (source === undefined) return null;
+          if (source.surfaceMode?.kind === "phase-migration") return null;
+          const newId = uuidv4();
+          const siblingNames = epicTabNames(state.tabsById, source.epicId);
+          const sourceCanvas =
+            state.canvasByTabId[tabId] ?? createEmptyCanvas();
+          const newTab: EpicViewTab = {
+            tabId: newId,
+            epicId: source.epicId,
+            name: nextCopyName(source.name, siblingNames),
+          };
+          set((current) => {
+            const insertAt = current.openTabOrder.indexOf(tabId) + 1;
+            return {
+              tabsById: { ...current.tabsById, [newId]: newTab },
+              canvasByTabId: {
+                ...current.canvasByTabId,
+                [newId]: cloneEpicCanvasState(sourceCanvas),
+              },
+              openTabOrder: [
+                ...current.openTabOrder.slice(0, insertAt),
+                newId,
+                ...current.openTabOrder.slice(insertAt),
+              ],
+              activeTabId: newId,
+              mostRecentTabIdByEpicId: {
+                ...current.mostRecentTabIdByEpicId,
+                [newTab.epicId]: newId,
+              },
+            };
+          });
+          return newId;
+        },
+
+        openTileInNewTab: (epicId, node, insertIndex) => {
+          const state = get();
+          const sourceTabId = resolveTabIdForEpic(state, epicId);
+          const sourceTab =
+            sourceTabId === null ? null : (state.tabsById[sourceTabId] ?? null);
+          const tabId = uuidv4();
+          const siblingNames = epicTabNames(state.tabsById, epicId);
+          const tabName =
+            sourceTab === null
+              ? node.name
+              : nextCopyName(sourceTab.name, siblingNames);
+          const tab: EpicViewTab = {
+            tabId,
+            epicId,
+            name: tabName,
+          };
+          set((current) => {
+            const insertAt =
+              insertIndex === null
+                ? current.openTabOrder.length
+                : Math.max(
+                    0,
+                    Math.min(insertIndex, current.openTabOrder.length),
+                  );
+            return {
+              tabsById: { ...current.tabsById, [tabId]: tab },
+              canvasByTabId: {
+                ...current.canvasByTabId,
+                [tabId]: createSingleTileCanvas(node),
+              },
+              openTabOrder: [
+                ...current.openTabOrder.slice(0, insertAt),
+                tabId,
+                ...current.openTabOrder.slice(insertAt),
+              ],
+              activeTabId: tabId,
+              mostRecentTabIdByEpicId: {
+                ...current.mostRecentTabIdByEpicId,
+                [epicId]: tabId,
+              },
+            };
+          });
+          const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
+          if (analyticsTarget !== null) {
+            Analytics.getInstance().track(AnalyticsEvent.TabCreated, {
+              target: analyticsTarget,
+            });
+          }
+          return tabId;
+        },
+
+        tearOffTabIntoNewHeaderTab: (args) => {
+          const state = get();
+          const sourceTab = state.tabsById[args.sourceTabId];
+          if (sourceTab === undefined) return null;
+          const sourceCanvas =
+            state.canvasByTabId[args.sourceTabId] ?? EMPTY_CANVAS;
+          const pane = findPaneById(sourceCanvas.root, args.sourcePaneId);
+          const node =
+            pane !== null && pane.tabInstanceIds.includes(args.sourceTileTabId)
+              ? (sourceCanvas.tilesByInstanceId[args.sourceTileTabId] ?? null)
+              : null;
+          if (pane === null || node === null) return null;
+          // Ticket 20: the torn-off tile always remounts - it moves from the
+          // source header tab's canvas root into a brand-new header tab's
+          // canvas root, a completely different React parent chain (MOVE
+          // semantics, same instanceId - see the corrected comment at
+          // `commitHeaderStripDrop`'s call site). When it was its source
+          // pane's only tab, `closeTileTab` below falls through to
+          // `closePane`, which can also dissolve that pane's parent group and
+          // remount a sibling. Flush both before `set()` commits the move.
+          flushChatTabViewportHandoff([
+            args.sourceTileTabId,
+            ...(pane.tabInstanceIds.length === 1
+              ? paneRemovalDissolveHandoffTargets(
+                  sourceCanvas.root,
+                  args.sourcePaneId,
+                )
+              : []),
+          ]);
+          const newId = uuidv4();
+          const siblingNames = epicTabNames(state.tabsById, sourceTab.epicId);
+          const newTab: EpicViewTab = {
+            tabId: newId,
+            epicId: sourceTab.epicId,
+            name: nextCopyName(sourceTab.name, siblingNames),
+          };
+          set((current) => {
+            const currentSource = current.tabsById[args.sourceTabId];
+            if (currentSource === undefined) return current;
+            const currentSourceCanvas =
+              current.canvasByTabId[args.sourceTabId] ?? EMPTY_CANVAS;
+            const insertAt = Math.max(
+              0,
+              Math.min(args.insertIndex, current.openTabOrder.length),
+            );
+            return {
+              tabsById: {
+                ...current.tabsById,
+                [newId]: newTab,
+              },
+              canvasByTabId: {
+                ...current.canvasByTabId,
+                [args.sourceTabId]: closeTileTab(
+                  currentSourceCanvas,
+                  args.sourcePaneId,
+                  args.sourceTileTabId,
+                ),
+                [newId]: createSingleTileCanvas(node),
+              },
+              openTabOrder: [
+                ...current.openTabOrder.slice(0, insertAt),
+                newId,
+                ...current.openTabOrder.slice(insertAt),
+              ],
+              activeTabId: newId,
+              mostRecentTabIdByEpicId: {
+                ...current.mostRecentTabIdByEpicId,
+                [newTab.epicId]: newId,
+              },
+            };
+          });
+          const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
+          if (analyticsTarget !== null) {
+            Analytics.getInstance().track(AnalyticsEvent.TabMoved, {
+              target: analyticsTarget,
+            });
+          }
+          return newId;
+        },
+
+        setActiveTab: (tabId) => {
+          set((state) => {
+            const tab = state.tabsById[tabId];
+            if (tab === undefined) return state;
+            const isOpen = state.openTabOrder.includes(tabId);
+            if (state.activeTabId === tabId && isOpen) return state;
+            // Activation only moves order/active/recent pointers; the tab record
+            // stays stable so header-strip / command-palette consumers (which read
+            // tab metadata) don't re-render on every tab switch.
+            return {
+              openTabOrder: isOpen
+                ? state.openTabOrder
+                : [...state.openTabOrder, tabId],
+              activeTabId: tabId,
+              mostRecentTabIdByEpicId: {
+                ...state.mostRecentTabIdByEpicId,
+                [tab.epicId]: tabId,
+              },
+            };
+          });
+        },
+
+        renameTab: (tabId, name) => {
+          const trimmed = name.trim();
+          if (trimmed.length === 0) return;
+          set((state) => {
+            const tab = state.tabsById[tabId];
+            if (tab === undefined || tab.name === trimmed) return state;
+            return {
+              tabsById: {
+                ...state.tabsById,
+                [tabId]: { ...tab, name: trimmed },
+              },
+            };
+          });
+        },
+
+        discardTabState: (tabId) => {
+          if (isTabStructurallyLocked({ kind: "epic", id: tabId })) {
+            return null;
+          }
+          const tab = get().tabsById[tabId];
+          if (tab === undefined) return null;
+          set((state) => {
+            const removed = new Set([tabId]);
+            return {
+              tabsById: withoutTabIds(state.tabsById, removed),
+              canvasByTabId: withoutCanvasByTabIds(
+                state.canvasByTabId,
+                removed,
+              ),
+              closedTilePayloadsByTabId: withoutClosedTilePayloadsByTabIds(
+                state.closedTilePayloadsByTabId,
+                removed,
+              ),
+              openTabOrder: state.openTabOrder.filter((id) => id !== tabId),
+              activeTabId:
+                state.activeTabId === tabId
+                  ? nextOpenTabAfterClose(state.openTabOrder, tabId)
+                  : state.activeTabId,
+              mostRecentTabIdByEpicId: withoutRecentTabIds(
+                state.mostRecentTabIdByEpicId,
+                removed,
+              ),
+            };
+          });
+          return {
+            epicTabs: projectTabsForDesktop(get()),
+            activeTabId: get().activeTabId,
+            canvasByTabId: { [tabId]: null },
+          };
+        },
+
+        resolveTargetTabForEpic: (epicId, name) => {
+          const state = get();
+          const existing = resolveTabIdForEpic(state, epicId);
+          if (existing !== null) {
+            if (!state.openTabOrder.includes(existing)) {
+              state.setActiveTab(existing);
+            }
+            return existing;
+          }
+          // Caller-supplied name comes from the row the user clicked on
+          // (history list, command palette, deep link). Falls back to
+          // "Untitled task" only when the caller has no title in hand.
+          return state.openEpicTab(epicId, name ?? UNTITLED_EPIC_TITLE);
+        },
+
+        resolveTabIdForEpic: (epicId) => resolveTabIdForEpic(get(), epicId),
+
+        openTileInTab: (tabId, node) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              openTile(canvas, node, false, null),
+            ),
+          );
+        },
+
+        prepareOpenTileInTabFocusTarget: (tabId, node) => {
+          get().openTileInTab(tabId, node);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          return after;
+        },
+
+        prepareOpenTileInTabFocusTargetFromSource: (tabId, node, source) => {
+          const before = canvasForExistingTab(get(), tabId);
+          get().openTileInTab(tabId, node);
+          const canvas = canvasForExistingTab(get(), tabId);
+          if (before !== canvas) trackOpenedCanvasTile(node, source);
+          return currentNestedFocusTargetForTab(get(), tabId);
+        },
+
+        openTilePreviewInTab: (tabId, node) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              openTile(canvas, node, true, null),
+            ),
+          );
+        },
+
+        prepareOpenTilePreviewInTabFocusTarget: (tabId, node) => {
+          get().openTilePreviewInTab(tabId, node);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          return after;
+        },
+
+        prepareOpenTilePreviewInTabFocusTargetFromSource: (
+          tabId,
+          node,
+          source,
+        ) => {
+          const before = canvasForExistingTab(get(), tabId);
+          get().openTilePreviewInTab(tabId, node);
+          const canvas = canvasForExistingTab(get(), tabId);
+          if (before !== canvas) trackOpenedCanvasTile(node, source);
+          return currentNestedFocusTargetForTab(get(), tabId);
+        },
+
+        restoreClosedTilePreview: (tabId, preferredPaneId, node) => {
+          set((state) => {
+            const forTab = state.closedTilePayloadsByTabId[tabId];
+            const restoredPayload = forTab?.[node.instanceId];
+            const withoutRestored =
+              forTab === undefined || restoredPayload === undefined
+                ? state.closedTilePayloadsByTabId
+                : {
+                    ...state.closedTilePayloadsByTabId,
+                    [tabId]: withoutClosedTilePayload(forTab, node.instanceId),
+                  };
+            const pendingCreateArtifactIds = restoredPayload?.pendingCreate
+              ? withId(state.pendingCreateArtifactIds, node.id)
+              : state.pendingCreateArtifactIds;
+            // Strip the entry being restored BEFORE the canvas update runs its
+            // own eviction-capture: capturing against a map that still counts
+            // the restored entry can push a same-transaction preview eviction
+            // (e.g. the destination pane's prior preview) past the per-tab FIFO
+            // cap and needlessly evict an unrelated payload.
+            const baseState = {
+              ...state,
+              closedTilePayloadsByTabId: withoutRestored,
+              pendingCreateArtifactIds,
+            };
+            const canvasUpdate = updateTabCanvas(baseState, tabId, (canvas) =>
+              restoreTilePreviewCanvas(canvas, node, preferredPaneId),
+            );
+            if (canvasUpdate === baseState) {
+              return withoutRestored === state.closedTilePayloadsByTabId
+                ? state
+                : { closedTilePayloadsByTabId: withoutRestored };
+            }
+            return pendingCreateArtifactIds === state.pendingCreateArtifactIds
+              ? canvasUpdate
+              : { ...canvasUpdate, pendingCreateArtifactIds };
+          });
+        },
+
+        discardClosedTilePayload: (tabId, instanceId) => {
+          set((state) => {
+            const forTab = state.closedTilePayloadsByTabId[tabId];
+            if (forTab === undefined || forTab[instanceId] === undefined) {
+              return state;
+            }
+            return {
+              closedTilePayloadsByTabId: {
+                ...state.closedTilePayloadsByTabId,
+                [tabId]: withoutClosedTilePayload(forTab, instanceId),
+              },
+            };
+          });
+        },
+
+        openTileInBackgroundTab: (tabId, node) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              openTileInBackgroundTabCanvas(canvas, node),
+            ),
+          );
+        },
+
+        prepareOpenTileInBackgroundTabFocusTarget: (tabId, node) => {
+          get().openTileInBackgroundTab(tabId, node);
+          return null;
+        },
+
+        prepareOpenTileInBackgroundTabFocusTargetFromSource: (
+          tabId,
+          node,
+          source,
+        ) => {
+          const before = canvasForExistingTab(get(), tabId);
+          get().openTileInBackgroundTab(tabId, node);
+          const after = canvasForExistingTab(get(), tabId);
+          if (before !== after) trackOpenedCanvasTile(node, source);
+          return null;
+        },
+
+        openTileInPane: (tabId, paneId, ref) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              openTileInPaneCanvas(canvas, paneId, ref),
+            ),
+          );
+        },
+
+        prepareOpenTileInPaneFocusTarget: (tabId, paneId, ref) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const targetPane =
+            before === null ? null : findPaneById(before.root, paneId);
+          get().openTileInPane(tabId, paneId, ref);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = targetPane === null ? null : after;
+          return target;
+        },
+
+        prepareOpenSingletonTileInPaneFocusTarget: (tabId, paneId, ref) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const targetPane =
+            before === null ? null : findPaneById(before.root, paneId);
+          const existingSingleton =
+            before === null ? null : findPaneTabByContentId(before, ref.id);
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              openSingletonTileInPaneCanvas(canvas, paneId, ref),
+            ),
+          );
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          // A focus of an ALREADY-OPEN singleton is still a real focus target
+          // even when the requested pane is stale - the canvas focused the
+          // existing instance in ITS pane regardless. Null only when nothing
+          // could have happened: no pane to insert into AND no existing
+          // instance to focus.
+          return targetPane === null && existingSingleton === null
+            ? null
+            : after;
+        },
+
+        prepareOpenTileInPaneFocusTargetFromSource: (
+          tabId,
           paneId,
-          tileInstanceId: tileTabId,
-        });
-        return target;
-      },
+          ref,
+          source,
+        ) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const targetPane =
+            before === null ? null : findPaneById(before.root, paneId);
+          get().openTileInPane(tabId, paneId, ref);
+          const canvas = canvasForExistingTab(get(), tabId);
+          if (before !== canvas) trackOpenedCanvasTile(ref, source);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = targetPane === null ? null : after;
+          return target;
+        },
 
-      setActiveTilePane: (tabId, paneId) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            setActivePane(canvas, paneId),
-          ),
-        );
-      },
+        openBlankTabInPane: (tabId, paneId) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              openBlankTabInPaneCanvas(canvas, paneId),
+            ),
+          );
+        },
 
-      prepareSetActiveTilePaneFocusTarget: (tabId, paneId) => {
-        get().setActiveTilePane(tabId, paneId);
-        const target = currentNestedFocusTargetForTab(get(), tabId);
-        const returned = target?.paneId === paneId ? target : null;
-        return returned;
-      },
+        prepareOpenBlankTabInPaneFocusTarget: (tabId, paneId) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const targetPane =
+            before === null ? null : findPaneById(before.root, paneId);
+          get().openBlankTabInPane(tabId, paneId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = targetPane === null ? null : after;
+          return target;
+        },
 
-      insertNodeOnTabStrip: (tabId, targetPaneId, targetIndex, node) => {
-        // Ticket 20: mirrors `dropOnTabStrip`'s own node-kind resolution -
-        // dropping a node already open in a DIFFERENT pane routes through
-        // `moveTabAcrossPanes` there, remounting that pane's painted tile
-        // exactly like an explicit cross-pane drag (and, if it empties its
-        // source pane, can also dissolve a sibling's parent group). Flush
-        // both before `set()` commits the move.
-        const before = canvasForExistingTab(get(), tabId);
-        if (before !== null) {
-          const existing = findPaneTabByContentId(before, node.id);
-          if (existing !== null && existing.pane.id !== targetPaneId) {
+        updateGitDiffTileViewInTab: (tabId, tileId, view) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              updateGitDiffTileView(canvas, tileId, view),
+            ),
+          );
+        },
+
+        updateSnapshotDiffTileViewInTab: (tabId, tileId, view) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              updateSnapshotDiffTileView(canvas, tileId, view),
+            ),
+          );
+        },
+
+        updateCommGraphTileViewInTab: (tabId, tileId, view) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              updateCommGraphTileView(canvas, tileId, view),
+            ),
+          );
+        },
+
+        updatePrDiffTileViewInTab: (tabId, tileId, view) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              updatePrDiffTileView(canvas, tileId, view),
+            ),
+          );
+        },
+
+        togglePrDiffFileCollapsedInTab: (tabId, tileId, filePath) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              togglePrDiffFileCollapsed(canvas, tileId, filePath),
+            ),
+          );
+        },
+
+        toggleGitDiffBundleFileCollapsedInTab: (tabId, tileId, filePath) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              toggleGitDiffBundleFileCollapsed(canvas, tileId, filePath),
+            ),
+          );
+        },
+
+        toggleSnapshotDiffBundleFileCollapsedInTab: (
+          tabId,
+          tileId,
+          filePath,
+        ) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              toggleSnapshotDiffBundleFileCollapsed(canvas, tileId, filePath),
+            ),
+          );
+        },
+
+        promotePreviewInTab: (tabId, paneId) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              promotePreview(canvas, paneId),
+            ),
+          );
+        },
+
+        applyNestedRouteFocus: (tabId, target) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              target.tileInstanceId === undefined
+                ? setActivePane(canvas, target.paneId)
+                : setActiveTileTabCanvas(
+                    canvas,
+                    target.paneId,
+                    target.tileInstanceId,
+                  ),
+            ),
+          );
+        },
+
+        setActiveTileTab: (tabId, paneId, tileTabId) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              setActiveTileTabCanvas(canvas, paneId, tileTabId),
+            ),
+          );
+        },
+
+        prepareSetActiveTileTabFocusTarget: (tabId, paneId, tileTabId) => {
+          get().setActiveTileTab(tabId, paneId, tileTabId);
+          const target = exactNestedFocusTargetForTab(get(), tabId, {
+            paneId,
+            tileInstanceId: tileTabId,
+          });
+          return target;
+        },
+
+        setActiveTilePane: (tabId, paneId) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              setActivePane(canvas, paneId),
+            ),
+          );
+        },
+
+        prepareSetActiveTilePaneFocusTarget: (tabId, paneId) => {
+          get().setActiveTilePane(tabId, paneId);
+          const target = currentNestedFocusTargetForTab(get(), tabId);
+          const returned = target?.paneId === paneId ? target : null;
+          return returned;
+        },
+
+        insertNodeOnTabStrip: (tabId, targetPaneId, targetIndex, node) => {
+          // Ticket 20: mirrors `dropOnTabStrip`'s own node-kind resolution -
+          // dropping a node already open in a DIFFERENT pane routes through
+          // `moveTabAcrossPanes` there, remounting that pane's painted tile
+          // exactly like an explicit cross-pane drag (and, if it empties its
+          // source pane, can also dissolve a sibling's parent group). Flush
+          // both before `set()` commits the move.
+          const before = canvasForExistingTab(get(), tabId);
+          if (before !== null) {
+            const existing = findPaneTabByContentId(before, node.id);
+            if (existing !== null && existing.pane.id !== targetPaneId) {
+              flushChatTabViewportHandoff([
+                existing.instanceId,
+                ...(existing.pane.tabInstanceIds.length === 1
+                  ? paneRemovalDissolveHandoffTargets(
+                      before.root,
+                      existing.pane.id,
+                    )
+                  : []),
+              ]);
+            }
+          }
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              dropOnTabStrip(
+                canvas,
+                { kind: "node", node },
+                targetPaneId,
+                targetIndex,
+              ),
+            ),
+          );
+        },
+
+        prepareInsertNodeOnTabStripFocusTarget: (
+          tabId,
+          targetPaneId,
+          targetIndex,
+          node,
+        ) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const targetPane =
+            before === null ? null : findPaneById(before.root, targetPaneId);
+          get().insertNodeOnTabStrip(tabId, targetPaneId, targetIndex, node);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = targetPane === null ? null : after;
+          return target;
+        },
+
+        moveTabOnTabStrip: (tabId, args) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const node = before?.tilesByInstanceId[args.tabId];
+          // Ticket 20: a cross-pane move remounts the dragged tab's painted
+          // chat (the keyed layer moves from the source `TabGroupView` to the
+          // target one - `moveTabAcrossPanes`). When the dragged tab was its
+          // source pane's only tab, that pane also closes and can dissolve its
+          // parent group, remounting a SIBLING pane too. Flush both before
+          // `set()` commits. A same-pane reorder never remounts anything.
+          if (before !== null && args.sourcePaneId !== args.targetPaneId) {
+            const sourcePane = findPaneById(before.root, args.sourcePaneId);
             flushChatTabViewportHandoff([
-              existing.instanceId,
-              ...(existing.pane.tabInstanceIds.length === 1
+              args.tabId,
+              ...(sourcePane !== null && sourcePane.tabInstanceIds.length === 1
+                ? paneRemovalDissolveHandoffTargets(
+                    before.root,
+                    args.sourcePaneId,
+                  )
+                : []),
+            ]);
+          }
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) => {
+              const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
+              const node = canvas.tilesByInstanceId[args.tabId];
+              if (sourcePane === null || node === undefined) return canvas;
+              return dropOnTabStrip(
+                canvas,
+                {
+                  kind: "tab",
+                  sourcePaneId: args.sourcePaneId,
+                  tabId: args.tabId,
+                  node,
+                },
+                args.targetPaneId,
+                args.targetIndex,
+              );
+            }),
+          );
+          const after = canvasForExistingTab(get(), tabId);
+          const analyticsTarget =
+            node === undefined
+              ? null
+              : analyticsTargetForCanvasTileType(node.type);
+          if (before !== after && analyticsTarget !== null) {
+            Analytics.getInstance().track(AnalyticsEvent.TabMoved, {
+              target: analyticsTarget,
+            });
+          }
+        },
+
+        prepareMoveActiveTabOnTabStripFocusTarget: (tabId, args) => {
+          const beforeCanvas = canvasForExistingTab(get(), tabId);
+          const before = currentNestedFocusTargetForTab(get(), tabId);
+          get().moveTabOnTabStrip(tabId, args);
+          const afterCanvas = canvasForExistingTab(get(), tabId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target =
+            before?.tileInstanceId !== args.tabId ||
+            beforeCanvas === null ||
+            afterCanvas === null ||
+            beforeCanvas === afterCanvas
+              ? null
+              : changedNestedFocusTarget(before, after);
+          return target;
+        },
+
+        splitPaneWithNode: (tabId, targetPaneId, position, node) => {
+          const before = canvasForExistingTab(get(), tabId);
+          // Ticket 20 (review round 1, finding 1): when the target pane's
+          // parent group runs perpendicular to `position` (or the target is
+          // the bare root pane), inserting beside it WRAPS the target instead
+          // of a flat insertion (`insertPaneAtEdge`) - the target's own
+          // painted chat remounts even though this call never touches its
+          // content. Flushing its active tab's viewport unconditionally is
+          // cheap and correct either way (a flat, non-wrapping insertion
+          // leaves it mounted, and the flush is simply harmless there).
+          //
+          // Separately: `splitPaneAtEdge` (actions.ts) resolves a `node`
+          // source whose content is ALREADY OPEN somewhere into a `tab`-kind
+          // move BEFORE doing anything else - the same "already open"
+          // resolution `insertNodeOnTabStrip`/`dropOnTabStrip` perform, but
+          // this call creates a BRAND NEW pane for the moved tab unconditionally
+          // (`createPaneWithTab`), regardless of whether the existing tab's
+          // source pane is the same as `targetPaneId` - so the moved instance
+          // always remounts, not just on a genuine cross-pane move. When its
+          // source pane empties (and isn't the target itself - the
+          // `splitsIntoItself` case deliberately keeps that pane alive as the
+          // split's other half instead of dissolving it), flush the promoted
+          // dissolve survivors too.
+          if (before !== null) {
+            const targetPane = findPaneById(before.root, targetPaneId);
+            const existing = findPaneTabByContentId(before, node.id);
+            flushChatTabViewportHandoff([
+              ...(targetPane !== null && targetPane.activeTabId !== null
+                ? [targetPane.activeTabId]
+                : []),
+              ...(existing !== null ? [existing.instanceId] : []),
+              ...(existing !== null &&
+              existing.pane.tabInstanceIds.length === 1 &&
+              existing.pane.id !== targetPaneId
                 ? paneRemovalDissolveHandoffTargets(
                     before.root,
                     existing.pane.id,
@@ -2010,750 +2161,619 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
                 : []),
             ]);
           }
-        }
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            dropOnTabStrip(
-              canvas,
-              { kind: "node", node },
-              targetPaneId,
-              targetIndex,
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              splitPaneAtEdge(canvas, targetPaneId, position, {
+                kind: "node",
+                node,
+              }),
             ),
-          ),
-        );
-      },
+          );
+          const after = canvasForExistingTab(get(), tabId);
+          const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
+          if (before !== after && analyticsTarget !== null) {
+            Analytics.getInstance().track(AnalyticsEvent.TabSplit, {
+              target: analyticsTarget,
+            });
+          }
+        },
 
-      prepareInsertNodeOnTabStripFocusTarget: (
-        tabId,
-        targetPaneId,
-        targetIndex,
-        node,
-      ) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const targetPane =
-          before === null ? null : findPaneById(before.root, targetPaneId);
-        get().insertNodeOnTabStrip(tabId, targetPaneId, targetIndex, node);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = targetPane === null ? null : after;
-        return target;
-      },
+        prepareSplitPaneWithNodeFocusTarget: (
+          tabId,
+          targetPaneId,
+          position,
+          node,
+        ) => {
+          const before = canvasForExistingTab(get(), tabId);
+          get().splitPaneWithNode(tabId, targetPaneId, position, node);
+          const after = canvasForExistingTab(get(), tabId);
+          const target = changedCanvasFocusTarget(before, after);
+          return target;
+        },
 
-      moveTabOnTabStrip: (tabId, args) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const node = before?.tilesByInstanceId[args.tabId];
-        // Ticket 20: a cross-pane move remounts the dragged tab's painted
-        // chat (the keyed layer moves from the source `TabGroupView` to the
-        // target one - `moveTabAcrossPanes`). When the dragged tab was its
-        // source pane's only tab, that pane also closes and can dissolve its
-        // parent group, remounting a SIBLING pane too. Flush both before
-        // `set()` commits. A same-pane reorder never remounts anything.
-        if (before !== null && args.sourcePaneId !== args.targetPaneId) {
-          const sourcePane = findPaneById(before.root, args.sourcePaneId);
-          flushChatTabViewportHandoff([
-            args.tabId,
-            ...(sourcePane !== null && sourcePane.tabInstanceIds.length === 1
-              ? paneRemovalDissolveHandoffTargets(
-                  before.root,
-                  args.sourcePaneId,
-                )
-              : []),
-          ]);
-        }
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) => {
-            const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
-            const node = canvas.tilesByInstanceId[args.tabId];
-            if (sourcePane === null || node === undefined) return canvas;
-            return dropOnTabStrip(
-              canvas,
-              {
+        splitPaneWithTab: (tabId, args) => {
+          const before = canvasForExistingTab(get(), tabId);
+          const node = before?.tilesByInstanceId[args.tabId];
+          // Ticket 20: the dragged tab always lands in a brand-new pane
+          // (`createPaneWithTab` inside `splitPaneAtEdge`) - it remounts
+          // unconditionally, unlike a same-pane/same-axis flat split of a
+          // DIFFERENT tab. The target pane can also wrap (see
+          // `splitPaneWithNode`'s comment) and, when the drag emptied its
+          // source pane, that pane's own close can dissolve a THIRD pane's
+          // parent. Flush all three defensively before `set()`.
+          if (before !== null) {
+            const targetPane = findPaneById(before.root, args.targetPaneId);
+            const sourcePane = findPaneById(before.root, args.sourcePaneId);
+            flushChatTabViewportHandoff([
+              args.tabId,
+              ...(targetPane !== null && targetPane.activeTabId !== null
+                ? [targetPane.activeTabId]
+                : []),
+              ...(sourcePane !== null &&
+              sourcePane.tabInstanceIds.length === 1 &&
+              args.sourcePaneId !== args.targetPaneId
+                ? paneRemovalDissolveHandoffTargets(
+                    before.root,
+                    args.sourcePaneId,
+                  )
+                : []),
+            ]);
+          }
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) => {
+              const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
+              const node = canvas.tilesByInstanceId[args.tabId];
+              if (sourcePane === null || node === undefined) return canvas;
+              return splitPaneAtEdge(canvas, args.targetPaneId, args.position, {
                 kind: "tab",
                 sourcePaneId: args.sourcePaneId,
                 tabId: args.tabId,
                 node,
-              },
-              args.targetPaneId,
-              args.targetIndex,
-            );
-          }),
-        );
-        const after = canvasForExistingTab(get(), tabId);
-        const analyticsTarget =
-          node === undefined
-            ? null
-            : analyticsTargetForCanvasTileType(node.type);
-        if (before !== after && analyticsTarget !== null) {
-          Analytics.getInstance().track(AnalyticsEvent.TabMoved, {
-            target: analyticsTarget,
-          });
-        }
-      },
-
-      prepareMoveActiveTabOnTabStripFocusTarget: (tabId, args) => {
-        const beforeCanvas = canvasForExistingTab(get(), tabId);
-        const before = currentNestedFocusTargetForTab(get(), tabId);
-        get().moveTabOnTabStrip(tabId, args);
-        const afterCanvas = canvasForExistingTab(get(), tabId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target =
-          before?.tileInstanceId !== args.tabId ||
-          beforeCanvas === null ||
-          afterCanvas === null ||
-          beforeCanvas === afterCanvas
-            ? null
-            : changedNestedFocusTarget(before, after);
-        return target;
-      },
-
-      splitPaneWithNode: (tabId, targetPaneId, position, node) => {
-        const before = canvasForExistingTab(get(), tabId);
-        // Ticket 20 (review round 1, finding 1): when the target pane's
-        // parent group runs perpendicular to `position` (or the target is
-        // the bare root pane), inserting beside it WRAPS the target instead
-        // of a flat insertion (`insertPaneAtEdge`) - the target's own
-        // painted chat remounts even though this call never touches its
-        // content. Flushing its active tab's viewport unconditionally is
-        // cheap and correct either way (a flat, non-wrapping insertion
-        // leaves it mounted, and the flush is simply harmless there).
-        //
-        // Separately: `splitPaneAtEdge` (actions.ts) resolves a `node`
-        // source whose content is ALREADY OPEN somewhere into a `tab`-kind
-        // move BEFORE doing anything else - the same "already open"
-        // resolution `insertNodeOnTabStrip`/`dropOnTabStrip` perform, but
-        // this call creates a BRAND NEW pane for the moved tab unconditionally
-        // (`createPaneWithTab`), regardless of whether the existing tab's
-        // source pane is the same as `targetPaneId` - so the moved instance
-        // always remounts, not just on a genuine cross-pane move. When its
-        // source pane empties (and isn't the target itself - the
-        // `splitsIntoItself` case deliberately keeps that pane alive as the
-        // split's other half instead of dissolving it), flush the promoted
-        // dissolve survivors too.
-        if (before !== null) {
-          const targetPane = findPaneById(before.root, targetPaneId);
-          const existing = findPaneTabByContentId(before, node.id);
-          flushChatTabViewportHandoff([
-            ...(targetPane !== null && targetPane.activeTabId !== null
-              ? [targetPane.activeTabId]
-              : []),
-            ...(existing !== null ? [existing.instanceId] : []),
-            ...(existing !== null &&
-            existing.pane.tabInstanceIds.length === 1 &&
-            existing.pane.id !== targetPaneId
-              ? paneRemovalDissolveHandoffTargets(before.root, existing.pane.id)
-              : []),
-          ]);
-        }
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            splitPaneAtEdge(canvas, targetPaneId, position, {
-              kind: "node",
-              node,
+              });
             }),
-          ),
-        );
-        const after = canvasForExistingTab(get(), tabId);
-        const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
-        if (before !== after && analyticsTarget !== null) {
-          Analytics.getInstance().track(AnalyticsEvent.TabSplit, {
-            target: analyticsTarget,
-          });
-        }
-      },
-
-      prepareSplitPaneWithNodeFocusTarget: (
-        tabId,
-        targetPaneId,
-        position,
-        node,
-      ) => {
-        const before = canvasForExistingTab(get(), tabId);
-        get().splitPaneWithNode(tabId, targetPaneId, position, node);
-        const after = canvasForExistingTab(get(), tabId);
-        const target = changedCanvasFocusTarget(before, after);
-        return target;
-      },
-
-      splitPaneWithTab: (tabId, args) => {
-        const before = canvasForExistingTab(get(), tabId);
-        const node = before?.tilesByInstanceId[args.tabId];
-        // Ticket 20: the dragged tab always lands in a brand-new pane
-        // (`createPaneWithTab` inside `splitPaneAtEdge`) - it remounts
-        // unconditionally, unlike a same-pane/same-axis flat split of a
-        // DIFFERENT tab. The target pane can also wrap (see
-        // `splitPaneWithNode`'s comment) and, when the drag emptied its
-        // source pane, that pane's own close can dissolve a THIRD pane's
-        // parent. Flush all three defensively before `set()`.
-        if (before !== null) {
-          const targetPane = findPaneById(before.root, args.targetPaneId);
-          const sourcePane = findPaneById(before.root, args.sourcePaneId);
-          flushChatTabViewportHandoff([
-            args.tabId,
-            ...(targetPane !== null && targetPane.activeTabId !== null
-              ? [targetPane.activeTabId]
-              : []),
-            ...(sourcePane !== null &&
-            sourcePane.tabInstanceIds.length === 1 &&
-            args.sourcePaneId !== args.targetPaneId
-              ? paneRemovalDissolveHandoffTargets(
-                  before.root,
-                  args.sourcePaneId,
-                )
-              : []),
-          ]);
-        }
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) => {
-            const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
-            const node = canvas.tilesByInstanceId[args.tabId];
-            if (sourcePane === null || node === undefined) return canvas;
-            return splitPaneAtEdge(canvas, args.targetPaneId, args.position, {
-              kind: "tab",
-              sourcePaneId: args.sourcePaneId,
-              tabId: args.tabId,
-              node,
+          );
+          const after = canvasForExistingTab(get(), tabId);
+          const analyticsTarget =
+            node === undefined
+              ? null
+              : analyticsTargetForCanvasTileType(node.type);
+          if (before !== after && analyticsTarget !== null) {
+            Analytics.getInstance().track(AnalyticsEvent.TabSplit, {
+              target: analyticsTarget,
             });
-          }),
-        );
-        const after = canvasForExistingTab(get(), tabId);
-        const analyticsTarget =
-          node === undefined
-            ? null
-            : analyticsTargetForCanvasTileType(node.type);
-        if (before !== after && analyticsTarget !== null) {
-          Analytics.getInstance().track(AnalyticsEvent.TabSplit, {
-            target: analyticsTarget,
-          });
-        }
-      },
-
-      prepareSplitPaneWithTabFocusTarget: (tabId, args) => {
-        const before = canvasForExistingTab(get(), tabId);
-        get().splitPaneWithTab(tabId, args);
-        const after = canvasForExistingTab(get(), tabId);
-        const target = changedCanvasFocusTarget(before, after);
-        return target;
-      },
-
-      splitPaneEmptyInTab: (tabId, targetPaneId, direction) => {
-        let newPaneId: string | null = null;
-        // Ticket 20: an empty placeholder pane can still WRAP the target
-        // (same `insertPaneAtEdge` mechanism as `splitPaneWithNode`), even
-        // though this action opens no content of its own.
-        const before = canvasForExistingTab(get(), tabId);
-        if (before !== null) {
-          const targetPane = findPaneById(before.root, targetPaneId);
-          if (targetPane !== null && targetPane.activeTabId !== null) {
-            flushChatTabViewportHandoff([targetPane.activeTabId]);
           }
-        }
-        set((state) => {
-          const tab = state.tabsById[tabId];
-          if (tab === undefined) return state;
-          const canvas = state.canvasByTabId[tabId] ?? EMPTY_CANVAS;
-          const nextCanvas = splitPaneEmpty(canvas, targetPaneId, direction);
-          if (nextCanvas === canvas) return state;
-          newPaneId = nextCanvas.activePaneId;
-          return {
-            canvasByTabId: {
-              ...state.canvasByTabId,
-              [tabId]: nextCanvas,
-            },
-          };
-        });
-        return newPaneId;
-      },
+        },
 
-      prepareSplitPaneEmptyFocusTarget: (tabId, targetPaneId, direction) => {
-        const paneId = get().splitPaneEmptyInTab(
-          tabId,
-          targetPaneId,
-          direction,
-        );
-        const target =
-          paneId === null ? null : { paneId, tileInstanceId: undefined };
-        return target;
-      },
+        prepareSplitPaneWithTabFocusTarget: (tabId, args) => {
+          const before = canvasForExistingTab(get(), tabId);
+          get().splitPaneWithTab(tabId, args);
+          const after = canvasForExistingTab(get(), tabId);
+          const target = changedCanvasFocusTarget(before, after);
+          return target;
+        },
 
-      splitPaneEmptyRightInTab: (tabId, targetPaneId) =>
-        get().splitPaneEmptyInTab(tabId, targetPaneId, "horizontal"),
-
-      closeCanvasTab: (tabId, paneId, tileTabId) => {
-        const beforeCanvas = get().canvasByTabId[tabId];
-        // Ticket 20: closing a pane's LAST tab removes the pane itself
-        // (`closeTab` falls through to `closePane`), which can dissolve its
-        // parent group and remount a sibling's painted chat. Predict this
-        // BEFORE `set()`, from the state as it stands right now.
-        if (beforeCanvas !== undefined) {
-          const pane = findPaneById(beforeCanvas.root, paneId);
-          if (pane !== null && pane.tabInstanceIds.length === 1) {
-            flushChatTabViewportHandoff(
-              paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
-            );
+        splitPaneEmptyInTab: (tabId, targetPaneId, direction) => {
+          let newPaneId: string | null = null;
+          // Ticket 20: an empty placeholder pane can still WRAP the target
+          // (same `insertPaneAtEdge` mechanism as `splitPaneWithNode`), even
+          // though this action opens no content of its own.
+          const before = canvasForExistingTab(get(), tabId);
+          if (before !== null) {
+            const targetPane = findPaneById(before.root, targetPaneId);
+            if (targetPane !== null && targetPane.activeTabId !== null) {
+              flushChatTabViewportHandoff([targetPane.activeTabId]);
+            }
           }
-        }
-        // `tileTabId` is a tab instanceId; pendingCreate tracking is keyed by
-        // content id, so resolve the closed tab's content id before clearing.
-        set((state) => {
-          const canvas = state.canvasByTabId[tabId] ?? EMPTY_CANVAS;
-          const pane = findPaneById(canvas.root, paneId);
-          const contentId =
-            pane !== null && pane.tabInstanceIds.includes(tileTabId)
-              ? (canvas.tilesByInstanceId[tileTabId]?.id ?? null)
-              : null;
-          const pendingNext =
-            contentId === null
-              ? state.pendingCreateArtifactIds
-              : withoutId(state.pendingCreateArtifactIds, contentId);
-          const updated = updateTabCanvas(state, tabId, (canvas) =>
-            closeTileTab(canvas, paneId, tileTabId),
-          );
-          return pendingNext === state.pendingCreateArtifactIds
-            ? updated
-            : { ...updated, pendingCreateArtifactIds: pendingNext };
-        });
-        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
-      },
-
-      prepareCloseCanvasTabFocusTarget: (tabId, paneId, tileTabId) => {
-        const before = currentNestedFocusTargetForTab(get(), tabId);
-        get().closeCanvasTab(tabId, paneId, tileTabId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = changedNestedFocusTarget(before, after);
-        return target;
-      },
-
-      prepareCloseOtherCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
-        const before = currentNestedFocusTargetForTab(get(), tabId);
-        get().closeOtherCanvasTabs(tabId, paneId, tileTabId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = changedNestedFocusTarget(before, after);
-        return target;
-      },
-
-      closeOtherCanvasTabs: (tabId, paneId, tileTabId) => {
-        const beforeCanvas = get().canvasByTabId[tabId];
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            closeOtherTileTabs(canvas, paneId, tileTabId),
-          ),
-        );
-        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
-      },
-
-      closeRightCanvasTabs: (tabId, paneId, tileTabId) => {
-        const beforeCanvas = get().canvasByTabId[tabId];
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            closeRightTabs(canvas, paneId, tileTabId),
-          ),
-        );
-        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
-      },
-
-      prepareCloseRightCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
-        const before = currentNestedFocusTargetForTab(get(), tabId);
-        get().closeRightCanvasTabs(tabId, paneId, tileTabId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = changedNestedFocusTarget(before, after);
-        return target;
-      },
-
-      closeAllCanvasTabs: (tabId, paneId) => {
-        const beforeCanvas = get().canvasByTabId[tabId];
-        // Ticket 20: `closeAllTabs` always falls through to `closePane` for
-        // a non-empty pane - same dissolve risk as `closeCanvasTab`.
-        if (beforeCanvas !== undefined) {
-          const pane = findPaneById(beforeCanvas.root, paneId);
-          if (pane !== null && pane.tabInstanceIds.length > 0) {
-            flushChatTabViewportHandoff(
-              paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
-            );
-          }
-        }
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            closeAllTabs(canvas, paneId),
-          ),
-        );
-        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
-      },
-
-      prepareCloseAllCanvasTabsFocusTarget: (tabId, paneId) => {
-        const before = currentNestedFocusTargetForTab(get(), tabId);
-        get().closeAllCanvasTabs(tabId, paneId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = changedNestedFocusTarget(before, after);
-        return target;
-      },
-
-      closeCanvasPane: (tabId, paneId) => {
-        const beforeCanvas = get().canvasByTabId[tabId];
-        // Ticket 20: same dissolve risk as `closeCanvasTab`/`closeAllCanvasTabs`
-        // - `closePane` always removes the whole pane.
-        if (beforeCanvas !== undefined) {
-          flushChatTabViewportHandoff(
-            paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
-          );
-        }
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) => closePane(canvas, paneId)),
-        );
-        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
-      },
-
-      prepareCloseCanvasPaneFocusTarget: (tabId, paneId) => {
-        const before = currentNestedFocusTargetForTab(get(), tabId);
-        get().closeCanvasPane(tabId, paneId);
-        const after = currentNestedFocusTargetForTab(get(), tabId);
-        const target = changedNestedFocusTarget(before, after);
-        return target;
-      },
-
-      resizeSplitInTab: (tabId, groupId, sizes) => {
-        set((state) =>
-          updateTabCanvas(state, tabId, (canvas) =>
-            resizeSplit(canvas, groupId, sizes),
-          ),
-        );
-      },
-
-      prepareResizeSplitFocusTarget: (tabId, groupId, sizes) => {
-        get().resizeSplitInTab(tabId, groupId, sizes);
-        return null;
-      },
-
-      renameArtifactInTab: (tabId, artifactId, name) => {
-        const trimmed = name.trim();
-        if (trimmed.length === 0) return;
-        set((state) => {
-          const tab = state.tabsById[tabId];
-          if (tab === undefined) return state;
-          const canvasPatch = updateTabCanvas(state, tabId, (canvas) =>
-            renameArtifact(canvas, artifactId, trimmed),
-          );
-          const records = state.artifactTreeByEpicId[tab.epicId] ?? [];
-          const target = records.find((r) => r.id === artifactId);
-          if (target === undefined || target.name === trimmed) {
-            return canvasPatch;
-          }
-          return {
-            ...canvasPatch,
-            artifactTreeByEpicId: {
-              ...state.artifactTreeByEpicId,
-              [tab.epicId]: records.map((r) =>
-                r.id === artifactId ? { ...r, name: trimmed } : r,
-              ),
-            },
-          };
-        });
-      },
-
-      updateTerminalNameSnapshots: (hostId, sessionId, name) => {
-        const trimmed = name.trim();
-        if (trimmed.length === 0) return;
-        set((state) => {
-          const entries = Object.entries(state.canvasByTabId).map(
-            ([tabId, canvas]) =>
-              [
-                tabId,
-                canvas === undefined
-                  ? canvas
-                  : renameTerminalTiles(canvas, hostId, sessionId, trimmed),
-              ] as const,
-          );
-          if (
-            entries.every(
-              ([tabId, canvas]) => canvas === state.canvasByTabId[tabId],
-            )
-          ) {
-            return state;
-          }
-          return { canvasByTabId: Object.fromEntries(entries) };
-        });
-      },
-
-      seedEpic: (epicId, tab, artifacts) => {
-        set((state) => {
-          const existing = state.tabsById[tab.tabId];
-          if (existing !== undefined) {
+          set((state) => {
+            const tab = state.tabsById[tabId];
+            if (tab === undefined) return state;
+            const canvas = state.canvasByTabId[tabId] ?? EMPTY_CANVAS;
+            const nextCanvas = splitPaneEmpty(canvas, targetPaneId, direction);
+            if (nextCanvas === canvas) return state;
+            newPaneId = nextCanvas.activePaneId;
             return {
+              canvasByTabId: {
+                ...state.canvasByTabId,
+                [tabId]: nextCanvas,
+              },
+            };
+          });
+          return newPaneId;
+        },
+
+        prepareSplitPaneEmptyFocusTarget: (tabId, targetPaneId, direction) => {
+          const paneId = get().splitPaneEmptyInTab(
+            tabId,
+            targetPaneId,
+            direction,
+          );
+          const target =
+            paneId === null ? null : { paneId, tileInstanceId: undefined };
+          return target;
+        },
+
+        splitPaneEmptyRightInTab: (tabId, targetPaneId) =>
+          get().splitPaneEmptyInTab(tabId, targetPaneId, "horizontal"),
+
+        closeCanvasTab: (tabId, paneId, tileTabId) => {
+          const beforeCanvas = get().canvasByTabId[tabId];
+          // Ticket 20: closing a pane's LAST tab removes the pane itself
+          // (`closeTab` falls through to `closePane`), which can dissolve its
+          // parent group and remount a sibling's painted chat. Predict this
+          // BEFORE `set()`, from the state as it stands right now.
+          if (beforeCanvas !== undefined) {
+            const pane = findPaneById(beforeCanvas.root, paneId);
+            if (pane !== null && pane.tabInstanceIds.length === 1) {
+              flushChatTabViewportHandoff(
+                paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
+              );
+            }
+          }
+          // `tileTabId` is a tab instanceId; pendingCreate tracking is keyed by
+          // content id, so resolve the closed tab's content id before clearing.
+          set((state) => {
+            const canvas = state.canvasByTabId[tabId] ?? EMPTY_CANVAS;
+            const pane = findPaneById(canvas.root, paneId);
+            const contentId =
+              pane !== null && pane.tabInstanceIds.includes(tileTabId)
+                ? (canvas.tilesByInstanceId[tileTabId]?.id ?? null)
+                : null;
+            const pendingNext =
+              contentId === null
+                ? state.pendingCreateArtifactIds
+                : withoutId(state.pendingCreateArtifactIds, contentId);
+            const updated = updateTabCanvas(state, tabId, (canvas) =>
+              closeTileTab(canvas, paneId, tileTabId),
+            );
+            return pendingNext === state.pendingCreateArtifactIds
+              ? updated
+              : { ...updated, pendingCreateArtifactIds: pendingNext };
+          });
+          trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
+        },
+
+        prepareCloseCanvasTabFocusTarget: (tabId, paneId, tileTabId) => {
+          const before = currentNestedFocusTargetForTab(get(), tabId);
+          get().closeCanvasTab(tabId, paneId, tileTabId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = changedNestedFocusTarget(before, after);
+          return target;
+        },
+
+        prepareCloseOtherCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
+          const before = currentNestedFocusTargetForTab(get(), tabId);
+          get().closeOtherCanvasTabs(tabId, paneId, tileTabId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = changedNestedFocusTarget(before, after);
+          return target;
+        },
+
+        closeOtherCanvasTabs: (tabId, paneId, tileTabId) => {
+          const beforeCanvas = get().canvasByTabId[tabId];
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              closeOtherTileTabs(canvas, paneId, tileTabId),
+            ),
+          );
+          trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
+        },
+
+        closeRightCanvasTabs: (tabId, paneId, tileTabId) => {
+          const beforeCanvas = get().canvasByTabId[tabId];
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              closeRightTabs(canvas, paneId, tileTabId),
+            ),
+          );
+          trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
+        },
+
+        prepareCloseRightCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
+          const before = currentNestedFocusTargetForTab(get(), tabId);
+          get().closeRightCanvasTabs(tabId, paneId, tileTabId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = changedNestedFocusTarget(before, after);
+          return target;
+        },
+
+        closeAllCanvasTabs: (tabId, paneId) => {
+          const beforeCanvas = get().canvasByTabId[tabId];
+          // Ticket 20: `closeAllTabs` always falls through to `closePane` for
+          // a non-empty pane - same dissolve risk as `closeCanvasTab`.
+          if (beforeCanvas !== undefined) {
+            const pane = findPaneById(beforeCanvas.root, paneId);
+            if (pane !== null && pane.tabInstanceIds.length > 0) {
+              flushChatTabViewportHandoff(
+                paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
+              );
+            }
+          }
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              closeAllTabs(canvas, paneId),
+            ),
+          );
+          trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
+        },
+
+        prepareCloseAllCanvasTabsFocusTarget: (tabId, paneId) => {
+          const before = currentNestedFocusTargetForTab(get(), tabId);
+          get().closeAllCanvasTabs(tabId, paneId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = changedNestedFocusTarget(before, after);
+          return target;
+        },
+
+        closeCanvasPane: (tabId, paneId) => {
+          const beforeCanvas = get().canvasByTabId[tabId];
+          // Ticket 20: same dissolve risk as `closeCanvasTab`/`closeAllCanvasTabs`
+          // - `closePane` always removes the whole pane.
+          if (beforeCanvas !== undefined) {
+            flushChatTabViewportHandoff(
+              paneRemovalDissolveHandoffTargets(beforeCanvas.root, paneId),
+            );
+          }
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              closePane(canvas, paneId),
+            ),
+          );
+          trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
+        },
+
+        prepareCloseCanvasPaneFocusTarget: (tabId, paneId) => {
+          const before = currentNestedFocusTargetForTab(get(), tabId);
+          get().closeCanvasPane(tabId, paneId);
+          const after = currentNestedFocusTargetForTab(get(), tabId);
+          const target = changedNestedFocusTarget(before, after);
+          return target;
+        },
+
+        resizeSplitInTab: (tabId, groupId, sizes) => {
+          set((state) =>
+            updateTabCanvas(state, tabId, (canvas) =>
+              resizeSplit(canvas, groupId, sizes),
+            ),
+          );
+        },
+
+        prepareResizeSplitFocusTarget: (tabId, groupId, sizes) => {
+          get().resizeSplitInTab(tabId, groupId, sizes);
+          return null;
+        },
+
+        renameArtifactInTab: (tabId, artifactId, name) => {
+          const trimmed = name.trim();
+          if (trimmed.length === 0) return;
+          set((state) => {
+            const tab = state.tabsById[tabId];
+            if (tab === undefined) return state;
+            const canvasPatch = updateTabCanvas(state, tabId, (canvas) =>
+              renameArtifact(canvas, artifactId, trimmed),
+            );
+            const records = state.artifactTreeByEpicId[tab.epicId] ?? [];
+            const target = records.find((r) => r.id === artifactId);
+            if (target === undefined || target.name === trimmed) {
+              return canvasPatch;
+            }
+            return {
+              ...canvasPatch,
+              artifactTreeByEpicId: {
+                ...state.artifactTreeByEpicId,
+                [tab.epicId]: records.map((r) =>
+                  r.id === artifactId ? { ...r, name: trimmed } : r,
+                ),
+              },
+            };
+          });
+        },
+
+        updateTerminalNameSnapshots: (hostId, sessionId, name) => {
+          const trimmed = name.trim();
+          if (trimmed.length === 0) return;
+          set((state) => {
+            const entries = Object.entries(state.canvasByTabId).map(
+              ([tabId, canvas]) =>
+                [
+                  tabId,
+                  canvas === undefined
+                    ? canvas
+                    : renameTerminalTiles(canvas, hostId, sessionId, trimmed),
+                ] as const,
+            );
+            if (
+              entries.every(
+                ([tabId, canvas]) => canvas === state.canvasByTabId[tabId],
+              )
+            ) {
+              return state;
+            }
+            return { canvasByTabId: Object.fromEntries(entries) };
+          });
+        },
+
+        seedEpic: (epicId, tab, artifacts) => {
+          set((state) => {
+            const existing = state.tabsById[tab.tabId];
+            if (existing !== undefined) {
+              return {
+                artifactTreeByEpicId: {
+                  ...state.artifactTreeByEpicId,
+                  [epicId]: artifacts,
+                },
+                activeTabId: tab.tabId,
+                mostRecentTabIdByEpicId: {
+                  ...state.mostRecentTabIdByEpicId,
+                  [epicId]: tab.tabId,
+                },
+              };
+            }
+            const viewTab: EpicViewTab = {
+              tabId: tab.tabId,
+              epicId,
+              name: tab.name,
+            };
+            return {
+              tabsById: { ...state.tabsById, [viewTab.tabId]: viewTab },
+              canvasByTabId: {
+                ...state.canvasByTabId,
+                [viewTab.tabId]: createEmptyCanvas(),
+              },
+              openTabOrder: [...state.openTabOrder, viewTab.tabId],
+              activeTabId: viewTab.tabId,
+              mostRecentTabIdByEpicId: {
+                ...state.mostRecentTabIdByEpicId,
+                [epicId]: viewTab.tabId,
+              },
               artifactTreeByEpicId: {
                 ...state.artifactTreeByEpicId,
                 [epicId]: artifacts,
               },
-              activeTabId: tab.tabId,
-              mostRecentTabIdByEpicId: {
-                ...state.mostRecentTabIdByEpicId,
-                [epicId]: tab.tabId,
-              },
             };
-          }
-          const viewTab: EpicViewTab = {
-            tabId: tab.tabId,
+          });
+        },
+
+        createEpicFromPrompt: (prompt) => {
+          const epicId = uuidv4();
+          // `createEpicName` yields "" for an empty/whitespace prompt; this create
+          // path bakes a non-empty stored tab name, so apply the "Untitled task"
+          // fallback here.
+          const name = createEpicName(prompt) || UNTITLED_EPIC_TITLE;
+          const tabId = uuidv4();
+          const tab: EpicViewTab = {
+            tabId,
             epicId,
-            name: tab.name,
+            name,
           };
-          return {
-            tabsById: { ...state.tabsById, [viewTab.tabId]: viewTab },
+          set((state) => ({
+            tabsById: { ...state.tabsById, [tabId]: tab },
             canvasByTabId: {
               ...state.canvasByTabId,
-              [viewTab.tabId]: createEmptyCanvas(),
+              [tabId]: createEmptyCanvas(),
             },
-            openTabOrder: [...state.openTabOrder, viewTab.tabId],
-            activeTabId: viewTab.tabId,
+            openTabOrder: [...state.openTabOrder, tabId],
+            activeTabId: tabId,
             mostRecentTabIdByEpicId: {
               ...state.mostRecentTabIdByEpicId,
-              [epicId]: viewTab.tabId,
+              [epicId]: tabId,
             },
             artifactTreeByEpicId: {
               ...state.artifactTreeByEpicId,
-              [epicId]: artifacts,
+              [epicId]: [],
             },
-          };
-        });
-      },
+          }));
+          return { epicId, name, tabId };
+        },
 
-      createEpicFromPrompt: (prompt) => {
-        const epicId = uuidv4();
-        // `createEpicName` yields "" for an empty/whitespace prompt; this create
-        // path bakes a non-empty stored tab name, so apply the "Untitled task"
-        // fallback here.
-        const name = createEpicName(prompt) || UNTITLED_EPIC_TITLE;
-        const tabId = uuidv4();
-        const tab: EpicViewTab = {
-          tabId,
-          epicId,
-          name,
-        };
-        set((state) => ({
-          tabsById: { ...state.tabsById, [tabId]: tab },
-          canvasByTabId: {
-            ...state.canvasByTabId,
-            [tabId]: createEmptyCanvas(),
-          },
-          openTabOrder: [...state.openTabOrder, tabId],
-          activeTabId: tabId,
-          mostRecentTabIdByEpicId: {
-            ...state.mostRecentTabIdByEpicId,
-            [epicId]: tabId,
-          },
-          artifactTreeByEpicId: {
-            ...state.artifactTreeByEpicId,
-            [epicId]: [],
-          },
-        }));
-        return { epicId, name, tabId };
-      },
-
-      addRootArtifact: (tabId, type, hostId) => {
-        let createdId = "";
-        set((state) => {
-          const tab = state.tabsById[tabId];
-          if (tab === undefined) return state;
-          const result = appendArtifactRecord({
-            state,
-            epicId: tab.epicId,
-            parentId: null,
-            type,
-            hostId,
+        addRootArtifact: (tabId, type, hostId) => {
+          let createdId = "";
+          set((state) => {
+            const tab = state.tabsById[tabId];
+            if (tab === undefined) return state;
+            const result = appendArtifactRecord({
+              state,
+              epicId: tab.epicId,
+              parentId: null,
+              type,
+              hostId,
+            });
+            if (result === null) return state;
+            createdId = result.id;
+            if (result.node === null) return result.patch;
+            const node = result.node;
+            return {
+              ...result.patch,
+              ...updateTabCanvas(state, tabId, (canvas) =>
+                openTile(canvas, node, false, null),
+              ),
+            };
           });
-          if (result === null) return state;
-          createdId = result.id;
-          if (result.node === null) return result.patch;
-          const node = result.node;
-          return {
-            ...result.patch,
-            ...updateTabCanvas(state, tabId, (canvas) =>
-              openTile(canvas, node, false, null),
-            ),
-          };
-        });
-        return createdId;
-      },
+          return createdId;
+        },
 
-      addChildArtifact: (epicId, parentId, type, hostId) => {
-        let createdId: string | null = null;
-        set((state) => {
-          const result = appendArtifactRecord({
-            state,
-            epicId,
-            parentId,
-            type,
-            hostId,
+        addChildArtifact: (epicId, parentId, type, hostId) => {
+          let createdId: string | null = null;
+          set((state) => {
+            const result = appendArtifactRecord({
+              state,
+              epicId,
+              parentId,
+              type,
+              hostId,
+            });
+            if (result === null) return state;
+            createdId = result.id;
+            return result.patch;
           });
-          if (result === null) return state;
-          createdId = result.id;
-          return result.patch;
-        });
-        return createdId;
-      },
+          return createdId;
+        },
 
-      markArtifactSelfDeleted: (artifactId) => {
-        // Pending-title map is id-keyed so a stale spinner anchor would
-        // orphan the 30s backstop timer until it fires as a no-op.
-        // `clearScheduledTitlePending` is a no-op when the id isn't present.
-        clearScheduledTitlePending(chatTitleTimers, artifactId);
-        set((s) => {
-          const next = withId(s.selfDeletedArtifactIds, artifactId);
-          const nextChat = Object.hasOwn(s.pendingChatTitles, artifactId)
-            ? (() => {
-                const c = { ...s.pendingChatTitles };
-                delete c[artifactId];
-                return c;
-              })()
-            : s.pendingChatTitles;
-          if (
-            next === s.selfDeletedArtifactIds &&
-            nextChat === s.pendingChatTitles
-          ) {
-            return s;
-          }
-          return {
-            selfDeletedArtifactIds: next,
-            pendingChatTitles: nextChat,
-          };
-        });
-      },
+        markArtifactSelfDeleted: (artifactId) => {
+          // Pending-title map is id-keyed so a stale spinner anchor would
+          // orphan the 30s backstop timer until it fires as a no-op.
+          // `clearScheduledTitlePending` is a no-op when the id isn't present.
+          clearScheduledTitlePending(chatTitleTimers, artifactId);
+          set((s) => {
+            const next = withId(s.selfDeletedArtifactIds, artifactId);
+            const nextChat = Object.hasOwn(s.pendingChatTitles, artifactId)
+              ? (() => {
+                  const c = { ...s.pendingChatTitles };
+                  delete c[artifactId];
+                  return c;
+                })()
+              : s.pendingChatTitles;
+            if (
+              next === s.selfDeletedArtifactIds &&
+              nextChat === s.pendingChatTitles
+            ) {
+              return s;
+            }
+            return {
+              selfDeletedArtifactIds: next,
+              pendingChatTitles: nextChat,
+            };
+          });
+        },
 
-      unmarkArtifactSelfDeleted: (artifactId) => {
-        set((s) => {
-          const next = withoutId(s.selfDeletedArtifactIds, artifactId);
-          return next === s.selfDeletedArtifactIds
-            ? s
-            : { selfDeletedArtifactIds: next };
-        });
-      },
+        unmarkArtifactSelfDeleted: (artifactId) => {
+          set((s) => {
+            const next = withoutId(s.selfDeletedArtifactIds, artifactId);
+            return next === s.selfDeletedArtifactIds
+              ? s
+              : { selfDeletedArtifactIds: next };
+          });
+        },
 
-      markArtifactPendingCreate: (artifactId) => {
-        set((s) => {
-          const next = withId(s.pendingCreateArtifactIds, artifactId);
-          return next === s.pendingCreateArtifactIds
-            ? s
-            : { pendingCreateArtifactIds: next };
-        });
-      },
+        markArtifactPendingCreate: (artifactId) => {
+          set((s) => {
+            const next = withId(s.pendingCreateArtifactIds, artifactId);
+            return next === s.pendingCreateArtifactIds
+              ? s
+              : { pendingCreateArtifactIds: next };
+          });
+        },
 
-      unmarkArtifactPendingCreate: (artifactId) => {
-        set((s) => {
-          const next = withoutId(s.pendingCreateArtifactIds, artifactId);
-          const nextClosedTilePayloads = clearClosedTilePendingCreate(
-            s.closedTilePayloadsByTabId,
-            artifactId,
+        unmarkArtifactPendingCreate: (artifactId) => {
+          set((s) => {
+            const next = withoutId(s.pendingCreateArtifactIds, artifactId);
+            const nextClosedTilePayloads = clearClosedTilePendingCreate(
+              s.closedTilePayloadsByTabId,
+              artifactId,
+            );
+            return next === s.pendingCreateArtifactIds &&
+              nextClosedTilePayloads === s.closedTilePayloadsByTabId
+              ? s
+              : {
+                  pendingCreateArtifactIds: next,
+                  closedTilePayloadsByTabId: nextClosedTilePayloads,
+                };
+          });
+        },
+
+        beginPreAckRootCreate: (epicId, tempId, name) => {
+          set((s) => {
+            const cur = s.preAckRootCreatesByEpic[epicId] ?? [];
+            return {
+              preAckRootCreatesByEpic: {
+                ...s.preAckRootCreatesByEpic,
+                [epicId]: [...cur, { tempId, name }],
+              },
+            };
+          });
+        },
+
+        endPreAckRootCreate: (epicId, tempId) => {
+          set((s) => {
+            const cur = s.preAckRootCreatesByEpic[epicId];
+            if (cur === undefined) return s;
+            return {
+              preAckRootCreatesByEpic: {
+                ...s.preAckRootCreatesByEpic,
+                [epicId]: cur.filter((e) => e.tempId !== tempId),
+              },
+            };
+          });
+        },
+
+        registerPendingRootCreate: (epicId, pendingId, name) => {
+          set((s) => {
+            const cur = s.pendingRootCreatesByEpic[epicId] ?? [];
+            return {
+              pendingRootCreatesByEpic: {
+                ...s.pendingRootCreatesByEpic,
+                [epicId]: [...cur, { id: pendingId, name }],
+              },
+            };
+          });
+        },
+
+        clearPendingRootCreate: (epicId, pendingId) => {
+          set((s) => {
+            const cur = s.pendingRootCreatesByEpic[epicId];
+            if (cur === undefined || !cur.some((e) => e.id === pendingId)) {
+              return s;
+            }
+            return {
+              pendingRootCreatesByEpic: {
+                ...s.pendingRootCreatesByEpic,
+                [epicId]: cur.filter((e) => e.id !== pendingId),
+              },
+            };
+          });
+        },
+
+        markEpicTitlePending: (epicId, expectedTitle) => {
+          scheduleTitlePendingClear(epicTitleTimers, epicId, () =>
+            get().clearEpicTitlePending(epicId),
           );
-          return next === s.pendingCreateArtifactIds &&
-            nextClosedTilePayloads === s.closedTilePayloadsByTabId
-            ? s
-            : {
-                pendingCreateArtifactIds: next,
-                closedTilePayloadsByTabId: nextClosedTilePayloads,
-              };
-        });
-      },
-
-      beginPreAckRootCreate: (epicId, tempId, name) => {
-        set((s) => {
-          const cur = s.preAckRootCreatesByEpic[epicId] ?? [];
-          return {
-            preAckRootCreatesByEpic: {
-              ...s.preAckRootCreatesByEpic,
-              [epicId]: [...cur, { tempId, name }],
+          set((s) => ({
+            pendingEpicTitles: {
+              ...s.pendingEpicTitles,
+              [epicId]: { expectedTitle, startedAt: Date.now() },
             },
-          };
-        });
-      },
+          }));
+        },
 
-      endPreAckRootCreate: (epicId, tempId) => {
-        set((s) => {
-          const cur = s.preAckRootCreatesByEpic[epicId];
-          if (cur === undefined) return s;
-          return {
-            preAckRootCreatesByEpic: {
-              ...s.preAckRootCreatesByEpic,
-              [epicId]: cur.filter((e) => e.tempId !== tempId),
+        clearEpicTitlePending: (epicId) => {
+          clearScheduledTitlePending(epicTitleTimers, epicId);
+          set((s) => {
+            if (!Object.hasOwn(s.pendingEpicTitles, epicId)) return s;
+            const next = { ...s.pendingEpicTitles };
+            delete next[epicId];
+            return { pendingEpicTitles: next };
+          });
+        },
+
+        markChatTitlePending: (chatId, expectedTitle) => {
+          scheduleTitlePendingClear(chatTitleTimers, chatId, () =>
+            get().clearChatTitlePending(chatId),
+          );
+          set((s) => ({
+            pendingChatTitles: {
+              ...s.pendingChatTitles,
+              [chatId]: { expectedTitle, startedAt: Date.now() },
             },
-          };
-        });
-      },
+          }));
+        },
 
-      registerPendingRootCreate: (epicId, pendingId, name) => {
-        set((s) => {
-          const cur = s.pendingRootCreatesByEpic[epicId] ?? [];
-          return {
-            pendingRootCreatesByEpic: {
-              ...s.pendingRootCreatesByEpic,
-              [epicId]: [...cur, { id: pendingId, name }],
-            },
-          };
-        });
-      },
+        clearChatTitlePending: (chatId) => {
+          clearScheduledTitlePending(chatTitleTimers, chatId);
+          set((s) => {
+            if (!Object.hasOwn(s.pendingChatTitles, chatId)) return s;
+            const next = { ...s.pendingChatTitles };
+            delete next[chatId];
+            return { pendingChatTitles: next };
+          });
+        },
 
-      clearPendingRootCreate: (epicId, pendingId) => {
-        set((s) => {
-          const cur = s.pendingRootCreatesByEpic[epicId];
-          if (cur === undefined || !cur.some((e) => e.id === pendingId)) {
-            return s;
-          }
-          return {
-            pendingRootCreatesByEpic: {
-              ...s.pendingRootCreatesByEpic,
-              [epicId]: cur.filter((e) => e.id !== pendingId),
-            },
-          };
-        });
-      },
-
-      markEpicTitlePending: (epicId, expectedTitle) => {
-        scheduleTitlePendingClear(epicTitleTimers, epicId, () =>
-          get().clearEpicTitlePending(epicId),
-        );
-        set((s) => ({
-          pendingEpicTitles: {
-            ...s.pendingEpicTitles,
-            [epicId]: { expectedTitle, startedAt: Date.now() },
-          },
-        }));
-      },
-
-      clearEpicTitlePending: (epicId) => {
-        clearScheduledTitlePending(epicTitleTimers, epicId);
-        set((s) => {
-          if (!Object.hasOwn(s.pendingEpicTitles, epicId)) return s;
-          const next = { ...s.pendingEpicTitles };
-          delete next[epicId];
-          return { pendingEpicTitles: next };
-        });
-      },
-
-      markChatTitlePending: (chatId, expectedTitle) => {
-        scheduleTitlePendingClear(chatTitleTimers, chatId, () =>
-          get().clearChatTitlePending(chatId),
-        );
-        set((s) => ({
-          pendingChatTitles: {
-            ...s.pendingChatTitles,
-            [chatId]: { expectedTitle, startedAt: Date.now() },
-          },
-        }));
-      },
-
-      clearChatTitlePending: (chatId) => {
-        clearScheduledTitlePending(chatTitleTimers, chatId);
-        set((s) => {
-          if (!Object.hasOwn(s.pendingChatTitles, chatId)) return s;
-          const next = { ...s.pendingChatTitles };
-          delete next[chatId];
-          return { pendingChatTitles: next };
-        });
-      },
-
-      clearAllTitleGenerationPending: () => {
-        clearAllScheduledTitlePending(epicTitleTimers);
-        clearAllScheduledTitlePending(chatTitleTimers);
-        set({
-          pendingEpicTitles: {},
-          pendingChatTitles: {},
-        });
-      },
+        clearAllTitleGenerationPending: () => {
+          clearAllScheduledTitlePending(epicTitleTimers);
+          clearAllScheduledTitlePending(chatTitleTimers);
+          set({
+            pendingEpicTitles: {},
+            pendingChatTitles: {},
+          });
+        },
       };
     },
     {

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -14,6 +14,7 @@ import {
 } from "zustand/middleware";
 import { v4 as uuidv4 } from "uuid";
 import { basePersistOptions, epicCanvasKey } from "@/lib/persist";
+import { appLogger } from "@/lib/logger";
 import {
   DEFAULT_EPIC_NODE_NAMES,
   type EpicNodeKind,
@@ -132,6 +133,10 @@ import {
   scheduleTitlePendingClear,
   type PendingTitleEntry,
 } from "@/stores/epics/canvas/canvas-title-timers";
+import {
+  collectTileIdentityRegistry,
+  enforceTileIdentityInvariant,
+} from "@/stores/epics/canvas/tile-identity-invariant";
 export { parseEpicNodeRef as parseArtifactRef } from "@/stores/epics/canvas/tile-schema/artifact-tile";
 
 function trackOpenedCanvasTile(
@@ -1154,9 +1159,74 @@ function appendArtifactRecord(args: AppendArtifactRecordArgs): {
   };
 }
 
+/**
+ * Options for `guardCanvasMutation`. This guard is always strict: the sole
+ * sanctioned epicId resolution (`resolveTabEpicIdentity`) does not call it at
+ * all - it commits through the module-private raw setter directly, so
+ * provenance is enforced by module privacy rather than a parameter every
+ * ingress has to thread and every caller of this function has to reason
+ * about.
+ */
+interface CanvasMutationGuardOptions {
+  readonly ingressContext: string;
+  readonly throwOnViolation: boolean;
+}
+
+/**
+ * Shared identity guard for every canvas-mutation ingress: the closure-local
+ * `set` below (which delegates to the guarded public `setState` wrapper) and
+ * persisted hydration. `epicId` lives on `tabsById`, not `canvasByTabId`, so
+ * a candidate must be checked whenever EITHER map changes - a
+ * `tabsById`-only patch can repoint every tile in a tab without ever
+ * touching `canvasByTabId`.
+ */
+function guardCanvasMutation(
+  state: EpicCanvasStore,
+  resolved: Partial<EpicCanvasStore>,
+  options: CanvasMutationGuardOptions,
+): boolean {
+  const { ingressContext, throwOnViolation } = options;
+  const nextCanvasByTabId = resolved.canvasByTabId ?? state.canvasByTabId;
+  const nextTabsById = resolved.tabsById ?? state.tabsById;
+  if (
+    nextCanvasByTabId === state.canvasByTabId &&
+    nextTabsById === state.tabsById
+  ) {
+    return true;
+  }
+  return enforceTileIdentityInvariant(
+    collectTileIdentityRegistry(
+      state.canvasByTabId,
+      (tabId) => state.tabsById[tabId]?.epicId ?? null,
+    ),
+    {
+      canvasByTabId: nextCanvasByTabId,
+      epicIdForTabId: (tabId) => nextTabsById[tabId]?.epicId ?? null,
+      ingressContext,
+    },
+    throwOnViolation,
+  );
+}
+
 export const useEpicCanvasStore = create<EpicCanvasStore>()(
   persist(
-    (set, get) => ({
+    (_rawSet, get) => {
+      // Single choke point for every internal canvas mutation (all ~60 call
+      // sites below funnel through this closure's `set`, including the ones
+      // that write `canvasByTabId` directly rather than via `updateTabCanvas`
+      // - e.g. `tearOffTabIntoNewHeaderTab`, `duplicateTab`). Delegates to
+      // the guarded public `setState` wrapper (defined after this store is
+      // created) rather than duplicating its guard logic - persisted
+      // hydration is the only other ingress point, since it runs through the
+      // `merge` option below instead of this closure.
+      const set = (
+        partial:
+          | Partial<EpicCanvasStore>
+          | ((state: EpicCanvasStore) => Partial<EpicCanvasStore>),
+      ): void => {
+        useEpicCanvasStore.setState(partial, undefined);
+      };
+      return {
       tabsById: {},
       canvasByTabId: {},
       closedTilePayloadsByTabId: {},
@@ -2684,7 +2754,8 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           pendingChatTitles: {},
         });
       },
-    }),
+      };
+    },
     {
       ...basePersistOptions(epicCanvasKey(null)),
       storage: createJSONStorage(() => epicCanvasStorage),
@@ -2698,22 +2769,164 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         mostRecentTabIdByEpicId: state.mostRecentTabIdByEpicId,
         artifactTreeByEpicId: state.artifactTreeByEpicId,
       }),
-      merge: (persistedState, currentState) => ({
-        ...currentState,
-        ...sanitizePersistedCanvasState(persistedState),
-      }),
+      merge: (persistedState, currentState) => {
+        const sanitized = sanitizePersistedCanvasState(persistedState);
+        // Never throw here, even in dev/test: zustand's `hydrate()` swallows
+        // a `merge()` throw internally and never rethrows, which also skips
+        // `set(stateFromStorage, true)` - so `hasHydrated`/`onFinishHydration`
+        // never fire and consumers waiting on hydration (history-prune-
+        // provider.tsx, epic-tab-existence-reconciler.tsx) hang forever. Fail
+        // closed by rejecting the candidate and returning normally instead;
+        // the diagnostic below is the surfaced signal in every mode.
+        const accepted = guardCanvasMutation(currentState, sanitized, {
+          ingressContext: "persisted-migration",
+          throwOnViolation: false,
+        });
+        if (!accepted) return currentState;
+        return {
+          ...currentState,
+          ...sanitized,
+        };
+      },
     },
   ),
 );
+
+const rawPublicSetState = useEpicCanvasStore.setState.bind(useEpicCanvasStore);
+/**
+ * Guards every PUBLIC-API canvas mutation. The closure-local `set` above
+ * delegates here; anything else reaching the store through the public API -
+ * `applyEpicCanvasDesktopProjection`, or a future caller - goes through this
+ * wrapper too. Reassigning `setState` itself - rather than adding a guard at
+ * each known call site - means a caller added later is covered too. This
+ * path is always strict: `resolveTabEpicIdentity` below is the one function
+ * that changes a tab's epicId, and it bypasses this wrapper entirely,
+ * committing straight through `rawPublicSetState` - provenance is enforced
+ * by that module privacy, not by a parameter threaded through this guard.
+ */
+useEpicCanvasStore.setState = (
+  partial:
+    | EpicCanvasStore
+    | Partial<EpicCanvasStore>
+    | ((state: EpicCanvasStore) => EpicCanvasStore | Partial<EpicCanvasStore>),
+  replace: boolean | undefined,
+): void => {
+  const state = useEpicCanvasStore.getState();
+  const resolved = typeof partial === "function" ? partial(state) : partial;
+  if (
+    resolved !== state &&
+    !guardCanvasMutation(state, resolved, {
+      ingressContext: "public-setstate",
+      throwOnViolation: import.meta.env.DEV,
+    })
+  ) {
+    return;
+  }
+  if (replace === true) {
+    // `replace: true` callers (store resets in tests) pass a full state by
+    // contract; the union param type above can't express that correlation to
+    // zustand's overloaded signature without this cast.
+    rawPublicSetState(resolved as EpicCanvasStore, true);
+  } else {
+    rawPublicSetState(resolved);
+  }
+};
+
+/**
+ * The ONLY function authorized to change a tab's `epicId` for an
+ * already-live tile set. It bypasses the guarded public `setState` wrapper
+ * above (which is always strict) and commits through `rawPublicSetState`
+ * directly - provenance is enforced by this function being the sole caller
+ * of that module-private raw setter, not by a parameter every guarded
+ * ingress has to understand. `tab-command-coordinator.ts`'s
+ * `resolveMigratedEpicActivation` and `completePhaseMigration` are its only
+ * two callers; both publish success from a POST-commit `getState()`
+ * read-back rather than trusting this function's return, because a
+ * synchronous subscriber can re-enter and move the same tab's epicId again
+ * before the outer caller regains control (see their own doc comments) - so
+ * this function reports nothing about outcome.
+ *
+ * Also owns the `mostRecentTabIdByEpicId` reindex (move the entry from the
+ * prior epicId to the resolved one) - both call sites needed the exact same
+ * bookkeeping, so it lives here once instead of twice.
+ *
+ * Preconditions, enforced here rather than trusted from the caller:
+ * - the tab exists;
+ * - `resolvedEpicId` actually differs from the tab's current epicId (a
+ *   same-value call is a silent no-op, not an error - safe for an
+ *   idempotent retry);
+ * - the tab's CURRENT epicId equals `expectedCurrentEpicId`. This is the
+ *   strongest precondition genuinely available to BOTH real callers today:
+ *   `resolveMigratedEpicActivation` already checks the tab's epicId against
+ *   `target.sourceEpicId` before calling, and `completePhaseMigration`
+ *   already checks it against `command.phaseId` (via `surfaceMode.phaseId`).
+ *   A tab-level `surfaceMode.kind === "phase-migration"` check was
+ *   considered and REJECTED as a UNIVERSAL precondition here:
+ *   `resolveMigratedEpicActivation`'s own existing check never examines
+ *   `surfaceMode` at all (its target is a more general "migrated-epic"
+ *   activation, not necessarily a phase-migration tab), so requiring it
+ *   would incorrectly narrow this action to serve only
+ *   `completePhaseMigration`. Each coordinator call site keeps its own
+ *   additional, shape-specific precondition (surfaceMode+phaseId, or
+ *   sourceEpicId-or-already-resolved) before ever calling this action - this
+ *   action's `expectedCurrentEpicId` check is a second, independent layer
+ *   against a stale/racing caller, not a replacement for those.
+ */
+export function resolveTabEpicIdentity(
+  tabId: string,
+  expectedCurrentEpicId: string,
+  resolvedEpicId: string,
+): void {
+  const state = useEpicCanvasStore.getState();
+  const current = state.tabsById[tabId];
+  if (current === undefined) return;
+  if (current.epicId === resolvedEpicId) return;
+  if (current.epicId !== expectedCurrentEpicId) {
+    appLogger.error(
+      "resolveTabEpicIdentity precondition failed: tab's current epicId does not match the caller's expectation",
+      {
+        tabId,
+        expectedCurrentEpicId,
+        actualCurrentEpicId: current.epicId,
+        resolvedEpicId,
+      },
+      new Error("resolveTabEpicIdentity precondition failed"),
+    );
+    return;
+  }
+  const nextMostRecentTabIdByEpicId = {
+    ...state.mostRecentTabIdByEpicId,
+    [resolvedEpicId]: tabId,
+  };
+  if (nextMostRecentTabIdByEpicId[expectedCurrentEpicId] === tabId) {
+    delete nextMostRecentTabIdByEpicId[expectedCurrentEpicId];
+  }
+  rawPublicSetState({
+    tabsById: {
+      ...state.tabsById,
+      [tabId]: { ...current, epicId: resolvedEpicId },
+    },
+    mostRecentTabIdByEpicId: nextMostRecentTabIdByEpicId,
+  });
+}
 
 export function applyEpicCanvasDesktopProjection(
   snapshot: DesktopPerWindowSnapshot,
 ): void {
   applyingDesktopProjection = true;
-  useEpicCanvasStore.setState((state) =>
-    buildDesktopProjectionPatch(state, snapshot),
-  );
-  applyingDesktopProjection = false;
+  try {
+    // The guarded public `setState` wrapper validates this patch itself -
+    // no separate guard call needed here, it would just re-check the
+    // identical patch a second time.
+    useEpicCanvasStore.setState((state) =>
+      buildDesktopProjectionPatch(state, snapshot),
+    );
+  } finally {
+    // Always release the suppression flag, even when the dev/test guard
+    // throws mid-`setState` - otherwise every later outbound projection is
+    // silently dropped by the subscriber below for the module's lifetime.
+    applyingDesktopProjection = false;
+  }
 }
 
 useEpicCanvasStore.subscribe((state) => {

--- a/clients/gui-app/src/stores/epics/canvas/tile-identity-invariant.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-identity-invariant.ts
@@ -1,0 +1,179 @@
+/**
+ * Canvas-store-wide immutable tile identity: once an `instanceId` is
+ * observed, its `{tile kind, content id, epic id, host id}` tuple must never
+ * change. `epicId` is not stored on most tile refs - it is derived from
+ * whichever tab currently owns the tile (`tabsById[tabId].epicId`), so every
+ * check here takes a canvas-wide `canvasByTabId` snapshot plus an epicId
+ * resolver rather than a single tile in isolation. A repoint under an
+ * unchanged `instanceId` is the exact hazard `ChatMessages` cannot survive -
+ * it freezes `(instanceId, epicId, chatId)` once per mount.
+ *
+ * This module is strict, full stop - no ingress may commit an epicId change
+ * under a retained `instanceId`. The one sanctioned resolution
+ * (`store.ts`'s `resolveTabEpicIdentity`) does not pass through here at all:
+ * it is the sole caller of the module-private raw setter, so provenance is
+ * enforced by module privacy rather than a parameter this module has to
+ * understand.
+ *
+ * Pure detection lives here; the dev/test-throws-vs-production-fails-closed
+ * policy is applied by `enforceTileIdentityInvariant`, and committing (or
+ * rejecting) a candidate state is the caller's job - this module never
+ * touches the store.
+ */
+import { appLogger, type AppLogFields } from "@/lib/logger";
+import type { EpicCanvasState, EpicCanvasTileRef } from "./types";
+
+export interface TileIdentityTuple {
+  readonly tileKind: EpicCanvasTileRef["type"];
+  readonly contentId: string;
+  readonly epicId: string;
+  readonly hostId: string;
+}
+
+export interface TileIdentityViolation {
+  readonly instanceId: string;
+  readonly previous: TileIdentityTuple;
+  readonly incoming: TileIdentityTuple;
+}
+
+/** Resolves the epicId a tab's tiles currently inherit, or `null` for an unknown tab. */
+export type EpicIdForTabId = (tabId: string) => string | null;
+
+/** A candidate `canvasByTabId` to validate, plus where it came from (for diagnostics). */
+export interface TileIdentityIngress {
+  readonly canvasByTabId: Readonly<Record<string, EpicCanvasState | undefined>>;
+  readonly epicIdForTabId: EpicIdForTabId;
+  readonly ingressContext: string;
+}
+
+function tileIdentityTuple(
+  node: EpicCanvasTileRef,
+  epicId: string,
+): TileIdentityTuple {
+  return { tileKind: node.type, contentId: node.id, epicId, hostId: node.hostId };
+}
+
+function tileIdentityTuplesEqual(
+  a: TileIdentityTuple,
+  b: TileIdentityTuple,
+): boolean {
+  return (
+    a.tileKind === b.tileKind &&
+    a.contentId === b.contentId &&
+    a.epicId === b.epicId &&
+    a.hostId === b.hostId
+  );
+}
+
+/** Plain-literal projection - `AppLogFields` needs a string index signature, which a named interface value does not structurally satisfy. */
+function tileIdentityTupleLogFields(tuple: TileIdentityTuple): AppLogFields {
+  return {
+    tileKind: tuple.tileKind,
+    contentId: tuple.contentId,
+    epicId: tuple.epicId,
+    hostId: tuple.hostId,
+  };
+}
+
+/**
+ * Canvas-wide `instanceId -> tuple` snapshot, scanning every tab's tiles.
+ * Callers pass an ALREADY-VALIDATED `canvasByTabId` (the store's committed
+ * state) to build the `previous` baseline a candidate is checked against -
+ * `findTileIdentityViolation` is what validates a candidate before it is
+ * ever folded into that baseline.
+ */
+export function collectTileIdentityRegistry(
+  canvasByTabId: Readonly<Record<string, EpicCanvasState | undefined>>,
+  epicIdForTabId: EpicIdForTabId,
+): ReadonlyMap<string, TileIdentityTuple> {
+  const out = new Map<string, TileIdentityTuple>();
+  for (const [tabId, canvas] of Object.entries(canvasByTabId)) {
+    if (canvas === undefined) continue;
+    const epicId = epicIdForTabId(tabId);
+    if (epicId === null) continue;
+    for (const [instanceId, node] of Object.entries(canvas.tilesByInstanceId)) {
+      if (node === undefined) continue;
+      out.set(instanceId, tileIdentityTuple(node, epicId));
+    }
+  }
+  return out;
+}
+
+/**
+ * Scans a CANDIDATE `canvasByTabId` (canvas-wide) for the first `instanceId`
+ * whose tuple conflicts with either (a) another tab in the same candidate
+ * snapshot, or (b) `previous`, the last known-valid registry. An
+ * `instanceId` absent from `previous` (a fresh mint) or absent from the
+ * candidate (a close) is never a violation; a RETAINED `instanceId` with a
+ * CHANGED tuple is always a violation.
+ */
+export function findTileIdentityViolation(
+  previous: ReadonlyMap<string, TileIdentityTuple>,
+  canvasByTabId: Readonly<Record<string, EpicCanvasState | undefined>>,
+  epicIdForTabId: EpicIdForTabId,
+): TileIdentityViolation | null {
+  const seenInCandidate = new Map<string, TileIdentityTuple>();
+  for (const [tabId, canvas] of Object.entries(canvasByTabId)) {
+    if (canvas === undefined) continue;
+    const epicId = epicIdForTabId(tabId);
+    if (epicId === null) continue;
+    for (const [instanceId, node] of Object.entries(canvas.tilesByInstanceId)) {
+      if (node === undefined) continue;
+      const incoming = tileIdentityTuple(node, epicId);
+      const withinCandidate = seenInCandidate.get(instanceId);
+      if (
+        withinCandidate !== undefined &&
+        !tileIdentityTuplesEqual(withinCandidate, incoming)
+      ) {
+        return { instanceId, previous: withinCandidate, incoming };
+      }
+      seenInCandidate.set(instanceId, incoming);
+      const prior = previous.get(instanceId);
+      if (prior !== undefined && !tileIdentityTuplesEqual(prior, incoming)) {
+        return { instanceId, previous: prior, incoming };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Enforces the invariant at one ingress. Always emits a diagnostic on
+ * violation. `throwOnViolation` is the dev/test-vs-production policy switch -
+ * production callers pass `import.meta.env.DEV`; tests drive it directly
+ * rather than stubbing Vite's static env. Returns whether the candidate
+ * `canvasByTabId` may be committed: a `false` result means the caller must
+ * retain its last valid state (drop the candidate patch entirely) - this
+ * function never commits or mutates anything itself.
+ */
+export function enforceTileIdentityInvariant(
+  previous: ReadonlyMap<string, TileIdentityTuple>,
+  ingress: TileIdentityIngress,
+  throwOnViolation: boolean,
+): boolean {
+  const { canvasByTabId, epicIdForTabId, ingressContext } = ingress;
+  const violation = findTileIdentityViolation(
+    previous,
+    canvasByTabId,
+    epicIdForTabId,
+  );
+  if (violation === null) return true;
+  appLogger.error(
+    "canvas tile identity invariant violated",
+    {
+      ingressContext,
+      instanceId: violation.instanceId,
+      previous: tileIdentityTupleLogFields(violation.previous),
+      incoming: tileIdentityTupleLogFields(violation.incoming),
+    },
+    new Error("canvas tile identity invariant violated"),
+  );
+  if (throwOnViolation) {
+    throw new Error(
+      `Canvas tile identity invariant violated in ${ingressContext} for instanceId ` +
+        `${violation.instanceId}: previous=${JSON.stringify(violation.previous)} ` +
+        `incoming=${JSON.stringify(violation.incoming)}`,
+    );
+  }
+  return false;
+}

--- a/clients/gui-app/src/stores/epics/canvas/tile-identity-invariant.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-identity-invariant.ts
@@ -50,7 +50,12 @@ function tileIdentityTuple(
   node: EpicCanvasTileRef,
   epicId: string,
 ): TileIdentityTuple {
-  return { tileKind: node.type, contentId: node.id, epicId, hostId: node.hostId };
+  return {
+    tileKind: node.type,
+    contentId: node.id,
+    epicId,
+    hostId: node.hostId,
+  };
 }
 
 function tileIdentityTuplesEqual(

--- a/clients/gui-app/src/stores/epics/canvas/tile-tree.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-tree.ts
@@ -364,6 +364,36 @@ export function removePaneFromTree(
   };
 }
 
+/**
+ * Ticket 20: read-only mirror of {@link removePaneFromTree}'s single-survivor
+ * dissolve branch - if removing `paneId` would leave its parent group with
+ * exactly one remaining child, that child is promoted into the parent's slot
+ * and every pane in ITS subtree gets a new React ancestor (a dissolve whose
+ * promoted subtree holds more than one pane remounts every one of them, not
+ * just the direct sibling). Returns the active-tab instanceId of every pane
+ * in the promoted subtree - the tiles a caller must flush a pre-mutation
+ * viewport handoff for - or `[]` when no dissolve would occur (the parent
+ * has other children, or `paneId` is the root).
+ */
+export function paneRemovalDissolveHandoffTargets(
+  root: TileLayoutNode | null,
+  paneId: string,
+): ReadonlyArray<string> {
+  if (root === null) return [];
+  const path = findPanePath(root, paneId);
+  if (path === null || path.length === 0) return [];
+  const parentPath = path.slice(0, -1);
+  const parentNode = getNodeAtPath(root, parentPath);
+  if (parentNode.kind !== "group" || parentNode.children.length !== 2) {
+    return [];
+  }
+  const removeIndex = path[path.length - 1];
+  const survivor = parentNode.children[removeIndex === 0 ? 1 : 0];
+  return collectPanes(survivor)
+    .map((pane) => pane.activeTabId)
+    .filter((activeTabId): activeTabId is string => activeTabId !== null);
+}
+
 export interface InsertPaneAtEdgeArgs {
   readonly state: TileTreeState;
   readonly targetPaneId: string;

--- a/clients/gui-app/src/stores/epics/canvas/tile-tree.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-tree.ts
@@ -198,6 +198,23 @@ export function findPaneById(
   return null;
 }
 
+/**
+ * The tab a pane actually shows: `activeTabId` when it names a live tab,
+ * otherwise the pane's first tab (matching `TabGroupView`'s inline fallback).
+ * Shared by the renderer and, from Ticket 21 slice 2 on, host membership -
+ * the two must agree or a chat the renderer paints can go unhosted. Returns
+ * `null` for an empty pane.
+ */
+export function resolveActivePaneTab(
+  activeTabId: string | null,
+  tabInstanceIds: ReadonlyArray<string>,
+): string | null {
+  if (activeTabId !== null && tabInstanceIds.includes(activeTabId)) {
+    return activeTabId;
+  }
+  return tabInstanceIds[0] ?? null;
+}
+
 export function getNodeAtPath(
   root: TileLayoutNode,
   path: NodePath,

--- a/clients/gui-app/src/stores/epics/canvas/tile-tree.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-tree.ts
@@ -407,8 +407,8 @@ export function paneRemovalDissolveHandoffTargets(
   const removeIndex = path[path.length - 1];
   const survivor = parentNode.children[removeIndex === 0 ? 1 : 0];
   return collectPanes(survivor)
-    .map((pane) => pane.activeTabId)
-    .filter((activeTabId): activeTabId is string => activeTabId !== null);
+    .map((pane) => resolveActivePaneTab(pane.activeTabId, pane.tabInstanceIds))
+    .filter((instanceId): instanceId is string => instanceId !== null);
 }
 
 export interface InsertPaneAtEdgeArgs {

--- a/clients/gui-app/src/stores/tabs/__tests__/top-level-surface-retention.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/top-level-surface-retention.test.ts
@@ -51,13 +51,11 @@ describe("retainedTopLevelSurfaceKeys (pure)", () => {
       "draft:4",
       "epic:new",
     ];
-    const retained = retainedTopLevelSurfaceKeys(available, ["epic:new"], [
-      "draft:4",
-      "draft:3",
-      "draft:2",
-      "draft:1",
-      "epic:old",
-    ]);
+    const retained = retainedTopLevelSurfaceKeys(
+      available,
+      ["epic:new"],
+      ["draft:4", "draft:3", "draft:2", "draft:1", "epic:old"],
+    );
     expect(retained).not.toContain("epic:old");
     expect(retained).toContain("epic:new");
     expect(retained.length).toBe(MAX_RETAINED_TOP_LEVEL_SURFACES);

--- a/clients/gui-app/src/stores/tabs/__tests__/top-level-surface-retention.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/top-level-surface-retention.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_RETAINED_TOP_LEVEL_SURFACES,
+  advanceTopLevelSurfaceRecency,
+  retainedTopLevelSurfaceKeys,
+} from "@/stores/tabs/top-level-surface-retention";
+
+describe("retainedTopLevelSurfaceKeys (pure)", () => {
+  it("retains every key that is active or already in recency, under the cap", () => {
+    const retained = retainedTopLevelSurfaceKeys(
+      ["a", "b", "c"],
+      ["c"],
+      ["a", "b"],
+    );
+    expect(new Set(retained)).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("does not retain an available key that has never been active or recorded into recency", () => {
+    const retained = retainedTopLevelSurfaceKeys(["a", "b", "c"], ["c"], []);
+    expect(retained).toEqual(["c"]);
+  });
+
+  it("retains a brand-new key immediately once it is active, even with no recency history", () => {
+    const retained = retainedTopLevelSurfaceKeys(["a", "new"], ["new"], ["a"]);
+    expect(new Set(retained)).toEqual(new Set(["a", "new"]));
+  });
+
+  it("pins the active key first and evicts the least-recently-active over the cap", () => {
+    const available = ["0", "1", "2", "3", "4", "5"];
+    const retained = retainedTopLevelSurfaceKeys(
+      available,
+      ["5"],
+      ["4", "3", "2", "1", "0"],
+    );
+    expect(retained).not.toContain("0");
+    expect(retained).toContain("5");
+    expect(retained.length).toBe(MAX_RETAINED_TOP_LEVEL_SURFACES);
+  });
+
+  it("drops keys no longer available even if still in recency", () => {
+    const retained = retainedTopLevelSurfaceKeys(["a"], ["a"], ["a", "stale"]);
+    expect(retained).toEqual(["a"]);
+  });
+
+  it("applies one global cap across mixed-kind keys, not a per-kind cap", () => {
+    const available = [
+      "epic:old",
+      "draft:1",
+      "draft:2",
+      "draft:3",
+      "draft:4",
+      "epic:new",
+    ];
+    const retained = retainedTopLevelSurfaceKeys(available, ["epic:new"], [
+      "draft:4",
+      "draft:3",
+      "draft:2",
+      "draft:1",
+      "epic:old",
+    ]);
+    expect(retained).not.toContain("epic:old");
+    expect(retained).toContain("epic:new");
+    expect(retained.length).toBe(MAX_RETAINED_TOP_LEVEL_SURFACES);
+  });
+});
+
+describe("advanceTopLevelSurfaceRecency (pure)", () => {
+  it("moves active keys to the front, preserving the relative order of the rest", () => {
+    const next = advanceTopLevelSurfaceRecency(["b"], ["a", "b", "c"]);
+    expect(next).toEqual(["b", "a", "c"]);
+  });
+
+  it("is idempotent for repeated calls with the same active keys", () => {
+    const once = advanceTopLevelSurfaceRecency(["b"], ["a", "b", "c"]);
+    const twice = advanceTopLevelSurfaceRecency(["b"], once);
+    expect(twice).toEqual(once);
+  });
+
+  it("appends a brand-new active key without dropping prior recency", () => {
+    const next = advanceTopLevelSurfaceRecency(["new"], ["a", "b"]);
+    expect(next).toEqual(["new", "a", "b"]);
+  });
+});

--- a/clients/gui-app/src/stores/tabs/__tests__/top-level-surface-retention.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/top-level-surface-retention.test.ts
@@ -42,6 +42,18 @@ describe("retainedTopLevelSurfaceKeys (pure)", () => {
     expect(retained).toEqual(["a"]);
   });
 
+  it("does not let an unavailable active key consume a retention slot", () => {
+    const available = ["0", "1", "2", "3", "4", "5"];
+    const retained = retainedTopLevelSurfaceKeys(
+      available,
+      ["stale-active"],
+      ["5", "4", "3", "2", "1", "0"],
+    );
+
+    expect(retained).toHaveLength(MAX_RETAINED_TOP_LEVEL_SURFACES);
+    expect(retained).toEqual(["1", "2", "3", "4", "5"]);
+  });
+
   it("applies one global cap across mixed-kind keys, not a per-kind cap", () => {
     const available = [
       "epic:old",

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -3,6 +3,7 @@ import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe
 import { releaseOpenEpicSessionIfUnused } from "@/lib/registries/epic-session-registry";
 import { evictChatTabPersistenceForEpics } from "@/stores/chats/chat-tab-persistence-eviction";
 import {
+  resolveTabEpicIdentity,
   resolveTabIdForEpic,
   resolveTabIdForPhaseMigration,
   useEpicCanvasStore,
@@ -1068,37 +1069,37 @@ export class TabCommandCoordinator {
     }
     const ref: TabRef = { kind: "epic", id: target.tabId };
     return this.activationForRef(layout, ref, () => {
+      resolveTabEpicIdentity(target.tabId, target.sourceEpicId, target.epicId);
+      // The gate below keeps a failed resolution write-free (no
+      // openTabOrder/activeTabId change), and the read-back after it catches
+      // a listener that raced this same resolution to a different epicId
+      // during `execute`'s synchronous `notify()` (which runs before
+      // `applySources` - see `execute` below): this closure can't return a
+      // value (`resolveMigratedEpicActivation` already returned the
+      // `ResolvedCoordinatedActivation` object bundling it), so a mismatch
+      // throws instead, riding `execute`'s existing catch/record/rethrow
+      // path (the same one a `replaceLayoutForTransaction` failure takes) to
+      // carry the failure out through `activateTab` - before
+      // `replaceLayoutForTransaction` ever runs, so layout/focus stay
+      // untouched.
       useEpicCanvasStore.setState((state) => {
         const current = state.tabsById[target.tabId];
-        if (
-          current === undefined ||
-          (current.epicId !== target.sourceEpicId &&
-            current.epicId !== target.epicId)
-        ) {
+        if (current === undefined || current.epicId !== target.epicId) {
           return state;
         }
-        const mostRecentTabIdByEpicId = {
-          ...state.mostRecentTabIdByEpicId,
-          [target.epicId]: target.tabId,
-        };
-        if (
-          target.sourceEpicId !== target.epicId &&
-          mostRecentTabIdByEpicId[target.sourceEpicId] === target.tabId
-        ) {
-          delete mostRecentTabIdByEpicId[target.sourceEpicId];
-        }
         return {
-          tabsById: {
-            ...state.tabsById,
-            [target.tabId]: { ...current, epicId: target.epicId },
-          },
           openTabOrder: state.openTabOrder.includes(target.tabId)
             ? state.openTabOrder
             : [...state.openTabOrder, target.tabId],
           activeTabId: target.tabId,
-          mostRecentTabIdByEpicId,
         };
       });
+      const final = useEpicCanvasStore.getState().tabsById[target.tabId];
+      if (final === undefined || final.epicId !== target.epicId) {
+        throw new Error(
+          "Tab command migrated-epic activation could not resolve tab epicId",
+        );
+      }
     });
   }
 
@@ -1228,41 +1229,49 @@ export class TabCommandCoordinator {
       projectSourceCompatibility: true,
       applySources: () => {
         this.applyExpectedSourceMutation(() => {
+          resolveTabEpicIdentity(command.tabId, command.phaseId, command.epicId);
           useEpicCanvasStore.setState((state) => {
             const current = state.tabsById[command.tabId];
+            // Gated on the epicId resolution having ACTUALLY landed (whether
+            // from the call above or a prior one) rather than only on
+            // surfaceMode - keeps the two updates sequenced instead of
+            // trusting they always land together.
             if (
-              current?.surfaceMode?.kind !== "phase-migration" ||
+              current === undefined ||
+              current.epicId !== command.epicId ||
+              current.surfaceMode?.kind !== "phase-migration" ||
               current.surfaceMode.phaseId !== command.phaseId
             ) {
               return state;
-            }
-            const mostRecentTabIdByEpicId = {
-              ...state.mostRecentTabIdByEpicId,
-              [command.epicId]: command.tabId,
-            };
-            if (
-              command.phaseId !== command.epicId &&
-              mostRecentTabIdByEpicId[command.phaseId] === command.tabId
-            ) {
-              delete mostRecentTabIdByEpicId[command.phaseId];
             }
             return {
               tabsById: {
                 ...state.tabsById,
                 [command.tabId]: {
                   ...current,
-                  epicId: command.epicId,
                   surfaceMode: { kind: "epic" },
                 },
               },
-              mostRecentTabIdByEpicId,
             };
           });
         });
       },
       applyRemovals: () => undefined,
     });
-    return true;
+    // Derived from OBSERVED final state, not a claim recorded mid-commit: a
+    // synchronous subscriber re-entering `resolveTabEpicIdentity` during
+    // `execute`'s `notify()` can move this same tab's epicId again before
+    // this frame regains control, which makes any flag captured at write
+    // time stale. A `false` return routes into
+    // `PhaseMigrationController.succeed()`'s existing rejection branch
+    // (status -> "error"), which its `retry()` path already knows how to
+    // resume from.
+    const final = useEpicCanvasStore.getState().tabsById[command.tabId];
+    return (
+      final !== undefined &&
+      final.epicId === command.epicId &&
+      final.surfaceMode?.kind !== "phase-migration"
+    );
   }
 
   closeRef(ref: TabRef): boolean {

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -1229,7 +1229,11 @@ export class TabCommandCoordinator {
       projectSourceCompatibility: true,
       applySources: () => {
         this.applyExpectedSourceMutation(() => {
-          resolveTabEpicIdentity(command.tabId, command.phaseId, command.epicId);
+          resolveTabEpicIdentity(
+            command.tabId,
+            command.phaseId,
+            command.epicId,
+          );
           useEpicCanvasStore.setState((state) => {
             const current = state.tabsById[command.tabId];
             // Gated on the epicId resolution having ACTUALLY landed (whether

--- a/clients/gui-app/src/stores/tabs/top-level-surface-retention.ts
+++ b/clients/gui-app/src/stores/tabs/top-level-surface-retention.ts
@@ -41,9 +41,7 @@ export function retainedTopLevelSurfaceKeys(
   const available = new Set(availableKeys);
   const ordered = [
     ...activeKeys,
-    ...recency.filter(
-      (key) => available.has(key) && !activeKeys.includes(key),
-    ),
+    ...recency.filter((key) => available.has(key) && !activeKeys.includes(key)),
   ];
   const retained = new Set(ordered.slice(0, MAX_RETAINED_TOP_LEVEL_SURFACES));
   return availableKeys.filter((key) => retained.has(key));

--- a/clients/gui-app/src/stores/tabs/top-level-surface-retention.ts
+++ b/clients/gui-app/src/stores/tabs/top-level-surface-retention.ts
@@ -1,0 +1,50 @@
+/**
+ * The global top-level-surface MRU/retention policy, shared by
+ * `TopLevelTabHost`'s keep-alive layer and Ticket 21 slice 2's stable
+ * tile-surface-host membership mirror (`tile-surface-membership.ts`).
+ *
+ * Pure recency + cap algorithm over kind-qualified `TabRef` keys (the
+ * `"<kind>:<id>"` format shared with `tabRefKey` in `stores/tabs/layout.ts`),
+ * applying ONE global cap across every top-level tab kind (epic, draft,
+ * history, settings) - never a per-kind cap. Callers own deriving
+ * `availableKeys`/`activeKeys` from their own reactive inputs and persisting
+ * `recency` between calls.
+ */
+export const MAX_RETAINED_TOP_LEVEL_SURFACES = 5;
+
+/**
+ * Advances the recency order: every currently active key moves to the
+ * front, preserving the relative order of everything else. Idempotent for
+ * repeated calls with the same `activeKeys` against its own prior output -
+ * callers may call this unconditionally on every recompute rather than
+ * gating on an active-set-changed comparison.
+ */
+export function advanceTopLevelSurfaceRecency(
+  activeKeys: ReadonlyArray<string>,
+  previousRecency: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  return [
+    ...activeKeys,
+    ...previousRecency.filter((key) => !activeKeys.includes(key)),
+  ];
+}
+
+/**
+ * The retained subset of `availableKeys`: every active key, plus enough of
+ * `recency` (in order) to fill {@link MAX_RETAINED_TOP_LEVEL_SURFACES}.
+ */
+export function retainedTopLevelSurfaceKeys(
+  availableKeys: ReadonlyArray<string>,
+  activeKeys: ReadonlyArray<string>,
+  recency: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const available = new Set(availableKeys);
+  const ordered = [
+    ...activeKeys,
+    ...recency.filter(
+      (key) => available.has(key) && !activeKeys.includes(key),
+    ),
+  ];
+  const retained = new Set(ordered.slice(0, MAX_RETAINED_TOP_LEVEL_SURFACES));
+  return availableKeys.filter((key) => retained.has(key));
+}

--- a/clients/gui-app/src/stores/tabs/top-level-surface-retention.ts
+++ b/clients/gui-app/src/stores/tabs/top-level-surface-retention.ts
@@ -39,8 +39,9 @@ export function retainedTopLevelSurfaceKeys(
   recency: ReadonlyArray<string>,
 ): ReadonlyArray<string> {
   const available = new Set(availableKeys);
+  const availableActiveKeys = activeKeys.filter((key) => available.has(key));
   const ordered = [
-    ...activeKeys,
+    ...availableActiveKeys,
     ...recency.filter((key) => available.has(key) && !activeKeys.includes(key)),
   ];
   const retained = new Set(ordered.slice(0, MAX_RETAINED_TOP_LEVEL_SURFACES));


### PR DESCRIPTION
## Summary

- cancel active anchoring when native scrollbar or otherwise unowned scroll movement proves the reader has departed, while preserving library-owned motion
- capture and hand off the live chat viewport before same-commit canvas moves, splits, dissolves, and header tear-offs can remount a transcript
- repair anchored-turn drift after row-size and viewport-geometry changes, and isolate navigation highlights so only the affected timeline rows update
- enforce immutable canvas tile identity and host selected chat bodies in a stable, geometry-coordinated surface across structural canvas operations
- freeze offscreen transcript rows during panel resize and drive resize drags from window-level pointer listeners
- enable the stable tile surface host by default after the permanent lifecycle matrix and recorded live rollout evidence passed

## Verification

- current-head targeted canvas/renderer suites: 158 passed
- current-head hosted activation/surface suites: 69 passed
- split-target mutation control: reverting the shared painted-tab resolver made all 6 null/stale activation pins fail; byte-exact restoration returned all 6 green
- hosted activation mutation controls: flipping the plane claim back to bubble made 3 phase/ordering pins fail; severing per-pane dispatch made 6 activation/focus pins fail; breaking bridge identity made its exact-provider pin fail; every mutation was restored byte-exact and returned green
- full current-head GUI-app suite: 9,929 passed, 1 skipped (969 files passed, 1 skipped)
- current-head GUI-app compile: passed
- current-head whole-package lint: passed
- DCO, prohibited-reference, and attribution sweeps: passed

## Viewport handoff identity audit

| Producer | Identity rule | Verdict |
| --- | --- | --- |
| `tearOffTabIntoNewHeaderTab` | `sourceTileTabId` is the exact torn-off instance; dissolve survivors use the shared painted-tab resolver | justified exact + resolved |
| `insertNodeOnTabStrip` | `findPaneTabByContentId().instanceId` is the exact already-open instance being moved; dissolve survivors use the shared resolver | justified exact + resolved |
| `moveTabOnTabStrip` | `args.tabId` is the exact dragged instance; dissolve survivors use the shared resolver | justified exact + resolved |
| `splitPaneWithNode` | target pane uses the shared painted-tab resolver; an already-open source uses its exact moved instance; dissolve survivors use the shared resolver | resolved + justified exact |
| `splitPaneWithTab` | `args.tabId` is the exact dragged instance; target pane and dissolve survivors use the shared resolver | justified exact + resolved |
| `splitPaneEmptyInTab` | target pane uses the shared painted-tab resolver | resolved |
| `closeCanvasTab` | only promoted dissolve survivors are handoff targets; all use the shared resolver | resolved |
| `closeAllCanvasTabs` | only promoted dissolve survivors are handoff targets; all use the shared resolver | resolved |
| `closeCanvasPane` | only promoted dissolve survivors are handoff targets; all use the shared resolver | resolved |
| live chat registration | the mounted `ChatMessages` instance registers under its own immutable `instanceId` | justified exact |

## Recorded evidence

The full stable-host rollout evidence was recorded before this landing replay. A minimal post-replay re-drive remains an explicit merge-ready blocker on exact head `598cf3e0925ef5e4ace61b6998ff32e66002743a`: full activation row, partial focus/presentation row, one lifecycle spot-check, and the hosted two-pane focus-steal observation.

Internal repository pin: traycerai/traycer-internal#4772.


