### PR TITLE
fix(gui-app): stop the 15s host-directory poll from churning every consumer

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/host-picker.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/host-picker.test.tsx
@@ -1,6 +1,12 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 /**
@@ -16,6 +22,11 @@ const mocks = vi.hoisted(() => ({
   selectById: vi.fn(),
   openExternalLink: vi.fn(() => Promise.resolve()),
   requestClose: vi.fn(),
+  // `HostClient` keeps the active host outside React and announces swaps
+  // through `onChange`, so the fake has to be a real listener store for the
+  // picker's subscription to be observable.
+  activeHostId: "local-1",
+  hostClientListeners: new Set<() => void>(),
 }));
 
 vi.mock("@/hooks/host/use-remote-hosts-plan-gate", () => ({
@@ -42,8 +53,13 @@ vi.mock("@/lib/host", () => ({
       onChange: () => ({ dispose: () => undefined }),
     },
     hostClient: {
-      onChange: () => () => undefined,
-      getActiveHostId: () => "local-1",
+      onChange: (listener: () => void) => {
+        mocks.hostClientListeners.add(listener);
+        return () => {
+          mocks.hostClientListeners.delete(listener);
+        };
+      },
+      getActiveHostId: () => mocks.activeHostId,
     },
   }),
 }));
@@ -91,6 +107,8 @@ function renderPicker(): void {
 
 beforeEach(() => {
   mocks.planRestricted.mockReturnValue(false);
+  mocks.activeHostId = "local-1";
+  mocks.hostClientListeners.clear();
 });
 
 afterEach(() => {
@@ -134,5 +152,42 @@ describe("HostPicker paid-plan gating", () => {
     fireEvent.click(remote);
     expect(mocks.selectById).toHaveBeenCalledWith("remote-1");
     expect(mocks.requestClose).toHaveBeenCalled();
+  });
+
+  it("moves the checked row when the active host changes while the dialog is open", () => {
+    // REGRESSION: the picker used to re-render on `hostClient.onChange` via a
+    // revision counter that also keyed the list query. The query key is now
+    // stable, and a host swap leaves the directory contents untouched - so
+    // structural sharing preserves `data` and the query is NOT a render
+    // signal for the active host. The selected row must come from a
+    // subscription, not from a render-time `getActiveHostId()` read.
+    renderPicker();
+
+    expect(
+      screen
+        .getByTestId("host-picker-option-local-1")
+        .getAttribute("data-selected"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByTestId("host-picker-option-remote-1")
+        .getAttribute("data-selected"),
+    ).toBe("false");
+
+    act(() => {
+      mocks.activeHostId = "remote-1";
+      for (const listener of mocks.hostClientListeners) listener();
+    });
+
+    expect(
+      screen
+        .getByTestId("host-picker-option-remote-1")
+        .getAttribute("data-selected"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByTestId("host-picker-option-local-1")
+        .getAttribute("data-selected"),
+    ).toBe("false");
   });
 });

--- a/clients/gui-app/src/components/layout/header/__tests__/host-picker.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/host-picker.test.tsx
@@ -1,6 +1,7 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 /**
  * The host picker's paid-plan gating: on a free plan, remote rows are inert
@@ -75,6 +76,19 @@ vi.mock("@/hooks/host/use-host-picker-list", () => ({
 
 import { HostPicker } from "@/components/layout/header/host-picker";
 
+/**
+ * The picker invalidates its own list query on directory / host-client
+ * changes, so it needs a real client even though the list hook itself is
+ * mocked here.
+ */
+function renderPicker(): void {
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <HostPicker />
+    </QueryClientProvider>,
+  );
+}
+
 beforeEach(() => {
   mocks.planRestricted.mockReturnValue(false);
 });
