### PR TITLE
fix(gui-app): preserve resolved prompt icons

### DIFF
--- a/clients/gui-app/src/components/notifications/__tests__/notification-indicator-tones.test.ts
+++ b/clients/gui-app/src/components/notifications/__tests__/notification-indicator-tones.test.ts
@@ -33,7 +33,7 @@ describe("notification status tone registry", () => {
         NOTIFICATION_STATUS_TONES[pendingKind].Icon,
       );
       expect(NOTIFICATION_STATUS_TONES[resolvedKind].className).toBe(
-        NOTIFICATION_STATUS_TONES.done.className,
+        NOTIFICATION_STATUS_TONES[pendingKind].className,
       );
       expect(NOTIFICATION_STATUS_TONES[resolvedKind].Icon).not.toBe(
         NOTIFICATION_STATUS_TONES.done.Icon,

--- a/clients/gui-app/src/components/notifications/__tests__/notification-indicator-tones.test.ts
+++ b/clients/gui-app/src/components/notifications/__tests__/notification-indicator-tones.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  NOTIFICATION_STATUS_TONES,
+  notificationFeedTone,
+} from "@/components/notifications/notification-indicator-tones";
+
+describe("notification status tone registry", () => {
+  it.each([
+    ["approval.requested", null, "approval"],
+    ["interview.requested", null, "interview"],
+    ["approval.requested", 10, "approval-resolved"],
+    ["interview.requested", 10, "interview-resolved"],
+  ] as const)(
+    "maps %s resolved at %s to the shared %s presentation",
+    (hostKind, resolvedAt, status) => {
+      expect(
+        notificationFeedTone({
+          severity: "needs_action",
+          hostKind,
+          resolvedAt,
+        }),
+      ).toBe(NOTIFICATION_STATUS_TONES[status]);
+    },
+  );
+
+  it.each([
+    ["approval", "approval-resolved"],
+    ["interview", "interview-resolved"],
+  ] as const)(
+    "preserves the %s glyph when its notification is resolved",
+    (pendingKind, resolvedKind) => {
+      expect(NOTIFICATION_STATUS_TONES[resolvedKind].Icon).toBe(
+        NOTIFICATION_STATUS_TONES[pendingKind].Icon,
+      );
+      expect(NOTIFICATION_STATUS_TONES[resolvedKind].className).toBe(
+        NOTIFICATION_STATUS_TONES.done.className,
+      );
+      expect(NOTIFICATION_STATUS_TONES[resolvedKind].Icon).not.toBe(
+        NOTIFICATION_STATUS_TONES.done.Icon,
+      );
+    },
+  );
+
+  it("maps terminal outcomes through the same done and failure presentations", () => {
+    expect(
+      notificationFeedTone({
+        severity: "done",
+        hostKind: "agent.stopped",
+        resolvedAt: null,
+      }),
+    ).toBe(NOTIFICATION_STATUS_TONES.done);
+    expect(
+      notificationFeedTone({
+        severity: "failure",
+        hostKind: "agent.stalled",
+        resolvedAt: null,
+      }),
+    ).toBe(NOTIFICATION_STATUS_TONES.failure);
+  });
+
+  it("leaves informational events to their surface-specific neutral icon", () => {
+    expect(
+      notificationFeedTone({
+        severity: "info",
+        hostKind: "host.operation.finished",
+        resolvedAt: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover-feed-controls.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover-feed-controls.test.tsx
@@ -1238,6 +1238,9 @@ describe("NotificationsPopover feed controls (T05)", () => {
 
       const pill = await screen.findByTestId("notifications-new-arrivals");
       expect(pill.textContent).toMatch(/1 new notification$/);
+      expect(pill.className).toContain("sticky");
+      expect(pill.className).toContain("top-2");
+      expect(pill.className).toContain("z-30");
 
       const scrollToSpy = vi.fn();
       scrollport.scrollTo = scrollToSpy as typeof scrollport.scrollTo;

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -985,6 +985,9 @@ describe("NotificationsPopover", () => {
       expect.arrayContaining([
         "hover:bg-muted/70",
         "has-[:focus-visible]:bg-muted/70",
+        "py-2.5",
+        "pl-6",
+        "pr-4",
       ]),
     );
     // Unread rows prepend an absolute rail span; the glyph holder is the
@@ -1263,6 +1266,9 @@ describe("NotificationsPopover", () => {
     // Desktop-pass subordination: micro/muted sentence case, not overline caps.
     for (const separator of separators) {
       expect(separator.className).toContain("text-micro");
+      expect(separator.className).toContain("sticky");
+      expect(separator.className).toContain("top-5");
+      expect(separator.className).toContain("bg-popover");
       expect(separator.className).not.toContain("uppercase");
       expect(separator.className).not.toContain("font-semibold");
       expect(separator.className).not.toContain("text-overline");
@@ -1271,6 +1277,9 @@ describe("NotificationsPopover", () => {
     expect(recentHeader.className).toContain("text-overline");
     expect(recentHeader.className).toContain("uppercase");
     expect(recentHeader.className).toContain("font-semibold");
+    expect(recentHeader.className).toContain("sticky");
+    expect(recentHeader.className).toContain("top-0");
+    expect(recentHeader.className).toContain("bg-popover");
   });
 
   it("renders failed host outcomes and stalled rows as failure severity", async () => {

--- a/clients/gui-app/src/components/notifications/notification-indicator-tones.ts
+++ b/clients/gui-app/src/components/notifications/notification-indicator-tones.ts
@@ -66,7 +66,7 @@ export const NOTIFICATION_STATUS_TONES: Readonly<
   "interview-resolved": {
     testId: "interview-resolved",
     title: "Question resolved",
-    className: "text-success-foreground",
+    className: "text-warning-foreground",
     Icon: MessageSquareQuestionMark,
   },
   approval: {
@@ -78,7 +78,7 @@ export const NOTIFICATION_STATUS_TONES: Readonly<
   "approval-resolved": {
     testId: "approval-resolved",
     title: "Approval resolved",
-    className: "text-success-foreground",
+    className: "text-warning-foreground",
     Icon: MessageSquareWarning,
   },
 };
@@ -109,9 +109,10 @@ interface NotificationFeedToneInput {
 
 /** Resolve a durable feed event onto the same semantic status vocabulary used
  * by live chat surfaces. A prompt's kind and disposition are independent:
- * resolution changes its tone to success without replacing its approval or
- * question glyph with the generic completion glyph. Informational events have
- * no agent-work tone and stay on the notification center's neutral fallback. */
+ * resolution changes its tooltip without replacing its approval/question
+ * glyph or color with the generic completion presentation. Informational
+ * events have no agent-work tone and stay on the notification center's neutral
+ * fallback. */
 export function notificationFeedTone(
   input: NotificationFeedToneInput,
 ): IndicatorTone | null {

--- a/clients/gui-app/src/components/notifications/notification-indicator-tones.ts
+++ b/clients/gui-app/src/components/notifications/notification-indicator-tones.ts
@@ -6,6 +6,10 @@ import {
 } from "lucide-react";
 import { MessageSquareQuestionMark } from "@/components/notifications/message-square-question-mark";
 import type { NotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
+import type {
+  HostNotificationKind,
+  HostNotificationSeverity,
+} from "@traycer/protocol/host/notifications/contracts";
 
 /**
  * Shared presentation metadata for the notification status tiers. Both the
@@ -15,42 +19,78 @@ import type { NotificationIndicatorState } from "@/stores/notifications/notifica
  * precedence (failure > interview > approval); the running and unread-done
  * tiers slot in below it at each consumer per its activity signal.
  */
+export type NotificationStatusKind =
+  | "failure"
+  | "interview"
+  | "interview-resolved"
+  | "approval"
+  | "approval-resolved"
+  | "done";
+
 export interface IndicatorTone {
-  readonly testId: "failure" | "interview" | "approval" | "done";
+  readonly testId: NotificationStatusKind;
   readonly title: string;
   readonly className: string;
   readonly Icon: LucideIcon;
 }
 
-export const DONE_TONE: IndicatorTone = {
-  testId: "done",
-  title: "Task completed",
-  // `--success-foreground` (unlike `--success`) is verified >=3:1 against
-  // every preset's `--background`/`--canvas` - see index.css.
-  className: "text-success-foreground",
-  Icon: MessageSquareCheck,
+/**
+ * Source of truth for agent-work status presentation. Chat rows, canvas tabs,
+ * descendant rollups, and notification-center rows all resolve through this
+ * registry, so adding a future surface cannot silently invent another glyph
+ * or color for the same state.
+ */
+export const NOTIFICATION_STATUS_TONES: Readonly<
+  Record<NotificationStatusKind, IndicatorTone>
+> = {
+  done: {
+    testId: "done",
+    title: "Task completed",
+    // `--success-foreground` (unlike `--success`) is verified >=3:1 against
+    // every preset's `--background`/`--canvas` - see index.css.
+    className: "text-success-foreground",
+    Icon: MessageSquareCheck,
+  },
+  failure: {
+    testId: "failure",
+    title: "Task needs attention",
+    className: "text-destructive",
+    Icon: MessageSquareX,
+  },
+  interview: {
+    testId: "interview",
+    title: "Task waiting for your interview response",
+    className: "text-warning-foreground",
+    Icon: MessageSquareQuestionMark,
+  },
+  "interview-resolved": {
+    testId: "interview-resolved",
+    title: "Question resolved",
+    className: "text-success-foreground",
+    Icon: MessageSquareQuestionMark,
+  },
+  approval: {
+    testId: "approval",
+    title: "Task waiting for your approval",
+    className: "text-warning-foreground",
+    Icon: MessageSquareWarning,
+  },
+  "approval-resolved": {
+    testId: "approval-resolved",
+    title: "Approval resolved",
+    className: "text-success-foreground",
+    Icon: MessageSquareWarning,
+  },
 };
 
-export const FAILURE_TONE: IndicatorTone = {
-  testId: "failure",
-  title: "Task needs attention",
-  className: "text-destructive",
-  Icon: MessageSquareX,
-};
-
-export const INTERVIEW_TONE: IndicatorTone = {
-  testId: "interview",
-  title: "Task waiting for your interview response",
-  className: "text-warning-foreground",
-  Icon: MessageSquareQuestionMark,
-};
-
-export const APPROVAL_TONE: IndicatorTone = {
-  testId: "approval",
-  title: "Task waiting for your approval",
-  className: "text-warning-foreground",
-  Icon: MessageSquareWarning,
-};
+export const DONE_TONE = NOTIFICATION_STATUS_TONES.done;
+export const FAILURE_TONE = NOTIFICATION_STATUS_TONES.failure;
+export const INTERVIEW_TONE = NOTIFICATION_STATUS_TONES.interview;
+export const APPROVAL_TONE = NOTIFICATION_STATUS_TONES.approval;
+export const RESOLVED_INTERVIEW_TONE =
+  NOTIFICATION_STATUS_TONES["interview-resolved"];
+export const RESOLVED_APPROVAL_TONE =
+  NOTIFICATION_STATUS_TONES["approval-resolved"];
 
 export function attentionTone(
   state: NotificationIndicatorState,
@@ -58,5 +98,31 @@ export function attentionTone(
   if (state.unreadFailure) return FAILURE_TONE;
   if (state.pendingInterview) return INTERVIEW_TONE;
   if (state.pendingApproval) return APPROVAL_TONE;
+  return null;
+}
+
+interface NotificationFeedToneInput {
+  readonly severity: HostNotificationSeverity;
+  readonly hostKind: HostNotificationKind | null;
+  readonly resolvedAt: number | null;
+}
+
+/** Resolve a durable feed event onto the same semantic status vocabulary used
+ * by live chat surfaces. A prompt's kind and disposition are independent:
+ * resolution changes its tone to success without replacing its approval or
+ * question glyph with the generic completion glyph. Informational events have
+ * no agent-work tone and stay on the notification center's neutral fallback. */
+export function notificationFeedTone(
+  input: NotificationFeedToneInput,
+): IndicatorTone | null {
+  if (input.severity === "failure") return FAILURE_TONE;
+  if (input.severity === "done") return DONE_TONE;
+  if (input.severity !== "needs_action") return null;
+  if (input.hostKind === "interview.requested") {
+    return input.resolvedAt === null ? INTERVIEW_TONE : RESOLVED_INTERVIEW_TONE;
+  }
+  if (input.hostKind === "approval.requested") {
+    return input.resolvedAt === null ? APPROVAL_TONE : RESOLVED_APPROVAL_TONE;
+  }
   return null;
 }

--- a/clients/gui-app/src/components/notifications/notification-row.tsx
+++ b/clients/gui-app/src/components/notifications/notification-row.tsx
@@ -3,7 +3,6 @@ import {
   Bell,
   Check,
   CheckCircle2,
-  CircleAlert,
   MessageCircle,
   MessageSquarePlus,
   MessageSquareX,
@@ -12,6 +11,10 @@ import {
   UserPlus,
   type LucideIcon,
 } from "lucide-react";
+import {
+  FAILURE_TONE,
+  notificationFeedTone,
+} from "@/components/notifications/notification-indicator-tones";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
 import { notificationPayloadRequiresOriginHost } from "@/hooks/notifications/use-notification-activation";
@@ -69,8 +72,8 @@ function isBlockingAttentionRow(row: MergedNotificationRow): boolean {
  * visibility), so its presence never shifts row content. The row itself
  * spans the popover's true edge-to-edge width (no section-level inset) so
  * its bottom divider isn't cut off short of the popover's edges - `pl-6`/
- * `pr-4` reproduce the old section inset (px-4) plus the rail gutter purely
- * as content padding.
+ * `pr-4` reproduce the section inset plus the rail gutter purely as content
+ * padding.
  */
 export function NotificationRow(props: NotificationRowProps): ReactNode {
   const row = useMergedNotificationRow(props.feedId);
@@ -295,9 +298,7 @@ interface RowGlyph {
   readonly colorClassName: string;
 }
 
-const PROMPT_COLOR = "text-amber-600 dark:text-amber-400";
 const FAILURE_COLOR = "text-destructive";
-const DONE_COLOR = "text-blue-600 dark:text-blue-400";
 const NEUTRAL_COLOR = "text-muted-foreground";
 const SUCCESS_COLOR = "text-success-foreground";
 const INVITE_COLOR = "text-primary";
@@ -310,31 +311,25 @@ function notificationRowGlyph(row: MergedNotificationRow): RowGlyph {
     return globalEventGlyph(row.globalEntry.event);
   }
   if (row.appLocalKind !== null) {
-    return { icon: CircleAlert, colorClassName: FAILURE_COLOR };
-  }
-  if (row.severity === "failure") {
-    return { icon: CircleAlert, colorClassName: FAILURE_COLOR };
-  }
-  if (row.severity === "needs_action") {
     return {
-      icon: row.hostKind === "approval.requested" ? Shield : MessageCircle,
-      colorClassName: PROMPT_COLOR,
+      icon: FAILURE_TONE.Icon,
+      colorClassName: FAILURE_TONE.className,
     };
   }
-  if (row.severity === "done") {
-    return { icon: Bell, colorClassName: DONE_COLOR };
+  const statusTone = notificationFeedTone(row);
+  if (statusTone !== null) {
+    return { icon: statusTone.Icon, colorClassName: statusTone.className };
   }
   switch (row.hostKind) {
     case "agent.stopped":
-      return { icon: Bell, colorClassName: DONE_COLOR };
+      return { icon: Bell, colorClassName: NEUTRAL_COLOR };
     case "agent.stalled":
-      return { icon: CircleAlert, colorClassName: FAILURE_COLOR };
+      return { icon: MessageSquareX, colorClassName: FAILURE_COLOR };
     case "approval.requested":
-      return { icon: Shield, colorClassName: PROMPT_COLOR };
     case "interview.requested":
-      return { icon: MessageCircle, colorClassName: PROMPT_COLOR };
+      return { icon: Bell, colorClassName: NEUTRAL_COLOR };
     case "workspace.operation.failed":
-      return { icon: CircleAlert, colorClassName: FAILURE_COLOR };
+      return { icon: MessageSquareX, colorClassName: FAILURE_COLOR };
     // Only reachable for an `info` row: the severity branches above already
     // claim every `done`/`failure`/`needs_action` host-operation row, and the
     // kind itself says nothing about how the operation ended.

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -914,7 +914,7 @@ function RecentRow(props: RecentRowProps): ReactNode {
       {group !== previousGroup && (
         <li
           data-testid="notification-temporal-separator"
-          className="px-4 pt-2 pb-0.5 text-micro text-muted-foreground/60 first:pt-0"
+          className="sticky top-5 z-10 bg-popover px-4 py-1 text-micro text-muted-foreground/60 first:mt-0"
         >
           {TEMPORAL_GROUP_LABEL[group]}
         </li>
@@ -931,7 +931,7 @@ function RecentRow(props: RecentRowProps): ReactNode {
 
 function SectionLabel(props: { readonly children: ReactNode }): ReactNode {
   return (
-    <div className="mb-1 text-overline font-semibold uppercase tracking-wide text-muted-foreground">
+    <div className="sticky top-0 z-20 -mx-4 mb-1 bg-popover px-4 py-1 text-overline font-semibold uppercase tracking-wide text-muted-foreground">
       {props.children}
     </div>
   );

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -462,7 +462,7 @@ export function NotificationsPopover(
               type="button"
               onClick={revealNewArrivals}
               data-testid="notifications-new-arrivals"
-              className="sticky top-2 z-10 mx-auto mb-1 block w-max rounded-full border border-border bg-popover px-2.5 py-1 text-ui-xs font-medium text-foreground shadow-sm"
+              className="sticky top-2 z-30 mx-auto mb-1 block w-max rounded-full border border-border bg-popover px-2.5 py-1 text-ui-xs font-medium text-foreground shadow-sm"
             >
               {newArrivalCount} new notification
               {newArrivalCount === 1 ? "" : "s"}


### PR DESCRIPTION
## Summary
- centralize notification status icons and tones with the shared agent-work vocabulary
- keep question and approval glyphs after resolution while switching them to the success tone
- retain airy notification rows and sticky section/date headers with regression coverage

## Validation
- focused notification suites: 52 tests passed
- affected pre-commit validation: lint, format, compile, build, and DCO checks passed
- React Doctor: clean (verified in the implementation pass)
- git diff --check: passed