### PR TITLE
fix(gui-app): preserve prompt stash editor identity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -169,6 +169,7 @@
         "zustand": "catalog:",
       },
       "devDependencies": {
+        "@rolldown/plugin-babel": "catalog:",
         "@tanstack/eslint-plugin-query": "catalog:",
         "@tanstack/eslint-plugin-router": "catalog:",
         "@tanstack/react-query-devtools": "catalog:",
@@ -182,6 +183,8 @@
         "@types/react-dom": "catalog:",
         "@typescript-eslint/eslint-plugin": "catalog:",
         "@typescript-eslint/parser": "catalog:",
+        "@vitejs/plugin-react": "catalog:",
+        "babel-plugin-react-compiler": "catalog:",
         "eslint": "catalog:",
         "eslint-plugin-jsx-a11y": "catalog:",
         "eslint-plugin-react": "catalog:",

--- a/clients/gui-app/package.json
+++ b/clients/gui-app/package.json
@@ -114,6 +114,7 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
+    "@rolldown/plugin-babel": "catalog:",
     "@tanstack/eslint-plugin-query": "catalog:",
     "@tanstack/eslint-plugin-router": "catalog:",
     "@tanstack/react-query-devtools": "catalog:",
@@ -125,6 +126,8 @@
     "@types/pdfmake": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "eslint": "catalog:",

--- a/clients/gui-app/src/components/chat/composer/__tests__/chat-composer-prompt-stash-source.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/chat-composer-prompt-stash-source.test.tsx
@@ -14,6 +14,10 @@ import type { RefObject } from "react";
 
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
 import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
+import {
   useChatPromptStashDestination,
   useChatPromptStashSource,
 } from "@/components/chat/composer/use-chat-prompt-stash-adapters";
@@ -76,10 +80,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "chat-stash-entry-id"),
-}));
-
 function textDoc(text: string): JsonContent {
   return {
     type: "doc",
@@ -105,12 +105,16 @@ function makeEditorHandle(
     | {
         ready?: boolean;
         onFocus?: () => void;
+        editorIncarnation?: ComposerEditorIncarnation;
       }
     | undefined,
 ): ComposerPromptEditorHandle {
   const ready = options?.ready ?? true;
+  const editorIncarnation =
+    options?.editorIncarnation ?? createComposerEditorIncarnation();
   return {
     isReady: () => ready,
+    getEditorIncarnation: () => (ready ? editorIncarnation : null),
     hasFocus: () => false,
     focus: () => {
       options?.onFocus?.();
@@ -136,17 +140,21 @@ function makeEditor(content: JsonContent): {
   readonly focuses: number[];
   readonly handle: ComposerPromptEditorHandle;
   /**
-   * Simulates remount: new ready handle object under the same task id.
+   * Simulates React Compiler facade churn: new handle, same Tiptap editor.
    */
+  replaceFacade: () => ComposerPromptEditorHandle;
+  /** Simulates a real editor remount under the same task id. */
   remount: () => ComposerPromptEditorHandle;
 } {
   const focuses: number[] = [];
   const editorRef: { current: ComposerPromptEditorHandle | null } = {
     current: null,
   };
+  let editorIncarnation = createComposerEditorIncarnation();
 
   const create = (): ComposerPromptEditorHandle => {
     const handle = makeEditorHandle(content, {
+      editorIncarnation,
       onFocus: () => {
         focuses.push(1);
       },
@@ -161,7 +169,11 @@ function makeEditor(content: JsonContent): {
     editorRef,
     focuses,
     handle: initial,
-    remount: () => create(),
+    replaceFacade: () => create(),
+    remount: () => {
+      editorIncarnation = createComposerEditorIncarnation();
+      return create();
+    },
   };
 }
 
@@ -643,7 +655,31 @@ describe("chat composer prompt-stash destination acknowledgement", () => {
     expect(unreadyDest.current.captureIdentity()).toBeNull();
   });
 
-  it("does not insert or consume when ready handle remounts under the same taskId", async () => {
+  it("accepts React Compiler handle-facade churn for the same editor incarnation", async () => {
+    useComposerDraftStore.getState().setSnapshot(taskId, emptyDoc(), null);
+    const editor = makeEditor(emptyDoc());
+    const { result } = renderHook(() =>
+      useChatPromptStashDestination(taskId, editor.editorRef),
+    );
+    const captured = result.current.captureIdentity();
+    if (captured === null) throw new Error("expected capture");
+
+    const replacement = editor.replaceFacade();
+    expect(replacement).not.toBe(editor.handle);
+    expect(replacement.getEditorIncarnation()).toBe(captured.editorIncarnation);
+
+    const insertResult = await result.current.importAndInsert({
+      identity: captured,
+      content: textDoc("restored after facade churn"),
+    });
+
+    expect(insertResult).toEqual({ status: "accepted" });
+    expect(useComposerDraftStore.getState().drafts[taskId]?.content).toEqual(
+      textDoc("restored after facade churn"),
+    );
+  });
+
+  it("does not insert or consume when the editor remounts under the same taskId", async () => {
     useComposerDraftStore.getState().setSnapshot(taskId, emptyDoc(), null);
 
     let resolveMaterialize: ((content: JsonContent) => void) | undefined;
@@ -676,7 +712,7 @@ describe("chat composer prompt-stash destination acknowledgement", () => {
     });
     expect(resolveMaterialize).toBeTypeOf("function");
 
-    // Same taskId, new ready handle object (editor remount).
+    // Same taskId, genuinely new editor incarnation.
     const remounted = editor.remount();
     expect(remounted).not.toBe(capturedHandle);
     expect(editor.editorRef.current).toBe(remounted);

--- a/clients/gui-app/src/components/chat/composer/__tests__/chat-composer-submit-steer.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/chat-composer-submit-steer.test.tsx
@@ -11,6 +11,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import { createComposerPickerStore } from "../picker/composer-picker-store";
 import type { ComposerPromptEditorHandle } from "../composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import {
   useChatComposerSubmit,
   type ChatComposerSubmitResult,
@@ -687,8 +688,10 @@ function mountSubmit(input: MountSubmitInput): {
 }
 
 function editorHandle(content: JsonContent): ComposerPromptEditorHandle {
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-prompt-editor-document-selection-contract.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-prompt-editor-document-selection-contract.test.tsx
@@ -88,6 +88,65 @@ async function flushEditor(): Promise<void> {
 }
 
 describe("ComposerPromptEditor document vs selection contract", () => {
+  it("keeps one incarnation for the Tiptap editor and changes it on remount", async () => {
+    const onDocumentChange = vi.fn();
+    const onSelectionChange = vi.fn();
+    const handleRef: { current: ComposerPromptEditorHandle | null } = {
+      current: null,
+    };
+    const initialContent = emptyDoc();
+
+    const mounted = render(
+      <Harness
+        handleRef={handleRef}
+        onDocumentChange={onDocumentChange}
+        onSelectionChange={onSelectionChange}
+        initialContent={initialContent}
+        initialSelection={null}
+      />,
+    );
+    await flushEditor();
+
+    const firstHandle = handleRef.current;
+    if (firstHandle === null) throw new Error("editor handle missing");
+    const firstIncarnation = firstHandle.getEditorIncarnation();
+    expect(firstIncarnation).not.toBeNull();
+
+    // This suite runs through the same React Compiler preset as production.
+    // A render may replace the imperative facade, but not the Tiptap Editor.
+    mounted.rerender(
+      <Harness
+        handleRef={handleRef}
+        onDocumentChange={onDocumentChange}
+        onSelectionChange={onSelectionChange}
+        initialContent={textDoc("new prop, same mounted editor")}
+        initialSelection={null}
+      />,
+    );
+    await flushEditor();
+
+    const rerenderedHandle = handleRef.current;
+    if (rerenderedHandle === null) throw new Error("editor handle missing");
+    expect(rerenderedHandle).not.toBe(firstHandle);
+    expect(rerenderedHandle.getEditorIncarnation()).toBe(firstIncarnation);
+
+    mounted.unmount();
+    render(
+      <Harness
+        handleRef={handleRef}
+        onDocumentChange={onDocumentChange}
+        onSelectionChange={onSelectionChange}
+        initialContent={initialContent}
+        initialSelection={null}
+      />,
+    );
+    await flushEditor();
+
+    const remountedHandle = handleRef.current;
+    if (remountedHandle === null) throw new Error("editor handle missing");
+    expect(remountedHandle.getEditorIncarnation()).not.toBe(firstIncarnation);
+  });
+
   it("fires onDocumentChange for a real document mutation", async () => {
     const onDocumentChange = vi.fn();
     const onSelectionChange = vi.fn();

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-prompt-editor-handle-fixtures.ts
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-prompt-editor-handle-fixtures.ts
@@ -10,6 +10,10 @@ import { vi, type Mock } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import type { ComposerPromptEditorHandle } from "../composer-prompt-editor";
+import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
 
 export type FakeEditorSelection = {
   readonly from: number;
@@ -68,6 +72,7 @@ export function createFakeComposerPromptEditorHandle(
   }> = [];
   const clears: number[] = [];
   const focuses: number[] = [];
+  let editorIncarnation = createComposerEditorIncarnation();
 
   const applyContent = (
     next: JsonContent,
@@ -86,8 +91,11 @@ export function createFakeComposerPromptEditorHandle(
     applyContent(next, nextSelection, "sync");
   });
 
-  const buildHandle = (): ComposerPromptEditorHandle => ({
+  const buildHandle = (
+    incarnation: ComposerEditorIncarnation,
+  ): ComposerPromptEditorHandle => ({
     isReady: () => ready,
+    getEditorIncarnation: () => (ready ? incarnation : null),
     hasFocus: () => false,
     focus: () => {
       focuses.push(1);
@@ -116,7 +124,7 @@ export function createFakeComposerPromptEditorHandle(
     dismissActiveSuggestion: () => false,
   });
 
-  const handle = buildHandle();
+  const handle = buildHandle(editorIncarnation);
   const editorRef: { current: ComposerPromptEditorHandle | null } = {
     current: handle,
   };
@@ -136,7 +144,8 @@ export function createFakeComposerPromptEditorHandle(
     editorRef,
     rebuild: () => {
       ready = true;
-      const next = buildHandle();
+      editorIncarnation = createComposerEditorIncarnation();
+      const next = buildHandle(editorIncarnation);
       editorRef.current = next;
       return next;
     },

--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -19,6 +19,10 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 
 import type { ChatComposerSubmitSource } from "@/lib/chats/resolve-steer-submit";
+import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
 import type { MentionAttachment } from "@/lib/composer/types";
 import { cn } from "@/lib/utils";
 import { registerComposerFocus } from "@/lib/composer/composer-focus-registry";
@@ -47,6 +51,20 @@ import {
 import type { ImageAttachmentAttrs } from "./editor/extensions/image-attachment-extension";
 import type { ComposerPickerStore } from "./picker/composer-picker-store";
 
+const composerEditorIncarnations = new WeakMap<
+  Editor,
+  ComposerEditorIncarnation
+>();
+
+function incarnationForEditor(editor: Editor): ComposerEditorIncarnation {
+  const existing = composerEditorIncarnations.get(editor);
+  if (existing !== undefined) return existing;
+
+  const created = createComposerEditorIncarnation();
+  composerEditorIncarnations.set(editor, created);
+  return created;
+}
+
 export interface ComposerPromptEditorHandle {
   /**
    * Whether the async Tiptap editor behind this handle exists yet. The handle
@@ -57,6 +75,12 @@ export interface ComposerPromptEditorHandle {
    * as "ready".
    */
   readonly isReady: () => boolean;
+  /**
+   * Identity of the actual Tiptap editor behind this capability facade.
+   * Stable across facade replacement; changes only when the editor is
+   * genuinely recreated. Returns `null` while the editor is not ready.
+   */
+  readonly getEditorIncarnation: () => ComposerEditorIncarnation | null;
   readonly focus: () => void;
   readonly focusAtEnd: () => void;
   readonly hasFocus: () => boolean;
@@ -623,10 +647,17 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     return true;
   }, [editor, pickerStore]);
 
+  const getEditorIncarnation = useCallback(
+    (): ComposerEditorIncarnation | null =>
+      editor === null ? null : incarnationForEditor(editor),
+    [editor],
+  );
+
   useImperativeHandle(
     ref,
     () => ({
       isReady,
+      getEditorIncarnation,
       focus,
       focusAtEnd,
       hasFocus,
@@ -649,6 +680,7 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
       dismissActiveSuggestion,
       focus,
       focusAtEnd,
+      getEditorIncarnation,
       hasFocus,
       getJSON,
       insertImageAttachments,

--- a/clients/gui-app/src/components/chat/composer/use-chat-prompt-stash-adapters.ts
+++ b/clients/gui-app/src/components/chat/composer/use-chat-prompt-stash-adapters.ts
@@ -56,7 +56,7 @@ export function useChatPromptStashSource(
 
 /**
  * Chat surface prompt-stash destination: restore requires the exact ready
- * editor generation captured at restore start, and appends against the
+ * editor incarnation captured at restore start, and appends against the
  * draft store's latest content at insertion time (not a pre-materialization
  * snapshot). Selection is intentionally reset so the editor applies the
  * replacement with its focus-at-end behavior.
@@ -70,20 +70,26 @@ export function useChatPromptStashDestination(
       captureIdentity: (): PromptStashDestinationIdentity | null => {
         const handle = editorRef.current;
         if (handle === null || !handle.isReady()) return null;
+        const editorIncarnation = handle.getEditorIncarnation();
+        if (editorIncarnation === null) return null;
         return {
           surface: "chat",
           identity: taskId,
-          editorGeneration: handle,
+          editorIncarnation,
         };
       },
       importAndInsert: (args) => {
         const handle = editorRef.current;
+        const editorIncarnation =
+          handle !== null && handle.isReady()
+            ? handle.getEditorIncarnation()
+            : null;
         if (
           args.identity.surface !== "chat" ||
           args.identity.identity !== taskId ||
           handle === null ||
-          !handle.isReady() ||
-          args.identity.editorGeneration !== handle
+          editorIncarnation === null ||
+          args.identity.editorIncarnation !== editorIncarnation
         ) {
           return Promise.resolve({ status: "stale" });
         }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-prompt-stash-destination.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-prompt-stash-destination.test.ts
@@ -9,6 +9,10 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
 import { useNewConversationPromptStashDestination } from "@/components/epic-canvas/sidebar/use-new-conversation-prompt-stash-adapters";
+import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
 import type { DraftSelection } from "@/stores/composer/composer-draft-store";
 import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 
@@ -57,6 +61,7 @@ function makeEditorHandle(options: {
   }>;
   setReady: (ready: boolean) => void;
   unmount: () => void;
+  replaceFacade: () => ComposerPromptEditorHandle;
   remount: () => ComposerPromptEditorHandle;
 } {
   let ready = options.ready ?? true;
@@ -65,9 +70,13 @@ function makeEditorHandle(options: {
     content: JsonContent;
     selection: DraftSelection | null;
   }> = [];
+  let editorIncarnation = createComposerEditorIncarnation();
 
-  const buildHandle = (): ComposerPromptEditorHandle => ({
+  const buildHandle = (
+    incarnation: ComposerEditorIncarnation,
+  ): ComposerPromptEditorHandle => ({
     isReady: () => ready,
+    getEditorIncarnation: () => (ready ? incarnation : null),
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,
@@ -93,7 +102,7 @@ function makeEditorHandle(options: {
     dismissActiveSuggestion: () => false,
   });
 
-  const handle = buildHandle();
+  const handle = buildHandle(editorIncarnation);
   const editorRef: { current: ComposerPromptEditorHandle | null } = {
     current: handle,
   };
@@ -108,9 +117,15 @@ function makeEditorHandle(options: {
     unmount: () => {
       editorRef.current = null;
     },
+    replaceFacade: () => {
+      const next = buildHandle(editorIncarnation);
+      editorRef.current = next;
+      return next;
+    },
     remount: () => {
       ready = true;
-      const next = buildHandle();
+      editorIncarnation = createComposerEditorIncarnation();
+      const next = buildHandle(editorIncarnation);
       editorRef.current = next;
       return next;
     },
@@ -158,7 +173,7 @@ describe("new-conversation modal prompt-stash destination acknowledgement", () =
     expect(captured).toEqual({
       surface: "new-conversation",
       identity: epicId,
-      editorGeneration: editor.handle,
+      editorIncarnation: editor.handle.getEditorIncarnation(),
     });
 
     editor.unmount();
@@ -170,7 +185,7 @@ describe("new-conversation modal prompt-stash destination acknowledgement", () =
     expect(editor.setContents).toHaveLength(0);
   });
 
-  it("returns stale when ready handle remounts under the same epic id", async () => {
+  it("accepts React Compiler handle-facade churn for the same editor incarnation", async () => {
     const editor = makeEditorHandle({ content: emptyDoc() });
     const { result } = renderModalDestination({
       epicId,
@@ -179,11 +194,43 @@ describe("new-conversation modal prompt-stash destination acknowledgement", () =
     });
     const captured = result.current.captureIdentity();
     if (captured === null) throw new Error("expected capture");
-    expect(captured.editorGeneration).toBe(editor.handle);
+
+    const replacement = editor.replaceFacade();
+    expect(replacement).not.toBe(editor.handle);
+    expect(replacement.getEditorIncarnation()).toBe(captured.editorIncarnation);
+
+    const insertResult = await result.current.importAndInsert({
+      identity: captured,
+      content: textDoc("restored after facade churn"),
+    });
+    expect(insertResult).toEqual({ status: "accepted" });
+    expect(editor.setContents).toEqual([
+      {
+        content: textDoc("restored after facade churn"),
+        selection: null,
+      },
+    ]);
+  });
+
+  it("returns stale when the editor remounts under the same epic id", async () => {
+    const editor = makeEditorHandle({ content: emptyDoc() });
+    const { result } = renderModalDestination({
+      epicId,
+      seedContent: emptyDoc(),
+      editorRef: editor.editorRef,
+    });
+    const captured = result.current.captureIdentity();
+    if (captured === null) throw new Error("expected capture");
+    expect(captured.editorIncarnation).toBe(
+      editor.handle.getEditorIncarnation(),
+    );
 
     const remounted = editor.remount();
     expect(remounted).not.toBe(editor.handle);
     expect(editor.editorRef.current).toBe(remounted);
+    expect(remounted.getEditorIncarnation()).not.toBe(
+      captured.editorIncarnation,
+    );
 
     const insertResult = await result.current.importAndInsert({
       identity: captured,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-prompt-stash-source.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-prompt-stash-source.test.ts
@@ -15,6 +15,7 @@ import type { RefObject } from "react";
 import { toast } from "sonner";
 
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import {
   useNewConversationPromptStashDestination,
   useNewConversationPromptStashSource,
@@ -61,10 +62,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "modal-stash-entry-id"),
-}));
-
 function textDoc(text: string): JsonContent {
   return {
     type: "doc",
@@ -95,8 +92,10 @@ function makeEditorHandle(
       }
     | undefined,
 ): ComposerPromptEditorHandle {
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => options?.ready ?? true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-prompt-stash-source.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-modal-prompt-stash-source.test.ts
@@ -95,7 +95,8 @@ function makeEditorHandle(
   const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => options?.ready ?? true,
-    getEditorIncarnation: () => editorIncarnation,
+    getEditorIncarnation: () =>
+      (options?.ready ?? true) ? editorIncarnation : null,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx
@@ -13,6 +13,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import type { ComposerBodyProps } from "@/components/home/composer/composer-body";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
 import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 import { SurfacePresentationBoundary } from "@/components/layout/surface-presentation-boundary";
@@ -401,8 +402,10 @@ describe("NewConversationModalBody direct submit gate", () => {
 });
 
 function editorHandle(): ComposerPromptEditorHandle {
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/use-new-conversation-prompt-stash-adapters.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/use-new-conversation-prompt-stash-adapters.ts
@@ -68,7 +68,7 @@ export function useNewConversationPromptStashSource(args: {
 
 /**
  * New-conversation modal prompt-stash destination: restore requires the
- * exact ready editor generation captured at restore start, and appends
+ * exact ready editor incarnation captured at restore start, and appends
  * against the modal draft's latest content at insertion time. Materialization
  * is owned by the restore hook's default inline-base64 path. Selection is
  * reset so the next edit starts after the inserted prompt.
@@ -84,20 +84,26 @@ export function useNewConversationPromptStashDestination(args: {
       captureIdentity: (): PromptStashDestinationIdentity | null => {
         const handle = editorRef.current;
         if (handle === null || !handle.isReady()) return null;
+        const editorIncarnation = handle.getEditorIncarnation();
+        if (editorIncarnation === null) return null;
         return {
           surface: "new-conversation",
           identity: epicId,
-          editorGeneration: handle,
+          editorIncarnation,
         };
       },
       importAndInsert: (importArgs) => {
         const handle = editorRef.current;
+        const editorIncarnation =
+          handle !== null && handle.isReady()
+            ? handle.getEditorIncarnation()
+            : null;
         if (
           importArgs.identity.surface !== "new-conversation" ||
           importArgs.identity.identity !== epicId ||
           handle === null ||
-          !handle.isReady() ||
-          importArgs.identity.editorGeneration !== handle
+          editorIncarnation === null ||
+          importArgs.identity.editorIncarnation !== editorIncarnation
         ) {
           return Promise.resolve({ status: "stale" });
         }

--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -12,6 +12,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
@@ -725,8 +726,10 @@ describe("<HomePage />", () => {
 
 function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
   const content = jsonContentForPrompt(prompt);
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../../../__tests__/test-browser-apis";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { hostQueryKeys } from "@/lib/query-keys/host-query-keys";
 import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
 
@@ -1929,8 +1930,10 @@ function defaultToolbar() {
 
 function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
   const content = jsonContentForPrompt(prompt);
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-destination-identity.test.ts
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-destination-identity.test.ts
@@ -138,6 +138,37 @@ describe("landing composer prompt-stash destination identity/acceptance", () => 
     });
     expect(dest.current.captureIdentity()).toBeNull();
   });
+  it("accepts React Compiler handle-facade churn for the same editor incarnation", async () => {
+    const runtimeStore = createStore<DraftRuntimeState>(() => emptyRuntime());
+    const editor = makeEditorHandle({ content: emptyDoc() });
+    const { result } = renderLandingDestination({
+      stashIdentity: "draft-compiler-churn",
+      draftId: "draft-compiler-churn",
+      runtimeStore,
+      editorRef: editor.editorRef,
+    });
+    const captured = requireDefined(
+      result.current.captureIdentity(),
+      "capture",
+    );
+
+    const replacement = editor.replaceFacade();
+    expect(replacement).not.toBe(editor.handle);
+    expect(replacement.getEditorIncarnation()).toBe(captured.editorIncarnation);
+
+    const insertResult = await result.current.importAndInsert({
+      identity: captured,
+      content: textDoc("restored after facade churn"),
+    });
+
+    expect(insertResult).toEqual({ status: "accepted" });
+    expect(editor.setContents).toEqual([
+      {
+        content: textDoc("restored after facade churn"),
+        selection: null,
+      },
+    ]);
+  });
   it("returns stale on identity switch after materialize and releases reservation", async () => {
     const bytes = bytesOf([7, 7, 7]);
     const stashHash = await seedStashImage(bytes);
@@ -216,7 +247,9 @@ describe("landing composer prompt-stash destination identity/acceptance", () => 
     });
     const dest = destResult.current;
     const captured = requireDefined(dest.captureIdentity(), "capture");
-    expect(captured.editorGeneration).toBe(editor.handle);
+    expect(captured.editorIncarnation).toBe(
+      editor.handle.getEditorIncarnation(),
+    );
     const materialize = requireDefined(dest.materialize, "materialize");
 
     const pendingMaterialize = materialize(
@@ -236,6 +269,9 @@ describe("landing composer prompt-stash destination identity/acceptance", () => 
     await held.waitedUntilHeld();
     const remounted = editor.remount();
     expect(remounted).not.toBe(editor.handle);
+    expect(remounted.getEditorIncarnation()).not.toBe(
+      captured.editorIncarnation,
+    );
     held.release();
     const materialized = await pendingMaterialize;
     held.restore();

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-destination-test-helpers.ts
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-destination-test-helpers.ts
@@ -7,6 +7,10 @@ import { vi } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
 import { useLandingPromptStashDestination } from "@/components/home/composer/use-landing-prompt-stash-adapters";
 import {
   deleteImage,
@@ -171,6 +175,7 @@ export function makeEditorHandle(options: {
   }>;
   setReady: (ready: boolean) => void;
   unmount: () => void;
+  replaceFacade: () => ComposerPromptEditorHandle;
   remount: () => ComposerPromptEditorHandle;
 } {
   let ready = options.ready ?? true;
@@ -179,9 +184,13 @@ export function makeEditorHandle(options: {
     content: JsonContent;
     selection: DraftSelection | null;
   }> = [];
+  let editorIncarnation = createComposerEditorIncarnation();
 
-  const buildHandle = (): ComposerPromptEditorHandle => ({
+  const buildHandle = (
+    incarnation: ComposerEditorIncarnation,
+  ): ComposerPromptEditorHandle => ({
     isReady: () => ready,
+    getEditorIncarnation: () => (ready ? incarnation : null),
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,
@@ -207,7 +216,7 @@ export function makeEditorHandle(options: {
     dismissActiveSuggestion: () => false,
   });
 
-  const handle = buildHandle();
+  const handle = buildHandle(editorIncarnation);
   const editorRef: { current: ComposerPromptEditorHandle | null } = {
     current: handle,
   };
@@ -222,9 +231,15 @@ export function makeEditorHandle(options: {
     unmount: () => {
       editorRef.current = null;
     },
+    replaceFacade: () => {
+      const next = buildHandle(editorIncarnation);
+      editorRef.current = next;
+      return next;
+    },
     remount: () => {
       ready = true;
-      const next = buildHandle();
+      editorIncarnation = createComposerEditorIncarnation();
+      const next = buildHandle(editorIncarnation);
       editorRef.current = next;
       return next;
     },

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-source.test.ts
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-source.test.ts
@@ -87,7 +87,8 @@ function makeEditorHandle(
   const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => options?.ready ?? true,
-    getEditorIncarnation: () => editorIncarnation,
+    getEditorIncarnation: () =>
+      (options?.ready ?? true) ? editorIncarnation : null,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-source.test.ts
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-prompt-stash-source.test.ts
@@ -15,6 +15,7 @@ import type { RefObject } from "react";
 import { toast } from "sonner";
 
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import {
   landingStashIdentity,
   useLandingPromptStashDestination,
@@ -63,10 +64,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "landing-stash-entry-id"),
-}));
-
 function textDoc(text: string): JsonContent {
   return {
     type: "doc",
@@ -87,8 +84,10 @@ function makeEditorHandle(
       }
     | undefined,
 ): ComposerPromptEditorHandle {
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => options?.ready ?? true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
@@ -6,6 +6,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import type { ComposerBodyProps } from "@/components/home/composer/composer-body";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { LandingComposer } from "../landing-composer";
 
 const DIRTY_CONTENT: JsonContent = {
@@ -443,8 +444,10 @@ describe("LandingComposer direct submit gate", () => {
 });
 
 function editorHandle(): ComposerPromptEditorHandle {
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-paste-lifecycle.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-paste-lifecycle.test.tsx
@@ -151,6 +151,7 @@ vi.mock(
       instance: ComposerPromptEditorHandle,
     ): ComposerPromptEditorHandle => ({
       isReady: () => instance.isReady(),
+      getEditorIncarnation: () => instance.getEditorIncarnation(),
       hasFocus: () => false,
       focus: () => instance.focus(),
       focusAtEnd: () => instance.focusAtEnd(),

--- a/clients/gui-app/src/components/home/composer/use-landing-prompt-stash-adapters.ts
+++ b/clients/gui-app/src/components/home/composer/use-landing-prompt-stash-adapters.ts
@@ -126,7 +126,7 @@ export function useLandingPromptStashSource(args: {
  * (never through the fire-and-forget base64 reingest sweep) and returns a
  * still-held budget reservation the restore hook releases exactly once,
  * right after `importAndInsert` resolves. `importAndInsert` requires the
- * exact ready editor generation captured at restore start and appends
+ * exact ready editor incarnation captured at restore start and appends
  * against the runtime's latest content, resetting selection so the caret
  * lands after the inserted prompt.
  */
@@ -142,10 +142,12 @@ export function useLandingPromptStashDestination(args: {
       captureIdentity: (): PromptStashDestinationIdentity | null => {
         const handle = editorRef.current;
         if (handle === null || !handle.isReady()) return null;
+        const editorIncarnation = handle.getEditorIncarnation();
+        if (editorIncarnation === null) return null;
         return {
           surface: "landing",
           identity: stashIdentity,
-          editorGeneration: handle,
+          editorIncarnation,
         };
       },
       materialize: async (
@@ -163,12 +165,16 @@ export function useLandingPromptStashDestination(args: {
       },
       importAndInsert: (importArgs) => {
         const handle = editorRef.current;
+        const editorIncarnation =
+          handle !== null && handle.isReady()
+            ? handle.getEditorIncarnation()
+            : null;
         if (
           importArgs.identity.surface !== "landing" ||
           importArgs.identity.identity !== stashIdentity ||
           handle === null ||
-          !handle.isReady() ||
-          importArgs.identity.editorGeneration !== handle
+          editorIncarnation === null ||
+          importArgs.identity.editorIncarnation !== editorIncarnation
         ) {
           return Promise.resolve({ status: "stale" });
         }

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -16,6 +16,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { useLandingComposerActions } from "@/components/home/hooks/use-landing-composer-actions";
 import { draftRuntimeRegistry } from "@/stores/home/draft-runtime-registry";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
@@ -871,8 +872,10 @@ function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
       },
     ],
   };
+  const editorIncarnation = createComposerEditorIncarnation();
   return {
     isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
     hasFocus: () => false,
     focus: () => undefined,
     focusAtEnd: () => undefined,

--- a/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-capture-source.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-capture-source.test.tsx
@@ -133,12 +133,11 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "fixed-entry-id"),
-}));
-
 describe("usePromptStash capture/source CAS", () => {
   beforeEach(() => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000001",
+    );
     resetActivePromptStashForTests();
     idbData.clear();
     materializeMocks.impl = null;
@@ -298,7 +297,7 @@ describe("usePromptStash capture/source CAS", () => {
       entry: PromptStashEntry;
       imagesByHash: Map<string, { bytes: Uint8Array; mimeType: string }>;
     };
-    expect(snapshot.entry.id).toBe("fixed-entry-id");
+    expect(snapshot.entry.id).toBe("00000000-0000-4000-8000-000000000001");
     // Ticket 5 snapshot shape: blob is bytes + canonical mimeType.
     expect(snapshot.imagesByHash.get(hash)).toEqual({
       bytes: imageBytes,

--- a/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-command-menu.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-command-menu.test.tsx
@@ -130,10 +130,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "fixed-entry-id"),
-}));
-
 describe("usePromptStash command/menu state", () => {
   beforeEach(() => {
     resetActivePromptStashForTests();

--- a/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-restore-destination-races.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-restore-destination-races.test.tsx
@@ -13,6 +13,7 @@ import {
   hookArgs,
   makeDestination,
   makeEditor,
+  makeEditorIncarnation,
   textDoc,
   type MutableDestination,
 } from "./use-prompt-stash-test-helpers";
@@ -128,10 +129,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "fixed-entry-id"),
-}));
-
 describe("usePromptStash restore destination races", () => {
   beforeEach(() => {
     resetActivePromptStashForTests();
@@ -212,7 +209,7 @@ describe("usePromptStash restore destination races", () => {
       expect(toast.error).not.toHaveBeenCalled();
     });
 
-    it("does not insert or consume when ready editor generation remounts under same owner id", async () => {
+    it("does not insert or consume when ready editor incarnation remounts under same owner id", async () => {
       const entry: PromptStashEntry = {
         id: "entry-remount-gen",
         createdAt: 1,
@@ -230,7 +227,7 @@ describe("usePromptStash restore destination races", () => {
         identity: "task-same",
         surface: "chat",
         latestContent: emptyDoc(),
-        editorGeneration: Object.freeze({ generation: "handle-v1" }),
+        editorIncarnation: makeEditorIncarnation(),
       });
       const { result } = renderHook(() =>
         usePromptStash(
@@ -246,9 +243,7 @@ describe("usePromptStash restore destination races", () => {
         restorePromise = result.current.restore(entry);
         await Promise.resolve();
       });
-      destination.setEditorGeneration(
-        Object.freeze({ generation: "handle-v2" }),
-      );
+      destination.setEditorIncarnation(makeEditorIncarnation());
 
       let ok = true;
       await act(async () => {
@@ -410,7 +405,7 @@ describe("usePromptStash restore destination races", () => {
           identity: {
             surface: "test",
             identity: "owner-1",
-            editorGeneration: owner1.getEditorGeneration(),
+            editorIncarnation: owner1.getEditorIncarnation(),
           },
         }),
       );
@@ -433,11 +428,11 @@ describe("usePromptStash restore destination races", () => {
       };
       let currentKey = "key-a";
       let resolveMaterialize: (() => void) | undefined;
-      const editorGeneration = Object.freeze({ generation: "g1" });
+      const editorIncarnation = makeEditorIncarnation();
 
       const destination: MutableDestination = makeDestination({
         identity: "key-a",
-        editorGeneration,
+        editorIncarnation,
         latestContent: emptyDoc(),
         materialize: () =>
           new Promise((resolve) => {
@@ -449,7 +444,7 @@ describe("usePromptStash restore destination races", () => {
           // Live read of currentKey (not closed-over at materialize start).
           if (
             args.identity.identity !== currentKey ||
-            args.identity.editorGeneration !== editorGeneration
+            args.identity.editorIncarnation !== editorIncarnation
           ) {
             return Promise.resolve({ status: "stale" });
           }

--- a/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-restore-destination.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-restore-destination.test.tsx
@@ -136,10 +136,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("uuid", () => ({
-  v4: vi.fn(() => "fixed-entry-id"),
-}));
-
 describe("usePromptStash restore/destination lifecycle", () => {
   beforeEach(() => {
     resetActivePromptStashForTests();
@@ -226,7 +222,7 @@ describe("usePromptStash restore/destination lifecycle", () => {
     expect(call.identity).toEqual({
       surface: "test",
       identity: "dest-restore",
-      editorGeneration: destination.getEditorGeneration(),
+      editorIncarnation: destination.getEditorIncarnation(),
     });
     expect(call.content).toEqual(materializedContent);
     expect(storeMocks.remove).toHaveBeenCalledWith("entry-restore");

--- a/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-test-helpers.ts
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-prompt-stash-test-helpers.ts
@@ -6,6 +6,10 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { RefObject } from "react";
 
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
 import { appendPromptStashContent } from "@/lib/composer/prompt-stash-content";
 import type {
   PromptStashDestinationAdapter,
@@ -37,6 +41,10 @@ export function emptyDoc(): JsonContent {
     type: "doc",
     content: [{ type: "paragraph" }],
   };
+}
+
+export function makeEditorIncarnation(): ComposerEditorIncarnation {
+  return createComposerEditorIncarnation();
 }
 
 export function imageDoc(attrs: Record<string, unknown>): JsonContent {
@@ -143,11 +151,11 @@ export interface MutableDestination extends PromptStashDestinationAdapter {
   setIdentity: (identity: string | null) => void;
   setSurface: (surface: string) => void;
   /**
-   * Replaces the ready editor generation token (simulates remount under the
-   * same owner id). Import against a previously captured generation is stale.
+   * Replaces the ready editor incarnation token (simulates remount under the
+   * same owner id). Import against a previously captured incarnation is stale.
    */
-  setEditorGeneration: (generation: object) => void;
-  getEditorGeneration: () => object;
+  setEditorIncarnation: (incarnation: ComposerEditorIncarnation) => void;
+  getEditorIncarnation: () => ComposerEditorIncarnation;
   setLatestContent: (content: JsonContent) => void;
   getLatestContent: () => JsonContent;
   getInserts: () => readonly InsertedPayload[];
@@ -155,7 +163,7 @@ export interface MutableDestination extends PromptStashDestinationAdapter {
 
 /**
  * Controllable destination for Ticket 2/3. Default path mirrors production
- * chat/modal adapters: surface + identity + same editorGeneration, append
+ * chat/modal adapters: surface + identity + same editor incarnation, append
  * against latest content, and place the caret at the end. Materialization
  * defaults to the hook's `materializePromptStashEntry` unless `materialize`
  * is passed.
@@ -165,7 +173,7 @@ export function makeDestination(
     | {
         surface?: string;
         identity?: string | null;
-        editorGeneration?: object;
+        editorIncarnation?: ComposerEditorIncarnation;
         latestContent?: JsonContent;
         importResult?: PromptStashDestinationResult;
         importAndInsert?: PromptStashDestinationAdapter["importAndInsert"];
@@ -176,8 +184,8 @@ export function makeDestination(
   let surface = options?.surface ?? "test";
   let identity: string | null =
     options?.identity === undefined ? "dest-1" : options.identity;
-  let editorGeneration: object =
-    options?.editorGeneration ?? Object.freeze({ generation: "default" });
+  let editorIncarnation: ComposerEditorIncarnation =
+    options?.editorIncarnation ?? makeEditorIncarnation();
   let latestContent = options?.latestContent ?? emptyDoc();
   const inserts: InsertedPayload[] = [];
 
@@ -185,7 +193,7 @@ export function makeDestination(
     PromptStashDestinationAdapter["captureIdentity"]
   > = vi.fn((): PromptStashDestinationIdentity | null => {
     if (identity === null) return null;
-    return { surface, identity, editorGeneration };
+    return { surface, identity, editorIncarnation };
   });
 
   const defaultImport: PromptStashDestinationAdapter["importAndInsert"] = (
@@ -209,7 +217,7 @@ export function makeDestination(
       identity === null ||
       args.identity.surface !== surface ||
       args.identity.identity !== identity ||
-      args.identity.editorGeneration !== editorGeneration
+      args.identity.editorIncarnation !== editorIncarnation
     ) {
       return Promise.resolve({ status: "stale" });
     }
@@ -239,10 +247,10 @@ export function makeDestination(
     setSurface: (next) => {
       surface = next;
     },
-    setEditorGeneration: (next) => {
-      editorGeneration = next;
+    setEditorIncarnation: (next) => {
+      editorIncarnation = next;
     },
-    getEditorGeneration: () => editorGeneration,
+    getEditorIncarnation: () => editorIncarnation,
     setLatestContent: (next) => {
       latestContent = next;
     },
@@ -265,9 +273,11 @@ export function makeEditor(initial: {
   const ready = initial.ready ?? true;
   const clears: number[] = [];
   const focuses: number[] = [];
+  const editorIncarnation = makeEditorIncarnation();
 
   const handle: ComposerPromptEditorHandle = {
     isReady: () => ready,
+    getEditorIncarnation: () => (ready ? editorIncarnation : null),
     hasFocus: () => false,
     focus: () => {
       focuses.push(1);

--- a/clients/gui-app/src/hooks/composer/use-prompt-stash.ts
+++ b/clients/gui-app/src/hooks/composer/use-prompt-stash.ts
@@ -7,7 +7,6 @@ import {
   type RefObject,
 } from "react";
 
-import { v4 as uuidv4 } from "uuid";
 import { toast } from "sonner";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
 import { contentIsSubmittable } from "@/lib/composer/composer-content";
@@ -164,7 +163,7 @@ export function usePromptStash(
     setSaving(true);
     try {
       const entrySnapshot = await buildPromptStashSnapshot({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         createdAt: Date.now(),
         content: snapshot.content,
         readHashImage,

--- a/clients/gui-app/src/lib/composer/__tests__/prompt-stash-ownership-transfer-test-helpers.ts
+++ b/clients/gui-app/src/lib/composer/__tests__/prompt-stash-ownership-transfer-test-helpers.ts
@@ -6,6 +6,10 @@ import { expect, onTestFinished, vi } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import { bytesToBase64 } from "@/lib/composer/image-base64";
 import {
+  createComposerEditorIncarnation,
+  type ComposerEditorIncarnation,
+} from "@/lib/composer/composer-editor-incarnation";
+import {
   pngBytesOfSize,
   twoFrameGifBytesOfSize,
 } from "./prompt-stash-image-fixtures";
@@ -147,9 +151,11 @@ export function makeEditorHandle(
     content: JsonContent;
     selection: { from: number; to: number } | null;
   }> = [];
+  let editorIncarnation = createComposerEditorIncarnation();
 
-  const build = (): EditorHandle => ({
+  const build = (incarnation: ComposerEditorIncarnation): EditorHandle => ({
     isReady: () => ready,
+    getEditorIncarnation: () => (ready ? incarnation : null),
     hasFocus: () => false,
     focus: () => {
       options?.onFocus?.();
@@ -187,7 +193,7 @@ export function makeEditorHandle(
     dismissActiveSuggestion: () => false,
   });
 
-  const handle = build();
+  const handle = build(editorIncarnation);
   const editorRef: { current: EditorHandle | null } = { current: handle };
   return {
     handle,
@@ -195,7 +201,8 @@ export function makeEditorHandle(
     setContents,
     remount: () => {
       ready = true;
-      const next = build();
+      editorIncarnation = createComposerEditorIncarnation();
+      const next = build(editorIncarnation);
       editorRef.current = next;
       return next;
     },

--- a/clients/gui-app/src/lib/composer/composer-editor-incarnation.ts
+++ b/clients/gui-app/src/lib/composer/composer-editor-incarnation.ts
@@ -1,0 +1,22 @@
+/**
+ * Opaque identity for one live editor incarnation.
+ *
+ * React owns the imperative handle facade, so that facade may be replaced
+ * during an ordinary render. The Tiptap Editor object is the actual lifecycle
+ * boundary: it stays stable for the lifetime of one mounted editor and is
+ * replaced when that editor is genuinely recreated.
+ */
+const composerEditorIncarnationBrand = Symbol("composer-editor-incarnation");
+
+export interface ComposerEditorIncarnation {
+  readonly [composerEditorIncarnationBrand]: true;
+}
+
+/** Allocate an incarnation token for an editor lifecycle owner. */
+export function createComposerEditorIncarnation(): ComposerEditorIncarnation {
+  const created: ComposerEditorIncarnation = {
+    [composerEditorIncarnationBrand]: true,
+  };
+  Object.freeze(created);
+  return created;
+}

--- a/clients/gui-app/src/lib/composer/landing-stash-import.ts
+++ b/clients/gui-app/src/lib/composer/landing-stash-import.ts
@@ -10,7 +10,6 @@
  */
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
-import { v4 as uuidv4 } from "uuid";
 import {
   collectImageAtoms,
   type ComposerImageAtom,
@@ -163,7 +162,7 @@ function rewriteToLandingHashes(
     if (landingHash !== undefined) {
       return {
         ...node,
-        attrs: { ...node.attrs, id: uuidv4(), hash: landingHash },
+        attrs: { ...node.attrs, id: crypto.randomUUID(), hash: landingHash },
       };
     }
   }

--- a/clients/gui-app/src/lib/composer/prompt-stash-content.ts
+++ b/clients/gui-app/src/lib/composer/prompt-stash-content.ts
@@ -1,6 +1,5 @@
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
-import { v4 as uuidv4 } from "uuid";
 import { base64ToBytes, bytesToBase64 } from "@/lib/composer/image-base64";
 import {
   canonicalPromptStashImageFileName,
@@ -205,7 +204,7 @@ export async function materializePromptStashEntry(
     }
     return Promise.resolve({
       ...attrs,
-      id: uuidv4(),
+      id: crypto.randomUUID(),
       b64content: bytesToBase64(blob.bytes),
       hash: null,
     });

--- a/clients/gui-app/src/lib/composer/prompt-stash-destination.ts
+++ b/clients/gui-app/src/lib/composer/prompt-stash-destination.ts
@@ -1,22 +1,23 @@
 import type { JsonContent } from "@traycer/protocol/common/registry";
+import type { ComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import type { PromptStashEntry } from "@/lib/composer/prompt-stash-codec";
 
 /**
  * Names the exact active destination surface a restore must land in.
  * Captured before materialization; `importAndInsert` only accepts when the
- * same surface identity *and* the same ready editor generation are still the
+ * same surface identity *and* the same ready editor incarnation are still the
  * active destination afterward. A remounted editor under the same task/draft
- * /epic id is a different generation and must be treated as stale.
+ * /epic id is a different incarnation and must be treated as stale.
  */
 export interface PromptStashDestinationIdentity {
   readonly surface: string;
   readonly identity: string;
   /**
-   * Opaque in-memory token for the exact ready editor generation at capture.
-   * Adapters typically capture the ready handle object itself; identity is by
-   * reference, not by owner id.
+   * Opaque in-memory token for the actual Tiptap editor at capture. This must
+   * not be the React imperative handle: React Compiler-driven renders may
+   * replace that capability facade without replacing the editor.
    */
-  readonly editorGeneration: object;
+  readonly editorIncarnation: ComposerEditorIncarnation;
 }
 
 export type PromptStashDestinationResult =
@@ -74,10 +75,11 @@ export interface PromptStashDestinationAdapter {
    * destination's *latest* canonical content at insertion time. Must not use
    * a pre-materialization content snapshot. Optional-chained missing/unready
    * editors are `stale`, never `accepted`. A ready handle that is not the
-   * captured generation is also `stale`. The destination places the caret at
-   * the end of the resulting document; editor selection is transient state
-   * and is never persisted with a stash, so it cannot make the next
-   * keystroke overwrite restored content.
+   * captured incarnation is also `stale`. A replacement handle facade for the
+   * same incarnation is accepted and used as the freshest capability object.
+   * The destination places the caret at the end of the resulting document;
+   * editor selection is transient state and is never persisted with a stash,
+   * so it cannot make the next keystroke overwrite restored content.
    */
   readonly importAndInsert: (args: {
     readonly identity: PromptStashDestinationIdentity;

--- a/clients/gui-app/vitest.config.ts
+++ b/clients/gui-app/vitest.config.ts
@@ -1,5 +1,7 @@
 import path from "path";
 import os from "node:os";
+import babel from "@rolldown/plugin-babel";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 const availableParallelism =
@@ -10,8 +12,25 @@ const MAX_TEST_WORKERS = Math.min(
   2,
   Math.max(1, Math.floor(availableParallelism / 2)),
 );
+const REACT_COMPILER_REGRESSION_FILES =
+  /[/\\](?:composer-prompt-editor|use-(?:chat|landing|new-conversation)-prompt-stash-adapters)\.(?:ts|tsx)$/;
 
 export default defineConfig({
+  // Run the affected composer boundary through the packaged desktop
+  // renderer's compiler preset. The stash regression was invisible when
+  // tests skipped this pass because the compiler may replace a React
+  // imperative-handle facade during an ordinary editor render. The filter
+  // keeps unrelated GUI tests on their existing fast transform path.
+  plugins: [
+    react(),
+    babel({
+      include: REACT_COMPILER_REGRESSION_FILES,
+      presets: [reactCompilerPreset()],
+    }).then((plugin) => ({
+      ...plugin,
+      enforce: "post" as const,
+    })),
+  ],
   resolve: {
     alias: [
       { find: "@", replacement: path.resolve(__dirname, "src") },


### PR DESCRIPTION
## Summary

Fix prompt-stash restore freshness across the three composer surfaces by tracking the live Tiptap editor incarnation instead of the React imperative-handle facade. React Compiler facade churn is accepted, while genuine editor remounts remain stale and cannot consume a stash.

The change also enables the production React Compiler transform for the affected Vitest boundary, updates fixtures/regressions, and uses native `crypto.randomUUID()` for stash-local identifiers.

## Related issue

Not applicable.

## Validation

- [x] `bun run build`, affected compile, lint, and format checks pass via pre-commit.
- [x] 17 targeted GUI regression files pass (154 tests).
- [x] `git diff --check` passes.
- [x] Tests added/updated where it makes sense.
- [x] Commit is signed off (`git commit -s`) per the DCO.