### PR TITLE
feat(protocol,traycer-cli): frozen-prompt contract and promptSubmitted hook pull

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-queue-edit-steer.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-queue-edit-steer.test.tsx
@@ -276,6 +276,8 @@ function emitChatSnapshot(
         createdAt: 0,
         updatedAt: 0,
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
         isTitleEditedByUser: false,
         settings: QUEUED_SETTINGS,
         activeSessionChain: null,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -458,6 +458,8 @@ function emitChatSnapshotWithMessages(input: {
         messages: [...input.messages],
         events: [],
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
       },
       access: {
         role: input.access,

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
@@ -164,6 +164,8 @@ function emitSnapshot(
         messages: [...messages],
         events: [...events],
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
       },
       access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
       queue: { status: "idle", items: [] },

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/stable-tile-surface-host-permanent-lifecycle-matrix.test.tsx
@@ -453,6 +453,8 @@ function emitChatSnapshot(
         createdAt: 0,
         updatedAt: 0,
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
         isTitleEditedByUser: false,
         settings: CHAT_RUN_SETTINGS,
         activeSessionChain: null,

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -455,6 +455,14 @@ export const HOST_METHOD_POLL_TABLE = {
     joinResponseTimeoutMs: null,
     poll: null,
   },
+  // Optional replacement for the recordActivity start edge: records the
+  // activity edge and pulls the role-registry digest cursor forward when
+  // behind (roles-snapshot-delivery). Same scheduling as its sibling hooks.
+  "agent.tui.promptSubmitted": {
+    mode: "fifo",
+    joinResponseTimeoutMs: null,
+    poll: null,
+  },
   // Creating an agent persists a new collaboration record.
   "agent.create": { mode: "fifo", joinResponseTimeoutMs: null, poll: null },
   "agent.selectionGuide": { ...LATEST_SCHEDULING, poll: null },

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -374,6 +374,8 @@ function emitSnapshotFrame(input: SnapshotFrameInput): void {
         messages: [...input.messages],
         events: [],
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
       },
       access: {
         role: input.access,
@@ -424,6 +426,8 @@ function emitSnapshotWithWorktree(
         messages: [],
         events: [...events],
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
       },
       access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
       queue: { status: "idle", items: [] },
@@ -3704,6 +3708,8 @@ describe("createChatSessionStore", () => {
           ],
           events: [],
           archivedAt: null,
+          pinnedUserProviderHandle: null,
+          lastDeliveredRolesDigest: null,
         },
         access: {
           role: "owner",
@@ -3869,6 +3875,8 @@ describe("createChatSessionStore", () => {
           ],
           events: [],
           archivedAt: null,
+          pinnedUserProviderHandle: null,
+          lastDeliveredRolesDigest: null,
         },
         access: {
           role: "owner",

--- a/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
@@ -115,6 +115,8 @@ function emitSnapshot(harness: Harness): void {
         messages: [],
         events: [],
         archivedAt: null,
+        pinnedUserProviderHandle: null,
+        lastDeliveredRolesDigest: null,
       },
       access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
       queue: { status: "idle", items: [] },

--- a/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAgentActivityFromHookCommand } from "../agent-activity-from-hook";
 import { callHostRpcFastFail } from "../../internal/host-rpc";
 import { cliError, CLI_ERROR_CODES } from "../../runner/errors";
+import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
 import {
   makeCtx,
   restoreAgentIdentityEnv,
@@ -38,7 +39,7 @@ const rpcMock = vi.mocked(callHostRpcFastFail);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  rpcMock.mockResolvedValue({ accepted: true });
+  rpcMock.mockResolvedValue({ accepted: true, pendingPromptContext: null });
   setAgentIdentityEnv();
 });
 
@@ -50,8 +51,8 @@ afterEach(() => {
   restoreAgentIdentityEnv();
 });
 
-describe("buildAgentActivityFromHookCommand", () => {
-  it("sends the observed Claude session id read from the hook stdin payload", async () => {
+describe("buildAgentActivityFromHookCommand - start edge (promptSubmitted)", () => {
+  it("calls promptSubmitted with the observed Claude session id read from stdin", async () => {
     stubStdin({
       isTTY: false,
       chunks: [JSON.stringify({ session_id: "sess-live-9", cwd: "/tmp" })],
@@ -66,40 +67,65 @@ describe("buildAgentActivityFromHookCommand", () => {
     const result = await fn(makeCtx());
 
     expect(rpcMock).toHaveBeenCalledTimes(1);
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
       epicId: "epic-1",
       tuiAgentId: "agent-1",
       harnessSessionId: null,
       harnessId: "claude",
-      event: "start",
       observedHarnessSessionId: "sess-live-9",
     });
     expect(result.exitCode).toBe(0);
     expect(result.data).toEqual({ accepted: true, reason: null });
+    expect(result.human).toBeNull();
   });
 
-  it("carries the observed id on the stop edge too", async () => {
+  it("emits the UserPromptSubmit additionalContext envelope when pendingPromptContext is non-null", async () => {
+    rpcMock.mockResolvedValue({
+      accepted: true,
+      pendingPromptContext: "Traycer role registry update:\n- role= scope=",
+    });
     stubStdin({
       isTTY: false,
-      chunks: [JSON.stringify({ session_id: "sess-live-stop" })],
+      chunks: [JSON.stringify({ session_id: "sess-live-9" })],
     });
     const fn = buildAgentActivityFromHookCommand({
       provider: "claude",
-      event: "stop",
+      event: "start",
       epicId: null,
       agentId: null,
       harnessSessionId: null,
     });
-    await fn(makeCtx());
+    const result = await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
-      epicId: "epic-1",
-      tuiAgentId: "agent-1",
-      harnessSessionId: null,
-      harnessId: "claude",
-      event: "stop",
-      observedHarnessSessionId: "sess-live-stop",
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({ accepted: true, reason: null });
+    expect(result.human).toBe(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: "Traycer role registry update:\n- role= scope=",
+        },
+      }),
+    );
+  });
+
+  it("emits no stdout when pendingPromptContext is null", async () => {
+    rpcMock.mockResolvedValue({ accepted: true, pendingPromptContext: null });
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-live-9" })],
     });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(result.human).toBeNull();
+    expect(result.data).toEqual({ accepted: true, reason: null });
   });
 
   it("never reads stdin for a non-claude provider (observed id stays null)", async () => {
@@ -118,12 +144,11 @@ describe("buildAgentActivityFromHookCommand", () => {
     });
     await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
       epicId: "epic-1",
       tuiAgentId: "agent-1",
       harnessSessionId: null,
       harnessId: "codex",
-      event: "start",
       observedHarnessSessionId: null,
     });
   });
@@ -142,12 +167,11 @@ describe("buildAgentActivityFromHookCommand", () => {
     });
     await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
       epicId: "epic-1",
       tuiAgentId: "agent-1",
       harnessSessionId: null,
       harnessId: "opencode",
-      event: "start",
       observedHarnessSessionId: "ses-oc-live-2",
     });
   });
@@ -162,19 +186,18 @@ describe("buildAgentActivityFromHookCommand", () => {
     });
     const fn = buildAgentActivityFromHookCommand({
       provider: "opencode",
-      event: "stop",
+      event: "start",
       epicId: null,
       agentId: null,
       harnessSessionId: "ses-oc-1",
     });
     await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
       epicId: null,
       tuiAgentId: null,
       harnessSessionId: "ses-oc-1",
       harnessId: "opencode",
-      event: "stop",
       observedHarnessSessionId: null,
     });
   });
