### PR TITLE
fix(protocol): move two fields off the lines host-v1.1.10 froze

### DIFF
--- a/protocol/src/host/__tests__/provider-native-schemas.test.ts
+++ b/protocol/src/host/__tests__/provider-native-schemas.test.ts
@@ -18,6 +18,7 @@ import {
   providersDeleteEnvOverrideRequestSchema,
   providersDeleteEnvOverrideResponseSchemaV20,
   providersListRequestSchema,
+  providersListRequestSchemaBeforeV70,
   providersListResponseSchema,
   providersListResponseSchemaV10,
   providersListResponseSchemaV20,
@@ -296,9 +297,56 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
     expect(() => providersListResponseSchema.parse(upgraded)).not.toThrow();
   });
 
-  it("upgrades v3.0 requests with native:null", () => {
-    const upgraded = providersListUpgradeV3ToV4.upgradeRequest({});
+  // `native` rides v7.0 ALONE. It was authored against the live request object
+  // while v6.0 was unreleased, so it silently grew the already-shipped
+  // v4.0/v5.0/v6.0 request lines too - and `host-v1.1.10` then froze those
+  // three lines WITHOUT it, because the commit that added it missed the
+  // release cherry-pick. These three tests pin where the carrier is allowed to
+  // exist, so the same drift cannot come back through a "helpful" fill.
+  it("keeps native off every released request line below v7.0", () => {
+    expect(
+      providersListRequestSchemaBeforeV70.parse({
+        forceAuthRefresh: true,
+        native: {
+          kind: "mcp",
+          providerId: "claude-code",
+          scope: "global",
+          workspaceRoot: null,
+        },
+      }),
+    ).not.toHaveProperty("native");
+    expect(providersListRequestSchema.parse({}).native).toBeNull();
+  });
+
+  it("upgrades v3.0 requests as identity (both lines predate native)", () => {
+    const upgraded = providersListUpgradeV3ToV4.upgradeRequest({
+      forceAuthRefresh: true,
+    });
+    expect(upgraded).not.toHaveProperty("native");
+    expect(upgraded.forceAuthRefresh).toBe(true);
+  });
+
+  it("upgrades v6.0 requests with native:null", () => {
+    const upgraded = providersListUpgradeV6ToV7.upgradeRequest({});
     expect(upgraded.native).toBeNull();
+  });
+
+  it("downgrades v7.0 → v6.0 requests by stripping native", () => {
+    const result = providersListDowngradeV7ToV6.downgradeRequest(
+      providersListRequestSchema.parse({
+        forceAuthRefresh: true,
+        native: {
+          kind: "mcp",
+          providerId: "claude-code",
+          scope: "global",
+          workspaceRoot: null,
+        },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).not.toHaveProperty("native");
+    expect(result.value.forceAuthRefresh).toBe(true);
   });
 
   // The adjacent hop, and the one most likely to rot: v6.0 is a RELEASED line

--- a/protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts
+++ b/protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Both-direction bridge coverage for the lines `host-v1.1.10` froze without
+ * the fields that had been riding them (`epic.createTuiAgent@1.0` without
+ * `forkSourceHarnessSessionId`, `providers.list@4.0/5.0/6.0` requests without
+ * `native` - the release cherry-pick dropped the commits that added them).
+ *
+ * Drives the real registries through the same traversal helpers the host
+ * handler (`upgradeRequestToVersion` / `downgradeResponseAcrossMajors`) and
+ * the client transport (zod-strip on the older minor's request schema,
+ * `downgradeRequestAcrossMajors`) execute at runtime, so a transform that
+ * drops or leaks one of these fields fails here, not against a released peer.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  downgradeRequestAcrossMajors,
+  downgradeResponseAcrossMajors,
+  upgradeRequestToVersion,
+  upgradeResponseToVersion,
+} from "@traycer/protocol/framework/versioned-rpc";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
+import {
+  createTuiAgentRequestSchemaV10,
+  createTuiAgentRequestSchema,
+} from "@traycer/protocol/host/epic/unary-schemas";
+import {
+  providersListRequestSchema,
+  providersListRequestSchemaBeforeV70,
+  providersListResponseSchema,
+  providersListResponseSchemaV60,
+} from "@traycer/protocol/host/provider-schemas";
+
+const createTuiRegistry = hostRpcRegistry["epic.createTuiAgent"];
+const providersListRegistry = hostRpcRegistry["providers.list"];
+
+const canonicalCreateRequest = createTuiAgentRequestSchema.parse({
+  epicId: "e1",
+  parentId: null,
+  title: "t",
+  harnessId: "claude",
+  harnessSessionId: "sess-1",
+  terminalShellCommand: null,
+  terminalShellArgs: null,
+  hostId: "h1",
+  workspaceFolders: ["/w"],
+  model: null,
+  agentMode: "regular",
+  forkSourceHarnessSessionId: "fork-src-1",
+});
+
+describe("epic.createTuiAgent 1.0 <-> 1.1", () => {
+  it("released 1.0 client -> new host: V10 parse accepts the released shape, chain fills null", () => {
+    // Exactly what a released v1.1.10 client sends (no fork field).
+    const released = {
+      epicId: "e1",
+      parentId: null,
+      title: "t",
+      harnessId: "claude",
+      harnessSessionId: null,
+      terminalShellCommand: null,
+      terminalShellArgs: null,
+      hostId: "h1",
+      workspaceFolders: ["/w"],
+      model: null,
+      agentMode: "regular",
+    };
+    const parsed = createTuiAgentRequestSchemaV10.parse(released);
+    const canonical = upgradeRequestToVersion(
+      createTuiRegistry,
+      { major: 1, minor: 0 },
+      { major: 1, minor: 1 },
+      parsed,
+    );
+    expect(canonical.forkSourceHarnessSessionId).toBeNull();
+    expect(() => createTuiAgentRequestSchema.parse(canonical)).not.toThrow();
+    // Host response leg back to the 1.0 caller: same-major identity + strip.
+    const response = { tuiAgentId: "a1" };
+    const up = upgradeResponseToVersion(
+      createTuiRegistry,
+      { major: 1, minor: 0 },
+      { major: 1, minor: 1 },
+      response,
+    );
+    expect(up).toEqual(response);
+  });
+
+  it("new 1.1 client -> released 1.0 host: transport zod-strip projects the fork field away", () => {
+    // Mirrors prepareRequestPayload's same-major newer-client branch.
+    const stripped = createTuiAgentRequestSchemaV10.safeParse(
+      canonicalCreateRequest,
+    );
+    expect(stripped.success).toBe(true);
+    if (!stripped.success) return;
+    expect(stripped.data).not.toHaveProperty("forkSourceHarnessSessionId");
+    // Everything the released host's schema models survives projection.
+    expect(stripped.data.harnessSessionId).toBe("sess-1");
+    expect(stripped.data.profileId).toBeNull();
+  });
+});
+
+const releasedProvidersRequest = { forceAuthRefresh: true };
+
+describe("providers.list request lines 1.0..6.0 <-> 7.0", () => {
+  it("released callers at every major upgrade to canonical with native:null", () => {
+    for (const major of [1, 2, 3, 4, 5, 6] as const) {
+      const parsed =
+        providersListRequestSchemaBeforeV70.parse(releasedProvidersRequest);
+      const canonical = upgradeRequestToVersion(
+        providersListRegistry,
+        { major, minor: 0 },
+        { major: 7, minor: 0 },
+        parsed,
+      );
+      expect(canonical, `major ${major}`).toEqual({
+        forceAuthRefresh: true,
+        native: null,
+      });
+      expect(() => providersListRequestSchema.parse(canonical)).not.toThrow();
+    }
+  });
+
+  it("a new 7.0 client downgrades its request to every released major without leaking native", () => {
+    const canonical = providersListRequestSchema.parse({
+      forceAuthRefresh: true,
+      native: {
+        kind: "mcp",
+        providerId: "claude-code",
+        scope: "global",
+        workspaceRoot: null,
+      },
+    });
+    for (const major of [1, 2, 3, 4, 5, 6] as const) {
+      const down = downgradeRequestAcrossMajors(
+        providersListRegistry,
+        7,
+        major,
+        canonical,
+      );
+      expect(down.ok, `major ${major}`).toBe(true);
+      if (!down.ok) continue;
+      expect(down.value, `major ${major}`).not.toHaveProperty("native");
+      expect(
+        providersListRequestSchemaBeforeV70.safeParse(down.value).success,
+        `major ${major} reparse`,
+      ).toBe(true);
+    }
+  });
+
+  it("response round-trip 7.0 -> 6.0 -> 7.0 still parses at both ends", () => {
+    const canonicalResponse = providersListResponseSchema.parse({
+      providers: [],
+      native: null,
+    });
+    const down = downgradeResponseAcrossMajors(
+      providersListRegistry,
+      7,
+      6,
+      canonicalResponse,
+    );
+    expect(down.ok).toBe(true);
+    if (!down.ok) return;
+    expect(down.value).not.toHaveProperty("native");
+    expect(providersListResponseSchemaV60.safeParse(down.value).success).toBe(
+      true,
+    );
+    const back = upgradeResponseToVersion(
+      providersListRegistry,
+      { major: 6, minor: 0 },
+      { major: 7, minor: 0 },
+      providersListResponseSchemaV60.parse(down.value),
+    );
+    expect(back.native).toBeNull();
+    expect(providersListResponseSchema.safeParse(back).success).toBe(true);
+  });
+});

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -16,6 +16,7 @@ import {
   createEpicRequestSchema,
   createEpicResponseSchema,
   createTuiAgentRequestSchema,
+  createTuiAgentRequestSchemaV10,
   createTuiAgentResponseSchema,
   deleteArtifactRequestSchema,
   deleteArtifactResponseSchema,
@@ -371,6 +372,22 @@ export const epicSetChatArchivedV10 = defineRpcContract({
 export const epicCreateTuiAgentV10 = defineRpcContract({
   method: "epic.createTuiAgent",
   schemaVersion: { major: 1, minor: 0 } as const,
+  // Frozen: `host-v1.1.10` shipped this line. It pointed at the live request
+  // schema until then, which is how `forkSourceHarnessSessionId` grew an
+  // already-released contract.
+  requestSchema: createTuiAgentRequestSchemaV10,
+  responseSchema: createTuiAgentResponseSchema,
+});
+
+// v1.1 adds `forkSourceHarnessSessionId`: the upstream session a forked TUI
+// agent was minted from, persisted verbatim so a provider failure between PTY
+// spawn and destination-transcript establishment still has durable provenance
+// to retry the fork from. Folded onto this method as a minor rather than a new
+// method name, which would fatally fail the equal-set handshake against an
+// already-shipped host. See the RPC backward-compat decision log.
+export const epicCreateTuiAgentV11 = defineRpcContract({
+  method: "epic.createTuiAgent",
+  schemaVersion: { major: 1, minor: 1 } as const,
   requestSchema: createTuiAgentRequestSchema,
   responseSchema: createTuiAgentResponseSchema,
 });

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -1148,9 +1148,45 @@ export const createTuiAgentRequestSchema = z.object({
   // establishment still has durable provenance to retry the fork from -
   // the renderer's own prepared-launch stash is cleared on PTY creation,
   // well before that establishment point.
+  // Rides @1.1 alone - see `createTuiAgentRequestSchemaV10` below.
   forkSourceHarnessSessionId: z.string().nullable().default(null).catch(null),
 });
 export type CreateTuiAgentRequest = z.infer<typeof createTuiAgentRequestSchema>;
+
+/**
+ * Frozen `epic.createTuiAgent@1.0` request, exactly as shipped through
+ * `host-v1.1.10`: everything above except `forkSourceHarnessSessionId`.
+ *
+ * That field was authored straight onto the live object while @1.0 was the
+ * only registered version, so it silently grew an already-released contract;
+ * `host-v1.1.10` then froze @1.0 without it, because the commit that added it
+ * was not in the release cherry-pick. It rides @1.1 now.
+ *
+ * Hand-pinned field-for-field rather than derived from the live schema via
+ * `.omit()` - a field added to the live shape must not silently leak back into
+ * this contract, which is the exact failure this freeze exists to prevent.
+ */
+export const createTuiAgentRequestSchemaV10 = z.object({
+  epicId: z.string(),
+  parentId: z.string().nullable(),
+  title: z.string(),
+  harnessId: tuiHarnessIdSchema,
+  harnessSessionId: z.string().nullable().catch(null),
+  terminalAgentArgs: z.string().nullable().default(null).catch(null),
+  terminalShellCommand: z.string().nullable().catch(null),
+  terminalShellArgs: z.array(z.string()).nullable().catch(null),
+  hostId: z.string(),
+  workspaceFolders: z.array(z.string()),
+  workspaceMode: worktreeBindingWorkspaceModeSchema.optional(),
+  model: z.string().nullable(),
+  reasoningEffort: z.string().nullable().default(null),
+  agentMode: agentModeSchema,
+  tuiAgentId: z.string().nullable().optional(),
+  profileId: z.string().nullable().default(null),
+});
+export type CreateTuiAgentRequestV10 = z.infer<
+  typeof createTuiAgentRequestSchemaV10
+>;
 
 export const createTuiAgentResponseSchema = z.object({
   tuiAgentId: z.string(),

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -943,9 +943,18 @@ export const providerCliStateSchema = z.object({
 export type ProviderCliState = z.infer<typeof providerCliStateSchema>;
 
 /**
- * `providers.list@3.1` request. Optional `native` list/discover query folds
- * the unreleased mcp/plugins/skills list verbs onto this carrier. Classic
- * callers omit it (upgrade defaults to null).
+ * Live `providers.list@7.0` request. Optional `native` list/discover query
+ * folds the mcp/plugins/skills list verbs onto this carrier. Callers on any
+ * earlier line predate it, so the v6.0 -> v7.0 upgrade fills `native: null`
+ * ("classic caller, no native query").
+ *
+ * `native` rides v7.0 ALONE. It was authored against the live request object
+ * while v6.0 was still unreleased, which silently grew the already-shipped
+ * v4.0/v5.0/v6.0 request lines too; `host-v1.1.10` then froze those three
+ * lines without it, because the commit that added it was not in the release
+ * cherry-pick. Every line below v7.0 is pinned to
+ * `providersListRequestSchemaBeforeV70` for that reason - do not point a
+ * released line back at this schema.
  */
 export const providersListRequestSchema = z.object({
   forceAuthRefresh: z.boolean().optional(),
@@ -953,12 +962,17 @@ export const providersListRequestSchema = z.object({
 });
 export type ProvidersListRequest = z.infer<typeof providersListRequestSchema>;
 
-/** Frozen `providers.list@3.0` request (no native field). */
-export const providersListRequestSchemaV30 = z.object({
+/**
+ * Frozen request shape for every released `providers.list` line before v7.0
+ * (v1.0 through v6.0 all shipped exactly this). Hand-pinned rather than
+ * derived from the live schema via `.omit()` so a future request field cannot
+ * leak into a shipped line the way `native` did.
+ */
+export const providersListRequestSchemaBeforeV70 = z.object({
   forceAuthRefresh: z.boolean().optional(),
 });
-export type ProvidersListRequestV30 = z.infer<
-  typeof providersListRequestSchemaV30
+export type ProvidersListRequestBeforeV70 = z.infer<
+  typeof providersListRequestSchemaBeforeV70
 >;
 
 /**

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -202,6 +202,7 @@ import {
   epicCreateChatV10,
   epicCreateCommentThreadV10,
   epicCreateTuiAgentV10,
+  epicCreateTuiAgentV11,
   epicCreateV10,
   epicDeleteArtifactV10,
   epicDeleteChatV10,
@@ -462,7 +463,7 @@ import {
   providersEnsurePackRequestSchema,
   providersEnsurePackResponseSchema,
   providersListRequestSchema,
-  providersListRequestSchemaV30,
+  providersListRequestSchemaBeforeV70,
   providersListResponseSchema,
   providersListResponseSchemaV10,
   providersListResponseSchemaV20,
@@ -912,14 +913,14 @@ export const worktreeGetBindingV10 = defineRpcContract({
 export const providersListV10 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 1, minor: 0 } as const,
-  requestSchema: providersListRequestSchemaV30,
+  requestSchema: providersListRequestSchemaBeforeV70,
   responseSchema: providersListResponseSchemaV10,
 });
 
 export const providersListV20 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 2, minor: 0 } as const,
-  requestSchema: providersListRequestSchemaV30,
+  requestSchema: providersListRequestSchemaBeforeV70,
   responseSchema: providersListResponseSchemaV20,
 });
 
@@ -1075,7 +1076,7 @@ export const providersListDowngradeV2ToV1 = defineDowngradePath<
 export const providersListV30 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 3, minor: 0 } as const,
-  requestSchema: providersListRequestSchemaV30,
+  requestSchema: providersListRequestSchemaBeforeV70,
   responseSchema: providersListResponseSchemaV30,
 });
 
@@ -1132,7 +1133,12 @@ export const providersListDowngradeV3ToV1 = defineDowngradePath<
 export const providersListV40 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 4, minor: 0 } as const,
-  requestSchema: providersListRequestSchema,
+  // Frozen: `cli-v1.1.4` shipped this line, and `host-v1.1.10` re-froze it
+  // without `native`. It pointed at the live request schema until then, which
+  // is how the native list/discover carrier grew three already-released
+  // request lines at once - the response side of this same method was frozen
+  // per line for the identical reason (see `providersListV50`/`V60`).
+  requestSchema: providersListRequestSchemaBeforeV70,
   responseSchema: providersListResponseSchemaV40,
 });
 
@@ -1154,11 +1160,10 @@ export const providersListUpgradeV3ToV4 = defineUpgradePath<
   // model them, so a fill here is discarded - they are filled on the
   // v5.0 -> v6.0 hop instead, whose target is the live shape.
   //
-  // The REQUEST is not identity: the v4.0 line is pinned to the live request
-  // schema, which carries the `native` list/discover carrier. A v3.0 caller
-  // predates it, so it upgrades to `native: null` ("classic caller, no native
-  // query").
-  upgradeRequest: (request) => ({ ...request, native: null }),
+  // The request upgrade is identity: v3.0 and v4.0 are both pinned to
+  // `providersListRequestSchemaBeforeV70`. `native` rides v7.0 alone and is
+  // filled on the v6.0 -> v7.0 hop, the first bridge whose target models it.
+  upgradeRequest: (request) => request,
   upgradeResponse: (response) => ({
     providers: response.providers.map((provider) => ({
       ...provider,
@@ -1176,7 +1181,7 @@ export const providersListDowngradeV4ToV3 = defineDowngradePath<
   to: { major: 3, minor: 0 },
   downgradeRequest: (request) => ({
     ok: true,
-    value: providersListRequestSchemaV30.parse({
+    value: providersListRequestSchemaBeforeV70.parse({
       forceAuthRefresh: request.forceAuthRefresh,
     }),
   }),
@@ -1196,7 +1201,7 @@ export const providersListDowngradeV4ToV2 = defineDowngradePath<
   to: { major: 2, minor: 0 },
   downgradeRequest: (request) => ({
     ok: true,
-    value: providersListRequestSchemaV30.parse({
+    value: providersListRequestSchemaBeforeV70.parse({
       forceAuthRefresh: request.forceAuthRefresh,
     }),
   }),
@@ -1216,7 +1221,7 @@ export const providersListDowngradeV4ToV1 = defineDowngradePath<
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({
     ok: true,
-    value: providersListRequestSchemaV30.parse({
+    value: providersListRequestSchemaBeforeV70.parse({
       forceAuthRefresh: request.forceAuthRefresh,
     }),
   }),
@@ -1231,7 +1236,9 @@ export const providersListDowngradeV4ToV1 = defineDowngradePath<
 export const providersListV50 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 5, minor: 0 } as const,
-  requestSchema: providersListRequestSchema,
+  // Frozen without `native` for the same reason as the v4.0 line above:
+  // `host-v1.1.10` shipped this request shape.
+  requestSchema: providersListRequestSchemaBeforeV70,
   // Frozen: `cli-v1.1.8` shipped this line, so it must serve the v5.0 id set
   // rather than the live one. Before that release it pointed at the canonical
   // schema, which is exactly how `omp` first tried to ride v5.0.
@@ -1241,7 +1248,9 @@ export const providersListV50 = defineRpcContract({
 export const providersListV60 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 6, minor: 0 } as const,
-  requestSchema: providersListRequestSchema,
+  // Frozen without `native` for the same reason as the v4.0 line above:
+  // `host-v1.1.10` shipped this request shape.
+  requestSchema: providersListRequestSchemaBeforeV70,
   // Frozen: `cli-v1.1.9` shipped this line. It pointed at the canonical schema
   // until then, which is how the provider-pack-registry fields grew an
   // already-released version - the same way `omp` first tried to ride v5.0.
@@ -1295,7 +1304,13 @@ export const providersListUpgradeV6ToV7 = defineUpgradePath<
   // job is `nativeCapabilities` - the fill must not silently depend on a
   // re-parse that exists for another field. See
   // `upgradeLoginCapabilityFromV40`.
-  upgradeRequest: (request) => request,
+  //
+  // The REQUEST is not identity either, and for the same reason: v7.0 is the
+  // first line whose request models the `native` list/discover carrier, so a
+  // v6.0-or-older caller upgrades to `native: null` ("classic caller, no
+  // native query"). This fill used to sit on the v3.0 -> v4.0 hop, back when
+  // v4.0/v5.0/v6.0 were still pinned to the live request schema.
+  upgradeRequest: (request) => ({ ...request, native: null }),
   upgradeResponse: (response) => ({
     providers: upgradeProviderCliStateListToLatest(
       response.providers.map((provider) => ({
@@ -1392,7 +1407,16 @@ export const providersListDowngradeV7ToV6 = defineDowngradePath<
 >({
   from: { major: 7, minor: 0 },
   to: { major: 6, minor: 0 },
-  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // v7.0 is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
   // The id sets are identical, so this hop exists purely to strip the
   // provider-pack-registry fields: reparsing through the frozen v6.0 schema
   // drops the keys it does not model, which is exactly what `cli-v1.1.9`
@@ -1411,7 +1435,16 @@ export const providersListDowngradeV7ToV5 = defineDowngradePath<
 >({
   from: { major: 7, minor: 0 },
   to: { major: 5, minor: 0 },
-  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // v7.0 is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
   downgradeResponse: (response) => ({
     ok: true,
     value: providersListResponseSchemaV50.parse({
@@ -1426,7 +1459,16 @@ export const providersListDowngradeV7ToV4 = defineDowngradePath<
 >({
   from: { major: 7, minor: 0 },
   to: { major: 4, minor: 0 },
-  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // v7.0 is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
   downgradeResponse: (response) => ({
     ok: true,
     value: providersListResponseSchemaV40.parse({
@@ -1441,7 +1483,16 @@ export const providersListDowngradeV7ToV3 = defineDowngradePath<
 >({
   from: { major: 7, minor: 0 },
   to: { major: 3, minor: 0 },
-  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // v7.0 is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
   downgradeResponse: (response) => ({
     ok: true,
     value: providersListResponseSchemaV30.parse({
@@ -1456,7 +1507,16 @@ export const providersListDowngradeV7ToV2 = defineDowngradePath<
 >({
   from: { major: 7, minor: 0 },
   to: { major: 2, minor: 0 },
-  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // v7.0 is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
   downgradeResponse: (response) => ({
     ok: true,
     value: providersListResponseSchemaV20.parse({
@@ -1471,7 +1531,16 @@ export const providersListDowngradeV7ToV1 = defineDowngradePath<
 >({
   from: { major: 7, minor: 0 },
   to: { major: 1, minor: 0 },
-  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // v7.0 is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
   downgradeResponse: (response) => ({
     ok: true,
     value: providersListResponseSchemaV10.parse({
@@ -1487,8 +1556,8 @@ export const providersListUpgradeV4ToV5 = defineUpgradePath<
   from: { major: 4, minor: 0 },
   to: { major: 5, minor: 0 },
   // A v4.0 response without Hermes is a valid v5.0 response (purely
-  // additive), and both lines are pinned to the same live request schema -
-  // both upgrades are identity.
+  // additive), and both lines are pinned to the same frozen pre-v7.0 request
+  // schema - both upgrades are identity.
   upgradeRequest: (request) => request,
   upgradeResponse: (response) => response,
 });
@@ -2875,6 +2944,24 @@ export const workspacePrepareFoldersUpgradeV10ToV11 = defineUpgradePath<
     validation: null,
     recentWorkspaces: null,
   }),
+});
+
+// Additive upgrade from v1.0: a peer on the frozen v1.0 line predates fork
+// provenance entirely, so its creates carry no fork source. The newer side
+// runs this when bridging a v1.0 peer up to canonical (host: inbound v1.0
+// request). The response is unchanged across the two minors, so its upgrade is
+// identity.
+export const epicCreateTuiAgentUpgradeV10ToV11 = defineUpgradePath<
+  typeof epicCreateTuiAgentV10,
+  typeof epicCreateTuiAgentV11
+>({
+  from: epicCreateTuiAgentV10.schemaVersion,
+  to: epicCreateTuiAgentV11.schemaVersion,
+  upgradeRequest: (request) => ({
+    ...request,
+    forkSourceHarnessSessionId: null,
+  }),
+  upgradeResponse: (response) => response,
 });
 
 const HOST_RPC_REGISTRY_BASE_DEFINITION = {
@@ -4342,11 +4429,15 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
   },
   "epic.createTuiAgent": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: epicCreateTuiAgentV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: epicCreateTuiAgentV11,
+          upgradeFromPreviousVersion: epicCreateTuiAgentUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## Why

v1.1.10 was cut by cherry-picking a subset of `main`, and two commits that had
authored fields straight onto **live** schema objects were left behind. The
release then shipped those lines *without* the fields — which quietly converts
an edit-an-unreleased-version into a change-a-released-contract: same
`{ major, minor }` advertised at the handshake, two different shapes behind it.

`canBridgeFromMySide()` treats equal `{major, minor}` as "identical shape" and
returns `true` without transforming, so this class of drift passes the handshake
and only surfaces later, as a field that is present or absent depending on which
build the peer happens to be running.

Measured against the `protocol-surface.json` asset published on `host-v1.1.10`.
Both introducing commits are confirmed **not** ancestors of that tag:

| Method | Released versions carrying it | Slot | Field | From |
|---|---|---|---|---|
| `providers.list` | `4.0`, `5.0`, `6.0` | request | `native` | #284 |
| `epic.createTuiAgent` | `1.0` (its only version) | request | `forkSourceHarnessSessionId` | #859 |

## What changed

**`providers.list`** shares one request schema object across all seven majors, so
`native` leaked into every already-shipped line. Majors 1–6 are now pinned to a
frozen pre-native request (`providersListRequestSchemaBeforeV70`), and the
`native: null` fill moves from the v3→v4 hop to **v6→v7** — the first bridge
whose target actually models the carrier, which is the placement rule the
response side of this same method already follows. All six `V7ToV*` downgrades
now re-parse the request field-by-field instead of passing it through, so the
carrier cannot reach a peer with no room for it.

**`epic.createTuiAgent`** had a single registered version, so the field simply
rode released `v1.0`. `v1.0` is frozen as shipped; `v1.1` carries the field, with
an upgrade path filling `null` for callers that predate forks.

Both frozen request schemas are **hand-pinned field-for-field** rather than
derived with `.omit()`, matching the convention already used for
`providerCliStateSchemaV20` and `chatSnapshotSchemaV10` — a future field cannot
leak back in the way these two did.

## Not included: the `chat.subscribe` serverFrame paths

`backgroundTask` / `stopped` / `terminationReason` / `live` / `managedCommand`
also diverge on `chat.subscribe@1.0`–`1.5`, and are deliberately left alone.
Two reasons, both verified in code rather than assumed:

1. **A stream minor bump is a runtime no-op.** `framework/versioned-stream-rpc.ts`
   has no upgrade/downgrade machinery at all, and `buildProtocolSurface` hard-codes
   `downgradeTargets: []` for streams. Frames serialize from the live schema
   whatever minor was negotiated, so a peer on `@1.5` receives byte-identical
   frames whether or not a frozen `@1.6` exists.
2. **The cost is a fork of the persistence tree.** The "frozen"
   `chatSnapshotSchemaV10`…`V15` reach the live block union through
   `chatSchemaPreInReplyTo` → `messageSchemaPreInReplyTo` →
   `assistantMessageSchemaPreInReplyTo` → `contentBlockSchema`, which *is* the
   `epic@2.0` persistence contract. Freezing them means forking the command /
   tool-call blocks, the `autonomousResumeBlockSchema` codec and the
   runtime-event union — splitting definitions that are deliberately one tree.

All five paths were re-checked as genuinely absence-tolerant
(`.default(false)` / `.nullable().default(null)` / `.default("error")`), so their
existing `compat-exceptions.json` entries still hold. No governance file is
touched by this PR.

## Verification

Both directions, driven through the same traversal helpers the host handler
(`upgradeRequestToVersion` / `downgradeResponseAcrossMajors`) and the client
transport (zod-strip on the older minor's request schema /
`downgradeRequestAcrossMajors`) execute at runtime:

- released 1.0 caller → new host: frozen V10 parse, chain fills `null`, canonical re-parse passes
- new 1.1 client → released 1.0 host: projection drops the fork field, same bytes as pre-bump
- released majors 1–6 → 7.0: identity hops, `native: null` filled only on 6→7 (all six probed)
- 7.0 → released majors 1–6: `native` cannot leak (all six probed)
- response round-trip 7→6→7 parses at both ends

Committed as `protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts`
so a future transform edit that drops or leaks one of these fields fails in plain
`bun run test`.

Also: every version `host-v1.1.10` shipped is now **byte-identical** in the dumped
surface (only the six known excepted `chat.subscribe` rows differ);
`check-protocol-compat` reports compatible against host-v1.1.7 / 1.1.8 / 1.1.9 /
1.1.10; `released-baseline-handshake.test.ts` passes 18/18 against all four
baseline manifests; protocol suite 1776/1776.

A follow-up internal PR bumps the gitlink and carries two host test fixtures that
framed requests at versions this change makes unreachable.
