### PR TITLE
fix(gui-app): stop a Windows path link reloading the renderer

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-markdown-link-provider.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-markdown-link-provider.test.tsx
@@ -137,6 +137,35 @@ const SAME_EPIC_ARTIFACT_PATH = `/Users/me/.traycer/epics/${OPEN_EPIC_ID}/artifa
 const CROSS_EPIC_ARTIFACT_PATH =
   "/Users/them/.traycer/epics/epic-other/artifacts/parent/child-ticket/index.md";
 
+// The exact markdown a Windows agent emits when it lists an epic's artifacts:
+// a native drive path with backslash separators, wrapped in `<>` because the
+// home directory contains a space. Rendering this reloaded the production
+// renderer, so it is driven through the whole pipeline (markdown parse ->
+// url transform -> sanitize -> anchor -> link policy -> artifact RPC).
+// Assembled by joining rather than interpolated into one `String.raw` literal:
+// a `${…}` directly after a backslash reads as an escaped `$`, which would
+// quietly eat the separator this case is about.
+const WINDOWS_SAME_EPIC_ARTIFACT_PATH = [
+  String.raw`C:\Users\Traycer Dev\.traycer\epics`,
+  OPEN_EPIC_ID,
+  "artifacts",
+  "dummy-alpha",
+  "index.md",
+].join("\\");
+
+// What the link policy receives once the markdown parser is done with it. The
+// `\.` before `.traycer` is a CommonMark escape and is consumed by the parser
+// (spec behaviour, unrecoverable at render time) - every other separator
+// survives, so the root-agnostic `epics/<id>/artifacts/<chain>/index.md` marker
+// the artifact resolver keys on is intact and the link still resolves.
+const WINDOWS_SAME_EPIC_RESOLVED_PATH = [
+  String.raw`C:\Users\Traycer Dev.traycer\epics`,
+  OPEN_EPIC_ID,
+  "artifacts",
+  "dummy-alpha",
+  "index.md",
+].join("\\");
+
 beforeEach(() => {
   window.localStorage.clear();
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
@@ -399,6 +428,101 @@ describe("ChatMarkdownLinkProvider", () => {
     expect(mocks.navigate).not.toHaveBeenCalled();
     // It claimed the click without falling through to a file preview.
     expect(previewTabId(tabId)).toBeNull();
+  });
+
+  it("opens a Windows-authored artifact link without letting the browser navigate the anchor", async () => {
+    // The production crash: the drive-letter bypass in `markdownUrlTransform`
+    // only matched a LITERAL `\` or `/` after the colon, but remark hands it a
+    // percent-encoded destination (`C:%5CUsers…`). The bypass missed and
+    // `defaultUrlTransform` emptied the href as an unsafe `C:` scheme - and
+    // `<a href="">` points at the current document, so the click navigated for
+    // real and unloaded the whole renderer.
+    mocks.resolveArtifactByPath.mockResolvedValue({
+      artifactId: "artifact-dummy-alpha",
+      kind: "spec",
+    });
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    const { container } = renderProvider(
+      tabId,
+      <AgentReferenceMarkdown
+        isStreaming={false}
+        markdown={`- [Dummy Alpha](<${WINDOWS_SAME_EPIC_ARTIFACT_PATH}>)`}
+        proseSize="compact"
+        quotable={false}
+        components={null}
+      />,
+    );
+
+    // Addressed as an element, not by role: an anchor whose href was emptied
+    // (and therefore dropped) has no `link` role, and that href is the bug.
+    // Asserting the drive prefix specifically - a bare "not empty" check would
+    // pass on the dropped-attribute form the anchor falls back to.
+    const link = container.querySelector("a");
+    if (link === null) throw new Error("Expected a rendered anchor.");
+    expect(link.getAttribute("href")).toMatch(/^C:(%5C|\\)Users/i);
+
+    // `fireEvent.click` returns false when the handler called `preventDefault`.
+    // True means the browser owns the navigation - the renderer reload.
+    expect(fireEvent.click(link)).toBe(false);
+
+    await waitFor(() => {
+      expect(mocks.resolveArtifactByPath).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.resolveArtifactByPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostId: ACTIVE_HOST_ID,
+        epicId: OPEN_EPIC_ID,
+        filePath: WINDOWS_SAME_EPIC_RESOLVED_PATH,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        mocks.openProjectedSidebarNodeInTabWhenAvailable,
+      ).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      mocks.openProjectedSidebarNodeInTabWhenAvailable.mock.calls[0][0].nodeId,
+    ).toBe("artifact-dummy-alpha");
+  });
+
+  it("resolves an artifact whose chain folder contains a space", async () => {
+    // A POSIX artifact link into a folder named "space path test". The parser
+    // percent-encodes the space either way - whether the agent wrote `%20`
+    // itself or wrapped a literal space in `<>` - so the policy used to receive
+    // `space%20path%20test`, which matches no folder in the epic's
+    // `folderName -> id` index. The resolve came back null and the click ended
+    // in the "Couldn't open link" toast (the tolerable macOS symptom of the
+    // same encoding bug that reloads the renderer on Windows).
+    mocks.resolveArtifactByPath.mockResolvedValue({
+      artifactId: "artifact-spaced",
+      kind: "spec",
+    });
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    const decodedPath = `/Users/me/.traycer/epics/${OPEN_EPIC_ID}/artifacts/space path test/index.md`;
+    renderProvider(
+      tabId,
+      <AgentReferenceMarkdown
+        isStreaming={false}
+        markdown={`[Encoded](/Users/me/.traycer/epics/${OPEN_EPIC_ID}/artifacts/space%20path%20test/index.md) [Bracketed](<${decodedPath}>)`}
+        proseSize="compact"
+        quotable={false}
+        components={null}
+      />,
+    );
+
+    for (const name of ["Encoded", "Bracketed"]) {
+      mocks.resolveArtifactByPath.mockClear();
+      expect(fireEvent.click(screen.getByRole("link", { name }))).toBe(false);
+      await waitFor(() => {
+        expect(mocks.resolveArtifactByPath).toHaveBeenCalledWith(
+          expect.objectContaining({
+            epicId: OPEN_EPIC_ID,
+            filePath: decodedPath,
+          }),
+        );
+      });
+    }
   });
 
   it("lets an external click supersede a slow artifact resolution", async () => {

--- a/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
+++ b/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
@@ -532,6 +532,25 @@ describe("classifyHref", () => {
     });
   });
 
+  it("decodes reserved characters in a filename without reading them as syntax", () => {
+    // `#` and `:` are reserved, so `decodeURI` would leave them encoded and hand
+    // the surface policy a path no filesystem has. Splitting the fragment and
+    // the `:line[:col]` suffix off the ENCODED href is what keeps the decoded
+    // `%23` from being taken as a fragment and the decoded `%3A` as a location.
+    expect(classifyHref("/notes/release%231%3A2.md")).toEqual({
+      kind: "file",
+      path: "/notes/release#1:2.md",
+      line: null,
+      col: null,
+    });
+    expect(classifyHref("/notes/release%231%3A2.md:12:3")).toEqual({
+      kind: "file",
+      path: "/notes/release#1:2.md",
+      line: 12,
+      col: 3,
+    });
+  });
+
   it("rejects a degenerate location-only href with no file path", () => {
     // `:99` has a trailing line but no file in front of it. Reject at the
     // source as `ignore` (the click is still `preventDefault`ed) rather than

--- a/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
+++ b/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
@@ -298,7 +298,111 @@ describe("MarkdownAnchor", () => {
     });
     expect(host.openedExternalLinks).toEqual([]);
   });
