### PR TITLE
fix(gui-app): prevent tooltips from swallowing folder-picker clicks

### DIFF
--- a/clients/gui-app/src/components/ui/__tests__/tooltip-hit-testing.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/tooltip-hit-testing.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Regression coverage for traycerai/traycer#466 (and the click half of #446):
+ * a label-only tooltip swallowing clicks meant for whatever it covers.
+ *
+ * `TooltipContent`'s `pointer-events-none` is not enough on its own - Radix
+ * Popper renders that content inside a same-size positioning wrapper that keeps
+ * `pointer-events: auto`, and THAT wrapper won hit-testing. In the workspace
+ * folder picker (28px rows, `side="top"` tooltips) it landed on the row above,
+ * so clicking that row did nothing. The fix is one rule in `index.css`.
+ *
+ * jsdom has no layout and cannot hit-test, so the two halves are pinned
+ * separately and joined by construction: the CSS rule is read out of
+ * `index.css`, and its selector - the exact string, not a copy - is then
+ * matched against the wrapper a real Radix tooltip renders. Deleting the rule
+ * fails the first half; Radix changing its DOM shape (an extra wrapper level,
+ * a renamed attribute) fails the second. The end-to-end proof that the click
+ * reaches the covered control needs a real browser and lives outside vitest.
+ */
+import "../../../../__tests__/test-browser-apis";
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+
+const INDEX_CSS = readFileSync(
+  path.resolve(__dirname, "../../../index.css"),
+  "utf8",
+);
+
+/** The `pointer-events: none` rule guarding tooltip wrappers, as authored. */
+function tooltipWrapperRule(): { selector: string; body: string } | null {
+  for (const match of INDEX_CSS.matchAll(
+    /([^{}]*\[data-radix-popper-content-wrapper\][^{}]*)\{([^}]*)\}/g,
+  )) {
+    const body = match[2];
+    if (/pointer-events\s*:\s*none/.test(body)) {
+      return { selector: match[1].trim(), body };
+    }
+  }
+  return null;
+}
+
+afterEach(cleanup);
+
+describe("tooltip hit-testing", () => {
+  it("index.css takes the popper wrapper out of hit-testing", () => {
+    const rule = tooltipWrapperRule();
+    expect(rule).not.toBeNull();
+    // Scoped to tooltips only: popovers, dropdowns and hover cards hold real
+    // controls and must keep receiving pointer events.
+    expect(rule?.selector).toContain('[data-slot="tooltip-content"]');
+  });
+
+  it("that selector matches the wrapper a real tooltip renders", () => {
+    render(
+      <TooltipProvider>
+        <TooltipWrapper
+          label="Worktrees require a Git repository."
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <button type="button">Local</button>
+        </TooltipWrapper>
+      </TooltipProvider>,
+    );
+    // Focus, not hover: Radix honours it immediately, where pointer-enter sits
+    // behind the 500ms open delay (see `tooltip-probe.ts`).
+    fireEvent.focus(screen.getByRole("button", { name: "Local" }));
+
+    const content = screen.getByRole("tooltip");
+    const wrapper = content.parentElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.hasAttribute("data-radix-popper-content-wrapper")).toBe(
+      true,
+    );
+    // The rule as authored, applied to the DOM as rendered. jsdom will not
+    // compute `pointer-events` from a stylesheet we never load, but it does
+    // answer whether the selector selects this node.
+    const selector = tooltipWrapperRule()?.selector ?? "";
+    expect(wrapper?.matches(selector)).toBe(true);
+  });
+});

--- a/clients/gui-app/src/components/ui/tooltip.tsx
+++ b/clients/gui-app/src/components/ui/tooltip.tsx
@@ -74,6 +74,11 @@ function TooltipContent({
           // trigger, which otherwise can drive a hover/reposition loop when
           // the trigger sits directly under the content (e.g. a top-pinned
           // strip flipping the tooltip to `side="bottom"`).
+          //
+          // This class covers the content ONLY. Radix Popper's same-size
+          // positioning wrapper around it stays `pointer-events: auto` and
+          // swallowed clicks on its own until `index.css` opted it out too -
+          // keep both, neither is sufficient alone (traycerai/traycer#466).
           "pointer-events-none z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-ui-xs text-background [overflow-wrap:anywhere] has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -59,6 +59,23 @@
   animation: prompt-stash-count-flash 700ms ease-out both;
 }
 
+/* A label-only tooltip must never win hit-testing from what it covers.
+   `TooltipContent`'s own `pointer-events-none` is NOT enough: Radix Popper
+   renders the content inside a positioning wrapper of exactly the same size,
+   and that wrapper keeps `pointer-events: auto` (Popper only sets `none` on it
+   for `hideWhenDetached`). So the wrapper still swallowed every click that
+   landed on the tooltip's rect - measured in a real browser against the
+   workspace folder picker, where rows are 28px apart and a `side="top"`
+   tooltip lands squarely on the row above: the covered row's controls never
+   received the click, and the cursor read as a text caret over the tooltip's
+   text (traycerai/traycer#466, #446).
+
+   Scoped by the direct child so only tooltip wrappers opt out - popovers,
+   dropdowns and hover cards hold real controls and must stay hit-testable. */
+[data-radix-popper-content-wrapper]:has(> [data-slot="tooltip-content"]) {
+  pointer-events: none;
+}
+
 /* Attachment previews stay on one compact, independently scrollable row. */
 [data-composer-attachment-strip] {
   scrollbar-width: none;


### PR DESCRIPTION
## Summary

- Disable hit-testing on Radix Popper wrappers that contain label-only tooltips, so covered folder-picker rows receive clicks.
- Keep the tooltip content-level `pointer-events-none` class and document why both layers are required.
- Add jsdom regression coverage for the authored selector and the wrapper DOM Radix renders.

## Related issue

Closes #466

## Validation

- `bun run test -- src/components/ui/__tests__/tooltip-hit-testing.test.tsx` (2 passed)
- `bun run test -- src/components/ui/__tests__/hover-preview-surface.test.tsx src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx src/components/home/host-workspace-selector/__tests__/workspace-folders-refresh.test.tsx` (69 passed)
- Targeted Prettier and ESLint checks passed.
- Commit pre-commit hook passed affected build, compile, lint, and format checks.

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format` equivalent check passed)
- [x] Pre-commit hook passed on commit
- [x] Tests added/updated where it makes sense
- [x] Commit is signed off (`git commit -s`) per the DCO
