### PR TITLE
feat(cli): make host crashes diagnosable from the supervisor

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -17,11 +17,12 @@ import type { HostInstallRecord } from "../../manifest/host-install";
 import type { ILogger } from "../../logger";
 import {
   CRASH_REPORT_SPAWN_SLACK_MS,
+  STDERR_END_WAIT_TIMEOUT_MS,
   STDERR_HEAD_MAX_BYTES,
   STDERR_TAIL_MAX_BYTES,
   StderrCaptureBuffer,
   type CrashReportMatch,
-  type StderrLogTee,
+  type StderrTee,
 } from "../../host/crash-diagnostics";
 import type { Environment } from "../../runner/environment";
 import { hostHomeDir } from "../../store/paths";
@@ -198,6 +199,8 @@ interface Recorded {
   findCrashReportResult: CrashReportMatch | null;
   /** When set, findCrashReport never resolves (scan-timeout path). */
   findCrashReportHangs: boolean;
+  /** When set, findCrashReport rejects (must not skip marker/exit). */
+  findCrashReportRejects: boolean;
   lastStderrTee: MemoryStderrTee | null;
   readonly loggerErrors: Array<{
     message: string;
@@ -206,10 +209,10 @@ interface Recorded {
 }
 
 /**
- * Capture-only stderr tee: never opens host.log. Satisfies StderrLogTee's
- * structural surface used by persistChildExit.
+ * Capture-only stderr tee: never opens host.log. Typed as StderrTee so no
+ * cast is required (concrete StderrLogTee private fields stay out of deps).
  */
-class MemoryStderrTee {
+class MemoryStderrTee implements StderrTee {
   readonly capture = new StderrCaptureBuffer(
     STDERR_HEAD_MAX_BYTES,
     STDERR_TAIL_MAX_BYTES,
@@ -226,11 +229,6 @@ class MemoryStderrTee {
   flush(_timeoutMs: number): Promise<void> {
     return Promise.resolve();
   }
-}
-
-function asStderrLogTee(tee: MemoryStderrTee): StderrLogTee {
-  const asUnknown: unknown = tee;
-  return asUnknown as StderrLogTee;
 }
 
 interface RunStubs {
@@ -265,6 +263,7 @@ function makeRunStubs(
     findCrashReportCalls: [],
     findCrashReportResult: null,
     findCrashReportHangs: false,
+    findCrashReportRejects: false,
     lastStderrTee: null,
     loggerErrors: [],
   };
@@ -377,6 +376,9 @@ function makeRunStubs(
         sinceMs,
         excludeNames: new Set(excludeNames),
       });
+      if (recorded.findCrashReportRejects) {
+        throw new Error("injected findCrashReport failure");
+      }
       if (recorded.findCrashReportHangs) {
         return new Promise<CrashReportMatch | null>(() => {
           // Never resolves — exercises the scan timeout race.
@@ -384,10 +386,10 @@ function makeRunStubs(
       }
       return recorded.findCrashReportResult;
     },
-    createStderrTee: (_environment: Environment) => {
+    createStderrTee: (_environment: Environment): StderrTee => {
       const tee = new MemoryStderrTee();
       recorded.lastStderrTee = tee;
-      return asStderrLogTee(tee);
+      return tee;
     },
   };
   return { child, recorded, deps };
@@ -1216,6 +1218,160 @@ describe("runHostStart - signal/exit propagation", () => {
     expect(crashed).toBeDefined();
     expect(crashed?.fields.exitCode).toBe(7);
     expect(crashed?.fields.report).toBeUndefined();
+  }, 10_000);
+
+  it("writes the terminal marker and exits when findCrashReport rejects", async () => {
+    // Injected findCrashReport must not skip marker + deps.exit (the race
+    // has a .catch; without it a rejection leaves the supervisor alive).
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    recorded.findCrashReportRejects = true;
+
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          withChildExit(deps, child, 7, null),
+        ),
+      recorded,
+    );
+
+    expect(recorded.exited).toBe(7);
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    expect(crashed?.fields.exitCode).toBe(7);
+    expect(crashed?.fields.report).toBeUndefined();
+  });
+
+  it("survives an error on the stderr stream and still writes the terminal marker", async () => {
+    // Major: an unhandled Readable error on child.stderr used to kill the
+    // supervisor before persistChildExit wrote the marker Desktop reads.
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const stderr = new PassThrough();
+    Object.assign(child, { stderr });
+    const originalSpawn = deps.spawn;
+    if (originalSpawn === undefined) {
+      throw new Error("test spawn dependency missing");
+    }
+
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          {
+            ...deps,
+            spawn: (command, args, options) => {
+              const spawned = originalSpawn(command, args, options);
+              setImmediate(() => {
+                stderr.write(Buffer.from("partial fatal text\n"));
+                // Stream error instead of a clean end — must be swallowed.
+                stderr.emit("error", new Error("EIO on host stderr"));
+                child.emit("exit", 7, null);
+              });
+              return spawned;
+            },
+          },
+        ),
+      recorded,
+    );
+
+    expect(recorded.exited).toBe(7);
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    expect(crashed?.fields.exitCode).toBe(7);
+    // Bytes that arrived before the error are still worth recording.
+    expect(String(crashed?.fields.stderrTail)).toContain("partial fatal text");
+  });
+
+  it("includes stderr bytes that arrive after exit but before stream end", async () => {
+    // Major: `exit` ≠ drained pipe. Without awaiting stderrEnded before the
+    // marker, the fatal text still in the pipe is lost. This test FAILS if
+    // that await is removed.
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const stderr = new PassThrough();
+    Object.assign(child, { stderr });
+    const originalSpawn = deps.spawn;
+    if (originalSpawn === undefined) {
+      throw new Error("test spawn dependency missing");
+    }
+
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          {
+            ...deps,
+            spawn: (command, args, options) => {
+              const spawned = originalSpawn(command, args, options);
+              setImmediate(() => {
+                // Process dies first; fatal text is still in flight.
+                child.emit("exit", 7, null);
+                setImmediate(() => {
+                  stderr.write(
+                    Buffer.from(
+                      "FATAL ERROR: late-arriving OOM block after exit\n",
+                    ),
+                  );
+                  stderr.end();
+                });
+              });
+              return spawned;
+            },
+          },
+        ),
+      recorded,
+    );
+
+    expect(recorded.exited).toBe(7);
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    expect(String(crashed?.fields.stderrTail)).toContain(
+      "FATAL ERROR: late-arriving OOM block after exit",
+    );
+  });
+
+  it("writes the marker within the stderr-end deadline when the stream never ends", async () => {
+    // A grandchild holding the inherited stderr fd can delay close forever;
+    // the wait is bounded so the supervisor cannot hang on exit.
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const stderr = new PassThrough();
+    Object.assign(child, { stderr });
+    const originalSpawn = deps.spawn;
+    if (originalSpawn === undefined) {
+      throw new Error("test spawn dependency missing");
+    }
+
+    const started = Date.now();
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          {
+            ...deps,
+            spawn: (command, args, options) => {
+              const spawned = originalSpawn(command, args, options);
+              setImmediate(() => {
+                stderr.write(Buffer.from("partial\n"));
+                // Never end/close — only exit.
+                child.emit("exit", 7, null);
+              });
+              return spawned;
+            },
+          },
+        ),
+      recorded,
+    );
+    const elapsed = Date.now() - started;
+
+    expect(recorded.exited).toBe(7);
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    // Bound: wait is STDERR_END_WAIT_TIMEOUT_MS, not forever.
+    expect(elapsed).toBeLessThan(STDERR_END_WAIT_TIMEOUT_MS + 1_500);
+    expect(elapsed).toBeGreaterThanOrEqual(STDERR_END_WAIT_TIMEOUT_MS - 200);
   }, 10_000);
 
   it("omits crash-diagnostic fields on clean exit", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { constants as osConstants } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CliError, CLI_ERROR_CODES } from "../../runner/errors";
 import {
@@ -13,7 +14,16 @@ import {
   type RunHostStartDeps,
 } from "../host-start";
 import type { HostInstallRecord } from "../../manifest/host-install";
-import { noopLogger } from "../../logger";
+import type { ILogger } from "../../logger";
+import {
+  CRASH_REPORT_SPAWN_SLACK_MS,
+  STDERR_HEAD_MAX_BYTES,
+  STDERR_TAIL_MAX_BYTES,
+  StderrCaptureBuffer,
+  type CrashReportMatch,
+  type StderrLogTee,
+} from "../../host/crash-diagnostics";
+import type { Environment } from "../../runner/environment";
 import { hostHomeDir } from "../../store/paths";
 import { withDevDesktopSlotAsync as withDevDesktopSlot } from "@traycer-clients/shared/test-fixtures/dev-desktop-slot";
 import type { ProbeMarker } from "@traycer-clients/shared/host-lifecycle";
@@ -176,6 +186,51 @@ interface Recorded {
     stdio: unknown;
     windowsHide: boolean | undefined;
   }>;
+  // Crash-diagnostics DI observations (never touch real ~/.traycer).
+  readonly preparedCrashReportDirs: string[];
+  /** Names returned by the injected prepareCrashReportsDir (pre-existing set). */
+  prepareCrashReportsReturn: readonly string[];
+  readonly findCrashReportCalls: Array<{
+    dir: string;
+    sinceMs: number;
+    excludeNames: ReadonlySet<string>;
+  }>;
+  findCrashReportResult: CrashReportMatch | null;
+  /** When set, findCrashReport never resolves (scan-timeout path). */
+  findCrashReportHangs: boolean;
+  lastStderrTee: MemoryStderrTee | null;
+  readonly loggerErrors: Array<{
+    message: string;
+    fields: Record<string, unknown>;
+  }>;
+}
+
+/**
+ * Capture-only stderr tee: never opens host.log. Satisfies StderrLogTee's
+ * structural surface used by persistChildExit.
+ */
+class MemoryStderrTee {
+  readonly capture = new StderrCaptureBuffer(
+    STDERR_HEAD_MAX_BYTES,
+    STDERR_TAIL_MAX_BYTES,
+  );
+
+  append(chunk: Buffer): void {
+    this.capture.append(chunk);
+  }
+
+  teeDroppedBytes(): number {
+    return 0;
+  }
+
+  flush(_timeoutMs: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function asStderrLogTee(tee: MemoryStderrTee): StderrLogTee {
+  const asUnknown: unknown = tee;
+  return asUnknown as StderrLogTee;
 }
 
 interface RunStubs {
@@ -205,19 +260,38 @@ function makeRunStubs(
     spawnCalls: [],
     rotations: [],
     sequence: [],
+    preparedCrashReportDirs: [],
+    prepareCrashReportsReturn: [],
+    findCrashReportCalls: [],
+    findCrashReportResult: null,
+    findCrashReportHangs: false,
+    lastStderrTee: null,
+    loggerErrors: [],
   };
   // The stub implements only the surface `runHostStart` touches; route it
   // to `ChildProcess` through an explicit `unknown` intermediate rather than a
   // chained `as unknown as` assertion.
   const childAsUnknown: unknown = child;
   const childAsProcess: ChildProcess = childAsUnknown as ChildProcess;
+  const spyLogger: ILogger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: (message, fields, _error) => {
+      recorded.loggerErrors.push({
+        message,
+        fields: { ...fields },
+      });
+    },
+  };
   const deps: Partial<RunHostStartDeps> = {
     // `runHostStart` falls back to the REAL `createCliLogger` (writing to
     // the actual production `~/.traycer/cli/cli.log`) via `deps.logger ??
     // createCliLogger(...)` whenever this is left unset - `??` treats
     // `undefined` as nullish just like a missing key, so it must be
     // supplied explicitly here, not left to the `Partial` default.
-    logger: noopLogger,
+    // Spy wraps noop for crash-diagnostics message assertions.
+    logger: spyLogger,
     // Same hazard as `logger` above: left unset, the `Partial` default falls
     // through to the REAL `findLiveIncumbentHost`, which reads the developer's
     // actual `~/.traycer/host/pid.json` and probes whatever host is live on
@@ -291,6 +365,30 @@ function makeRunStubs(
     onError: (msg) => {
       recorded.errors.push(msg);
     },
+    // Crash diagnostics: always inject so suites never touch real
+    // ~/.traycer crash-reports or host.log tee paths.
+    prepareCrashReportsDir: async (dir) => {
+      recorded.preparedCrashReportDirs.push(dir);
+      return recorded.prepareCrashReportsReturn;
+    },
+    findCrashReport: async (dir, sinceMs, excludeNames) => {
+      recorded.findCrashReportCalls.push({
+        dir,
+        sinceMs,
+        excludeNames: new Set(excludeNames),
+      });
+      if (recorded.findCrashReportHangs) {
+        return new Promise<CrashReportMatch | null>(() => {
+          // Never resolves — exercises the scan timeout race.
+        });
+      }
+      return recorded.findCrashReportResult;
+    },
+    createStderrTee: (_environment: Environment) => {
+      const tee = new MemoryStderrTee();
+      recorded.lastStderrTee = tee;
+      return asStderrLogTee(tee);
+    },
   };
   return { child, recorded, deps };
 }
@@ -308,6 +406,38 @@ async function runUntilExit(
     });
   }
   expect(recorded.exited).not.toBeNull();