+
+  it("routes a NATIVE backslash Windows link through the surface policy end to end", () => {
+    // The shape a Windows agent actually writes: backslash separators, and the
+    // destination wrapped in `<>` because the home directory has a space in it.
+    // This must go through the real markdown parser, not `markdownUrlTransform`
+    // alone - remark percent-encodes the destination (`\` -> `%5C`, ` ` ->
+    // `%20`) BEFORE the transform runs, so the drive-letter bypass has to match
+    // the encoded separator and the anchor has to decode it back to a native
+    // path. Feeding a raw backslash href straight to the transform (see
+    // `classifyRenderedHref` below) skips that encoding entirely and hides this.
+    const host = createRunnerHost();
+    const openFileLink = vi.fn(() => true);
+    const { container } = render(
+      <RunnerHostContext.Provider value={host}>
+        <MarkdownLinkContext.Provider
+          value={{ openFileLink, supersedePendingFileLink: () => undefined }}
+        >
+          <TraycerMarkdown
+            className={null}
+            proseSize="normal"
+            components={null}
+            remarkPlugins={null}
+            rehypePlugins={null}
+            quotable={false}
+            isStreaming={false}
+          >
+            {String.raw`[App](<C:\Users\Traycer Dev\repo\app.ts>)`}
+          </TraycerMarkdown>
+        </MarkdownLinkContext.Provider>
+      </RunnerHostContext.Provider>,
+    );
+
+    // Queried as an element, not by role: a dropped href strips the anchor of
+    // its `link` role, and this assertion is about the href itself.
+    const link = requireAnchor(container);
+    // A blank href is the crash: it resolves to the current document, so the
+    // click performs a real navigation and unloads the SPA. Asserted against
+    // the drive prefix - "not empty" alone would pass on the dropped-attribute
+    // form the anchor falls back to when the transform empties an href.
+    expect(link.getAttribute("href")).toMatch(/^C:(%5C|\\)Users/i);
+
+    // `fireEvent.click` returns false when the handler called `preventDefault`.
+    // A true here means the browser owns the click - the renderer reload.
+    expect(fireEvent.click(link)).toBe(false);
+
+    expect(openFileLink).toHaveBeenCalledWith({
+      path: String.raw`C:\Users\Traycer Dev\repo\app.ts`,
+      line: null,
+      col: null,
+      isDirectory: false,
+    });
+    expect(host.openedExternalLinks).toEqual([]);
+  });
+
+  it("never renders an emptied href the browser could navigate", () => {
+    // `defaultUrlTransform` empties any href it deems unsafe, and an empty href
+    // is not inert: it points at the current document, so a click navigates for
+    // real and the whole renderer reloads. The anchor must drop the attribute
+    // rather than render a navigable blank. This is the general guard behind
+    // the Windows-path case above.
+    //
+    // `z:notapath` is emptied because the two layers disagree: the sanitize
+    // schema allows every single-letter scheme (drive letters), but the drive
+    // bypass in `markdownUrlTransform` only applies to an actual path, so this
+    // falls through to `defaultUrlTransform` and is emptied there.
+    const host = createRunnerHost();
+    const openFileLink = vi.fn(() => true);
+    const { container } = render(
+      <RunnerHostContext.Provider value={host}>
+        <MarkdownLinkContext.Provider
+          value={{ openFileLink, supersedePendingFileLink: () => undefined }}
+        >
+          <TraycerMarkdown
+            className={null}
+            proseSize="normal"
+            components={null}
+            remarkPlugins={null}
+            rehypePlugins={null}
+            quotable={false}
+            isStreaming={false}
+          >
+            {"[Blocked](z:notapath)"}
+          </TraycerMarkdown>
+        </MarkdownLinkContext.Provider>
+      </RunnerHostContext.Provider>,
+    );
+
+    const link = requireAnchor(container);
+    expect(link.getAttribute("href")).toBeNull();
+    fireEvent.click(link);
+    expect(openFileLink).not.toHaveBeenCalled();
+    expect(host.openedExternalLinks).toEqual([]);
+  });
 });
