### PR TITLE
fix(gui-app): retain resource monitor search

### DIFF
--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -576,6 +576,69 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
   });
 
+  it("retains the search query after an outside click closes the popover", async () => {
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(projection({ owners: [owner({})] }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: "Search resources" }),
+      { target: { value: "Alpha" } },
+    );
+    expect(await screen.findByText("Terminal Alpha")).not.toBeNull();
+
+    fireEvent.pointerDown(document.body, {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.mouseDown(document.body, { button: 0 });
+    fireEvent.pointerUp(document.body, {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.click(document.body);
+
+    expect(screen.queryByRole("dialog", { name: "Resources" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(
+      screen.getByRole<HTMLInputElement>("searchbox", {
+        name: "Search resources",
+      }).value,
+    ).toBe("Alpha");
+    expect(screen.getByText("Terminal Alpha")).not.toBeNull();
+  });
+
+  it("retains the search query after opening a matching resource", async () => {
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(projection({ owners: [owner({})] }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: "Search resources" }),
+      { target: { value: "Alpha" } },
+    );
+    fireEvent.click(await screen.findByText("Terminal Alpha"));
+
+    expect(screen.queryByRole("dialog", { name: "Resources" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(
+      screen.getByRole<HTMLInputElement>("searchbox", {
+        name: "Search resources",
+      }).value,
+    ).toBe("Alpha");
+    expect(screen.getByText("Terminal Alpha")).not.toBeNull();
+  });
+
   it("reveals matching nested processes and reports an empty search", () => {
     const stub = installStubFactory();
     renderPopover();

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -274,6 +274,7 @@ function noProcessToggle(): void {}
 
 export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
   const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   // While the panel is open, let the header drop its title-bar drag regions so a
   // click on the (otherwise event-swallowing) drag area dismisses the popover.
   useTitleBarDragSuppression("resource-monitor", open);
@@ -306,7 +307,11 @@ export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
         </TooltipWrapper>
 
         {open ? (
-          <ResourceMonitorContent onClose={() => setOpen(false)} />
+          <ResourceMonitorContent
+            searchQuery={searchQuery}
+            onSearchQueryChange={setSearchQuery}
+            onClose={() => setOpen(false)}
+          />
         ) : null}
       </Popover>
     </>
@@ -412,9 +417,13 @@ function useResourceKillSelection(
   };
 }
 
-function ResourceMonitorContent(props: { readonly onClose: () => void }) {
+function ResourceMonitorContent(props: {
+  readonly searchQuery: string;
+  readonly onSearchQueryChange: (value: string) => void;
+  readonly onClose: () => void;
+}) {
   const [sortOption, setSortOption] = useState<ResourceSortOption>("tab");
-  const [searchQuery, setSearchQuery] = useState("");
+  const searchQuery = props.searchQuery;
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [expandedOwners, setExpandedOwners] = useState<Set<string>>(
     () => new Set(),
@@ -558,7 +567,7 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
   );
   const updateSearchQuery = (value: string): void => {
     killSelection.clearSelection();
-    setSearchQuery(value);
+    props.onSearchQueryChange(value);
   };
 
   const toggleOwner = (key: string): void => {


### PR DESCRIPTION
## Summary
- retain the Resource Monitor search query when its popover is dismissed
- preserve the query after opening a matching resource so users can inspect successive matches
- add regressions for outside-click dismissal and resource selection

## Verification
- `bun run test src/components/resources/__tests__/resource-monitor-popover.test.tsx`
- `bun run compile`
- `bun x -y react-doctor@latest . --verbose --diff main --offline --no-score`
- pre-commit affected Nx build, compile, lint, and format checks