### PR TITLE
fix(traycer-cli): distinguish supervisor markers from raw host output

### DIFF
--- a/clients/traycer-cli/src/host/__tests__/bootstrap-log.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/bootstrap-log.test.ts
@@ -221,6 +221,41 @@ describe("bootstrap-log writer identity", () => {
     expect(entries.some((e) => e.phase === "starting")).toBe(false);
   });
 
+  it("keeps the previous CLI's crash markers across an upgrade", async () => {
+    // The ordinary upgrade path: an old CLI recorded a real crash, the user
+    // upgrades, and the next start stamps a marker into the SAME log. A
+    // whole-file rule would let that stamped marker retroactively delete
+    // the older crash - on every upgrade, not in some rare corner.
+    await appendFile(
+      mocks.logPath,
+      "[2026-01-01T00:00:00.000Z] phase=crashed code=139\n",
+    );
+    await writeBootstrapMarker("production", "starting", NO_FIELDS);
+
+    const entries = await readBootstrapMarkers("production", 10);
+    expect(entries.map((e) => e.phase)).toEqual(["crashed", "starting"]);
+    expect(entries[0]?.writer).toBe("unverified");
+    expect(entries[1]?.writer).toBe("supervisor");
+  });
+
+  it("still rejects mimicry that arrives after the first stamped marker", async () => {
+    // The other side of the same boundary: preserving the leading legacy
+    // block must not re-admit host output that lands AFTER the writer has
+    // proven it stamps its markers.
+    await appendFile(
+      mocks.logPath,
+      "[2026-01-01T00:00:00.000Z] phase=crashed code=139\n",
+    );
+    await writeBootstrapMarker("production", "starting", NO_FIELDS);
+    await appendFile(
+      mocks.logPath,
+      "[2026-01-01T00:00:09.000Z] phase=exited code=0\n",
+    );
+
+    const entries = await readBootstrapMarkers("production", 10);
+    expect(entries.map((e) => e.phase)).toEqual(["crashed", "starting"]);
+  });
+
   it("keeps every marker in a log no verified writer has touched", async () => {
     // N-1: an older CLI stamped nothing, so strictness here would blind
     // Doctor to a crash it genuinely recorded. Byte-identical to the old

--- a/clients/traycer-cli/src/host/__tests__/bootstrap-log.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/bootstrap-log.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { appendFile, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,9 +19,26 @@ vi.mock("../../store/paths", () => ({
 
 const {
   parseBootstrapLogLine,
+  writeBootstrapMarker,
   writeBootstrapTerminalMarker,
   readBootstrapMarkers,
+  retainAuthenticMarkers,
+  markersIdentifyWriter,
 } = await import("../bootstrap-log");
+
+const NO_FIELDS = {
+  shell: undefined,
+  args: undefined,
+  bundle: undefined,
+  exitCode: undefined,
+  signal: undefined,
+  error: undefined,
+  exitMeaning: undefined,
+  report: undefined,
+  stderrTail: undefined,
+  attemptId: undefined,
+  supervisorPid: undefined,
+} as const;
 
 describe("bootstrap-log crash diagnostic fields", () => {
   let root: string;
@@ -142,5 +159,115 @@ describe("bootstrap-log crash diagnostic fields", () => {
     expect(entries[0]?.fields.exitMeaning).toContain("0xC0000005");
     expect(entries[0]?.fields.report).toBe("r.json");
     expect(entries[0]?.fields.stderrTail).toBe("segv");
+  });
+});
+
+// `host.log` is both the marker destination and the child's stderr sink, so
+// a host line shaped like a marker used to parse as one. See the writer-field
+// contract at the top of `bootstrap-log.ts`.
+describe("bootstrap-log writer identity", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "traycer-bootstrap-writer-"));
+    mocks.homeDir = root;
+    mocks.logPath = join(root, "host.log");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("stamps writer=supervisor from BOTH writers", async () => {
+    // Both paths must stamp it: the guarantee is "every marker carries it",
+    // and one unstamped writer would mint markers its own parser rejects.
+    await writeBootstrapMarker("production", "starting", NO_FIELDS);
+    writeBootstrapTerminalMarker("production", "crashed", NO_FIELDS);
+
+    const lines = (await readFile(mocks.logPath, "utf8"))
+      .split(/\r?\n/)
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(line).toContain("writer=supervisor");
+      expect(parseBootstrapLogLine(line)?.writer).toBe("supervisor");
+    }
+  });
+
+  it("labels a marker-shaped line with no writer field as unverified", () => {
+    const forged = "[2026-01-01T00:00:00.000Z] phase=starting";
+    expect(parseBootstrapLogLine(forged)?.writer).toBe("unverified");
+    // Still parsed, not dropped - one line cannot tell an older CLI's
+    // marker from host output wearing the grammar.
+    expect(parseBootstrapLogLine(forged)?.phase).toBe("starting");
+  });
+
+  it("drops host output that mimics a marker once the writer is identified", async () => {
+    // The reported defect: this `starting` line is the host's own stderr,
+    // and Doctor's `lastCrashMarker` treats a later `starting` as proof the
+    // host recovered - so it cancelled a real crash and reported clean.
+    writeBootstrapTerminalMarker("production", "crashed", {
+      ...NO_FIELDS,
+      exitCode: 134,
+    });
+    await appendFile(
+      mocks.logPath,
+      "[2026-01-01T00:00:00.000Z] phase=starting\n",
+    );
+
+    const entries = await readBootstrapMarkers("production", 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.phase).toBe("crashed");
+    expect(entries.some((e) => e.phase === "starting")).toBe(false);
+  });
+
+  it("keeps every marker in a log no verified writer has touched", async () => {
+    // N-1: an older CLI stamped nothing, so strictness here would blind
+    // Doctor to a crash it genuinely recorded. Byte-identical to the old
+    // behaviour, including the `starting` that cancels the crash.
+    await appendFile(
+      mocks.logPath,
+      "[2026-01-01T00:00:00.000Z] phase=crashed code=7\n" +
+        "[2026-01-01T00:00:01.000Z] phase=starting\n",
+    );
+
+    const entries = await readBootstrapMarkers("production", 10);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.phase)).toEqual(["crashed", "starting"]);
+    expect(entries.every((e) => e.writer === "unverified")).toBe(true);
+  });
+
+  it("decides the era from the whole file, not the requested tail", async () => {
+    // Latch-then-slice. Slicing first would judge the era from the last N
+    // lines, so a burst of mimicking output at the end of an upgraded log
+    // would read as legacy and be trusted.
+    writeBootstrapTerminalMarker("production", "crashed", {
+      ...NO_FIELDS,
+      exitCode: 9,
+    });
+    await appendFile(
+      mocks.logPath,
+      "[2026-01-01T00:00:01.000Z] phase=starting\n" +
+        "[2026-01-01T00:00:02.000Z] phase=starting\n",
+    );
+
+    const entries = await readBootstrapMarkers("production", 2);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.phase).toBe("crashed");
+  });
+
+  it("keeps nothing when a capped window drops the verified marker", () => {
+    // Capability is monotonic, so `retainAuthenticMarkers` takes the bit
+    // rather than re-deriving it: a caller holding a truncated window that
+    // no longer contains the verified marker must stay strict.
+    const unverifiedOnly = [
+      "[2026-01-01T00:00:01.000Z] phase=starting",
+      "[2026-01-01T00:00:02.000Z] phase=starting",
+    ].map((line) => parseBootstrapLogLine(line)!);
+
+    expect(markersIdentifyWriter(unverifiedOnly)).toBe(false);
+    // Re-deriving the bit here would return both lines - the reopened hole.
+    expect(retainAuthenticMarkers(unverifiedOnly, true)).toHaveLength(0);
+    expect(retainAuthenticMarkers(unverifiedOnly, false)).toHaveLength(2);
   });
 });