+}
+
+/**
+ * Schedule the stub child's terminal event AFTER spawn returns so the
+ * supervisor has already attached its `exit` / `error` listeners.
+ *
+ * A plain `setTimeout(..., 0)` before `runHostStart` races the pre-spawn
+ * awaits (`rotateLog`, `pruneCrashReports`, marker write, open fd). When
+ * those take longer than a timer tick the exit event is lost and the test
+ * hangs on `runUntilExit`. Emitting from a `setImmediate` nested inside
+ * `spawn` always runs after the listener registration that follows spawn.
+ */
+function withChildExit(
+  deps: Partial<RunHostStartDeps>,
+  child: StubChild,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): Partial<RunHostStartDeps> {
+  const originalSpawn = deps.spawn;
+  if (originalSpawn === undefined) {
+    throw new Error("test spawn dependency missing");
+  }
+  return {
+    ...deps,
+    spawn: (command, args, options) => {
+      const spawned = originalSpawn(command, args, options);
+      setImmediate(() => {
+        child.emit("exit", code, signal);
+      });
+      return spawned;
+    },
+  };
 }
 
 /**
@@ -351,8 +481,10 @@ describe("runHostStart - incumbent host guard", () => {
     const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
 
     const invoke = () =>
-      runHostStart({ environment: "production", cwd: null }, deps);
-    setTimeout(() => child.emit("exit", 0, null));
+      runHostStart(
+        { environment: "production", cwd: null },
+        withChildExit(deps, child, 0, null),
+      );
     await runUntilExit(invoke, recorded);
 
     expect(recorded.spawnCalls).toHaveLength(1);
@@ -440,7 +572,14 @@ describe("runHostStart - label-derived reclaim probe", () => {
 
     await runUntilExit(invoke, recorded);
     expect(recorded.spawnCalls).toHaveLength(1);
-    expect(recorded.spawnCalls[0]?.stdio).toEqual(["ignore", 42, 42, "pipe"]);
+    // stdout stays on the log fd; stderr is piped for the crash-tail tee;
+    // probe status pipe remains index 3 (LAYER0_STATUS_FD).
+    expect(recorded.spawnCalls[0]?.stdio).toEqual([
+      "ignore",
+      42,
+      "pipe",
+      "pipe",
+    ]);
 
     // The status transport is authorised EXPLICITLY, never inferred. The
     // supervisor opened the pipe at stdio[3], so it must also name that
@@ -532,6 +671,10 @@ describe("runHostStart - label-derived reclaim probe", () => {
     const markerWrites: ProbeMarker[] = [];
     const status = new PassThrough();
     Object.assign(child, { stdio: [null, null, null, status] });
+    const originalSpawn = deps.spawn;
+    if (originalSpawn === undefined) {
+      throw new Error("test spawn dependency missing");
+    }
 
     const invoke = () =>
       runHostStart(
@@ -558,14 +701,18 @@ describe("runHostStart - label-derived reclaim probe", () => {
           writeProbeMarker: async (_environment, marker) => {
             markerWrites.push(marker);
           },
+          spawn: (command, args, options) => {
+            const spawned = originalSpawn(command, args, options);
+            setImmediate(() => {
+              status.end();
+              child.emit("error", new Error("ENOENT async"));
+              child.emit("exit", 66, null);
+            });
+            return spawned;
+          },
         },
       );
 
-    setTimeout(() => {
-      status.end();
-      child.emit("error", new Error("ENOENT async"));
-      child.emit("exit", 66, null);
-    });
     await runUntilExit(invoke, recorded);
 
     expect(recorded.exited).toBe(66);
@@ -589,11 +736,13 @@ describe("runHostStart - installed-record launch path", () => {
     process.env.TRAYCER_TEST_UNSET = "inherited";
 
     const invoke = () =>
-      runHostStart({ environment: "production", cwd: null }, deps);
+      runHostStart(
+        { environment: "production", cwd: null },
+        withChildExit(deps, child, 0, null),
+      );
 
-    // The supervisor only returns when the child exits - emit `exit 0`
-    // after a microtask so the spawn call has been recorded.
-    setTimeout(() => child.emit("exit", 0, null));
+    // Exit is scheduled from inside spawn (after listeners attach) so the
+    // pre-spawn awaits cannot race the terminal event away.
     try {
       await runUntilExit(invoke, recorded);
     } finally {
@@ -650,8 +799,11 @@ describe("runHostStart - installed-record launch path", () => {
   it("writes bootstrap markers under the dev environment and passes no environment arg", async () => {
     const exec = "/opt/traycer/host/dev/install/traycer-host";
     const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
-    const invoke = () => runHostStart({ environment: "dev", cwd: null }, deps);
-    setTimeout(() => child.emit("exit", 0, null));
+    const invoke = () =>
+      runHostStart(
+        { environment: "dev", cwd: null },
+        withChildExit(deps, child, 0, null),
+      );
     await runUntilExit(invoke, recorded);
     expect(recorded.markers.every((m) => m.environment === "dev")).toBe(true);
     expect(recorded.spawnCalls[0]?.args.slice(0, 2)).toEqual([
@@ -665,8 +817,11 @@ describe("runHostStart - installed-record launch path", () => {
   it("rotates the log for this environment before anything appends to the run", async () => {
     const exec = "/opt/traycer/host/dev/install/traycer-host";
     const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
-    const invoke = () => runHostStart({ environment: "dev", cwd: null }, deps);
-    setTimeout(() => child.emit("exit", 0, null));
+    const invoke = () =>
+      runHostStart(
+        { environment: "dev", cwd: null },
+        withChildExit(deps, child, 0, null),
+      );
     await runUntilExit(invoke, recorded);
 
     expect(recorded.rotations).toEqual(["dev"]);
@@ -691,8 +846,10 @@ describe("runHostStart - installed-record launch path", () => {
       const exec = "/opt/traycer/host/dev/install/traycer-host";
       const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
       const invoke = () =>
-        runHostStart({ environment: "dev", cwd: null }, deps);
-      setTimeout(() => child.emit("exit", 0, null));
+        runHostStart(
+          { environment: "dev", cwd: null },
+          withChildExit(deps, child, 0, null),
+        );
       await runUntilExit(invoke, recorded);
       expect(recorded.spawnCalls[0]?.args.slice(0, 2)).toEqual([
         "--host-data-dir",
@@ -712,8 +869,11 @@ describe("runHostStart - installed-record launch path", () => {
     // path - it does NOT branch on bundle / node-bin args anymore.
     const wrapper = "/Users/dev/.traycer/host/dev/runtime/traycer-host";
     const { child, recorded, deps } = makeRunStubs(sampleRecord(wrapper), null);
-    const invoke = () => runHostStart({ environment: "dev", cwd: null }, deps);
-    setTimeout(() => child.emit("exit", 0, null));
+    const invoke = () =>
+      runHostStart(
+        { environment: "dev", cwd: null },
+        withChildExit(deps, child, 0, null),
+      );
     await runUntilExit(invoke, recorded);
     expect(recorded.spawnCalls).toHaveLength(1);
     expect(recorded.spawnCalls[0]?.command).toBe(wrapper);
@@ -805,10 +965,12 @@ describe("runHostStart - signal/exit propagation", () => {
       },
     };
 
-    setTimeout(() => child.emit("exit", 7, null));
     await runUntilExit(
       () =>
-        runHostStart({ environment: "production", cwd: null }, durabilityDeps),
+        runHostStart(
+          { environment: "production", cwd: null },
+          withChildExit(durabilityDeps, child, 7, null),
+        ),
       recorded,
     );
 
@@ -819,8 +981,10 @@ describe("runHostStart - signal/exit propagation", () => {
     const exec = "/opt/traycer/host/install/traycer-host";
     const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
     const invoke = () =>
-      runHostStart({ environment: "production", cwd: null }, deps);
-    setTimeout(() => child.emit("exit", null, "SIGTERM"));
+      runHostStart(
+        { environment: "production", cwd: null },
+        withChildExit(deps, child, null, "SIGTERM"),
+      );
     await runUntilExit(invoke, recorded);
     expect(recorded.exited).toBe(143);
     const killed = recorded.markers.find((m) => m.phase === "killed");
@@ -844,12 +1008,11 @@ describe("runHostStart - signal/exit propagation", () => {
         },
       };
 
-      setTimeout(() => child.emit("exit", code, signal));
       await runUntilExit(
         () =>
           runHostStart(
             { environment: "production", cwd: null },
-            throwingWriter,
+            withChildExit(throwingWriter, child, code, signal),
           ),
         recorded,
       );
@@ -862,12 +1025,215 @@ describe("runHostStart - signal/exit propagation", () => {
     const exec = "/opt/traycer/host/install/traycer-host";
     const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
     const invoke = () =>
-      runHostStart({ environment: "production", cwd: null }, deps);
-    setTimeout(() => child.emit("exit", 7, null));
+      runHostStart(
+        { environment: "production", cwd: null },
+        withChildExit(deps, child, 7, null),
+      );
     await runUntilExit(invoke, recorded);
     expect(recorded.exited).toBe(7);
     const crashed = recorded.markers.find((m) => m.phase === "crashed");
     expect(crashed?.fields.exitCode).toBe(7);
+  });
+
+  it("enriches a crashed marker with exitMeaning, report, and stderrTail via injected deps", async () => {
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const stderr = new PassThrough();
+    Object.assign(child, { stderr });
+
+    // Pre-existing names returned by prepare — must be passed through to the scan.
+    recorded.prepareCrashReportsReturn = [
+      "report.prev-child.json",
+      "report.older.json",
+    ];
+    recorded.findCrashReportResult = {
+      filename: "report.oom.json",
+      summary: "event=Allocation failed trigger=FatalError",
+    };
+
+    const originalSpawn = deps.spawn;
+    if (originalSpawn === undefined) {
+      throw new Error("test spawn dependency missing");
+    }
+    const beforeSpawnMs = Date.now();
+    const enrichedDeps: Partial<RunHostStartDeps> = {
+      ...deps,
+      spawn: (command, args, options) => {
+        const spawned = originalSpawn(command, args, options);
+        setImmediate(() => {
+          stderr.write(
+            Buffer.from(
+              "FATAL ERROR: Reached heap limit\nAllocation failed - JavaScript heap out of memory\n",
+            ),
+          );
+          stderr.end();
+          // NTSTATUS fail-fast (Windows 0xC0000409) as a positive decimal.
+          child.emit("exit", 3221226505, null);
+        });
+        return spawned;
+      },
+    };
+
+    await runUntilExit(
+      () =>
+        runHostStart({ environment: "production", cwd: null }, enrichedDeps),
+      recorded,
+    );
+
+    expect(recorded.exited).toBe(3221226505);
+    // Crash-reports dir is prepared under the child cwd (host home for production).
+    expect(recorded.preparedCrashReportDirs).toEqual([
+      join(hostHomeDir("production"), "crash-reports"),
+    ]);
+    // Scan uses spawn time minus slack AND the pre-existing exclude set.
+    expect(recorded.findCrashReportCalls).toHaveLength(1);
+    const call = recorded.findCrashReportCalls[0]!;
+    expect(call.dir).toBe(join(hostHomeDir("production"), "crash-reports"));
+    expect(call.sinceMs).toBeGreaterThanOrEqual(
+      beforeSpawnMs - CRASH_REPORT_SPAWN_SLACK_MS - 50,
+    );
+    expect(call.sinceMs).toBeLessThanOrEqual(
+      Date.now() - CRASH_REPORT_SPAWN_SLACK_MS + 50,
+    );
+    expect([...call.excludeNames].sort()).toEqual([
+      "report.older.json",
+      "report.prev-child.json",
+    ]);
+
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    expect(crashed?.fields.exitCode).toBe(3221226505);
+    expect(String(crashed?.fields.exitMeaning)).toContain("0xC0000409");
+    expect(String(crashed?.fields.exitMeaning)).toContain(
+      "STATUS_STACK_BUFFER_OVERRUN",
+    );
+    expect(crashed?.fields.report).toBe("report.oom.json");
+    expect(String(crashed?.fields.stderrTail)).toContain("FATAL ERROR");
+    expect(String(crashed?.fields.stderrTail)).toContain("\\n");
+  });
+
+  it("enriches a killed+SIGABRT marker, logs Host crash diagnostics, and leaves SIGTERM bare", async () => {
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const sigabrtNum = osConstants.signals.SIGABRT;
+    expect(typeof sigabrtNum).toBe("number");
+    const expectedAbrtExit = 128 + (sigabrtNum as number);
+
+    {
+      const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+      const stderr = new PassThrough();
+      Object.assign(child, { stderr });
+      recorded.prepareCrashReportsReturn = ["report.preexisting.json"];
+      recorded.findCrashReportResult = {
+        filename: "report.abrt.json",
+        summary: "event=FatalError",
+      };
+      const originalSpawn = deps.spawn;
+      if (originalSpawn === undefined) {
+        throw new Error("test spawn dependency missing");
+      }
+      await runUntilExit(
+        () =>
+          runHostStart(
+            { environment: "production", cwd: null },
+            {
+              ...deps,
+              spawn: (command, args, options) => {
+                const spawned = originalSpawn(command, args, options);
+                setImmediate(() => {
+                  stderr.write(Buffer.from("abort: OOM\n"));
+                  stderr.end();
+                  child.emit("exit", null, "SIGABRT");
+                });
+                return spawned;
+              },
+            },
+          ),
+        recorded,
+      );
+      // Platform-correct signal number (macOS/Linux SIGABRT → 134).
+      expect(recorded.exited).toBe(expectedAbrtExit);
+      const killed = recorded.markers.find((m) => m.phase === "killed");
+      expect(killed?.fields.signal).toBe("SIGABRT");
+      expect(String(killed?.fields.exitMeaning)).toContain("SIGABRT");
+      expect(killed?.fields.report).toBe("report.abrt.json");
+      expect(String(killed?.fields.stderrTail)).toContain("abort");
+      expect(recorded.findCrashReportCalls).toHaveLength(1);
+      expect([...recorded.findCrashReportCalls[0]!.excludeNames]).toEqual([
+        "report.preexisting.json",
+      ]);
+      // Same support-log line as the nonzero-exit crash branch.
+      const diag = recorded.loggerErrors.find(
+        (e) => e.message === "Host crash diagnostics",
+      );
+      expect(diag).toBeDefined();
+      expect(String(diag?.fields.exitMeaning)).toContain("SIGABRT");
+      expect(diag?.fields.report).toBe("report.abrt.json");
+    }
+
+    {
+      const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+      await runUntilExit(
+        () =>
+          runHostStart(
+            { environment: "production", cwd: null },
+            withChildExit(deps, child, null, "SIGTERM"),
+          ),
+        recorded,
+      );
+      const killed = recorded.markers.find((m) => m.phase === "killed");
+      expect(killed?.fields.signal).toBe("SIGTERM");
+      expect(killed?.fields.exitMeaning).toBeUndefined();
+      expect(killed?.fields.report).toBeUndefined();
+      expect(killed?.fields.stderrTail).toBeUndefined();
+      // Forwarded shutdown signals must not scan for a crash report.
+      expect(recorded.findCrashReportCalls).toHaveLength(0);
+      expect(
+        recorded.loggerErrors.some(
+          (e) => e.message === "Host crash diagnostics",
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("writes a crashed marker without report when findCrashReport never resolves", async () => {
+    // Production races the scan against CRASH_REPORT_SCAN_TIMEOUT_MS (2s).
+    // A hanging findCrashReport must not block the terminal marker.
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    recorded.findCrashReportHangs = true;
+
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          withChildExit(deps, child, 7, null),
+        ),
+      recorded,
+    );
+
+    expect(recorded.exited).toBe(7);
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    expect(crashed?.fields.exitCode).toBe(7);
+    expect(crashed?.fields.report).toBeUndefined();
+  }, 10_000);
+
+  it("omits crash-diagnostic fields on clean exit", async () => {
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          withChildExit(deps, child, 0, null),
+        ),
+      recorded,
+    );
+    const exited = recorded.markers.find((m) => m.phase === "exited");
+    expect(exited?.fields.exitMeaning).toBeUndefined();
+    expect(exited?.fields.report).toBeUndefined();
+    expect(exited?.fields.stderrTail).toBeUndefined();
+    expect(recorded.findCrashReportCalls).toHaveLength(0);
   });
 
   it("spawn() throw is translated into HOST_SPAWN_FAILED + exit 66", async () => {

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -3,6 +3,7 @@ import {
   type ChildProcess,
   type SpawnOptions,
 } from "node:child_process";
+import { constants as osConstants } from "node:os";
 import { randomUUID } from "node:crypto";
 import { access } from "node:fs/promises";
 import type { Readable } from "node:stream";
@@ -25,6 +26,19 @@ import {
 import type { Environment } from "../runner/environment";
 import { CLI_ERROR_CODES, CliError, cliError } from "../runner/errors";
 import { withHostNodeOptions } from "../service/host-node-options";
+import {
+  CRASH_REPORT_SCAN_TIMEOUT_MS,
+  CRASH_REPORT_SPAWN_SLACK_MS,
+  MAX_KEPT_CRASH_REPORTS,
+  STDERR_FLUSH_TIMEOUT_MS,
+  StderrLogTee,
+  type CrashReportMatch,
+  crashReportsDirFor,
+  describeExitCode,
+  describeFatalSignal,
+  findCrashReportSince,
+  prepareCrashReportsDir,
+} from "../host/crash-diagnostics";
 import { hostHomeDir } from "../store/paths";
 import {
   attestLaunchdSupervisorPid,
@@ -245,6 +259,16 @@ export interface RunHostStartDeps extends ResolveHostStartTargetDeps {
     environment: Environment,
     marker: ProbeMarker,
   ) => Promise<void>;
+  // Crash-diagnostics operations. Injected so tests never touch the real
+  // host data dir: the defaults create/prune/scan real directories and tee
+  // real bytes into host.log.
+  readonly prepareCrashReportsDir: (dir: string) => Promise<readonly string[]>;
+  readonly findCrashReport: (
+    dir: string,
+    sinceMs: number,
+    excludeNames: ReadonlySet<string>,
+  ) => Promise<CrashReportMatch | null>;
+  readonly createStderrTee: (environment: Environment) => StderrLogTee;
 }
 
 const defaultRunDeps: RunHostStartDeps = {
@@ -269,6 +293,10 @@ const defaultRunDeps: RunHostStartDeps = {
   readLayer0Frame,
   attestProbeSupervisor: attestLaunchdSupervisorPid,
   writeProbeMarker: writeProbeMarkerAtomically,
+  prepareCrashReportsDir: (dir) =>
+    prepareCrashReportsDir(dir, MAX_KEPT_CRASH_REPORTS),
+  findCrashReport: findCrashReportSince,
+  createStderrTee: (environment) => new StderrLogTee(environment),
 };
 
 // Long-running entrypoint invoked by the OS service manager. Resolves
@@ -434,14 +462,19 @@ export async function runHostStart(
       await deps.writeMarker(
         opts.environment,
         "failed-to-spawn",
-        markerFields(attemptId, supervisorPid, {
-          shell: undefined,
-          args: undefined,
-          bundle: undefined,
-          exitCode: undefined,
-          signal: undefined,
-          error: `${err.code}: ${err.message}`,
-        }),
+        markerFields(
+          attemptId,
+          supervisorPid,
+          {
+            shell: undefined,
+            args: undefined,
+            bundle: undefined,
+            exitCode: undefined,
+            signal: undefined,
+            error: `${err.code}: ${err.message}`,
+          },
+          null,
+        ),
       );
       await writeProbeTerminalIfAttested({
         context: probeContext,
@@ -510,17 +543,31 @@ export async function runHostStart(
     rotation,
   });
 
+  // Create + prune the diagnostic-report destination BEFORE the spawn: the
+  // relative `--report-directory=crash-reports` in NODE_OPTIONS resolves
+  // against the child cwd, and a crash before the host's own runtime arming
+  // must still have somewhere to land. Never throws.
+  const crashReportsDirPath = crashReportsDirFor(target.cwd);
+  const preexistingReportNames = new Set(
+    await deps.prepareCrashReportsDir(crashReportsDirPath),
+  );
+
   await deps.writeMarker(
     opts.environment,
     "starting",
-    markerFields(attemptId, supervisorPid, {
-      shell: undefined,
-      args: target.args,
-      bundle: target.executable,
-      exitCode: undefined,
-      signal: undefined,
-      error: undefined,
-    }),
+    markerFields(
+      attemptId,
+      supervisorPid,
+      {
+        shell: undefined,
+        args: target.args,
+        bundle: target.executable,
+        exitCode: undefined,
+        signal: undefined,
+        error: undefined,
+      },
+      null,
+    ),
   );
 
   const logFd = await deps.openLogFd(opts.environment);
@@ -552,17 +599,25 @@ export async function runHostStart(
   // the executable directly.
   const launch = resolveSpawnInvocation(target.executable, hostArgs);
 
+  // Captured BEFORE the spawn: a loader-phase crash can write its diagnostic
+  // report before any post-spawn statement runs, and the report scan treats
+  // this as its lower bound (with additional slack for mtime granularity).
+  const childSpawnedAtMs = Date.now();
   let child: ChildProcess;
   try {
     child = deps.spawn(launch.command, launch.args, {
       cwd: target.cwd,
       env,
       // Index LAYER0_STATUS_FD of this vector IS the descriptor named by
-      // `--layer0-status-fd` above; the two must not drift apart.
+      // `--layer0-status-fd` above; the two must not drift apart. stdout
+      // stays on the log fd; stderr is piped so the supervisor can tee it -
+      // byte-for-byte into `host.log` BY PATH (a host-side log rotation
+      // strands an fd-bound copy in `host.log.1`) plus a bounded in-memory
+      // tail for the crash marker.
       stdio:
         probeContext === null
-          ? ["ignore", logFd, logFd]
-          : ["ignore", logFd, logFd, "pipe"],
+          ? ["ignore", logFd, "pipe"]
+          : ["ignore", logFd, "pipe", "pipe"],
       windowsHide: process.platform === "win32",
       ...(launch.windowsVerbatimArguments
         ? { windowsVerbatimArguments: true }
@@ -578,14 +633,19 @@ export async function runHostStart(
     await deps.writeMarker(
       opts.environment,
       "failed-to-spawn",
-      markerFields(attemptId, supervisorPid, {
-        shell: undefined,
-        args: undefined,
-        bundle: target.executable,
-        exitCode: undefined,
-        signal: undefined,
-        error: message,
-      }),
+      markerFields(
+        attemptId,
+        supervisorPid,
+        {
+          shell: undefined,
+          args: undefined,
+          bundle: target.executable,
+          exitCode: undefined,
+          signal: undefined,
+          error: message,
+        },
+        null,
+      ),
     );
     await writeProbeTerminalIfAttested({
       context: probeContext,
@@ -600,6 +660,14 @@ export async function runHostStart(
     );
     return deps.exit(66);
   }
+
+  // Stderr tee (see the stdio comment above): bounded path-addressed mirror
+  // into host.log plus the head+tail capture for the crash marker. Failures
+  // are swallowed - a diagnostics write must never take the supervisor down.
+  const stderrTee = deps.createStderrTee(opts.environment);
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderrTee.append(chunk);
+  });
 
   const probeObservation =
     probeContext === null
@@ -648,6 +716,10 @@ export async function runHostStart(
       supervisorPid,
       bundle: target.executable,
       probeObservation,
+      childSpawnedAtMs,
+      stderrTee,
+      crashReportsDirPath,
+      preexistingReportNames,
     });
   };
   const finalizeChildSpawnError = (cause: Error): void => {
@@ -712,14 +784,19 @@ async function persistAsyncChildSpawnFailure(input: {
   await input.deps.writeMarker(
     input.environment,
     "failed-to-spawn",
-    markerFields(input.attemptId, input.supervisorPid, {
-      shell: undefined,
-      args: undefined,
-      bundle: input.bundle,
-      exitCode: undefined,
-      signal: undefined,
-      error: message,
-    }),
+    markerFields(
+      input.attemptId,
+      input.supervisorPid,
+      {
+        shell: undefined,
+        args: undefined,
+        bundle: input.bundle,
+        exitCode: undefined,
+        signal: undefined,
+        error: message,
+      },
+      null,
+    ),
   );
   await writeProbeTerminalIfAttested({
     context: input.probeContext,
@@ -745,6 +822,10 @@ async function persistChildExit(input: {
   readonly supervisorPid: number;
   readonly bundle: string;
   readonly probeObservation: Promise<ProbeObservation> | null;
+  readonly childSpawnedAtMs: number;
+  readonly stderrTee: StderrLogTee;
+  readonly crashReportsDirPath: string;
+  readonly preexistingReportNames: ReadonlySet<string>;
 }): Promise<void> {
   if (input.probeObservation !== null) {
     try {
@@ -783,29 +864,69 @@ async function persistChildExit(input: {
     bundle,
     deps,
   } = input;
+  // Drain queued stderr tee writes (bounded) before any terminal marker:
+  // `process.exit()` below abandons pending appends, and the fatal text they
+  // carry is the evidence this whole path exists to keep.
+  await input.stderrTee.flush(STDERR_FLUSH_TIMEOUT_MS);
   // `process.exit()` is synchronous. Terminal markers are therefore written
   // synchronously before exit rather than scheduling an append that the
   // process could abandon. Desktop uses these as fail-now readiness evidence.
   if (signal !== null) {
+    // A fatal signal is a CRASH, not a shutdown: a Node fatal abort surfaces
+    // on macOS/Linux as `code=null, signal=SIGABRT`, and routing it through
+    // the bare killed path would discard the report and stderr evidence
+    // exactly where it matters most. Forwarded shutdown signals stay bare.
+    const fatalMeaning = describeFatalSignal(signal);
+    const crashReport =
+      fatalMeaning === null ? null : await boundedCrashReportScan(input);
     logger.warn("Host child exited by signal", {
       environment,
       signal,
       exitCode: 128 + signalNumber(signal),
       attemptId,
     });
+    if (fatalMeaning !== null) {
+      // Same support-log line as the nonzero-exit crash branch: a POSIX
+      // fatal is the same event wearing a signal, and cli.log is where a
+      // support pull reads the OOM-vs-native answer.
+      logger.error(
+        "Host crash diagnostics",
+        {
+          environment,
+          attemptId,
+          exitMeaning: fatalMeaning,
+          report: crashReport?.filename ?? "none",
+          reportSummary: crashReport?.summary ?? "none",
+        },
+        null,
+      );
+    }
     return persistTerminalMarkerAndExit({
       deps,
       logger,
       environment,
       phase: "killed",
-      fields: markerFields(attemptId, supervisorPid, {
-        shell: undefined,
-        args: undefined,
-        bundle,
-        exitCode: undefined,
-        signal,
-        error: undefined,
-      }),
+      fields: markerFields(
+        attemptId,
+        supervisorPid,
+        {
+          shell: undefined,
+          args: undefined,
+          bundle,
+          exitCode: undefined,
+          signal,
+          error: undefined,
+        },
+        fatalMeaning === null
+          ? null
+          : {
+              exitMeaning: fatalMeaning,
+              report: crashReport?.filename,
+              stderrTail: input.stderrTee.capture.isEmpty()
+                ? undefined
+                : input.stderrTee.capture.escapedForMarker(),
+            },
+      ),
       exitCode: 128 + signalNumber(signal),
     });
   }
@@ -820,14 +941,19 @@ async function persistChildExit(input: {
       logger,
       environment,
       phase: "exited",
-      fields: markerFields(attemptId, supervisorPid, {
-        shell: undefined,
-        args: undefined,
-        bundle,
-        exitCode: code,
-        signal: undefined,
-        error: undefined,
-      }),
+      fields: markerFields(
+        attemptId,
+        supervisorPid,
+        {
+          shell: undefined,
+          args: undefined,
+          bundle,
+          exitCode: code,
+          signal: undefined,
+          error: undefined,
+        },
+        null,
+      ),
       exitCode: code ?? 0,
     });
   }
@@ -840,21 +966,81 @@ async function persistChildExit(input: {
     },
     null,
   );
+  // Crash enrichment: decode the exit status, reference the diagnostic
+  // report this child wrote (if any), and attach the stderr capture - the
+  // fatal-error text that used to be stranded in a rotated-away log
+  // generation. All best-effort and time-bounded; the marker must be
+  // written regardless.
+  const exitMeaning = describeExitCode(code) ?? undefined;
+  const crashReport = await boundedCrashReportScan(input);
+  if (exitMeaning !== undefined || crashReport !== null) {
+    logger.error(
+      "Host crash diagnostics",
+      {
+        environment,
+        attemptId,
+        exitMeaning: exitMeaning ?? "unknown",
+        report: crashReport?.filename ?? "none",
+        reportSummary: crashReport?.summary ?? "none",
+      },
+      null,
+    );
+  }
   return persistTerminalMarkerAndExit({
     deps,
     logger,
     environment,
     phase: "crashed",
-    fields: markerFields(attemptId, supervisorPid, {
-      shell: undefined,
-      args: undefined,
-      bundle,
-      exitCode: code,
-      signal: undefined,
-      error: undefined,
-    }),
+    fields: markerFields(
+      attemptId,
+      supervisorPid,
+      {
+        shell: undefined,
+        args: undefined,
+        bundle,
+        exitCode: code,
+        signal: undefined,
+        error: undefined,
+      },
+      {
+        exitMeaning,
+        report: crashReport?.filename,
+        stderrTail: input.stderrTee.capture.isEmpty()
+          ? undefined
+          : input.stderrTee.capture.escapedForMarker(),
+      },
+    ),
     exitCode: code,
   });
+}
+
+/**
+ * Report scan bounded by {@link CRASH_REPORT_SCAN_TIMEOUT_MS}: the terminal
+ * marker is readiness authority and must not be lost to a slow disk - past
+ * the budget the marker goes out without a `report=` field. The lower bound
+ * gets {@link CRASH_REPORT_SPAWN_SLACK_MS} of slack for loader-phase crashes
+ * and mtime granularity.
+ */
+function boundedCrashReportScan(input: {
+  readonly deps: RunHostStartDeps;
+  readonly crashReportsDirPath: string;
+  readonly childSpawnedAtMs: number;
+  readonly preexistingReportNames: ReadonlySet<string>;
+}): Promise<CrashReportMatch | null> {
+  return Promise.race([
+    input.deps.findCrashReport(
+      input.crashReportsDirPath,
+      input.childSpawnedAtMs - CRASH_REPORT_SPAWN_SLACK_MS,
+      input.preexistingReportNames,
+    ),
+    new Promise<null>((resolve) => {
+      const timer = setTimeout(
+        () => resolve(null),
+        CRASH_REPORT_SCAN_TIMEOUT_MS,
+      );
+      timer.unref?.();
+    }),
+  ]);
 }
 
 /**
@@ -975,6 +1161,13 @@ function markerFields(
     readonly signal: string | null | undefined;
     readonly error: string | undefined;
   },
+  // Crash-only enrichment (decoded exit status, diagnostic-report reference,
+  // stderr tail). `null` everywhere except the `phase=crashed` writer.
+  diagnostics: {
+    readonly exitMeaning: string | undefined;
+    readonly report: string | undefined;
+    readonly stderrTail: string | undefined;
+  } | null,
 ): BootstrapMarkerFields {
   return {
     shell: fields.shell,
@@ -983,12 +1176,25 @@ function markerFields(
     exitCode: fields.exitCode,
     signal: fields.signal,
     error: fields.error,
+    exitMeaning: diagnostics?.exitMeaning,
+    report: diagnostics?.report,
+    stderrTail: diagnostics?.stderrTail,
     attemptId,
     supervisorPid,
   };
 }
 
 function signalNumber(signal: NodeJS.Signals): number {
+  // The platform's own table first: the newly crash-classified fatal signals
+  // (SIGABRT, SIGSEGV, ...) must map to their real numbers - reporting
+  // SIGABRT as the generic 15 fallback (exit 143 instead of 134) misfiles
+  // the crash for every consumer of the supervisor's exit code. Some numbers
+  // are platform-dependent (SIGBUS is 7 on Linux, 10 on macOS), which is why
+  // this is a lookup, not a table.
+  const known = osConstants.signals[signal];
+  if (typeof known === "number") {
+    return known;
+  }
   if (signal === "SIGINT") return 2;
   if (signal === "SIGTERM") return 15;
   if (signal === "SIGHUP") return 1;

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -30,8 +30,10 @@ import {
   CRASH_REPORT_SCAN_TIMEOUT_MS,
   CRASH_REPORT_SPAWN_SLACK_MS,
   MAX_KEPT_CRASH_REPORTS,
+  STDERR_END_WAIT_TIMEOUT_MS,
   STDERR_FLUSH_TIMEOUT_MS,
   StderrLogTee,
+  type StderrTee,
   type CrashReportMatch,
   crashReportsDirFor,
   describeExitCode,
@@ -268,7 +270,7 @@ export interface RunHostStartDeps extends ResolveHostStartTargetDeps {
     sinceMs: number,
     excludeNames: ReadonlySet<string>,
   ) => Promise<CrashReportMatch | null>;
-  readonly createStderrTee: (environment: Environment) => StderrLogTee;
+  readonly createStderrTee: (environment: Environment) => StderrTee;
 }
 
 const defaultRunDeps: RunHostStartDeps = {
@@ -665,9 +667,39 @@ export async function runHostStart(
   // into host.log plus the head+tail capture for the crash marker. Failures
   // are swallowed - a diagnostics write must never take the supervisor down.
   const stderrTee = deps.createStderrTee(opts.environment);
-  child.stderr?.on("data", (chunk: Buffer) => {
-    stderrTee.append(chunk);
+  // Resolves when the stderr stream ends (or errors). `exit` fires when the
+  // process dies, NOT when its pipes have drained, so the finalize path waits
+  // on THIS (bounded) before writing the marker - otherwise the fatal text can
+  // still be unread in the pipe and the capture comes out empty in exactly the
+  // abnormal-death case this feature exists for.
+  let resolveStderrEnded: () => void = () => undefined;
+  const stderrEnded = new Promise<void>((resolve) => {
+    resolveStderrEnded = resolve;
   });
+  if (child.stderr === null || child.stderr === undefined) {
+    resolveStderrEnded();
+  } else {
+    const stderr = child.stderr;
+    stderr.on("data", (chunk: Buffer) => {
+      stderrTee.append(chunk);
+    });
+    // MANDATORY, not defensive: the stream is a live `Readable` this process
+    // owns, and Node rethrows an unhandled stream `error` as an uncaught
+    // exception. A read error on this pipe (EIO, or EPIPE after an abnormal
+    // child death - i.e. precisely the crash case) would kill the supervisor
+    // BEFORE it writes the terminal marker Desktop reads. Swallow it and
+    // settle the wait: whatever bytes arrived are still worth recording, and
+    // `error` may arrive instead of `end`.
+    stderr.on("error", () => {
+      resolveStderrEnded();
+    });
+    stderr.on("end", () => {
+      resolveStderrEnded();
+    });
+    stderr.on("close", () => {
+      resolveStderrEnded();
+    });
+  }
 
   const probeObservation =
     probeContext === null
@@ -718,6 +750,7 @@ export async function runHostStart(
       probeObservation,
       childSpawnedAtMs,
       stderrTee,
+      stderrEnded,
       crashReportsDirPath,
       preexistingReportNames,
     });
@@ -823,7 +856,8 @@ async function persistChildExit(input: {
   readonly bundle: string;
   readonly probeObservation: Promise<ProbeObservation> | null;
   readonly childSpawnedAtMs: number;
-  readonly stderrTee: StderrLogTee;
+  readonly stderrTee: StderrTee;
+  readonly stderrEnded: Promise<void>;
   readonly crashReportsDirPath: string;
   readonly preexistingReportNames: ReadonlySet<string>;
 }): Promise<void> {
@@ -864,9 +898,14 @@ async function persistChildExit(input: {
     bundle,
     deps,
   } = input;
-  // Drain queued stderr tee writes (bounded) before any terminal marker:
-  // `process.exit()` below abandons pending appends, and the fatal text they
-  // carry is the evidence this whole path exists to keep.
+  // TWO waits, and they are not interchangeable. First: let the stderr pipe
+  // reach `end` - `exit` does not imply drained pipes, so without this the
+  // capture can be empty precisely when the child died hard. Second: drain
+  // the tee's queued `appendFile` writes, which `process.exit()` below would
+  // otherwise abandon. Both are bounded, because a grandchild holding the
+  // inherited stderr fd can keep the stream open indefinitely and a
+  // diagnostics path must never hang the supervisor's exit.
+  await withDeadline(input.stderrEnded, STDERR_END_WAIT_TIMEOUT_MS);
   await input.stderrTee.flush(STDERR_FLUSH_TIMEOUT_MS);
   // `process.exit()` is synchronous. Terminal markers are therefore written
   // synchronously before exit rather than scheduling an append that the
@@ -1028,16 +1067,45 @@ function boundedCrashReportScan(input: {
   readonly preexistingReportNames: ReadonlySet<string>;
 }): Promise<CrashReportMatch | null> {
   return Promise.race([
-    input.deps.findCrashReport(
-      input.crashReportsDirPath,
-      input.childSpawnedAtMs - CRASH_REPORT_SPAWN_SLACK_MS,
-      input.preexistingReportNames,
-    ),
+    // `.catch` is load-bearing, not decoration. `persistChildExit` is invoked
+    // as `void persistChildExit(...)`, so a rejection here would skip the
+    // terminal marker AND `deps.exit` - leaving the supervisor alive with no
+    // evidence written, which is strictly worse than having no `report=`
+    // field. The default implementation swallows its own I/O errors, but the
+    // INJECTED dependency contract makes no such promise.
+    input.deps
+      .findCrashReport(
+        input.crashReportsDirPath,
+        input.childSpawnedAtMs - CRASH_REPORT_SPAWN_SLACK_MS,
+        input.preexistingReportNames,
+      )
+      .catch(() => null),
     new Promise<null>((resolve) => {
       const timer = setTimeout(
         () => resolve(null),
         CRASH_REPORT_SCAN_TIMEOUT_MS,
       );
+      timer.unref?.();
+    }),
+  ]);
+}
+
+/**
+ * Resolves when `promise` settles or `timeoutMs` elapses, whichever is first.
+ * Never rejects: every caller here is on the exit path, where the only
+ * acceptable outcome is "continue and write the marker".
+ */
+function withDeadline(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  return Promise.race([
+    promise.then(
+      () => undefined,
+      () => undefined,
+    ),
+    new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs);
       timer.unref?.();
     }),
   ]);

