### PR TITLE
fix(traycer-cli): latch writer identity on stream markers, not just the seed

### DIFF
--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -486,6 +486,33 @@ describe("spawn-evidence substrate", () => {
       expect(findPostBaselineTerminalMarker(markers)?.phase).toBe("crashed");
     });
 
+    it("remembers a stamped marker seen in the stream across a rotation", async () => {
+      // The stamped marker arrives POST-baseline (the ordinary case - the
+      // supervisor writes `starting` after the baseline is taken), so the
+      // pre-baseline seed never sees it. If that is not latched, rotation
+      // clears `observed`, the replacement has no stamped prefix to re-seed
+      // from, and a marker-shaped host line in the new file is trusted.
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      const reader = createPostBaselineMarkerReader(baseline);
+
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=starting writer=supervisor\n",
+      );
+      expect(await reader.read()).toHaveLength(1);
+
+      // Rotation: a brand new file, no stamped prefix, and the host's own
+      // output is the first thing in it.
+      await rm(mocks.logPath, { force: true });
+      await writeFile(
+        mocks.logPath,
+        "[2026-01-01T00:05:00.000Z] phase=starting\n",
+        "utf8",
+      );
+
+      expect(await reader.read()).toHaveLength(0);
+    });
+
     it("scans a pre-baseline region larger than one chunk without buffering it whole", async () => {
       // The prefix is streamed in 64KiB chunks, so a stamped marker beyond
       // the first chunk must still be found - and a marker split across a

--- a/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/spawn-evidence.test.ts
@@ -557,6 +557,39 @@ describe("spawn-evidence substrate", () => {
       expect(markers[0]?.writer).toBe("unverified");
       expect(markers[1]?.writer).toBe("supervisor");
     });
+
+    it("keeps the pre-boundary line on later polls of the same file", async () => {
+      // The boundary is positional WITHIN a file. A stamped marker in the
+      // window proves the writer stamps from here on - it does not
+      // retroactively convict the lines before it, which is the whole point
+      // of the N-1 overlap. Re-deriving the era from that marker on the next
+      // poll would delete the previous CLI's evidence one read late, so the
+      // marker would be reported once and then vanish.
+      const baseline = await captureLogFileBaseline(mocks.logPath);
+      const reader = createPostBaselineMarkerReader(baseline);
+
+      await appendFile(
+        mocks.logPath,
+        "[2026-01-01T00:00:00.000Z] phase=crashed code=9\n" +
+          "[2026-01-01T00:00:01.000Z] phase=starting writer=supervisor\n",
+      );
+      expect((await reader.read()).map((m) => m.phase)).toEqual([
+        "crashed",
+        "starting",
+      ]);
+
+      // Poll with no new bytes, then a poll with an unrelated append. Neither
+      // may demote the legacy marker.
+      expect((await reader.read()).map((m) => m.phase)).toEqual([
+        "crashed",
+        "starting",
+      ]);
+      await appendFile(mocks.logPath, "some raw host output\n");
+      expect((await reader.read()).map((m) => m.phase)).toEqual([
+        "crashed",
+        "starting",
+      ]);
+    });
   });
 
   describe("collectSpawnEvidence preference order", () => {

--- a/clients/traycer-cli/src/host/spawn-evidence.ts
+++ b/clients/traycer-cli/src/host/spawn-evidence.ts
@@ -390,12 +390,19 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         // `runTaskAndVerifyStart` would time out on a spawn that had in
         // fact left evidence.
         const retained = retainAuthenticMarkers(combined, writerIdentified);
-        // Retaining first also makes the cap safe for the positional
-        // boundary, without needing to remember what it evicted. Everything
-        // kept past the boundary is stamped, and the cap keeps the most
-        // RECENT entries - so once a stamped marker has been seen, the
-        // window still holds one. The boundary can never fall out from
-        // under the survivors and leave them looking pre-boundary.
+        // Latch on a stamped marker seen in the STREAM, not just in the
+        // pre-baseline seed. Capability belongs to the writer, but `observed`
+        // does not outlive the file: a rotation clears it, and the
+        // replacement has no stamped prefix to re-seed from, so without this
+        // the boundary is forgotten and an unstamped marker-shaped line in
+        // the new file reads as pre-boundary evidence - the collision this
+        // reader exists to reject.
+        //
+        // The CAP cannot lose the boundary that way (everything kept past it
+        // is stamped, and the cap keeps the most recent entries), which is
+        // why no promotion is needed there. Rotation is a different loss and
+        // needs this.
+        writerIdentified = writerIdentified || markersIdentifyWriter(retained);
         observed = retained.slice(-MAX_RETAINED_MARKERS);
         return observed;
       } finally {

--- a/clients/traycer-cli/src/host/spawn-evidence.ts
+++ b/clients/traycer-cli/src/host/spawn-evidence.ts
@@ -319,12 +319,22 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
   let pending = "";
   // Labelled and unfiltered; the authoritative view is derived per read.
   let observed: readonly BootstrapLogEntry[] = [];
-  // Sticky: a writer that has identified itself once cannot stop being
-  // capable, and `observed` is capped below - so re-deriving this from the
-  // retained window would let a burst of marker-shaped host output evict
-  // the verified marker and reopen the hole.
-  let writerIdentified = false;
-  // The era also has to account for what came BEFORE the baseline, which
+  // TWO bits, deliberately. They answer different questions and conflating
+  // them breaks one of the two cases this reader has to serve.
+  //
+  // `boundaryIdentified` is about THIS file: had the writer already stamped
+  // before the window we are accumulating began? Only that justifies
+  // filtering the window wholesale. It is per-file and never set from a
+  // marker inside the window - within one file the boundary is POSITIONAL,
+  // which is what keeps an N-1 legacy marker that precedes the first stamped
+  // one (the ordinary upgrade, both eras in one file).
+  let boundaryIdentified = false;
+  // `sawSupervisorMarker` is about the WRITER, and outlives any single file.
+  // Sticky because `observed` is capped below, so re-deriving it from the
+  // retained window would let a burst of marker-shaped host output evict the
+  // verified marker and reopen the hole.
+  let sawSupervisorMarker = false;
+  // The boundary also has to account for what came BEFORE the baseline, which
   // this reader never otherwise looks at: the verified marker can sit in
   // the pre-baseline region (a service-managed start writes no CLI marker
   // for this attempt), and reading only forward would call that log legacy.
@@ -354,26 +364,33 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         if (!sameOpenFile) {
           pending = "";
           observed = [];
-          // `writerIdentified` deliberately survives a replaced file:
+          // A replacement INHERITS the boundary answer we already proved:
           // capability belongs to the WRITER, and rotation hands the same
-          // supervisor a fresh file it will keep identifying itself in.
-          // The seed is per-file, so a replacement re-seeds from its own
-          // pre-baseline region.
+          // supervisor a fresh file it will keep identifying itself in. That
+          // file has no pre-baseline region to re-seed from, so without this
+          // the boundary is forgotten and a marker-shaped host line in the
+          // replacement reads as legacy evidence - the collision this reader
+          // exists to reject.
+          boundaryIdentified = sawSupervisorMarker;
           seeded = false;
         }
         if (!seeded) {
           seeded = true;
           // Streamed, not buffered whole: this runs in a 250ms poll loop
           // against a log that may have outgrown its start-time cap.
-          writerIdentified =
-            writerIdentified ||
-            (await prefixIdentifiesWriter(handle, readOffset));
+          if (
+            !boundaryIdentified &&
+            (await prefixIdentifiesWriter(handle, readOffset))
+          ) {
+            boundaryIdentified = true;
+            sawSupervisorMarker = true;
+          }
         }
         dev = info.dev;
         ino = info.ino;
         offset = info.size;
         if (info.size <= readOffset) {
-          return retainAuthenticMarkers(observed, writerIdentified);
+          return retainAuthenticMarkers(observed, boundaryIdentified);
         }
         const length = info.size - readOffset;
         const buffer = Buffer.alloc(length);
@@ -389,20 +406,20 @@ export function createPostBaselineMarkerReader(baseline: LogFileBaseline): {
         // evicted, the reader would report no marker, and
         // `runTaskAndVerifyStart` would time out on a spawn that had in
         // fact left evidence.
-        const retained = retainAuthenticMarkers(combined, writerIdentified);
-        // Latch on a stamped marker seen in the STREAM, not just in the
-        // pre-baseline seed. Capability belongs to the writer, but `observed`
-        // does not outlive the file: a rotation clears it, and the
-        // replacement has no stamped prefix to re-seed from, so without this
-        // the boundary is forgotten and an unstamped marker-shaped line in
-        // the new file reads as pre-boundary evidence - the collision this
-        // reader exists to reject.
+        const retained = retainAuthenticMarkers(combined, boundaryIdentified);
+        // Record the capability from a marker seen in the STREAM, not just
+        // from the pre-baseline seed - post-baseline is where the supervisor
+        // ordinarily stamps, so the seed usually never sees one. This feeds
+        // ONLY the next file (see the rotation branch); promoting it into
+        // `boundaryIdentified` here would re-filter this same window on the
+        // next poll and delete the pre-boundary legacy marker that
+        // `retainAuthenticMarkers` was given a positional boundary to keep.
         //
-        // The CAP cannot lose the boundary that way (everything kept past it
-        // is stamped, and the cap keeps the most recent entries), which is
-        // why no promotion is needed there. Rotation is a different loss and
-        // needs this.
-        writerIdentified = writerIdentified || markersIdentifyWriter(retained);
+        // The CAP needs no equivalent: everything kept past the boundary is
+        // stamped and the cap keeps the most recent entries, so it cannot
+        // lose the boundary. Rotation is a different loss and needs this.
+        sawSupervisorMarker =
+          sawSupervisorMarker || markersIdentifyWriter(retained);
         observed = retained.slice(-MAX_RETAINED_MARKERS);
         return observed;
       } finally {


### PR DESCRIPTION
Follow-up to #987, found by Codex reviewing the submodule contents through the internal gitlink bump — after #987 had already merged.

## The defect

`writerIdentified` in `createPostBaselineMarkerReader` was set **only** by the pre-baseline prefix scan. A stamped marker appearing in the *post-baseline stream* — the ordinary case, since the supervisor writes `phase=starting` after the baseline is taken — filtered correctly for that poll through the positional boundary, but never set the bit.

So this comment, which #987 shipped, was **vacuous**:

> `writerIdentified` deliberately survives a replaced file: capability belongs to the WRITER…

In the common case it was never true, so there was nothing to survive.

**The consequence is a rotation.** `observed` is cleared along with the old file, the replacement has no stamped prefix for the seed to find, and an unstamped marker-shaped host line in the new file is read as pre-boundary evidence. That is exactly the collision this reader exists to reject.

## How it got in

I introduced it in `722d2202` by deleting the overflow-promotion branch as unreachable. That deletion was **correct about the cap**: everything retained past the boundary is stamped and the cap keeps the most recent entries, so the cap cannot lose the boundary. The error was generalising it to *"no promotion is needed anywhere"*. Rotation is a different kind of loss, and it needs one.

The fix latches on `markersIdentifyWriter(retained)` after filtering, and the comment now states which loss the cap handles and which one it does not.

## Verification

- New test: *remembers a stamped marker seen in the stream across a rotation* — stamped marker post-baseline, then the file is replaced with one whose first line is unstamped host output. Expects it rejected.
- Mutation probe: removing the latch line kills exactly that test and nothing else.
- Full `traycer-cli` suite: **1307 passed**, 0 failed. format → lint → compile green.

## Note

int #4819 currently pins `c22c825b`, which contains this bug. I'll re-point that PR at this commit once it merges rather than land a known-defective pin.