### PR TITLE
fix(gui-app): close the window for the sole blank Start Page

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/use-close-tab-flow.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/use-close-tab-flow.test.tsx
@@ -9,11 +9,21 @@ import { selectHostFocusedRef } from "@/stores/tabs/selectors";
 import { executeTabSplitCommand } from "@/stores/tabs/tab-split-commands";
 import { installTabSyncCoordinator } from "@/lib/tab-sync/tab-sync-coordinator";
 import * as TabNav from "@/lib/tab-navigation";
+import type { HeaderTab } from "@/stores/tabs/types";
 
 installTabSyncCoordinator({ readyPromise: Promise.resolve() });
 
 const routerState = vi.hoisted(() => ({ pathname: "/" }));
 const navigateSpy = vi.hoisted(() => vi.fn());
+const requestCloseWindowSpy = vi.hoisted(() =>
+  vi.fn((_windowId: string) => Promise.resolve()),
+);
+const windowsBridgeState = vi.hoisted(() => ({
+  bridge: null as {
+    readonly windowId: string;
+    readonly requestClose: typeof requestCloseWindowSpy;
+  } | null,
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => navigateSpy,
@@ -33,6 +43,10 @@ vi.mock("@tanstack/react-router", () => ({
   }) => select({ location: { pathname: routerState.pathname } }),
 }));
 
+vi.mock("@/providers/windows-bridge-context", () => ({
+  useWindowsBridge: () => windowsBridgeState.bridge,
+}));
+
 vi.mock("@/lib/registries/epic-session-registry", () => ({
   epicHasUnsyncedEdits: () => false,
   releaseOpenEpicSessionIfUnused: () => undefined,
@@ -48,10 +62,24 @@ function resetStores(): void {
   });
 }
 
+function draftHeaderTab(draftId: string): HeaderTab {
+  return {
+    kind: "draft",
+    id: draftId,
+    route: `/draft/${draftId}`,
+    name: "Start Page",
+    icon: null,
+    canDuplicate: false,
+    canOpenInNewWindow: false,
+  };
+}
+
 describe("useCloseTabFlow", () => {
   beforeEach(() => {
     routerState.pathname = "/";
     navigateSpy.mockReset();
+    requestCloseWindowSpy.mockClear();
+    windowsBridgeState.bridge = null;
     resetStores();
   });
   afterEach(() => {
@@ -79,6 +107,122 @@ describe("useCloseTabFlow", () => {
       tabId: a,
       epicId: "epic-a",
     });
+  });
+
+  it("closes the desktop window instead of removing its only blank Start Page", () => {
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    routerState.pathname = `/draft/${draftId}`;
+    windowsBridgeState.bridge = {
+      windowId: "window-b",
+      requestClose: requestCloseWindowSpy,
+    };
+
+    const { result } = renderHook(() => useCloseTabFlow());
+    act(() => {
+      result.current.requestCloseTab(draftHeaderTab(draftId));
+    });
+
+    expect(requestCloseWindowSpy).toHaveBeenCalledExactlyOnceWith("window-b");
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the recreate-Start-Page flow for a lone non-empty draft", () => {
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    useLandingDraftStore.getState().setDraftContent(
+      draftId,
+      {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "Keep me" }] },
+        ],
+      },
+      null,
+    );
+    routerState.pathname = `/draft/${draftId}`;
+    windowsBridgeState.bridge = {
+      windowId: "window-b",
+      requestClose: requestCloseWindowSpy,
+    };
+
+    const { result } = renderHook(() => useCloseTabFlow());
+    act(() => {
+      result.current.requestCloseTab(draftHeaderTab(draftId));
+    });
+
+    expect(requestCloseWindowSpy).not.toHaveBeenCalled();
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(0);
+    expect(navigateSpy).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("does not mistake an image-only draft for a blank Start Page", () => {
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    useLandingDraftStore.getState().setDraftContent(
+      draftId,
+      {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "imageAttachment",
+                attrs: {
+                  id: "image-1",
+                  fileName: "reference.png",
+                  hash: "image-hash",
+                  mimeType: "image/png",
+                  size: 42,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      null,
+    );
+    routerState.pathname = `/draft/${draftId}`;
+    windowsBridgeState.bridge = {
+      windowId: "window-b",
+      requestClose: requestCloseWindowSpy,
+    };
+
+    const { result } = renderHook(() => useCloseTabFlow());
+    act(() => {
+      result.current.requestCloseTab(draftHeaderTab(draftId));
+    });
+
+    expect(requestCloseWindowSpy).not.toHaveBeenCalled();
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(0);
+    expect(navigateSpy).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("closes a recreated blank Start Page on the next close gesture", () => {
+    const epicId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-only", "Only task");
+    routerState.pathname = `/epics/epic-only/${epicId}`;
+    windowsBridgeState.bridge = {
+      windowId: "window-b",
+      requestClose: requestCloseWindowSpy,
+    };
+    const { result, rerender } = renderHook(() => useCloseTabFlow());
+
+    act(() => {
+      result.current.closeActiveTab();
+    });
+    expect(requestCloseWindowSpy).not.toHaveBeenCalled();
+    expect(navigateSpy).toHaveBeenCalledWith({ to: "/" });
+
+    const recreatedDraftId = useLandingDraftStore.getState().createDraft(null);
+    routerState.pathname = `/draft/${recreatedDraftId}`;
+    rerender();
+    act(() => {
+      result.current.closeActiveTab();
+    });
+
+    expect(requestCloseWindowSpy).toHaveBeenCalledExactlyOnceWith("window-b");
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
   });
 
   it("closes the route-backed tab when a split focuses its fillable half", () => {

--- a/clients/gui-app/src/components/layout/dialogs/use-close-tab-flow.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/use-close-tab-flow.tsx
@@ -18,6 +18,9 @@ import { useTabCloseCommand } from "@/components/layout/tabs/use-tab-close-comma
 import { useNeighborTabPicker } from "@/components/layout/tabs/use-neighbor-tab-picker";
 import { useUnsyncedCloseDialog } from "@/components/layout/dialogs/use-unsynced-close-dialog";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { useWindowsBridge } from "@/providers/windows-bridge-context";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { isEmptyLandingDraftContent } from "@/lib/composer/landing-draft-empty";
 
 export interface CloseTabFlow {
   readonly requestCloseTab: (tab: HeaderTab) => void;
@@ -31,12 +34,17 @@ export function useCloseTabFlow(): CloseTabFlow {
   const closeTab = useTabCloseCommand();
   const picker = useNeighborTabPicker();
   const dialog = useUnsyncedCloseDialog();
+  const windowsBridge = useWindowsBridge();
   const activePathname = useRouterState({
     select: (s) => s.location.pathname,
   });
 
   const requestCloseTab = useCallback(
     (tab: HeaderTab) => {
+      if (windowsBridge !== null && isOnlyBlankStartPage(tab)) {
+        void windowsBridge.requestClose(windowsBridge.windowId);
+        return;
+      }
       const captured = picker.capture(tab);
       const finalize = () => {
         closeTab(tab);
@@ -50,7 +58,7 @@ export function useCloseTabFlow(): CloseTabFlow {
       if (dialog.promptOrConfirm(tab, finalize)) return;
       finalize();
     },
-    [closeTab, dialog, picker],
+    [closeTab, dialog, picker, windowsBridge],
   );
 
   const closeOtherTabs = useCallback(
@@ -118,4 +126,16 @@ export function useCloseTabFlow(): CloseTabFlow {
     }),
     [closeActiveTab, closeOtherTabs, dialog.dialog, requestCloseTab],
   );
+}
+
+function isOnlyBlankStartPage(tab: HeaderTab): boolean {
+  if (tab.kind !== "draft") return false;
+  const tabs = getHeaderTabs();
+  if (tabs.length !== 1 || tabs[0]?.kind !== "draft" || tabs[0].id !== tab.id) {
+    return false;
+  }
+  const draft = useLandingDraftStore
+    .getState()
+    .drafts.find((candidate) => candidate.id === tab.id);
+  return draft !== undefined && isEmptyLandingDraftContent(draft.content);
 }

--- a/clients/gui-app/src/lib/commands/actions/open-epic-from-list.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-from-list.ts
@@ -4,8 +4,7 @@ import {
   openEpicFromListIntent,
 } from "@/lib/tab-navigation";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
-import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
-import { containsImageAtoms } from "@/lib/composer/image-atoms";
+import { isEmptyLandingDraftContent } from "@/lib/composer/landing-draft-empty";
 import {
   Analytics,
   AnalyticsEvent,
@@ -74,11 +73,6 @@ function readActiveEmptyDraftId(currentPathname: string): string | null {
   // "Empty" is now derived from content: no typed text AND no image atoms. An
   // image-only draft is real content, so replacing it in-place (which closes it)
   // would silently drop the image - treat it as non-empty.
-  if (
-    extractPlainTextFromComposerJSONContent(draft.content).trim().length > 0
-  ) {
-    return null;
-  }
-  if (containsImageAtoms(draft.content)) return null;
+  if (!isEmptyLandingDraftContent(draft.content)) return null;
   return draft.id;
 }

--- a/clients/gui-app/src/lib/composer/landing-draft-empty.ts
+++ b/clients/gui-app/src/lib/composer/landing-draft-empty.ts
@@ -1,0 +1,15 @@
+import type { JsonContent } from "@traycer/protocol/common/registry";
+import { containsImageAtoms } from "@/lib/composer/image-atoms";
+import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
+
+/**
+ * A draft is still a blank Start Page only while it has neither typed text nor
+ * an attached image. Image-only drafts are real drafts even though their tab
+ * title falls back to "Start Page".
+ */
+export function isEmptyLandingDraftContent(content: JsonContent): boolean {
+  return (
+    extractPlainTextFromComposerJSONContent(content).trim().length === 0 &&
+    !containsImageAtoms(content)
+  );
+}


### PR DESCRIPTION
## Summary

- Close the current desktop window when the sole remaining tab is a genuinely blank Start Page.
- Preserve the existing close-and-recreate-Start-Page flow for lone tasks, settings/history tabs, text drafts, and image-only drafts.
- Share the blank-draft predicate so opening an epic never replaces an image-only draft.

## Verification

- Targeted close-tab suites: 12 tests passed.
- GUI compile passed.
- GUI ESLint passed.
- React Doctor passed.
- OSS pre-commit affected build, compile, lint, and format checks passed.
- Commit carries and locally verifies `Signed-off-by: anurag <anurag@traycer.ai>`.

## Checklist

- [x] Tests added/updated where it makes sense
- [x] Code is formatted
- [x] Pre-commit hooks pass
- [x] Commit is signed off with `git commit -s`