### PR TITLE
fix(gui-app): fit communication graph viewport

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
@@ -1,0 +1,93 @@
+import "../../../../../__tests__/test-browser-apis";
+
+const reactFlowMock = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return { ...actual, ReactFlow: reactFlowMock };
+});
+
+vi.mock("@/providers/use-resolved-theme", () => ({
+  useResolvedTheme: () => ({
+    resolvedTheme: "light" as const,
+    themePreset: "default",
+  }),
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicAgentActivityTiers: () => new Map(),
+}));
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommGraphCanvas } from "@/components/epic-canvas/comm-graph/comm-graph-canvas";
+import type { CommGraphAgentNode } from "@/lib/comm-graph/comm-graph-model";
+import { DEFAULT_COMM_GRAPH_VIEW } from "@/stores/epics/canvas/tile-schema/comm-graph-tile";
+import type { CommGraphTileViewState } from "@/stores/epics/canvas/types";
+
+const AGENT: CommGraphAgentNode = {
+  id: "agent-1",
+  kind: "chat",
+  name: "Agent",
+  hostId: "host-1",
+  parentId: null,
+  harnessId: null,
+  archived: false,
+  createdAt: 1,
+};
+
+function renderCanvas(view: CommGraphTileViewState): void {
+  render(
+    <CommGraphCanvas
+      epicId="epic-1"
+      agents={[AGENT]}
+      agentIds={new Set([AGENT.id])}
+      events={[]}
+      hosts={[]}
+      pulse={null}
+      view={view}
+      onViewChange={vi.fn()}
+      canJump={() => false}
+      onJump={vi.fn()}
+      canJumpToSender={() => false}
+      onJumpToSender={vi.fn()}
+      canJumpToCreated={() => false}
+      onJumpToCreated={vi.fn()}
+      canJumpToNoticed={() => false}
+      onJumpToNoticed={vi.fn()}
+      onOpenAgent={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  reactFlowMock.mockClear();
+});
+
+describe("CommGraphCanvas viewport", () => {
+  it("fits every node on first open and permits a full-graph overview", () => {
+    renderCanvas(DEFAULT_COMM_GRAPH_VIEW);
+
+    expect(reactFlowMock.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        defaultViewport: DEFAULT_COMM_GRAPH_VIEW,
+        fitView: true,
+        minZoom: 0.1,
+      }),
+    );
+  });
+
+  it("restores a user-positioned viewport instead of fitting it again", () => {
+    const persistedView = { x: 120, y: -80, zoom: 0.75 };
+    renderCanvas(persistedView);
+
+    expect(reactFlowMock.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        defaultViewport: persistedView,
+        fitView: false,
+        minZoom: 0.1,
+      }),
+    );
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
@@ -1,6 +1,6 @@
 import "../../../../../__tests__/test-browser-apis";
 
-const reactFlowMock = vi.hoisted(() => vi.fn(() => null));
+const reactFlowMock = vi.hoisted(() => vi.fn((_props: unknown) => null));
 
 vi.mock("@xyflow/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@xyflow/react")>();
@@ -53,8 +53,6 @@ function renderCanvas(view: CommGraphTileViewState): void {
       onJumpToSender={vi.fn()}
       canJumpToCreated={() => false}
       onJumpToCreated={vi.fn()}
-      canJumpToNoticed={() => false}
-      onJumpToNoticed={vi.fn()}
       onOpenAgent={vi.fn()}
     />,
   );

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
@@ -15,7 +15,6 @@ import {
   Background,
   Controls,
   ReactFlow,
-  ReactFlowProvider,
   type NodeMouseHandler,
   type Viewport,
 } from "@xyflow/react";
@@ -59,11 +58,14 @@ import type {
   CommGraphPulseKind,
 } from "@/lib/comm-graph/comm-graph-timeline";
 import type { CommGraphTileViewState } from "@/stores/epics/canvas/types";
+import { DEFAULT_COMM_GRAPH_VIEW } from "@/stores/epics/canvas/tile-schema/comm-graph-tile";
 
 const NODE_TYPES = { [COMM_GRAPH_AGENT_NODE_TYPE]: CommGraphAgentNodeView };
 const EDGE_TYPES = { [COMM_GRAPH_EDGE_TYPE]: CommGraphEdgeView };
 // React Flow's attribution link is not part of this surface.
 const PRO_OPTIONS = { hideAttribution: true };
+// React Flow defaults to 0.5, which is too close for a wide agent graph to fit.
+const COMM_GRAPH_MIN_ZOOM = 0.1;
 
 /** Which detail surface the canvas has open, if any. */
 type CommGraphSelectedDetail =
@@ -129,10 +131,17 @@ function nodeHostStatus(
 }
 
 export function CommGraphCanvas(props: CommGraphCanvasProps) {
+  // ReactFlow must create its own provider from the computed nodes below. An
+  // empty outer provider would make it reuse a store initialized before those
+  // nodes exist, so the first fit-to-view would have no graph to frame.
+  return <CommGraphCanvasBody {...props} />;
+}
+
+function isDefaultView(view: CommGraphTileViewState): boolean {
   return (
-    <ReactFlowProvider>
-      <CommGraphCanvasBody {...props} />
-    </ReactFlowProvider>
+    view.x === DEFAULT_COMM_GRAPH_VIEW.x &&
+    view.y === DEFAULT_COMM_GRAPH_VIEW.y &&
+    view.zoom === DEFAULT_COMM_GRAPH_VIEW.zoom
   );
 }
 
@@ -338,6 +347,11 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
           nodeTypes={NODE_TYPES}
           edgeTypes={EDGE_TYPES}
           defaultViewport={view}
+          // A neutral schema viewport means this graph has never been framed by
+          // the user. Let React Flow derive its first viewport from every node;
+          // a persisted pan/zoom still restores exactly as the user left it.
+          fitView={isDefaultView(view)}
+          minZoom={COMM_GRAPH_MIN_ZOOM}
           onMoveEnd={handleMoveEnd}
           // REQUIRED, and not merely as a tidier click path. React Flow's
           // `NodeWrapper` computes


### PR DESCRIPTION
## Summary
- lower the communication graph zoom floor so wide graphs can be fully framed
- fit the untouched default viewport to the visible graph while preserving a user’s saved framing
- cover default-fit and persisted-viewport behavior

## Verification
- `bun run test src/components/epic-canvas/comm-graph/__tests__/comm-graph-tile.test.tsx src/components/epic-canvas/comm-graph/__tests__/comm-graph-timeline.test.tsx src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx`
- `bun run react-doctor`