### PR TITLE
docs(gui-app,shared): correct the catalog carve-out comments

### DIFF
--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -64,8 +64,12 @@ import { getConditionPollEpisodeCoordinator } from "@/lib/query/condition-poll-e
 // `staleTime: Infinity` and re-probe every harness at once - a provider CLI
 // spawn burst that stalls a slow host, flaps stream health, and triggers the
 // next sweep (traycer#912). `query-invalidator.ts` therefore exempts
-// `agent.gui.listModels` / `agent.gui.listCommands` from active recovery
-// refetches: they are marked stale and picked up at the intent edges above.
+// `agent.gui.listModels` / `agent.gui.listCommands` from the recovery sweep
+// ENTIRELY - not refetched, and not marked stale either. Marking them would
+// only defer the burst: an invalidated query is stale regardless of
+// `staleTime`, so the next mount of this hook would re-probe every harness at
+// once. Recovery leaves them untouched and the intent edges above pick up
+// whatever is genuinely due.
 export const HARNESS_CATALOG_REFRESH_AFTER_MS = 15 * 60 * 1000;
 const HARNESS_AVAILABILITY_REFRESH_MS = 15 * 60 * 1000;
 

--- a/clients/shared/host-client/host-client.ts
+++ b/clients/shared/host-client/host-client.ts
@@ -249,11 +249,13 @@ export class HostClient<Registry extends VersionedRpcRegistry> {
             // registry's previous token is aborted as this new binding is made.
             this.authorityRegistry.capture(entry, entry);
           });
-          // The GUI's invalidator adapter exempts the harness-catalog methods
-          // from this active refetch (they are marked stale and recover at
-          // the picker's intent edges instead): a transport flap is exactly
-          // what a busy-host storm produces, and refetching catalogs here
-          // would fan provider probes back out mid-storm (traycer#912).
+          // The GUI's invalidator adapter skips the harness-catalog methods on
+          // this sweep entirely - it does not even mark them stale, since an
+          // invalidated entry re-probes at the next picker mount and that just
+          // moves the burst. They recover at the picker's own intent edges
+          // instead: a transport flap is exactly what a busy-host storm
+          // produces, and refetching catalogs here would fan provider probes
+          // back out mid-storm (traycer#912).
           this.invalidator.invalidateHostScope(entry.hostId, {
             refetchActive: true,
           });


### PR DESCRIPTION
Follow-up to #977. Comment-only.

Both call-site comments still describe the behaviour that PR's review round
removed — "marked stale and picked up at the intent edges". The shipped code
skips the harness-catalog keys entirely: it does not refetch them **and does
not mark them stale**.

That distinction is the whole point of the fix, so a comment asserting the
opposite is actively misleading to the next reader. `Query.isStaleByTime`
returns `true` on `state.isInvalidated` *before* it consults the time budget
(query-core 5.101.4, `query.js:134`), and `shouldFetchOnMount` routes through
it — so an invalidated entry refetches at the next mount regardless of
`staleTime: Infinity`. Marking these keys would have moved the ~14-harness
provider-CLI burst from the recovery sweep to the user's next picker open,
rather than preventing it.

No executable change.