### PR TITLE
fix(gui-app): report a workspace-file transport failure against the host

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-host-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-host-gate.test.tsx
@@ -57,6 +57,7 @@ vi.mock("@/markdown/shiki-highlighter", () => ({
 
 import { WorkspaceFileTile } from "../workspace-file-tile";
 import { TabHostProvider } from "../../tab-host-provider";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 
 const NODE = {
   id: "workspace-file:host-A:/work/repo:src/index.ts",
@@ -174,6 +175,85 @@ describe("<WorkspaceFileTile /> host-binding gate", () => {
       message: "The workspace file preview could not be loaded.",
       code: null,
       source: "Workspace file",
+    });
+  });
+
+  it("reports a transport failure against the host, not as a file-read failure", () => {
+    state.readFile = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new HostRpcError({
+        code: "UNAUTHORIZED",
+        message: "fetch failed",
+        requestId: "req-1",
+        method: "workspace.readFile",
+        fatalDetails: null,
+      }),
+    };
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    renderTile("host-A", NODE);
+
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    // The host never answered, so this must not be filed as a file-read
+    // failure: that is what sent one field report's triage looking for an fs
+    // error that never happened.
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Workspace file preview failed to load from the host",
+      message:
+        "The app could not reach the Traycer host to load the file preview.",
+      code: "UNAUTHORIZED",
+      source: "Host",
+    });
+  });
+
+  it("keeps host-supplied error text out of a transport report", () => {
+    state.readFile = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new HostRpcError({
+        code: "FORBIDDEN",
+        message: "denied reading /Users/me/private/api-key.txt",
+        requestId: "req-2",
+        method: "workspace.readFile",
+        fatalDetails: null,
+      }),
+    };
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    renderTile("host-A", NODE);
+
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("api-key.txt");
+    expect(JSON.stringify(context)).not.toContain(
+      "denied reading /Users/me/private/api-key.txt",
+    );
+    expect(context?.code).toBe("FORBIDDEN");
+  });
+
+  it("survives a non-HostRpcError in the query error channel", () => {
+    // TanStack's error generic is an unchecked cast, so a bare `Error` can
+    // occupy this channel - reading `.code` off it must not crash the view.
+    state.readFile = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("boom"),
+    };
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    renderTile("host-A", NODE);
+
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Workspace file preview failed to load from the host",
+      message:
+        "The app could not reach the Traycer host to load the file preview.",
+      code: null,
+      source: "Host",
     });
   });
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
@@ -3,7 +3,11 @@ import { ReportIssueAction } from "@/components/report-issue/report-issue-action
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { useWorkspaceReadFile } from "@/hooks/workspace/use-read-file-query";
 import { languageFromFilePath } from "@/lib/file-change-diff-hunks";
-import { createReportIssueContext } from "@/lib/report-issue-context";
+import {
+  createReportIssueContext,
+  type ReportIssueContext,
+} from "@/lib/report-issue-context";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { cn } from "@/lib/utils";
 import { TraycerMarkdown } from "@/markdown";
 import { useShikiHighlighter } from "@/markdown/shiki-highlighter";