@@ -193,12 +216,11 @@ describe("buildAgentActivityFromHookCommand", () => {
     });
     await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
       epicId: "epic-1",
       tuiAgentId: "agent-1",
       harnessSessionId: null,
       harnessId: "claude",
-      event: "start",
       observedHarnessSessionId: null,
     });
   });
@@ -215,7 +237,7 @@ describe("buildAgentActivityFromHookCommand", () => {
     await fn(makeCtx());
 
     expect(rpcMock).toHaveBeenCalledWith(
-      "agent.tui.recordActivity",
+      "agent.tui.promptSubmitted",
       expect.objectContaining({ observedHarnessSessionId: null }),
     );
   });
@@ -232,7 +254,7 @@ describe("buildAgentActivityFromHookCommand", () => {
     await fn(makeCtx());
 
     expect(rpcMock).toHaveBeenCalledWith(
-      "agent.tui.recordActivity",
+      "agent.tui.promptSubmitted",
       expect.objectContaining({ observedHarnessSessionId: null }),
     );
   });
@@ -290,5 +312,219 @@ describe("buildAgentActivityFromHookCommand", () => {
       reason: "host-unreachable",
     });
     expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildAgentActivityFromHookCommand - start edge fallback (host too old)", () => {
+  it("falls back to recordActivity silently when the host doesn't support promptSubmitted", async () => {
+    rpcMock.mockRejectedValueOnce(
+      new HostRpcError({
+        code: "E_HOST_UNSUPPORTED",
+        message:
+          "This host does not support 'agent.tui.promptSubmitted'. Upgrade the host to use this feature.",
+        requestId: "req-1",
+        method: "agent.tui.promptSubmitted",
+        fatalDetails: null,
+      }),
+    );
+    rpcMock.mockResolvedValueOnce({ accepted: true });
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-live-9" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(2);
+    expect(rpcMock).toHaveBeenNthCalledWith(1, "agent.tui.promptSubmitted", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      observedHarnessSessionId: "sess-live-9",
+    });
+    expect(rpcMock).toHaveBeenNthCalledWith(2, "agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "start",
+      observedHarnessSessionId: "sess-live-9",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({ accepted: true, reason: null });
+    expect(result.human).toBeNull();
+  });
+
+  it("noops with exit 0 if the recordActivity fallback also hits a dead host", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    rpcMock.mockRejectedValueOnce(
+      new HostRpcError({
+        code: "E_HOST_UNSUPPORTED",
+        message: "This host does not support 'agent.tui.promptSubmitted'.",
+        requestId: "req-1",
+        method: "agent.tui.promptSubmitted",
+        fatalDetails: null,
+      }),
+    );
+    rpcMock.mockRejectedValueOnce(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
+        message: "traycer: host not running",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "host-unreachable",
+    });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("still surfaces a genuine host RPC_ERROR from promptSubmitted (not swallowed as a fallback trigger)", async () => {
+    rpcMock.mockRejectedValueOnce(
+      new HostRpcError({
+        code: "RPC_ERROR",
+        message: "terminal agent not found",
+        requestId: "req-2",
+        method: "agent.tui.promptSubmitted",
+        fatalDetails: null,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await expect(fn(makeCtx())).rejects.toThrow(/terminal agent not found/);
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildAgentActivityFromHookCommand - stop edge (recordActivity, unchanged)", () => {
+  it("carries the observed id on the stop edge via recordActivity", async () => {
+    rpcMock.mockResolvedValue({ accepted: true });
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-live-stop" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "stop",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "stop",
+      observedHarnessSessionId: "sess-live-stop",
+    });
+    expect(result.data).toEqual({ accepted: true, reason: null });
+    expect(result.human).toBeNull();
+  });
+
+  it("noops with exit 0 when the host is not running", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    rpcMock.mockRejectedValueOnce(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
+        message: "traycer: host not running",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "stop",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "host-unreachable",
+    });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildAgentActivityFromHookCommand - shared identity/event parsing", () => {
+  it("noops on unknown provider without an RPC call", async () => {
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "bogus",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "unknown-provider",
+    });
+  });
+
+  it("noops on an unknown event without an RPC call", async () => {
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "resume",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "unknown-event",
+    });
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
@@ -153,7 +153,11 @@ describe("buildAgentActivityFromHookCommand - start edge (promptSubmitted)", () 
     });
   });
 
