### PR TITLE
fix(gui-app): accept image attachments for Kimi K3 and K2.7 models

### DIFF
--- a/clients/gui-app/src/lib/composer/__tests__/model-capability-overrides.test.ts
+++ b/clients/gui-app/src/lib/composer/__tests__/model-capability-overrides.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { ModelOption } from "@/components/home/data/landing-options";
+import { modelSupportsImageAttachments } from "../chat-run-settings";
+import { modelImageSupportOverride } from "../model-capability-overrides";
+
+function model(overrides: {
+  readonly harnessId: ModelOption["harnessId"];
+  readonly slug: string;
+  readonly label: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}): ModelOption {
+  return {
+    harnessId: overrides.harnessId,
+    slug: overrides.slug,
+    label: overrides.label,
+    description: null,
+    contextWindow: null,
+    maxOutputTokens: null,
+    defaultReasoningEffort: null,
+    supportedReasoningEfforts: [],
+    defaultServiceTier: null,
+    supportedServiceTiers: [],
+    metadata: overrides.metadata ?? {},
+  };
+}
+
+describe("modelImageSupportOverride", () => {
+  it("flags Kimi K3 slugs as vision-capable", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "kimi",
+        slug: "kimi-k3",
+        label: "Kimi K3",
+      }),
+    ).toBe(true);
+  });
+
+  it("flags Kimi K2.7 slugs as vision-capable", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "kimi",
+        slug: "kimi-k2.7-code",
+        label: "Kimi K2.7 Code",
+      }),
+    ).toBe(true);
+  });
+
+  it("flags provider-prefixed Kimi K3 slugs (OMP route)", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "omp",
+        slug: "moonshot/kimi-k3-turbo",
+        label: "kimi-k3-turbo",
+      }),
+    ).toBe(true);
+  });
+
+  it("flags bare-generation slugs on the Kimi harness (slug 'k3', label 'K3')", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "kimi",
+        slug: "k3",
+        label: "K3",
+      }),
+    ).toBe(true);
+    expect(
+      modelImageSupportOverride({
+        harnessId: "kimi",
+        slug: "k2.7",
+        label: "K2.7",
+      }),
+    ).toBe(true);
+  });
+
+  it("has no opinion on bare slugs outside the Kimi harness", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "omp",
+        slug: "k3",
+        label: "K3",
+      }),
+    ).toBe(null);
+  });
+
+  it("has no opinion on older Kimi generations", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "kimi",
+        slug: "kimi-k2.5",
+        label: "Kimi K2.5",
+      }),
+    ).toBe(null);
+  });
+
+  it("has no opinion on non-Kimi models", () => {
+    expect(
+      modelImageSupportOverride({
+        harnessId: "codex",
+        slug: "gpt-5.2",
+        label: "GPT-5.2",
+      }),
+    ).toBe(null);
+  });
+});
+
+describe("modelSupportsImageAttachments with overrides", () => {
+  it("accepts images for kimi-k3 even with empty host metadata", () => {
+    expect(
+      modelSupportsImageAttachments(
+        model({ harnessId: "kimi", slug: "kimi-k3", label: "Kimi K3" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("still trusts host metadata for other models", () => {
+    expect(
+      modelSupportsImageAttachments(
+        model({
+          harnessId: "claude-code",
+          slug: "claude-opus-5",
+          label: "Opus 5",
+          metadata: { supportsImages: true },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      modelSupportsImageAttachments(
+        model({
+          harnessId: "codex",
+          slug: "gpt-5.2",
+          label: "GPT-5.2",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/composer/chat-run-settings.ts
+++ b/clients/gui-app/src/lib/composer/chat-run-settings.ts
@@ -11,6 +11,7 @@ import type {
   ReasoningLevel,
   ServiceTier,
 } from "@/components/home/data/landing-options";
+import { modelImageSupportOverride } from "./model-capability-overrides";
 
 const IMAGE_INPUT_MODALITIES = new Set([
   "image",
@@ -80,6 +81,9 @@ export function serviceTierFromChatRunSettings(
 }
 
 export function modelSupportsImageAttachments(model: ModelOption): boolean {
+  // Client-curated overrides win over host metadata (e.g. Kimi K3 / K2.7
+  // families accept images but the host catalog does not flag them).
+  if (modelImageSupportOverride(model) === true) return true;
   const inputModalities = model.metadata.inputModalities;
   return (
     (Array.isArray(inputModalities) &&

--- a/clients/gui-app/src/lib/composer/model-capability-overrides.ts
+++ b/clients/gui-app/src/lib/composer/model-capability-overrides.ts
@@ -1,0 +1,48 @@
+/**
+ * Client-side capability overrides for models whose host-provided metadata
+ * misses a capability the model actually has. Curated family matches only;
+ * an override here wins over host metadata, and overrides only ever ADD a
+ * capability (never strip one the host claims).
+ */
+
+/** Structural identity this module needs — satisfied by GuiAgentModelOption. */
+export interface ModelCapabilityIdentity {
+  readonly harnessId: string;
+  readonly slug: string;
+  readonly label: string;
+}
+
+function normalizeModelText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Kimi K3 and K2.7 families accept image input, but the host model catalog
+ * does not flag them, so the composer refuses image attachments for them.
+ *
+ * Two match shapes:
+ * - Kimi harness (`harnessId === "kimi"`): the harness itself is Kimi, so the
+ *   generation marker alone is enough — covers bare slugs like "k3" whose
+ *   label may be just "K3".
+ * - Any other harness (omp/opencode/...): require "kimi" in slug+label plus
+ *   the generation marker — covers "Kimi K3 (ClinePass)", "moonshot/kimi-k3".
+ */
+function isKimiVisionFamily(identity: ModelCapabilityIdentity): boolean {
+  const normalized = normalizeModelText(`${identity.slug} ${identity.label}`);
+  const generation = normalized.includes("k3") || normalized.includes("k27");
+  if (identity.harnessId === "kimi") return generation;
+  return normalized.includes("kimi") && generation;
+}
+
+/**
+ * Returns `true` when the model is known to accept image attachments despite
+ * host metadata, `null` when this module has no opinion (caller falls back to
+ * host metadata). Never returns `false`: absence of an override is not a
+ * denial.
+ */
+export function modelImageSupportOverride(
+  identity: ModelCapabilityIdentity,
+): boolean | null {
+  if (isKimiVisionFamily(identity)) return true;
+  return null;
+}


### PR DESCRIPTION
## Summary

The host model catalog does not flag the Kimi K3 / K2.7 families as vision-capable, so the composer blocks image attachments for them ("Attached images are not supported by the selected model") — even though these models accept image input. The Kimi CLI's own catalog marks them as such (`kimi-code` exposes `k3` / `k3-256k` with `images=yes`).

This adds a curated client-side capability override consulted before host metadata in `modelSupportsImageAttachments()`:

- On the `kimi` harness, the generation marker (`k3` / `k2.7`) alone suffices — slugs there can be bare `k3` with label `K3`.
- Cross-harness slugs (e.g. `cline-pass/kimi-k3`, `moonshot/kimi-k3`) must also carry the `kimi` name.
- Overrides are additive only and never strip a host-claimed capability.

If the host catalog gains proper flags for these models, the override becomes a harmless no-op — happy to drop it in favor of a host-side fix.

## Related issue

None filed — can open one if you'd rather track the host-side catalog gap.

## Checklist

- [x] `bunx nx run traycer-clients-gui-app:compile` passes (typecheck); `bun run build` covered by CI
- [x] ESLint clean on the changed files; Prettier check passes
- [x] Tests added: `model-capability-overrides.test.ts` (9 tests — both match shapes + negative cases)
- [x] Commits are signed off (`git commit -s`) per the DCO