### PR TITLE
fix(gui-app): keep the composer root menu compact, viewport-cap only submenus

### DIFF
--- a/clients/gui-app/src/components/chat/composer/menu/composer-menu.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/composer-menu.tsx
@@ -354,7 +354,17 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
           ref={listRef}
           id={menuId}
           role="listbox"
-          className="max-h-[70vh] overflow-y-auto py-1"
+          // The first menu (mention categories, slash commands) stays compact:
+          // tall enough for the full category roster without a scrollbar,
+          // while typed-query results scroll behind the cap. A provider
+          // submenu mirrors a bounded roster (terminals, git refs), so it
+          // grows to the viewport cap instead of scrolling.
+          className={cn(
+            "overflow-y-auto py-1",
+            kind === "mention" && step.kind === "provider"
+              ? "max-h-[70vh]"
+              : "max-h-[min(50vh,16rem)]",
+          )}
         >
           <ComposerMenuBody
             renderedItems={renderedItems}


### PR DESCRIPTION
## Summary

#997 raised the composer picker listbox to `max-h-[70vh]` for every step so a provider roster (Terminals, git refs) renders without a scrollbar — but the root `@` search shares that listbox, and its merged results are only capped per source (25 per provider per root since #623), so a typed query now fills most of the screen ([screenshot from a teammate](https://github.com/traycerai/traycer/pull/997)).

This sizes the list by step instead:

- **First menu** (mention categories, slash commands, typed `@` search): `max-h-[min(50vh,16rem)]` — fits the full 8-category roster scroll-free (the pre-#997 `12rem` actually scrolled it), while long typed-query result lists scroll behind the cap.
- **Provider submenus** (`step.kind === "provider"`): keep the `70vh` viewport cap from #997, so a full terminal/git roster still renders without a scrollbar.

No behavior change to ranking or result counts — display sizing only.