### PR TITLE
test(gui-app): fire a real wheel before asserting a follow departure

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
@@ -896,8 +896,17 @@ async function waitForPillVisible(
 /**
  * Real gesture to strict bottom: leave the end first (so this is not just the
  * fresh-mount bootstrap default), then land at max scrollTop.
+ *
+ * The wheel is load-bearing, not decoration. Since #1042 the follow latch
+ * treats only PUBLISHING READER INPUT as a departure and leaves layout-owned
+ * scroll reports (MVCP, deferred measurement, inset compensation) corrective —
+ * so a bare `scrollTop =` assignment no longer leaves the end, and this helper
+ * was asserting a departure it never actually performed. `noteReaderGesture`
+ * is armed from the wheel/touch listeners, which is what a real reader
+ * produces; the same `fireEvent.wheel` idiom is used by the pill tests below.
  */
 async function gestureToTrueBottom(scrollNode: HTMLElement): Promise<void> {
+  fireEvent.wheel(scrollNode, { deltaY: -80 });
   act(() => {
     scrollNode.scrollTop = 1000;
   });
@@ -1786,19 +1795,11 @@ describe("StableTileSurfaceHost permanent lifecycle matrix (real store/coordinat
     await waitForHostedChatLoaded(container, CHAT_TRACKED.instanceId);
 
     const trackedScroll = messagesScroll(container, CHAT_TRACKED.instanceId);
-    // Real gesture: leave the bottom, then scroll back down to the true max -
-    // not just the untouched fresh-mount bootstrap default.
-    act(() => {
-      trackedScroll.scrollTop = 1000;
-    });
-    await settleLegendList();
-    expect(trackedScroll.dataset.scrollMode).toBe("free-scrolling");
-    act(() => {
-      trackedScroll.scrollTop =
-        trackedScroll.scrollHeight - trackedScroll.clientHeight;
-    });
-    await settleLegendList();
-    expect(trackedScroll.dataset.scrollMode).toBe("following-end");
+    // The shared helper, not a second copy of it. This block was a verbatim
+    // inline duplicate that drifted: when the helper gained the wheel that
+    // makes the departure real (see its note on #1042), this one did not, so
+    // it kept asserting a departure it never performed.
+    await gestureToTrueBottom(trackedScroll);
     const bottomTop = trackedScroll.scrollTop;
     expect(bottomTop).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

`main` is currently red on the **`test (traycer-clients-gui-app shard 3)`** job. Four rows of the StableTileSurfaceHost lifecycle matrix fail with `expected 'following-end' to be 'free-scrolling'`. First red at #1042; the two commits before it were green.

**The product is right — the test was stale.** #1042 deliberately changed the follow latch to *"treat only publishing reader input as a follow departure; keep layout-owned scroll reports corrective"*, so MVCP, deferred row measurement and inset compensation stop knocking a reader off the tail. Reader input is armed from the wheel/touch listeners via `noteReaderGesture`.

`gestureToTrueBottom` assigned `scrollNode.scrollTop` and nothing else. Under the new rule that is a layout-owned report by construction, so the latch correctly holds `following-end` — and the helper was asserting a departure it never performed, despite its own docstring calling itself a *"Real gesture"*. It now fires the wheel a real reader would, using the same `fireEvent.wheel` idiom the pill tests in this file already use.

Row 15 carried a **verbatim inline copy** of that helper and had drifted from it, so it failed for the same reason once the helper was fixed. It now calls the helper rather than holding a third copy of the gesture.

## Related issue

None — found while rebasing #1050 onto `main`.

## Why this is a test fix and not a masked regression

The post-fix assertion is the interesting one: with a real wheel gesture the latch **does** still leave the end and report `free-scrolling`. So #1042's narrowing did not over-reach — only the simulation of a reader was out of date.

## Checklist

- [x] `bun run lint` / `bun run compile` pass (pre-commit, `nx affected`)
- [x] Code is formatted
- [x] Pre-commit hooks pass
- [x] Tests updated
- [x] Commits are signed off (`git commit -s`) per the DCO

## Verification

| Check | Result |
|---|---|
| `stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx` | **27 passed** (was 4 failed / 23 passed) |
| Full CI shard, `--shard=3/4` | **280 files, 2638 tests passed** |
| Non-vacuity: delete the single `fireEvent.wheel` line | reproduces exactly the original 4 failures |
| Pristine `origin/main` before this change | same 4 failures — confirms pre-existing, not environmental |

Test-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
