### PR TITLE
feat(protocol): add a config_unreadable native error code

### DIFF
--- a/clients/gui-app/src/hooks/providers/native-response-map.ts
+++ b/clients/gui-app/src/hooks/providers/native-response-map.ts
@@ -12,6 +12,7 @@ import type {
 import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcRegistry } from "@/lib/host";
+import { nativeErrorMessage } from "@/lib/providers/native-error-copy";
 
 export type ProvidersListWireResponse = ResponseOfMethod<
   HostRpcRegistry,
@@ -52,7 +53,15 @@ export class ProviderNativeRpcError extends HostRpcError {
   }) {
     super({
       code: "RPC_ERROR",
-      message: args.detail ?? `Native provider error: ${args.code}`,
+      // `nativeErrorMessage`, not `detail ?? code`. The panels render
+      // `error.message` directly, so a protocol-valid `{ detail: null }` put
+      // the raw enum member on screen ("Native provider error:
+      // config_unreadable") and the friendly copy map was never consulted on
+      // the list path at all. Building the message here fixes every code at
+      // once rather than the one that happened to surface it, and
+      // `nativeErrorMessage` already prefers a non-blank trimmed `detail`, so
+      // a whitespace-only detail falls back too.
+      message: nativeErrorMessage(args.code, args.detail),
       requestId: "native-error",
       method: args.method,
       fatalDetails: null,

--- a/clients/gui-app/src/lib/providers/__tests__/native-error-copy.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/native-error-copy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { nativeErrorMessage } from "@/lib/providers/native-error-copy";
+import { ProviderNativeRpcError } from "@/hooks/providers/native-response-map";
 
 describe("nativeErrorMessage", () => {
   it("prefers non-empty detail over code copy", () => {
@@ -15,5 +16,56 @@ describe("nativeErrorMessage", () => {
     expect(nativeErrorMessage("unsupported_scope", "   ")).toBe(
       "This action is not supported for the selected scope.",
     );
+  });
+});
+
+// The MCP/plugins/skills panels render `error.message` directly, so the copy
+// map is only reachable if the error CARRIES it. Building the message from
+// `detail ?? code` put the raw enum member on screen and made every string in
+// that map dead on the list path.
+describe("ProviderNativeRpcError message", () => {
+  it("uses the friendly copy when the host sends no detail", () => {
+    const err = new ProviderNativeRpcError({
+      code: "config_unreadable",
+      detail: null,
+      method: "providers.list",
+    });
+    expect(err.message).toBe(
+      "This provider's config could not be read. Check the file, then try again.",
+    );
+    // The raw enum member must not reach the user.
+    expect(err.message).not.toContain("config_unreadable");
+  });
+
+  it("falls back for a whitespace-only detail too", () => {
+    expect(
+      new ProviderNativeRpcError({
+        code: "duplicate_name",
+        detail: "   ",
+        method: "providers.nativeMutate",
+      }).message,
+    ).toBe("A server with this name already exists in this scope.");
+  });
+
+  it("still prefers a real detail from the host", () => {
+    // Discriminating: the host's redacted parser message is more specific than
+    // any static copy, so it must win when present.
+    expect(
+      new ProviderNativeRpcError({
+        code: "config_unreadable",
+        detail: "Failed to parse config /x/config.yaml: bad indent at line 3",
+        method: "providers.list",
+      }).message,
+    ).toBe("Failed to parse config /x/config.yaml: bad indent at line 3");
+  });
+
+  it("keeps the typed code available for callers that branch on it", () => {
+    const err = new ProviderNativeRpcError({
+      code: "config_unreadable",
+      detail: null,
+      method: "providers.list",
+    });
+    expect(err.nativeCode).toBe("config_unreadable");
+    expect(err.nativeDetail).toBeNull();
   });
 });

--- a/clients/gui-app/src/lib/providers/native-error-copy.ts
+++ b/clients/gui-app/src/lib/providers/native-error-copy.ts
@@ -12,6 +12,13 @@ const NATIVE_ERROR_COPY: Readonly<Record<ProviderNativeErrorCode, string>> = {
     "This provider store version is not supported for writes.",
   rollback_failed:
     "The change failed and automatic rollback could not restore the previous config.",
+  // The only LIST-side code: the provider's own config file is malformed or
+  // unreadable, so this provider has nothing to show. Deliberately says the
+  // config could not be read rather than "no servers configured", which is the
+  // wrong-bug answer this code exists to stop the UI from giving. The host
+  // sends a redacted parser/errno message as `detail`, which supersedes this.
+  config_unreadable:
+    "This provider's config could not be read. Check the file, then try again.",
 };
 
 export function nativeErrorMessage(

--- a/protocol/src/host/__tests__/provider-native-schemas.test.ts
+++ b/protocol/src/host/__tests__/provider-native-schemas.test.ts
@@ -999,6 +999,7 @@ describe("carrier envelopes (object-preserving, no unions)", () => {
       "external_drift",
       "store_version_unsupported",
       "rollback_failed",
+      "config_unreadable",
     ] as const) {
       expect(providerNativeErrorCodeSchema.parse(code)).toBe(code);
     }

--- a/protocol/src/host/provider-native-schemas.ts
+++ b/protocol/src/host/provider-native-schemas.ts
@@ -101,6 +101,22 @@ export const providerNativeErrorCodeSchema = z.enum([
   "external_drift",
   "store_version_unsupported",
   "rollback_failed",
+  // The provider's own config could not be READ or PARSED - a malformed
+  // `config.yaml`/`config.toml`/`mcp.json`, or an unreadable one.
+  //
+  // This is a LIST-side failure, unlike every code above it, and it exists
+  // because the alternative is worse in both directions. Swallowing the
+  // failure into an empty list tells the user "this provider has no MCP
+  // servers", which is indistinguishable from the truth and sends them
+  // looking for the wrong bug. Letting it reject instead takes down the whole
+  // `providers.list` response - native results ride on that call, so one
+  // malformed file would empty the entire provider catalog on every poll.
+  //
+  // A typed result is the only option that scopes the failure to the provider
+  // it belongs to. `detail` carries a REDACTED parser message (see
+  // `ConfigParseError`, which redacts at construction): parse errors quote the
+  // offending source line, which is routinely a credential.
+  "config_unreadable",
 ]);
 export type ProviderNativeErrorCode = z.infer<
   typeof providerNativeErrorCodeSchema


### PR DESCRIPTION
## Summary

Adds one native error code, `config_unreadable`, so the host can say "this provider's own config could not be read or parsed" as a **typed result** instead of choosing between two wrong behaviours.

Native list results ride on `providers.list`, which also carries the classic provider catalog. Without a typed code the host had to either:

- swallow the failure into an empty list — indistinguishable from "no MCP servers configured", which sends the user after the wrong bug; or
- let it reject — which empties the **entire** provider catalog on every 800ms poll because one user's `settings.json` is malformed.

`config_unreadable` scopes the failure to the provider that owns the broken file. `detail` carries a **redacted** parser message: `ConfigParseError` redacts at construction, because TOML and YAML errors quote the offending source line back and that line is routinely a credential.

Consumed by traycerai/traycer-internal#4871, which maps `ConfigParseError` at the resolver boundary.

## Related issue

None — from review of #1046.

## Compatibility

Widening this enum is safe, and I verified it rather than assuming it:

- `protocol/src/host/provider-native-schemas.ts` **does not exist** at `host-v1.1.10` or any earlier release tag — the whole native surface postdates every release, so no released peer parses these codes.
- The compat gate reports **compatible against all 16 released baselines**, run the way `protocol-compat.yml` runs it (baselines resolved from remote release tags; surfaces from published assets where present, reconstructed from the tag commit otherwise).
- This PR touches no file in the `guarded-files-tripwire` list.

## Checklist

- [x] `bun run lint` / `bun run compile` clean (pre-commit hook, `nx affected`)
- [x] Code is formatted
- [x] Pre-commit hooks pass
- [x] Tests updated (`provider-native-schemas.test.ts` round-trips the new code)
- [x] Commits are signed off (`git commit -s`) per the DCO

## Verification

| Check | Result |
|---|---|
| `protocol` suite | **1782 passed** |
| Protocol compat, all 16 released baselines | compatible |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
