### PR TITLE
fix(gui-app): stop reasoning-body clicks acting on controls inside the trace

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/reasoning-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/reasoning-segment.test.tsx
@@ -650,6 +650,79 @@ describe("<ReasoningSegment />", () => {
     expect(promote).toHaveBeenCalledTimes(1);
   });
 
+  // `<summary>` is the interactive element that looks least like one: no ARIA
+  // role, not focusable by default, styled as prose. But `<details>` is
+  // supported end to end - `MERGEABLE_HTML_CONTAINERS` exists precisely to keep
+  // a blank-line-split disclosure in a single block - so a trace can ship one,
+  // and its summary is a real control the reader clicks to open the nested
+  // section, not to fold the reasoning around it.
+  const DETAILS_TRACE = [
+    "Before the disclosure.",
+    "",
+    "<details>",
+    "<summary>Show the sub-trace</summary>",
+    "",
+    "Nested detail.",
+    "",
+    "</details>",
+  ].join("\n");
+
+  it("does not collapse the trace when a nested <summary> is clicked", () => {
+    render(
+      <ReasoningSegment
+        findUnitId={null}
+        markdown={DETAILS_TRACE}
+        isStreaming={false}
+        durationMs={3000}
+        bodyBoundedByParent={false}
+        headerless={false}
+        initiallyExpanded={false}
+      />,
+    );
+
+    const header = screen.getByRole("button", { name: "Thought for 3s" });
+    fireEvent.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+
+    // The disclosure really rendered - otherwise this test proves nothing about
+    // a control it never showed.
+    const summary = screen.getByText("Show the sub-trace");
+    expect(summary.tagName).toBe("SUMMARY");
+
+    fireEvent.click(summary);
+
+    // Opening the nested section left the reasoning block the reader is reading
+    // exactly where it was.
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+
+    // ...and the guard suppressed the control's click, not the whole listener.
+    fireEvent.click(screen.getByText("Before the disclosure."));
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("does not promote when a nested <summary> is clicked in the live window", () => {
+    const promote = vi.fn();
+    render(
+      <LiveActivityPromoteContext.Provider value={promote}>
+        <ReasoningSegment
+          findUnitId={null}
+          markdown={DETAILS_TRACE}
+          isStreaming
+          durationMs={null}
+          bodyBoundedByParent
+          headerless
+          initiallyExpanded={false}
+        />
+      </LiveActivityPromoteContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByText("Show the sub-trace"));
+    expect(promote).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Before the disclosure."));
+    expect(promote).toHaveBeenCalledTimes(1);
+  });
+
   // The companion to "keeps a trace the reader opened when the header appears".
   // That pin is deliberate, but on a COMPLETED headerless block the gesture is
   // invisible - the body is already fully shown - so a second click un-pinning

--- a/clients/gui-app/src/components/chat/segments/__tests__/reasoning-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/reasoning-segment.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReasoningSegment } from "@/components/chat/segments/reasoning-segment";
 import { LiveActivityPromoteContext } from "@/components/chat/segments/live-activity-promote-context";
@@ -573,7 +579,13 @@ describe("<ReasoningSegment />", () => {
   // into the trace. Indistinguishable from a removal blur at dispatch time,
   // which is why the layout effect re-reads real focus ownership every commit
   // and corrects the latch while the control still exists.
-  it("does not reclaim focus after the reader clicks away to nothing", () => {
+  // NO intervening render between the click-away and the completion that
+  // removes the control. The first version of this test put a streaming rerender
+  // in between, which is what the then-current fix needed to observe the blur -
+  // so the test passed for a reason the product could not rely on, and the bug
+  // it claimed to cover still reproduced without that extra commit. The latch is
+  // now settled off the event itself, not off the next render.
+  it("does not reclaim focus after the reader clicks away to nothing", async () => {
     const props = {
       findUnitId: null,
       markdown: "Detailed chain of thought",
@@ -594,24 +606,81 @@ describe("<ReasoningSegment />", () => {
     fireEvent.blur(control, { relatedTarget: null });
     expect(document.activeElement).toBe(document.body);
 
-    // A streaming commit - the transcript is producing these constantly - is
-    // what lets the sampler observe that the control no longer holds focus.
-    rerender(
-      <ReasoningSegment {...props} isStreaming markdown="More thought" />,
-    );
+    // Let the microtask that settles the ambiguous blur run. This is the only
+    // thing standing between the click and the completion - no re-render.
+    await act(async () => {});
 
     rerender(
-      <ReasoningSegment
-        {...props}
-        isStreaming={false}
-        durationMs={3000}
-        markdown="More thought"
-      />,
+      <ReasoningSegment {...props} isStreaming={false} durationMs={3000} />,
     );
 
     // Control gone, and focus left where the reader put it.
     expect(screen.queryByRole("button")).toBeNull();
     expect(document.activeElement).toBe(document.body);
+  });
+
+  // The click-to-toggle listener spans the whole body, and reasoning markdown
+  // renders real controls into it - a code block's copy button, links, reference
+  // chips. Without a guard the control's own click ALSO promotes: the copy runs,
+  // and then the group opens, scrolls and takes focus for a gesture that asked
+  // for none of it.
+  it("does not promote when an interactive element inside the trace is clicked", () => {
+    const promote = vi.fn();
+    render(
+      <LiveActivityPromoteContext.Provider value={promote}>
+        <ReasoningSegment
+          findUnitId={null}
+          markdown="Consider `code`\n\n[a link](https://example.com)"
+          isStreaming
+          durationMs={null}
+          bodyBoundedByParent
+          headerless
+          initiallyExpanded={false}
+        />
+      </LiveActivityPromoteContext.Provider>,
+    );
+
+    const link = screen.getByRole("link");
+    fireEvent.click(link);
+    expect(promote).not.toHaveBeenCalled();
+
+    // ...and the body still toggles for a click on ordinary prose, so the guard
+    // suppressed the control's click rather than the whole listener.
+    fireEvent.click(screen.getByText(/Consider/));
+    expect(promote).toHaveBeenCalledTimes(1);
+  });
+
+  // The companion to "keeps a trace the reader opened when the header appears".
+  // That pin is deliberate, but on a COMPLETED headerless block the gesture is
+  // invisible - the body is already fully shown - so a second click un-pinning
+  // it means two identical, equally invisible gestures produce opposite results.
+  // Where the click cannot be seen it only ever pins.
+  it("does not un-pin a completed headerless trace on a second invisible click", () => {
+    const props = {
+      findUnitId: null,
+      markdown: "Detailed chain of thought",
+      isStreaming: false,
+      durationMs: 3000,
+      bodyBoundedByParent: false,
+      initiallyExpanded: false,
+    } as const;
+    const { rerender } = render(<ReasoningSegment {...props} headerless />);
+
+    // Body on screen, no header of its own - so neither click changes a pixel.
+    expect(screen.getByText("Detailed chain of thought")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+
+    const trace = screen.getByText("Detailed chain of thought");
+    fireEvent.click(trace);
+    fireEvent.click(trace);
+
+    // A sibling segment arrives and the block gets its header back. The trace
+    // the reader was reading stays put; the second click did not undo the first.
+    rerender(<ReasoningSegment {...props} headerless={false} />);
+
+    const header = screen.getByRole("button", { name: "Thought for 3s" });
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Detailed chain of thought")).toBeTruthy();
   });
 
   // jsdom dispatches NO blur when a focused element is removed; Chromium - the
@@ -622,6 +691,17 @@ describe("<ReasoningSegment />", () => {
   //
   // This test simulates the browser jsdom is not, so it fails only for the code
   // under test and not for the environment.
+  //
+  // KNOWN UNTESTABLE HERE: the `control.isConnected` check inside the blur's
+  // microtask. Removing it leaves every test in this file green, and that is the
+  // environment, not a gap. In Chromium the removal blur fires during the
+  // commit, the microtask flushes before React's passive effects, and the
+  // control is already detached - so the check preserves the latch and the
+  // handoff below runs. Clearing unconditionally would put the latch at false
+  // before the effect reads it and silently kill the handoff again. jsdom
+  // dispatches no removal blur at all, so that ordering never occurs here and no
+  // assertion can reach it. Do not delete the check on the strength of a
+  // surviving mutant.
   it("still hands off when removal itself blurs the control", () => {
     const props = {
       findUnitId: null,

--- a/clients/gui-app/src/components/chat/segments/reasoning-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/reasoning-segment.tsx
@@ -8,7 +8,6 @@ import {
   useCallback,
   useEffect,
   useId,
-  useLayoutEffect,
   useRef,
   useState,
   type FocusEvent,
@@ -85,6 +84,77 @@ const MUTED_PROSE = cn(
   "[--tw-prose-invert-bold:var(--color-muted-foreground)]",
 );
 
+/**
+ * Whether a click landing anywhere in the trace body was aimed at the
+ * disclosure, rather than at something inside it.
+ *
+ * Two things it is not. Reasoning markdown renders real controls - a code
+ * block's copy button, links, reference chips - and the listener spans the whole
+ * body, so without the first check the control's own click ALSO toggles: the
+ * copy runs and then the group promotes, opening, scrolling and taking focus for
+ * a gesture that asked for none of that. And a click ending a drag-selection
+ * *inside this block* is the reader copying text, not collapsing it; a stray
+ * selection elsewhere on the page must not swallow the click, which is why this
+ * is scoped to `node`.
+ */
+function bodyClickIsDisclosure(
+  event: MouseEvent,
+  node: HTMLDivElement,
+): boolean {
+  const target = event.target;
+  if (
+    target instanceof Element &&
+    target.closest("a, button, [role='button'], input, select, textarea")
+  ) {
+    return false;
+  }
+  const selection = window.getSelection();
+  return !(
+    selection !== null &&
+    !selection.isCollapsed &&
+    selection.anchorNode !== null &&
+    node.contains(selection.anchorNode)
+  );
+}
+
+/**
+ * Whether a click on the trace body can only PIN it open, never fold it.
+ *
+ * True for a finished headerless block outside the live window: its body shows
+ * because `headerless` shows it, there is no tail left to collapse to, and the
+ * click therefore changes no pixels. The write to `expanded` still matters
+ * later - it decides whether the trace survives a sibling arriving and giving
+ * this block a header - so the gesture is kept, but only in the direction the
+ * reader can be assumed to want. Toggling an invisible gesture means two
+ * identical clicks give opposite results with no feedback either way.
+ */
+function bodyClickOnlyPins(
+  headerless: boolean,
+  isStreaming: boolean,
+  promotes: boolean,
+): boolean {
+  return headerless && !isStreaming && !promotes;
+}
+
+/**
+ * Settles a blur that named no new focus owner, once the DOM has stopped
+ * moving. A control still in the document was LEFT BEHIND by the reader; a
+ * detached one was TAKEN AWAY by completion, and the focus handoff still needs
+ * to know it had the caret.
+ *
+ * A microtask rather than a re-render: resampling in a layout effect only works
+ * if some other commit happens to land between the click and the removal.
+ */
+function settleAmbiguousBlur(
+  control: HTMLElement,
+  onLeftBehind: () => void,
+): void {
+  queueMicrotask(() => {
+    if (!control.isConnected) return;
+    onLeftBehind();
+  });
+}
+
 function ReasoningContent(props: ReasoningContentProps) {
   const { className, markdown, isStreaming } = props;
   return (
@@ -131,22 +201,35 @@ export function ReasoningSegment(props: ReasoningSegmentProps) {
   // selectable element: the header button is the keyboard/assistive-tech
   // control, and a click that ends a text selection (click-drag) must not
   // collapse the trace, so reasoning stays copyable.
+  // On a FINISHED headerless block the click changes no pixels: the body is
+  // shown because `headerless` shows it, not because `expanded` is set, and
+  // there is no tail to collapse back to. It still WRITES `expanded`, and that
+  // write is read later - when a sibling segment arrives and gives this block a
+  // header, `expanded` decides whether the trace the reader is looking at stays
+  // put or folds away under them.
+  //
+  // Keeping that pin is deliberate (see the `headerless` prop docs: `expanded`
+  // is the only signal that means intent). TOGGLING it is not: a second click,
+  // equally invisible, silently un-pins, so a reader clicking around in the
+  // trace gets opposite outcomes from identical gestures with no feedback
+  // either way. Where the gesture cannot be seen it only ever pins.
+  //
+  // `promote !== null` is excluded because inside the live window the click
+  // leaves the window, which is very much visible.
+  const bodyPinsOnly = bodyClickOnlyPins(
+    headerless,
+    isStreaming,
+    promote !== null,
+  );
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const bindBodyToggle = useCallback(
     (node: HTMLDivElement | null) => {
       bodyRef.current = node;
       if (node === null) return;
-      const onClick = () => {
-        const selection = window.getSelection();
-        // Suppress the toggle only when the click ends a text selection *within
-        // this block* (drag-to-copy); a stray selection elsewhere on the page
-        // must not swallow the click.
-        if (
-          selection !== null &&
-          !selection.isCollapsed &&
-          selection.anchorNode !== null &&
-          node.contains(selection.anchorNode)
-        ) {
+      const onClick = (event: MouseEvent) => {
+        if (!bodyClickIsDisclosure(event, node)) return;
+        if (bodyPinsOnly) {
+          setExpanded(true);
           return;
         }
         toggle();
@@ -160,7 +243,7 @@ export function ReasoningSegment(props: ReasoningSegmentProps) {
         if (bodyRef.current === node) bodyRef.current = null;
       };
     },
-    [toggle],
+    [bodyPinsOnly, toggle],
   );
 
   // The tail preview is this block's OWN bounded scroller. Inside a container
@@ -282,20 +365,28 @@ export function ReasoningSegment(props: ReasoningSegmentProps) {
   }, []);
   const onHeaderBlur = useCallback(
     (event: FocusEvent<HTMLButtonElement>): void => {
-      if (event.relatedTarget === null) return;
-      headerFocusedRef.current = false;
+      if (event.relatedTarget !== null) {
+        headerFocusedRef.current = false;
+        return;
+      }
+      // A blur naming no new focus owner is TWO different events: the reader
+      // clicking a non-focusable transcript surface, and Chromium removing the
+      // focused control (jsdom dispatches nothing at all there). They are
+      // identical at dispatch time, so decide once the DOM has settled - a
+      // control still in the document was left behind, a detached one was taken
+      // away.
+      //
+      // A microtask, not a re-render. The previous version resampled focus in a
+      // layout effect, which is correct only if some OTHER commit lands between
+      // the click and the completion that removes the control; with no commit in
+      // between the stale reading survived and completion stole focus back. This
+      // runs off the event itself, so it does not depend on a render arriving.
+      settleAmbiguousBlur(event.target, () => {
+        headerFocusedRef.current = false;
+      });
     },
     [],
   );
-  useLayoutEffect(() => {
-    const trigger =
-      rootRef.current?.querySelector("[data-activity-row-trigger]") ?? null;
-    // No trigger means this commit is the one that removed it, so the reading
-    // below is left untouched - it is focus ownership as of the last commit
-    // that still had a control, which is what the handoff needs.
-    if (trigger === null) return;
-    headerFocusedRef.current = trigger === document.activeElement;
-  });
   const controlRemoved = headerless && !headerActionable;
   useEffect(() => {
     if (!controlRemoved || !headerFocusedRef.current) return;

--- a/clients/gui-app/src/components/chat/segments/reasoning-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/reasoning-segment.tsx
@@ -89,13 +89,23 @@ const MUTED_PROSE = cn(
  * disclosure, rather than at something inside it.
  *
  * Two things it is not. Reasoning markdown renders real controls - a code
- * block's copy button, links, reference chips - and the listener spans the whole
- * body, so without the first check the control's own click ALSO toggles: the
- * copy runs and then the group promotes, opening, scrolling and taking focus for
- * a gesture that asked for none of that. And a click ending a drag-selection
- * *inside this block* is the reader copying text, not collapsing it; a stray
- * selection elsewhere on the page must not swallow the click, which is why this
- * is scoped to `node`.
+ * block's copy button, links, reference chips, and a `<summary>` the author
+ * wrote by hand - and the listener spans the whole body, so without the first
+ * check the control's own click ALSO toggles: the copy runs and then the group
+ * promotes, opening, scrolling and taking focus for a gesture that asked for
+ * none of that. And a click ending a drag-selection *inside this block* is the
+ * reader copying text, not collapsing it; a stray selection elsewhere on the
+ * page must not swallow the click, which is why this is scoped to `node`.
+ *
+ * The list is bounded, not open-ended, and the bound is `TRAYCER_SANITIZE_SCHEMA`
+ * - nothing else can reach this DOM. Of the tags it admits only `a`, `input` and
+ * `summary` self-activate on click (it allows no `role`, so `[role='button']`
+ * and `button` cover only what our own React components render). `summary` is
+ * the one that is easy to miss: it is not focusable-by-default, carries no ARIA
+ * role and looks like prose, yet `<details>` is deliberately supported end to
+ * end (`MERGEABLE_HTML_CONTAINERS` exists to keep a blank-line-split disclosure
+ * in one block), so a trace CAN ship one. Widening the schema means revisiting
+ * this selector.
  */
 function bodyClickIsDisclosure(
   event: MouseEvent,
@@ -104,7 +114,9 @@ function bodyClickIsDisclosure(
   const target = event.target;
   if (
     target instanceof Element &&
-    target.closest("a, button, [role='button'], input, select, textarea")
+    target.closest(
+      "a, button, [role='button'], input, select, textarea, summary",
+    )
   ) {
     return false;
   }


### PR DESCRIPTION
Three Codex P2s raised on #959 **after** it merged (comments at 15:50, merge at 15:49:20), so they land here.

## 1 — an interactive element inside the trace also promoted the row

The click-to-toggle listener spans the whole reasoning body, and the markdown renderer puts real controls inside it: a code block's copy button, links, reference chips. Clicking one ran the control **and** toggled — and inside the live window a toggle promotes, so the copy happened and then the group opened, scrolled and took focus for a gesture that asked for none of that.

## 2 — the focus latch depended on another render arriving

The fix in #959 resampled focus ownership in a layout effect. That is only correct if some *other* commit lands between the reader clicking a non-focusable surface and the completion that removes the control; with no commit in between the stale reading survived and completion stole focus back into the trace.

It now settles off the blur event itself, in a microtask — a control still in the document was left behind, a detached one was taken away. No render required.

**The test was propping it up.** It injected an extra streaming rerender before completion, which is precisely the crutch the old fix needed, so it passed for a reason the product could not rely on. That rerender is gone; the sequence is now click → completion with nothing in between.

## 3 — an invisible gesture could un-pin a trace

Codex asked for the body listener to be dropped entirely on a finished headerless block. **Not done as asked**, and here is why.

That click does change no pixels — the body shows because `headerless` shows it, and there is no tail to collapse back to. But the write to `expanded` is read later: it decides whether the trace the reader is looking at survives a sibling segment arriving and giving the block a header. Keeping that pin is a documented decision of #959 (`expanded` is the only signal that means intent) with a test asserting it, so removing the listener would reverse a product decision, not fix a bug.

What *is* broken is that it is a **toggle**: a second, equally invisible click silently un-pins, so two identical gestures give opposite outcomes with no feedback either way. Where the gesture cannot be seen, it now only ever pins.

## Verification

- lint, format and compile clean
- full gui-app suite green: **1034 files / 10592 tests**, 1 skipped
- probed: reverting the interactive guard, and reverting pin-only to toggle, each fail their own test

### A surviving mutant that is not a gap

Removing `control.isConnected` from the blur's microtask leaves **every** test green. That is the environment, not missing coverage — and it is the same blind spot that caused the original bug. jsdom dispatches no blur when a focused element is removed, so the ordering that makes the check observable never happens here. In Chromium the removal blur fires during the commit, the microtask runs before React's passive effects, and the control is already detached, so the check preserves the latch and the handoff runs. Clearing unconditionally would silently kill it again.

This is written into the test file. Please don't delete the check on the strength of a surviving single-guard mutation.

## Still unverified

Nothing in #959 or this follow-up has been exercised in a running Electron window.