-  it("reads stdin for an env-identified opencode hook (root-session form)", async () => {
+  it("routes an opencode start through recordActivity, never promptSubmitted", async () => {
+    // OpenCode's in-process plugin consumes no hook stdout, so the pull path
+    // would let the host advance its roles cursor for a snapshot the model
+    // never receives. The start edge must stay a plain activity edge - with
+    // no stdout, since anything printed may surface back into the TUI.
     stubStdin({
       isTTY: false,
       chunks: [JSON.stringify({ session_id: "ses-oc-live-2" })],
@@ -165,15 +169,18 @@ describe("buildAgentActivityFromHookCommand - start edge (promptSubmitted)", () 
       agentId: null,
       harnessSessionId: null,
     });
-    await fn(makeCtx());
+    const result = await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
       epicId: "epic-1",
       tuiAgentId: "agent-1",
       harnessSessionId: null,
       harnessId: "opencode",
+      event: "start",
       observedHarnessSessionId: "ses-oc-live-2",
     });
+    expect(result.human).toBeNull();
   });
 
   it("never reads stdin for a session-id-keyed opencode hook", async () => {
@@ -193,11 +200,12 @@ describe("buildAgentActivityFromHookCommand - start edge (promptSubmitted)", () 
     });
     await fn(makeCtx());
 
-    expect(rpcMock).toHaveBeenCalledWith("agent.tui.promptSubmitted", {
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
       epicId: null,
       tuiAgentId: null,
       harnessSessionId: "ses-oc-1",
       harnessId: "opencode",
+      event: "start",
       observedHarnessSessionId: null,
     });
   });

