### PR TITLE
fix(gui-app): scope select-all to the active tile (#592)

### DIFF
--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -2350,6 +2350,12 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
         <div
           ref={transcriptContainerRef}
           data-testid="chat-transcript-container"
+          // Ctrl/Cmd+A selects the transcript, not the whole window (#592).
+          // Marked here rather than on the chat tile's transcript wrapper: that
+          // wrapper also holds the absolutely-positioned lower-surfaces dock
+          // (composer, approvals, todo), which must stay out of the selection.
+          // The timeline is virtualized, so this covers the mounted rows.
+          data-selection-root=""
           onPointerDown={handleTranscriptPointerDown}
           className="relative flex-1 overflow-hidden"
         >

--- a/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-shell.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-shell.tsx
@@ -33,7 +33,13 @@ export function DiffTabShell(props: DiffTabShellProps) {
         </div>
         <div className="flex shrink-0 items-center gap-1">{props.toolbar}</div>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      {/* Ctrl/Cmd+A selects the diff body, not the whole window (#592). Shared
+          by the git, PR and snapshot diff tiles, so all three opt in here; the
+          title/toolbar header above stays out of the selection. */}
+      <div
+        data-selection-root=""
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
         {props.children}
       </div>
     </div>

--- a/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
@@ -278,6 +278,10 @@ function WorkspaceFileTileLive(props: {
         <div
           ref={scrollContainerRef}
           onScroll={onScroll}
+          // Ctrl/Cmd+A selects the file body, not the whole window (#592). The
+          // line-number gutter inside is `select-none`, so copying the result
+          // still yields the file text without line numbers.
+          data-selection-root=""
           className={cn(
             "relative min-h-0 flex-1 overflow-auto",
             props.isActive && "selection:bg-primary/25",

--- a/clients/gui-app/src/components/epic-canvas/tile-find/__tests__/tile-find-owner-blocker.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/tile-find/__tests__/tile-find-owner-blocker.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { resolveTileFindOwnerBlocker } from "@/components/epic-canvas/tile-find/tile-find-owner-blocker";
+
+const CLEAR = {
+  commandPaletteOpen: false,
+  systemOverlayActive: false,
+  appDialogActive: false,
+  desktopDialogActive: false,
+  migrationDialogActive: false,
+  notificationPopoverOpen: false,
+  domDialogActive: false,
+} as const;
+
+describe("resolveTileFindOwnerBlocker", () => {
+  // The regression from traycerai/traycer#592: `TopLevelTabHost` mounts the
+  // restored Epic surface from the tabs store, and the router is only navigated
+  // when a tab is ACTIVATED. A restored window therefore sits at `/` with a
+  // focused Epic surface and an open file tile, and the old epic-path allow-list
+  // blocked ownership there - killing select-all AND find in the app's normal
+  // startup state.
+  it("does not block the restored canvas at the root pathname", () => {
+    expect(resolveTileFindOwnerBlocker({ ...CLEAR, pathname: "/" })).toBe(null);
+  });
+
+  it("does not block routes whose signed-in body renders nothing", () => {
+    for (const pathname of [
+      "/",
+      "/epics",
+      "/epics/epic-1/tab-1",
+      "/draft/draft-1",
+      "/draft/new",
+    ]) {
+      expect(resolveTileFindOwnerBlocker({ ...CLEAR, pathname })).toBe(null);
+    }
+  });
+
+  it("blocks routes that paint their own body over the tab host", () => {
+    for (const pathname of [
+      "/onboarding",
+      "/settings",
+      "/settings/general",
+      "/settings/keybindings",
+    ]) {
+      expect(resolveTileFindOwnerBlocker({ ...CLEAR, pathname })).toEqual({
+        reason: "non-canvas-route",
+        ownerId: pathname,
+      });
+    }
+  });
+
+  it("keeps every overlay blocker, including at the root pathname", () => {
+    expect(
+      resolveTileFindOwnerBlocker({
+        ...CLEAR,
+        pathname: "/",
+        commandPaletteOpen: true,
+      }),
+    ).toEqual({ reason: "command-palette", ownerId: "command-palette" });
+
+    expect(
+      resolveTileFindOwnerBlocker({
+        ...CLEAR,
+        pathname: "/",
+        systemOverlayActive: true,
+      }),
+    ).toEqual({ reason: "system-overlay", ownerId: "system-overlay" });
+
+    expect(
+      resolveTileFindOwnerBlocker({
+        ...CLEAR,
+        pathname: "/epics/epic-1/tab-1",
+        notificationPopoverOpen: true,
+      }),
+    ).toEqual({ reason: "notification-popover", ownerId: "notifications" });
+
+    expect(
+      resolveTileFindOwnerBlocker({
+        ...CLEAR,
+        pathname: "/",
+        domDialogActive: true,
+      }),
+    ).toEqual({ reason: "dom-dialog", ownerId: "dom-dialog" });
+  });
+
+  it("prefers the route body over an overlay when both apply", () => {
+    expect(
+      resolveTileFindOwnerBlocker({
+        ...CLEAR,
+        pathname: "/settings/general",
+        appDialogActive: true,
+      }),
+    ).toEqual({ reason: "non-canvas-route", ownerId: "/settings/general" });
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/tile-find/tile-find-owner-blocker.ts
+++ b/clients/gui-app/src/components/epic-canvas/tile-find/tile-find-owner-blocker.ts
@@ -1,0 +1,68 @@
+import type { TileFindOwnerBlocker } from "@/stores/tile-find/types";
+
+/**
+ * Routes whose body actually paints OVER `TopLevelTabHost`.
+ *
+ * This is deliberately NOT "is the pathname an epic canvas path". For a
+ * signed-in user every ordinary route body renders `null` - `/`
+ * (`RootLandingPage`), `/draft/$draftId`, `/epics` and `/epics/$epicId/$tabId`
+ * (once the tab record exists) - because the visible surface is mounted by
+ * `TopLevelTabHost` from the tabs store, not by the router. The router only
+ * lags along: it is navigated when a tab is ACTIVATED, so a restored window
+ * legitimately sits at `/` with a focused Epic surface showing a file tile.
+ * Gating ownership on an epic-path match therefore blocked find and select-all
+ * in the app's normal startup state (traycerai/traycer#592).
+ *
+ * Which surface is frontmost is already answered, route-independently, by pane
+ * activity: `TileFindScope` registers `isEligible: isActive && paneFocused`,
+ * and `paneFocused` derives from the tabs store's active item. That is the
+ * signal that decides ownership. This list only has to name the routes that
+ * take the viewport away from the tab host entirely.
+ *
+ * Adding a route that renders its own full-screen body? Add it here too.
+ */
+function routeOwnsViewport(pathname: string): boolean {
+  return (
+    pathname === "/onboarding" ||
+    pathname.startsWith("/onboarding/") ||
+    pathname === "/settings" ||
+    pathname.startsWith("/settings/")
+  );
+}
+
+export function resolveTileFindOwnerBlocker(args: {
+  readonly pathname: string;
+  readonly commandPaletteOpen: boolean;
+  readonly systemOverlayActive: boolean;
+  readonly appDialogActive: boolean;
+  readonly desktopDialogActive: boolean;
+  readonly migrationDialogActive: boolean;
+  readonly notificationPopoverOpen: boolean;
+  readonly domDialogActive: boolean;
+}): TileFindOwnerBlocker | null {
+  if (routeOwnsViewport(args.pathname)) {
+    return { reason: "non-canvas-route", ownerId: args.pathname };
+  }
+  if (args.commandPaletteOpen) {
+    return { reason: "command-palette", ownerId: "command-palette" };
+  }
+  if (args.systemOverlayActive) {
+    return { reason: "system-overlay", ownerId: "system-overlay" };
+  }
+  if (args.appDialogActive) {
+    return { reason: "app-dialog", ownerId: "app-dialog" };
+  }
+  if (args.desktopDialogActive) {
+    return { reason: "desktop-dialog", ownerId: "desktop-dialog" };
+  }
+  if (args.migrationDialogActive) {
+    return { reason: "migration-dialog", ownerId: "migration-dialog" };
+  }
+  if (args.notificationPopoverOpen) {
+    return { reason: "notification-popover", ownerId: "notifications" };
+  }
+  if (args.domDialogActive) {
+    return { reason: "dom-dialog", ownerId: "dom-dialog" };
+  }
+  return null;
+}

--- a/clients/gui-app/src/components/epic-canvas/tile-find/tile-find-owner-bridge.tsx
+++ b/clients/gui-app/src/components/epic-canvas/tile-find/tile-find-owner-bridge.tsx
@@ -12,9 +12,7 @@ import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { useMigrationRunStore } from "@/stores/migration/migration-run-store";
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
 import { useTileFindStore } from "@/stores/tile-find";
-import type { TileFindOwnerBlocker } from "@/stores/tile-find/types";
-
-const EPIC_CANVAS_ROUTE_PATTERN = /^\/epics\/[^/]+\/[^/]+\/?$/;
+import { resolveTileFindOwnerBlocker } from "@/components/epic-canvas/tile-find/tile-find-owner-blocker";
 
 export function TileFindOwnerBridge(): ReactNode {
   const pathname = useRouterState({
@@ -80,43 +78,6 @@ export function TileFindOwnerBridge(): ReactNode {
     [setOwnerBlocker],
   );
 
-  return null;
-}
-
-function resolveTileFindOwnerBlocker(args: {
-  readonly pathname: string;
-  readonly commandPaletteOpen: boolean;
-  readonly systemOverlayActive: boolean;
-  readonly appDialogActive: boolean;
-  readonly desktopDialogActive: boolean;
-  readonly migrationDialogActive: boolean;
-  readonly notificationPopoverOpen: boolean;
-  readonly domDialogActive: boolean;
-}): TileFindOwnerBlocker | null {
-  if (!EPIC_CANVAS_ROUTE_PATTERN.test(args.pathname)) {
-    return { reason: "non-canvas-route", ownerId: args.pathname };
-  }
-  if (args.commandPaletteOpen) {
-    return { reason: "command-palette", ownerId: "command-palette" };
-  }
-  if (args.systemOverlayActive) {
-    return { reason: "system-overlay", ownerId: "system-overlay" };
-  }
-  if (args.appDialogActive) {
-    return { reason: "app-dialog", ownerId: "app-dialog" };
-  }
-  if (args.desktopDialogActive) {
-    return { reason: "desktop-dialog", ownerId: "desktop-dialog" };
-  }
-  if (args.migrationDialogActive) {
-    return { reason: "migration-dialog", ownerId: "migration-dialog" };
-  }
-  if (args.notificationPopoverOpen) {
-    return { reason: "notification-popover", ownerId: "notifications" };
-  }
-  if (args.domDialogActive) {
-    return { reason: "dom-dialog", ownerId: "dom-dialog" };
-  }
   return null;
 }
 

--- a/clients/gui-app/src/components/epic-canvas/tile-select-all-bridge.tsx
+++ b/clients/gui-app/src/components/epic-canvas/tile-select-all-bridge.tsx
@@ -1,0 +1,47 @@
+import { useEffect, type ReactNode } from "react";
+import { hasPlatformModKey } from "@/lib/keybindings/chord";
+import { isEditableEventTarget } from "@/lib/keybindings/editable-target";
+import { selectAllInActiveTile } from "@/lib/commands/tile-select-all";
+import { isCanvasCoveredByBlocker } from "@/stores/active-tile-owner";
+
+/**
+ * The app's single owner of Ctrl/Cmd+A.
+ *
+ * One window listener rather than one per tile: two tiles both claiming the key
+ * would race on `preventDefault` and let DOM order pick the winner, which is
+ * exactly what the active-owner resolution exists to prevent.
+ *
+ * Deliberately not a `lib/keybindings` action - select-all is not rebindable,
+ * and routing it through chord dispatch would put it in the conflict table
+ * against user bindings for no gain.
+ *
+ * A text field keeps the native behavior (select the field, not the tile), and
+ * the default also runs untouched whenever no tile owns the key, so the desktop
+ * Edit > Select All role stays correct off-canvas.
+ */
+export function TileSelectAllBridge(): ReactNode {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "a" && event.key !== "A") return;
+      if (!hasPlatformModKey(event)) return;
+      if (event.altKey || event.shiftKey) return;
+      if (isEditableEventTarget(event.target)) return;
+      // preventDefault only once the selection actually moved - a tile that
+      // owns the key but renders no selection root must not swallow it.
+      if (selectAllInActiveTile()) {
+        event.preventDefault();
+        return;
+      }
+      // No owner, but an overlay is frontmost with the canvas still mounted
+      // behind it. Chromium's document-wide default would select those hidden
+      // tiles, so swallow the key instead. With nothing behind the overlay the
+      // native default is correct and runs untouched.
+      if (isCanvasCoveredByBlocker()) event.preventDefault();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
+  return null;
+}

--- a/clients/gui-app/src/components/layout/app-shell.tsx
+++ b/clients/gui-app/src/components/layout/app-shell.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { DiffWorkerPoolProvider } from "@/components/diff-worker-pool-provider";
 import { RootDndProvider } from "@/components/epic-canvas/dnd/root-dnd-provider";
 import { TileFindOwnerBridge } from "@/components/epic-canvas/tile-find/tile-find-owner-bridge";
+import { TileSelectAllBridge } from "@/components/epic-canvas/tile-select-all-bridge";
 import { QuitInterceptBridge } from "@/components/layout/bridges/quit-intercept-bridge";
 import { MigrationBlockingModalHost } from "@/components/layout/dialogs/migration-blocking-modal-host";
 import { AppHeader } from "@/components/layout/header/app-header";
@@ -58,6 +59,7 @@ export function AppShell(props: AppShellProps) {
                 </HostScopeReady>
               </div>
               <TileFindOwnerBridge />
+              <TileSelectAllBridge />
             </main>
             <OpenFolderDialog />
             <RemoteWorkspacePathPickerHost />

--- a/clients/gui-app/src/lib/commands/__tests__/tile-select-all.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/tile-select-all.test.tsx
@@ -1,0 +1,193 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { TileSelectAllBridge } from "@/components/epic-canvas/tile-select-all-bridge";
+import { selectAllInActiveTile } from "@/lib/commands/tile-select-all";
+import { createUnavailableTileFindAdapter } from "@/stores/tile-find";
+import { useTileFindStore } from "@/stores/tile-find/tile-find-store";
+import type { TileFindOwnerBlockerReason } from "@/stores/tile-find/types";
+
+const TILE_A = "inst-a";
+const TILE_B = "inst-b";
+
+/**
+ * Two tiles plus app chrome, in the same shape the canvas renders: the tile
+ * wrapper carries `data-tile-instance-id`, the content root carries
+ * `data-selection-root`, and the tile header sits outside it.
+ */
+function mountCanvas(): void {
+  document.body.innerHTML = `
+    <div id="sidebar">Chat names and headings</div>
+    <div data-tile-instance-id="${TILE_A}">
+      <div id="header-a">src/index.ts</div>
+      <div data-selection-root=""><pre>FILE A BODY</pre></div>
+    </div>
+    <div data-tile-instance-id="${TILE_B}">
+      <div data-selection-root=""><pre>FILE B BODY</pre></div>
+    </div>
+    <div data-tile-instance-id="inst-rootless"><pre>NO ROOT DECLARED</pre></div>
+  `;
+}
+
+function makeOwner(tileInstanceId: string): () => void {
+  return useTileFindStore.getState().registerTarget({
+    tileInstanceId,
+    contentId: `content-${tileInstanceId}`,
+    viewTabId: "tab-1",
+    tileId: "tile-1",
+    epicId: "epic-1",
+    tileKind: "workspace-file",
+    isEligible: true,
+    adapter: createUnavailableTileFindAdapter({
+      tileInstanceId,
+      tileKind: "workspace-file",
+      message: null,
+    }),
+  });
+}
+
+function block(reason: TileFindOwnerBlockerReason): void {
+  useTileFindStore.getState().setOwnerBlocker({ reason, ownerId: "owner-1" });
+}
+
+function selectedText(): string {
+  const selection = window.getSelection();
+  if (selection === null || selection.rangeCount === 0) return "";
+  return selection.getRangeAt(0).toString();
+}
+
+function pressSelectAll(target: EventTarget): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "a",
+    ctrlKey: true,
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  useTileFindStore.getState().resetForTests();
+  window.getSelection()?.removeAllRanges();
+  mountCanvas();
+});
+
+afterEach(() => {
+  cleanup();
+  useTileFindStore.getState().resetForTests();
+  document.body.innerHTML = "";
+});
+
+describe("selectAllInActiveTile", () => {
+  it("selects only the active tile's content root", () => {
+    makeOwner(TILE_A);
+
+    expect(selectAllInActiveTile()).toBe(true);
+    const selected = selectedText();
+    expect(selected).toContain("FILE A BODY");
+    expect(selected).not.toContain("Chat names and headings");
+    expect(selected).not.toContain("src/index.ts");
+    expect(selected).not.toContain("FILE B BODY");
+  });
+
+  it("follows the owner when the active tile changes", () => {
+    makeOwner(TILE_A);
+    makeOwner(TILE_B);
+
+    expect(selectAllInActiveTile()).toBe(true);
+    expect(selectedText()).toContain("FILE B BODY");
+    expect(selectedText()).not.toContain("FILE A BODY");
+  });
+
+  it("declines when no tile is eligible", () => {
+    const release = makeOwner(TILE_A);
+    release();
+
+    expect(selectAllInActiveTile()).toBe(false);
+  });
+
+  it("declines while an overlay holds global keys", () => {
+    makeOwner(TILE_A);
+    block("command-palette");
+
+    expect(selectAllInActiveTile()).toBe(false);
+    expect(selectedText()).toBe("");
+  });
+
+  it("declines when the owning tile declares no selection root", () => {
+    makeOwner("inst-rootless");
+
+    expect(selectAllInActiveTile()).toBe(false);
+  });
+});
+
+describe("TileSelectAllBridge", () => {
+  beforeEach(() => {
+    render(<TileSelectAllBridge />);
+  });
+
+  it("claims Ctrl/Cmd+A for the active tile", () => {
+    makeOwner(TILE_A);
+
+    const event = pressSelectAll(window);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(selectedText()).toContain("FILE A BODY");
+  });
+
+  it("leaves the browser default alone inside a text field", () => {
+    makeOwner(TILE_A);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    expect(pressSelectAll(input).defaultPrevented).toBe(false);
+    expect(selectedText()).toBe("");
+  });
+
+  it("leaves the browser default alone when there is no canvas at all", () => {
+    expect(pressSelectAll(window).defaultPrevented).toBe(false);
+  });
+
+  // jsdom never runs Chromium's document-wide select-all, so this pins the
+  // mechanism that suppresses it - preventDefault - plus the selection staying
+  // put. The real default is covered by the CDP pass, not here.
+  it("swallows the key when an overlay covers a live canvas", () => {
+    makeOwner(TILE_A);
+    block("app-dialog");
+
+    expect(pressSelectAll(window).defaultPrevented).toBe(true);
+    expect(selectedText()).toBe("");
+  });
+
+  it("still swallows it for a route-body overlay such as Settings", () => {
+    makeOwner(TILE_A);
+    block("non-canvas-route");
+
+    expect(pressSelectAll(window).defaultPrevented).toBe(true);
+    expect(selectedText()).toBe("");
+  });
+
+  it("leaves the default alone when a blocker covers nothing", () => {
+    block("command-palette");
+
+    expect(pressSelectAll(window).defaultPrevented).toBe(false);
+  });
+
+  it("ignores modified variants that are not select-all", () => {
+    makeOwner(TILE_A);
+
+    const shifted = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(shifted);
+
+    expect(shifted.defaultPrevented).toBe(false);
+    expect(selectedText()).toBe("");
+  });
+});

--- a/clients/gui-app/src/lib/commands/tile-select-all.ts
+++ b/clients/gui-app/src/lib/commands/tile-select-all.ts
@@ -1,0 +1,60 @@
+import { getActiveTileOwner } from "@/stores/active-tile-owner";
+
+// Canonical command surface for active-owner select-all, mirroring
+// `lib/commands/tile-find.ts`: owner resolution and scope policy live here, not
+// re-implemented at each call site.
+
+/**
+ * The opt-in a tile writes to declare what Ctrl/Cmd+A should select. Put it on
+ * the tile's CONTENT root only - not the tile wrapper - so headers, toolbars and
+ * absolutely-positioned chrome (a chat composer overlay, an approval dock) stay
+ * out of the selection. First match inside the owning tile wins, so an outer
+ * root shadows any nested one. A tile that declares none keeps the browser
+ * default.
+ */
+const TILE_SELECTION_ROOT_ATTRIBUTE = "data-selection-root";
+
+/**
+ * Confines select-all to the active tile's content.
+ *
+ * Without this, Ctrl/Cmd+A outside a text field falls through to Chromium's
+ * document-wide select-all, which sweeps up the sidebar, the tab strip and every
+ * other tile (traycerai/traycer#592).
+ *
+ * Returns false when no tile owns the key or the owner declares no selection
+ * root, so the caller can let the browser default through untouched - that is
+ * what keeps select-all working normally on non-canvas routes and under an open
+ * overlay.
+ */
+export function selectAllInActiveTile(): boolean {
+  const owner = getActiveTileOwner();
+  if (owner === null) return false;
+  const root = findTileSelectionRoot(owner.tileInstanceId);
+  if (root === null) return false;
+  const selection = window.getSelection();
+  if (selection === null) return false;
+  const range = document.createRange();
+  range.selectNodeContents(root);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+}
+
+/**
+ * Matched by walking up from each declared root rather than by interpolating the
+ * instance id into a selector - tile instance ids are opaque strings, and an
+ * attribute-selector match would need escaping to stay correct for all of them.
+ * Document order, so an outer root wins over a nested one.
+ */
+function findTileSelectionRoot(tileInstanceId: string): HTMLElement | null {
+  const roots = document.querySelectorAll<HTMLElement>(
+    `[${TILE_SELECTION_ROOT_ATTRIBUTE}]`,
+  );
+  for (const root of roots) {
+    const owner = root.closest<HTMLElement>("[data-tile-instance-id]");
+    if (owner !== null && owner.dataset.tileInstanceId === tileInstanceId) {
+      return root;
+    }
+  }
+  return null;
+}

--- a/clients/gui-app/src/stores/active-tile-owner.ts
+++ b/clients/gui-app/src/stores/active-tile-owner.ts
@@ -1,0 +1,48 @@
+import { useTileFindStore } from "@/stores/tile-find";
+import type { TileFindActiveOwner } from "@/stores/tile-find/types";
+
+/**
+ * The tile that owns pane-scoped global keys right now, or `null` when nothing
+ * does.
+ *
+ * Ownership is NOT find-specific, even though it currently lives in the
+ * tile-find store - find was simply its first consumer. Two inputs decide it,
+ * and both are generic:
+ *
+ *  - every tile registers a target through `TileFindScope` with
+ *    `isEligible: isActive && paneFocused`, so the owner is the active tile of
+ *    the focused pane (most recent registration wins a tie);
+ *  - `TileFindOwnerBridge` clears the owner outright while a command palette,
+ *    system overlay, app/desktop/migration dialog, notification popover, native
+ *    `<dialog>`, or non-canvas route holds global keys.
+ *
+ * Any feature answering "which tile does this keystroke belong to" must resolve
+ * it HERE. Re-deriving from `isActive` + `usePaneFocused` in the feature looks
+ * equivalent and is not: it cannot see that blocker policy, so it keeps claiming
+ * keys underneath an open overlay.
+ *
+ * This module is the seam. If owner resolution is ever lifted out of the find
+ * store into its own registry, this file changes and its consumers do not.
+ */
+export type ActiveTileOwner = TileFindActiveOwner;
+
+export function getActiveTileOwner(): ActiveTileOwner | null {
+  return useTileFindStore.getState().activeOwner;
+}
+
+/**
+ * True when a blocker holds global keys while canvas tiles are still mounted
+ * behind it.
+ *
+ * The distinction matters for any key whose browser default is destructive at
+ * document scope. Under an open overlay there is no owner, but the canvas is
+ * still in the document, so letting Chromium's document-wide select-all run
+ * would sweep up the hidden tiles - the same defect as #592 wearing an overlay.
+ * With no tiles registered (signed out, onboarding, an empty window) nothing of
+ * ours is behind the overlay and the native default is the correct behavior.
+ */
+export function isCanvasCoveredByBlocker(): boolean {
+  const state = useTileFindStore.getState();
+  if (state.ownerBlocker === null) return false;
+  return Object.keys(state.targetsByTileInstanceId).length > 0;
+}


### PR DESCRIPTION
## Summary

Fixes #592. Ctrl/Cmd+A now selects the content of the active tile instead of sweeping the entire window.

## Root cause

The renderer did not claim Ctrl/Cmd+A, so Chromium's document-wide select-all ran whenever focus was outside a text field. The existing pane-scoped global-key owner also had a router pathname gate that blocked ownership for restored windows at `/`, even though `TopLevelTabHost` had mounted a focused Epic surface.

## What changed

- Extracted the tile-find owner blocker policy and changed its route handling to deny only routes that paint over the tab host, such as onboarding and settings. Existing overlay, dialog and popover blockers remain unchanged.
- Added a shared active-tile-owner seam and a canonical tile select-all command.
- Mounted one window-level select-all bridge beside the tile-find bridge. It scopes selection to the active tile, lets text fields keep native behavior, and suppresses document-wide selection while an overlay covers live canvas tiles.
- Opted the workspace-file body, shared diff body, and chat transcript content roots into selection with `data-selection-root`. Headers, toolbars, chat composer surfaces and other tile chrome stay excluded.

## Verification

- Full gui-app suite: 10842 passed, 1 skipped. `compile` and `lint` clean.
- Live Electron verification over CDP at pathname `/` after a fresh renderer boot, with no forced route: file selection was scoped correctly; tile headers and the tab strip were excluded; the notifications popover swallowed the key; switching to the Start Page released ownership; switching back reacquired it; focused text inputs kept native behavior.
- The live check used in-page synthetic KeyboardEvents because `Input.dispatchKeyEvent` does not reach this Electron target. It verifies the bridge, owner resolution and real DOM scoping, including `preventDefault` behavior.

## Known limitations

- Clicking the native Edit > Select All menu item still performs document-wide selection. The `role: "selectAll"` is intentionally preserved so native text-field select-all behavior is not reimplemented. This fix targets the keyboard path.
- Chat and bundle-diff surfaces are virtualized, so select-all covers mounted rows.
- A focused non-tile top-level surface such as Start Page or a landing draft still uses document-wide select-all. It registers no tile and sets no blocker, and is out of scope for #592.