--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -405,6 +405,53 @@ describe("spawn-evidence substrate", () => {
       expect(await reader.read()).toHaveLength(0);
     });
 
+    it("reads the era from the whole file, not just the post-baseline slice", async () => {
+      // The verified marker sits BEFORE the baseline - a service-managed
+      // start writes no CLI marker for this attempt. Deciding the era from
+      // the slice alone would call this log legacy and promote the host's
+      // stderr line to `starting-marker` evidence.
+      await writeFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=exited code=0 writer=supervisor\n",
+        "utf8",
+      );
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:05.000Z] phase=starting\n",
+      );
+
+      expect(await readPostBaselineMarkers(baseline)).toHaveLength(0);
+      const evidence = await collectSpawnEvidence(
+        {
+          log: baseline,
+          pidMetadata: await capturePidMetadataBaseline(
+            mocks.pidPath,
+            "production",
+          ),
+        },
+        "production",
+      );
+      expect(evidence?.kind).not.toBe("starting-marker");
+    });
+
+    it("seeds the incremental reader's era from the pre-baseline region", async () => {
+      await writeFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=exited code=0 writer=supervisor\n",
+        "utf8",
+      );
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      const reader = createPostBaselineMarkerReader(baseline);
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:05.000Z] phase=starting\n",
+      );
+
+      // Reading only forward would never see the verified marker.
+      expect(await reader.read()).toHaveLength(0);
+    });
+
     it("demotes earlier unverified lines when a verified marker arrives later", async () => {
       const baseline = await captureLogFileBaseline(mocks.logPath);
       const reader = createPostBaselineMarkerReader(baseline);

--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -381,7 +381,7 @@ describe("spawn-evidence substrate", () => {
   // written against the constant would follow a rename that silently broke
   // every log written before it.
   describe("writer identity across incremental reads", () => {
-    it("stays strict after the cap evicts the verified marker", async () => {
+    it("rejects a marker-shaped burst without losing the stamped marker", async () => {
       const baseline = await captureLogFileBaseline(mocks.logPath);
       const reader = createPostBaselineMarkerReader(baseline);
 
@@ -391,10 +391,10 @@ describe("spawn-evidence substrate", () => {
       );
       expect(await reader.read()).toHaveLength(1);
 
-      // The host now emits a burst of marker-shaped output - more than the
-      // reader's 64-entry buffer, so the one verified marker is evicted.
-      // Re-deriving the era from the retained window would find no verified
-      // line, fall back to legacy, and hand back all 64 forgeries.
+      // A burst of marker-shaped host output, larger than the reader's
+      // window. None of it may be trusted, and it must not displace the
+      // real marker either - filtering happens before the cap, so the
+      // burst never occupies the window in the first place.
       const burst = Array.from(
         { length: 70 },
         (_unused, i) =>
@@ -402,7 +402,9 @@ describe("spawn-evidence substrate", () => {
       ).join("\n");
       await appendFile(mocks.logPath, `${burst}\n`);
 
-      expect(await reader.read()).toHaveLength(0);
+      const markers = await reader.read();
+      expect(markers).toHaveLength(1);
+      expect(markers[0]?.phase).toBe("crashed");
     });
 
     it("reads the era from the whole file, not just the post-baseline slice", async () => {
@@ -450,6 +452,57 @@ describe("spawn-evidence substrate", () => {
 
       // Reading only forward would never see the verified marker.
       expect(await reader.read()).toHaveLength(0);
+    });
+
+    it("does not let raw output evict an authentic marker from the window", async () => {
+      // `runTaskAndVerifyStart` polls this reader and gives up if no marker
+      // appears. Capping before filtering would let a burst of marker-shaped
+      // host output push the real terminal marker out of the window, so a
+      // spawn that DID leave evidence reports none and the verifier times out.
+      await writeFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=exited code=0 writer=supervisor\n",
+        "utf8",
+      );
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      const reader = createPostBaselineMarkerReader(baseline);
+
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:01:00.000Z] phase=crashed code=134 writer=supervisor\n",
+      );
+      expect(await reader.read()).toHaveLength(1);
+
+      const burst = Array.from(
+        { length: 200 },
+        (_unused, i) =>
+          `[2026-01-01T00:02:${String(i % 60).padStart(2, "0")}.000Z] phase=starting`,
+      ).join("\n");
+      await appendFile(mocks.logPath, `${burst}\n`);
+
+      const markers = await reader.read();
+      expect(markers).toHaveLength(1);
+      expect(markers[0]?.phase).toBe("crashed");
+      expect(findPostBaselineTerminalMarker(markers)?.phase).toBe("crashed");
+    });
+
+    it("scans a pre-baseline region larger than one chunk without buffering it whole", async () => {
+      // The prefix is streamed in 64KiB chunks, so a stamped marker beyond
+      // the first chunk must still be found - and a marker split across a
+      // chunk boundary must not be missed.
+      const filler = `${"x".repeat(120)}\n`.repeat(2000); // ~240KB, > 3 chunks
+      await writeFile(
+        mocks.logPath,
+        `${filler}[2026-01-01T00:00:00.000Z] phase=exited code=0 writer=supervisor\n${filler}`,
+        "utf8",
+      );
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:05.000Z] phase=starting\n",
+      );
+
+      expect(await readPostBaselineMarkers(baseline)).toHaveLength(0);
     });
 
     it("keeps pre-boundary lines but rejects what follows the first stamped marker", async () => {

--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -452,7 +452,7 @@ describe("spawn-evidence substrate", () => {
       expect(await reader.read()).toHaveLength(0);
     });
 
-    it("demotes earlier unverified lines when a verified marker arrives later", async () => {
+    it("keeps pre-boundary lines but rejects what follows the first stamped marker", async () => {
       const baseline = await captureLogFileBaseline(mocks.logPath);
       const reader = createPostBaselineMarkerReader(baseline);
 
@@ -460,18 +460,22 @@ describe("spawn-evidence substrate", () => {
         mocks.logPath,
         "[2026-01-01T00:00:00.000Z] phase=starting\n",
       );
-      // Nothing has identified a writer yet, so this reads as legacy.
+      // Nothing has stamped yet, so this may be the previous CLI's marker.
       expect(await reader.read()).toHaveLength(1);
 
       await appendFile(
         mocks.logPath,
-        "[2026-01-01T00:00:01.000Z] phase=crashed code=9 writer=supervisor\n",
+        "[2026-01-01T00:00:01.000Z] phase=crashed code=9 writer=supervisor\n" +
+          "[2026-01-01T00:00:02.000Z] phase=starting\n",
       );
-      // The verified marker proves the writer stamps its lines, which
-      // retroactively reclassifies the earlier one as host output.
+
+      // The first line stays - it precedes the boundary, so demoting it
+      // would delete a genuine older marker on every upgrade. The third
+      // does not: it arrives after the writer proved it stamps.
       const markers = await reader.read();
-      expect(markers).toHaveLength(1);
-      expect(markers[0]?.phase).toBe("crashed");
+      expect(markers.map((m) => m.phase)).toEqual(["starting", "crashed"]);
+      expect(markers[0]?.writer).toBe("unverified");
+      expect(markers[1]?.writer).toBe("supervisor");
     });
   });
 

--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -1,4 +1,5 @@
 import {
+  appendFile,
   mkdtemp,
   open,
   rename,
@@ -372,6 +373,58 @@ describe("spawn-evidence substrate", () => {
       expect(findPostBaselineTerminalMarker(markers)?.phase).toBe(
         "failed-to-spawn",
       );
+    });
+  });
+
+  // Literal `writer=supervisor` throughout rather than the exported
+  // constant: these fixtures stand in for bytes already on disk, and a test
+  // written against the constant would follow a rename that silently broke
+  // every log written before it.
+  describe("writer identity across incremental reads", () => {
+    it("stays strict after the cap evicts the verified marker", async () => {
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      const reader = createPostBaselineMarkerReader(baseline);
+
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=crashed code=134 writer=supervisor\n",
+      );
+      expect(await reader.read()).toHaveLength(1);
+
+      // The host now emits a burst of marker-shaped output - more than the
+      // reader's 64-entry buffer, so the one verified marker is evicted.
+      // Re-deriving the era from the retained window would find no verified
+      // line, fall back to legacy, and hand back all 64 forgeries.
+      const burst = Array.from(
+        { length: 70 },
+        (_unused, i) =>
+          `[2026-01-01T00:01:${String(i % 60).padStart(2, "0")}.000Z] phase=starting`,
+      ).join("\n");
+      await appendFile(mocks.logPath, `${burst}\n`);
+
+      expect(await reader.read()).toHaveLength(0);
+    });
+
+    it("demotes earlier unverified lines when a verified marker arrives later", async () => {
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      const reader = createPostBaselineMarkerReader(baseline);
+
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=starting\n",
+      );
+      // Nothing has identified a writer yet, so this reads as legacy.
+      expect(await reader.read()).toHaveLength(1);
+
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:01.000Z] phase=crashed code=9 writer=supervisor\n",
+      );
+      // The verified marker proves the writer stamps its lines, which
+      // retroactively reclassifies the earlier one as host output.
+      const markers = await reader.read();
+      expect(markers).toHaveLength(1);
+      expect(markers[0]?.phase).toBe("crashed");
     });
   });
 

--- a/clients/traycer-cli/src/host/bootstrap-log.ts
+++ b/clients/traycer-cli/src/host/bootstrap-log.ts
@@ -13,11 +13,54 @@ import {
 const openRawFd = promisify(openCallback);
 
 // Bootstrap-log line format (contract shared with the host writer):
-//   [<iso-timestamp>] phase=<name> key=value key=value …
+//   [<iso-timestamp>] phase=<name> key=value key=value … writer=supervisor
 // Values containing whitespace or quotes are wrapped in double quotes with
 // inner quotes doubled. The renderer's failure card and `traycer host
 // status` both parse these markers; raw stdout/stderr lines from the shell
 // and host are also captured in the same file and pass through as-is.
+//
+// ## Why markers carry a writer field
+//
+// `host.log` is BOTH the marker destination and the child's stderr sink -
+// the supervisor spawns with `stdio: ["ignore", logFd, logFd]`, and the
+// host's own logger appends to the same path. So any line the host prints
+// that happens to start `[<iso>] phase=<name>` used to parse as a marker
+// indistinguishable from one the supervisor wrote. That is not theoretical
+// bookkeeping: consumers treat markers as authority (`spawn-evidence`,
+// `host-status`, Doctor's `RECENT_CRASH_MARKERS`, and gui-app's bootstrap
+// attempt summary), and a stray `phase=starting` line cancels a real crash
+// signal in Doctor's `lastCrashMarker` scan - a crashed host reporting
+// clean. Every marker therefore ends with `writer=supervisor`, emitted by
+// {@link formatMarkerLine} for every writer, never by a caller.
+//
+// **What this does and does not defend against.** The host can write to
+// this file, so it could copy any token we put in the line. This is not a
+// security boundary and no in-band field could make it one - the fix for
+// that is separate sinks (see `host-log-rotation.ts`, which already scopes
+// that out). What it does close is ACCIDENTAL collision, which is the real
+// exposure: one refactor that starts a host log message with `phase=` is
+// enough today.
+//
+// ## N-1 overlap: strictness is latched on the file's own evidence
+//
+// Markers written by an older CLI carry no `writer` field, and they persist
+// in `host.log` across restarts until rotation. Dropping unverified lines
+// unconditionally would blind Doctor to a genuine crash recorded by the
+// previous version; trusting them unconditionally leaves the hole open. So
+// {@link retainAuthenticMarkers} decides per file:
+//
+//   - the file contains NO verified marker -> legacy era, the writer is not
+//     yet capable of identifying itself, so every marker-shaped line is kept
+//     (byte-identical behaviour to before this change);
+//   - the file contains ANY verified marker -> the writer demonstrably emits
+//     the field, so an unverified marker-shaped line in that same file did
+//     not come from it, and is raw output.
+//
+// Known limitation, accepted deliberately: if an OLDER CLI writes markers
+// into a log that already holds newer ones (a downgrade, or a stale binary
+// earlier on PATH), the latch reads those as raw output and Doctor loses
+// them. That is rarer than the collision it closes, and fails in the same
+// direction - under-reporting - rather than inventing a crash.
 
 export type BootstrapPhase =
   "starting" | "exited" | "crashed" | "killed" | "failed-to-spawn";
@@ -56,10 +99,29 @@ export interface BootstrapMarkerFields {
   readonly supervisorPid: number | undefined;
 }
 
+// The key/value that identify a line as supervisor-written. Deliberately
+// NOT a member of `BootstrapMarkerFields`: a caller that forgot to pass it
+// would silently mint an unverified marker, so `formatMarkerLine` appends
+// it for every writer instead.
+export const MARKER_WRITER_KEY = "writer";
+export const MARKER_WRITER_SUPERVISOR = "supervisor";
+
+/**
+ * Provenance of a parsed marker line.
+ *
+ * `"supervisor"` - carries {@link MARKER_WRITER_KEY}, so a marker writer
+ * produced it. `"unverified"` - marker-SHAPED, but with no writer field:
+ * either an older CLI wrote it, or it is host/shell output that happens to
+ * match the grammar. Which of those it is cannot be decided per line; see
+ * {@link retainAuthenticMarkers}, which decides it per file.
+ */
+export type BootstrapMarkerWriter = "supervisor" | "unverified";
+
 export interface BootstrapLogEntry {
   readonly timestamp: string;
   readonly phase: BootstrapPhase;
   readonly fields: Record<string, string>;
+  readonly writer: BootstrapMarkerWriter;
 }
 
 function escapeValue(value: string): string {
@@ -99,15 +161,33 @@ function formatFields(fields: BootstrapMarkerFields): string {
   return parts.join(" ");
 }
 
+// The single place a marker line is built. Both writers go through it so
+// the writer field cannot be emitted by one path and forgotten by the
+// other - the whole guarantee is "every marker carries it", and two
+// independent format strings are how that guarantee rots.
+//
+// The writer field goes LAST, with the other identity fields, for the
+// reason already recorded above `formatFields`: a human reading the line
+// sees the diagnostic payload first.
+function formatMarkerLine(
+  timestamp: string,
+  phase: BootstrapPhase,
+  fields: BootstrapMarkerFields,
+): string {
+  const fieldsStr = formatFields(fields);
+  const identity = `${MARKER_WRITER_KEY}=${MARKER_WRITER_SUPERVISOR}`;
+  const payload =
+    fieldsStr.length === 0 ? identity : `${fieldsStr} ${identity}`;
+  return `[${timestamp}] phase=${phase} ${payload}\n`;
+}
+
 export async function writeBootstrapMarker(
   environment: Environment,
   phase: BootstrapPhase,
   fields: BootstrapMarkerFields,
 ): Promise<void> {
   await ensureHostHomeDir(environment);
-  const ts = new Date().toISOString();
-  const fieldsStr = formatFields(fields);
-  const line = `[${ts}] phase=${phase}${fieldsStr.length === 0 ? "" : ` ${fieldsStr}`}\n`;
+  const line = formatMarkerLine(new Date().toISOString(), phase, fields);
   await appendFile(bootstrapLogPath(environment), line);
 }
 
@@ -122,9 +202,7 @@ export function writeBootstrapTerminalMarker(
   fields: BootstrapMarkerFields,
 ): void {
   mkdirSync(hostHomeDir(environment), { recursive: true });
-  const ts = new Date().toISOString();
-  const fieldsStr = formatFields(fields);
-  const line = `[${ts}] phase=${phase}${fieldsStr.length === 0 ? "" : ` ${fieldsStr}`}\n`;
+  const line = formatMarkerLine(new Date().toISOString(), phase, fields);
   appendFileSync(bootstrapLogPath(environment), line);
 }
 
@@ -157,8 +235,46 @@ const LINE_RE = /^\[([^\]]+)\] phase=(\w[\w-]*)(?:\s+(.*))?$/;
 // Exported so spawn-evidence and unit tests can parse a single log line
 // without re-implementing the key=value grammar. Unknown keys (including
 // the additive attempt/supervisorPid fields) land in `fields` as strings.
+//
+// A single line CANNOT decide whether an unverified marker is an older
+// CLI's or host output wearing the grammar, so this labels
+// (`entry.writer`) and never drops. Run the result through
+// {@link retainAuthenticMarkers} before treating markers as authority.
 export function parseBootstrapLogLine(line: string): BootstrapLogEntry | null {
   return parseLine(line);
+}
+
+/** True once any entry proves the writer emits {@link MARKER_WRITER_KEY}. */
+export function markersIdentifyWriter(
+  entries: readonly BootstrapLogEntry[],
+): boolean {
+  return entries.some((entry) => entry.writer === "supervisor");
+}
+
+/**
+ * Applies the N-1 latch described at the top of this file: with no
+ * identified writer, keep every marker-shaped line (legacy era); once the
+ * writer is known to identify itself, keep only the lines that do.
+ *
+ * `writerIdentified` is a parameter rather than re-derived from `entries`
+ * because capability is MONOTONIC while `entries` may be a truncated
+ * window. A caller that caps its buffer can evict the one verified marker
+ * and be left holding unverified lines - re-deriving there would flip the
+ * era back to legacy and trust exactly the lines this exists to reject.
+ * Whole-file callers pass {@link markersIdentifyWriter} of the same array;
+ * incremental readers pass a bit that latches on and never clears.
+ *
+ * Pure and idempotent, so an accumulating caller can hold the labelled
+ * entries and re-derive the authoritative view on each read - which it
+ * must, since a verified marker arriving in a later chunk retroactively
+ * demotes the unverified lines that preceded it.
+ */
+export function retainAuthenticMarkers(
+  entries: readonly BootstrapLogEntry[],
+  writerIdentified: boolean,
+): readonly BootstrapLogEntry[] {
+  if (!writerIdentified) return entries;
+  return entries.filter((entry) => entry.writer === "supervisor");
 }
 
 function parseLine(line: string): BootstrapLogEntry | null {
@@ -204,7 +320,11 @@ function parseLine(line: string): BootstrapLogEntry | null {
     }
     fields[key] = value;
   }
-  return { timestamp, phase, fields };
+  const writer: BootstrapMarkerWriter =
+    fields[MARKER_WRITER_KEY] === MARKER_WRITER_SUPERVISOR
+      ? "supervisor"
+      : "unverified";
+  return { timestamp, phase, fields, writer };
 }
 
 export async function readBootstrapMarkers(
@@ -222,7 +342,13 @@ export async function readBootstrapMarkers(
     const parsed = parseLine(line);
     if (parsed !== null) entries.push(parsed);
   }
-  return entries.slice(-maxEntries);
+  // Latch over the WHOLE file, then take the tail. Doing it the other way
+  // round would decide the era from the last `maxEntries` lines, so a log
+  // whose recent tail happens to hold only unverified lines would read as
+  // legacy and trust them.
+  return retainAuthenticMarkers(entries, markersIdentifyWriter(entries)).slice(
+    -maxEntries,
+  );
 }
 
 export async function readBootstrapLogTail(

--- a/clients/traycer-cli/src/host/bootstrap-log.ts
+++ b/clients/traycer-cli/src/host/bootstrap-log.ts
@@ -44,23 +44,30 @@ const openRawFd = promisify(openCallback);
 // ## N-1 overlap: strictness is latched on the file's own evidence
 //
 // Markers written by an older CLI carry no `writer` field, and they persist
-// in `host.log` across restarts until rotation. Dropping unverified lines
+// in `host.log` across restarts until rotation. Dropping unstamped lines
 // unconditionally would blind Doctor to a genuine crash recorded by the
 // previous version; trusting them unconditionally leaves the hole open. So
-// {@link retainAuthenticMarkers} decides per file:
+// {@link retainAuthenticMarkers} splits the file at a POSITION - the first
+// stamped marker:
 //
-//   - the file contains NO verified marker -> legacy era, the writer is not
-//     yet capable of identifying itself, so every marker-shaped line is kept
-//     (byte-identical behaviour to before this change);
-//   - the file contains ANY verified marker -> the writer demonstrably emits
-//     the field, so an unverified marker-shaped line in that same file did
-//     not come from it, and is raw output.
+//   - before it -> the writer had not yet identified itself, so every
+//     marker-shaped line is kept (byte-identical behaviour to before);
+//   - from it onward -> the writer demonstrably stamps its markers, so an
+//     unstamped marker-shaped line is raw output.
+//
+// The boundary has to be positional rather than a property of the whole
+// file, because the ORDINARY upgrade puts both eras in one log: an old CLI
+// records a real `phase=crashed`, the user upgrades, and the next start
+// appends a stamped `phase=starting` to the same file. A whole-file rule
+// would let that stamped marker retroactively delete the older real crash
+// on every upgrade - destroying the history this compatibility path exists
+// to protect.
 //
 // Known limitation, accepted deliberately: if an OLDER CLI writes markers
-// into a log that already holds newer ones (a downgrade, or a stale binary
-// earlier on PATH), the latch reads those as raw output and Doctor loses
-// them. That is rarer than the collision it closes, and fails in the same
-// direction - under-reporting - rather than inventing a crash.
+// AFTER a stamped one (a downgrade, or a stale binary earlier on PATH),
+// those land past the boundary and are read as raw output. That is far
+// rarer than the upgrade path, and it fails in the same direction as the
+// collision it closes - under-reporting - rather than inventing a crash.
 
 export type BootstrapPhase =
   "starting" | "exited" | "crashed" | "killed" | "failed-to-spawn";
@@ -252,29 +259,44 @@ export function markersIdentifyWriter(
 }
 
 /**
- * Applies the N-1 latch described at the top of this file: with no
- * identified writer, keep every marker-shaped line (legacy era); once the
- * writer is known to identify itself, keep only the lines that do.
+ * Applies the N-1 latch described at the top of this file. The boundary is
+ * POSITIONAL, not a property of the whole region: entries before the first
+ * stamped marker are kept as-is, and only from that marker onward is an
+ * unstamped line treated as raw output.
  *
- * `writerIdentified` is a parameter rather than re-derived from `entries`
- * because capability is MONOTONIC while `entries` may be a truncated
- * window. A caller that caps its buffer can evict the one verified marker
- * and be left holding unverified lines - re-deriving there would flip the
- * era back to legacy and trust exactly the lines this exists to reject.
- * Whole-file callers pass {@link markersIdentifyWriter} of the same array;
- * incremental readers pass a bit that latches on and never clears.
+ * Position matters because the ordinary upgrade path puts both eras in one
+ * file. An old CLI records a genuine `phase=crashed`, the user upgrades,
+ * and the next start appends a stamped `phase=starting` to the same
+ * `host.log`. Filtering the region as a whole would let that first stamped
+ * marker retroactively delete the older real crash - destroying exactly the
+ * history the N-1 path exists to preserve, on every upgrade rather than in
+ * some rare corner.
+ *
+ * `writerIdentifiedBefore` says the writer had already stamped a marker
+ * STRICTLY BEFORE this region, which makes the whole region post-boundary.
+ * It is a parameter rather than something re-derived from `entries` because
+ * capability is monotonic while `entries` may be a truncated window: a
+ * caller that caps its buffer can evict the stamped marker and be left
+ * holding unstamped lines, and re-deriving there would reopen the hole.
  *
  * Pure and idempotent, so an accumulating caller can hold the labelled
  * entries and re-derive the authoritative view on each read - which it
- * must, since a verified marker arriving in a later chunk retroactively
- * demotes the unverified lines that preceded it.
+ * must, since a stamped marker arriving in a later chunk retroactively
+ * demotes the unstamped lines that followed the boundary.
  */
 export function retainAuthenticMarkers(
   entries: readonly BootstrapLogEntry[],
-  writerIdentified: boolean,
+  writerIdentifiedBefore: boolean,
 ): readonly BootstrapLogEntry[] {
-  if (!writerIdentified) return entries;
-  return entries.filter((entry) => entry.writer === "supervisor");
+  if (writerIdentifiedBefore) {
+    return entries.filter((entry) => entry.writer === "supervisor");
+  }
+  const boundary = entries.findIndex((entry) => entry.writer === "supervisor");
+  if (boundary === -1) return entries;
+  return [
+    ...entries.slice(0, boundary),
+    ...entries.slice(boundary).filter((entry) => entry.writer === "supervisor"),
+  ];
 }
 
 function parseLine(line: string): BootstrapLogEntry | null {
@@ -342,13 +364,12 @@ export async function readBootstrapMarkers(
     const parsed = parseLine(line);
     if (parsed !== null) entries.push(parsed);
   }
-  // Latch over the WHOLE file, then take the tail. Doing it the other way
-  // round would decide the era from the last `maxEntries` lines, so a log
-  // whose recent tail happens to hold only unverified lines would read as
-  // legacy and trust them.
-  return retainAuthenticMarkers(entries, markersIdentifyWriter(entries)).slice(
-    -maxEntries,
-  );
+  // Locate the boundary in the WHOLE file, then take the tail. The other
+  // order would look for it only within the last `maxEntries` lines, so a
+  // log whose recent tail happens to hold nothing stamped would read as
+  // pre-boundary and trust it. Nothing precedes the start of a file, hence
+  // `false`.
+  return retainAuthenticMarkers(entries, false).slice(-maxEntries);
 }
 
 export async function readBootstrapLogTail(

--- a/clients/traycer-cli/src/host/spawn-evidence.ts
+++ b/clients/traycer-cli/src/host/spawn-evidence.ts
@@ -181,50 +181,55 @@ function offsetForBaseline(baseline: LogFileBaseline, info: Stats): number {
 }
 
 interface BaselineSlicedLog {
-  /** Everything in the file, for deciding the writer-identity era. */
-  readonly fullText: string;
+  /** What preceded the baseline; decides whether the slice is post-boundary. */
+  readonly preBaselineText: string;
   /** Only what was appended after the baseline, the evidence window. */
   readonly postBaselineText: string;
 }
 
 /**
- * Reads the whole log and the post-baseline slice from ONE open.
+ * Reads the pre-baseline region and the post-baseline slice from ONE open.
  *
- * The era must be decided over the full file while evidence is drawn only
- * from the slice: the supervisor's `writer=supervisor` marker can sit
- * BEFORE the baseline (a service-managed start writes no CLI marker for
- * this attempt), which would leave the slice looking like a legacy log and
- * promote a marker-shaped host stderr line to `starting-marker` evidence.
+ * Evidence is drawn only from the slice, but whether the slice sits past
+ * the writer-identity boundary depends on what came BEFORE it: the
+ * supervisor's `writer=supervisor` marker can be pre-baseline entirely (a
+ * service-managed start writes no CLI marker for this attempt), which would
+ * otherwise leave the slice looking pre-boundary and promote a marker-shaped
+ * host stderr line to `starting-marker` evidence.
  *
  * Both come from a single handle so a rotation between two opens cannot
- * pair one file's era with another file's slice - the same reason `offset`
- * is taken from the opened handle's stat rather than a path stat.
+ * pair one file's boundary with another file's slice - the same reason
+ * `offset` is taken from the opened handle's stat rather than a path stat.
  */
 async function readBaselineSlicedLog(
   baseline: LogFileBaseline,
 ): Promise<BaselineSlicedLog> {
+  const empty: BaselineSlicedLog = {
+    preBaselineText: "",
+    postBaselineText: "",
+  };
   let handle: FileHandle;
   try {
     handle = await spawnEvidenceFileDeps.openRead(baseline.path);
   } catch {
-    return { fullText: "", postBaselineText: "" };
+    return empty;
   }
   try {
     const info = await handle.stat();
     // Identity and offset must come from the opened handle. A path stat before
     // open can observe the old log while open lands on a rotated replacement.
     const offset = offsetForBaseline(baseline, info);
-    if (info.size === 0) return { fullText: "", postBaselineText: "" };
+    if (info.size === 0) return empty;
     const buffer = Buffer.alloc(info.size);
     const { bytesRead } = await handle.read(buffer, 0, info.size, 0);
     const read = buffer.subarray(0, bytesRead);
+    // Slice the BUFFER, not the decoded string: `offset` is a byte offset,
+    // and slicing the string would mis-cut any multi-byte sequence ahead
+    // of it.
+    const split = Math.min(offset, bytesRead);
     return {
-      fullText: read.toString("utf8"),
-      // Slice the BUFFER, not the decoded string: `offset` is a byte
-      // offset, and slicing the string would mis-cut any multi-byte
-      // sequence ahead of it.
-      postBaselineText:
-        bytesRead <= offset ? "" : read.subarray(offset).toString("utf8"),
+      preBaselineText: read.subarray(0, split).toString("utf8"),
+      postBaselineText: read.subarray(split).toString("utf8"),
     };
   } finally {
     await handle.close();
@@ -240,6 +245,9 @@ export async function readPostBaselineLogText(
 ): Promise<string> {
   return (await readBaselineSlicedLog(baseline)).postBaselineText;
 }
+
+/** Bound on the reader's retained window; see the eviction note in `read`. */
+const MAX_RETAINED_MARKERS = 64;
 
 export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
   readonly read: () => Promise<readonly BootstrapLogEntry[]>;
@@ -322,9 +330,18 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         const text = pending + buffer.subarray(0, bytesRead).toString("utf8");
         const lines = text.split(/\r?\n/);
         pending = lines.pop() ?? "";
-        const parsed = parseMarkerLines(lines.join("\n"));
-        writerIdentified = writerIdentified || markersIdentifyWriter(parsed);
-        observed = [...observed, ...parsed].slice(-64);
+        const combined = [...observed, ...parseMarkerLines(lines.join("\n"))];
+        // The boundary is positional, so anything the cap evicts has to be
+        // remembered as "already past it" - otherwise dropping the stamped
+        // marker out of the window would make the survivors look
+        // pre-boundary and readmit exactly the lines this rejects.
+        const overflow = combined.length - MAX_RETAINED_MARKERS;
+        if (overflow > 0) {
+          writerIdentified =
+            writerIdentified ||
+            markersIdentifyWriter(combined.slice(0, overflow));
+        }
+        observed = combined.slice(-MAX_RETAINED_MARKERS);
         return retainAuthenticMarkers(observed, writerIdentified);
       } finally {
         await handle.close();
@@ -348,24 +365,27 @@ function parseMarkerLines(text: string): readonly BootstrapLogEntry[] {
   return entries;
 }
 
+// Standalone text with nothing known to precede it, so the boundary is
+// located within the text itself.
 export function parseBootstrapMarkersFromText(
   text: string,
 ): readonly BootstrapLogEntry[] {
-  const entries = parseMarkerLines(text);
-  return retainAuthenticMarkers(entries, markersIdentifyWriter(entries));
+  return retainAuthenticMarkers(parseMarkerLines(text), false);
 }
 
 export async function readPostBaselineMarkers(
   baseline: LogFileBaseline,
 ): Promise<readonly BootstrapLogEntry[]> {
-  // Era from the whole file, evidence from the slice. Deciding both from
-  // the slice would let a pre-baseline `writer=supervisor` marker fall
-  // outside the window, read the log as legacy, and hand
-  // `collectSpawnEvidence` a host stderr line as a `starting-marker`.
-  const { fullText, postBaselineText } = await readBaselineSlicedLog(baseline);
+  // Evidence from the slice; whether the slice is already past the
+  // boundary is answered by what preceded it. Asking only the slice would
+  // let a pre-baseline `writer=supervisor` marker fall outside the window
+  // and hand `collectSpawnEvidence` a host stderr line as a
+  // `starting-marker`.
+  const { preBaselineText, postBaselineText } =
+    await readBaselineSlicedLog(baseline);
   return retainAuthenticMarkers(
     parseMarkerLines(postBaselineText),
-    markersIdentifyWriter(parseMarkerLines(fullText)),
+    markersIdentifyWriter(parseMarkerLines(preBaselineText)),
   );
 }
 

--- a/clients/traycer-cli/src/host/spawn-evidence.ts
+++ b/clients/traycer-cli/src/host/spawn-evidence.ts
@@ -180,6 +180,57 @@ function offsetForBaseline(baseline: LogFileBaseline, info: Stats): number {
   return info.size < baseline.size ? 0 : baseline.size;
 }
 
+interface BaselineSlicedLog {
+  /** Everything in the file, for deciding the writer-identity era. */
+  readonly fullText: string;
+  /** Only what was appended after the baseline, the evidence window. */
+  readonly postBaselineText: string;
+}
+
+/**
+ * Reads the whole log and the post-baseline slice from ONE open.
+ *
+ * The era must be decided over the full file while evidence is drawn only
+ * from the slice: the supervisor's `writer=supervisor` marker can sit
+ * BEFORE the baseline (a service-managed start writes no CLI marker for
+ * this attempt), which would leave the slice looking like a legacy log and
+ * promote a marker-shaped host stderr line to `starting-marker` evidence.
+ *
+ * Both come from a single handle so a rotation between two opens cannot
+ * pair one file's era with another file's slice - the same reason `offset`
+ * is taken from the opened handle's stat rather than a path stat.
+ */
+async function readBaselineSlicedLog(
+  baseline: LogFileBaseline,
+): Promise<BaselineSlicedLog> {
+  let handle: FileHandle;
+  try {
+    handle = await spawnEvidenceFileDeps.openRead(baseline.path);
+  } catch {
+    return { fullText: "", postBaselineText: "" };
+  }
+  try {
+    const info = await handle.stat();
+    // Identity and offset must come from the opened handle. A path stat before
+    // open can observe the old log while open lands on a rotated replacement.
+    const offset = offsetForBaseline(baseline, info);
+    if (info.size === 0) return { fullText: "", postBaselineText: "" };
+    const buffer = Buffer.alloc(info.size);
+    const { bytesRead } = await handle.read(buffer, 0, info.size, 0);
+    const read = buffer.subarray(0, bytesRead);
+    return {
+      fullText: read.toString("utf8"),
+      // Slice the BUFFER, not the decoded string: `offset` is a byte
+      // offset, and slicing the string would mis-cut any multi-byte
+      // sequence ahead of it.
+      postBaselineText:
+        bytesRead <= offset ? "" : read.subarray(offset).toString("utf8"),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
 /**
  * Read the host log slice written after the baseline, identity-aware.
  * Handles rotation that lands new markers at offset 0 of a fresh file.
@@ -187,25 +238,7 @@ function offsetForBaseline(baseline: LogFileBaseline, info: Stats): number {
 export async function readPostBaselineLogText(
   baseline: LogFileBaseline,
 ): Promise<string> {
-  let handle: FileHandle;
-  try {
-    handle = await spawnEvidenceFileDeps.openRead(baseline.path);
-  } catch {
-    return "";
-  }
-  try {
-    const info = await handle.stat();
-    // Identity and offset must come from the opened handle. A path stat before
-    // open can observe the old log while open lands on a rotated replacement.
-    const offset = offsetForBaseline(baseline, info);
-    if (info.size <= offset) return "";
-    const length = info.size - offset;
-    const buffer = Buffer.alloc(length);
-    await handle.read(buffer, 0, length, offset);
-    return buffer.toString("utf8");
-  } finally {
-    await handle.close();
-  }
+  return (await readBaselineSlicedLog(baseline)).postBaselineText;
 }
 
 export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
@@ -222,6 +255,12 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
   // retained window would let a burst of marker-shaped host output evict
   // the verified marker and reopen the hole.
   let writerIdentified = false;
+  // The era also has to account for what came BEFORE the baseline, which
+  // this reader never otherwise looks at: the verified marker can sit in
+  // the pre-baseline region (a service-managed start writes no CLI marker
+  // for this attempt), and reading only forward would call that log legacy.
+  // Seeded once per observed file; seeding can only turn the bit ON.
+  let seeded = false;
 
   return {
     read: async (): Promise<readonly BootstrapLogEntry[]> => {
@@ -249,6 +288,26 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
           // `writerIdentified` deliberately survives a replaced file:
           // capability belongs to the WRITER, and rotation hands the same
           // supervisor a fresh file it will keep identifying itself in.
+          // The seed is per-file, so a replacement re-seeds from its own
+          // pre-baseline region.
+          seeded = false;
+        }
+        if (!seeded) {
+          seeded = true;
+          if (readOffset > 0) {
+            const head = Buffer.alloc(readOffset);
+            const { bytesRead: headBytes } = await handle.read(
+              head,
+              0,
+              readOffset,
+              0,
+            );
+            writerIdentified =
+              writerIdentified ||
+              markersIdentifyWriter(
+                parseMarkerLines(head.subarray(0, headBytes).toString("utf8")),
+              );
+          }
         }
         dev = info.dev;
         ino = info.ino;
@@ -299,8 +358,15 @@ export function parseBootstrapMarkersFromText(
 export async function readPostBaselineMarkers(
   baseline: LogFileBaseline,
 ): Promise<readonly BootstrapLogEntry[]> {
-  const text = await readPostBaselineLogText(baseline);
-  return parseBootstrapMarkersFromText(text);
+  // Era from the whole file, evidence from the slice. Deciding both from
+  // the slice would let a pre-baseline `writer=supervisor` marker fall
+  // outside the window, read the log as legacy, and hand
+  // `collectSpawnEvidence` a host stderr line as a `starting-marker`.
+  const { fullText, postBaselineText } = await readBaselineSlicedLog(baseline);
+  return retainAuthenticMarkers(
+    parseMarkerLines(postBaselineText),
+    markersIdentifyWriter(parseMarkerLines(fullText)),
+  );
 }
 
 /**

--- a/clients/traycer-cli/src/host/spawn-evidence.ts
+++ b/clients/traycer-cli/src/host/spawn-evidence.ts
@@ -1,7 +1,9 @@
 import type { Stats } from "node:fs";
 import { open, stat, type FileHandle } from "node:fs/promises";
 import {
+  markersIdentifyWriter,
   parseBootstrapLogLine,
+  retainAuthenticMarkers,
   type BootstrapLogEntry,
   type BootstrapPhase,
 } from "./bootstrap-log";
@@ -213,7 +215,13 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
   let dev: number | null = null;
   let ino: number | null = null;
   let pending = "";
-  let entries: readonly BootstrapLogEntry[] = [];
+  // Labelled and unfiltered; the authoritative view is derived per read.
+  let observed: readonly BootstrapLogEntry[] = [];
+  // Sticky: a writer that has identified itself once cannot stop being
+  // capable, and `observed` is capped below - so re-deriving this from the
+  // retained window would let a burst of marker-shaped host output evict
+  // the verified marker and reopen the hole.
+  let writerIdentified = false;
 
   return {
     read: async (): Promise<readonly BootstrapLogEntry[]> => {
@@ -237,12 +245,17 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
             : offsetForBaseline(baseline, info);
         if (!sameOpenFile) {
           pending = "";
-          entries = [];
+          observed = [];
+          // `writerIdentified` deliberately survives a replaced file:
+          // capability belongs to the WRITER, and rotation hands the same
+          // supervisor a fresh file it will keep identifying itself in.
         }
         dev = info.dev;
         ino = info.ino;
         offset = info.size;
-        if (info.size <= readOffset) return entries;
+        if (info.size <= readOffset) {
+          return retainAuthenticMarkers(observed, writerIdentified);
+        }
         const length = info.size - readOffset;
         const buffer = Buffer.alloc(length);
         const { bytesRead } = await handle.read(buffer, 0, length, readOffset);
@@ -250,11 +263,10 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         const text = pending + buffer.subarray(0, bytesRead).toString("utf8");
         const lines = text.split(/\r?\n/);
         pending = lines.pop() ?? "";
-        entries = [
-          ...entries,
-          ...parseBootstrapMarkersFromText(lines.join("\n")),
-        ].slice(-64);
-        return entries;
+        const parsed = parseMarkerLines(lines.join("\n"));
+        writerIdentified = writerIdentified || markersIdentifyWriter(parsed);
+        observed = [...observed, ...parsed].slice(-64);
+        return retainAuthenticMarkers(observed, writerIdentified);
       } finally {
         await handle.close();
       }
@@ -262,9 +274,12 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
   };
 }
 
-export function parseBootstrapMarkersFromText(
-  text: string,
-): readonly BootstrapLogEntry[] {
+// Labelled but UNFILTERED - the writer latch is a property of the whole
+// scanned region, so a caller that accumulates across chunks has to apply
+// it itself over everything it has seen (see
+// `createPostBaselineMarkerReader`). Filtering per chunk would let a chunk
+// that happens to contain no verified marker read as legacy.
+function parseMarkerLines(text: string): readonly BootstrapLogEntry[] {
   const entries: BootstrapLogEntry[] = [];
   for (const line of text.split(/\r?\n/)) {
     if (line.length === 0) continue;
@@ -272,6 +287,13 @@ export function parseBootstrapMarkersFromText(
     if (parsed !== null) entries.push(parsed);
   }
   return entries;
+}
+
+export function parseBootstrapMarkersFromText(
+  text: string,
+): readonly BootstrapLogEntry[] {
+  const entries = parseMarkerLines(text);
+  return retainAuthenticMarkers(entries, markersIdentifyWriter(entries));
 }
 
 export async function readPostBaselineMarkers(

--- a/clients/traycer-cli/src/host/spawn-evidence.ts
+++ b/clients/traycer-cli/src/host/spawn-evidence.ts
@@ -180,15 +180,76 @@ function offsetForBaseline(baseline: LogFileBaseline, info: Stats): number {
   return info.size < baseline.size ? 0 : baseline.size;
 }
 
+/**
+ * Prefix scan window. The pre-baseline region is only ever asked a yes/no
+ * question, so it is streamed in fixed chunks rather than buffered whole:
+ * `host-log-rotation.ts` caps `host.log` only at START, and states plainly
+ * that a long-lived host can grow it past the cap within one lifetime. This
+ * reader runs inside the 250ms `runTaskAndVerifyStart` poll loop on the
+ * failure path, which must time out and report Last Run Result - allocating
+ * a multi-megabyte stale log there could block or OOM the very path whose
+ * job is to give up cleanly.
+ */
+const PREFIX_SCAN_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Upper bound on a partial line carried between chunks. Marker lines are far
+ * shorter (`stderrTail` itself is capped in `crash-diagnostics.ts`), so a
+ * "line" past this length is host output that cannot be a marker; dropping
+ * the excess keeps the carry bounded on a log with no newlines at all.
+ */
+const MAX_CARRY_BYTES = 64 * 1024;
+
+/**
+ * Answers only "did the writer stamp a marker before `prefixBytes`?", in
+ * bounded memory, returning at the first stamped marker.
+ *
+ * The carry is kept as BYTES, not a decoded string: a chunk boundary can
+ * land mid-sequence in UTF-8, and decoding each chunk independently would
+ * corrupt the characters that straddle it.
+ */
+async function prefixIdentifiesWriter(
+  handle: FileHandle,
+  prefixBytes: number,
+): Promise<boolean> {
+  if (prefixBytes <= 0) return false;
+  const chunk = Buffer.alloc(Math.min(PREFIX_SCAN_CHUNK_BYTES, prefixBytes));
+  let carry = Buffer.alloc(0);
+  let position = 0;
+  while (position < prefixBytes) {
+    const want = Math.min(chunk.length, prefixBytes - position);
+    const { bytesRead } = await handle.read(chunk, 0, want, position);
+    if (bytesRead === 0) break;
+    position += bytesRead;
+    const combined = Buffer.concat([carry, chunk.subarray(0, bytesRead)]);
+    const lastNewline = combined.lastIndexOf(0x0a);
+    if (lastNewline === -1) {
+      carry =
+        combined.length > MAX_CARRY_BYTES
+          ? combined.subarray(combined.length - MAX_CARRY_BYTES)
+          : combined;
+      continue;
+    }
+    carry = combined.subarray(lastNewline + 1);
+    const complete = combined.subarray(0, lastNewline).toString("utf8");
+    if (markersIdentifyWriter(parseMarkerLines(complete))) return true;
+  }
+  return (
+    carry.length > 0 &&
+    markersIdentifyWriter(parseMarkerLines(carry.toString("utf8")))
+  );
+}
+
 interface BaselineSlicedLog {
-  /** What preceded the baseline; decides whether the slice is post-boundary. */
-  readonly preBaselineText: string;
+  /** Whether the writer had already stamped a marker before the baseline. */
+  readonly writerIdentifiedBefore: boolean;
   /** Only what was appended after the baseline, the evidence window. */
   readonly postBaselineText: string;
 }
 
 /**
- * Reads the pre-baseline region and the post-baseline slice from ONE open.
+ * Resolves the pre-baseline boundary answer and the post-baseline slice
+ * from ONE open.
  *
  * Evidence is drawn only from the slice, but whether the slice sits past
  * the writer-identity boundary depends on what came BEFORE it: the
@@ -205,7 +266,7 @@ async function readBaselineSlicedLog(
   baseline: LogFileBaseline,
 ): Promise<BaselineSlicedLog> {
   const empty: BaselineSlicedLog = {
-    preBaselineText: "",
+    writerIdentifiedBefore: false,
     postBaselineText: "",
   };
   let handle: FileHandle;
@@ -220,16 +281,16 @@ async function readBaselineSlicedLog(
     // open can observe the old log while open lands on a rotated replacement.
     const offset = offsetForBaseline(baseline, info);
     if (info.size === 0) return empty;
-    const buffer = Buffer.alloc(info.size);
-    const { bytesRead } = await handle.read(buffer, 0, info.size, 0);
-    const read = buffer.subarray(0, bytesRead);
-    // Slice the BUFFER, not the decoded string: `offset` is a byte offset,
-    // and slicing the string would mis-cut any multi-byte sequence ahead
-    // of it.
-    const split = Math.min(offset, bytesRead);
+    const split = Math.min(offset, info.size);
+    const writerIdentifiedBefore = await prefixIdentifiesWriter(handle, split);
+    if (info.size <= split)
+      return { writerIdentifiedBefore, postBaselineText: "" };
+    const length = info.size - split;
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, split);
     return {
-      preBaselineText: read.subarray(0, split).toString("utf8"),
-      postBaselineText: read.subarray(split).toString("utf8"),
+      writerIdentifiedBefore,
+      postBaselineText: buffer.subarray(0, bytesRead).toString("utf8"),
     };
   } finally {
     await handle.close();
@@ -302,20 +363,11 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         }
         if (!seeded) {
           seeded = true;
-          if (readOffset > 0) {
-            const head = Buffer.alloc(readOffset);
-            const { bytesRead: headBytes } = await handle.read(
-              head,
-              0,
-              readOffset,
-              0,
-            );
-            writerIdentified =
-              writerIdentified ||
-              markersIdentifyWriter(
-                parseMarkerLines(head.subarray(0, headBytes).toString("utf8")),
-              );
-          }
+          // Streamed, not buffered whole: this runs in a 250ms poll loop
+          // against a log that may have outgrown its start-time cap.
+          writerIdentified =
+            writerIdentified ||
+            (await prefixIdentifiesWriter(handle, readOffset));
         }
         dev = info.dev;
         ino = info.ino;
@@ -331,18 +383,21 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         const lines = text.split(/\r?\n/);
         pending = lines.pop() ?? "";
         const combined = [...observed, ...parseMarkerLines(lines.join("\n"))];
-        // The boundary is positional, so anything the cap evicts has to be
-        // remembered as "already past it" - otherwise dropping the stamped
-        // marker out of the window would make the survivors look
-        // pre-boundary and readmit exactly the lines this rejects.
-        const overflow = combined.length - MAX_RETAINED_MARKERS;
-        if (overflow > 0) {
-          writerIdentified =
-            writerIdentified ||
-            markersIdentifyWriter(combined.slice(0, overflow));
-        }
-        observed = combined.slice(-MAX_RETAINED_MARKERS);
-        return retainAuthenticMarkers(observed, writerIdentified);
+        // Retain BEFORE capping. Capping first lets marker-shaped host
+        // output consume the window: a real `starting` or terminal marker
+        // followed by more than MAX_RETAINED_MARKERS raw lines would be
+        // evicted, the reader would report no marker, and
+        // `runTaskAndVerifyStart` would time out on a spawn that had in
+        // fact left evidence.
+        const retained = retainAuthenticMarkers(combined, writerIdentified);
+        // Retaining first also makes the cap safe for the positional
+        // boundary, without needing to remember what it evicted. Everything
+        // kept past the boundary is stamped, and the cap keeps the most
+        // RECENT entries - so once a stamped marker has been seen, the
+        // window still holds one. The boundary can never fall out from
+        // under the survivors and leave them looking pre-boundary.
+        observed = retained.slice(-MAX_RETAINED_MARKERS);
+        return observed;
       } finally {
         await handle.close();
       }
@@ -381,11 +436,11 @@ export async function readPostBaselineMarkers(
   // let a pre-baseline `writer=supervisor` marker fall outside the window
   // and hand `collectSpawnEvidence` a host stderr line as a
   // `starting-marker`.
-  const { preBaselineText, postBaselineText } =
+  const { writerIdentifiedBefore, postBaselineText } =
     await readBaselineSlicedLog(baseline);
   return retainAuthenticMarkers(
     parseMarkerLines(postBaselineText),
-    markersIdentifyWriter(parseMarkerLines(preBaselineText)),
+    writerIdentifiedBefore,
   );
 }
 


### PR DESCRIPTION
Closes #984.

## The defect

`host.log` is **both** the bootstrap-marker destination and the child's stderr sink — the supervisor spawns with `stdio: ["ignore", logFd, logFd]`, and the host's own logger appends to the same path. `LINE_RE` accepted any line shaped `[<iso>] phase=<name>`, so a host line of that shape produced a record indistinguishable from a supervisor-written marker.

That matters because four consumers read markers as authority: `spawn-evidence.ts`, `host-status.ts`, Doctor's `RECENT_CRASH_MARKERS`, and gui-app's bootstrap attempt summary. The sharpest consequence is Doctor's `lastCrashMarker` scan, which treats a later `phase=starting` as proof the host recovered — so one stray line cancels a real crash signal and a crashed host reports clean.

Pre-existing, not a regression from #982: that PR changed the route (pipe → tee → path-addressed append) but not the bytes or the destination. `host-log-rotation.ts` already documents the shared sink.

## The fix

Every marker now ends `writer=supervisor`, emitted by a single `formatMarkerLine` that both the async and the terminal writer go through. Deliberately **not** a member of `BootstrapMarkerFields` — a caller that forgot to pass it would silently mint an unverified marker.

The parser **labels** provenance (`entry.writer`) rather than dropping, because a single line genuinely cannot distinguish an older CLI's marker from host output wearing the grammar.

## The N-1 overlap

Markers from an older CLI carry no writer field and persist across restarts until rotation. Dropping unverified lines unconditionally would blind Doctor to a crash the previous version genuinely recorded; trusting them unconditionally leaves the hole open. So strictness latches on **the file's own evidence**:

| Scanned region | Behaviour |
| --- | --- |
| No verified marker anywhere | Legacy era — keep every marker-shaped line, byte-identical to before |
| Any verified marker present | The writer demonstrably stamps its lines, so unverified ones are raw output |

Every existing marker test in the suite uses unstamped fixtures, so they all exercise the legacy path and pass unchanged — that is the compat property, not a coincidence.

Two subtleties, both mutation-probed:

- **The capability bit is passed, not re-derived.** Capability is monotonic but `entries` may be a truncated window. `createPostBaselineMarkerReader` caps at 64, so a burst of marker-shaped host output can evict the one verified marker; re-deriving there would flip the era back to legacy and trust exactly the lines this exists to reject.
- **Latch over the whole file, then slice the tail.** The other order decides the era from the last `maxEntries` lines.

## What this does not do

**This is not a security boundary.** The host can write this file, so it could copy any in-band token, and no field could change that. The real fix is separate sinks, which `host-log-rotation.ts` already scopes out. What this closes is **accidental** collision — the real exposure, since one refactor that starts a host log message with `phase=` is enough today.

No protocol change: `BootstrapMarkerEntry` on the wire stays `timestamp`/`phase`/`fields`, and filtering happens CLI-side before markers cross it, so gui-app inherits the fix without a change.

I also considered hardening Doctor's `lastCrashMarker` directly and deliberately did not — with the latch in place it would be a redundant second guard, and redundant guards mask each other under single-mutation probing.

## Verification

- `format` → `lint` → `compile` (compile last, since `lint --fix` rewrites code) — all green across 5 projects
- Full `traycer-cli` suite: **1300 passed**, 12 skipped, 0 failed
- Pre-commit hook (nx affected build/compile/lint/format + DCO): passed

Mutation probes, to show the new tests discriminate rather than merely pass:

| Probe | Tests killed |
| --- | --- |
| Writers omit `writer=` | 3 |
| Latch never filters | 5 |
| Reader re-derives capability instead of latching | 1 — *stays strict after the cap evicts the verified marker* |
| Slice tail before latching | 1 — *decides the era from the whole file* |

The last two each kill exactly one test, which is what makes those two design decisions load-bearing rather than decorative.
