### PR TITLE
fix(clients): read negotiated schema versions per session, not per client

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-stream-test-fixtures.ts
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-stream-test-fixtures.ts
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 /**
  * The one mock stream session + client the `pr.*` suites drive.
  *
@@ -47,6 +48,11 @@ export class MockStreamSession<
     _binaryPayload: Uint8Array | null,
   ): void {
     this.sentClientFrames.push(envelope);
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-active-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-active-gate.test.tsx
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import "../../../../../__tests__/test-browser-apis";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -68,6 +69,11 @@ class MockStreamSession implements IStreamSession {
   sendClientFrame(): void {
     // Not exercised here.
   }
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
+  }
+
   requestReconnect(): void {
     // Not exercised here.
   }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -240,6 +241,11 @@ class MockStreamSession implements IStreamSession {
   sendClientFrame(envelope: { readonly kind: string }): void {
     this.clientFrameKinds.push(envelope.kind);
   }
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
+  }
+
   requestReconnect(): void {}
   close(): void {
     this.statusChangeHandler?.("closed", { kind: "caller" });

--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -2199,5 +2199,45 @@ describe("useGitListChangedFilesSubscription", () => {
       // next peer may not be able to echo.
       expect(mockWsStreamClient.subscribeCallCount).toBe(before);
     });
+
+    it("does not answer a TERMINATED stream from a live sibling's version", async () => {
+      // Clearing the closed session and its stamp is not enough on its own: the
+      // fallback below them is the client-wide value, and with repo B still
+      // live at >= 1.1 that value is not empty - it is B's. Repo A would go on
+      // reporting the stream owns its rich slot, with A's stream dead and no
+      // way to refill it.
+      //
+      // The single-repo case hides this, because reconciliation empties the
+      // client-wide value when the only session closes. A sibling keeps it
+      // populated, which is exactly the skew this PR is about.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 1 };
+      const repoA = await renderRepo("/repo-a");
+      repoA.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+      const repoB = await renderRepo("/repo-b");
+      repoB.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+
+      const ownership = renderHook(
+        () =>
+          useGitSubscriptionOwnsRichSlot({
+            wsStreamClient: mockWsStreamClient,
+            hostId: "host1",
+            runningDir: "/repo-a",
+            ignoreWhitespace: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => expect(ownership.result.current).toBe(true));
+
+      // A dies; B lives, so the client-wide value STAYS at 1.1 throughout.
+      repoA.session.emitFrame(
+        { type: "error", message: "fatal git error", isFatal: true },
+        null,
+      );
+
+      await waitFor(() => expect(ownership.result.current).toBe(false));
+      expect(
+        mockWsStreamClient.getMethodSchemaVersion("git.subscribeStatus"),
+      ).toEqual({ major: 1, minor: 1 });
+    });
   });
 });

--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -2163,5 +2163,41 @@ describe("useGitListChangedFilesSubscription", () => {
 
       await waitFor(() => expect(ownership.result.current).toBe(false));
     });
+
+    it("refuses a fresh-nonce refresh while the session is between connections", async () => {
+      // The nonce gate is an ACTION taken against whatever session exists now,
+      // so a stamp from a handshake that has already ended is not evidence for
+      // it. A host that restarts and rolls back to v1.1 cannot echo a
+      // `freshNonce`, and the caller treats a non-null return as "the stream is
+      // handling it" and skips its unary fallback - so guessing high here costs
+      // a real refresh and parks the user on the 10s timeout instead.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 2 };
+      const repo = await renderRepo("/repo-a");
+      repo.session.negotiatedSchemaVersion = { major: 1, minor: 2 };
+      repo.session.emitFrame(v12SnapshotFor("/repo-a", "parent-a"), null);
+      await waitFor(() =>
+        expect(repo.result.current.data?.fingerprint).toBe("parent-a"),
+      );
+
+      // Mid-reconnect: `resetForReconnect` clears the session's negotiated
+      // version, and reconciliation empties the client-wide one with it. Only
+      // the delivered stamp still says 1.2.
+      repo.session.negotiatedSchemaVersion = null;
+      mockWsStreamClient.methodSchemaVersion = null;
+      const before = mockWsStreamClient.subscribeCallCount;
+
+      expect(
+        refreshGitSubscriptionWithFreshNonce({
+          wsStreamClient: mockWsStreamClient,
+          queryClient,
+          hostId: "host1",
+          runningDir: "/repo-a",
+          ignoreWhitespace: false,
+        }),
+      ).toBeNull();
+      // No replacement was started, so nothing is left waiting on a nonce the
+      // next peer may not be able to echo.
+      expect(mockWsStreamClient.subscribeCallCount).toBe(before);
+    });
   });
 });

--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -2239,5 +2239,42 @@ describe("useGitListChangedFilesSubscription", () => {
         mockWsStreamClient.getMethodSchemaVersion("git.subscribeStatus"),
       ).toEqual({ major: 1, minor: 1 });
     });
+
+    it("publishes this session's version at OPEN, before any frame", async () => {
+      // The snapshot was already correct on read - `entrySchemaVersion` asks the
+      // live session first - but nothing asked it. The entry channel only fires
+      // on delivery, and `subscribeMethodSupport` fires only when the
+      // CLIENT-WIDE value changes: with repo A already holding it at 1.1,
+      // reconciliation keeps answering with A, so repo B negotiating 1.0 moves
+      // nothing. B's hook kept its stale pre-handshake `true` until B's first
+      // frame - and during a slow initial git scan that is a long time to sit
+      // with the unary query disabled and a v1.0 stream that will never write
+      // the rich slot.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 1 };
+      const repoA = await renderRepo("/repo-a");
+      repoA.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+      const repoB = await renderRepo("/repo-b");
+
+      const ownership = renderHook(
+        () =>
+          useGitSubscriptionOwnsRichSlot({
+            wsStreamClient: mockWsStreamClient,
+            hostId: "host1",
+            runningDir: "/repo-b",
+            ignoreWhitespace: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+      // Pre-handshake, B defers to the client-wide value - which is A's.
+      await waitFor(() => expect(ownership.result.current).toBe(true));
+
+      // B's handshake settles at 1.0. The client-wide value does NOT move.
+      repoB.session.negotiatedSchemaVersion = { major: 1, minor: 0 };
+      repoB.session.emitStatus("open", null);
+
+      // No frame has been delivered on B at any point in this test.
+      await waitFor(() => expect(ownership.result.current).toBe(false));
+      expect(repoB.result.current.data).toBeNull();
+    });
   });
 });

--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -34,6 +34,7 @@ import { __resetRichSlotOrderingForTesting } from "@/lib/git/git-rich-slot-order
 import {
   useGitListChangedFilesSubscription,
   refreshGitSubscriptionWithFreshNonce,
+  useGitSubscriptionOwnsRichSlot,
   useGitSubscriptionRefreshState,
   __resetSubscriptionsForTesting,
   type GitListChangedFilesSubscriptionResult,
@@ -44,9 +45,21 @@ class MockStreamSession implements IStreamSession {
   private serverFrameHandler: ServerFrameHandler | null = null;
   private statusChangeHandler: StatusChangeHandler | null = null;
   closed: boolean = false;
+  /**
+   * The version THIS session negotiated, which is deliberately settable
+   * independently of `MockWsStreamClient.methodSchemaVersion`. The two are
+   * independent in production too: `reconcileMethodSchemaVersion` reports
+   * whichever live session for the method it reaches FIRST, so a second repo's
+   * stream can sit at a different minor and never be consulted.
+   */
+  negotiatedSchemaVersion: SchemaVersion | null = null;
 
   onServerFrame(handler: ServerFrameHandler): void {
     this.serverFrameHandler = handler;
+  }
+
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return this.negotiatedSchemaVersion;
   }
 
   onStatusChange(handler: StatusChangeHandler): void {
@@ -127,7 +140,13 @@ class MockWsStreamClient extends WsStreamClient<HostStreamRpcRegistry> {
     const key = JSON.stringify({ method, params });
 
     if (!this.sessions.has(key)) {
-      this.sessions.set(key, new MockStreamSession());
+      const created = new MockStreamSession();
+      // A session negotiates AT OPEN, so it starts life carrying whatever this
+      // client negotiates now. Tests that need the two to diverge - the skew a
+      // client-wide read cannot see, and a renegotiation that moves one session
+      // and not its sibling - assign the session's own value afterwards.
+      created.negotiatedSchemaVersion = this.methodSchemaVersion;
+      this.sessions.set(key, created);
     }
 
     const session = this.sessions.get(key);
@@ -1241,6 +1260,10 @@ describe("useGitListChangedFilesSubscription", () => {
     queryClient.removeQueries({
       queryKey: gitQueryKeys.listChangedFiles("host1", "/repo", false),
     });
+    // THIS session is what renegotiated down - replay reads the entry's own
+    // session, so moving only the client-wide value would model a DIFFERENT
+    // repo's stream dropping to minor 0, which must not touch this one.
+    session.negotiatedSchemaVersion = { major: 1, minor: 0 };
     mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 0 };
 
     renderHook(
@@ -1757,6 +1780,9 @@ describe("useGitListChangedFilesSubscription", () => {
       );
       await waitFor(() => expect(result.current.watcherStatus).not.toBeNull());
 
+      // THIS session is what renegotiated down; the client-wide value follows
+      // it only because it is the sole live session for the method.
+      session.negotiatedSchemaVersion = { major: 1, minor: 2 };
       mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 2 };
       const downgraded: GitSubscribeStatusEventV12 = {
         type: "updated",
@@ -1780,36 +1806,49 @@ describe("useGitListChangedFilesSubscription", () => {
       expect(result.current.watcherStatus).toBeNull();
     });
 
-    it("still accepts a v1.2 frame while the client-wide version reads 1.3", async () => {
-      // `getMethodSchemaVersion` is client-wide PER METHOD, rebuilt from the
-      // first still-live session — so two repo streams on one client can sit at
-      // different minors while a host restart renegotiates one and not the
-      // other. `watcher` is required at v1.3, so a strict v1.3-only parse would
-      // reject every frame from the v1.2 session and the dispatcher's `return`
-      // would drop it: that repo's changes freeze until it reconnects.
+    it("DROPS a watcher-less frame on a session that itself negotiated 1.3", async () => {
+      // The invariant that replaced the tolerant v1.2 fallback. That fallback
+      // existed because the tier came from the CLIENT-WIDE version and could
+      // belong to a sibling repo's stream, making a watcher-less frame ordinary
+      // version skew; the skew case now lives in "per-session schema version"
+      // below, where it is accepted because that session really is at 1.2.
+      //
+      // Here the delivering session negotiated 1.3 itself, so this host agreed
+      // to send `watcher` and a frame without one is malformed. Degrading it to
+      // a v1.2 parse would strip the offending shape and accept a payload the
+      // contract exists to reject.
       const { result, session } = await renderAtMinor(3);
-      const v12Frame: GitSubscribeStatusEventV12 = {
+      session.emitFrame(v13Snapshot({ state: "watching", detail: null }), null);
+      await waitFor(() =>
+        expect(result.current.data?.fingerprint).toBe("parent-1"),
+      );
+
+      const watcherless: GitSubscribeStatusEventV12 = {
         type: "snapshot",
         runningDir: "/repo",
         headSha: "head",
         branch: "main",
         files: [],
-        fingerprint: "parent-v12",
-        nestedFingerprint: "nested-v12",
+        fingerprint: "parent-watcherless",
+        nestedFingerprint: "nested-watcherless",
         repoMode: "normal",
         repoState: { kind: "clean" },
         submodules: [],
         pollStartedAtMs: 1_000,
         freshNonce: null,
       };
-      session.emitFrame(v12Frame, null);
+      session.emitFrame(watcherless, null);
 
-      // Delivered, not dropped...
+      // ORDERING, not a sleep: `emitFrame` is synchronous, so a later
+      // well-formed frame becoming visible proves the dropped one was already
+      // processed.
+      const base = v13Snapshot({ state: "watching", detail: null });
+      if (base.type !== "snapshot") throw new Error("expected a snapshot");
+      session.emitFrame({ ...base, fingerprint: "parent-after" }, null);
       await waitFor(() =>
-        expect(result.current.data?.fingerprint).toBe("parent-v12"),
+        expect(result.current.data?.fingerprint).toBe("parent-after"),
       );
-      // ...and the missing field reads as UNKNOWN rather than healthy.
-      expect(result.current.watcherStatus).toBeNull();
+      expect(result.current.data?.fingerprint).not.toBe("parent-watcherless");
     });
 
     it("DROPS a malformed watcher rather than downgrading it into a v1.2 parse", async () => {
@@ -1913,6 +1952,175 @@ describe("useGitListChangedFilesSubscription", () => {
       // Cleared at replacement time - BEFORE the new session's first frame,
       // which is the whole window this covers.
       await waitFor(() => expect(result.current.watcherStatus).toBeNull());
+    });
+  });
+
+  describe("per-session schema version", () => {
+    // `getMethodSchemaVersion` is CLIENT-WIDE per method:
+    // `reconcileMethodSchemaVersion` (`ws-stream-client.ts:682-701`) walks the
+    // owned sessions, takes the FIRST one carrying a version for that method,
+    // and breaks. Two repos open on one host are two sessions on one client, so
+    // a host restart that renegotiates one and not the other leaves the
+    // client-wide value describing whichever session it reached first - and
+    // every consumer reading that value gets the other repo's answer.
+    //
+    // Both tests below pin the SAME invariant from opposite directions: a frame
+    // is parsed at the version ITS OWN session negotiated.
+
+    function v12SnapshotFor(
+      runningDir: string,
+      fingerprint: string,
+    ): GitSubscribeStatusEventV12 {
+      return {
+        type: "snapshot",
+        runningDir,
+        headSha: "head",
+        branch: "main",
+        files: [],
+        fingerprint,
+        nestedFingerprint: `nested-${fingerprint}`,
+        repoMode: "normal",
+        repoState: { kind: "clean" },
+        submodules: [],
+        pollStartedAtMs: 1_000,
+        freshNonce: null,
+      };
+    }
+
+    function v13SnapshotFor(
+      runningDir: string,
+      fingerprint: string,
+      watcher: GitWatcherStatus,
+    ): GitSubscribeStatusEventV13 {
+      // Narrowed before the spread: the v1.2 helper is typed as the whole
+      // union, and spreading it unnarrowed leaves `type` a union, so TS cannot
+      // pick the member `watcher` belongs to.
+      const base = v12SnapshotFor(runningDir, fingerprint);
+      if (base.type !== "snapshot") throw new Error("expected a snapshot");
+      return { ...base, watcher };
+    }
+
+    async function renderRepo(runningDir: string) {
+      const rendered = renderHook(
+        () =>
+          useGitListChangedFilesSubscription({
+            hostId: "host1",
+            runningDir,
+            ignoreWhitespace: false,
+            enabled: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+      const params = { hostId: "host1", runningDir, ignoreWhitespace: false };
+      await waitFor(() => {
+        expect(
+          mockWsStreamClient.getSession("git.subscribeStatus", params),
+        ).toBeDefined();
+      });
+      const session = mockWsStreamClient.getSession(
+        "git.subscribeStatus",
+        params,
+      );
+      if (session === undefined) {
+        throw new Error(`Expected a session for ${runningDir}`);
+      }
+      return { result: rendered.result, session };
+    }
+
+    it("keeps a v1.3 frame's watcher health when the CLIENT-WIDE value reads 1.2", async () => {
+      // The skew direction `tolerantV13Parse` cannot rescue, because the
+      // fallback only ever degrades a v1.3 read DOWN. Here the client-wide
+      // value is already the lower one: repo B reconnected against a rolled-back
+      // host and answers reconciliation first, so repo A - still on 1.3 - has
+      // its frames parsed with the v1.2 schema. That parse STRIPS `watcher`
+      // (asserted directly by "ignores a watcher field arriving on a connection
+      // negotiated at 1.2"), so repo A's degrade notice silently never appears:
+      // the panel claims live updates while the watcher is off.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 2 };
+
+      const repoB = await renderRepo("/repo-b");
+      repoB.session.negotiatedSchemaVersion = { major: 1, minor: 2 };
+      const repoA = await renderRepo("/repo-a");
+      repoA.session.negotiatedSchemaVersion = { major: 1, minor: 3 };
+
+      repoA.session.emitFrame(
+        v13SnapshotFor("/repo-a", "parent-a", {
+          state: "degraded-capacity",
+          detail: "over budget",
+        }),
+        null,
+      );
+
+      await waitFor(() =>
+        expect(repoA.result.current.data?.fingerprint).toBe("parent-a"),
+      );
+      expect(repoA.result.current.watcherStatus).toEqual({
+        state: "degraded-capacity",
+        detail: "over budget",
+      });
+      // Repo B is genuinely at 1.2 and must stay UNKNOWN - the fix routes each
+      // frame to its own session's minor, it does not raise everyone to the max.
+      expect(repoB.result.current.watcherStatus).toBeNull();
+    });
+
+    it("accepts a v1.2 frame when the CLIENT-WIDE value reads 1.3", async () => {
+      // The mirror direction, and the one that GUARDS THE DELETION of
+      // `tolerantV13Parse` rather than discriminating on its own: it passes
+      // today only because that fallback degrades a failed v1.3 parse to v1.2.
+      // Once delivery reads the delivering session it passes for the right
+      // reason - repo B's frame is parsed with the v1.2 schema because repo B
+      // negotiated 1.2 - which is what makes the fallback safe to remove.
+      // Without either, the required `watcher` fails the parse and the frame is
+      // dropped: repo B's changeset freezes until it reconnects.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 3 };
+
+      const repoA = await renderRepo("/repo-a");
+      repoA.session.negotiatedSchemaVersion = { major: 1, minor: 3 };
+      const repoB = await renderRepo("/repo-b");
+      repoB.session.negotiatedSchemaVersion = { major: 1, minor: 2 };
+
+      repoB.session.emitFrame(v12SnapshotFor("/repo-b", "parent-b"), null);
+
+      await waitFor(() =>
+        expect(repoB.result.current.data?.fingerprint).toBe("parent-b"),
+      );
+      expect(repoB.result.current.watcherStatus).toBeNull();
+    });
+
+    it("scopes rich-slot ownership to the repo asking, not to the client", async () => {
+      // The failure this closes has no fallback to soften it. The ownership
+      // read used to take NO arguments at all while its caller is worktree-
+      // scoped, so repo A at >= 1.1 disabled repo B's unary query - and with
+      // B's own session at 1.0 the stream does not write B's rich slot either.
+      // Both writers off: that panel has no writer at all.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 1 };
+
+      const repoA = await renderRepo("/repo-a");
+      repoA.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+      const repoB = await renderRepo("/repo-b");
+      repoB.session.negotiatedSchemaVersion = { major: 1, minor: 0 };
+
+      const ownership = renderHook(
+        () => ({
+          a: useGitSubscriptionOwnsRichSlot({
+            wsStreamClient: mockWsStreamClient,
+            hostId: "host1",
+            runningDir: "/repo-a",
+            ignoreWhitespace: false,
+          }),
+          b: useGitSubscriptionOwnsRichSlot({
+            wsStreamClient: mockWsStreamClient,
+            hostId: "host1",
+            runningDir: "/repo-b",
+            ignoreWhitespace: false,
+          }),
+        }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(ownership.result.current.a).toBe(true));
+      // The whole point: B answers for itself, and answers differently.
+      expect(ownership.result.current.b).toBe(false);
     });
   });
 });

--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -2122,5 +2122,46 @@ describe("useGitListChangedFilesSubscription", () => {
       // The whole point: B answers for itself, and answers differently.
       expect(ownership.result.current.b).toBe(false);
     });
+
+    it("hands the rich slot back when the stream terminates", async () => {
+      // A terminated stream will never write the slot again, so the unary
+      // query has to take it back. The client-wide value used to do this by
+      // itself: closing a session removes it from `ownedSessions` and
+      // reconciles the method's version away, leaving no owner. Reading the
+      // entry's own session instead loses that for free - `StreamSession.close`
+      // does NOT clear its negotiated version (only `resetForReconnect` does),
+      // so a closed session keeps answering with the minor it last negotiated
+      // and the slot stays disabled with nothing left to fill it.
+      mockWsStreamClient.methodSchemaVersion = { major: 1, minor: 1 };
+      const repo = await renderRepo("/repo-a");
+      repo.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+
+      const ownership = renderHook(
+        () =>
+          useGitSubscriptionOwnsRichSlot({
+            wsStreamClient: mockWsStreamClient,
+            hostId: "host1",
+            runningDir: "/repo-a",
+            ignoreWhitespace: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => expect(ownership.result.current).toBe(true));
+
+      // Fatal domain frame -> `markTerminal`. Reconciliation drops the
+      // client-wide value the same way it always did; the entry must not go on
+      // answering from the session it just closed.
+      // Reconciliation drops the client-wide value as the session leaves
+      // `ownedSessions`, which happens DURING the close - so it is already gone
+      // by the time anything re-reads. Setting it afterwards would leave the
+      // store holding a snapshot taken while it was still 1.1.
+      mockWsStreamClient.methodSchemaVersion = null;
+      repo.session.emitFrame(
+        { type: "error", message: "fatal git error", isFatal: true },
+        null,
+      );
+
+      await waitFor(() => expect(ownership.result.current).toBe(false));
+    });
   });
 });

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
@@ -320,12 +320,23 @@ export function refreshGitSubscriptionWithFreshNonce(args: {
   const key = subscriptionKeyFor(client, subscriptionArgs);
   const shared = subscriptions.get(key);
   if (shared === undefined) return null;
-  // The entry is looked up BEFORE the version gate so the gate can read this
-  // stream's own stamp. Asking the client-wide value would let a sibling repo
-  // that negotiated 1.2 authorize a fresh-nonce replacement against a session
-  // that cannot correlate the nonce - and nothing would then settle the refresh
-  // except its 10s timeout.
-  const version = entrySchemaVersion(shared, client);
+  // The LIVE session only - not `entrySchemaVersion`. This gate is unlike the
+  // other two entry-scoped reads: they answer "who owns this slot", where
+  // holding the last known value through a blip beats thrashing ownership.
+  // This one authorizes an ACTION against whatever session exists right now,
+  // and a stamp is evidence about a handshake that has already ended.
+  //
+  // Both stale sources fail the same way. A sibling repo at 1.2 (the
+  // client-wide value) or this stream's own previous handshake (the stamp)
+  // would authorize a fresh-nonce replacement whose peer may be a restarted,
+  // rolled-back v1.1 host that cannot echo the nonce. The caller reads a
+  // non-null return as "the stream is handling it" and skips its unary
+  // fallback, so the refresh the user asked for never happens and they wait
+  // out the 10s timeout instead.
+  //
+  // `null` here (no handshake yet, or between connections) correctly declines
+  // and lets the caller do a plain unary refresh.
+  const version = shared.session?.getNegotiatedSchemaVersion() ?? null;
   if (version === null || version.major !== 1 || version.minor < 2) {
     return null;
   }
@@ -602,9 +613,15 @@ function sameSchemaVersion(
 }
 
 /**
- * The version to answer a question about THIS repo's stream with, in falling
- * order of authority: the live session, the last delivered stamp, the
- * client-wide value.
+ * The version to answer an OWNERSHIP question about THIS repo's stream with -
+ * "who writes this slot" - in falling order of authority: the live session, the
+ * last delivered stamp, the client-wide value.
+ *
+ * NOT for authorizing an action. `refreshGitSubscriptionWithFreshNonce` reads
+ * the live session directly and declines when it is `null`, because a stamp is
+ * evidence about a handshake that has already ended, and acting on it commits
+ * the caller to a stream that may no longer be able to honour it. Ownership can
+ * hold a last-known value through a blip; an action cannot.
  *
  * - The LIVE session is exact and needs no frame to become true, so a
  *   renegotiation is visible the moment it happens.

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
@@ -93,11 +93,11 @@ interface SharedSubscription {
    * `reconcileMethodSchemaVersion` reached first and can therefore belong to
    * another repo entirely.
    *
-   * `null` before the first frame; readers fall back to the client-wide value
-   * there, which is today's behaviour exactly, so the stamp can only ever
-   * improve on it. The host forces an immediate tick for a new subscriber and
-   * replays its cached snapshot, so that window is one frame wide even on a
-   * repo that never changes.
+   * `null` before the first frame; ownership readers fall back past it (see
+   * `entrySchemaVersion`), which is today's behaviour exactly, so the stamp can
+   * only ever improve on it. The host forces an immediate tick for a new
+   * subscriber and replays its cached snapshot, so that window is one frame
+   * wide even on a repo that never changes.
    */
   negotiatedVersion: SchemaVersion | null;
   /**
@@ -108,6 +108,21 @@ interface SharedSubscription {
    * next delivered frame.
    */
   session: IStreamSession | null;
+  /**
+   * Whether this entry's stream has gone TERMINAL - distinct from "no session
+   * yet", and they must fall back differently.
+   *
+   * Before a first handshake, deferring to the client-wide value is right: this
+   * stream is about to negotiate and fill the slot, so handing ownership to the
+   * unary query would buy a redundant fetch on every mount to close a window
+   * the first frame closes anyway.
+   *
+   * After a terminal close nothing will ever arrive again, and the client-wide
+   * value is NOT empty just because this session died - a sibling repo's live
+   * stream keeps it populated. Falling back there would report an owner that
+   * cannot write, leaving the panel with no writer at all.
+   */
+  terminated: boolean;
   consumers: Map<symbol, () => void>;
   sessionGeneration: number;
   closeCurrentSession: () => void;
@@ -528,6 +543,7 @@ function createSharedSubscription(
     lastWatcherStatus: null,
     negotiatedVersion: null,
     session: null,
+    terminated: false,
     consumers: new Map(),
     sessionGeneration: 0,
     closeCurrentSession: () => undefined,
@@ -638,6 +654,9 @@ function entrySchemaVersion(
   shared: SharedSubscription | undefined,
   client: IHostStreamClient<HostStreamRpcRegistry>,
 ): SchemaVersion | null {
+  // A dead stream owns nothing, and says so instead of deferring. Everything
+  // below this line describes a stream that may still write.
+  if (shared?.terminated === true) return null;
   const live = shared?.session?.getNegotiatedSchemaVersion() ?? null;
   if (live !== null) return live;
   const stamped = shared?.negotiatedVersion ?? null;
@@ -674,6 +693,8 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     freshNonce,
   });
   shared.session = session;
+  // A new session means this entry is live again, whatever became of the last.
+  shared.terminated = false;
   let sessionClosed = false;
   shared.closeCurrentSession = () => {
     sessionClosed = true;
@@ -714,6 +735,7 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     // version away, which is how this case used to resolve itself.
     shared.session = null;
     shared.negotiatedVersion = null;
+    shared.terminated = true;
     settleSharedRefresh(shared, subscriptionKeyFor(wsStreamClient, args));
     notifyEntryChanged(subscriptionKeyFor(wsStreamClient, args));
     notifyConsumers(shared);

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
@@ -685,7 +685,20 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     // periodic refreshes that have permanently stopped - most misleading in
     // the panel, where cached data keeps the view looking alive.
     shared.lastWatcherStatus = null;
+    // Same cliff for the negotiated version, and it needs BOTH halves dropped.
+    // A closed `StreamSession` keeps reporting the minor it last negotiated -
+    // only `resetForReconnect` clears that, not `close()` - and the stamp is
+    // just as stale. Left in place, this entry would go on claiming the stream
+    // owns the rich slot while no stream remains to write it, so the unary
+    // query stays disabled and the panel has no writer at all.
+    //
+    // Falling back to the client-wide value here is exactly right: closing the
+    // session removes it from `ownedSessions` and reconciles the method's
+    // version away, which is how this case used to resolve itself.
+    shared.session = null;
+    shared.negotiatedVersion = null;
     settleSharedRefresh(shared, subscriptionKeyFor(wsStreamClient, args));
+    notifyEntryChanged(subscriptionKeyFor(wsStreamClient, args));
     notifyConsumers(shared);
   };
 

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
@@ -249,8 +249,17 @@ export function useGitSubscriptionRefreshState(
   args: GitSubscriptionRefreshStateArgs,
 ): boolean {
   const key = entryKeyFor(args);
+  // Memoized on `key`: `useSyncExternalStore` compares the subscriber by
+  // reference, so a fresh closure each render tears the listener down and
+  // re-adds it every time - and because the unsubscribe drops the key once its
+  // set empties, the `Set` is rebuilt too. Matches
+  // `useGitSubscriptionOwnsRichSlot` below.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => subscribeToEntry(key)(onStoreChange),
+    [key],
+  );
   return useSyncExternalStore(
-    subscribeToEntry(key),
+    subscribe,
     () =>
       key === null ? false : (subscriptions.get(key)?.isRefreshing ?? false),
     () => false,
@@ -620,6 +629,29 @@ function frameTierOf(
   return "frozen";
 }
 
+/**
+ * Records this session's negotiated version on the entry and wakes the readers
+ * that have no session of their own.
+ *
+ * Called at BOTH the handshake and every delivery, and the handshake is the one
+ * that is easy to miss. The client-wide change signal cannot stand in for it:
+ * `reconcileMethodSchemaVersion` answers with whichever session it reaches
+ * first, so a sibling repo already holding the value means this session
+ * negotiating something different moves nothing and notifies nobody. The
+ * snapshot would be right the moment anything asked - and nothing would ask
+ * until this stream's first frame, which on a slow initial scan is a long time
+ * to render from a sibling's minor.
+ */
+function publishNegotiatedVersion(
+  shared: SharedSubscription,
+  negotiated: SchemaVersion | null,
+  key: string,
+): void {
+  if (sameSchemaVersion(shared.negotiatedVersion, negotiated)) return;
+  shared.negotiatedVersion = negotiated;
+  notifyEntryChanged(key);
+}
+
 function sameSchemaVersion(
   left: SchemaVersion | null,
   right: SchemaVersion | null,
@@ -666,6 +698,7 @@ function entrySchemaVersion(
 
 function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
   const { shared, wsStreamClient, queryClient, args, freshNonce } = opts;
+  const entryKey = subscriptionKeyFor(wsStreamClient, args);
   // Retire the old generation BEFORE close. A synchronous close callback is
   // then ignored and cannot publish a terminal error over the preserved cache.
   shared.sessionGeneration += 1;
@@ -736,8 +769,8 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     shared.session = null;
     shared.negotiatedVersion = null;
     shared.terminated = true;
-    settleSharedRefresh(shared, subscriptionKeyFor(wsStreamClient, args));
-    notifyEntryChanged(subscriptionKeyFor(wsStreamClient, args));
+    settleSharedRefresh(shared, entryKey);
+    notifyEntryChanged(entryKey);
     notifyConsumers(shared);
   };
 
@@ -750,15 +783,7 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     // React render. It is read off the DELIVERING SESSION, so a sibling repo's
     // stream sitting at another minor cannot decide how this frame is parsed.
     const negotiated = session.getNegotiatedSchemaVersion();
-    // Delivery is also where the value gets STAMPED for the readers that have
-    // no session in scope - the fresh-nonce refresh entry point, the replay a
-    // joining consumer triggers, and the rich-slot ownership the submodule hook
-    // renders from. Notifying on change is what makes that last one reactive;
-    // it rides the per-key channel the refresh indicator already listens on.
-    if (!sameSchemaVersion(shared.negotiatedVersion, negotiated)) {
-      shared.negotiatedVersion = negotiated;
-      notifyEntryChanged(subscriptionKeyFor(wsStreamClient, args));
-    }
+    publishNegotiatedVersion(shared, negotiated, entryKey);
     const tier = frameTierOf(negotiated);
     const v13Frames = tier === "v13";
     const v12Frames = tier === "v13" || tier === "v12";
@@ -786,7 +811,25 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
       const parsed = v13Frames
         ? gitSubscribeStatusEventSchemaV13.safeParse(envelope.value)
         : gitSubscribeStatusEventSchemaV12.safeParse(envelope.value);
-      if (!parsed.success) return;
+      if (!parsed.success) {
+        // Newly reachable now that the tolerant fallback is gone: this used to
+        // degrade to the v1.2 schema and apply the frame anyway. A silent drop
+        // freezes the panel on its last fingerprint until another frame
+        // arrives, so say something - matching `TerminalStreamClient`, which
+        // handles the same failure class the same way.
+        //
+        // Issue PATHS only. Never `parsed.error` or `envelope.value`: git
+        // frames carry file paths and repository content.
+        const issuePaths = parsed.error.issues
+          .map((issue) =>
+            issue.path.length > 0 ? issue.path.join(".") : "(root)",
+          )
+          .join(", ");
+        console.warn(
+          `[stream] git.subscribeStatus frame failed schema validation (tier=${tier}, issues=[${issuePaths}]); dropping frame`,
+        );
+        return;
+      }
       handleNonceCorrelatedFrame({
         event: parsed.data,
         shared,
@@ -851,6 +894,16 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
   // a pending state forever (the stuck git-diff skeleton incident).
   session.onStatusChange((status, reason) => {
     if (sessionClosed || generation !== shared.sessionGeneration) return;
+    if (status === "open") {
+      // The handshake has settled, so this session finally knows its own minor.
+      // Publishing here is what makes ownership correct BEFORE the first frame.
+      publishNegotiatedVersion(
+        shared,
+        session.getNegotiatedSchemaVersion(),
+        entryKey,
+      );
+      return;
+    }
     if (status === "reconnecting") {
       // A recoverable drop never reaches `"closed"` - `resetForReconnect()`
       // parks the logical session here - so `markTerminal` is not on this

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-subscription.ts
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useMemo,
   useEffect,
   useReducer,
@@ -7,8 +8,12 @@ import {
 } from "react";
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
-import type { StreamCloseReason } from "@traycer-clients/shared/host-transport/i-stream-session";
+import type {
+  IStreamSession,
+  StreamCloseReason,
+} from "@traycer-clients/shared/host-transport/i-stream-session";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import {
   gitSubscribeStatusEventSchema,
@@ -82,6 +87,27 @@ interface SharedSubscription {
    * the panel is showing stale data and the user most wants to know why.
    */
   lastWatcherStatus: GitWatcherStatus | null;
+  /**
+   * The version negotiated by the session that delivered the last frame - NOT
+   * the client-wide value, which describes whichever stream for this method
+   * `reconcileMethodSchemaVersion` reached first and can therefore belong to
+   * another repo entirely.
+   *
+   * `null` before the first frame; readers fall back to the client-wide value
+   * there, which is today's behaviour exactly, so the stamp can only ever
+   * improve on it. The host forces an immediate tick for a new subscriber and
+   * replays its cached snapshot, so that window is one frame wide even on a
+   * repo that never changes.
+   */
+  negotiatedVersion: SchemaVersion | null;
+  /**
+   * The session currently bound to this entry, so a reader with no session of
+   * its own can still ask THE RIGHT ONE rather than the client-wide value.
+   * Preferred over `negotiatedVersion` wherever the caller can sample at will:
+   * it is live, so a renegotiation is visible immediately instead of at the
+   * next delivered frame.
+   */
+  session: IStreamSession | null;
   consumers: Map<symbol, () => void>;
   sessionGeneration: number;
   closeCurrentSession: () => void;
@@ -127,7 +153,7 @@ interface NonceCorrelatedFrameHandlerArgs {
  * entry against the new client.
  */
 const subscriptions = new Map<string, SharedSubscription>();
-const refreshStateListeners = new Map<string, Set<() => void>>();
+const entryListeners = new Map<string, Set<() => void>>();
 
 function subscriptionKeyFor(
   client: IHostStreamClient<HostStreamRpcRegistry>,
@@ -164,41 +190,109 @@ export function __resetSubscriptionsForTesting(): void {
     sub.unsubscribeFromStream();
   }
   subscriptions.clear();
-  refreshStateListeners.clear();
+  entryListeners.clear();
+}
+
+function entryKeyFor(args: GitSubscriptionRefreshStateArgs): string | null {
+  if (
+    args.wsStreamClient === null ||
+    args.hostId === null ||
+    args.runningDir === null
+  ) {
+    return null;
+  }
+  return subscriptionKeyFor(args.wsStreamClient, {
+    hostId: args.hostId,
+    runningDir: args.runningDir,
+    ignoreWhitespace: args.ignoreWhitespace,
+  });
+}
+
+/** `useSyncExternalStore` subscriber for one entry's change channel. */
+function subscribeToEntry(
+  key: string | null,
+): (listener: () => void) => () => void {
+  return (onStoreChange) => {
+    if (key === null) return () => undefined;
+    let listeners = entryListeners.get(key);
+    if (listeners === undefined) {
+      listeners = new Set();
+      entryListeners.set(key, listeners);
+    }
+    listeners.add(onStoreChange);
+    return () => {
+      const current = entryListeners.get(key);
+      if (current === undefined) return;
+      current.delete(onStoreChange);
+      if (current.size === 0) entryListeners.delete(key);
+    };
+  };
 }
 
 /** Shared replacement state for every refresh surface addressing one stream. */
 export function useGitSubscriptionRefreshState(
   args: GitSubscriptionRefreshStateArgs,
 ): boolean {
-  const key =
-    args.wsStreamClient === null ||
-    args.hostId === null ||
-    args.runningDir === null
-      ? null
-      : subscriptionKeyFor(args.wsStreamClient, {
-          hostId: args.hostId,
-          runningDir: args.runningDir,
-          ignoreWhitespace: args.ignoreWhitespace,
-        });
+  const key = entryKeyFor(args);
   return useSyncExternalStore(
-    (onStoreChange) => {
-      if (key === null) return () => undefined;
-      let listeners = refreshStateListeners.get(key);
-      if (listeners === undefined) {
-        listeners = new Set();
-        refreshStateListeners.set(key, listeners);
-      }
-      listeners.add(onStoreChange);
-      return () => {
-        const current = refreshStateListeners.get(key);
-        if (current === undefined) return;
-        current.delete(onStoreChange);
-        if (current.size === 0) refreshStateListeners.delete(key);
-      };
-    },
+    subscribeToEntry(key),
     () =>
       key === null ? false : (subscriptions.get(key)?.isRefreshing ?? false),
+    () => false,
+  );
+}
+
+/**
+ * Whether the stream owns the rich slot FOR THIS REPO - the reactive read the
+ * unary nested-snapshot query disables itself on.
+ *
+ * Worktree-scoped by construction, which is the point. The client-wide
+ * `getMethodSchemaVersion` cannot answer this: with two repos open, repo A
+ * negotiating >= 1.1 would disable repo B's unary query, and if B's own session
+ * is at 1.0 the stream never writes B's rich slot either - leaving that panel
+ * with no writer at all.
+ *
+ * Reactive through the entry's change channel, which delivery notifies when the
+ * stamp moves. Before the first frame this falls back to the client-wide value
+ * (see `entrySchemaVersion`), so a cold mount behaves exactly as it did before
+ * the stamp existed.
+ */
+export function useGitSubscriptionOwnsRichSlot(
+  args: GitSubscriptionRefreshStateArgs,
+): boolean {
+  const key = entryKeyFor(args);
+  const client = args.wsStreamClient;
+  // BOTH signals, deliberately. The entry channel carries the stamp, but the
+  // stamp only lands with the first frame; `subscribeMethodSupport` is what
+  // re-renders when the handshake settles, which is when the fallback value
+  // this hook starts on becomes meaningful. Dropping it would leave the unary
+  // query enabled - and fetching - until the first frame on every mount.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const unsubscribeEntry = subscribeToEntry(key)(onStoreChange);
+      const unsubscribeSupport =
+        client === null
+          ? () => undefined
+          : client.subscribeMethodSupport(onStoreChange);
+      return () => {
+        unsubscribeEntry();
+        unsubscribeSupport();
+      };
+    },
+    [key, client],
+  );
+  return useSyncExternalStore(
+    subscribe,
+    () => {
+      if (client === null) return false;
+      const negotiated = entrySchemaVersion(
+        key === null ? undefined : subscriptions.get(key),
+        client,
+      );
+      return (
+        negotiated !== null && negotiated.major === 1 && negotiated.minor >= 1
+      );
+    },
     () => false,
   );
 }
@@ -218,10 +312,6 @@ export function refreshGitSubscriptionWithFreshNonce(args: {
   if (client === null || args.hostId === null || args.runningDir === null) {
     return null;
   }
-  const version = client.getMethodSchemaVersion("git.subscribeStatus");
-  if (version === null || version.major !== 1 || version.minor < 2) {
-    return null;
-  }
   const subscriptionArgs: ActiveSubscriptionArgs = {
     hostId: args.hostId,
     runningDir: args.runningDir,
@@ -230,6 +320,15 @@ export function refreshGitSubscriptionWithFreshNonce(args: {
   const key = subscriptionKeyFor(client, subscriptionArgs);
   const shared = subscriptions.get(key);
   if (shared === undefined) return null;
+  // The entry is looked up BEFORE the version gate so the gate can read this
+  // stream's own stamp. Asking the client-wide value would let a sibling repo
+  // that negotiated 1.2 authorize a fresh-nonce replacement against a session
+  // that cannot correlate the nonce - and nothing would then settle the refresh
+  // except its 10s timeout.
+  const version = entrySchemaVersion(shared, client);
+  if (version === null || version.major !== 1 || version.minor < 2) {
+    return null;
+  }
   if (shared.refreshPromise !== null) return shared.refreshPromise;
 
   const freshNonce = crypto.randomUUID();
@@ -237,7 +336,7 @@ export function refreshGitSubscriptionWithFreshNonce(args: {
   shared.refreshPromise = new Promise<void>((resolve) => {
     shared.settleRefresh = resolve;
   });
-  notifyRefreshState(key);
+  notifyEntryChanged(key);
   replaceStreamSession({
     shared,
     wsStreamClient: client,
@@ -310,7 +409,7 @@ export function useGitListChangedFilesSubscription(args: {
         activeArgs,
       );
       subscriptions.set(key, shared);
-      notifyRefreshState(key);
+      notifyEntryChanged(key);
     }
 
     // Increment ref count and register local consumer.
@@ -325,12 +424,13 @@ export function useGitListChangedFilesSubscription(args: {
     // to refill it. Slot writes only; per-path diff invalidation is not
     // replayed for a frame that already invalidated on delivery.
     if (shared.lastEvent !== null) {
-      replayLastEventIntoCache(
+      replayLastEventIntoCache({
+        shared,
         wsStreamClient,
         queryClient,
-        activeArgs,
-        shared.lastEvent,
-      );
+        args: activeArgs,
+        event: shared.lastEvent,
+      });
       forceRender();
     }
 
@@ -343,7 +443,7 @@ export function useGitListChangedFilesSubscription(args: {
       if (shared.refCount === 0) {
         shared.unsubscribeFromStream();
         subscriptions.delete(key);
-        notifyRefreshState(key);
+        notifyEntryChanged(key);
       }
     };
   }, [stableArgs, queryClient, wsStreamClient, consumerId]);
@@ -415,6 +515,8 @@ function createSharedSubscription(
     unsubscribeFromStream: () => undefined,
     lastEvent: null,
     lastWatcherStatus: null,
+    negotiatedVersion: null,
+    session: null,
     consumers: new Map(),
     sessionGeneration: 0,
     closeCurrentSession: () => undefined,
@@ -465,66 +567,65 @@ function recordDeliveredFrame(
 }
 
 /**
- * v1.3 parse that DEGRADES to v1.2 instead of dropping the frame.
+ * Which frame shape a negotiated version corresponds to, as one value instead
+ * of a ladder of independent booleans.
  *
- * The tier is chosen from a client-wide, per-method schema version, but the
- * frame arrives on one specific session - and those can disagree while a host
- * restart renegotiates one repo's stream and not another's. A strict v1.3 parse
- * of a genuine v1.2 frame fails on the required `watcher`, and the caller's
- * `return` would then freeze that repo's changes until it reconnects.
- *
- * Degrading is safe in the direction that matters: the v1.2 schema is
- * non-strict, so any v1.3 field present is stripped rather than trusted, and
- * the absent `watcher` is recorded as UNKNOWN - never as healthy.
- */
-function tolerantV13Parse(value: unknown):
-  | {
-      success: true;
-      data: GitSubscribeStatusEventV12 | GitSubscribeStatusEventV13;
-    }
-  | { success: false } {
-  const strict = gitSubscribeStatusEventSchemaV13.safeParse(value);
-  if (strict.success) return { success: true, data: strict.data };
-  // ONLY the version-skew shape gets the fallback: a frame that has no
-  // `watcher` at all. A frame that HAS one and still fails v1.3 is malformed -
-  // an unknown `state`, say - and the v1.2 schema would "rescue" it by
-  // stripping the offending field, quietly recording the watcher as UNKNOWN and
-  // accepting a payload the wire contract rejects. Dropping it is the point of
-  // having the contract. (`git-submodule-compat.test.ts` asserts v1.3 rejects
-  // exactly that.)
-  if (!isFrameMissingWatcher(value)) return { success: false };
-  const relaxed = gitSubscribeStatusEventSchemaV12.safeParse(value);
-  if (relaxed.success) return { success: true, data: relaxed.data };
-  return { success: false };
-}
-
-/**
- * Whether a decoded frame carries no `watcher` key at all - the signature of a
- * peer that negotiated below 1.3, as distinct from one that sent a broken value.
- */
-function isFrameMissingWatcher(value: unknown): boolean {
-  if (typeof value !== "object" || value === null) return false;
-  return !("watcher" in value);
-}
-
-/**
- * Which frame shape this connection negotiated, as one value instead of a
- * ladder of independent booleans.
+ * Callers must source that version from the SESSION that delivered the frame,
+ * never from the client-wide `getMethodSchemaVersion` - with two repos open on
+ * one client the latter can report the sibling stream's minor (see
+ * `IStreamSession.getNegotiatedSchemaVersion`). Parsing repo A's frame at repo
+ * B's minor silently strips fields A's host did send, or demands fields B's
+ * host cannot send.
  *
  * Unknown or non-major-1 collapses to the FROZEN v1.0 tier, which is the only
  * safe default: a client that guessed high would parse with a schema the peer
  * never agreed to and could write fields into the rich slot the host does not
- * own on that connection.
+ * own on that connection. `null` (no handshake yet) takes that same default -
+ * never the client-wide value, which is the skew this function exists to avoid.
  */
-function negotiatedFrameTier(
-  client: IHostStreamClient<HostStreamRpcRegistry>,
+function frameTierOf(
+  negotiated: SchemaVersion | null,
 ): "v13" | "v12" | "rich" | "frozen" {
-  const negotiated = client.getMethodSchemaVersion("git.subscribeStatus");
   if (negotiated === null || negotiated.major !== 1) return "frozen";
   if (negotiated.minor >= 3) return "v13";
   if (negotiated.minor >= 2) return "v12";
   if (negotiated.minor >= 1) return "rich";
   return "frozen";
+}
+
+function sameSchemaVersion(
+  left: SchemaVersion | null,
+  right: SchemaVersion | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return left.major === right.major && left.minor === right.minor;
+}
+
+/**
+ * The version to answer a question about THIS repo's stream with, in falling
+ * order of authority: the live session, the last delivered stamp, the
+ * client-wide value.
+ *
+ * - The LIVE session is exact and needs no frame to become true, so a
+ *   renegotiation is visible the moment it happens.
+ * - The STAMP covers the gap while a session is mid-reconnect and reports
+ *   `null`: ownership genuinely is unknown then, and the last value this
+ *   stream actually delivered under beats thrashing the slot over a blip.
+ * - The CLIENT-WIDE value is the cold-start fallback only. Answering "unknown"
+ *   before anything has negotiated would hand the rich slot back to the unary
+ *   query on every mount - a redundant fetch per panel to close a window the
+ *   handshake closes on its own. It is also exactly what this code read before
+ *   any of this existed, so the fallback cannot regress a cold mount.
+ */
+function entrySchemaVersion(
+  shared: SharedSubscription | undefined,
+  client: IHostStreamClient<HostStreamRpcRegistry>,
+): SchemaVersion | null {
+  const live = shared?.session?.getNegotiatedSchemaVersion() ?? null;
+  if (live !== null) return live;
+  const stamped = shared?.negotiatedVersion ?? null;
+  if (stamped !== null) return stamped;
+  return client.getMethodSchemaVersion("git.subscribeStatus");
 }
 
 function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
@@ -540,6 +641,10 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
   // incarnation, before its first frame lands. `markTerminal` covers the
   // terminal path; this covers replacement, which bypasses it.
   shared.lastWatcherStatus = null;
+  // Same reasoning for the stamped version: it describes the session being
+  // retired. Holding it across the replacement would answer for a session that
+  // is gone, which is the whole failure mode the stamp exists to end.
+  shared.negotiatedVersion = null;
   // Clearing the field is not enough on its own - the render-time value is read
   // through the store snapshot, so without a notify the notice stays on screen
   // until some later frame happens to publish.
@@ -551,10 +656,15 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     ignoreWhitespace: args.ignoreWhitespace,
     freshNonce,
   });
+  shared.session = session;
   let sessionClosed = false;
   shared.closeCurrentSession = () => {
     sessionClosed = true;
     session.close();
+    // Only ever clears the handle it installed: `replaceStreamSession` may
+    // already have swapped a newer session in, and dropping that one would
+    // send every entry-scoped reader back to the client-wide value.
+    if (shared.session === session) shared.session = null;
   };
   const awaitingFreshNonce = { current: freshNonce };
 
@@ -585,8 +695,19 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     // The negotiated version is read AT DELIVERY TIME (never from a
     // render-stale closure): the handshake can settle after the subscribe,
     // and ownership of the rich slot must flip with the version, not with a
-    // React render.
-    const tier = negotiatedFrameTier(wsStreamClient);
+    // React render. It is read off the DELIVERING SESSION, so a sibling repo's
+    // stream sitting at another minor cannot decide how this frame is parsed.
+    const negotiated = session.getNegotiatedSchemaVersion();
+    // Delivery is also where the value gets STAMPED for the readers that have
+    // no session in scope - the fresh-nonce refresh entry point, the replay a
+    // joining consumer triggers, and the rich-slot ownership the submodule hook
+    // renders from. Notifying on change is what makes that last one reactive;
+    // it rides the per-key channel the refresh indicator already listens on.
+    if (!sameSchemaVersion(shared.negotiatedVersion, negotiated)) {
+      shared.negotiatedVersion = negotiated;
+      notifyEntryChanged(subscriptionKeyFor(wsStreamClient, args));
+    }
+    const tier = frameTierOf(negotiated);
     const v13Frames = tier === "v13";
     const v12Frames = tier === "v13" || tier === "v12";
     const richFrames = v12Frames || tier === "rich";
@@ -598,21 +719,20 @@ function replaceStreamSession(opts: ReplaceStreamSessionArgs): void {
     // the negotiated minor is what keeps a v1.3-only field off a connection
     // that negotiated 1.2, independently of the host projecting correctly.
     if (v12Frames) {
-      // `getMethodSchemaVersion` is CLIENT-WIDE per method, not per session:
-      // `reconcileMethodSchemaVersion` rebuilds it from the first still-live
-      // session for that method. Two repo streams on one client can therefore
-      // sit at different minors - a host restart mid-session renegotiates one
-      // and not the other - and this frame's session may be the v1.2 one while
-      // the client-wide value reads v1.3.
+      // STRICT at both minors: `watcher` is required at v1.3, and this session
+      // is the one that agreed to send it, so a v1.3 frame without it is
+      // malformed rather than skewed.
       //
-      // `watcher` is REQUIRED at v1.3, so a strict v1.3-only parse would reject
-      // every frame from that session and `return` would drop it silently:
-      // the repo's changes freeze until it reconnects. Falling back to the v1.2
-      // schema costs nothing and cannot leak - a non-strict zod parse strips
-      // unknown keys, and a frame with no `watcher` is recorded as UNKNOWN
-      // rather than as healthy.
+      // This used to degrade a failed v1.3 parse to the v1.2 schema, because
+      // the tier came from the client-wide version and could belong to a
+      // sibling repo's stream - a genuine v1.2 frame would then fail the v1.3
+      // parse and be dropped, freezing that repo's changes. Reading the
+      // delivering session removes the skew, and with it the only benign reason
+      // that fallback could fire. Keeping it would leave a lenient re-parse
+      // standing in front of the contract for malformed frames alone, which is
+      // exactly the bypass it was already narrowed once to avoid.
       const parsed = v13Frames
-        ? tolerantV13Parse(envelope.value)
+        ? gitSubscribeStatusEventSchemaV13.safeParse(envelope.value)
         : gitSubscribeStatusEventSchemaV12.safeParse(envelope.value);
       if (!parsed.success) return;
       handleNonceCorrelatedFrame({
@@ -751,11 +871,11 @@ function settleSharedRefresh(shared: SharedSubscription, key: string): void {
   if (!shared.isRefreshing && settle === null) return;
   shared.isRefreshing = false;
   settle?.();
-  notifyRefreshState(key);
+  notifyEntryChanged(key);
 }
 
-function notifyRefreshState(key: string): void {
-  for (const listener of refreshStateListeners.get(key) ?? []) listener();
+function notifyEntryChanged(key: string): void {
+  for (const listener of entryListeners.get(key) ?? []) listener();
 }
 
 function notifyConsumers(shared: SharedSubscription): void {
@@ -987,20 +1107,24 @@ function writeRichEventIntoCache(
  * delivery, and an unchanged repo emits no later frame to refill it. The
  * negotiated version is re-read at replay time - a rich event replays into
  * the rich slot only while the stream still owns it.
+ *
+ * OWNERSHIP, not provenance: this asks who writes the rich slot NOW, so it
+ * reads the entry's current stamp rather than any tier recorded on the event
+ * itself. The two questions look alike and must not share a field.
  */
-function replayLastEventIntoCache(
-  wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>,
-  queryClient: QueryClient,
-  args: ActiveSubscriptionArgs,
-  event: GitSubscribeStatusStreamEvent,
-): void {
+function replayLastEventIntoCache(opts: {
+  readonly shared: SharedSubscription;
+  readonly wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>;
+  readonly queryClient: QueryClient;
+  readonly args: ActiveSubscriptionArgs;
+  readonly event: GitSubscribeStatusStreamEvent;
+}): void {
+  const { shared, wsStreamClient, queryClient, args, event } = opts;
   if (event.type === "error") {
     return;
   }
   if ("nestedFingerprint" in event) {
-    const negotiated = wsStreamClient.getMethodSchemaVersion(
-      "git.subscribeStatus",
-    );
+    const negotiated = entrySchemaVersion(shared, wsStreamClient);
     const richOwned =
       negotiated !== null && negotiated.major === 1 && negotiated.minor >= 1;
     writeRichEventIntoCache(queryClient, args, event, {

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { useEffect, useRef } from "react";
 import {
   CancelledError,
   queryOptions,
@@ -23,6 +23,7 @@ import {
   richSlotOrderingKey,
 } from "@/lib/git/git-rich-slot-ordering";
 import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
+import { useGitSubscriptionOwnsRichSlot } from "./use-git-list-changed-files-subscription";
 
 export interface GitListChangedFilesWithSubmodulesResult {
   readonly data: GitListChangedFilesResponseV11 | null;
@@ -208,27 +209,28 @@ function useRichSlotOwnershipTransitions(opts: {
 }
 
 /**
- * Reactive read of whether the `git.subscribeStatus` stream owns the rich
- * slot: negotiated minor >= 1 on major 1. `null`/unknown/minor-0 all mean the
- * unary+timer pair owns it (today's behavior verbatim). Tracked through
- * `subscribeMethodSupport` so a handshake settling (or a host swap changing
- * the negotiated version) re-renders consumers.
+ * Reactive read of whether the `git.subscribeStatus` stream owns the rich slot
+ * FOR THIS REPO: negotiated minor >= 1 on major 1. `null`/unknown/minor-0 all
+ * mean the unary+timer pair owns it (today's behavior verbatim).
+ *
+ * Scoped to this hook's `(hostId, runningDir, ignoreWhitespace)`. It used to
+ * read the client-wide negotiated version with no arguments at all, which
+ * answered for whichever repo's stream reconciliation reached first: repo A at
+ * >= 1.1 disabled repo B's unary query, and a repo B session still at 1.0 never
+ * wrote the rich slot either, leaving that panel with no writer.
  */
-function useStreamOwnsRichSlot(): boolean {
+function useStreamOwnsRichSlot(args: {
+  readonly hostId: string | null;
+  readonly runningDir: string | null;
+  readonly ignoreWhitespace: boolean;
+}): boolean {
   const wsStreamClient = useWsStreamClient();
-  const subscribe = useCallback(
-    (onStoreChange: () => void) =>
-      wsStreamClient === null
-        ? () => undefined
-        : wsStreamClient.subscribeMethodSupport(onStoreChange),
-    [wsStreamClient],
-  );
-  const getSnapshot = useCallback(() => {
-    const version =
-      wsStreamClient?.getMethodSchemaVersion("git.subscribeStatus") ?? null;
-    return version !== null && version.major === 1 && version.minor >= 1;
-  }, [wsStreamClient]);
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useGitSubscriptionOwnsRichSlot({
+    wsStreamClient,
+    hostId: args.hostId,
+    runningDir: args.runningDir,
+    ignoreWhitespace: args.ignoreWhitespace,
+  });
 }
 
 /**
@@ -283,7 +285,11 @@ export function useGitListChangedFilesWithSubmodules(args: {
   const conditionPollCoordinator =
     getConditionPollEpisodeCoordinator(queryClient);
   const wsStreamClient = useWsStreamClient();
-  const streamOwnsRichSlot = useStreamOwnsRichSlot();
+  const streamOwnsRichSlot = useStreamOwnsRichSlot({
+    hostId: args.hostId,
+    runningDir: args.runningDir,
+    ignoreWhitespace: args.ignoreWhitespace,
+  });
 
   const hostId = args.hostId;
   const runningDir = args.runningDir;

--- a/clients/gui-app/src/hooks/pr/__tests__/use-pr-detail-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/pr/__tests__/use-pr-detail-subscription.test.tsx
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -98,6 +99,11 @@ class MockStreamSession implements IStreamSession {
     _binaryPayload: Uint8Array | null,
   ): void {
     this.sentClientFrames.push(envelope);
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {

--- a/clients/gui-app/src/hooks/pr/__tests__/use-pr-list-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/pr/__tests__/use-pr-list-subscription.test.tsx
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -54,6 +55,11 @@ class MockStreamSession implements IStreamSession {
     _binaryPayload: Uint8Array | null,
   ): void {
     this.sentClientFrames.push(envelope);
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {

--- a/clients/gui-app/src/hooks/workspace/__tests__/use-workspace-file-list-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/workspace/__tests__/use-workspace-file-list-subscription.test.tsx
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import "../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
@@ -53,6 +54,11 @@ class MockStreamSession implements IStreamSession {
 
   sendClientFrame(envelope: StreamFrameEnvelope): void {
     this.clientFrames.push(envelope);
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {}

--- a/clients/gui-app/src/lib/registries/__tests__/chat-session-registry.test.tsx
+++ b/clients/gui-app/src/lib/registries/__tests__/chat-session-registry.test.tsx
@@ -133,6 +133,8 @@ function fakeStreamSession(): IStreamSession {
     sendClientFrame: () => undefined,
     onServerFrame: () => undefined,
     onStatusChange: () => undefined,
+    // Never negotiates: this fake exercises no version-dependent path.
+    getNegotiatedSchemaVersion: () => null,
     requestReconnect: () => undefined,
     close: () => undefined,
   };

--- a/clients/gui-app/src/lib/registries/__tests__/terminal-session-registry.test.tsx
+++ b/clients/gui-app/src/lib/registries/__tests__/terminal-session-registry.test.tsx
@@ -122,6 +122,8 @@ function fakeStreamSession(): IStreamSession {
     sendClientFrame: () => undefined,
     onServerFrame: () => undefined,
     onStatusChange: () => undefined,
+    // Never negotiates: this fake exercises no version-dependent path.
+    getNegotiatedSchemaVersion: () => null,
     requestReconnect: () => undefined,
     close: () => undefined,
   };

--- a/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import "../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
@@ -278,6 +279,11 @@ class MockStreamSession implements IStreamSession {
 
   onStatusChange(handler: StatusChangeHandler): void {
     this.statusChangeHandler = handler;
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -158,6 +158,17 @@ class ProtocolMockStreamSession implements IStreamSession {
     // Protocol-chain tests only need status + schema version, not outbound frames.
   }
 
+  /**
+   * The version THIS session negotiated - what `ChatStreamClient` reads to gate
+   * steering. Set by the owning mock client; every chat tab is its own session,
+   * so the gate must not be answerable from a client-wide value.
+   */
+  negotiatedSchemaVersion: SchemaVersion | null = null;
+
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return this.negotiatedSchemaVersion;
+  }
+
   requestReconnect(): void {
     // No-op: reconnect is owned by the real StreamSession.
   }
@@ -202,6 +213,7 @@ class ProtocolMockWsStreamClient extends WsStreamClient<HostStreamRpcRegistry> {
       maxBackoffMs: 1_000,
     });
     this.negotiatedVersion = negotiatedVersion;
+    this.session.negotiatedSchemaVersion = negotiatedVersion;
   }
 
   override subscribe<Method extends keyof HostStreamRpcRegistry & string>(

--- a/clients/gui-app/src/stores/notifications/__tests__/cloud-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/cloud-notifications-store.test.ts
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   IStreamSession,
@@ -84,6 +85,11 @@ class ControlledSession implements IStreamSession {
 
   onStatusChange(handler: StatusChangeHandler): void {
     this.statusChangeHandler = handler;
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {}

--- a/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hostStreamRpcRegistry,
@@ -149,6 +150,11 @@ class MockStreamSession implements IStreamSession {
 
   onStatusChange(handler: StatusChangeHandler): void {
     this.statusChangeHandler = handler;
+  }
+
+  /** Never negotiates: this fake exercises no version-dependent path. */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return null;
   }
 
   requestReconnect(): void {

--- a/clients/shared/host-transport/__tests__/agent-activity-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/agent-activity-stream-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import type {
   IStreamSession,
   ServerFrameHandler,
@@ -12,6 +13,8 @@ import { WsStreamClient } from "../ws-stream-client";
 class StubSession implements IStreamSession {
   private serverFrameHandler: ServerFrameHandler = () => undefined;
   private statusChangeHandler: StatusChangeHandler = () => undefined;
+  /** Settable so a test can model this session's own negotiated minor. */
+  negotiatedSchemaVersion: SchemaVersion | null = null;
 
   readonly close = vi.fn();
 
@@ -23,6 +26,10 @@ class StubSession implements IStreamSession {
 
   onStatusChange(handler: StatusChangeHandler): void {
     this.statusChangeHandler = handler;
+  }
+
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return this.negotiatedSchemaVersion;
   }
 
   requestReconnect(): void {}

--- a/clients/shared/host-transport/chat-stream-client.ts
+++ b/clients/shared/host-transport/chat-stream-client.ts
@@ -139,12 +139,10 @@ export interface ChatStreamClientOptions {
 export class ChatStreamClient {
   private readonly session: IStreamSession;
   private readonly callbacks: ChatStreamCallbacks;
-  private readonly wsStreamClient: IStreamClient<HostStreamRpcRegistry>;
   private closed: boolean;
 
   constructor(options: ChatStreamClientOptions) {
     this.callbacks = options.callbacks;
-    this.wsStreamClient = options.wsStreamClient;
     this.closed = false;
     this.session = options.wsStreamClient.subscribe("chat.subscribe", {
       epicId: options.epicId,
@@ -173,8 +171,14 @@ export class ChatStreamClient {
    * `TerminalStreamClient`'s per-frame version read.
    */
   sameTurnSteeringProtocolSupported(): boolean {
-    const version =
-      this.wsStreamClient.getMethodSchemaVersion("chat.subscribe");
+    // THIS session's negotiated version, not the client-wide one. Every open
+    // chat tab is its own `chat.subscribe` session, and the client-wide
+    // accessor reports whichever of them reconciliation reached first - so a
+    // tab talking to a <=1.4 host could be told steering is supported because a
+    // sibling tab negotiated 1.5. That gates a SEND, not a parse: the message
+    // would be injected into a host that predates the ordering policy, which is
+    // the exact failure this guard exists to prevent.
+    const version = this.session.getNegotiatedSchemaVersion();
     return version !== null && version.major === 1 && version.minor >= 5;
   }
 

--- a/clients/shared/host-transport/i-stream-session.ts
+++ b/clients/shared/host-transport/i-stream-session.ts
@@ -1,3 +1,4 @@
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
 
 /**
@@ -102,6 +103,28 @@ export interface IStreamSession {
    * the session has already been closed.
    */
   requestReconnect(): void;
+
+  /**
+   * The schema version THIS session negotiated for its method, or `null` before
+   * the handshake has settled (and again after a disconnect drops it).
+   *
+   * Takes no method argument: a session is bound to one streaming method for
+   * life, so the method is already implied.
+   *
+   * Prefer this over `IHostStreamClient.getMethodSchemaVersion(method)`
+   * ANYWHERE a specific session's frames are being parsed, gated, or sent. That
+   * accessor is client-wide per method: `reconcileMethodSchemaVersion` reports
+   * whichever live session for the method it reaches first, so with two streams
+   * open on one client - two repos, two chat tabs - it can describe the OTHER
+   * one. The skew is not exotic; a reconnect may reach a new host incarnation
+   * and renegotiate one session while its sibling keeps the version it had.
+   *
+   * `null` must be treated as "not yet known", never as a floor or a ceiling:
+   * fall back to the same conservative default the caller would use before any
+   * handshake, and never to the client-wide value - that reintroduces exactly
+   * the skew this exists to remove.
+   */
+  getNegotiatedSchemaVersion(): SchemaVersion | null;
 
   /**
    * Tears down the session: cancels any pending reconnect backoff, closes

--- a/clients/shared/host-transport/remote/__tests__/logical-stream.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/logical-stream.test.ts
@@ -86,4 +86,39 @@ describe("LogicalStream", () => {
     stream.requestReconnect();
     expect(reconnectReasons).toHaveLength(1);
   });
+
+  // The constructor is seeded with a PROVISIONAL client-canonical version
+  // (`RemoteSession.subscribe` opens the stream before the host manifest can be
+  // consulted). Reporting that as negotiated would tell consumers the host
+  // agreed to a version it has never seen - and they parse frames against it.
+  it("reports no negotiated version until the session has opened it", () => {
+    const stream = createStream([], []);
+    expect(stream.getNegotiatedSchemaVersion()).toBeNull();
+    // ...even though a provisional version is already in hand.
+    expect(stream.currentSchemaVersion()).toEqual({ major: 1, minor: 0 });
+
+    stream.updateSchemaVersion({ major: 1, minor: 4 });
+    expect(stream.getNegotiatedSchemaVersion()).toEqual({
+      major: 1,
+      minor: 4,
+    });
+  });
+
+  // A negotiated version belongs to the connection that negotiated it. Holding
+  // it across a drop would let a consumer parse the first post-resume frame at
+  // the OLD host incarnation's minor, before the resume has re-established one.
+  it("drops the negotiated version when the connection goes away", () => {
+    const stream = createStream([], []);
+    stream.updateSchemaVersion({ major: 1, minor: 4 });
+
+    stream.notifyStatus("reconnecting", null);
+    expect(stream.getNegotiatedSchemaVersion()).toBeNull();
+
+    // The resume re-establishes it; nothing else does.
+    stream.updateSchemaVersion({ major: 1, minor: 2 });
+    expect(stream.getNegotiatedSchemaVersion()).toEqual({
+      major: 1,
+      minor: 2,
+    });
+  });
 });

--- a/clients/shared/host-transport/remote/logical-stream.ts
+++ b/clients/shared/host-transport/remote/logical-stream.ts
@@ -62,6 +62,17 @@ export class LogicalStream implements IStreamSession {
   readonly params: unknown;
   readonly qos: QosClassValue;
   private schemaVersion: SchemaVersion;
+  /**
+   * Whether `schemaVersion` has survived a real negotiation against the host
+   * manifest, as opposed to the PROVISIONAL client-canonical value the
+   * constructor is seeded with (`RemoteSession.subscribe` opens the stream
+   * before the host's manifest can be consulted).
+   *
+   * `getNegotiatedSchemaVersion` is gated on this: reporting the provisional
+   * value would claim a version the host never agreed to, which is precisely
+   * the "guessed high" failure the consumers of that value parse against.
+   */
+  private negotiated = false;
   private readonly port: LogicalStreamPort;
 
   private serverFrameHandler: ServerFrameHandler | null = null;
@@ -130,6 +141,17 @@ export class LogicalStream implements IStreamSession {
   /** Updated by the session when a resume renegotiates the version. */
   updateSchemaVersion(version: SchemaVersion): void {
     this.schemaVersion = version;
+    this.negotiated = true;
+  }
+
+  /**
+   * `IStreamSession.getNegotiatedSchemaVersion`. `null` until the session has
+   * actually opened this stream against the host manifest, and `null` again
+   * from the moment the connection drops - mirroring the local
+   * `StreamSession`, which clears its own value in `resetForReconnect`.
+   */
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return this.negotiated ? this.schemaVersion : null;
   }
 
   isDisposed(): boolean {
@@ -163,6 +185,12 @@ export class LogicalStream implements IStreamSession {
     }
     if (status === "closed") {
       this.disposed = true;
+    }
+    if (status !== "open") {
+      // The negotiated version belongs to the connection that negotiated it. A
+      // resume re-runs `openSubscription`, which re-establishes it; until then
+      // this stream has no agreed version, exactly as before its first open.
+      this.negotiated = false;
     }
     this.transition(status, reason);
   }

--- a/clients/shared/host-transport/terminal-stream-client.ts
+++ b/clients/shared/host-transport/terminal-stream-client.ts
@@ -94,12 +94,10 @@ export interface TerminalStreamClientOptions {
  */
 export class TerminalStreamClient {
   private readonly session: IStreamSession;
-  private readonly wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>;
   private readonly callbacks: TerminalStreamCallbacks;
   private closed: boolean;
 
   constructor(options: TerminalStreamClientOptions) {
-    this.wsStreamClient = options.wsStreamClient;
     this.callbacks = options.callbacks;
     this.closed = false;
     this.session = options.wsStreamClient.subscribe("terminal.subscribe", {
@@ -130,8 +128,12 @@ export class TerminalStreamClient {
     envelope: StreamFrameEnvelope,
     binaryPayload: Uint8Array | null,
   ): void {
-    const version =
-      this.wsStreamClient.getMethodSchemaVersion("terminal.subscribe");
+    // THIS session's negotiated version: each terminal tab is its own
+    // `terminal.subscribe` session, and the client-wide accessor answers for
+    // whichever one reconciliation reached first. Parsing a frame at a sibling
+    // tab's minor either strips fields this host did send or demands fields it
+    // cannot.
+    const version = this.session.getNegotiatedSchemaVersion();
     const parsed =
       version !== null && version.major === 1 && version.minor >= 5
         ? terminalSubscribeServerFrameSchemaV15.safeParse(envelope)

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -141,6 +141,9 @@ function createInertStreamSession(closedReason: string): IStreamSession {
   return {
     sendClientFrame: () => undefined,
     onServerFrame: () => undefined,
+    // Never handshook, so it has no negotiated version - consumers take the
+    // same conservative default they use before any session settles.
+    getNegotiatedSchemaVersion: () => null,
     onStatusChange: (handler) => {
       statusHandler = handler;
       if (emissionScheduled) {


### PR DESCRIPTION
## Problem

`IHostStreamClient.getMethodSchemaVersion(method)` is **client-wide per method**. `reconcileMethodSchemaVersion` walks the owned sessions, takes the *first* one carrying a version for that method, and `break`s — every other live session for the same method is invisible to it.

Two repos open on one host are two `git.subscribeStatus` sessions on one client. Two chat tabs are two `chat.subscribe` sessions. A reconnect may reach a new host incarnation and renegotiate one while its sibling keeps the version it had — `resetMethodSupport` already documents exactly this ("negotiated schema versions belong to individual live sessions"). Nothing exposed them, so every consumer asking about one specific stream was reading whichever stream reconciliation happened to reach first.

## What that actually broke

| Site | Failure |
|---|---|
| `useStreamOwnsRichSlot` | Took **no arguments** while its caller is worktree-scoped. Repo A at ≥1.1 disabled repo B's unary query; with B's own session at 1.0 the stream never wrote B's rich slot either — **that panel had no writer at all.** |
| git frame parsing | A v1.3 frame on a 1.3 session was parsed with the v1.2 schema whenever a sibling held the client-wide value at 1.2, silently stripping `watcher`. The degrade notice never appeared while the panel claimed live updates. |
| `sameTurnSteeringProtocolSupported` | Gated a **send**, not a parse. One chat tab could steer into a ≤1.4 host because a sibling tab negotiated 1.5 — the exact injection the guard exists to prevent. |

## Approach

Adds `IStreamSession.getNegotiatedSchemaVersion()` and routes per-stream readers through it.

Readers with no session in scope (the fresh-nonce refresh gate, the replay a joining consumer triggers, the render-time ownership read) go through the shared entry in falling order of authority: **live session → version stamped at delivery → client-wide value**. That last step is what this code read before, so a cold mount cannot regress.

`tolerantV13Parse` is removed *with its cause*. It degraded a failed v1.3 parse to v1.2 because the tier could belong to another repo's stream; reading the delivering session removes the only benign reason it could fire, and a fallback that can only fire for malformed frames is a bypass of the contract it sits behind. A watcher-less frame on a session that itself negotiated 1.3 is now dropped, with a test.

## Note for reviewers

`LogicalStream` reports its real per-stream version instead of `null`, so **stream frames over a remote host stop being frozen at the v1.0 tier**. That is a behaviour change beyond the stated defect and is called out deliberately rather than left to be discovered. It is seeded with a *provisional* client-canonical version before the host manifest is consulted, so the accessor returns `null` until `updateSchemaVersion` has run and again after a drop — reporting the provisional value would claim a version the host never agreed to.

`RemoteStreamClient.getMethodSchemaVersion` still returns `null`; making the *client-wide* accessor work for remote hosts needs the mux to carry per-method negotiation, which is separate work.

## Verification

- gui-app **10778 pass**, shared **877 pass**, compile clean across 5 projects.
- The two-session discriminator test was **written first and failed** with the watcher stripped to `null` before any fix landed.
- Mutation-probed: reverting the entry scoping fails only the rich-slot ownership test; reporting the provisional version fails both `LogicalStream` tests.