@@ -87,7 +101,7 @@ afterEach(() => {
 describe("HostPicker paid-plan gating", () => {
   it("free plan: remote rows are inert with a Paid plan affordance, and the upsell links to subscription management", () => {
     mocks.planRestricted.mockReturnValue(true);
-    render(<HostPicker />);
+    renderPicker();
 
     const remote = screen.getByTestId("host-picker-option-remote-1");
     expect(remote.getAttribute("data-plan-restricted")).toBe("true");
@@ -111,7 +125,7 @@ describe("HostPicker paid-plan gating", () => {
 
   it("paid plan: remote rows select normally and no upsell renders", () => {
     mocks.planRestricted.mockReturnValue(false);
-    render(<HostPicker />);
+    renderPicker();
 
     expect(screen.queryByTestId("host-picker-remote-upsell")).toBeNull();
     const remote = screen.getByTestId("host-picker-option-remote-1");

--- a/clients/gui-app/src/components/layout/header/__tests__/host-picker.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/host-picker.test.tsx
@@ -163,31 +163,18 @@ describe("HostPicker paid-plan gating", () => {
     // subscription, not from a render-time `getActiveHostId()` read.
     renderPicker();
 
-    expect(
-      screen
-        .getByTestId("host-picker-option-local-1")
-        .getAttribute("data-selected"),
-    ).toBe("true");
-    expect(
-      screen
-        .getByTestId("host-picker-option-remote-1")
-        .getAttribute("data-selected"),
-    ).toBe("false");
+    const checkedState = (name: RegExp): string | null =>
+      screen.getByRole("radio", { name }).getAttribute("aria-checked");
+
+    expect(checkedState(/This Mac/)).toBe("true");
+    expect(checkedState(/Office workstation/)).toBe("false");
 
     act(() => {
       mocks.activeHostId = "remote-1";
       for (const listener of mocks.hostClientListeners) listener();
     });
 
-    expect(
-      screen
-        .getByTestId("host-picker-option-remote-1")
-        .getAttribute("data-selected"),
-    ).toBe("true");
-    expect(
-      screen
-        .getByTestId("host-picker-option-local-1")
-        .getAttribute("data-selected"),
-    ).toBe("false");
+    expect(checkedState(/Office workstation/)).toBe("true");
+    expect(checkedState(/This Mac/)).toBe("false");
   });
 });

--- a/clients/gui-app/src/components/layout/header/host-picker.tsx
+++ b/clients/gui-app/src/components/layout/header/host-picker.tsx
@@ -16,6 +16,7 @@ import {
   useHostPickerList,
 } from "@/hooks/host/use-host-picker-list";
 import { useRemoteHostsPlanRestricted } from "@/hooks/host/use-remote-hosts-plan-gate";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
 import { useRefreshHostDirectoryOnOpen } from "@/hooks/host/use-refresh-host-directory-on-open";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
@@ -141,6 +142,12 @@ function HostPickerList(props: HostPickerListProps) {
 
   const query = useHostPickerList(directoryId);
   const remoteRestricted = useRemoteHostsPlanRestricted();
+  // Subscribed, not read at render time: `getActiveHostId()` lives outside
+  // React, and the list query is no longer a proxy render signal for it - a
+  // host swap leaves the directory contents (and, through structural
+  // sharing, `data`'s identity) untouched, so nothing here would re-render
+  // and the selected row would keep pointing at the previous host.
+  const activeId = useReactiveActiveHostId();
 
   if (directory === null || query.isLoading) {
     return (
@@ -191,7 +198,6 @@ function HostPickerList(props: HostPickerListProps) {
     );
   }
 
-  const activeId = hostClient === null ? null : hostClient.getActiveHostId();
   const showUpsell =
     remoteRestricted && entries.some((entry) => entry.kind === "remote");
 

--- a/clients/gui-app/src/components/layout/header/host-picker.tsx
+++ b/clients/gui-app/src/components/layout/header/host-picker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -21,6 +22,7 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { createReportIssueContext } from "@/lib/report-issue-context";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import { uiQueryKeys } from "@/lib/query-keys";
 
 /**
  * Generic shell-agnostic host picker.
@@ -103,37 +105,41 @@ interface HostPickerListProps {
 
 function HostPickerList(props: HostPickerListProps) {
   const binding = useHostBinding();
+  const queryClient = useQueryClient();
   const directory = binding === null ? null : binding.directory;
   const hostClient = binding === null ? null : binding.hostClient;
-  const [revision, setRevision] = useState<number>(0);
   const directoryId =
     directory === null ? null : registerHostPickerDirectory(directory);
 
   useEffect(() => {
-    if (directory === null) {
+    if (directory === null || directoryId === null) {
       return;
     }
     const subscription = directory.onChange(() => {
-      setRevision((prev) => prev + 1);
+      void queryClient.invalidateQueries({
+        queryKey: uiQueryKeys.hostPicker(directoryId),
+      });
     });
     return () => {
       subscription.dispose();
     };
-  }, [directory]);
+  }, [directory, directoryId, queryClient]);
 
   useEffect(() => {
-    if (hostClient === null) {
+    if (hostClient === null || directoryId === null) {
       return;
     }
     const unsubscribe = hostClient.onChange(() => {
-      setRevision((prev) => prev + 1);
+      void queryClient.invalidateQueries({
+        queryKey: uiQueryKeys.hostPicker(directoryId),
+      });
     });
     return () => {
       unsubscribe();
     };
-  }, [hostClient]);
+  }, [hostClient, directoryId, queryClient]);
 
-  const query = useHostPickerList(directoryId, revision);
+  const query = useHostPickerList(directoryId);
   const remoteRestricted = useRemoteHostsPlanRestricted();
 
   if (directory === null || query.isLoading) {

--- a/clients/gui-app/src/hooks/host/__tests__/use-host-directory-list-query.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-host-directory-list-query.test.tsx
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import { mockRemoteHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+
+interface DirectoryListener {
+  (): void;
+}
+
+const directoryRef = vi.hoisted(() => ({
+  value: null as {
+    list(): Promise<readonly HostDirectoryEntry[]>;
+    onChange(listener: DirectoryListener): { dispose(): void };
+  } | null,
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostBinding: () =>
+    directoryRef.value === null ? null : { directory: directoryRef.value },
+}));
+
+import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query";
+
+/**
+ * Fake directory whose `onChange` listeners the test fires by hand, standing
+ * in for `HostDirectoryService`'s emit (local-host change or registry poll).
+ */
+function makeDirectory(entries: readonly HostDirectoryEntry[]) {
+  const listeners = new Set<DirectoryListener>();
+  let current = entries;
+  const list = vi.fn(() => Promise.resolve(current));
+  return {
+    directory: {
+      list,
+      onChange: (listener: DirectoryListener) => {
+        listeners.add(listener);
+        return {
+          dispose: () => {
+            listeners.delete(listener);
+          },
+        };
+      },
+    },
+    list,
+    emit: (next: readonly HostDirectoryEntry[]) => {
+      current = next;
+      for (const listener of listeners) listener();
+    },
+  };
+}
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper(props: { readonly children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  directoryRef.value = null;
+});
+
+describe("useHostDirectoryList", () => {
+  it("keeps the previous entries visible across a directory emit instead of blanking to undefined", async () => {
+    // REGRESSION: the directory revision used to be part of the query key, so
+    // every emit minted a FRESH cache entry - `data: undefined` + fetching -
+    // for every consumer at once. `useHostReachability` maps that to
+    // "checking", which swapped each terminal tile for a loading skeleton and
+    // unmounted its xterm subtree; the 15s registry poll made it a permanent
+    // ~15s flicker across the host picker, workspace selector and tiles.
+    const fake = makeDirectory([mockRemoteHostEntry]);
+    directoryRef.value = fake.directory;
+    const queryClient = makeQueryClient();
+
+    const observed: Array<readonly HostDirectoryEntry[] | undefined> = [];
+    const rendered = renderHook(
+      () => {
+        const query = useHostDirectoryList();
+        observed.push(query.data);
+        return query;
+      },
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(rendered.result.current.data).toHaveLength(1);
+    });
+    const rendersBeforeEmit = observed.length;
+
+    fake.emit([mockRemoteHostEntry, { ...mockRemoteHostEntry, hostId: "b" }]);
+
+    await waitFor(() => {
+      expect(rendered.result.current.data).toHaveLength(2);
+    });
+
+    // Every render from the emit onwards must still carry entries - no
+    // undefined window, which is what the consumers rendered a loading state
+    // (and the tiles an unmount) for.
+    expect(observed.slice(rendersBeforeEmit)).not.toContain(undefined);
+  });
+
+  it("refetches through the SAME cache entry on a directory emit rather than accumulating keys", async () => {
+    const fake = makeDirectory([mockRemoteHostEntry]);
+    directoryRef.value = fake.directory;
+    const queryClient = makeQueryClient();
+
+    const rendered = renderHook(() => useHostDirectoryList(), {
+      wrapper: wrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(rendered.result.current.data).toHaveLength(1);
+    });
+    expect(fake.list).toHaveBeenCalledTimes(1);
+
+    fake.emit([{ ...mockRemoteHostEntry, label: "Renamed" }]);
+    await waitFor(() => {
+      // The emit must still REACH the consumer - a stable key that never
+      // refetches would pass the no-undefined assertion above by serving a
+      // stale list forever (the 2026-07-14 boot-empty-list incident).
+      expect(rendered.result.current.data?.[0]?.label).toBe("Renamed");
+    });
+    expect(fake.list).toHaveBeenCalledTimes(2);
+
+    fake.emit([{ ...mockRemoteHostEntry, label: "Renamed twice" }]);
+    await waitFor(() => {
+      expect(rendered.result.current.data?.[0]?.label).toBe("Renamed twice");
+    });
+
+    const hostPickerEntries = queryClient
+      .getQueryCache()
+      .getAll()
+      .filter((entry) => entry.queryKey[0] === "host-picker");
+    expect(hostPickerEntries).toHaveLength(1);
+  });
+});

--- a/clients/gui-app/src/hooks/host/use-host-directory-list-query.ts
+++ b/clients/gui-app/src/hooks/host/use-host-directory-list-query.ts
@@ -1,40 +1,46 @@
-import { useEffect, useState } from "react";
-import { type UseQueryResult } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import { useHostBinding } from "@/lib/host";
 import {
   registerHostPickerDirectory,
   useHostPickerList,
 } from "@/hooks/host/use-host-picker-list";
+import { uiQueryKeys } from "@/lib/query-keys";
 
 /**
  * Hook form of `useHostPickerList` that internalizes directory binding,
- * registration, and revision bumping. Used by the combined host/folder
+ * registration, and change wiring. Used by the combined host/folder
  * chip; the legacy host-picker dialog uses `useHostPickerList` directly.
  */
 export function useHostDirectoryList(): UseQueryResult<
   readonly HostDirectoryEntry[]
 > {
   const binding = useHostBinding();
+  const queryClient = useQueryClient();
   const directory = binding === null ? null : binding.directory;
   const directoryId =
     directory === null ? null : registerHostPickerDirectory(directory);
-  const [revision, setRevision] = useState<number>(0);
 
   useEffect(() => {
-    if (directory === null) return;
+    if (directory === null || directoryId === null) return;
     // The host publishing during boot (the 2026-07-14 incident) arrives as an
-    // onChange well after this subscription is installed, so bumping the
-    // revision here refetches and surfaces it. Paired with `staleTime: 0` in
+    // onChange well after this subscription is installed, so invalidating here
+    // refetches and surfaces it. Paired with `staleTime: 0` in
     // `useHostPickerList`, which stops a boot-time empty fetch from being
     // served fresh for the session - that pairing is the load-bearing fix.
+    // Invalidate the SAME key rather than minting a new one (the old
+    // revision-in-key design): a same-key refetch keeps the previous `data`,
+    // so consumers never regress to a loading state on a directory emit.
     const subscription = directory.onChange(() => {
-      setRevision((prev) => prev + 1);
+      void queryClient.invalidateQueries({
+        queryKey: uiQueryKeys.hostPicker(directoryId),
+      });
     });
     return () => {
       subscription.dispose();
     };
-  }, [directory]);
+  }, [directory, directoryId, queryClient]);
 
-  return useHostPickerList(directoryId, revision);
+  return useHostPickerList(directoryId);
 }

--- a/clients/gui-app/src/hooks/host/use-host-picker-list.ts
+++ b/clients/gui-app/src/hooks/host/use-host-picker-list.ts
@@ -34,24 +34,24 @@ export function registerHostPickerDirectory(
 /**
  * Loads the entries for the currently bound host directory.
  *
- * The directory id + revision is part of the query key so directory-change
- * notifications can force a refetch simply by bumping `revision`. When no
+ * The key is STABLE (directory id only). Directory-change notifications force
+ * a refetch via `invalidateQueries` on this key - never by minting a new key:
+ * a revision-in-key design blanked `data` to `undefined` for every consumer
+ * on every emit, and the 15s registry poll turned that into an app-wide
+ * loading flash (terminal tiles unmounted through the reachability gate).
+ * A same-key invalidate keeps the previous `data` during the refetch. When no
  * directory is bound the query is keyed on `queryKeys.hostPickerMissing()`
  * and disabled, matching the rest of the host-aware query surface.
  */
 export function useHostPickerList(
   directoryId: string | null,
-  revision: number,
 ): UseQueryResult<readonly HostDirectoryEntry[]> {
   return useQuery<readonly HostDirectoryEntry[]>(
-    hostPickerListQueryOptions(directoryId, revision),
+    hostPickerListQueryOptions(directoryId),
   );
 }
 
-function hostPickerListQueryOptions(
-  directoryId: string | null,
-  revision: number,
-) {
+function hostPickerListQueryOptions(directoryId: string | null) {
   if (directoryId === null) {
     return queryOptions<readonly HostDirectoryEntry[]>({
       queryKey: uiQueryKeys.hostPickerMissing(),
@@ -60,7 +60,7 @@ function hostPickerListQueryOptions(
     });
   }
   return queryOptions<readonly HostDirectoryEntry[]>({
-    queryKey: uiQueryKeys.hostPicker(directoryId, revision),
+    queryKey: uiQueryKeys.hostPicker(directoryId),
     queryFn: () => {
       const registeredDirectory = directoriesById.get(directoryId);
       if (registeredDirectory === undefined) {
@@ -70,11 +70,12 @@ function hostPickerListQueryOptions(
     },
     // `list()` is a synchronous in-memory snapshot behind a promise - there
     // is nothing to cache. Under the global 60s staleTime, a consumer that
-    // mounted at revision 0 was served ANOTHER consumer's boot-time fetch of
-    // the same key - an empty list captured before the host published - and
-    // never refetched, rendering every bound tab "Bound host is offline" for
-    // the whole session (2026-07-14 incident). Always refetch on mount, and
-    // let superseded revision entries fall out of the cache quickly.
+    // mounted late was served ANOTHER consumer's boot-time fetch of the same
+    // key - an empty list captured before the host published - and never
+    // refetched, rendering every bound tab "Bound host is offline" for the
+    // whole session (2026-07-14 incident). `staleTime: 0` (every mount
+    // refetches) paired with the onChange -> invalidate wiring in
+    // `useHostDirectoryList` is the load-bearing fix - keep BOTH.
     staleTime: 0,
     gcTime: 30_000,
   });

--- a/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
@@ -996,6 +996,109 @@ describe("HostDirectoryService", () => {
     expect(observed).toEqual([]);
   });
 
+  it("does not notify onChange when a poll delivers a field-identical snapshot, and still notifies when one actually changes", async () => {
+    const host = makeHost(null);
+    const { fetcher } = queuedFetcher([
+      { kind: "hosts", entries: [mockRemoteHostEntry] },
+      // Fresh object literals, field-identical to the previous batch - what a
+      // real 15s poll produces when nothing about the registry changed. An
+      // unconditional emit here re-rendered/refetched every `onChange`
+      // consumer app-wide on every tick (terminal tiles unmounted through
+      // the reachability gate and reset to "Starting terminal session…").
+      { kind: "hosts", entries: [{ ...mockRemoteHostEntry }] },
+      {
+        kind: "hosts",
+        entries: [{ ...mockRemoteHostEntry, label: "Renamed" }],
+      },
+      { kind: "hosts", entries: [mockRemoteHostEntry, secondRemoteHostEntry] },
+    ]);
+    const directory = makeDirectory({
+      runnerHost: host,
+      localHostIdSeeder: null,
+      remoteFetcher: fetcher,
+    });
+    await directory.start();
+
+    const observed: Array<readonly HostDirectoryEntry[]> = [];
+    directory.onChange((entries) => {
+      observed.push(entries);
+    });
+
+    await directory.refresh();
+    expect(observed).toEqual([]);
+
+    // A changed FIELD on the same host must still reach every consumer -
+    // without this leg a "never emit" regression would pass the case above.
+    await directory.refresh();
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.[0]?.label).toBe("Renamed");
+
+    // As must a changed set of hosts.
+    await directory.refresh();
+    expect(observed).toHaveLength(2);
+    expect(observed[1]).toHaveLength(2);
+  });
+
+  it("notifies onChange when a poll adds a host even though the previously emitted entries are unchanged", async () => {
+    const host = makeHost(null);
+    const { fetcher } = queuedFetcher([
+      { kind: "hosts", entries: [mockRemoteHostEntry] },
+      { kind: "hosts", entries: [mockRemoteHostEntry, secondRemoteHostEntry] },
+    ]);
+    const directory = makeDirectory({
+      runnerHost: host,
+      localHostIdSeeder: null,
+      remoteFetcher: fetcher,
+    });
+    await directory.start();
+
+    const observed: Array<readonly HostDirectoryEntry[]> = [];
+    directory.onChange((entries) => {
+      observed.push(entries);
+    });
+
+    await directory.refresh();
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.map((entry) => entry.hostId)).toEqual([
+      mockRemoteHostEntry.hostId,
+      secondRemoteHostEntry.hostId,
+    ]);
+  });
+
+  it("keeps the no-change emit suppression armed against the LAST EMITTED snapshot, not the last poll", async () => {
+    const host = makeHost(null);
+    const { fetcher } = queuedFetcher([
+      { kind: "hosts", entries: [mockRemoteHostEntry] },
+      {
+        kind: "hosts",
+        entries: [{ ...mockRemoteHostEntry, label: "Renamed" }],
+      },
+      {
+        kind: "hosts",
+        entries: [{ ...mockRemoteHostEntry, label: "Renamed" }],
+      },
+    ]);
+    const directory = makeDirectory({
+      runnerHost: host,
+      localHostIdSeeder: null,
+      remoteFetcher: fetcher,
+    });
+    await directory.start();
+
+    const observed: Array<readonly HostDirectoryEntry[]> = [];
+    directory.onChange((entries) => {
+      observed.push(entries);
+    });
+
+    // Change, then hold. The second poll re-delivers the CHANGED value, which
+    // is now the emitted baseline - it must not emit a second time.
+    await directory.refresh();
+    await directory.refresh();
+
+    expect(observed).toHaveLength(1);
+  });
+
   it("retains the last-known remote entries and selection when a refresh fails (T20 / audit P4)", async () => {
     const host = makeHost(null);
     const { fetcher } = queuedFetcher([

--- a/clients/gui-app/src/lib/host/host-directory-service.ts
+++ b/clients/gui-app/src/lib/host/host-directory-service.ts
@@ -99,6 +99,12 @@ export class HostDirectoryService implements IHostDirectoryService {
    */
   private lastKnownLocalHostId: string | null = loadPersistedLocalHostId();
   private remoteEntries: readonly HostDirectoryEntry[] = [];
+  /**
+   * The snapshot most recently fanned out through `emit()`, kept so the poll
+   * path (`emitIfSnapshotChanged`) can suppress no-change re-emits. `null`
+   * only before the first emit.
+   */
+  private lastEmittedSnapshot: readonly HostDirectoryEntry[] | null = null;
   private selected: HostDirectoryEntry | null = null;
   /**
    * Tracks the user's explicit selection gesture via `selectById(...)`
@@ -495,7 +501,11 @@ export class HostDirectoryService implements IHostDirectoryService {
       this.consumeUnboundFollowUpRestore(outcome.entries);
     }
     this.reconcileSelection();
-    this.emit();
+    // Emit only when the merged snapshot actually changed. The 15s registry
+    // poll lands here on every tick; an unconditional emit made every
+    // `onChange` consumer (17 query call sites) re-render/refetch app-wide
+    // each tick even when nothing changed.
+    this.emitIfSnapshotChanged();
     appLogger.debug("[host-directory] refresh complete", {
       outcome: outcome.kind,
       localCount: this.localEntry === null ? 0 : 1,
@@ -830,9 +840,26 @@ export class HostDirectoryService implements IHostDirectoryService {
 
   private emit(): void {
     const snapshot = this.snapshot();
+    this.lastEmittedSnapshot = snapshot;
     for (const listener of this.listeners) {
       listener(snapshot, this.localEntry);
     }
+  }
+
+  /**
+   * Poll-path emit: skips the fan-out when the snapshot is value-equal to the
+   * last one emitted. Every non-poll mutation (local host change, selection,
+   * re-enrollment) still emits unconditionally and refreshes the baseline, so
+   * a change landing between two polls can never be swallowed.
+   */
+  private emitIfSnapshotChanged(): void {
+    if (
+      this.lastEmittedSnapshot !== null &&
+      hostDirectorySnapshotsEqual(this.lastEmittedSnapshot, this.snapshot())
+    ) {
+      return;
+    }
+    this.emit();
   }
 }
 
@@ -939,6 +966,17 @@ function hostDirectoryEntriesEqual(
 
 function remotePublicKeyOf(entry: HostDirectoryEntry): string | null {
   return isRemoteHostDirectoryEntry(entry) ? entry.publicKey : null;
+}
+
+function hostDirectorySnapshotsEqual(
+  a: readonly HostDirectoryEntry[],
+  b: readonly HostDirectoryEntry[],
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  // Index access is in-bounds for both arrays under the length check above.
+  return a.every((entry, index) => hostDirectoryEntriesEqual(entry, b[index]));
 }
 
 /**

--- a/clients/gui-app/src/lib/query-keys/ui-query-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/ui-query-keys.ts
@@ -1,8 +1,7 @@
 export const uiQueryKeys = {
   workspaceEntries: (query: string) =>
     ["composer:workspace-entries", query] as const,
-  hostPicker: (directoryId: string, revision: number) =>
-    ["host-picker", directoryId, revision] as const,
+  hostPicker: (directoryId: string) => ["host-picker", directoryId] as const,
   hostPickerMissing: () => ["host-picker", "missing"] as const,
   cloudEpicTasksDisabled: () =>
     ["host", "missing", "cloud.listTasks", "disabled"] as const,


### PR DESCRIPTION
## The bug

Terminal and TUI tiles flashed **"Starting terminal session…"** every ~15 seconds, wall-aligned, losing keyboard focus each time. The same cadence blipped the host picker, the workspace selector, the settings panels and the re-auth banner into their loading states.

Nothing appeared in any log: the warm session registry keeps the pty stream alive across the flap, so no stream ever closed and no host event fired. It only surfaced under tile-level mount/unmount instrumentation.

## The chain

1. `HostDirectoryService`'s remote-registry refresh poll (15s) called `this.emit()` on **every** tick, changed content or not.
2. `useHostDirectoryList` bumped a `revision` counter on each emit — and that revision was **part of the query key**, so every emit minted a *fresh* cache entry: `data === undefined`, refetching.
3. All 17 consumers of that query saw `data === undefined` at once.
4. `useHostReachability` maps that state to `"checking"`, and `TerminalTile` / `TuiAgentTile` render a loading skeleton instead of `TerminalTileLive` while "checking" — so the xterm subtree **unmounted**. The refetch resolved ~150 ms later, the tile remounted, and the fresh bootstrap sat on the 2 s grid-measure timeout showing "Starting terminal session…".

Most consumers only flashed for the refetch RTT; the tiles paid a full remount plus focus loss.

## The fix

**Producer** — `performRefresh()` now emits only when the merged snapshot actually differs from the last one emitted (field equality, reusing the existing entry comparison). Every other emit site — local-host change, selection, re-enrollment — stays unconditional and refreshes the baseline, so a change landing between two polls can't be swallowed.

**Consumers** — the picker query key drops the revision. Directory changes invalidate that stable key instead, and TanStack keeps the previous `data` through a same-key refetch, so no consumer regresses to a loading state once it has loaded. Defence in depth: even a legitimate future emit is now non-destructive.

`staleTime: 0` is kept and now pairs with the onChange invalidation. That pairing is what stops a boot-time empty fetch from being served fresh for the whole session, and it is load-bearing independently of the key change.

## Tests

- `host-directory-service.test.ts` — a field-identical poll does **not** notify `onChange`; a changed field, an added host, and a re-delivered changed value (baseline tracking) all behave correctly.
- `use-host-directory-list-query.test.tsx` (new) — entries stay visible across a directory emit with no `undefined` window, the emit still reaches consumers, and the cache holds exactly one host-picker entry after repeated emits.

Both suites were mutation-probed: reverting the producer fix fails the first pair; restoring the revision-in-key fails the second pair with `expected [ undefined, … ] to not include undefined` and 3 accumulated cache keys.

Verified in a local staging build — terminal tiles, host list and pickers all sit still across the 15s boundary.
