### PR TITLE
feat(gui-app): add translate-to-spanish action to selection popover

### DIFF
--- a/clients/gui-app/src/components/chat/quote/__tests__/quote-selection-popover.test.tsx
+++ b/clients/gui-app/src/components/chat/quote/__tests__/quote-selection-popover.test.tsx
@@ -140,6 +140,24 @@ describe("QuoteSelectionPopover - quote action", () => {
   });
 });
 
+describe("QuoteSelectionPopover - translate action", () => {
+  it("prefills the draft with a Spanish translation request and dismisses on click", () => {
+    const { snapshot } = makeAnchoredSnapshot();
+    const onDismiss = vi.fn();
+    renderPopover(snapshot, onDismiss);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Traducir al español" }),
+    );
+
+    const draft = readComposerDraftSnapshot("task-1");
+    const contentText = JSON.stringify(draft.content);
+    expect(contentText).toContain("Traduce al español");
+    expect(contentText).toContain("quotable text");
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("QuoteSelectionPopover - anchor guard", () => {
   it("stays mounted while the anchor range is connected and paintable", () => {
     const onDismiss = vi.fn();

--- a/clients/gui-app/src/components/chat/quote/__tests__/translate-to-spanish.test.ts
+++ b/clients/gui-app/src/components/chat/quote/__tests__/translate-to-spanish.test.ts
@@ -1,0 +1,118 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import {
+  readComposerDraftSnapshot,
+  useComposerDraftStore,
+} from "@/stores/composer/composer-draft-store";
+
+import {
+  appendTranslateToSpanishToDraft,
+  buildTranslateToSpanishRequest,
+  TRANSLATE_TO_SPANISH_INSTRUCTION,
+} from "../translate-to-spanish";
+
+afterEach(() => {
+  useComposerDraftStore.setState({ drafts: {} });
+});
+
+function paragraph(text: string): JsonContent {
+  return { type: "paragraph", content: [{ type: "text", text }] };
+}
+
+function emptyParagraph(): JsonContent {
+  return { type: "paragraph" };
+}
+
+function doc(content: JsonContent[]): JsonContent {
+  return { type: "doc", content };
+}
+
+describe("buildTranslateToSpanishRequest", () => {
+  it("prefixes the instruction and quotes the selection verbatim", () => {
+    expect(
+      buildTranslateToSpanishRequest({
+        text: "This is the selected text.",
+        fenceLanguage: null,
+      }),
+    ).toEqual(
+      doc([
+        paragraph(TRANSLATE_TO_SPANISH_INSTRUCTION),
+        {
+          type: "blockquote",
+          content: [paragraph("This is the selected text.")],
+        },
+      ]),
+    );
+  });
+
+  it("keeps a code-fence selection in a code block", () => {
+    expect(
+      buildTranslateToSpanishRequest({
+        text: "const x = 1;",
+        fenceLanguage: "typescript",
+      }),
+    ).toEqual(
+      doc([
+        paragraph(TRANSLATE_TO_SPANISH_INSTRUCTION),
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "codeBlock",
+              attrs: { language: "typescript" },
+              content: [{ type: "text", text: "const x = 1;" }],
+            },
+          ],
+        },
+      ]),
+    );
+  });
+});
+
+describe("appendTranslateToSpanishToDraft", () => {
+  it("appends the request into a draft that already has content", () => {
+    const taskId = "task-1";
+    useComposerDraftStore
+      .getState()
+      .setSnapshot(taskId, doc([paragraph("hello")]), null);
+
+    appendTranslateToSpanishToDraft(taskId, {
+      text: "This is the selected text.",
+      fenceLanguage: null,
+    });
+
+    const draft = readComposerDraftSnapshot(taskId);
+    expect(draft.content).toEqual(
+      doc([
+        paragraph("hello"),
+        paragraph(TRANSLATE_TO_SPANISH_INSTRUCTION),
+        {
+          type: "blockquote",
+          content: [paragraph("This is the selected text.")],
+        },
+        emptyParagraph(),
+      ]),
+    );
+    expect(draft.selection).toBeNull();
+  });
+
+  it("appends into a task with no prior draft", () => {
+    const taskId = "task-2";
+
+    appendTranslateToSpanishToDraft(taskId, {
+      text: "Selected text.",
+      fenceLanguage: null,
+    });
+
+    const draft = readComposerDraftSnapshot(taskId);
+    expect(draft.content).toEqual(
+      doc([
+        paragraph(TRANSLATE_TO_SPANISH_INSTRUCTION),
+        { type: "blockquote", content: [paragraph("Selected text.")] },
+        emptyParagraph(),
+      ]),
+    );
+  });
+});

--- a/clients/gui-app/src/components/chat/quote/quote-selection-popover.tsx
+++ b/clients/gui-app/src/components/chat/quote/quote-selection-popover.tsx
@@ -1,4 +1,9 @@
-import { useLayoutEffect, useRef, type RefObject } from "react";
+import {
+  useLayoutEffect,
+  useRef,
+  type ReactElement,
+  type RefObject,
+} from "react";
 import { createPortal } from "react-dom";
 import {
   autoUpdate,
@@ -7,7 +12,7 @@ import {
   offset,
   shift,
 } from "@floating-ui/dom";
-import { TextQuote } from "lucide-react";
+import { Languages, TextQuote } from "lucide-react";
 import { usePaneFocused } from "@/components/epic-tabs/pane-visibility-context";
 import { chatBottomOverlayClampedRect } from "@/components/chat/chat-scroll-region-geometry";
 import { cn } from "@/lib/utils";
@@ -15,6 +20,7 @@ import {
   appendQuoteToDraft,
   buildQuoteBlockquote,
 } from "./append-quote-to-draft";
+import { appendTranslateToSpanishToDraft } from "./translate-to-spanish";
 import { firstLineRect, firstVisibleLineRect } from "./quote-anchor-rect";
 import type { QuoteSelectionSnapshot } from "./use-quote-selection";
 
@@ -137,6 +143,14 @@ export function QuoteSelectionPopover(props: QuoteSelectionPopoverProps) {
     onDismiss();
   };
 
+  const handleTranslateToSpanish = (): void => {
+    // Same contract as the quote action: consume the mouseup snapshot, never the
+    // live Selection.
+    appendTranslateToSpanishToDraft(taskId, snapshot);
+    clearBrowserSelection();
+    onDismiss();
+  };
+
   if (!paneFocused || typeof document === "undefined") return null;
 
   return createPortal(
@@ -150,27 +164,55 @@ export function QuoteSelectionPopover(props: QuoteSelectionPopoverProps) {
       // to the anchor. The app's other floating popovers (FloatingDraftPopover,
       // MentionPreviewPanel) position with transform and add no entrance
       // animation for the same reason; match them.
-      className="absolute top-0 left-0 z-50 rounded-md border border-border bg-popover p-0.5 text-popover-foreground shadow-lg"
+      className="absolute top-0 left-0 z-50 flex items-center gap-0.5 rounded-md border border-border bg-popover p-0.5 text-popover-foreground shadow-lg"
     >
-      <button
-        type="button"
-        // preventDefault keeps focus off the button and stops the browser from
-        // collapsing the selection before the click fires; the quote action
-        // runs on click. Its visible "Quote" label is the accessible name.
-        onMouseDown={(event) => event.preventDefault()}
+      <SelectionActionButton
+        label="Quote"
+        icon={<TextQuote className="size-3.5" aria-hidden />}
         onClick={handleQuote}
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded-sm px-2 py-1",
-          "text-xs font-medium text-popover-foreground transition-colors",
-          "hover:bg-accent hover:text-accent-foreground",
-          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
-        )}
-      >
-        <TextQuote className="size-3.5" aria-hidden />
-        Quote
-      </button>
+      />
+      <SelectionActionButton
+        label="Traducir al español"
+        icon={<Languages className="size-3.5" aria-hidden />}
+        onClick={handleTranslateToSpanish}
+      />
     </div>,
     document.body,
+  );
+}
+
+interface SelectionActionButtonProps {
+  readonly label: string;
+  readonly icon: ReactElement;
+  readonly onClick: () => void;
+}
+
+/**
+ * A single action in the selection popover. `mousedown` preventDefault keeps
+ * focus off the button and stops the browser from collapsing the selection
+ * before the click fires; the action runs on click. The visible label is the
+ * accessible name.
+ */
+function SelectionActionButton({
+  label,
+  icon,
+  onClick,
+}: SelectionActionButtonProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-sm px-2 py-1",
+        "text-xs font-medium text-popover-foreground transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+      )}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 

--- a/clients/gui-app/src/components/chat/quote/translate-to-spanish.ts
+++ b/clients/gui-app/src/components/chat/quote/translate-to-spanish.ts
@@ -1,0 +1,58 @@
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import {
+  appendBlocks,
+  buildQuoteBlockquote,
+  type QuoteTextSnapshot,
+} from "./append-quote-to-draft";
+import {
+  readComposerDraftSnapshot,
+  useComposerDraftStore,
+} from "@/stores/composer/composer-draft-store";
+
+/** Instruction line prefixed to the quoted selection in a translation request. */
+export const TRANSLATE_TO_SPANISH_INSTRUCTION =
+  "Traduce al español el siguiente texto:";
+
+/**
+ * Builds the composer document for a translate-to-Spanish request over a
+ * validated selection: the instruction paragraph followed by the selection
+ * quoted verbatim (a blockquote, or a code block when the selection sat inside
+ * a code fence). The agent reads the instruction and translates only the quoted
+ * portion.
+ */
+export function buildTranslateToSpanishRequest(
+  snapshot: QuoteTextSnapshot,
+): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: TRANSLATE_TO_SPANISH_INSTRUCTION }],
+      },
+      buildQuoteBlockquote(snapshot),
+    ],
+  };
+}
+
+/**
+ * Appends a translate-to-Spanish request for `snapshot` to the chat tab's
+ * composer draft. Non-destructive by design: existing draft content is kept via
+ * `appendBlocks`, matching `appendQuoteToDraft`'s contract. Riding
+ * `replaceDraft(taskId, next, null)` reuses the composer's
+ * `setContent(..., null)` -> `focus("end")` path, so the user lands in the
+ * composer with the request ready to send.
+ */
+export function appendTranslateToSpanishToDraft(
+  taskId: string,
+  snapshot: QuoteTextSnapshot,
+): void {
+  const request = buildTranslateToSpanishRequest(snapshot);
+  const draft = readComposerDraftSnapshot(taskId);
+  const next = appendBlocks(draft.content, [
+    ...(request.content ?? []),
+    { type: "paragraph" },
+  ]);
+  useComposerDraftStore.getState().replaceDraft(taskId, next, null);
+}


### PR DESCRIPTION
## Summary

Adds a "Traducir al español" action (Languages icon) to the transcript selection popover, next to the existing Quote action.

- `clients/gui-app/src/components/chat/quote/translate-to-spanish.ts` (new): builds the composer request (`Traduce al español el siguiente texto:` + quoted selection) and appends it via the composer's `replaceDraft` focus-end path.
- `quote-selection-popover.tsx`: renders a second action button reusing the existing Quote button styling; consumes the same mouseup-selection snapshot contract.
- Tests: new unit coverage for the request builder/append plus a popover test for the new action.

## Verification

- GUI compile (`tsc -b`) passed
- ESLint passed (`--max-warnings 0`)
- quote popover + translate-to-spanish suites: 77/77 tests pass

---

Commit signed off per the repo DCO requirement.