@@ -143,6 +147,11 @@ function WorkspaceFileTileLive(props: {
     [rawContent],
   );
   const displayError = readFileDisplayError(
+    readFilePayloadError(query.data),
+    query.isError,
+    query.error,
+  );
+  const reportContext = readFileReportContext(
     readFilePayloadError(query.data),
     query.isError,
     query.error,
@@ -290,6 +299,7 @@ function WorkspaceFileTileLive(props: {
           <WorkspaceFilePreviewContent
             content={content}
             displayError={displayError}
+            reportContext={reportContext}
             fileName={node.name}
             isLoading={query.isLoading}
             language={language}
@@ -335,9 +345,47 @@ function readFileDisplayError(
   return transportErrorMessage(error);
 }
 
+/**
+ * The preview fails in two unrelated ways, and the filed report has to say
+ * which: a payload error means the host answered and named a file-level
+ * problem, while a transport error means the request never reached a verdict
+ * at all (host unreachable, session rejected, method unsupported). Reporting
+ * the second as "could not be read" sent one field report's triage hunting an
+ * `ENOENT` that never existed - the failure was an auth-plane outage.
+ *
+ * Neither arm may carry error text: `createReportIssueContext` deliberately
+ * does not redact, the payload string can embed the user's absolute path, and
+ * `HostRpcError.message` can carry host-supplied detail. Only fixed copy and
+ * the stable wire code cross into a public issue.
+ */
+function readFileReportContext(
+  payloadError: string | null,
+  isTransportError: boolean,
+  error: unknown,
+): ReportIssueContext {
+  if (payloadError === null && isTransportError) {
+    return createReportIssueContext({
+      title: "Workspace file preview failed to load from the host",
+      message:
+        "The app could not reach the Traycer host to load the file preview.",
+      // Narrowed, never asserted: TanStack's error generic is an unchecked
+      // cast, so a bare `Error` can occupy this channel.
+      code: error instanceof HostRpcError ? error.code : null,
+      source: "Host",
+    });
+  }
+  return createReportIssueContext({
+    title: "Workspace file could not be read",
+    message: "The workspace file preview could not be loaded.",
+    code: null,
+    source: "Workspace file",
+  });
+}
+
 function WorkspaceFilePreviewContent(props: {
   readonly content: string | null;
   readonly displayError: string | null;
+  readonly reportContext: ReportIssueContext;
   readonly fileName: string;
   readonly isLoading: boolean;
   readonly language: string;
@@ -366,12 +414,7 @@ function WorkspaceFilePreviewContent(props: {
       <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-ui-sm text-muted-foreground">
         <p>{props.displayError}</p>
         <ReportIssueAction
-          context={createReportIssueContext({
-            title: "Workspace file could not be read",
-            message: "The workspace file preview could not be loaded.",
-            code: null,
-            source: "Workspace file",
-          })}
+          context={props.reportContext}
           presentation="text"
           className={undefined}
         />


### PR DESCRIPTION
## Problem

The workspace-file preview tile already distinguishes two unrelated failures:

- **payload** — the host answered and named a file-level problem (`data.error`: "File is unavailable.", "Binary files cannot be previewed.", …)
- **transport** — the request never reached a verdict (`query.isError`: host unreachable, session rejected, method unsupported)

…but it filed **both** under one report title, "Workspace file could not be read", with area "Workspace file".

Issue #928 arrived under that title. It was not a file error: the host had rejected every RPC as `UNAUTHORIZED / fetch failed` after a sleep-resume with DNS down. Triage spent its first pass hunting an `ENOENT` that never existed, and the Sentry feedback area aggregates the two classes together.

## Change

Split the report context along the discrimination the tile already makes. A transport failure now reports against the host and carries the stable wire code — matching what `toastFromHostError` already files for the same failure class.

The user-visible message is unchanged; only the filed report differs.

## Guardrails

- **No error text in either arm.** `createReportIssueContext` deliberately does not redact, the payload string can embed the user's absolute path, and `HostRpcError.message` can carry host-supplied detail — so only fixed copy and the wire code cross into a public issue. The existing payload-arm test that pins this is untouched and still passes; a new test pins the same guarantee for the transport arm.
- **`.code` is narrowed, not asserted.** TanStack's error generic is an unchecked cast; reading `.code` off a bare `Error` in that channel has white-screened a view before. Covered by a regression test.

## Tests

Three added to `workspace-file-tile-host-gate.test.tsx`; all three were confirmed to **fail against the unfixed source** before being kept:

- transport failure reports against the host, with `code`
- host-supplied error text stays out of a transport report
- a non-`HostRpcError` in the error channel yields `code: null` and does not crash

`bunx vitest run src/components/epic-canvas/renderers` → 41 files, 301 tests passing. `bun run compile` clean.

## Non-goals

The ~160 other `createReportIssueContext` call sites. Several siblings plausibly share the defect, but a blind sweep would re-title surfaces whose failure classes nobody has traced; #928 gives evidence for this tile only.