+
+/**
+ * The rendered anchor, addressed as an element. `getByRole("link")` is the
+ * usual query, but an anchor whose href the transform emptied loses its `link`
+ * role - and that anchor is exactly what the reload cases assert against.
+ */
+function requireAnchor(container: HTMLElement): HTMLAnchorElement {
+  const anchor = container.querySelector("a");
+  if (anchor === null) throw new Error("Expected a rendered anchor.");
+  return anchor;
+}
 
 function readNeutralToastOptions(): ExternalToast {
   const call = neutralToast.mock.lastCall;
@@ -404,6 +508,26 @@ describe("classifyHref", () => {
       kind: "file",
       path: "/a/b:c/d.ts",
       line: null,
+      col: null,
+    });
+  });
+
+  it("decodes percent-encoded separators and spaces out of a rendered path", () => {
+    // remark percent-encodes the link destination before the anchor sees it, so
+    // a native Windows path arrives as `C:%5C…%20…`. The surface policy resolves
+    // against a real filesystem and needs the decoded form.
+    expect(classifyRenderedHref("C:%5CUsers%5CTraycer%20Dev%5Capp.ts")).toEqual(
+      {
+        kind: "file",
+        path: String.raw`C:\Users\Traycer Dev\app.ts`,
+        line: null,
+        col: null,
+      },
+    );
+    expect(classifyRenderedHref("/Users/them%20dev/app.ts:12")).toEqual({
+      kind: "file",
+      path: "/Users/them dev/app.ts",
+      line: 12,
       col: null,
     });
   });