--- a/clients/traycer-cli/src/doctor/__tests__/engine-recent-crash.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/engine-recent-crash.test.ts
@@ -1,0 +1,274 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Doctor used to CANCEL a crash marker whenever a later `starting` marker
+// existed - which erased the evidence on the exact auto-respawn path that
+// recovered the host. It now keeps the crash and downgrades severity to
+// "recovered by restart".
+
+const osHome = vi.hoisted(() => ({ current: "" }));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => osHome.current || actual.tmpdir() };
+});
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+let workHome: string;
+
+beforeEach(() => {
+  workHome = mkdtempSync(join(tmpdir(), "traycer-doctor-crash-"));
+  osHome.current = workHome;
+  process.env.HOME = workHome;
+  process.env.USERPROFILE = workHome;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (ORIGINAL_USERPROFILE === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  }
+  rmSync(workHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("../../manifest/host-install");
+  vi.doUnmock("../../host/bootstrap-log");
+  vi.doUnmock("../../host/pid-metadata");
+  vi.doUnmock("../../service");
+  vi.doUnmock("../../store/cli-lock");
+});
+
+interface Marker {
+  readonly timestamp: string;
+  readonly phase: string;
+  readonly fields: Record<string, string>;
+}
+
+function stageQuietHost(markers: readonly Marker[]): void {
+  const hostExecutablePath = join(workHome, "bin", "host");
+  mkdirSync(join(workHome, "bin"), { recursive: true });
+  writeFileSync(hostExecutablePath, "host-bin");
+  vi.doMock("../../manifest/host-install", () => ({
+    readHostInstallRecord: () => ({
+      version: "1.4.0",
+      environment: "production",
+      executablePath: hostExecutablePath,
+      installedAt: "2026-04-01T00:00:00Z",
+      source: "registry",
+      archiveSha256: "f".repeat(64),
+      signatureKeyId: "registry:prod-2026",
+    }),
+  }));
+  vi.doMock("../../host/bootstrap-log", () => ({
+    readBootstrapMarkers: async () => markers,
+  }));
+  // No live host / no service - so unrecovered crash severity is "error".
+  vi.doMock("../../host/pid-metadata", () => ({
+    readHostPidMetadata: async () => null,
+  }));
+  vi.doMock("../../service", () => ({
+    createServiceController: () => ({
+      status: async () => ({
+        state: "stopped",
+        version: "1.4.0",
+        listenUrl: null,
+        pid: null,
+      }),
+      install: async () => undefined,
+      uninstall: async () => undefined,
+      start: async () => undefined,
+      stop: async () => undefined,
+      restart: async () => undefined,
+    }),
+    serviceLabelFor: (environment: string) => ({
+      id: `ai.traycer.host.${environment}`,
+    }),
+  }));
+  vi.doMock("../../store/cli-lock", () => ({
+    isProcessAlive: () => false,
+  }));
+}
+
+describe("runDoctor RECENT_CRASH_MARKERS recovery", () => {
+  it("downgrades a crash followed by a later starting marker to recovered warning", async () => {
+    stageQuietHost([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "crashed",
+        fields: {
+          code: "3221226505",
+          exitMeaning: "0xC0000409 STATUS_STACK_BUFFER_OVERRUN",
+          report: "report.json",
+        },
+      },
+      {
+        timestamp: "2026-01-01T00:00:05.000Z",
+        phase: "starting",
+        fields: {},
+      },
+    ]);
+
+    const { runDoctor } = await import("../engine");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: { runCommand: async () => null, platform: "darwin" },
+    });
+
+    const issue = result.issues.find((i) => i.code === "RECENT_CRASH_MARKERS");
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("warning");
+    expect(issue?.title).toContain("recovered by restart");
+    expect(issue?.details).toMatchObject({
+      phase: "crashed",
+      recovered: true,
+    });
+    expect(issue?.message).toContain("meaning=0xC0000409");
+    expect(issue?.message).toContain("report=report.json");
+  });
+
+  it("keeps an unrecovered crash as error when no later start exists", async () => {
+    stageQuietHost([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "crashed",
+        fields: {
+          code: "7",
+        },
+      },
+    ]);
+
+    const { runDoctor } = await import("../engine");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: { runCommand: async () => null, platform: "darwin" },
+    });
+
+    const issue = result.issues.find((i) => i.code === "RECENT_CRASH_MARKERS");
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("error");
+    expect(issue?.title).toBe("Host crashed recently");
+    expect(issue?.title).not.toContain("recovered");
+    expect(issue?.details).toMatchObject({
+      phase: "crashed",
+      recovered: false,
+    });
+  });
+
+  it("reports failed-to-spawn with recovered=true after a later starting marker", async () => {
+    stageQuietHost([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "failed-to-spawn",
+        fields: { error: "ENOENT" },
+      },
+      {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        phase: "starting",
+        fields: {},
+      },
+    ]);
+
+    const { runDoctor } = await import("../engine");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: { runCommand: async () => null, platform: "darwin" },
+    });
+
+    const issue = result.issues.find((i) => i.code === "RECENT_CRASH_MARKERS");
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("warning");
+    expect(issue?.title).toBe(
+      "Host failed to spawn recently (recovered by restart)",
+    );
+    expect(issue?.details).toMatchObject({ recovered: true });
+  });
+
+  it("treats killed+SIGABRT as a crash (unrecovered → error)", async () => {
+    stageQuietHost([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "killed",
+        fields: {
+          signal: "SIGABRT",
+          exitMeaning:
+            "SIGABRT abort (V8 fatal/OOM, assertion, or native abort)",
+          report: "report.json",
+        },
+      },
+    ]);
+
+    const { runDoctor } = await import("../engine");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: { runCommand: async () => null, platform: "darwin" },
+    });
+
+    const issue = result.issues.find((i) => i.code === "RECENT_CRASH_MARKERS");
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("error");
+    expect(issue?.title).toBe("Host crashed recently");
+    expect(issue?.details).toMatchObject({
+      phase: "killed",
+      recovered: false,
+    });
+    expect(issue?.message).toContain("signal=SIGABRT");
+  });
+
+  it("treats killed+SIGABRT followed by starting as recovered crash", async () => {
+    stageQuietHost([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "killed",
+        fields: { signal: "SIGABRT" },
+      },
+      {
+        timestamp: "2026-01-01T00:00:05.000Z",
+        phase: "starting",
+        fields: {},
+      },
+    ]);
+
+    const { runDoctor } = await import("../engine");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: { runCommand: async () => null, platform: "darwin" },
+    });
+
+    const issue = result.issues.find((i) => i.code === "RECENT_CRASH_MARKERS");
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("warning");
+    expect(issue?.title).toContain("recovered by restart");
+    expect(issue?.details).toMatchObject({
+      phase: "killed",
+      recovered: true,
+    });
+  });
+
+  it("does not treat killed+SIGTERM as a crash marker", async () => {
+    stageQuietHost([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "killed",
+        fields: { signal: "SIGTERM" },
+      },
+    ]);
+
+    const { runDoctor } = await import("../engine");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: { runCommand: async () => null, platform: "darwin" },
+    });
+
+    const crash = result.issues.find((i) => i.code === "RECENT_CRASH_MARKERS");
+    expect(crash).toBeUndefined();
+  });
+});

