### PR TITLE
fix(gui-app): restore sidebar item separators

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
@@ -124,6 +124,9 @@ describe("<SplitResizeHandle />", () => {
     expect(className).toContain("h-1");
     expect(className).toContain("before:h-px");
     expect(className).toContain("before:top-1/2");
+    // Without `absolute` the pseudo-element is an inline box: h-px/inset-x-0
+    // do not apply and the separator paints nothing at all.
+    expect(className).toContain("before:absolute");
     expect(className).toContain("before:bg-border");
     expect(className).not.toContain("after:");
   });

--- a/clients/gui-app/src/components/epic-canvas/canvas/use-pointer-drag-commit.ts
+++ b/clients/gui-app/src/components/epic-canvas/canvas/use-pointer-drag-commit.ts
@@ -148,7 +148,7 @@ export function inFlowPointerDragHandleAxisClassName(
 ): string {
   return axis === "horizontal"
     ? "w-1 cursor-col-resize touch-none before:pointer-events-none before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-border before:content-['']"
-    : "h-1 cursor-row-resize touch-none before:pointer-events-none before:inset-x-0 before:top-1/2 before:h-px before:-translate-y-1/2 before:bg-border before:content-['']";
+    : "h-1 cursor-row-resize touch-none before:pointer-events-none before:absolute before:inset-x-0 before:top-1/2 before:h-px before:-translate-y-1/2 before:bg-border before:content-['']";
 }
 
 export function usePointerDragCommit(

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -838,7 +838,9 @@ function ResizableSectionRun(props: {
   );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    // The run wrapper carries the boundary border its inner sections cannot:
+    // each is an only child, so their own `last:border-b-0` always wins.
+    <div className="flex min-h-0 flex-1 flex-col border-b border-border/60 last:border-b-0">
       {panels.map((panel, panelIndex) => (
         <Fragment key={panel.id}>
           {panelIndex > 0 ? (


### PR DESCRIPTION
## Summary

Restore the missing separator lines between tiled sidebar panels and vertically split canvas panes.

- Add `before:absolute` to the vertical in-flow drag handle pseudo-element.
- Put the expanded-run bottom border on the run wrapper so it separates adjacent runs.
- Assert `before:absolute` in the resize handle regression test.

## Root cause

PR #924 reintroduced the 1px divider as a `::before` pseudo-element. The horizontal branch had `before:absolute`, but the vertical branch did not, so its static inline pseudo-element ignored the height and inset styles. In a multi-panel expanded run, each section is the only child of its split wrapper, so `last:border-b-0` always wins and the section border never paints.

## Verification

- Focused GUI suites: 53 tests passed across the sidebar and resize-handle files.
- Pre-commit affected build, compile, lint, and format checks passed.
- `bun.lock` is unchanged.
- Commit includes the required DCO sign-off.