--- a/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
@@ -42,14 +42,23 @@ interface HookActivityIdentity {
  *
  * The `stop` edge still rides `agent.tui.recordActivity`. The `start` edge
  * (the `UserPromptSubmit` hook chain) is the roles-snapshot-delivery pull
- * point: it calls `agent.tui.promptSubmitted@1.0` instead, an optional unary
- * method that does both jobs in one round trip - it records the same
- * activity edge `recordActivity` would have, then runs the host's
- * roles-digest-cursor check. A non-null `pendingPromptContext` in the
- * response is emitted on stdout as the `UserPromptSubmit` `additionalContext`
- * envelope (`{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit",
- * "additionalContext":"..."}}`), which Claude Code appends to the outgoing
- * prompt; `null` (nothing to deliver) means no stdout at all.
+ * point FOR ENVELOPE-CONSUMING PROVIDERS ONLY (Claude, and Codex via its
+ * Claude-compatible hook runner): it calls `agent.tui.promptSubmitted@1.0`
+ * instead, an optional unary method that does both jobs in one round trip -
+ * it records the same activity edge `recordActivity` would have, then runs
+ * the host's roles-digest-cursor check. A non-null `pendingPromptContext` in
+ * the response is emitted on stdout as the `UserPromptSubmit`
+ * `additionalContext` envelope (`{"hookSpecificOutput":{"hookEventName":
+ * "UserPromptSubmit","additionalContext":"..."}}`), which the provider
+ * appends to the outgoing prompt; `null` (nothing to deliver) means no
+ * stdout at all.
+ *
+ * Every OTHER provider's `start` edge stays on plain `recordActivity`: the
+ * response contract lets the host advance its roles cursor when it returns
+ * pending context, so calling `promptSubmitted` from a hook whose stdout is
+ * NOT injected into the prompt (OpenCode's in-process plugin consumes no
+ * hook stdout) would acknowledge a snapshot the model never receives -
+ * a silent permanent delivery loss, not a degrade.
  *
  * `promptSubmitted` is registered with `degrade: { kind: "unsupported" }`
  * (a brand-new method, not a new minor of `recordActivity`): against a host
@@ -118,11 +127,20 @@ export function buildAgentActivityFromHookCommand(opts: {
       observedHarnessSessionId,
     };
 
-    if (event === "stop") {
-      const stopResult = await callRecordActivity(identity, "stop");
-      if (stopResult === "host-unreachable") return noop("host-unreachable");
+    // Only providers whose hook runner injects this command's stdout into
+    // the outgoing prompt may take the promptSubmitted pull path - the host
+    // advances its roles cursor when it hands back pending context, so a
+    // provider that discards stdout (OpenCode's in-process plugin) would
+    // silently strand the snapshot as "delivered". Those stay on the plain
+    // activity edge.
+    const consumesPromptEnvelope =
+      identity.harnessId === "claude" || identity.harnessId === "codex";
+
+    if (event === "stop" || !consumesPromptEnvelope) {
+      const edgeResult = await callRecordActivity(identity, event);
+      if (edgeResult === "host-unreachable") return noop("host-unreachable");
       return {
-        data: { accepted: stopResult.accepted, reason: null },
+        data: { accepted: edgeResult.accepted, reason: null },
         human: null,
         exitCode: 0,
       };

--- a/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
@@ -1,8 +1,15 @@
 import {
   recordTuiAgentActivityRequestSchemaV11,
   recordTuiAgentActivityResponseSchema,
+  tuiAgentPromptSubmittedRequestSchema,
+  tuiAgentPromptSubmittedResponseSchema,
+  type RecordTuiAgentActivityRequestV11,
+  type RecordTuiAgentActivityResponse,
 } from "@traycer/protocol/host/agent/tui/unary-schemas";
-import { tuiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
+import {
+  tuiHarnessIdSchema,
+  type TuiHarnessId,
+} from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpcFastFail,
   parseHostResponse,
@@ -19,9 +26,40 @@ type ActivityHookEvent = "start" | "stop";
 type NoopReason =
   "missing-context" | "unknown-event" | "unknown-provider" | "host-unreachable";
 
+// Identity fields shared by the `promptSubmitted` call and its `recordActivity`
+// fallback - both carry the exact same payload (see the module doc).
+interface HookActivityIdentity {
+  readonly epicId: string | null;
+  readonly tuiAgentId: string | null;
+  readonly harnessSessionId: string | null;
+  readonly harnessId: TuiHarnessId;
+  readonly observedHarnessSessionId: string | null;
+}
+
 /**
  * `traycer agent activity-from-hook` - invoked by provider TUI lifecycle
  * hooks. It reports provider-native turn start/stop edges to the host.
+ *
+ * The `stop` edge still rides `agent.tui.recordActivity`. The `start` edge
+ * (the `UserPromptSubmit` hook chain) is the roles-snapshot-delivery pull
+ * point: it calls `agent.tui.promptSubmitted@1.0` instead, an optional unary
+ * method that does both jobs in one round trip - it records the same
+ * activity edge `recordActivity` would have, then runs the host's
+ * roles-digest-cursor check. A non-null `pendingPromptContext` in the
+ * response is emitted on stdout as the `UserPromptSubmit` `additionalContext`
+ * envelope (`{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit",
+ * "additionalContext":"..."}}`), which Claude Code appends to the outgoing
+ * prompt; `null` (nothing to deliver) means no stdout at all.
+ *
+ * `promptSubmitted` is registered with `degrade: { kind: "unsupported" }`
+ * (a brand-new method, not a new minor of `recordActivity`): against a host
+ * that doesn't advertise it, the shared transport never sends the request -
+ * it fails locally with `HostRpcError({ code: "E_HOST_UNSUPPORTED" })`,
+ * which `toAgentCliError` maps to `CliError({ code:
+ * CLI_ERROR_CODES.HOST_UNSUPPORTED })`. That specific code degrades silently
+ * to a plain `recordActivity` `start` call carrying the identical payload -
+ * today's semantics, unnoticed by the user. Every other error (a genuine
+ * host `RPC_ERROR`, auth failure, etc.) still surfaces.
  *
  * It also piggybacks the live provider session id (stamped on the hook's
  * stdin payload) as `observedHarnessSessionId` so the host can resync the
@@ -35,9 +73,9 @@ type NoopReason =
  * resync from it anyway). A missing/slow/garbage payload yields `null` and
  * never fails the hook.
  *
- * Like the title hook command, this is intentionally quiet: hooks can fire
- * outside Traycer-managed sessions, and their stdout may be surfaced back into
- * the provider TUI.
+ * Like the title hook command, this is intentionally quiet on the `stop`
+ * edge and on every benign miss: hooks can fire outside Traycer-managed
+ * sessions, and their stdout may be surfaced back into the provider TUI.
  */
 export function buildAgentActivityFromHookCommand(opts: {
   readonly provider: string;
@@ -72,39 +110,116 @@ export function buildAgentActivityFromHookCommand(opts: {
         ? await readObservedHarnessSessionId()
         : null;
 
-    const request = parseUserInput(recordTuiAgentActivityRequestSchemaV11, {
+    const identity: HookActivityIdentity = {
       epicId,
       tuiAgentId,
       harnessSessionId,
       harnessId: parsedHarness.data,
-      event,
       observedHarnessSessionId,
-    });
-    const rpcResult = await toAgentCliError(
-      callHostRpcFastFail("agent.tui.recordActivity", request),
-    ).catch((err: unknown) => {
-      if (
-        err instanceof CliError &&
-        err.code === CLI_ERROR_CODES.HOST_NOT_RUNNING
-      ) {
-        return "host-unreachable" as const;
-      }
-      throw err;
-    });
-    if (rpcResult === "host-unreachable") {
-      return noop("host-unreachable");
+    };
+
+    if (event === "stop") {
+      const stopResult = await callRecordActivity(identity, "stop");
+      if (stopResult === "host-unreachable") return noop("host-unreachable");
+      return {
+        data: { accepted: stopResult.accepted, reason: null },
+        human: null,
+        exitCode: 0,
+      };
     }
 
-    const { accepted } = parseHostResponse(
-      recordTuiAgentActivityResponseSchema,
-      rpcResult,
-    );
+    return submitPrompt(identity);
+  };
+}
+
+async function submitPrompt(identity: HookActivityIdentity) {
+  const request = parseUserInput(tuiAgentPromptSubmittedRequestSchema, {
+    epicId: identity.epicId,
+    tuiAgentId: identity.tuiAgentId,
+    harnessSessionId: identity.harnessSessionId,
+    harnessId: identity.harnessId,
+    observedHarnessSessionId: identity.observedHarnessSessionId,
+  });
+  const rpcResult = await toAgentCliError(
+    callHostRpcFastFail("agent.tui.promptSubmitted", request),
+  ).catch((err: unknown) => {
+    if (
+      err instanceof CliError &&
+      err.code === CLI_ERROR_CODES.HOST_NOT_RUNNING
+    ) {
+      return "host-unreachable" as const;
+    }
+    if (
+      err instanceof CliError &&
+      err.code === CLI_ERROR_CODES.HOST_UNSUPPORTED
+    ) {
+      return "host-too-old" as const;
+    }
+    throw err;
+  });
+  if (rpcResult === "host-unreachable") return noop("host-unreachable");
+  if (rpcResult === "host-too-old") {
+    const fallback = await callRecordActivity(identity, "start");
+    if (fallback === "host-unreachable") return noop("host-unreachable");
     return {
-      data: { accepted, reason: null },
+      data: { accepted: fallback.accepted, reason: null },
       human: null,
       exitCode: 0,
     };
+  }
+
+  const { accepted, pendingPromptContext } = parseHostResponse(
+    tuiAgentPromptSubmittedResponseSchema,
+    rpcResult,
+  );
+  return {
+    data: { accepted, reason: null },
+    human:
+      pendingPromptContext === null
+        ? null
+        : userPromptSubmitEnvelope(pendingPromptContext),
+    exitCode: 0,
   };
+}
+
+async function callRecordActivity(
+  identity: HookActivityIdentity,
+  event: ActivityHookEvent,
+): Promise<RecordTuiAgentActivityResponse | "host-unreachable"> {
+  const requestInput: RecordTuiAgentActivityRequestV11 = {
+    epicId: identity.epicId,
+    tuiAgentId: identity.tuiAgentId,
+    harnessSessionId: identity.harnessSessionId,
+    harnessId: identity.harnessId,
+    event,
+    observedHarnessSessionId: identity.observedHarnessSessionId,
+  };
+  const request = parseUserInput(
+    recordTuiAgentActivityRequestSchemaV11,
+    requestInput,
+  );
+  const rpcResult = await toAgentCliError(
+    callHostRpcFastFail("agent.tui.recordActivity", request),
+  ).catch((err: unknown) => {
+    if (
+      err instanceof CliError &&
+      err.code === CLI_ERROR_CODES.HOST_NOT_RUNNING
+    ) {
+      return "host-unreachable" as const;
+    }
+    throw err;
+  });
+  if (rpcResult === "host-unreachable") return "host-unreachable";
+  return parseHostResponse(recordTuiAgentActivityResponseSchema, rpcResult);
+}
+
+function userPromptSubmitEnvelope(additionalContext: string): string {
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext,
+    },
+  });
 }
 
 function parseActivityHookEvent(value: string): ActivityHookEvent | null {

--- a/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
@@ -55,6 +55,8 @@ const chat: Chat = {
   messages: [userMessage],
   events: [],
   archivedAt: null,
+  pinnedUserProviderHandle: null,
+  lastDeliveredRolesDigest: null,
 };
 
 const event: ChatEvent = {

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -22,6 +22,7 @@ import {
   chatSchema,
   chatSchemaPreInReplyTo,
   chatSchemaV14,
+  chatSchemaV15,
   userMessagePayloadSchema,
   userMessageSchema,
   userMessageSchemaPreInReplyTo,
@@ -1744,8 +1745,14 @@ export const chatSubscribeV14 = defineStreamRpcContract({
 // nothing else it holds, so it reuses the live frame - retro-pin it here if a
 // later minor touches background items again (that is exactly what happened to
 // `1.3` and `1.4`).
+//
+// `chat: chatSchemaV15` (not live `chatSchema`) for the same reason `1.4`
+// uses `chatSchemaV14`: a released line must not follow the persistence
+// schema by reference, or every later field addition to `chatSchema` (e.g.
+// `pinnedUserProviderHandle`, `lastDeliveredRolesDigest`) silently leaks onto
+// this frozen wire shape. Caught by `released-baseline-compat.test.ts`.
 const chatSnapshotSchemaV15 = z.object({
-  chat: chatSchema,
+  chat: chatSchemaV15,
   access: chatAccessSchema,
   queue: chatQueueStateSchemaPreManagedCommand,
   runStatus: chatRunStatusSchema,

--- a/protocol/src/host/agent/tui/contracts.ts
+++ b/protocol/src/host/agent/tui/contracts.ts
@@ -13,6 +13,8 @@ import {
   recordTuiAgentActivityRequestSchema,
   recordTuiAgentActivityRequestSchemaV11,
   recordTuiAgentActivityResponseSchema,
+  tuiAgentPromptSubmittedRequestSchema,
+  tuiAgentPromptSubmittedResponseSchema,
   tuiAgentTurnEndedRequestSchema,
   tuiAgentTurnEndedResponseSchema,
   validateTuiForkProfileRequestSchema,
@@ -132,4 +134,20 @@ export const agentTuiRecordActivityUpgradeV10ToV11 = defineUpgradePath<
     observedHarnessSessionId: null,
   }),
   upgradeResponse: (response) => response,
+});
+
+/**
+ * Optional (non-floor) capability: the `UserPromptSubmit` hook's combined
+ * activity-edge + roles-digest-pull call (roles-snapshot-delivery pull point
+ * 1). Registered with a `degrade: unsupported` strategy in `registry.ts` so
+ * an old host that lacks it fails only this call and the CLI hook falls back
+ * to plain `recordActivity` - it must never enter the released floor, which
+ * would be handshake-fatal for existing peers. See the schema doc in
+ * `unary-schemas.ts`.
+ */
+export const agentTuiPromptSubmittedV10 = defineRpcContract({
+  method: "agent.tui.promptSubmitted",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: tuiAgentPromptSubmittedRequestSchema,
+  responseSchema: tuiAgentPromptSubmittedResponseSchema,
 });

--- a/protocol/src/host/agent/tui/unary-schemas.ts
+++ b/protocol/src/host/agent/tui/unary-schemas.ts
@@ -352,3 +352,49 @@ export const recordTuiAgentActivityRequestSchemaV11 =
 export type RecordTuiAgentActivityRequestV11 = z.infer<
   typeof recordTuiAgentActivityRequestSchemaV11
 >;
+
+// ─── `agent.tui.promptSubmitted@1.0` - prompt-submit activity + roles pull ─
+//
+// New optional unary method (roles-snapshot-delivery pull point 1): the
+// `UserPromptSubmit` hook chain's one call, replacing the start-edge
+// `recordActivity` call for peers that support it. Request shape mirrors the
+// `recordActivity@1.1` prompt-submit payload (epicId, tuiAgentId,
+// harnessSessionId, harnessId, observedHarnessSessionId) - same fields, same
+// resync semantics on `observedHarnessSessionId` - but drops `event` (this
+// method IS the start/prompt-submit edge, never stop/resync).
+//
+// Adding a response field to unary `recordActivity` would be a breaking
+// change (new major + bridges); this new method is the sanctioned
+// evolution instead. Host side: record the activity edge, then run the
+// role-registry digest-cursor check (`lastDeliveredRolesDigest`) - behind
+// renders the snapshot and stamps the new digest; current returns `null`.
+// Degrade story: method absent on an older host, or an older CLI against a
+// newer host, both fall back to plain `recordActivity` - roles then only
+// reachable via the static prompt's `role list` instruction.
+
+export const tuiAgentPromptSubmittedRequestSchema = z.object({
+  epicId: z.string().nullable().default(null),
+  tuiAgentId: z.string().nullable().default(null),
+  harnessSessionId: z.string().nullable().default(null),
+  harnessId: tuiHarnessIdSchema,
+  observedHarnessSessionId: z.string().nullable().default(null),
+});
+export type TuiAgentPromptSubmittedRequest = z.infer<
+  typeof tuiAgentPromptSubmittedRequestSchema
+>;
+
+export const tuiAgentPromptSubmittedResponseSchema = z.object({
+  // Mirrors `recordActivity`'s `accepted` semantics: true when the resolver
+  // recorded the activity edge; false for a benign no-op (record missing,
+  // ownership/harness mismatch).
+  accepted: z.boolean(),
+  // Non-null only when the agent's `lastDeliveredRolesDigest` cursor was
+  // behind the current claims registry at call time: a rendered snapshot
+  // block for the CLI hook to emit as the `UserPromptSubmit`
+  // `additionalContext` envelope. `null` when current (nothing to deliver)
+  // or on a benign no-op.
+  pendingPromptContext: z.string().nullable(),
+});
+export type TuiAgentPromptSubmittedResponse = z.infer<
+  typeof tuiAgentPromptSubmittedResponseSchema
+>;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -182,6 +182,7 @@ import {
   agentTuiPrepareLaunchV10,
   agentTuiPrepareLaunchV11,
   agentTuiPrepareLaunchUpgradeV10ToV11,
+  agentTuiPromptSubmittedV10,
   agentTuiRecordActivityV10,
   agentTuiRecordActivityV11,
   agentTuiRecordActivityUpgradeV10ToV11,
@@ -3647,6 +3648,27 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
       },
       downgradePathsFromLatest: {},
     },
+  },
+  // Optional (non-floor) capability: the `UserPromptSubmit` hook's combined
+  // activity-edge + roles-digest-pull call (roles-snapshot-delivery pull
+  // point 1). The `degrade: unsupported` strategy EXCLUDES it from the
+  // released floor and the released-method-names snapshot - adding it to the
+  // floor would be handshake-fatal for existing clients. An old host lacks
+  // it in its optional manifest; the CLI hook falls back to plain
+  // `recordActivity` rather than calling a method the host would reject.
+  // Mirrors `agent.tui.validateForkProfile`'s degrade strategy above.
+  "agent.tui.promptSubmitted": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentTuiPromptSubmittedV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
   },
   "agent.create": {
     1: {

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
@@ -5375,6 +5375,28 @@ export const epicSchemaSurfaceBaseline = {
                 },
               ],
             },
+            pinnedUserProviderHandle: {
+              default: null,
+              anyOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            lastDeliveredRolesDigest: {
+              default: null,
+              anyOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
           },
           required: [
             "parentId",
@@ -5967,6 +5989,28 @@ export const epicSchemaSurfaceBaseline = {
                     },
                   ],
                 },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
                 harnessSessionId: {
                   type: "string",
                 },
@@ -6119,6 +6163,28 @@ export const epicSchemaSurfaceBaseline = {
                   ],
                 },
                 pendingForkSourceHarnessSessionId: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
                   default: null,
                   anyOf: [
                     {
@@ -6298,6 +6364,28 @@ export const epicSchemaSurfaceBaseline = {
                     },
                   ],
                 },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
                 harnessSessionId: {
                   type: "string",
                 },
@@ -6450,6 +6538,28 @@ export const epicSchemaSurfaceBaseline = {
                   ],
                 },
                 pendingForkSourceHarnessSessionId: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
                   default: null,
                   anyOf: [
                     {
@@ -12214,6 +12324,28 @@ export const epicSchemaSurfaceBaseline = {
                 },
               ],
             },
+            pinnedUserProviderHandle: {
+              default: null,
+              anyOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            lastDeliveredRolesDigest: {
+              default: null,
+              anyOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
           },
           required: [
             "parentId",
@@ -12230,6 +12362,8 @@ export const epicSchemaSurfaceBaseline = {
             "messages",
             "events",
             "archivedAt",
+            "pinnedUserProviderHandle",
+            "lastDeliveredRolesDigest",
           ],
           additionalProperties: false,
         },
@@ -12820,6 +12954,28 @@ export const epicSchemaSurfaceBaseline = {
                     },
                   ],
                 },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
                 harnessSessionId: {
                   type: "string",
                 },
@@ -12844,6 +13000,8 @@ export const epicSchemaSurfaceBaseline = {
                 "profileId",
                 "archivedAt",
                 "pendingForkSourceHarnessSessionId",
+                "pinnedUserProviderHandle",
+                "lastDeliveredRolesDigest",
                 "harnessSessionId",
               ],
               additionalProperties: false,
@@ -12990,6 +13148,28 @@ export const epicSchemaSurfaceBaseline = {
                     },
                   ],
                 },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
                 harnessSessionId: {
                   default: null,
                   anyOf: [
@@ -13022,6 +13202,8 @@ export const epicSchemaSurfaceBaseline = {
                 "profileId",
                 "archivedAt",
                 "pendingForkSourceHarnessSessionId",
+                "pinnedUserProviderHandle",
+                "lastDeliveredRolesDigest",
                 "harnessSessionId",
               ],
               additionalProperties: false,
@@ -13168,6 +13350,28 @@ export const epicSchemaSurfaceBaseline = {
                     },
                   ],
                 },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
                 harnessSessionId: {
                   type: "string",
                 },
@@ -13192,6 +13396,8 @@ export const epicSchemaSurfaceBaseline = {
                 "profileId",
                 "archivedAt",
                 "pendingForkSourceHarnessSessionId",
+                "pinnedUserProviderHandle",
+                "lastDeliveredRolesDigest",
                 "harnessSessionId",
               ],
               additionalProperties: false,
@@ -13338,6 +13544,28 @@ export const epicSchemaSurfaceBaseline = {
                     },
                   ],
                 },