--- a/clients/traycer-cli/src/doctor/engine.ts
+++ b/clients/traycer-cli/src/doctor/engine.ts
@@ -11,6 +11,7 @@ import {
   readBootstrapMarkers,
   type BootstrapLogEntry,
 } from "../host/bootstrap-log";
+import { isFatalSignal } from "../host/crash-diagnostics";
 import {
   readHostPidMetadata,
   type HostPidMetadata,
@@ -501,23 +502,28 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorResult> {
   const recentMarkers = await readBootstrapMarkers(opts.environment, 20);
   const recentCrash = lastCrashMarker(recentMarkers);
   if (recentCrash !== null) {
-    const fields = recentCrash.fields;
+    const fields = recentCrash.entry.fields;
+    const baseTitle =
+      recentCrash.entry.phase === "failed-to-spawn"
+        ? "Host failed to spawn recently"
+        : "Host crashed recently";
     issues.push({
       code: DOCTOR_ISSUE_CODES.RECENT_CRASH_MARKERS,
-      severity:
-        hostProcessAlive || serviceStatus?.state === "running"
+      severity: recentCrash.recovered
+        ? "warning"
+        : hostProcessAlive || serviceStatus?.state === "running"
           ? "warning"
           : "error",
-      title:
-        recentCrash.phase === "failed-to-spawn"
-          ? "Host failed to spawn recently"
-          : "Host crashed recently",
-      message: formatMarkerMessage(recentCrash),
+      title: recentCrash.recovered
+        ? `${baseTitle} (recovered by restart)`
+        : baseTitle,
+      message: formatMarkerMessage(recentCrash.entry),
       fixAction: "host-logs",
       terminalCommand: `traycer host logs --tail 200`,
       details: {
-        phase: recentCrash.phase,
-        timestamp: recentCrash.timestamp,
+        phase: recentCrash.entry.phase,
+        timestamp: recentCrash.entry.timestamp,
+        recovered: recentCrash.recovered,
         fields,
       },
     });
@@ -581,16 +587,27 @@ function layer0GuaranteeIssue(
 
 function lastCrashMarker(
   entries: readonly BootstrapLogEntry[],
-): BootstrapLogEntry | null {
+): { readonly entry: BootstrapLogEntry; readonly recovered: boolean } | null {
+  let recovered = false;
   for (let i = entries.length - 1; i >= 0; i -= 1) {
     const entry = entries[i];
     if (entry === undefined) continue;
-    if (entry.phase === "crashed" || entry.phase === "failed-to-spawn") {
-      return entry;
+    if (
+      entry.phase === "crashed" ||
+      entry.phase === "failed-to-spawn" ||
+      // A fatal signal (SIGABRT et al.) is a crash wearing the killed phase:
+      // Node fatal aborts on POSIX surface as signal deaths, and skipping
+      // them here would hide exactly the evidence the enrichment attaches.
+      (entry.phase === "killed" && isFatalSignal(entry.fields.signal))
+    ) {
+      return { entry, recovered };
     }
     if (entry.phase === "starting") {
-      // A more recent successful start cancels the older crash signal.
-      return null;
+      // A more recent start used to CANCEL the crash signal entirely - which
+      // erased the evidence in exactly the auto-respawn-recovered case where
+      // the crash is the only thing worth diagnosing. It now only downgrades
+      // the finding to "recovered".
+      recovered = true;
     }
   }
   return null;
@@ -599,10 +616,14 @@ function lastCrashMarker(
 function formatMarkerMessage(entry: BootstrapLogEntry): string {
   const parts: string[] = [`phase=${entry.phase}`, `at=${entry.timestamp}`];
   if (entry.fields.code !== undefined) parts.push(`code=${entry.fields.code}`);
+  if (entry.fields.exitMeaning !== undefined)
+    parts.push(`meaning=${entry.fields.exitMeaning}`);
   if (entry.fields.signal !== undefined)
     parts.push(`signal=${entry.fields.signal}`);
   if (entry.fields.error !== undefined)
     parts.push(`error=${entry.fields.error}`);
+  if (entry.fields.report !== undefined)
+    parts.push(`report=${entry.fields.report}`);
   return parts.join(" ");
 }
 

--- a/clients/traycer-cli/src/host/__tests__/bootstrap-log.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/bootstrap-log.test.ts
@@ -1,0 +1,146 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StderrCaptureBuffer } from "../crash-diagnostics";
+
+const mocks = vi.hoisted(() => ({
+  logPath: "",
+  homeDir: "",
+}));
+
+vi.mock("../../store/paths", () => ({
+  bootstrapLogPath: () => mocks.logPath,
+  hostHomeDir: () => mocks.homeDir,
+  ensureHostHomeDir: async () => {
+    // No-op: the test creates the parent of logPath.
+  },
+}));
+
+const {
+  parseBootstrapLogLine,
+  writeBootstrapTerminalMarker,
+  readBootstrapMarkers,
+} = await import("../bootstrap-log");
+
+describe("bootstrap-log crash diagnostic fields", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "traycer-bootstrap-log-"));
+    mocks.homeDir = root;
+    mocks.logPath = join(root, "host.log");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("formatFields renders exitMeaning, report, and stderrTail and parse round-trips them", async () => {
+    const stderrTail =
+      "FATAL ERROR: Reached heap limit\\nAllocation failed - JavaScript heap out of memory";
+    writeBootstrapTerminalMarker("production", "crashed", {
+      shell: undefined,
+      args: undefined,
+      bundle: "/opt/traycer/host/install/traycer-host",
+      exitCode: 3221226505,
+      signal: undefined,
+      error: undefined,
+      exitMeaning:
+        "0xC0000409 STATUS_STACK_BUFFER_OVERRUN (fail-fast abort: V8 fatal/OOM, native stack overflow, or CRT abort)",
+      report: "report.2026-01-01.120000.1234.0.001.json",
+      stderrTail,
+      attemptId: "attempt-uuid",
+      supervisorPid: 42,
+    });
+
+    const raw = await readFile(mocks.logPath, "utf8");
+    const line = raw.trimEnd();
+    expect(line).toContain("phase=crashed");
+    expect(line).toContain("code=3221226505");
+    expect(line).toContain("exitMeaning=");
+    expect(line).toContain("0xC0000409");
+    expect(line).toContain("report=report.2026-01-01.120000.1234.0.001.json");
+    expect(line).toMatch(/stderrTail="/);
+
+    const parsed = parseBootstrapLogLine(line);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.phase).toBe("crashed");
+    expect(parsed?.fields.code).toBe("3221226505");
+    expect(parsed?.fields.exitMeaning).toContain("0xC0000409");
+    expect(parsed?.fields.report).toBe(
+      "report.2026-01-01.120000.1234.0.001.json",
+    );
+    expect(parsed?.fields.stderrTail).toBe(stderrTail);
+    expect(parsed?.fields.attempt).toBe("attempt-uuid");
+    expect(parsed?.fields.supervisorPid).toBe("42");
+  });
+
+  it("round-trips a stderrTail that contained U+2028/U+2029 after capture escape", async () => {
+    // Repro from cold review: a raw U+2028 inside a quoted marker value
+    // silently discards the whole marker line. Capture must escape it first.
+    const capture = new StderrCaptureBuffer(2048, 2048);
+    capture.append(Buffer.from("FATAL\u2028ERROR\u2029block\nnext"));
+    const stderrTail = capture.escapedForMarker();
+    expect(stderrTail).toBe("FATAL\\nERROR\\nblock\\nnext");
+    expect(stderrTail).not.toMatch(/[\u2028\u2029]/);
+
+    writeBootstrapTerminalMarker("production", "crashed", {
+      shell: undefined,
+      args: undefined,
+      bundle: undefined,
+      exitCode: 1,
+      signal: undefined,
+      error: undefined,
+      exitMeaning: undefined,
+      report: undefined,
+      stderrTail,
+      attemptId: "a",
+      supervisorPid: 1,
+    });
+
+    const raw = await readFile(mocks.logPath, "utf8");
+    const lines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+    // The marker must be a SINGLE parseable line (U+2028 must not split it).
+    expect(lines).toHaveLength(1);
+    const parsed = parseBootstrapLogLine(lines[0]!);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.phase).toBe("crashed");
+    expect(parsed?.fields.stderrTail).toBe(stderrTail);
+  });
+
+  it("parses legacy markers that lack the crash-diagnostic keys", () => {
+    const line =
+      "[2026-01-01T00:00:00.000Z] phase=crashed code=7 attempt=a1 supervisorPid=9";
+    const parsed = parseBootstrapLogLine(line);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.phase).toBe("crashed");
+    expect(parsed?.fields.code).toBe("7");
+    expect(parsed?.fields.exitMeaning).toBeUndefined();
+    expect(parsed?.fields.report).toBeUndefined();
+    expect(parsed?.fields.stderrTail).toBeUndefined();
+    expect(parsed?.fields.attempt).toBe("a1");
+  });
+
+  it("readBootstrapMarkers surfaces the new fields as strings", async () => {
+    writeBootstrapTerminalMarker("production", "crashed", {
+      shell: undefined,
+      args: undefined,
+      bundle: undefined,
+      exitCode: 1,
+      signal: undefined,
+      error: undefined,
+      exitMeaning: "0xC0000005 STATUS_ACCESS_VIOLATION (native crash)",
+      report: "r.json",
+      stderrTail: "segv",
+      attemptId: undefined,
+      supervisorPid: undefined,
+    });
+
+    const entries = await readBootstrapMarkers("production", 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.fields.exitMeaning).toContain("0xC0000005");
+    expect(entries[0]?.fields.report).toBe("r.json");
+    expect(entries[0]?.fields.stderrTail).toBe("segv");
+  });
+});

--- a/clients/traycer-cli/src/host/__tests__/crash-diagnostics.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/crash-diagnostics.test.ts
@@ -1,0 +1,504 @@
+import {
+  mkdtemp,
+  readdir,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Redirect host.log for StderrLogTee so tests never write under ~/.traycer.
+const teeMocks = vi.hoisted(() => ({
+  logPath: "",
+}));
+
+vi.mock("../../store/paths", () => ({
+  bootstrapLogPath: () => teeMocks.logPath,
+}));
+
+const {
+  CRASH_REPORT_SPAWN_SLACK_MS,
+  STDERR_FATAL_WINDOW_MAX_BYTES,
+  STDERR_MARKER_MAX_CHARS,
+  STDERR_TEE_MAX_PENDING_BYTES,
+  StderrCaptureBuffer,
+  StderrLogTee,
+  crashReportsDirFor,
+  describeExitCode,
+  describeFatalSignal,
+  findCrashReportSince,
+  isFatalSignal,
+  prepareCrashReportsDir,
+  pruneCrashReports,
+} = await import("../crash-diagnostics");
+
+const EMPTY_EXCLUDE: ReadonlySet<string> = new Set();
+
+// ---------------------------------------------------------------------------
+// StderrCaptureBuffer
+// ---------------------------------------------------------------------------
+
+describe("StderrCaptureBuffer", () => {
+  it("keeps first head bytes, elides the middle, and keeps last tail bytes (no fatal)", () => {
+    // head=4, tail=4: "AAAA" + "BBBBCCCC" + "DDDD" → head AAAA, elide 8, tail DDDD
+    // when middle is BBBBCCCC (8 bytes) and only 4 fit in tail, last 4 of middle+tail.
+    const buf = new StderrCaptureBuffer(4, 4);
+    buf.append(Buffer.from("AAAA")); // fills head
+    buf.append(Buffer.from("BBBB")); // starts tail
+    buf.append(Buffer.from("CCCC")); // tail overflow: BBBBCCCC → elide BBBB, keep CCCC
+    buf.append(Buffer.from("DDDD")); // tail: CCCCDDDD → elide CCCC, keep DDDD
+    // elided = 4 (BBBB) + 4 (CCCC) = 8
+    const escaped = buf.escapedForMarker();
+    expect(escaped).toBe("AAAA\\n[... 8 bytes elided ...]\\nDDDD");
+    expect(buf.isEmpty()).toBe(false);
+  });
+
+  it("concatenates head and tail without elision when nothing is dropped (no fatal)", () => {
+    const buf = new StderrCaptureBuffer(10, 10);
+    buf.append(Buffer.from("hello"));
+    buf.append(Buffer.from("world"));
+    expect(buf.escapedForMarker()).toBe("helloworld");
+  });
+
+  it("empty buffer reports isEmpty and empty escaped form", () => {
+    const buf = new StderrCaptureBuffer(64, 64);
+    expect(buf.isEmpty()).toBe(true);
+    expect(buf.escapedForMarker()).toBe("");
+  });
+
+  it("escapedForMarker escapes LF and U+2028/U+2029 as \\\\n", () => {
+    const buf = new StderrCaptureBuffer(2048, 2048);
+    // U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR — raw in a quoted
+    // marker value silently discard the whole marker line (parser is line-based).
+    buf.append(Buffer.from("a\nb\u2028c\u2029d\r\ne"));
+    expect(buf.escapedForMarker()).toBe("a\\nb\\nc\\nd\\ne");
+  });
+
+  it("escapedForMarker strips remaining C0 control chars but keeps tab", () => {
+    const buf = new StderrCaptureBuffer(2048, 2048);
+    buf.append(Buffer.from("ok\x00\x01\tkeep\x1f"));
+    expect(buf.escapedForMarker()).toBe("ok\tkeep");
+  });
+
+  it("clamps the escaped form after escaping at STDERR_MARKER_MAX_CHARS with ellipsis", () => {
+    const buf = new StderrCaptureBuffer(10_000, 10_000);
+    // Enough printable bytes that the escaped length exceeds the clamp.
+    buf.append(Buffer.alloc(STDERR_MARKER_MAX_CHARS + 50, 0x41)); // 'A'
+    const escaped = buf.escapedForMarker();
+    expect(escaped.length).toBe(STDERR_MARKER_MAX_CHARS);
+    expect(escaped.endsWith("…")).toBe(true);
+    expect(escaped.slice(0, -1)).toBe("A".repeat(STDERR_MARKER_MAX_CHARS - 1));
+  });
+
+  describe("FATAL-anchored window", () => {
+    it("keeps FATAL ERROR after ~3KB of prior noise + a multi-KB fatal block", () => {
+      // Round-3 repro: process-lifetime head fills with ordinary warnings, so
+      // head+tail alone loses the headline that sits near the START of a
+      // multi-KB OOM block. The fatal window latches at the needle.
+      const buf = new StderrCaptureBuffer(2048, 2048);
+      const prior = Buffer.from("warning: something noisy\n".repeat(150)); // ~3.6KB
+      expect(prior.length).toBeGreaterThan(3000);
+      buf.append(prior);
+
+      const fatalBody =
+        "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory\n" +
+        " 1: 0x1000 node::Abort()\n" +
+        " 2: 0x1001 v8::internal::V8::FatalProcessOutOfMemory\n" +
+        " 3: heap stats line early in the block\n" +
+        "X".repeat(5000);
+      expect(fatalBody.length).toBeGreaterThan(4000);
+      buf.append(Buffer.from(fatalBody));
+
+      const escaped = buf.escapedForMarker();
+      expect(escaped).toContain("FATAL ERROR");
+      expect(escaped).toContain("Reached heap limit");
+      expect(escaped).toContain("heap stats line early in the block");
+      // Prior warning noise must not dominate: fatal-window rendering prefers
+      // the latched fatal text (alone or with trailing elision), not head noise.
+      expect(escaped.startsWith("warning:")).toBe(false);
+    });
+
+    it("detects a needle split across two chunks", () => {
+      const buf = new StderrCaptureBuffer(2048, 2048);
+      buf.append(Buffer.from("prefix noise FATAL ER"));
+      buf.append(Buffer.from("ROR: heap OOM\nrest of block\n"));
+      const escaped = buf.escapedForMarker();
+      expect(escaped).toContain("FATAL ERROR");
+      expect(escaped).toContain("heap OOM");
+    });
+
+    it("renders fatal text alone when the fatal window never fills (uncapped)", () => {
+      const buf = new StderrCaptureBuffer(2048, 2048);
+      // Head noise first so without fatal-window this would still include it.
+      buf.append(Buffer.from("ordinary warning before the abort\n".repeat(20)));
+      buf.append(
+        Buffer.from(
+          "FATAL ERROR: Reached heap limit\nAllocation failed - short block\n",
+        ),
+      );
+      const escaped = buf.escapedForMarker();
+      // Uncapped fatal window → fatal text alone (no head noise, no trailing marker).
+      expect(escaped).toContain("FATAL ERROR: Reached heap limit");
+      expect(escaped).not.toContain("ordinary warning");
+      expect(escaped).not.toContain("trailing bytes");
+    });
+
+    it("appends trailing-bytes elision + tail when the fatal window caps", () => {
+      const buf = new StderrCaptureBuffer(2048, 2048);
+      // One chunk that starts with the needle and exceeds STDERR_FATAL_WINDOW_MAX_BYTES.
+      const fatal =
+        "FATAL ERROR: " +
+        "A".repeat(STDERR_FATAL_WINDOW_MAX_BYTES) +
+        "TAIL_MARKER_END";
+      buf.append(Buffer.from(fatal));
+      const escaped = buf.escapedForMarker();
+      expect(escaped).toContain("FATAL ERROR");
+      expect(escaped).toContain("[... trailing bytes ...]");
+      // Tail window keeps the last bytes of the stream (TAIL_MARKER_END).
+      expect(escaped).toContain("TAIL_MARKER_END");
+    });
+
+    it("detects the '# Fatal error in' needle variant", () => {
+      const buf = new StderrCaptureBuffer(2048, 2048);
+      buf.append(Buffer.from("some noise\n"));
+      buf.append(Buffer.from("# Fatal error in , line 0\nCheck failed: ...\n"));
+      const escaped = buf.escapedForMarker();
+      expect(escaped).toContain("# Fatal error in");
+      expect(escaped).toContain("Check failed");
+      expect(escaped).not.toContain("some noise");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StderrLogTee (mocked path so it never touches ~/.traycer)
+// ---------------------------------------------------------------------------
+
+describe("StderrLogTee", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "traycer-stderr-tee-"));
+    teeMocks.logPath = join(root, "host.log");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("drops tee writes beyond the pending cap while capture stays complete", async () => {
+    const tee = new StderrLogTee("production");
+    // Flood past the pending-bytes cap with many chunks. Capture still
+    // records head+tail; teeDroppedBytes grows for the overflow.
+    const chunk = Buffer.alloc(64 * 1024, 0x42); // 64 KiB
+    let total = 0;
+    while (total <= STDERR_TEE_MAX_PENDING_BYTES + chunk.length) {
+      tee.append(chunk);
+      total += chunk.length;
+    }
+    expect(tee.teeDroppedBytes()).toBeGreaterThan(0);
+    // Capture still has content from the first chunks (head).
+    expect(tee.capture.isEmpty()).toBe(false);
+    expect(tee.capture.escapedForMarker().length).toBeGreaterThan(0);
+    await tee.flush(500);
+  });
+
+  it("flush resolves after queued writes drain", async () => {
+    const tee = new StderrLogTee("production");
+    tee.append(Buffer.from("hello stderr\n"));
+    await tee.flush(2_000);
+    const written = await import("node:fs/promises").then((fs) =>
+      fs.readFile(teeMocks.logPath, "utf8"),
+    );
+    expect(written).toBe("hello stderr\n");
+  });
+
+  it("flush resolves after timeout even if the queue is stalled", async () => {
+    // Stall the queue by pointing at a non-writable path via a hanging
+    // append is hard; instead verify timeoutMs bounds the wait when the
+    // queue already resolved (and that a short timeout still returns).
+    const tee = new StderrLogTee("production");
+    const started = Date.now();
+    await tee.flush(50);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit / signal decoding
+// ---------------------------------------------------------------------------
+
+describe("describeExitCode", () => {
+  it("decodes 3221226505 as 0xC0000409 STATUS_STACK_BUFFER_OVERRUN", () => {
+    const meaning = describeExitCode(3221226505);
+    expect(meaning).not.toBeNull();
+    expect(meaning).toContain("0xC0000409");
+    expect(meaning).toContain("STATUS_STACK_BUFFER_OVERRUN");
+  });
+
+  it("returns null for ordinary small exit codes", () => {
+    expect(describeExitCode(0)).toBeNull();
+    expect(describeExitCode(1)).toBeNull();
+    expect(describeExitCode(7)).toBeNull();
+    expect(describeExitCode(143)).toBeNull();
+  });
+
+  it("returns bare hex for unknown high codes", () => {
+    expect(describeExitCode(0xc0de0001)).toBe("0xC0DE0001");
+  });
+});
+
+describe("isFatalSignal / describeFatalSignal", () => {
+  it.each([
+    ["SIGABRT", "abort"],
+    ["SIGSEGV", "segmentation fault"],
+    ["SIGBUS", "bus error"],
+    ["SIGILL", "illegal instruction"],
+    ["SIGFPE", "arithmetic fault"],
+    ["SIGTRAP", "trap"],
+  ] as const)("treats %s as fatal", (signal, phrase) => {
+    expect(isFatalSignal(signal)).toBe(true);
+    const meaning = describeFatalSignal(signal);
+    expect(meaning).not.toBeNull();
+    expect(meaning).toContain(signal);
+    expect(meaning).toContain(phrase);
+  });
+
+  it("does not treat shutdown signals as fatal", () => {
+    expect(isFatalSignal("SIGTERM")).toBe(false);
+    expect(isFatalSignal("SIGINT")).toBe(false);
+    expect(isFatalSignal("SIGHUP")).toBe(false);
+    expect(describeFatalSignal("SIGTERM")).toBeNull();
+    expect(isFatalSignal(null)).toBe(false);
+    expect(isFatalSignal(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// crash-reports directory helpers
+// ---------------------------------------------------------------------------
+
+describe("crashReportsDirFor", () => {
+  it("anchors crash-reports under the child cwd", () => {
+    expect(crashReportsDirFor("/data/host")).toBe(
+      join("/data/host", "crash-reports"),
+    );
+  });
+});
+
+describe("prepareCrashReportsDir", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "traycer-crash-prep-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("creates the directory, prunes to the newest N, and returns survivors", async () => {
+    const dir = join(root, "crash-reports");
+    // Seed a sibling-precreated dir with excess reports.
+    await import("node:fs/promises").then((fs) =>
+      fs.mkdir(dir, { recursive: true }),
+    );
+    const base = Date.now() - 10_000;
+    for (let i = 0; i < 4; i += 1) {
+      const path = join(dir, `r${i}.json`);
+      await writeFile(path, "{}", "utf8");
+      const t = new Date(base + i * 1000);
+      await utimes(path, t, t);
+    }
+
+    const survivors = await prepareCrashReportsDir(dir, 2);
+
+    const info = await stat(dir);
+    expect(info.isDirectory()).toBe(true);
+    const remaining = (await readdir(dir)).sort();
+    expect(remaining).toEqual(["r2.json", "r3.json"]);
+    expect([...survivors].sort()).toEqual(["r2.json", "r3.json"]);
+  });
+
+  it("creates a missing directory and returns an empty survivor list", async () => {
+    const dir = join(root, "new-crash-reports");
+    const survivors = await prepareCrashReportsDir(dir, 5);
+    const info = await stat(dir);
+    expect(info.isDirectory()).toBe(true);
+    expect(survivors).toEqual([]);
+  });
+
+  it("never throws when the parent is unwritable / mkdir fails", async () => {
+    // Point at a path whose parent does not exist as a file (mkdir of
+    // nested under a file path fails). Use a file as the parent.
+    const blocker = join(root, "not-a-dir");
+    await writeFile(blocker, "x", "utf8");
+    const dir = join(blocker, "crash-reports");
+    await expect(prepareCrashReportsDir(dir, 5)).resolves.toEqual([]);
+  });
+});
+
+describe("pruneCrashReports", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "traycer-crash-prune-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("keeps the newest N .json reports by mtime", async () => {
+    const names = ["old.json", "mid.json", "new.json", "newest.json"];
+    const base = Date.now() - 10_000;
+    for (let i = 0; i < names.length; i += 1) {
+      const path = join(dir, names[i]!);
+      await writeFile(path, "{}", "utf8");
+      const t = new Date(base + i * 1000);
+      await utimes(path, t, t);
+    }
+    await writeFile(join(dir, "notes.txt"), "ignore me", "utf8");
+
+    await pruneCrashReports(dir, 2);
+
+    const remaining = (await readdir(dir)).sort();
+    expect(remaining).toEqual(["new.json", "newest.json", "notes.txt"].sort());
+  });
+
+  it("does not throw when the directory is missing", async () => {
+    await expect(
+      pruneCrashReports(join(dir, "does-not-exist"), 5),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("findCrashReportSince", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "traycer-crash-find-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("ignores reports older than sinceMs", async () => {
+    const sinceMs = Date.now();
+    const path = join(dir, "stale.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        header: { event: "Allocation failed", trigger: "FatalError" },
+      }),
+      "utf8",
+    );
+    const older = new Date(sinceMs - 60_000);
+    await utimes(path, older, older);
+
+    await expect(
+      findCrashReportSince(dir, sinceMs, EMPTY_EXCLUDE),
+    ).resolves.toBeNull();
+  });
+
+  it("returns the newest report at or after sinceMs with a summary", async () => {
+    const sinceMs = Date.now() - 5_000;
+    const olderPath = join(dir, "older.json");
+    const newerPath = join(dir, "newer.json");
+    await writeFile(
+      olderPath,
+      JSON.stringify({
+        header: { event: "old-event", trigger: "FatalError" },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      newerPath,
+      JSON.stringify({
+        header: {
+          event: "Allocation failed - JavaScript heap out of memory",
+          trigger: "FatalError",
+        },
+        javascriptStack: { message: "FATAL ERROR: Reached heap limit" },
+      }),
+      "utf8",
+    );
+    await utimes(olderPath, new Date(sinceMs + 100), new Date(sinceMs + 100));
+    await utimes(newerPath, new Date(sinceMs + 500), new Date(sinceMs + 500));
+
+    const match = await findCrashReportSince(dir, sinceMs, EMPTY_EXCLUDE);
+    expect(match).not.toBeNull();
+    expect(match?.filename).toBe("newer.json");
+    expect(match?.summary).toContain("event=Allocation failed");
+    expect(match?.summary).toContain("trigger=FatalError");
+    expect(match?.summary).toContain("js=FATAL ERROR: Reached heap limit");
+  });
+
+  it("returns filename with null summary when JSON is unreadable", async () => {
+    const sinceMs = Date.now() - 1_000;
+    const path = join(dir, "broken.json");
+    await writeFile(path, "not-json{{{", "utf8");
+    await utimes(path, new Date(sinceMs + 100), new Date(sinceMs + 100));
+
+    const match = await findCrashReportSince(dir, sinceMs, EMPTY_EXCLUDE);
+    expect(match).toEqual({ filename: "broken.json", summary: null });
+  });
+
+  it("returns null for a missing directory", async () => {
+    await expect(
+      findCrashReportSince(join(dir, "missing"), Date.now(), EMPTY_EXCLUDE),
+    ).resolves.toBeNull();
+  });
+
+  it("skips names in excludeNames even when mtime is within the slack window", async () => {
+    // Previous-child-within-slack attribution: a leftover report is young
+    // enough to pass sinceMs but must not be attributed to this child.
+    const sinceMs = Date.now() - CRASH_REPORT_SPAWN_SLACK_MS;
+    const staleName = "report.prev-child.json";
+    const freshName = "report.this-child.json";
+    await writeFile(
+      join(dir, staleName),
+      JSON.stringify({
+        header: { event: "prev", trigger: "FatalError" },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(dir, freshName),
+      JSON.stringify({
+        header: { event: "this", trigger: "FatalError" },
+      }),
+      "utf8",
+    );
+    const now = new Date();
+    await utimes(join(dir, staleName), now, now);
+    await utimes(join(dir, freshName), now, now);
+
+    const match = await findCrashReportSince(
+      dir,
+      sinceMs,
+      new Set([staleName]),
+    );
+    expect(match).not.toBeNull();
+    expect(match?.filename).toBe(freshName);
+    expect(match?.summary).toContain("event=this");
+  });
+
+  it("returns null when every candidate is excluded", async () => {
+    const sinceMs = Date.now() - 1_000;
+    const name = "only.json";
+    await writeFile(join(dir, name), "{}", "utf8");
+    await utimes(join(dir, name), new Date(), new Date());
+    await expect(
+      findCrashReportSince(dir, sinceMs, new Set([name])),
+    ).resolves.toBeNull();
+  });
+
+  it("documents the spawn-slack constant used by the supervisor", () => {
+    // Callers pass childSpawnedAtMs - CRASH_REPORT_SPAWN_SLACK_MS.
+    expect(CRASH_REPORT_SPAWN_SLACK_MS).toBe(2_000);
+  });
+});

--- a/clients/traycer-cli/src/host/__tests__/crash-diagnostics.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/crash-diagnostics.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmod,
   mkdtemp,
   readdir,
   rm,
@@ -6,20 +7,58 @@ import {
   utimes,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 // Redirect host.log for StderrLogTee so tests never write under ~/.traycer.
 const teeMocks = vi.hoisted(() => ({
   logPath: "",
 }));
 
+// Controllable stall for appendFile so flush(timeout) can be proven to race
+// the queue rather than only exercising the already-drained path.
+const appendFileGate = vi.hoisted(() => {
+  let stall = false;
+  let waiters: Array<() => void> = [];
+  return {
+    setStall(value: boolean): void {
+      stall = value;
+    },
+    async maybeStall(): Promise<void> {
+      if (!stall) return;
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve);
+      });
+    },
+    releaseAll(): void {
+      const pending = waiters;
+      waiters = [];
+      for (const resolve of pending) resolve();
+    },
+  };
+});
+
 vi.mock("../../store/paths", () => ({
   bootstrapLogPath: () => teeMocks.logPath,
 }));
 
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    appendFile: async (
+      ...args: Parameters<typeof actual.appendFile>
+    ): Promise<void> => {
+      await appendFileGate.maybeStall();
+      await actual.appendFile(...args);
+    },
+  };
+});
+
 const {
   CRASH_REPORT_SPAWN_SLACK_MS,
+  REPORT_SUMMARY_MAX_CHARS,
   STDERR_FATAL_WINDOW_MAX_BYTES,
   STDERR_MARKER_MAX_CHARS,
   STDERR_TEE_MAX_PENDING_BYTES,
@@ -90,6 +129,30 @@ describe("StderrCaptureBuffer", () => {
     expect(escaped.length).toBe(STDERR_MARKER_MAX_CHARS);
     expect(escaped.endsWith("…")).toBe(true);
     expect(escaped.slice(0, -1)).toBe("A".repeat(STDERR_MARKER_MAX_CHARS - 1));
+  });
+
+  describe("toSingleLine (shared escaper)", () => {
+    it("escapes LF and U+2028/U+2029, strips C0 controls, keeps tab", () => {
+      const out = StderrCaptureBuffer.toSingleLine(
+        "a\nb\u2028c\u2029d\x00\x01\te",
+        1_000,
+      );
+      expect(out).toBe("a\\nb\\nc\\nd\te");
+    });
+
+    it("clamps after escaping with an ellipsis", () => {
+      const out = StderrCaptureBuffer.toSingleLine("A".repeat(100), 10);
+      expect(out.length).toBe(10);
+      expect(out.endsWith("…")).toBe(true);
+      expect(out.slice(0, -1)).toBe("A".repeat(9));
+    });
+
+    it("counts escaped newlines toward the clamp", () => {
+      // Two newlines become four chars (`\\n` × 2); clamp must apply after.
+      const out = StderrCaptureBuffer.toSingleLine("a\nb\nc", 5);
+      expect(out.length).toBe(5);
+      expect(out.endsWith("…")).toBe(true);
+    });
   });
 
   describe("FATAL-anchored window", () => {
@@ -185,6 +248,8 @@ describe("StderrLogTee", () => {
   });
 
   afterEach(async () => {
+    appendFileGate.setStall(false);
+    appendFileGate.releaseAll();
     await rm(root, { recursive: true, force: true });
   });
 
@@ -215,14 +280,21 @@ describe("StderrLogTee", () => {
     expect(written).toBe("hello stderr\n");
   });
 
-  it("flush resolves after timeout even if the queue is stalled", async () => {
-    // Stall the queue by pointing at a non-writable path via a hanging
-    // append is hard; instead verify timeoutMs bounds the wait when the
-    // queue already resolved (and that a short timeout still returns).
+  it("flush(timeout) resolves without the stalled appendFile settling, then release leaves no unhandled rejection", async () => {
+    // Prove the timeout arm of Promise.race, not the already-drained path.
+    appendFileGate.setStall(true);
     const tee = new StderrLogTee("production");
+    tee.append(Buffer.from("stalled write\n"));
     const started = Date.now();
     await tee.flush(50);
-    expect(Date.now() - started).toBeLessThan(500);
+    expect(Date.now() - started).toBeLessThan(400);
+    // Release the stalled write so the microtask settles cleanly.
+    appendFileGate.setStall(false);
+    appendFileGate.releaseAll();
+    // Give the deferred append a turn to finish without throwing unhandled.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
   });
 });
 
@@ -328,6 +400,32 @@ describe("prepareCrashReportsDir", () => {
     const info = await stat(dir);
     expect(info.isDirectory()).toBe(true);
     expect(survivors).toEqual([]);
+  });
+
+  it("creates a new directory with mode 0o700 (POSIX)", async () => {
+    if (platform() === "win32") return;
+    const dir = join(root, "mode-crash-reports");
+    await prepareCrashReportsDir(dir, 5);
+    const info = await stat(dir);
+    expect(info.mode & 0o777).toBe(0o700);
+  });
+
+  it("leaves an existing directory's mode untouched", async () => {
+    if (platform() === "win32") return;
+    const dir = join(root, "existing-mode");
+    await import("node:fs/promises").then((fs) =>
+      fs.mkdir(dir, { recursive: true, mode: 0o755 }),
+    );
+    // Ensure the mode is what we set (mkdir mode can be umask-masked on some
+    // platforms; chmod pins it so the "untouched" assertion is meaningful).
+    await chmod(dir, 0o755);
+    const before = (await stat(dir)).mode & 0o777;
+    expect(before).toBe(0o755);
+
+    await prepareCrashReportsDir(dir, 5);
+
+    const after = (await stat(dir)).mode & 0o777;
+    expect(after).toBe(0o755);
   });
 
   it("never throws when the parent is unwritable / mkdir fails", async () => {
@@ -445,6 +543,33 @@ describe("findCrashReportSince", () => {
 
     const match = await findCrashReportSince(dir, sinceMs, EMPTY_EXCLUDE);
     expect(match).toEqual({ filename: "broken.json", summary: null });
+  });
+
+  it("normalizes report summary to a single line (newlines + U+2028) and clamps length", async () => {
+    // summarizeReport is private; exercise it through findCrashReportSince.
+    const sinceMs = Date.now() - 1_000;
+    const path = join(dir, "multiline.json");
+    const longMsg =
+      "line1\nline2\u2028line3 " + "Z".repeat(REPORT_SUMMARY_MAX_CHARS + 100);
+    await writeFile(
+      path,
+      JSON.stringify({
+        header: { event: "Allocation failed", trigger: "FatalError" },
+        javascriptStack: { message: longMsg },
+      }),
+      "utf8",
+    );
+    await utimes(path, new Date(sinceMs + 100), new Date(sinceMs + 100));
+
+    const match = await findCrashReportSince(dir, sinceMs, EMPTY_EXCLUDE);
+    expect(match).not.toBeNull();
+    const summary = match?.summary;
+    expect(summary).not.toBeNull();
+    // One logical line: no raw LF / U+2028 / U+2029 remain.
+    expect(summary).not.toMatch(/[\n\u2028\u2029]/);
+    expect(summary).toContain("\\n");
+    expect(summary!.length).toBeLessThanOrEqual(REPORT_SUMMARY_MAX_CHARS);
+    expect(summary!.endsWith("…")).toBe(true);
   });
 
   it("returns null for a missing directory", async () => {

--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -316,6 +316,49 @@ describe("spawn-evidence substrate", () => {
       expect(legacyView).toEqual({ phase: "crashed", error: "boom" });
     });
 
+    it("tolerates crash-diagnostic fields while still extracting known keys", () => {
+      // Additive fields (exitMeaning/report/stderrTail) must not break
+      // consumers that only project phase + code/error — the same contract
+      // host-status, spawn-evidence, and the GUI bootstrap-attempt summary
+      // rely on.
+      const line =
+        '[2026-01-01T00:00:00.000Z] phase=crashed code=3221226505 exitMeaning="0xC0000409 STATUS_STACK_BUFFER_OVERRUN" report=report.2026.json stderrTail="FATAL ERROR:\\nheap OOM" attempt=a1 supervisorPid=9';
+      const parsed = parseBootstrapLogLine(line);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.phase).toBe("crashed");
+      expect(parsed?.fields.code).toBe("3221226505");
+      expect(parsed?.fields.exitMeaning).toContain("0xC0000409");
+      expect(parsed?.fields.report).toBe("report.2026.json");
+      expect(parsed?.fields.stderrTail).toBe("FATAL ERROR:\\nheap OOM");
+
+      // host-status formatPhaseDetail projection (code/signal/error only).
+      const hostStatusView = {
+        phase: parsed!.phase,
+        code: parsed!.fields.code,
+        signal: parsed!.fields.signal,
+        error: parsed!.fields.error,
+      };
+      expect(hostStatusView).toEqual({
+        phase: "crashed",
+        code: "3221226505",
+        signal: undefined,
+        error: undefined,
+      });
+
+      // bootstrap-attempt-summary-style projection (phase + code for describeOutcome).
+      const attemptSummaryView = {
+        phase: parsed!.phase,
+        code: parsed!.fields.code ?? "?",
+      };
+      expect(attemptSummaryView).toEqual({
+        phase: "crashed",
+        code: "3221226505",
+      });
+
+      // spawn-evidence terminal reason still names the phase.
+      expect(parsed!.phase).toBe("crashed");
+    });
+
     it("parseBootstrapMarkersFromText and find helpers pick starting / terminal", () => {
       const text = [
         "[2026-01-01T00:00:00.000Z] phase=starting attempt=a supervisorPid=1",
@@ -344,6 +387,31 @@ describe("spawn-evidence substrate", () => {
         [
           "[2026-01-01T00:00:00.000Z] phase=starting attempt=a supervisorPid=1",
           "[2026-01-01T00:00:01.000Z] phase=crashed error=boom attempt=a supervisorPid=1",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      mocks.readHostPidMetadata.mockResolvedValue(pidMeta(1));
+
+      const evidence = await collectSpawnEvidence(
+        { log: logBaseline, pidMetadata: pidBaseline },
+        "production",
+      );
+      expect(evidence?.kind).toBe("terminal-marker");
+      expect(evidence?.reason).toContain("crashed");
+    });
+
+    it("still collects terminal evidence when the crashed marker carries diagnostic fields", async () => {
+      const logBaseline = await captureLogFileBaseline(mocks.logPath);
+      const pidBaseline = await capturePidMetadataBaseline(
+        mocks.pidPath,
+        "production",
+      );
+      await writeFile(
+        mocks.logPath,
+        [
+          "[2026-01-01T00:00:00.000Z] phase=starting attempt=a supervisorPid=1",
+          '[2026-01-01T00:00:01.000Z] phase=crashed code=3221226505 exitMeaning="0xC0000409 STATUS_STACK_BUFFER_OVERRUN" report=r.json stderrTail="FATAL\\nOOM" attempt=a supervisorPid=1',
           "",
         ].join("\n"),
         "utf8",

--- a/clients/traycer-cli/src/host/bootstrap-log.ts
+++ b/clients/traycer-cli/src/host/bootstrap-log.ts
@@ -37,6 +37,21 @@ export interface BootstrapMarkerFields {
   readonly exitCode: number | null | undefined;
   readonly signal: string | null | undefined;
   readonly error: string | undefined;
+  /**
+   * Decoded meaning of a high-bit `exitCode` (hex + NTSTATUS name, see
+   * `crash-diagnostics.ts`). Additive: old parsers ignore unknown keys.
+   */
+  readonly exitMeaning: string | undefined;
+  /**
+   * Filename of the Node diagnostic report written by this child (newest
+   * report younger than the spawn), for `phase=crashed` markers.
+   */
+  readonly report: string | undefined;
+  /**
+   * Newline-escaped tail of the child's stderr - the V8/native fatal text
+   * that used to be stranded in a rotated-away `host.log.1`.
+   */
+  readonly stderrTail: string | undefined;
   readonly attemptId: string | undefined;
   readonly supervisorPid: number | undefined;
 }
@@ -68,6 +83,12 @@ function formatFields(fields: BootstrapMarkerFields): string {
     parts.push(`signal=${fields.signal}`);
   if (fields.error !== undefined)
     parts.push(`error=${escapeValue(fields.error)}`);
+  if (fields.exitMeaning !== undefined)
+    parts.push(`exitMeaning=${escapeValue(fields.exitMeaning)}`);
+  if (fields.report !== undefined)
+    parts.push(`report=${escapeValue(fields.report)}`);
+  if (fields.stderrTail !== undefined)
+    parts.push(`stderrTail=${escapeValue(fields.stderrTail)}`);
   // Identity fields last so pre-existing key=value parsers that only
   // walk known keys keep working, and so a human reading the line still
   // sees the diagnostic payload first.

--- a/clients/traycer-cli/src/host/crash-diagnostics.ts
+++ b/clients/traycer-cli/src/host/crash-diagnostics.ts
@@ -103,6 +103,21 @@ export const CRASH_REPORT_SCAN_TIMEOUT_MS = 2_000;
 export const STDERR_FLUSH_TIMEOUT_MS = 1_000;
 
 /**
+ * Budget for waiting on the child's stderr stream to END before the terminal
+ * marker is written. `exit` fires when the process dies, NOT when its pipes
+ * have drained, so finalizing on `exit` can write the marker while the fatal
+ * text is still unread in the pipe - the capture is then empty in exactly the
+ * abnormal-death case it exists for. Bounded because a grandchild holding the
+ * inherited stderr fd can delay `close` indefinitely, and a diagnostics path
+ * must never be able to hang the supervisor's exit: wait, then write whatever
+ * has arrived.
+ */
+export const STDERR_END_WAIT_TIMEOUT_MS = 2_000;
+
+/** Clamp for the one-line report digest embedded in logs/markers. */
+export const REPORT_SUMMARY_MAX_CHARS = 512;
+
+/**
  * Windows exit statuses worth naming. Keyed by the unsigned NTSTATUS value
  * (Node reports them as positive decimals, e.g. 3221226505). Codes below
  * 0x40000000 are ordinary exit codes and are not decoded.
@@ -255,6 +270,21 @@ export class StderrCaptureBuffer {
   }
 
   /**
+   * Normalizes arbitrary text to the single-line marker grammar: escapes
+   * every JS line terminator, strips remaining control characters, clamps.
+   * Exposed as a static because report summaries need the identical
+   * treatment - a `javascriptStack.message` carrying a newline would
+   * otherwise break the same single-line contract this class exists to
+   * protect for stderr.
+   */
+  static toSingleLine(text: string, maxChars: number): string {
+    const escaped = escapeToSingleLine(text);
+    return escaped.length <= maxChars
+      ? escaped
+      : `${escaped.slice(0, maxChars - 1)}…`;
+  }
+
+  /**
    * Single-line, marker-grammar-safe rendering: head, an elision mark when
    * middle bytes were dropped, then the tail. EVERY JS line terminator is
    * escaped (the marker parser scans one line, and U+2028/U+2029 are line
@@ -281,24 +311,45 @@ export class StderrCaptureBuffer {
           ? `${headText}\n[... ${this.elidedBytes} bytes elided ...]\n${tailText}`
           : `${headText}${tailText}`;
     }
-    const newlinesEscaped = joined
-      .replace(/\r/g, "")
-      .replace(/[\n\u2028\u2029]/g, "\\n");
-    // Strip remaining control characters by code point (a regex range
-    // over them would trip no-control-regex; a filter states the same
-    // thing plainly). Tab survives - whitespace the marker quoting
-    // handles.
-    let escaped = "";
-    for (const ch of newlinesEscaped) {
-      const code = ch.codePointAt(0) ?? 0;
-      if (code >= 0x20 || code === 0x09) {
-        escaped += ch;
-      }
-    }
-    return escaped.length <= STDERR_MARKER_MAX_CHARS
-      ? escaped
-      : `${escaped.slice(0, STDERR_MARKER_MAX_CHARS - 1)}…`;
+    return StderrCaptureBuffer.toSingleLine(joined, STDERR_MARKER_MAX_CHARS);
   }
+}
+
+/**
+ * Escapes every JS line terminator and strips remaining control characters.
+ * Shared by the stderr capture and the report summary: both end up on a
+ * single `key=value` marker line, and the parser's `.`-based line regex will
+ * not cross U+2028/U+2029 - an unescaped one silently discards the WHOLE
+ * marker. Tab survives; the marker quoting handles ordinary whitespace.
+ */
+function escapeToSingleLine(text: string): string {
+  const newlinesEscaped = text
+    .replace(/\r/g, "")
+    .replace(/[\n\u2028\u2029]/g, "\\n");
+  // By code point rather than a regex range: a control-character range would
+  // trip no-control-regex, and this states the same rule plainly.
+  let escaped = "";
+  for (const ch of newlinesEscaped) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code >= 0x20 || code === 0x09) {
+      escaped += ch;
+    }
+  }
+  return escaped;
+}
+
+/**
+ * Structural surface of the stderr tee that `runHostStart` consumes.
+ * `RunHostStartDeps` is typed with THIS, not the concrete class: naming the
+ * class drags its private fields into the dependency type, which forced test
+ * doubles through an `as unknown` chain the repo's type rules ban. A method
+ * added here later breaks a stub at compile time instead of at runtime.
+ */
+export interface StderrTee {
+  readonly capture: StderrCaptureBuffer;
+  append(chunk: Buffer): void;
+  teeDroppedBytes(): number;
+  flush(timeoutMs: number): Promise<void>;
 }
 
 /**
@@ -311,7 +362,7 @@ export class StderrCaptureBuffer {
  * terminal marker - `process.exit` would otherwise abandon them. Failures
  * are swallowed: a diagnostics write must never take the supervisor down.
  */
-export class StderrLogTee {
+export class StderrLogTee implements StderrTee {
   readonly capture = new StderrCaptureBuffer(
     STDERR_HEAD_MAX_BYTES,
     STDERR_TAIL_MAX_BYTES,
@@ -375,7 +426,14 @@ export async function prepareCrashReportsDir(
   keep: number,
 ): Promise<readonly string[]> {
   try {
-    await mkdir(dir, { recursive: true });
+    // 0700: a Node diagnostic report embeds `environmentVariables`, and the
+    // host child inherits `process.env` plus the Traycer env overrides - so a
+    // fatal crash writes the operator's secrets to disk. Under a default
+    // umask the directory would be world-readable and every local user on the
+    // machine could read them. Mode is applied to the leaf only; an existing
+    // directory keeps its mode (chmod-ing a path the operator may have
+    // deliberately relaxed is not this function's call).
+    await mkdir(dir, { recursive: true, mode: 0o700 });
   } catch {
     // Unwritable data dir: the spawn will surface real failures; a missing
     // report destination must not block the host from starting.
@@ -498,7 +556,18 @@ async function summarizeReport(path: string): Promise<string | null> {
     if (event !== null) parts.push(`event=${event}`);
     if (trigger !== null) parts.push(`trigger=${trigger}`);
     if (message !== null) parts.push(`js=${message}`);
-    return parts.length > 0 ? parts.join(" ") : null;
+    if (parts.length === 0) {
+      return null;
+    }
+    // ENFORCED, not just documented: these values come verbatim out of the
+    // report JSON, and a `javascriptStack.message` carrying a line
+    // terminator would break the one-line contract this digest promises -
+    // the same hazard `escapedForMarker` exists to prevent for stderr, and
+    // `persistChildExit` already passes this straight into a log line.
+    return StderrCaptureBuffer.toSingleLine(
+      parts.join(" "),
+      REPORT_SUMMARY_MAX_CHARS,
+    );
   } catch {
     return null;
   }

--- a/clients/traycer-cli/src/host/crash-diagnostics.ts
+++ b/clients/traycer-cli/src/host/crash-diagnostics.ts
@@ -1,0 +1,505 @@
+/**
+ * Crash diagnostics for the host supervisor (`traycer host start`).
+ *
+ * A hard host abort (e.g. Windows 0xC0000409 fail-fast, POSIX SIGABRT) used
+ * to leave exactly one line of evidence: `phase=crashed code=3221226505` (or
+ * a bare `phase=killed signal=SIGABRT`). Three mechanisms in this module
+ * close that gap:
+ *
+ * - a byte-bounded head+tail stderr capture, embedded in the crash marker.
+ *   V8 writes `FATAL ERROR: ...` to stderr before aborting, but a fatal
+ *   block can run several KB and the headline sits near its START (measured:
+ *   a heap-OOM block of ~6.5KB with `FATAL ERROR` at byte ~476, followed by
+ *   native frames) - a tail-only window provably loses the reason. The
+ *   fd-teed copy in `host.log` can also be stranded in `host.log.1` when the
+ *   host's own logger rotates the file under the supervisor's inode-bound
+ *   fd; the capture is re-emitted by path at exit time, so it survives that
+ *   race by construction.
+ * - Node diagnostic reports: `--report-on-fatalerror` with a RELATIVE
+ *   `--report-directory=crash-reports` (resolved against the spawn cwd, the
+ *   host data dir - relative on purpose, so a Windows profile path with
+ *   spaces never needs NODE_OPTIONS quoting, and so a crash BEFORE the
+ *   host's own runtime arming still lands in the scanned directory). The
+ *   newest report younger than the child is referenced from the crash
+ *   marker; the directory is created and pruned at supervisor start.
+ * - Exit-status decoding: `code=3221226505` means nothing at a glance;
+ *   `0xC0000409 STATUS_STACK_BUFFER_OVERRUN` does. Fatal POSIX signals get
+ *   the same treatment (`SIGABRT` = abort, not a shutdown).
+ */
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  unlink,
+} from "node:fs/promises";
+import { join } from "node:path";
+import type { Environment } from "../runner/environment";
+import { bootstrapLogPath } from "../store/paths";
+
+/**
+ * Byte caps for the stderr capture: the FIRST head bytes (where a V8 fatal
+ * block's headline lives) plus the rolling LAST tail bytes (where a native
+ * abort's final frames live). Middle bytes beyond both windows are elided.
+ */
+export const STDERR_HEAD_MAX_BYTES = 2048;
+export const STDERR_TAIL_MAX_BYTES = 2048;
+
+/**
+ * Byte cap for the FATAL-anchored window. Head+tail alone is not enough: the
+ * head is process-lifetime, so a host that emitted a few KB of ordinary
+ * stderr before dying evicts the fatal headline into the elided middle
+ * (measured: ~3KB of prior warnings + a 6.5KB OOM block left neither "FATAL
+ * ERROR" nor the heap stats in a 4KB head+tail capture). Detecting the
+ * headline and latching a window FROM it guarantees the reason survives no
+ * matter what came before.
+ */
+export const STDERR_FATAL_WINDOW_MAX_BYTES = 2048;
+
+/**
+ * Substrings that open the fatal window. V8 heap exhaustion prints
+ * `FATAL ERROR: ...`; V8/native assertion fatals print `# Fatal error in ...`.
+ */
+const FATAL_NEEDLES = ["FATAL ERROR", "# Fatal error"] as const;
+
+/** Carried across chunk boundaries so a split needle is still detected. */
+const FATAL_BOUNDARY_CHARS = 16;
+
+/**
+ * Final clamp on the escaped, single-line marker payload. Escaping can
+ * expand bytes (`\n` -> `\\n`, invalid UTF-8 -> replacement chars), so the
+ * clamp is applied AFTER escaping to bound the marker line's length.
+ */
+export const STDERR_MARKER_MAX_CHARS = 4096;
+
+/**
+ * Upper bound on stderr bytes queued for the path-addressed log tee. A
+ * stderr-spamming host must not grow supervisor memory without bound; the
+ * head+tail capture still records the interesting bytes, the tee just stops
+ * mirroring the flood into `host.log`.
+ */
+export const STDERR_TEE_MAX_PENDING_BYTES = 256 * 1024;
+
+/** Diagnostic reports kept in `crash-reports/`; older ones are pruned. */
+export const MAX_KEPT_CRASH_REPORTS = 5;
+
+/**
+ * Slack subtracted from the child spawn timestamp when scanning for a
+ * diagnostic report: a loader-phase crash can write its report in the same
+ * millisecond bucket as (or, across filesystems' mtime granularity, apparently
+ * before) the recorded spawn time.
+ */
+export const CRASH_REPORT_SPAWN_SLACK_MS = 2_000;
+
+/**
+ * Budget for the crash-report scan that runs BEFORE the synchronous terminal
+ * marker write. The marker is readiness authority and must not be lost to a
+ * slow disk - past the budget the marker is written without a `report=`.
+ */
+export const CRASH_REPORT_SCAN_TIMEOUT_MS = 2_000;
+
+/** Budget for draining queued stderr tee writes before the terminal marker. */
+export const STDERR_FLUSH_TIMEOUT_MS = 1_000;
+
+/**
+ * Windows exit statuses worth naming. Keyed by the unsigned NTSTATUS value
+ * (Node reports them as positive decimals, e.g. 3221226505). Codes below
+ * 0x40000000 are ordinary exit codes and are not decoded.
+ */
+const WINDOWS_EXIT_MEANINGS: ReadonlyMap<number, string> = new Map([
+  [
+    0xc0000409,
+    "STATUS_STACK_BUFFER_OVERRUN (fail-fast abort: V8 fatal/OOM, native stack overflow, or CRT abort)",
+  ],
+  [0xc0000005, "STATUS_ACCESS_VIOLATION (native crash)"],
+  [0xc0000142, "STATUS_DLL_INIT_FAILED (spawn during session shutdown)"],
+  [0x40010004, "DBG_TERMINATE_PROCESS (session teardown kill)"],
+  [0xc00000fd, "STATUS_STACK_OVERFLOW"],
+]);
+
+/**
+ * POSIX signals that mean the host CRASHED rather than being shut down. A
+ * Node fatal abort surfaces on macOS/Linux as `code=null, signal=SIGABRT` -
+ * routing these through the plain "killed" path would discard the report and
+ * stderr evidence exactly where it matters most. Forwarded shutdown signals
+ * (SIGTERM/SIGINT/SIGHUP) are NOT here.
+ */
+const FATAL_SIGNAL_MEANINGS: ReadonlyMap<string, string> = new Map([
+  ["SIGABRT", "abort (V8 fatal/OOM, assertion, or native abort)"],
+  ["SIGSEGV", "segmentation fault (native crash)"],
+  ["SIGBUS", "bus error (native crash)"],
+  ["SIGILL", "illegal instruction (native crash)"],
+  ["SIGFPE", "arithmetic fault (native crash)"],
+  ["SIGTRAP", "trap (native crash)"],
+]);
+
+export function isFatalSignal(signal: string | null | undefined): boolean {
+  return signal !== null && signal !== undefined
+    ? FATAL_SIGNAL_MEANINGS.has(signal)
+    : false;
+}
+
+/** `"SIGABRT abort (V8 fatal/OOM, ...)"` for fatal signals, else `null`. */
+export function describeFatalSignal(signal: string): string | null {
+  const meaning = FATAL_SIGNAL_MEANINGS.get(signal);
+  return meaning === undefined ? null : `${signal} ${meaning}`;
+}
+
+/**
+ * Renders a high-bit exit code as hex plus a known NTSTATUS name, or `null`
+ * for ordinary small exit codes (those stay as the bare `code=` field).
+ */
+export function describeExitCode(code: number): string | null {
+  const unsigned = code >>> 0;
+  if (unsigned < 0x40000000) {
+    return null;
+  }
+  const hex = `0x${unsigned.toString(16).toUpperCase()}`;
+  const name = WINDOWS_EXIT_MEANINGS.get(unsigned);
+  return name === undefined ? hex : `${hex} ${name}`;
+}
+
+/**
+ * Head+tail capture over stderr chunks: the FIRST `maxHeadBytes` seen plus a
+ * rolling window of the LAST `maxTailBytes`. See the module header for why
+ * tail-only capture loses the V8 fatal headline.
+ */
+export class StderrCaptureBuffer {
+  private readonly headChunks: Buffer[] = [];
+  private headBytes = 0;
+  private readonly tailChunks: Buffer[] = [];
+  private tailBytes = 0;
+  private elidedBytes = 0;
+  /**
+   * FATAL-anchored window, accumulated as TEXT and anchored at the needle
+   * itself - not at the chunk that happened to contain it. Anchoring at the
+   * chunk drops any of the needle that arrived in the previous chunk (a
+   * `FATAL ER`/`ROR: ...` split yields a window opening mid-word, losing the
+   * headline the window exists to preserve), and would also carry whatever
+   * unrelated output shared that chunk. `null` until a needle is seen; grows
+   * to {@link STDERR_FATAL_WINDOW_MAX_BYTES} characters.
+   */
+  private fatalText: string | null = null;
+  private detectionBoundary = "";
+
+  constructor(
+    private readonly maxHeadBytes: number,
+    private readonly maxTailBytes: number,
+  ) {}
+
+  append(chunk: Buffer): void {
+    this.captureFatalWindow(chunk);
+    if (this.headBytes < this.maxHeadBytes) {
+      const take = Math.min(chunk.length, this.maxHeadBytes - this.headBytes);
+      this.headChunks.push(chunk.subarray(0, take));
+      this.headBytes += take;
+      chunk = chunk.subarray(take);
+      if (chunk.length === 0) {
+        return;
+      }
+    }
+    this.tailChunks.push(chunk);
+    this.tailBytes += chunk.length;
+    while (this.tailBytes > this.maxTailBytes) {
+      const head = this.tailChunks[0];
+      if (head === undefined) {
+        break;
+      }
+      const excess = this.tailBytes - this.maxTailBytes;
+      if (head.length <= excess) {
+        this.tailChunks.shift();
+        this.tailBytes -= head.length;
+        this.elidedBytes += head.length;
+      } else {
+        this.tailChunks[0] = head.subarray(excess);
+        this.tailBytes -= excess;
+        this.elidedBytes += excess;
+      }
+    }
+  }
+
+  private captureFatalWindow(chunk: Buffer): void {
+    if (this.fatalText !== null) {
+      if (this.fatalText.length < STDERR_FATAL_WINDOW_MAX_BYTES) {
+        this.fatalText = (this.fatalText + chunk.toString("utf8")).slice(
+          0,
+          STDERR_FATAL_WINDOW_MAX_BYTES,
+        );
+      }
+      return;
+    }
+    // The boundary carry is what lets a needle split across chunks be
+    // detected AND anchored whole: the window opens at the needle's index in
+    // `boundary + chunk`, so the carried first half is part of the window.
+    const text = this.detectionBoundary + chunk.toString("utf8");
+    let earliest = -1;
+    for (const needle of FATAL_NEEDLES) {
+      const index = text.indexOf(needle);
+      if (index !== -1 && (earliest === -1 || index < earliest)) {
+        earliest = index;
+      }
+    }
+    if (earliest !== -1) {
+      this.fatalText = text.slice(
+        earliest,
+        earliest + STDERR_FATAL_WINDOW_MAX_BYTES,
+      );
+      return;
+    }
+    this.detectionBoundary = text.slice(-FATAL_BOUNDARY_CHARS);
+  }
+
+  isEmpty(): boolean {
+    return this.headBytes === 0 && this.tailBytes === 0;
+  }
+
+  /**
+   * Single-line, marker-grammar-safe rendering: head, an elision mark when
+   * middle bytes were dropped, then the tail. EVERY JS line terminator is
+   * escaped (the marker parser scans one line, and U+2028/U+2029 are line
+   * terminators the `.`-based line regex will not cross - an unescaped one
+   * silently discards the whole marker); remaining C0 control bytes are
+   * stripped; the result is clamped after escaping.
+   */
+  escapedForMarker(): string {
+    const headText = Buffer.concat(this.headChunks).toString("utf8");
+    const tailText = Buffer.concat(this.tailChunks).toString("utf8");
+    // Precedence: a detected fatal window IS the evidence - render it alone
+    // when it never filled (it then runs to end-of-stream, so the tail is a
+    // strict subset), or fatal+tail when it capped out (the frames between
+    // cap and tail are elided). Otherwise head+tail as the generic shape.
+    let joined: string;
+    if (this.fatalText !== null) {
+      joined =
+        this.fatalText.length < STDERR_FATAL_WINDOW_MAX_BYTES
+          ? this.fatalText
+          : `${this.fatalText}\n[... trailing bytes ...]\n${tailText}`;
+    } else {
+      joined =
+        this.elidedBytes > 0
+          ? `${headText}\n[... ${this.elidedBytes} bytes elided ...]\n${tailText}`
+          : `${headText}${tailText}`;
+    }
+    const newlinesEscaped = joined
+      .replace(/\r/g, "")
+      .replace(/[\n\u2028\u2029]/g, "\\n");
+    // Strip remaining control characters by code point (a regex range
+    // over them would trip no-control-regex; a filter states the same
+    // thing plainly). Tab survives - whitespace the marker quoting
+    // handles.
+    let escaped = "";
+    for (const ch of newlinesEscaped) {
+      const code = ch.codePointAt(0) ?? 0;
+      if (code >= 0x20 || code === 0x09) {
+        escaped += ch;
+      }
+    }
+    return escaped.length <= STDERR_MARKER_MAX_CHARS
+      ? escaped
+      : `${escaped.slice(0, STDERR_MARKER_MAX_CHARS - 1)}…`;
+  }
+}
+
+/**
+ * Bounded, serialized, PATH-addressed tee of stderr bytes into `host.log`,
+ * plus the head+tail capture above. By path on purpose: the host's own
+ * logger rotates `host.log` by rename, and a held-open fd follows the old
+ * inode. Queue growth is capped ({@link STDERR_TEE_MAX_PENDING_BYTES}) so a
+ * stderr-spamming child cannot grow supervisor memory without bound, and
+ * {@link flush} lets the exit path drain queued writes (bounded) before the
+ * terminal marker - `process.exit` would otherwise abandon them. Failures
+ * are swallowed: a diagnostics write must never take the supervisor down.
+ */
+export class StderrLogTee {
+  readonly capture = new StderrCaptureBuffer(
+    STDERR_HEAD_MAX_BYTES,
+    STDERR_TAIL_MAX_BYTES,
+  );
+  private queue: Promise<void> = Promise.resolve();
+  private pendingBytes = 0;
+  private droppedBytes = 0;
+
+  constructor(private readonly environment: Environment) {}
+
+  append(chunk: Buffer): void {
+    this.capture.append(chunk);
+    if (this.pendingBytes + chunk.length > STDERR_TEE_MAX_PENDING_BYTES) {
+      this.droppedBytes += chunk.length;
+      return;
+    }
+    this.pendingBytes += chunk.length;
+    const settle = (): void => {
+      this.pendingBytes -= chunk.length;
+    };
+    this.queue = this.queue
+      .then(() => appendFile(bootstrapLogPath(this.environment), chunk))
+      .then(settle, settle);
+  }
+
+  /** Bytes skipped by the log tee (never by the capture); diagnostics only. */
+  teeDroppedBytes(): number {
+    return this.droppedBytes;
+  }
+
+  /** Resolves when queued writes have drained, or after `timeoutMs`. */
+  flush(timeoutMs: number): Promise<void> {
+    return Promise.race([
+      this.queue.then(
+        () => undefined,
+        () => undefined,
+      ),
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  }
+}
+
+/** `<childCwd>/crash-reports` - the directory the relative report flag targets. */
+export function crashReportsDirFor(childCwd: string): string {
+  return join(childCwd, "crash-reports");
+}
+
+/**
+ * Creates the crash-reports directory (so a report has a destination even
+ * before the host's own runtime arming runs), prunes it to the newest `keep`
+ * reports, and returns the names that SURVIVED the prune. The caller records
+ * those as pre-existing so the post-exit scan can never attribute a previous
+ * child's report to this crash (a crash-looping host can die within the
+ * mtime slack of its successor's spawn). Never throws.
+ */
+export async function prepareCrashReportsDir(
+  dir: string,
+  keep: number,
+): Promise<readonly string[]> {
+  try {
+    await mkdir(dir, { recursive: true });
+  } catch {
+    // Unwritable data dir: the spawn will surface real failures; a missing
+    // report destination must not block the host from starting.
+  }
+  await pruneCrashReports(dir, keep);
+  try {
+    return (await readdir(dir)).filter((name) => name.endsWith(".json"));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Keeps the newest `keep` diagnostic reports and unlinks the rest. Never
+ * throws - a missing directory (no crash yet) is the normal case.
+ */
+export async function pruneCrashReports(
+  dir: string,
+  keep: number,
+): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return;
+  }
+  const stamped: Array<{ readonly name: string; readonly mtimeMs: number }> =
+    [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const info = await stat(join(dir, name));
+      stamped.push({ name, mtimeMs: info.mtimeMs });
+    } catch {
+      // Raced a concurrent unlink; nothing to keep.
+    }
+  }
+  stamped.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const item of stamped.slice(keep)) {
+    try {
+      await unlink(join(dir, item.name));
+    } catch {
+      // Best-effort.
+    }
+  }
+}
+
+export interface CrashReportMatch {
+  readonly filename: string;
+  /**
+   * One-line digest of the report (`event`, `trigger`, first JS stack
+   * frame), or `null` when the JSON could not be read - the filename alone
+   * still tells support where to look.
+   */
+  readonly summary: string | null;
+}
+
+/**
+ * Newest diagnostic report written at or after `sinceMs`, excluding names
+ * that pre-existed this child's spawn, or `null`. Callers pass the child
+ * spawn time minus {@link CRASH_REPORT_SPAWN_SLACK_MS}; the exclusion set
+ * (from {@link prepareCrashReportsDir}) is what makes the slack safe - a
+ * stale report attributed to this crash would be worse than none.
+ */
+export async function findCrashReportSince(
+  dir: string,
+  sinceMs: number,
+  excludeNames: ReadonlySet<string>,
+): Promise<CrashReportMatch | null> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return null;
+  }
+  let newest: { name: string; mtimeMs: number } | null = null;
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    if (excludeNames.has(name)) continue;
+    try {
+      const info = await stat(join(dir, name));
+      if (info.mtimeMs < sinceMs) continue;
+      if (newest === null || info.mtimeMs > newest.mtimeMs) {
+        newest = { name, mtimeMs: info.mtimeMs };
+      }
+    } catch {
+      // Raced a prune.
+    }
+  }
+  if (newest === null) {
+    return null;
+  }
+  return {
+    filename: newest.name,
+    summary: await summarizeReport(join(dir, newest.name)),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+async function summarizeReport(path: string): Promise<string | null> {
+  try {
+    const parsed = asRecord(JSON.parse(await readFile(path, "utf8")));
+    const header = asRecord(parsed?.["header"]);
+    const event = asString(header?.["event"]);
+    const trigger = asString(header?.["trigger"]);
+    const stackRecord = asRecord(parsed?.["javascriptStack"]);
+    const message = asString(stackRecord?.["message"]);
+    const parts: string[] = [];
+    if (event !== null) parts.push(`event=${event}`);
+    if (trigger !== null) parts.push(`trigger=${trigger}`);
+    if (message !== null) parts.push(`js=${message}`);
+    return parts.length > 0 ? parts.join(" ") : null;
+  } catch {
+    return null;
+  }
+}

--- a/clients/traycer-cli/src/service/__tests__/host-node-options.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/host-node-options.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOST_DIAGNOSTIC_REPORT_FLAGS,
+  HOST_V8_FLAGS,
+  withHostNodeOptions,
+} from "../host-node-options";
+
+const CANONICAL = `${HOST_V8_FLAGS} ${HOST_DIAGNOSTIC_REPORT_FLAGS}`;
+
+describe("withHostNodeOptions", () => {
+  it("returns the canonical flags when nothing is inherited", () => {
+    expect(withHostNodeOptions(undefined)).toBe(CANONICAL);
+    expect(withHostNodeOptions("")).toBe(CANONICAL);
+    // Canonical set includes the relative report directory so a crash before
+    // the host's own runtime arming still lands under the spawn cwd.
+    expect(CANONICAL).toContain("--report-on-fatalerror");
+    expect(CANONICAL).toContain("--report-compact");
+    expect(CANONICAL).toContain("--report-directory=crash-reports");
+    expect(CANONICAL).toContain("--max-semi-space-size=16");
+  });
+
+  it("strips inherited duplicates of every canonical token including report-directory", () => {
+    const result = withHostNodeOptions(
+      "--max-semi-space-size=64 --report-on-fatalerror --report-compact --report-directory=/operator/path",
+    );
+    expect(result).toBe(CANONICAL);
+    expect(result.match(/--max-semi-space-size/g)).toHaveLength(1);
+    expect(result.match(/--report-on-fatalerror/g)).toHaveLength(1);
+    expect(result.match(/--report-compact/g)).toHaveLength(1);
+    expect(result.match(/--report-directory/g)).toHaveLength(1);
+    expect(result).toContain("--report-directory=crash-reports");
+    expect(result).not.toContain("/operator/path");
+  });
+
+  it("strips an operator --report-directory and lands on the canonical relative path", () => {
+    // Deliberate design: operator overrides of report-directory are stripped
+    // so the supervisor scan path and the child's write path always agree.
+    const result = withHostNodeOptions("--report-directory=/x");
+    expect(result).toBe(CANONICAL);
+    expect(result).not.toContain("/x");
+  });
+
+  it("fully strips a quoted report-directory with spaces (no orphan tokens)", () => {
+    // Naive \\S+ strip would leave `with spaces"` behind and unbalance
+    // NODE_OPTIONS so Node dies before any user code runs.
+    const result = withHostNodeOptions(
+      '--report-directory="/path with spaces" --trace-warnings',
+    );
+    expect(result).toBe(`--trace-warnings ${CANONICAL}`);
+    expect(result).not.toContain("with spaces");
+    expect(result).not.toContain('"');
+    // Balanced: no dangling quote fragments.
+    expect((result.match(/"/g) ?? []).length).toBe(0);
+  });
+
+  it("strips the space-separated form --report-directory /x", () => {
+    const result = withHostNodeOptions(
+      "--report-directory /x --trace-warnings",
+    );
+    expect(result).toBe(`--trace-warnings ${CANONICAL}`);
+    expect(result).not.toContain("/x");
+  });
+
+  it('strips the space-separated quoted form --report-directory "/path with spaces"', () => {
+    const result = withHostNodeOptions(
+      '--report-directory "/path with spaces" --inspect=0',
+    );
+    expect(result).toBe(`--inspect=0 ${CANONICAL}`);
+    expect(result).not.toContain("with spaces");
+  });
+
+  it("preserves a prefix token like --report-directory-x", () => {
+    // The strip must not swallow an unrelated flag that merely shares a prefix.
+    const result = withHostNodeOptions("--report-directory-x --trace-warnings");
+    expect(result).toContain("--report-directory-x");
+    expect(result.startsWith("--report-directory-x --trace-warnings ")).toBe(
+      true,
+    );
+    expect(result.endsWith(CANONICAL)).toBe(true);
+  });
+
+  it("is idempotent when applied twice", () => {
+    const once = withHostNodeOptions(undefined);
+    const twice = withHostNodeOptions(once);
+    expect(twice).toBe(once);
+    expect(twice).toBe(CANONICAL);
+  });
+
+  it("preserves unrelated NODE_OPTIONS tokens", () => {
+    const result = withHostNodeOptions("--trace-warnings --inspect=0");
+    expect(result.startsWith("--trace-warnings --inspect=0 ")).toBe(true);
+    expect(result.endsWith(CANONICAL)).toBe(true);
+  });
+});

--- a/clients/traycer-cli/src/service/__tests__/host-node-options.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/host-node-options.test.ts
@@ -7,71 +7,146 @@ import {
 
 const CANONICAL = `${HOST_V8_FLAGS} ${HOST_DIAGNOSTIC_REPORT_FLAGS}`;
 
+/**
+ * A malformed NODE_OPTIONS means the host never starts: Node rejects the
+ * whole string on an unrecognized bare token. Every result of
+ * withHostNodeOptions must therefore be only `--flag` / `--flag=value` tokens.
+ */
+function assertOnlyFlagTokens(result: string): void {
+  for (const token of result.split(/\s+/).filter((t) => t.length > 0)) {
+    expect(token.startsWith("--")).toBe(true);
+  }
+}
+
 describe("withHostNodeOptions", () => {
   it("returns the canonical flags when nothing is inherited", () => {
     expect(withHostNodeOptions(undefined)).toBe(CANONICAL);
     expect(withHostNodeOptions("")).toBe(CANONICAL);
-    // Canonical set includes the relative report directory so a crash before
-    // the host's own runtime arming still lands under the spawn cwd.
     expect(CANONICAL).toContain("--report-on-fatalerror");
     expect(CANONICAL).toContain("--report-compact");
     expect(CANONICAL).toContain("--report-directory=crash-reports");
     expect(CANONICAL).toContain("--max-semi-space-size=16");
+    assertOnlyFlagTokens(CANONICAL);
   });
 
-  it("strips inherited duplicates of every canonical token including report-directory", () => {
+  describe("value-flag matrix (=value and space-separated)", () => {
+    const cases: ReadonlyArray<{
+      readonly name: string;
+      readonly input: string;
+      readonly preservedPrefix: string | null;
+    }> = [
+      // --max-semi-space-size
+      {
+        name: "max-semi-space-size =value mid",
+        input: "--trace-warnings --max-semi-space-size=64 --inspect=0",
+        preservedPrefix: "--trace-warnings --inspect=0",
+      },
+      {
+        name: "max-semi-space-size =value leading",
+        input: "--max-semi-space-size=64 --trace-warnings",
+        preservedPrefix: "--trace-warnings",
+      },
+      {
+        name: "max-semi-space-size =value trailing",
+        input: "--trace-warnings --max-semi-space-size=64",
+        preservedPrefix: "--trace-warnings",
+      },
+      {
+        name: "max-semi-space-size space-separated mid",
+        input: "--trace-warnings --max-semi-space-size 64 --inspect=0",
+        preservedPrefix: "--trace-warnings --inspect=0",
+      },
+      // --report-directory
+      {
+        name: "report-directory =value mid",
+        input: "--trace-warnings --report-directory=/tmp/x --inspect=0",
+        preservedPrefix: "--trace-warnings --inspect=0",
+      },
+      {
+        name: "report-directory space-separated mid",
+        input: "--trace-warnings --report-directory /tmp/x --inspect=0",
+        preservedPrefix: "--trace-warnings --inspect=0",
+      },
+      {
+        name: "report-directory =value leading",
+        input: "--report-directory=/tmp/x --trace-warnings",
+        preservedPrefix: "--trace-warnings",
+      },
+      {
+        name: "report-directory space-separated trailing",
+        input: "--trace-warnings --report-directory /tmp/x",
+        preservedPrefix: "--trace-warnings",
+      },
+      // --report-filename (stripped even though we do not append it)
+      {
+        name: "report-filename =value mid",
+        input: "--trace-warnings --report-filename=report.json --inspect=0",
+        preservedPrefix: "--trace-warnings --inspect=0",
+      },
+      {
+        name: "report-filename space-separated",
+        input: "--report-filename report.json --trace-warnings",
+        preservedPrefix: "--trace-warnings",
+      },
+    ];
+
+    it.each(cases)("$name → stripped cleanly", ({ input, preservedPrefix }) => {
+      const result = withHostNodeOptions(input);
+      assertOnlyFlagTokens(result);
+      expect(result.endsWith(CANONICAL)).toBe(true);
+      if (preservedPrefix !== null) {
+        expect(result.startsWith(`${preservedPrefix} `)).toBe(true);
+      }
+      expect(result).not.toMatch(/\/tmp\/x\b/);
+      expect(result).not.toContain("report.json");
+      // No duplicate owned flags.
+      expect(result.match(/--max-semi-space-size/g)).toHaveLength(1);
+      expect(result.match(/--report-directory/g)).toHaveLength(1);
+    });
+  });
+
+  it("does not corrupt neighbors when a value CONTAINS another flag name", () => {
+    // A path that embeds `--max-semi-space-size` must not re-trigger the
+    // semi-space strip or leave an orphan token.
     const result = withHostNodeOptions(
-      "--max-semi-space-size=64 --report-on-fatalerror --report-compact --report-directory=/operator/path",
+      "--report-directory=/tmp/--max-semi-space-size/x --trace-warnings",
     );
-    expect(result).toBe(CANONICAL);
+    assertOnlyFlagTokens(result);
+    expect(result).toBe(`--trace-warnings ${CANONICAL}`);
+    expect(result).not.toContain("/tmp/");
     expect(result.match(/--max-semi-space-size/g)).toHaveLength(1);
-    expect(result.match(/--report-on-fatalerror/g)).toHaveLength(1);
-    expect(result.match(/--report-compact/g)).toHaveLength(1);
-    expect(result.match(/--report-directory/g)).toHaveLength(1);
-    expect(result).toContain("--report-directory=crash-reports");
-    expect(result).not.toContain("/operator/path");
-  });
-
-  it("strips an operator --report-directory and lands on the canonical relative path", () => {
-    // Deliberate design: operator overrides of report-directory are stripped
-    // so the supervisor scan path and the child's write path always agree.
-    const result = withHostNodeOptions("--report-directory=/x");
-    expect(result).toBe(CANONICAL);
-    expect(result).not.toContain("/x");
   });
 
   it("fully strips a quoted report-directory with spaces (no orphan tokens)", () => {
-    // Naive \\S+ strip would leave `with spaces"` behind and unbalance
-    // NODE_OPTIONS so Node dies before any user code runs.
     const result = withHostNodeOptions(
       '--report-directory="/path with spaces" --trace-warnings',
     );
+    assertOnlyFlagTokens(result);
     expect(result).toBe(`--trace-warnings ${CANONICAL}`);
     expect(result).not.toContain("with spaces");
     expect(result).not.toContain('"');
-    // Balanced: no dangling quote fragments.
-    expect((result.match(/"/g) ?? []).length).toBe(0);
   });
 
-  it("strips the space-separated form --report-directory /x", () => {
-    const result = withHostNodeOptions(
-      "--report-directory /x --trace-warnings",
-    );
-    expect(result).toBe(`--trace-warnings ${CANONICAL}`);
-    expect(result).not.toContain("/x");
-  });
-
-  it('strips the space-separated quoted form --report-directory "/path with spaces"', () => {
+  it("strips the space-separated quoted form", () => {
     const result = withHostNodeOptions(
       '--report-directory "/path with spaces" --inspect=0',
     );
+    assertOnlyFlagTokens(result);
     expect(result).toBe(`--inspect=0 ${CANONICAL}`);
     expect(result).not.toContain("with spaces");
   });
 
+  it("does not swallow a following --flag when report-directory has no value", () => {
+    // Value-less token must not eat its neighbor.
+    const result = withHostNodeOptions("--report-directory --inspect");
+    assertOnlyFlagTokens(result);
+    expect(result).toContain("--inspect");
+    expect(result.endsWith(CANONICAL)).toBe(true);
+  });
+
   it("preserves a prefix token like --report-directory-x", () => {
-    // The strip must not swallow an unrelated flag that merely shares a prefix.
     const result = withHostNodeOptions("--report-directory-x --trace-warnings");
+    assertOnlyFlagTokens(result);
     expect(result).toContain("--report-directory-x");
     expect(result.startsWith("--report-directory-x --trace-warnings ")).toBe(
       true,
@@ -79,16 +154,30 @@ describe("withHostNodeOptions", () => {
     expect(result.endsWith(CANONICAL)).toBe(true);
   });
 
+  it("strips inherited duplicates of every canonical boolean token", () => {
+    const result = withHostNodeOptions(
+      "--report-on-fatalerror --report-compact --trace-warnings",
+    );
+    assertOnlyFlagTokens(result);
+    expect(result).toBe(`--trace-warnings ${CANONICAL}`);
+    expect(result.match(/--report-on-fatalerror/g)).toHaveLength(1);
+    expect(result.match(/--report-compact/g)).toHaveLength(1);
+  });
+
   it("is idempotent when applied twice", () => {
     const once = withHostNodeOptions(undefined);
     const twice = withHostNodeOptions(once);
     expect(twice).toBe(once);
     expect(twice).toBe(CANONICAL);
+    assertOnlyFlagTokens(twice);
   });
 
-  it("preserves unrelated NODE_OPTIONS tokens", () => {
-    const result = withHostNodeOptions("--trace-warnings --inspect=0");
-    expect(result.startsWith("--trace-warnings --inspect=0 ")).toBe(true);
-    expect(result.endsWith(CANONICAL)).toBe(true);
+  it("idempotent after stripping a messy inherited string", () => {
+    const messy =
+      '--report-directory="/path with spaces" --max-semi-space-size 99 --report-filename=x.json --report-on-fatalerror --trace-warnings';
+    const once = withHostNodeOptions(messy);
+    const twice = withHostNodeOptions(once);
+    expect(twice).toBe(once);
+    assertOnlyFlagTokens(once);
   });
 });

--- a/clients/traycer-cli/src/service/host-node-options.ts
+++ b/clients/traycer-cli/src/service/host-node-options.ts
@@ -37,33 +37,64 @@ export const HOST_DIAGNOSTIC_REPORT_FLAGS =
 
 const HOST_APPENDED_FLAGS = `${HOST_V8_FLAGS} ${HOST_DIAGNOSTIC_REPORT_FLAGS}`;
 
+// Value-taking flags this helper canonically owns. Each is stripped from the
+// inherited value before the canonical set is appended.
+//
+// The strip MUST be quote-aware and MUST cover the space-separated form:
+// NODE_OPTIONS accepts `--flag value` as well as `--flag=value`, and values
+// may be double-quoted (`--report-directory="/path with spaces"`). Removing
+// only the flag leaves the VALUE behind as a bare token, and Node rejects the
+// whole of NODE_OPTIONS on an unrecognized token - so the host never starts
+// at all. That is the worst failure a diagnostics change can ship, which is
+// why every arm goes through one shared pattern instead of hand-rolled
+// variants that drift (the `--max-semi-space-size` arm had exactly that gap).
+const VALUE_FLAGS_OWNED = [
+  "--max-semi-space-size",
+  "--report-directory",
+  // Not appended by us, but stripped: an inherited constant report filename
+  // makes every crash overwrite one file, which defeats the supervisor's
+  // "report newer than this child, and not one that pre-existed it" scan
+  // (and a non-`.json` name makes the scan ignore reports entirely).
+  "--report-filename",
+] as const;
+
+/** Boolean flags this helper appends; stripped so they cannot duplicate. */
+const BOOLEAN_FLAGS_OWNED = [
+  "--report-on-fatalerror",
+  "--report-compact",
+] as const;
+
+// `--flag`, optionally followed by `=value` or ` value`, where value may be
+// quoted. The space-separated arm refuses to swallow a following `--flag`, so
+// a malformed value-less token cannot eat its neighbor.
+function valueFlagPattern(flag: string): RegExp {
+  return new RegExp(
+    `(^|\\s)${flag}(?:=(?:"[^"]*"|\\S+)|\\s+(?:"[^"]*"|(?!--)\\S+))?(?=\\s|$)`,
+    "g",
+  );
+}
+
 // Appends the host's required creation-time flags to an inherited
-// NODE_OPTIONS value. Any pre-existing token this helper canonically appends
-// (`--max-semi-space-size`, the report flags, `--report-directory`) is
-// stripped first so the host always lands on the canonical set - whether the
-// inherited value is the macOS plist's identical copy (a true no-op) or some
-// other value an operator set in their shell, which would otherwise silently
-// defeat or duplicate it. Unrelated operator tokens are preserved.
+// NODE_OPTIONS value, after stripping every token this helper owns - so the
+// host always lands on the canonical set whether the inherited value is the
+// macOS plist's identical copy (a true no-op) or something an operator set in
+// their shell that would silently defeat or duplicate it. Unrelated operator
+// tokens are preserved.
 export function withHostNodeOptions(existing: string | undefined): string {
   if (existing === undefined || existing.length === 0) {
     return HOST_APPENDED_FLAGS;
   }
-  const stripped = existing
-    .replace(/(^|\s)--max-semi-space-size(?:=\S+)?(?=\s|$)/g, " ")
-    .replace(/(^|\s)--report-on-fatalerror(?=\s|$)/g, " ")
-    .replace(/(^|\s)--report-compact(?=\s|$)/g, " ")
-    // Quote-aware, and covers both `=value` and space-separated forms:
-    // NODE_OPTIONS values may be double-quoted (`--report-directory="/path
-    // with spaces"`), and a naive \S+ strip would leave `with spaces"`
-    // behind - an unterminated NODE_OPTIONS that kills Node before any user
-    // code runs. The space-separated arm refuses to swallow a following
-    // `--flag` so a malformed value-less token cannot eat its neighbor.
-    .replace(
-      /(^|\s)--report-directory(?:=(?:"[^"]*"|\S+)|\s+(?:"[^"]*"|(?!--)\S+))?(?=\s|$)/g,
+  let stripped = existing;
+  for (const flag of VALUE_FLAGS_OWNED) {
+    stripped = stripped.replace(valueFlagPattern(flag), " ");
+  }
+  for (const flag of BOOLEAN_FLAGS_OWNED) {
+    stripped = stripped.replace(
+      new RegExp(`(^|\\s)${flag}(?=\\s|$)`, "g"),
       " ",
-    )
-    .trim()
-    .replace(/\s+/g, " ");
+    );
+  }
+  stripped = stripped.trim().replace(/\s+/g, " ");
   return stripped.length > 0
     ? `${stripped} ${HOST_APPENDED_FLAGS}`
     : HOST_APPENDED_FLAGS;

--- a/clients/traycer-cli/src/service/host-node-options.ts
+++ b/clients/traycer-cli/src/service/host-node-options.ts
@@ -21,18 +21,50 @@
 // into third-party binaries.
 export const HOST_V8_FLAGS = "--max-semi-space-size=16";
 
-// Appends the host's required V8 flags to an inherited NODE_OPTIONS value.
-// Any pre-existing `--max-semi-space-size` token is stripped first so the
-// host always lands on the canonical cap - whether the inherited value is the
-// macOS plist's identical `=16` (a true no-op) or some larger value an operator
-// set in their shell, which would otherwise silently defeat the cap.
+// Diagnostic-report flags for the host process. `--report-on-fatalerror`
+// makes Node write a JSON report on a V8 fatal (OOM and friends) - the class
+// of abort that otherwise leaves nothing but `phase=crashed` in the log
+// (0xC0000409 on Windows). All tokens are in Node's NODE_OPTIONS allowlist
+// and space-free on purpose: the report directory is RELATIVE, resolved
+// against the spawn cwd (the host data dir), so a Windows profile path with
+// spaces never needs NODE_OPTIONS quoting - and a crash BEFORE the host's
+// own runtime arming still lands in the exact directory the supervisor
+// creates, prunes, and scans. The host entrypoint re-anchors the same
+// `<cwd>/crash-reports` absolutely at boot; the two always agree because
+// both derive from the spawn cwd.
+export const HOST_DIAGNOSTIC_REPORT_FLAGS =
+  "--report-on-fatalerror --report-compact --report-directory=crash-reports";
+
+const HOST_APPENDED_FLAGS = `${HOST_V8_FLAGS} ${HOST_DIAGNOSTIC_REPORT_FLAGS}`;
+
+// Appends the host's required creation-time flags to an inherited
+// NODE_OPTIONS value. Any pre-existing token this helper canonically appends
+// (`--max-semi-space-size`, the report flags, `--report-directory`) is
+// stripped first so the host always lands on the canonical set - whether the
+// inherited value is the macOS plist's identical copy (a true no-op) or some
+// other value an operator set in their shell, which would otherwise silently
+// defeat or duplicate it. Unrelated operator tokens are preserved.
 export function withHostNodeOptions(existing: string | undefined): string {
   if (existing === undefined || existing.length === 0) {
-    return HOST_V8_FLAGS;
+    return HOST_APPENDED_FLAGS;
   }
   const stripped = existing
     .replace(/(^|\s)--max-semi-space-size(?:=\S+)?(?=\s|$)/g, " ")
+    .replace(/(^|\s)--report-on-fatalerror(?=\s|$)/g, " ")
+    .replace(/(^|\s)--report-compact(?=\s|$)/g, " ")
+    // Quote-aware, and covers both `=value` and space-separated forms:
+    // NODE_OPTIONS values may be double-quoted (`--report-directory="/path
+    // with spaces"`), and a naive \S+ strip would leave `with spaces"`
+    // behind - an unterminated NODE_OPTIONS that kills Node before any user
+    // code runs. The space-separated arm refuses to swallow a following
+    // `--flag` so a malformed value-less token cannot eat its neighbor.
+    .replace(
+      /(^|\s)--report-directory(?:=(?:"[^"]*"|\S+)|\s+(?:"[^"]*"|(?!--)\S+))?(?=\s|$)/g,
+      " ",
+    )
     .trim()
     .replace(/\s+/g, " ");
-  return stripped.length > 0 ? `${stripped} ${HOST_V8_FLAGS}` : HOST_V8_FLAGS;
+  return stripped.length > 0
+    ? `${stripped} ${HOST_APPENDED_FLAGS}`
+    : HOST_APPENDED_FLAGS;
 }


### PR DESCRIPTION
Makes host crashes diagnosable from the supervisor side. Field evidence: #901 — a Windows host hard-aborted (`0xC0000409`) and the only trace was `phase=crashed code=3221226505`; the equivalent POSIX abort (`SIGABRT`) left even less.

## What

- **New `src/host/crash-diagnostics.ts`**
  - `StderrCaptureBuffer`: head+tail stderr capture with an explicit elision marker. Head+tail because a real V8 heap-OOM block measured ~6.5KB with `FATAL ERROR:` at byte ~476 followed by native frames — a tail-only window provably loses the reason. `escapedForMarker()` escapes every JS line terminator including U+2028/U+2029 (a raw one inside a quoted marker value silently discards the whole marker line — reproduced), strips remaining control bytes, and clamps after escaping.
  - `StderrLogTee`: bounded, serialized, path-addressed mirror of child stderr into `host.log` (by path on purpose: the host's own logger rotates `host.log` by rename, and the supervisor's inode-bound fd used to strand the fatal text in `host.log.1` while the crash marker landed alone in the fresh file), plus a bounded `flush()` for the exit path.
  - NTSTATUS decoding (`0xC0000409 STATUS_STACK_BUFFER_OVERRUN`, …) and a fatal-signal vocabulary (`SIGABRT`/`SIGSEGV`/…): a Node fatal abort on macOS/Linux is a signal death, not an exit code, and previously bypassed every enrichment path.
  - Diagnostic-report plumbing: `prepareCrashReportsDir` (create + prune before spawn, so a crash before the host's own runtime arming has a destination), `findCrashReportSince` with spawn-time slack, and a scan bounded by a hard timeout so the terminal marker (readiness authority) can never be lost to a slow disk.
- **`host-node-options.ts`** — appends `--report-on-fatalerror --report-compact --report-directory=crash-reports` to the host's NODE_OPTIONS. The directory is RELATIVE, resolving against the spawn cwd (the host data dir): no quoting hazard for Windows profile paths with spaces, and writer/scanner cannot diverge even under `traycer host start --cwd`.
- **`host-start.ts`** — stderr moves to a pipe (stdout stays on the log fd; the `--layer0-status-fd` probe pipe stays at index 3); crash markers gain `exitMeaning=` / `report=` / `stderrTail=` (additive fields; every existing parser ignores unknown keys); fatal-signal deaths get the same enrichment under `phase=killed`; forwarded shutdown signals stay bare. The crash-diagnostics operations are injected via `RunHostStartDeps`, so tests never touch a real `~/.traycer`.
- **`doctor/engine.ts`** — a recovered crash is now *downgraded*, not erased: `traycer host doctor` used to cancel the crash signal the moment a later `starting` marker existed, i.e. exactly when auto-respawn worked and the crash was the only thing worth diagnosing. Fatal-signal `killed` markers now count as crash evidence too.

## Verification

- 96/96 across six targeted suites (crash-diagnostics, host-node-options, bootstrap-log round-trips incl. the U+2028 marker repro, host-start exit branches with injected deps, doctor, spawn-evidence) + package compile.
- Cold review + verify pass: all round-1 findings (POSIX fatal bypass, sandbox escape, tail-only capture loss, report-directory divergence, marker durability, tee boundedness, marker corruption) closed.

Marker-format note for reviewers: all three new fields are additive `key=value` entries; `parseBootstrapLogLine`'s grammar and every existing consumer (spawn-evidence, host-status, gui-app attempt summary) ignore unknown keys by construction — covered by round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