--- a/clients/gui-app/src/markdown/components/markdown-anchor.tsx
+++ b/clients/gui-app/src/markdown/components/markdown-anchor.tsx
@@ -32,6 +32,10 @@ interface MarkdownAnchorProps {
  *   the runner host;
  * - file links (bare paths, rooted paths, Windows drives, `file://` URIs) are
  *   handed to the surface's `MarkdownLinkContext` policy.
+ *
+ * A BLANK href never reaches the DOM ({@link navigableHref}): `<a href="">`
+ * resolves to the current document, so a click on one navigates for real and
+ * unloads the app - the same crash, reached without any scheme we could route.
  */
 export function MarkdownAnchor({
   href,
@@ -44,13 +48,21 @@ export function MarkdownAnchor({
   const reportIssueAvailable = useDesktopDialogStore(
     (state) => state.reportIssueAvailable,
   );
+  // `defaultUrlTransform` empties every href it rejects, and an empty href is
+  // not inert - it points at the current document, so the browser treats a
+  // click as a real navigation and the whole renderer reloads. Drop the
+  // attribute instead, the way the sanitize layer already does for a rejected
+  // scheme: an anchor with no href has nothing to navigate to, whatever the
+  // event (click, keyboard, middle-click).
+  const navigableHref =
+    href === undefined || href.trim().length === 0 ? undefined : href;
   const routeLinkClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>): void => {
       // Same-document anchors should keep native browser hash scrolling.
       // Links that leave the current surface are routed explicitly below.
-      if (href === undefined) return;
+      if (navigableHref === undefined) return;
 
-      const classified = classifyHref(href);
+      const classified = classifyHref(navigableHref);
       if (classified.kind === "default") return;
 
       event.preventDefault();
@@ -95,7 +107,7 @@ export function MarkdownAnchor({
       linkPolicy?.supersedePendingFileLink();
       if (runnerHost !== null) void runnerHost.openExternalLink(classified.url);
     },
-    [href, linkPolicy, reportIssueAvailable, runnerHost],
+    [navigableHref, linkPolicy, reportIssueAvailable, runnerHost],
   );
 
   // Native `title` ON PURPOSE - see the eslint exemption for this file. This
@@ -104,7 +116,12 @@ export function MarkdownAnchor({
   // app's tooltip surface would restyle author content as UI and strip the
   // attribute off the rendered anchor.
   return (
-    <a href={href} className={className} title={title} onClick={routeLinkClick}>
+    <a
+      href={navigableHref}
+      className={className}
+      title={title}
+      onClick={routeLinkClick}
+    >
       {children}
     </a>
   );

--- a/clients/gui-app/src/markdown/links/__tests__/resolve-artifact-relative-link.test.ts
+++ b/clients/gui-app/src/markdown/links/__tests__/resolve-artifact-relative-link.test.ts
@@ -99,25 +99,31 @@ describe("resolveArtifactRelativeLinkPath", () => {
     ).toBe("epics/epic-1/artifacts/ticket-breakdown/decision-log/index.md");
   });
 
-  it("decodes a URL-encoded '..' segment before walking it", () => {
+  // `classifyHref` owns the single decode on the way here, so a percent escape
+  // that survives it is a LITERAL part of the folder name and must stay one.
+  // Decoding again would both miss the real folder and let an authored
+  // `%252E%252E` become a `..` that walks out of the linked folder.
+  it("keeps a literal percent escape in a folder name as authored", () => {
+    expect(
+      resolveArtifactRelativeLinkPath(EPIC_ID, SELF_CHAIN, "my%20folder"),
+    ).toBe(
+      "epics/epic-1/artifacts/ticket-breakdown/01-something/my%20folder/index.md",
+    );
+  });
+
+  it("does not resurrect a '..' traversal from an encoded segment", () => {
     expect(
       resolveArtifactRelativeLinkPath(
         EPIC_ID,
         SELF_CHAIN,
         "%2E%2E/decision-log/index.md",
       ),
-    ).toBe("epics/epic-1/artifacts/ticket-breakdown/decision-log/index.md");
-  });
-
-  it("decodes a URL-encoded space in a folder name", () => {
-    expect(
-      resolveArtifactRelativeLinkPath(EPIC_ID, SELF_CHAIN, "my%20folder"),
     ).toBe(
-      "epics/epic-1/artifacts/ticket-breakdown/01-something/my folder/index.md",
+      "epics/epic-1/artifacts/ticket-breakdown/01-something/%2E%2E/decision-log/index.md",
     );
   });
 
-  it("falls back to the raw string on a malformed percent-escape instead of throwing", () => {
+  it("passes a malformed percent-escape through unchanged instead of throwing", () => {
     expect(() =>
       resolveArtifactRelativeLinkPath(EPIC_ID, SELF_CHAIN, "bad%escape"),
     ).not.toThrow();

--- a/clients/gui-app/src/markdown/links/__tests__/resolve-artifact-relative-link.test.ts
+++ b/clients/gui-app/src/markdown/links/__tests__/resolve-artifact-relative-link.test.ts
@@ -87,6 +87,14 @@ describe("resolveArtifactRelativeLinkPath", () => {
     ).toBeNull();
   });
 
+  it("keeps an edge space that came out of a decoded %20 in a folder name", () => {
+    // `classifyHref` trims the raw href and decodes it, so a space still sitting
+    // at the edge here was authored as `%20` - part of the name, not padding.
+    expect(resolveArtifactRelativeLinkPath(EPIC_ID, SELF_CHAIN, " draft")).toBe(
+      "epics/epic-1/artifacts/ticket-breakdown/01-something/ draft/index.md",
+    );
+  });
+
   it("resolves a bare '.' to this artifact's own directory, like bare index.md", () => {
     expect(resolveArtifactRelativeLinkPath(EPIC_ID, SELF_CHAIN, ".")).toBe(
       "epics/epic-1/artifacts/ticket-breakdown/01-something/index.md",

--- a/clients/gui-app/src/markdown/links/classify-href.ts
+++ b/clients/gui-app/src/markdown/links/classify-href.ts
@@ -97,10 +97,21 @@ function fileUrlToPath(href: string): string {
  * normalizes a link destination on the way to the DOM, so a path with a space
  * or a Windows separator arrives as `…Traycer%20Dev%5Crepo…`. The surface
  * policies resolve against a real filesystem, so they need the native form.
+ *
+ * This is the ONE decode on a file path's way to a surface policy - consumers
+ * (`resolveArtifactRelativeLinkPath`, the workspace-file candidates) take the
+ * native path as given. A second decode downstream would eat a literal percent
+ * escape in a real name (`my%20folder` authored as `my%2520folder`) and could
+ * turn `%252E%252E` into a `..` that walks out of the linked folder.
+ *
+ * `decodeURIComponent`, not `decodeURI`: the latter preserves the reserved set,
+ * so a filename's `%23` or `%3A` would reach the filesystem literally. Splitting
+ * the `:line[:col]` suffix off the ENCODED href (see {@link fileHref}) is what
+ * keeps those from being read as a fragment or a location in the first place.
  */
 function decodePercentEncoding(path: string): string {
   try {
-    return decodeURI(path);
+    return decodeURIComponent(path);
   } catch {
     return path;
   }

--- a/clients/gui-app/src/markdown/links/classify-href.ts
+++ b/clients/gui-app/src/markdown/links/classify-href.ts
@@ -28,7 +28,11 @@ const EXTERNAL_SCHEMES = new Set(["http", "https", "mailto"]);
 export function classifyHref(rawHref: string): ClassifiedHref {
   const href = rawHref.trim();
   // Empty or in-page anchors (`#heading`): this renderer only routes clicks
-  // that leave the current document/surface.
+  // that leave the current document/surface. `default` means "not ours" - the
+  // editor surface relies on it to let ProseMirror place the caret. Rendered
+  // anchors must never carry an empty href in the first place (it resolves to
+  // the current document, so a click reloads the SPA); `MarkdownAnchor` drops
+  // the attribute rather than classifying its way out of it.
   if (href.length === 0 || href.startsWith("#")) return { kind: "default" };
 
   const schemeMatch = SCHEME_PATTERN.exec(href);
@@ -54,45 +58,47 @@ const LINE_SUFFIX_PATTERN = /:(\d+)(?::(\d+))?$/;
 
 // Builds a `file` classification, splitting off a trailing `:line[:col]` target
 // so the bare path is what resolves to a file and the location travels in
-// `line`/`col`.
-function fileHref(path: string): ClassifiedHref {
-  const match = LINE_SUFFIX_PATTERN.exec(path);
-  if (match === null) {
-    // A location-less href with no path is degenerate (nothing to open).
-    // `ignore` - not `default` - so the anchor still `preventDefault`s the
-    // click rather than letting the browser navigate the bare href and unload
-    // the SPA.
-    return path.length === 0
-      ? { kind: "ignore" }
-      : { kind: "file", path, line: null, col: null };
-  }
-  const barePath = path.slice(0, match.index);
-  // A trailing location with no file in front of it (`:99`, `:0`) is degenerate.
-  // Reject it here rather than emitting an empty-path file link that a consumer
-  // would have to special-case.
+// `line`/`col`. The split runs on the ENCODED href (so a `%23` in a filename is
+// never mistaken for a fragment and a `%3A` never for a location), and only the
+// resulting bare path is decoded.
+function fileHref(encodedPath: string): ClassifiedHref {
+  const match = LINE_SUFFIX_PATTERN.exec(encodedPath);
+  const barePath =
+    match === null ? encodedPath : encodedPath.slice(0, match.index);
+  // Nothing to open: either a bare href with no path at all, or a trailing
+  // location with no file in front of it (`:99`, `:0`). `ignore` - not
+  // `default` - so the anchor still `preventDefault`s the click rather than
+  // letting the browser navigate the href and unload the SPA.
   if (barePath.length === 0) return { kind: "ignore" };
+  const path = decodePercentEncoding(barePath);
+  if (match === null) return { kind: "file", path, line: null, col: null };
   const line = Number.parseInt(match[1], 10);
   // A non-positive line is not a valid 1-based location. Drop the bogus target
   // and open the real file at the top instead of relying on a downstream clamp.
-  if (line < 1) return { kind: "file", path: barePath, line: null, col: null };
+  if (line < 1) return { kind: "file", path, line: null, col: null };
   // `.at()` is `string | undefined` (the col group is optional), unlike index
   // access which the lib types as a bare `string`.
   const colRaw = match.at(2);
   const col = colRaw === undefined ? null : Number.parseInt(colRaw, 10);
-  return { kind: "file", path: barePath, line, col };
+  return { kind: "file", path, line, col };
 }
 
 function fileUrlToPath(href: string): string {
   const withoutScheme = href.replace(/^file:\/\//i, "");
   // `file:///C:/x` → `/C:/x`; drop the leading slash before a drive letter so
   // the host sees a native Windows path.
-  const nativePath = /^\/[a-zA-Z]:/.test(withoutScheme)
+  return /^\/[a-zA-Z]:/.test(withoutScheme)
     ? withoutScheme.slice(1)
     : withoutScheme;
-  return decodeFileUrlPath(nativePath);
 }
 
-function decodeFileUrlPath(path: string): string {
+/**
+ * Every href reaching this module is percent-encoded - the markdown parser
+ * normalizes a link destination on the way to the DOM, so a path with a space
+ * or a Windows separator arrives as `…Traycer%20Dev%5Crepo…`. The surface
+ * policies resolve against a real filesystem, so they need the native form.
+ */
+function decodePercentEncoding(path: string): string {
   try {
     return decodeURI(path);
   } catch {

--- a/clients/gui-app/src/markdown/links/markdown-url-transform.ts
+++ b/clients/gui-app/src/markdown/links/markdown-url-transform.ts
@@ -11,7 +11,14 @@ const FILE_URL_PATTERN = /^file:/i;
 // which routes a single-letter scheme as a native file path. The sanitize layer
 // runs earlier in the pipeline and must allow the drive scheme too - see the
 // single-letter schemes added to `href` in `rehype-sanitize-schema.ts`.
-const DRIVE_LETTER_PATTERN = /^[a-zA-Z]:[\\/]/;
+//
+// `%5C` matters as much as the literal separators: the markdown parser
+// percent-encodes a link destination before any transform sees it, so the
+// NATIVE form an agent writes on Windows (`C:\Users\…`) arrives here as
+// `C:%5CUsers%5C…`. Matching only the literal `\` let that fall through to
+// `defaultUrlTransform`, which emptied the href - and an empty href is a real
+// navigation to the current document, i.e. a full renderer reload.
+const DRIVE_LETTER_PATTERN = /^[a-zA-Z]:(?:[\\/]|%5c)/i;
 
 export function markdownUrlTransform(url: string, key: string): string {
   if (url === INCOMPLETE_LINK_PLACEHOLDER) return url;

--- a/clients/gui-app/src/markdown/links/resolve-artifact-relative-link.ts
+++ b/clients/gui-app/src/markdown/links/resolve-artifact-relative-link.ts
@@ -56,10 +56,12 @@ export function resolveArtifactRelativeLinkPath(
   selfChain: readonly string[],
   relativePath: string,
 ): string | null {
-  const trimmed = relativePath.trim();
-  if (trimmed.length === 0) return null;
+  // Trim only to decide emptiness, never to reshape the path: `classifyHref`
+  // already trimmed the raw href, so an edge space surviving to here came out of
+  // a `%20` the author encoded on purpose and is part of the folder name.
+  if (relativePath.trim().length === 0) return null;
 
-  const rawSegments = trimmed.split(/[\\/]+/u).filter((s) => s.length > 0);
+  const rawSegments = relativePath.split(/[\\/]+/u).filter((s) => s.length > 0);
   if (rawSegments.length === 0) return null;
 
   const lastSegment = rawSegments[rawSegments.length - 1];

--- a/clients/gui-app/src/markdown/links/resolve-artifact-relative-link.ts
+++ b/clients/gui-app/src/markdown/links/resolve-artifact-relative-link.ts
@@ -29,20 +29,16 @@ import {
   EPICS_DIRNAME,
 } from "@traycer/protocol/common/artifact-path";
 
-/** Decodes a URL-encoded href segment (`%2E%2E`, `my%20folder`) before any `.`/`..` traversal or comparison; malformed escapes fall back to the raw string. */
-function decodeHrefComponent(href: string): string {
-  try {
-    return decodeURIComponent(href);
-  } catch {
-    return href;
-  }
-}
-
 /**
- * Resolves `relativeHref` (as authored inside the artifact whose own
+ * Resolves `relativePath` (as authored inside the artifact whose own
  * folder-name chain is `selfChain`) to an artifact-shaped path string, or
- * `null` when the href is empty/degenerate or navigates above the epic's
+ * `null` when the path is empty/degenerate or navigates above the epic's
  * `artifacts/` root.
+ *
+ * The path arrives ALREADY percent-decoded - `classifyHref` performs the single
+ * decode on the way out of the markdown pipeline. Decoding again here would
+ * consume a literal escape in a real folder name and, worse, could resurrect a
+ * `..` out of an authored `%252E%252E` and walk out of the linked folder.
  *
  * A `null` return for an over-`../`'d href is a DELIBERATE dead end, not a
  * bug: an authoring agent that miscounts `../` depth either lands one level
@@ -58,13 +54,12 @@ function decodeHrefComponent(href: string): string {
 export function resolveArtifactRelativeLinkPath(
   epicId: string,
   selfChain: readonly string[],
-  relativeHref: string,
+  relativePath: string,
 ): string | null {
-  const trimmed = relativeHref.trim();
+  const trimmed = relativePath.trim();
   if (trimmed.length === 0) return null;
 
-  const decoded = decodeHrefComponent(trimmed);
-  const rawSegments = decoded.split(/[\\/]+/u).filter((s) => s.length > 0);
+  const rawSegments = trimmed.split(/[\\/]+/u).filter((s) => s.length > 0);
   if (rawSegments.length === 0) return null;
 
   const lastSegment = rawSegments[rawSegments.length - 1];


### PR DESCRIPTION
## What

A markdown link to a native Windows path unloaded the entire renderer on click — the desktop app appeared to crash and reload. Reported on production Windows against agent-authored artifact links:

```markdown
- [Dummy Alpha](<C:\Users\Traycer Dev\.traycer\epics\<id>\artifacts\dummy-alpha\index.md>)
```

It was never angle-bracket specific — **any** `C:\…` markdown link reproduced it.

## Root cause

1. The markdown parser percent-encodes a link destination before any hook we own runs, so the href reaches `markdownUrlTransform` as `C:%5CUsers%5C…`, not `C:\Users\…`.
2. The drive-letter bypass matched `/^[a-zA-Z]:[\/]/` — a *literal* separator. `C:%5C` missed, so the href fell through to `defaultUrlTransform`, which reads `C:` as an unsafe scheme and returns `""`.
3. `<a href="">` resolves to the current document. `MarkdownAnchor` returned before `preventDefault`, so the browser performed a real navigation and the SPA unloaded.

Nothing appears in the desktop log because this is a legitimate same-origin navigation — `installNavigationGuard` compares origins and lets it through. The only trace is an unexplained `[host-runtime] startup begin` mid-session.

Same class as the hyperlink issue patched previously (`MarkdownAnchor`'s docstring names it), with the empty-href hole left open. The existing suite missed it because `classifyRenderedHref` feeds a *raw* backslash href straight into the transform, skipping the parser's encoding entirely.

## Why POSIX only toasted

`defaultUrlTransform` treats text before a colon as a scheme only when that colon precedes the first `/`, `?`, or `#`. A POSIX path has no colon, so it was never emptied — it kept a href with a literal `%20`, producing a wrong path and the graceful "Couldn't open link" toast. The drive-letter colon is what escalated the same encoding bug into a page reload.

## Changes

- **`markdown-url-transform.ts`** — the drive bypass also matches the percent-encoded separator, so a Windows path keeps its href.
- **`classify-href.ts`** — percent-decode file paths, not just `file:` URLs. Even the previously-working `C:/Users/My%20Dir/f.ts` shape handed the surface policy a path with a literal `%20`, so any path containing a space silently failed to open on **both** platforms. The `:line[:col]` split still runs on the encoded form so a `%23`/`%3A` in a filename isn't misread.
- **`markdown-anchor.tsx`** — a blank href is dropped rather than rendered, the way the sanitize layer already does for a rejected scheme. This closes the reload class regardless of which layer empties an href.

The guard deliberately lives in `MarkdownAnchor`, not `classifyHref`: `artifact-link-popover.tsx` relies on an empty href classifying as `default` so ProseMirror can place the caret. Putting it in the classifier regressed that silently (no test covers it).

## Tests

- `chat-markdown-link-provider.test.tsx` — drives the full pipeline (parse → transform → sanitize → anchor → link policy → artifact RPC → tile open) for the agent-authored Windows shape, asserting the click is `preventDefault`ed. A `true` there *is* the reload.
- Same file — a macOS artifact folder containing a space, covering both the `%20` and `<literal space>` authoring forms (they converge to the same href).
- `markdown-anchor.test.tsx` — native backslash link routes with a decoded path; an emptied href renders no navigable attribute; percent-decoding unit cases.

Each of the three source changes was verified load-bearing by reverting it alone and confirming the corresponding tests fail.

## Verification

`bun run compile`, eslint and prettier clean. 1734 tests pass across `src/markdown`, `src/components/chat`, `src/editor-core`. Full gui-app suite: 9219 passing; the 5 failures are pre-existing/flaky and reproduce on a clean tree or pass in isolation (`use-epic-collaborators-query`, `use-worktree-get-binding-query`, `host-rpc-producer-inventory`, plus two load-sensitive suites).

## Known limitation (unchanged by this PR)

`\.` is a valid CommonMark escape, so the separator before a Windows dot-directory is consumed by the parser before any hook we own — `C:\Users\me\.traycer\…` arrives as `C:\Users\me.traycer\…`. That information is destroyed upstream of `urlTransform`, `rehypePlugins` and `components.a`, so it can't be recovered at render time.

Artifact links still resolve: the loss lands upstream of the `epics/<id>/artifacts/<chain>/index.md` marker, which both the client pre-check and the host resolver match root-agnostically. It does bite when an artifact folder name starts with ASCII punctuation (`.hidden-spec`, `[draft] spec`), which collapses into its parent and destroys the marker. Fixing that means either pre-escaping backslashes in link destinations before parsing (needs enough CommonMark re-implementation to avoid rewriting code spans and fenced blocks, and must stay stable across every streaming prefix) or emitting forward-slash paths at the source — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