+                pinnedUserProviderHandle: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                lastDeliveredRolesDigest: {
+                  default: null,
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
                 harnessSessionId: {
                   default: null,
                   anyOf: [
@@ -13370,6 +13598,8 @@ export const epicSchemaSurfaceBaseline = {
                 "profileId",
                 "archivedAt",
                 "pendingForkSourceHarnessSessionId",
+                "pinnedUserProviderHandle",
+                "lastDeliveredRolesDigest",
                 "harnessSessionId",
               ],
               additionalProperties: false,

--- a/protocol/src/persistence/epic/chat.ts
+++ b/protocol/src/persistence/epic/chat.ts
@@ -68,6 +68,34 @@ export const chatSchema = z.object({
    * before archiving existed parse unchanged.
    */
   archivedAt: z.number().nullable().default(null),
+  /**
+   * The user-facing provider handle, pinned once and rendered from this
+   * record forever (see the prompt-freeze decision log). Tristate, and the
+   * two "unset" states are NOT equivalent: ABSENT (the raw persisted key is
+   * missing - records written before this field existed) means "not pinned
+   * yet", read lazily and pinned on the next prompt build; an explicit
+   * `null` means "resolve failed at creation" and is final - render no
+   * handle sentence for this agent, permanently, never retried. A fork
+   * copies the source record's value rather than re-resolving. Defaulted
+   * (not just nullable) so an absent key still parses.
+   */
+  pinnedUserProviderHandle: z.string().nullable().default(null),
+  /**
+   * Digest cursor for the role-registry delivery channel (see
+   * roles-snapshot-delivery): the hash of the canonically-serialized claims
+   * last delivered to this agent. Unlike `pinnedUserProviderHandle`, an
+   * absent key and an explicit `null` are equivalent here - both read as
+   * "never delivered" (a brand-new agent, or a record persisted before this
+   * field existed). Compared against the current registry's digest to
+   * decide whether the next prompt pull owes a fresh snapshot. A third
+   * value is possible: the host may stamp a reserved sentinel string that
+   * can never equal a real content digest, meaning "a push was attempted
+   * but not confirmed delivered" - the next pull must treat the cursor as
+   * behind and deliver a fresh truth snapshot before stamping a clean
+   * digest again. The sentinel's literal value is host-owned, not part of
+   * this contract.
+   */
+  lastDeliveredRolesDigest: z.string().nullable().default(null),
 });
 export type Chat = z.infer<typeof chatSchema>;
 
@@ -111,4 +139,27 @@ export const chatSchemaV14 = z.object({
   claudePendingWakes: z.array(claudePendingWakeSchema).default([]),
   messages: z.array(messageSchema),
   events: z.array(chatEventSchema).default([]),
+});
+
+// Wire-freeze copy with `archivedAt` (the field `1.5` shipped) but without
+// `pinnedUserProviderHandle` / `lastDeliveredRolesDigest`, bound to
+// `chat.subscribe@1.5`'s snapshot serverFrame so that released line stays
+// verbatim. Hand-frozen (every other field reuses the live sub-schemas); NOT
+// derived from the live shape - see `chatSchemaV14`'s comment for why a
+// released line must not follow `chatSchema` by reference.
+export const chatSchemaV15 = z.object({
+  parentId: z.string().nullable(),
+  id: z.string(),
+  userId: z.string(),
+  hostId: z.string(),
+  title: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  isTitleEditedByUser: z.boolean(),
+  settings: chatRunSettingsSchema.nullable().default(null),
+  activeSessionChain: activeSessionChainSchema.nullable().default(null),
+  claudePendingWakes: z.array(claudePendingWakeSchema).default([]),
+  messages: z.array(messageSchema),
+  events: z.array(chatEventSchema).default([]),
+  archivedAt: z.number().nullable().default(null),
 });

--- a/protocol/src/persistence/epic/tui-agents.ts
+++ b/protocol/src/persistence/epic/tui-agents.ts
@@ -87,6 +87,30 @@ const baseTuiAgentFields = {
     .nullable()
     .default(null)
     .catch(null),
+  // The user-facing provider handle, pinned once and rendered from this
+  // record forever (see the prompt-freeze decision log). Tristate, and the
+  // two "unset" states are NOT equivalent: ABSENT (the raw persisted key is
+  // missing - records written before this field existed) means "not pinned
+  // yet", read lazily and pinned on the next prompt build; an explicit
+  // `null` means "resolve failed at creation" and is final - render no
+  // handle sentence for this agent, permanently, never retried. A fork
+  // copies the source record's value rather than re-resolving. Defaulted
+  // (not just nullable) so an absent key still parses.
+  pinnedUserProviderHandle: z.string().nullable().default(null).catch(null),
+  // Digest cursor for the role-registry delivery channel (see
+  // roles-snapshot-delivery): the hash of the canonically-serialized claims
+  // last delivered to this agent. Unlike `pinnedUserProviderHandle`, an
+  // absent key and an explicit `null` are equivalent here - both read as
+  // "never delivered" (a brand-new agent, or a record persisted before this
+  // field existed). Compared against the current registry's digest to
+  // decide whether the next prompt pull owes a fresh snapshot. A third
+  // value is possible: the host may stamp a reserved sentinel string that
+  // can never equal a real content digest, meaning "a push was attempted
+  // but not confirmed delivered" - the next pull must treat the cursor as
+  // behind and deliver a fresh truth snapshot before stamping a clean
+  // digest again. The sentinel's literal value is host-owned, not part of
+  // this contract.
+  lastDeliveredRolesDigest: z.string().nullable().default(null).catch(null),
 } as const;
 
 export const claudeTuiAgentSchema = z.object({


### PR DESCRIPTION
## What

Contract half of the internal "freeze the developer prompts" change (host consumption lands in the paired internal PR, which re-pins the submodule after this merges):

- **Protocol persistence**: nullable `pinnedUserProviderHandle` and `lastDeliveredRolesDigest` on the chat and tuiAgent record schemas. Absent-tolerant; the handle documents an absent-vs-null tristate (absent = lazy pin-on-first-use, null = final resolve failure), the digest documents that absent/null are equivalent plus a reserved host-owned dirty-sentinel clause.
- **New optional unary `agent.tui.promptSubmitted@1.0`**: records the prompt-submit activity edge and returns pending prompt context in one round trip. Registered `degrade: unsupported`, outside the released floor (same evolution shape as `agent.tui.validateForkProfile`).
- **Frozen `chatSchemaV15`**: the released `chat.subscribe@1.5` snapshot schema was referencing the live `chatSchema` by reference (unlike 1.4's hand-frozen copy) — any future chat field addition would have leaked onto released wire. Caught by `released-baseline-compat`; fixed the same way 1.4 was.
- **CLI**: `agent activity-from-hook --event start` now calls `promptSubmitted` and emits non-null `pendingPromptContext` as the `UserPromptSubmit` `additionalContext` envelope (verified against the Claude Agent SDK types); hosts without the method degrade silently to `recordActivity`, discriminated on `E_HOST_UNSUPPORTED` (a genuine `RPC_ERROR` still surfaces). Hook configuration is unchanged.
- **gui-app**: policy-table entry for the new method + `Chat` fixture ripple.

## Testing

- Protocol suite incl. released-wire/floor/surface compat: green.
- CLI suite (1335 tests) incl. new envelope/fallback matrix: green.
- Live two-leg smoke on the internal side: real CLI subprocess against a live host endpoint emitted the envelope exactly once (WS manifest negotiation of the optional method included) and a real `claude` binary injected the snapshot into model context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)