### PR TITLE
fix(notifications): add atomic cloud mark-all-read

### DIFF
--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -333,6 +333,11 @@ export const HOST_METHOD_POLL_TABLE = {
     joinResponseTimeoutMs: null,
     poll: null,
   },
+  "host.notifications.cloudFeed.markAllRead": {
+    mode: "fifo",
+    joinResponseTimeoutMs: null,
+    poll: null,
+  },
   "host.notifications.cloudFeed.resolve": {
     mode: "fifo",
     joinResponseTimeoutMs: null,

--- a/clients/gui-app/src/lib/query-keys/notifications-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/notifications-mutation-keys.ts
@@ -5,6 +5,7 @@ export const notificationsMutationKeys = {
   markEntityRead: () => ["notifications.markEntityRead"] as const,
   markAllRead: () => ["notifications.markAllRead"] as const,
   cloudMarkRead: () => ["notifications.cloudFeed.markRead"] as const,
+  cloudMarkAllRead: () => ["notifications.cloudFeed.markAllRead"] as const,
   cloudResolve: () => ["notifications.cloudFeed.resolve"] as const,
   cloudClear: () => ["notifications.cloudFeed.clear"] as const,
   cloudClearAll: () => ["notifications.cloudFeed.clearAll"] as const,

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
@@ -1056,28 +1056,21 @@ describe("useMergedNotificationsActions indicator invalidation", () => {
     expect(hostRequestMock).not.toHaveBeenCalled();
   });
 
-  it("optimistically marks the cloud feed at once while serializing mark-all RPCs", async () => {
+  it("uses one observed-version mark-all for renderable and summary-only unread entries", async () => {
     bindHostClient();
     notificationFeedMode.value = "cloud";
-    const settleRequests: Array<() => void> = [];
     hostRequestMock.mockImplementation((method: string) => {
-      if (method === "host.notifications.cloudFeed.markRead") {
-        return new Promise((resolve) => {
-          settleRequests.push(() => {
-            resolve({ status: "applied", version: 2 });
-          });
-        });
+      if (method === "host.notifications.cloudFeed.markAllRead") {
+        return Promise.resolve({ status: "applied", version: 2 });
       }
       return defaultHostRequest(method);
     });
     useCloudNotificationsStore.getState().applySnapshot({
-      rows: [
-        cloudDone("entry-a", 1, null),
-        cloudDone("entry-b", 2, null),
-        cloudDone("entry-c", 3, null),
-      ],
-      summary: { totalCount: 3, unreadCount: 3, attentionCount: 0 },
-      version: 1,
+      // The second unread entry exists in the raw cloud feed but was omitted
+      // by the relay's renderer conversion, so it appears only in the summary.
+      rows: [cloudDone("entry-a", 1, null)],
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 0 },
+      version: 10,
     });
     const { result } = renderHook(() => useMergedNotificationsActions(), {
       wrapper: createWrapper(),
@@ -1094,36 +1087,16 @@ describe("useMergedNotificationsActions indicator invalidation", () => {
       ),
     ).toBe(true);
     await waitFor(() => {
-      expect(
-        hostRequestMock.mock.calls.filter(
-          (call) => call[0] === "host.notifications.cloudFeed.markRead",
-        ),
-      ).toHaveLength(1);
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markAllRead",
+        { observedVersion: 10 },
+      );
     });
-
-    act(() => {
-      settleRequests[0]?.();
-    });
-    await waitFor(() => {
-      expect(
-        hostRequestMock.mock.calls.filter(
-          (call) => call[0] === "host.notifications.cloudFeed.markRead",
-        ),
-      ).toHaveLength(2);
-    });
-    act(() => {
-      settleRequests[1]?.();
-    });
-    await waitFor(() => {
-      expect(
-        hostRequestMock.mock.calls.filter(
-          (call) => call[0] === "host.notifications.cloudFeed.markRead",
-        ),
-      ).toHaveLength(3);
-    });
-    act(() => {
-      settleRequests[2]?.();
-    });
+    expect(
+      hostRequestMock.mock.calls.filter(
+        (call) => call[0] === "host.notifications.cloudFeed.markRead",
+      ),
+    ).toHaveLength(0);
   });
 
   it("ignores a cloud command completion from a replaced ownership epoch", async () => {

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
@@ -1152,6 +1152,46 @@ describe("useMergedNotificationsActions indicator invalidation", () => {
     );
   });
 
+  it("falls back when an older cloud server cannot acknowledge mark-all", async () => {
+    bindHostClient();
+    notificationFeedMode.value = "cloud";
+    hostRequestMock.mockImplementation((method: string) => {
+      if (method === "host.notifications.cloudFeed.markAllRead") {
+        return Promise.resolve({ status: "unsupported", version: null });
+      }
+      if (method === "host.notifications.cloudFeed.markRead") {
+        return Promise.resolve({ status: "applied", version: 10 });
+      }
+      return defaultHostRequest(method);
+    });
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [cloudDone("entry-a", 1, null), cloudDone("entry-b", 2, null)],
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 0 },
+      version: 10,
+    });
+    const { result } = renderHook(() => useMergedNotificationsActions(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.markAllAsRead();
+    });
+
+    await waitFor(() => {
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markRead",
+        { entryId: "entry-a" },
+      );
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markRead",
+        { entryId: "entry-b" },
+      );
+    });
+    expect(useCloudNotificationsStore.getState().connectionState).toBe(
+      "connected",
+    );
+  });
+
   it("does not mark a newer cloud snapshot from a stale action closure", () => {
     bindHostClient();
     notificationFeedMode.value = "cloud";

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
@@ -1192,6 +1192,99 @@ describe("useMergedNotificationsActions indicator invalidation", () => {
     );
   });
 
+  it("continues the compatibility fallback after one entry write fails", async () => {
+    bindHostClient();
+    notificationFeedMode.value = "cloud";
+    hostRequestMock.mockImplementation((method: string, params: unknown) => {
+      if (method === "host.notifications.cloudFeed.markAllRead") {
+        return Promise.resolve({ status: "unsupported", version: null });
+      }
+      if (method === "host.notifications.cloudFeed.markRead") {
+        if (isRecord(params) && params["entryId"] === "entry-a") {
+          return Promise.reject(new Error("transient entry write failure"));
+        }
+        return Promise.resolve({ status: "applied", version: 10 });
+      }
+      return defaultHostRequest(method);
+    });
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [cloudDone("entry-a", 1, null), cloudDone("entry-b", 2, null)],
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 0 },
+      version: 10,
+    });
+    const { result } = renderHook(() => useMergedNotificationsActions(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.markAllAsRead();
+    });
+
+    await waitFor(() => {
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markRead",
+        { entryId: "entry-b" },
+      );
+    });
+  });
+
+  it("does not replay a bulk compatibility fallback into a replacement cloud session", async () => {
+    bindHostClient();
+    notificationFeedMode.value = "cloud";
+    let resolveMarkAll:
+      | ((result: {
+          readonly status: "unsupported";
+          readonly version: null;
+        }) => void)
+      | undefined;
+    hostRequestMock.mockImplementation((method: string) => {
+      if (method === "host.notifications.cloudFeed.markAllRead") {
+        return new Promise((resolve) => {
+          resolveMarkAll = resolve;
+        });
+      }
+      if (method === "host.notifications.cloudFeed.markRead") {
+        return Promise.resolve({ status: "applied", version: 10 });
+      }
+      return defaultHostRequest(method);
+    });
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [cloudDone("entry-a", 1, null)],
+      summary: { totalCount: 1, unreadCount: 1, attentionCount: 0 },
+      version: 10,
+    });
+    const { result } = renderHook(() => useMergedNotificationsActions(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.markAllAsRead();
+    });
+    await waitFor(() => {
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markAllRead",
+        { observedVersion: 10 },
+      );
+    });
+    act(() => {
+      useCloudNotificationsStore.getState().reset();
+    });
+    if (resolveMarkAll === undefined) {
+      throw new Error("expected pending cloud mark-all request");
+    }
+    const resolvePendingMarkAll = resolveMarkAll;
+    await act(async () => {
+      resolvePendingMarkAll({ status: "unsupported", version: null });
+      await Promise.resolve();
+    });
+
+    expect(
+      hostRequestMock.mock.calls.filter(
+        (call) => call[0] === "host.notifications.cloudFeed.markRead",
+      ),
+    ).toHaveLength(0);
+  });
+
   it("does not mark a newer cloud snapshot from a stale action closure", () => {
     bindHostClient();
     notificationFeedMode.value = "cloud";

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-actions.test.tsx
@@ -1099,6 +1099,90 @@ describe("useMergedNotificationsActions indicator invalidation", () => {
     ).toHaveLength(0);
   });
 
+  it("falls back to renderable cloud entries when an older relay lacks mark-all", async () => {
+    bindHostClient();
+    notificationFeedMode.value = "cloud";
+    hostRequestMock.mockImplementation((method: string) => {
+      if (method === "host.notifications.cloudFeed.markAllRead") {
+        return Promise.reject(
+          new HostRpcError({
+            code: "E_HOST_UNSUPPORTED",
+            message: "host.notifications.cloudFeed.markAllRead is unsupported",
+            requestId: "test-request",
+            method,
+            fatalDetails: {
+              code: "E_HOST_UNSUPPORTED",
+              reason: "unsupported method",
+              incompatibleMethods: null,
+              upgradeGuidance: null,
+            },
+          }),
+        );
+      }
+      if (method === "host.notifications.cloudFeed.markRead") {
+        return Promise.resolve({ status: "applied", version: 10 });
+      }
+      return defaultHostRequest(method);
+    });
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [cloudDone("entry-a", 1, null), cloudDone("entry-b", 2, null)],
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 0 },
+      version: 10,
+    });
+    const { result } = renderHook(() => useMergedNotificationsActions(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.markAllAsRead();
+    });
+
+    await waitFor(() => {
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markRead",
+        { entryId: "entry-a" },
+      );
+      expect(hostRequestMock).toHaveBeenCalledWith(
+        "host.notifications.cloudFeed.markRead",
+        { entryId: "entry-b" },
+      );
+    });
+    expect(useCloudNotificationsStore.getState().connectionState).toBe(
+      "connected",
+    );
+  });
+
+  it("does not mark a newer cloud snapshot from a stale action closure", () => {
+    bindHostClient();
+    notificationFeedMode.value = "cloud";
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [cloudDone("entry-a", 1, null)],
+      summary: { totalCount: 1, unreadCount: 1, attentionCount: 0 },
+      version: 10,
+    });
+    const { result } = renderHook(() => useMergedNotificationsActions(), {
+      wrapper: createWrapper(),
+    });
+    const staleMarkAllAsRead = result.current.markAllAsRead;
+
+    act(() => {
+      useCloudNotificationsStore.getState().applySnapshot({
+        rows: [cloudDone("entry-a", 1, null), cloudDone("entry-b", 2, null)],
+        summary: { totalCount: 2, unreadCount: 2, attentionCount: 0 },
+        version: 11,
+      });
+      staleMarkAllAsRead();
+    });
+
+    expect(useCloudNotificationsStore.getState().summary?.unreadCount).toBe(2);
+    expect(
+      Object.values(useCloudNotificationsStore.getState().rows).every(
+        (row) => row?.entry.readAt === null,
+      ),
+    ).toBe(true);
+    expect(hostRequestMock).not.toHaveBeenCalled();
+  });
+
   it("ignores a cloud command completion from a replaced ownership epoch", async () => {
     bindHostClient();
     notificationFeedMode.value = "cloud";

--- a/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
@@ -35,7 +35,7 @@ export interface CloudNotificationsState {
   >;
   readonly summary: HostNotificationsCloudFeedSummary | null;
   /** The cloud's per-user change sequence, as of the last snapshot. This is
-   * what a `clearAll` names as the feed the user was looking at. */
+   * what a bulk mutation names as the feed the user was looking at. */
   readonly version: number | null;
   /** A cloud feed is authoritative only after this session has received a
    * complete snapshot. Until then an in-progress retry must not masquerade as
@@ -74,6 +74,9 @@ export interface CloudNotificationsState {
    * reconciles the row, but the common successful mutation never waits on a
    * wake or the relay's correctness poll to look read. */
   markReadLocally(entryId: string, readAt: number): void;
+  /** Optimistically covers the whole raw snapshot summary, including unread
+   * entries omitted from `rows` because this client cannot render them. */
+  markAllReadLocally(readAt: number): void;
   /** One atomic step for a view-consumption fan-out: claim every entry as
    * in-flight and apply its optimistic marker in a single write, so no
    * subscriber can observe the new rows before the claim is visible. */
@@ -230,6 +233,21 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
                   ...state.summary,
                   unreadCount: Math.max(0, state.summary.unreadCount - 1),
                 },
+        };
+      }),
+    markAllReadLocally: (readAt) =>
+      set((state) => {
+        const rows = { ...state.rows };
+        for (const [key, row] of Object.entries(rows)) {
+          if (row === undefined || row.entry.readAt !== null) continue;
+          rows[key] = { ...row, entry: { ...row.entry, readAt } };
+        }
+        return {
+          rows,
+          summary:
+            state.summary === null
+              ? null
+              : { ...state.summary, unreadCount: 0 },
         };
       }),
     beginEntityRead: (entryIds, readAt) =>

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
@@ -556,17 +556,24 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
     useCloudNotificationsStore.getState().setConnectionState("unavailable");
   };
   const handleCloudMutationResult = (data: {
-    readonly status: "applied" | "unavailable" | "unsupported";
+    readonly status: "applied" | "unavailable";
   }): void => {
     if (data.status === "unavailable") markCloudUnavailable();
   };
-  const captureCloudMutationContext = (): CloudFeedMutationContext => ({
-    hostId: client?.getActiveHostId() ?? null,
-    sessionEpoch: useCloudNotificationsStore.getState().sessionEpoch,
-  });
-  const isCurrentCloudMutation = (context: CloudFeedMutationContext): boolean =>
-    client?.getActiveHostId() === context.hostId &&
-    useCloudNotificationsStore.getState().sessionEpoch === context.sessionEpoch;
+  const captureCloudMutationContext = useCallback(
+    (): CloudFeedMutationContext => ({
+      hostId: client?.getActiveHostId() ?? null,
+      sessionEpoch: useCloudNotificationsStore.getState().sessionEpoch,
+    }),
+    [client],
+  );
+  const isCurrentCloudMutation = useCallback(
+    (context: CloudFeedMutationContext): boolean =>
+      client?.getActiveHostId() === context.hostId &&
+      useCloudNotificationsStore.getState().sessionEpoch ===
+        context.sessionEpoch,
+    [client],
+  );
   const cloudMarkRead = useHostMutation<
     HostRpcRegistry,
     "host.notifications.cloudFeed.markRead",
@@ -604,8 +611,11 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
       mutationKey: notificationsMutationKeys.cloudMarkAllRead(),
       onMutate: captureCloudMutationContext,
       onSuccess: (data, _variables, context) => {
-        if (isCurrentCloudMutation(context)) {
-          handleCloudMutationResult(data);
+        if (!isCurrentCloudMutation(context)) return;
+        if (data.status === "applied") {
+          handleCloudMutationResult({ status: "applied" });
+        } else if (data.status === "unavailable") {
+          handleCloudMutationResult({ status: "unavailable" });
         }
       },
       onError: (error, _variables, context) => {
@@ -1058,16 +1068,21 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
                 row !== undefined && row.entry.readAt === null,
             )
             .map((row) => row.entryId);
+          const fallbackContext = captureCloudMutationContext();
           cloudState.markAllReadLocally(Date.now());
           const fallBackToEntryMutations = async (): Promise<void> => {
             // An older cloud server cannot atomically include rows it did not
             // render, but it can preserve the released per-entry behavior for
             // every renderable row.
             for (const entryId of fallbackEntryIds) {
+              if (!isCurrentCloudMutation(fallbackContext)) return;
               try {
                 await cloudMarkRead.mutateAsync({ entryId });
               } catch {
-                return;
+                // Each per-entry marker is independent and idempotent. A
+                // transient failure must not prevent later entries from being
+                // persisted on the older relay.
+                continue;
               }
             }
           };
@@ -1214,6 +1229,8 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
       client,
       feedMode,
       cloudVersion,
+      captureCloudMutationContext,
+      isCurrentCloudMutation,
       cloudMarkRead,
       cloudMarkAllRead,
       cloudResolve,

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -556,7 +556,7 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
     useCloudNotificationsStore.getState().setConnectionState("unavailable");
   };
   const handleCloudMutationResult = (data: {
-    readonly status: "applied" | "unavailable";
+    readonly status: "applied" | "unavailable" | "unsupported";
   }): void => {
     if (data.status === "unavailable") markCloudUnavailable();
   };
@@ -1059,22 +1059,28 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
             )
             .map((row) => row.entryId);
           cloudState.markAllReadLocally(Date.now());
+          const fallBackToEntryMutations = async (): Promise<void> => {
+            // An older cloud server cannot atomically include rows it did not
+            // render, but it can preserve the released per-entry behavior for
+            // every renderable row.
+            for (const entryId of fallbackEntryIds) {
+              try {
+                await cloudMarkRead.mutateAsync({ entryId });
+              } catch {
+                return;
+              }
+            }
+          };
           void cloudMarkAllRead
             .mutateAsync({ observedVersion: cloudVersion })
+            .then(async (result) => {
+              if (result.status === "unsupported") {
+                await fallBackToEntryMutations();
+              }
+            })
             .catch(async (error: unknown) => {
               if (!isHostUnsupportedError(error)) return;
-              // An older relay cannot atomically include rows it did not
-              // render, but it can preserve the released per-entry behavior
-              // for every renderable row. Keep this compatibility path only
-              // for the optional-RPC rejection; ordinary failures retain the
-              // unavailable-state behavior owned by the mutation.
-              for (const entryId of fallbackEntryIds) {
-                try {
-                  await cloudMarkRead.mutateAsync({ entryId });
-                } catch {
-                  return;
-                }
-              }
+              await fallBackToEntryMutations();
             });
           return;
         }

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -76,6 +76,7 @@ import {
   type HostNotificationsResolveRequest,
   type HostNotificationsCloudFeedRow,
   type HostNotificationsCloudFeedEntryRequest,
+  type HostNotificationsCloudFeedMarkAllReadRequest,
   type HostNotificationsCloudFeedClearAllRequest,
   type HostNotificationsEntityRef,
 } from "@traycer/protocol/host/notifications/contracts";
@@ -585,6 +586,30 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
       },
     },
   });
+  const cloudMarkAllRead = useHostMutation<
+    HostRpcRegistry,
+    "host.notifications.cloudFeed.markAllRead",
+    CloudFeedMutationContext,
+    HostNotificationsCloudFeedMarkAllReadRequest
+  >({
+    client,
+    method: "host.notifications.cloudFeed.markAllRead",
+    mapVariables: (variables) => variables,
+    options: {
+      mutationKey: notificationsMutationKeys.cloudMarkAllRead(),
+      onMutate: captureCloudMutationContext,
+      onSuccess: (data, _variables, context) => {
+        if (isCurrentCloudMutation(context)) {
+          handleCloudMutationResult(data);
+        }
+      },
+      onError: (_error, _variables, context) => {
+        if (context !== undefined && isCurrentCloudMutation(context)) {
+          markCloudUnavailable();
+        }
+      },
+    },
+  });
   const cloudResolve = useHostMutation<
     HostRpcRegistry,
     "host.notifications.cloudFeed.resolve",
@@ -1012,32 +1037,9 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
         });
       },
       markAllAsRead: () => {
-        if (feedMode === "cloud") {
-          const readAt = Date.now();
-          const unreadEntryIds: string[] = [];
-          for (const row of Object.values(
-            useCloudNotificationsStore.getState().rows,
-          )) {
-            if (row !== undefined && row.entry.readAt === null) {
-              unreadEntryIds.push(row.entryId);
-              useCloudNotificationsStore
-                .getState()
-                .markReadLocally(row.entryId, readAt);
-            }
-          }
-          // Optimistic set-once markers land as one immediate UI update, then
-          // the wire work is serialized so a large cross-device feed cannot
-          // burst hundreds of unary requests through one host connection.
-          void (async (): Promise<void> => {
-            for (const entryId of unreadEntryIds) {
-              try {
-                await cloudMarkRead.mutateAsync({ entryId });
-              } catch {
-                // The mutation's onError owns availability state. Continue so
-                // one failed entry does not prevent later entries being sent.
-              }
-            }
-          })();
+        if (feedMode === "cloud" && cloudVersion !== null) {
+          useCloudNotificationsStore.getState().markAllReadLocally(Date.now());
+          cloudMarkAllRead.mutate({ observedVersion: cloudVersion });
           return;
         }
         if (feedMode !== "local") return;
@@ -1171,6 +1173,7 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
       feedMode,
       cloudVersion,
       cloudMarkRead,
+      cloudMarkAllRead,
       cloudResolve,
       cloudClear,
       cloudClearAll,

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { useHostBinding, type HostRpcRegistry } from "@/lib/host";
 import {
   Analytics,
@@ -115,6 +116,10 @@ export interface MergedNotificationRow {
   /** Product-vocabulary category, mapped from `source` at the projection
    * boundary so consumers never branch on the internal source seam. */
   readonly category: NotificationCategory;
+}
+
+function isHostUnsupportedError(error: unknown): boolean {
+  return error instanceof HostRpcError && error.code === "E_HOST_UNSUPPORTED";
 }
 
 export interface MergedNotificationsActions {
@@ -603,7 +608,10 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
           handleCloudMutationResult(data);
         }
       },
-      onError: (_error, _variables, context) => {
+      onError: (error, _variables, context) => {
+        // This is an optional RPC. Older cloud relays still support the
+        // established per-entry write used by the compatibility fallback.
+        if (isHostUnsupportedError(error)) return;
         if (context !== undefined && isCurrentCloudMutation(context)) {
           markCloudUnavailable();
         }
@@ -1038,8 +1046,36 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
       },
       markAllAsRead: () => {
         if (feedMode === "cloud" && cloudVersion !== null) {
-          useCloudNotificationsStore.getState().markAllReadLocally(Date.now());
-          cloudMarkAllRead.mutate({ observedVersion: cloudVersion });
+          // `cloudVersion` belongs to the rendered action closure, whereas a
+          // frame can update the store before the click reaches this handler.
+          // Do not locally consume rows that the versioned bulk command will
+          // deliberately leave unread.
+          const cloudState = useCloudNotificationsStore.getState();
+          if (cloudState.version !== cloudVersion) return;
+          const fallbackEntryIds = Object.values(cloudState.rows)
+            .filter(
+              (row): row is HostNotificationsCloudFeedRow =>
+                row !== undefined && row.entry.readAt === null,
+            )
+            .map((row) => row.entryId);
+          cloudState.markAllReadLocally(Date.now());
+          void cloudMarkAllRead
+            .mutateAsync({ observedVersion: cloudVersion })
+            .catch(async (error: unknown) => {
+              if (!isHostUnsupportedError(error)) return;
+              // An older relay cannot atomically include rows it did not
+              // render, but it can preserve the released per-entry behavior
+              // for every renderable row. Keep this compatibility path only
+              // for the optional-RPC rejection; ordinary failures retain the
+              // unavailable-state behavior owned by the mutation.
+              for (const entryId of fallbackEntryIds) {
+                try {
+                  await cloudMarkRead.mutateAsync({ entryId });
+                } catch {
+                  return;
+                }
+              }
+            });
           return;
         }
         if (feedMode !== "local") return;

--- a/protocol/src/host/notifications/__tests__/host-notifications.test.ts
+++ b/protocol/src/host/notifications/__tests__/host-notifications.test.ts
@@ -29,6 +29,7 @@ import {
   hostNotificationsCloudFeedClearAllRequestSchema,
   hostNotificationsCloudFeedMutationResponseSchema,
   hostNotificationsCloudFeedMarkRead,
+  hostNotificationsCloudFeedMarkAllRead,
   hostNotificationsCloudFeedResolve,
   hostNotificationsCloudFeedClear,
   hostNotificationsCloudFeedClearAll,
@@ -871,6 +872,10 @@ describe("host.notifications.cloudFeed@1.0 immutable-entry surface", () => {
         .contract,
     ).toBe(hostNotificationsCloudFeedMarkRead);
     expect(
+      hostRpcRegistry["host.notifications.cloudFeed.markAllRead"][1].versions[0]
+        .contract,
+    ).toBe(hostNotificationsCloudFeedMarkAllRead);
+    expect(
       hostRpcRegistry["host.notifications.cloudFeed.resolve"][1].versions[0]
         .contract,
     ).toBe(hostNotificationsCloudFeedResolve);
@@ -884,6 +889,7 @@ describe("host.notifications.cloudFeed@1.0 immutable-entry surface", () => {
     ).toBe(hostNotificationsCloudFeedClearAll);
     for (const method of [
       "host.notifications.cloudFeed.markRead",
+      "host.notifications.cloudFeed.markAllRead",
       "host.notifications.cloudFeed.resolve",
       "host.notifications.cloudFeed.clear",
       "host.notifications.cloudFeed.clearAll",
@@ -940,7 +946,10 @@ describe("host.notifications registry membership", () => {
         .contract,
     ).toBe(hostNotificationsFeedSubscribeV10);
     expect(
-      Object.hasOwn(hostStreamRpcRegistry["host.notifications.feed.subscribe"], "2"),
+      Object.hasOwn(
+        hostStreamRpcRegistry["host.notifications.feed.subscribe"],
+        "2",
+      ),
     ).toBe(false);
     expect(
       hostStreamRpcRegistry["host.notifications.cloudFeed.subscribe"][1]
@@ -950,8 +959,10 @@ describe("host.notifications registry membership", () => {
 
   it("keeps the local-feed method compatible in both directions while cloud feed remains explicitly unsupported by an old peer", () => {
     const currentManifest = buildStreamManifest(hostStreamRpcRegistry);
-    const { ["host.notifications.cloudFeed.subscribe"]: _cloudFeed, ...oldManifest } =
-      currentManifest;
+    const {
+      ["host.notifications.cloudFeed.subscribe"]: _cloudFeed,
+      ...oldManifest
+    } = currentManifest;
 
     expect(
       checkStreamMethodCompatibility(
@@ -981,7 +992,10 @@ describe("host.notifications registry membership", () => {
       ),
     ).toMatchObject({
       ok: false,
-      details: { code: "INCOMPATIBLE", upgradeGuidance: { hostShouldUpgrade: true } },
+      details: {
+        code: "INCOMPATIBLE",
+        upgradeGuidance: { hostShouldUpgrade: true },
+      },
     });
   });
 });

--- a/protocol/src/host/notifications/__tests__/host-notifications.test.ts
+++ b/protocol/src/host/notifications/__tests__/host-notifications.test.ts
@@ -28,6 +28,7 @@ import {
   hostNotificationsCloudFeedEntryRequestSchema,
   hostNotificationsCloudFeedClearAllRequestSchema,
   hostNotificationsCloudFeedMutationResponseSchema,
+  hostNotificationsCloudFeedMarkAllReadResponseSchema,
   hostNotificationsCloudFeedMarkRead,
   hostNotificationsCloudFeedMarkAllRead,
   hostNotificationsCloudFeedResolve,
@@ -839,7 +840,7 @@ describe("host.notifications.cloudFeed@1.0 immutable-entry surface", () => {
     ).toBe(false);
   });
 
-  it("answers a mutation with a status and a version that is null exactly when unavailable", () => {
+  it("answers released per-entry mutations with a status and a version that is null exactly when unavailable", () => {
     expect(
       hostNotificationsCloudFeedMutationResponseSchema.parse({
         status: "applied",
@@ -853,11 +854,11 @@ describe("host.notifications.cloudFeed@1.0 immutable-entry surface", () => {
       }),
     ).toEqual({ status: "unavailable", version: null });
     expect(
-      hostNotificationsCloudFeedMutationResponseSchema.parse({
+      hostNotificationsCloudFeedMutationResponseSchema.safeParse({
         status: "unsupported",
         version: null,
-      }),
-    ).toEqual({ status: "unsupported", version: null });
+      }).success,
+    ).toBe(false);
     expect(
       hostNotificationsCloudFeedMutationResponseSchema.safeParse({
         status: "applied",
@@ -870,6 +871,15 @@ describe("host.notifications.cloudFeed@1.0 immutable-entry surface", () => {
         version: 9,
       }).success,
     ).toBe(false);
+  });
+
+  it("answers the additive cloud mark-all-read operation as unsupported", () => {
+    expect(
+      hostNotificationsCloudFeedMarkAllReadResponseSchema.parse({
+        status: "unsupported",
+        version: null,
+      }),
+    ).toEqual({ status: "unsupported", version: null });
   });
 
   it("registers the whole family on the unary registry as optional methods", () => {

--- a/protocol/src/host/notifications/__tests__/host-notifications.test.ts
+++ b/protocol/src/host/notifications/__tests__/host-notifications.test.ts
@@ -853,6 +853,12 @@ describe("host.notifications.cloudFeed@1.0 immutable-entry surface", () => {
       }),
     ).toEqual({ status: "unavailable", version: null });
     expect(
+      hostNotificationsCloudFeedMutationResponseSchema.parse({
+        status: "unsupported",
+        version: null,
+      }),
+    ).toEqual({ status: "unsupported", version: null });
+    expect(
       hostNotificationsCloudFeedMutationResponseSchema.safeParse({
         status: "applied",
         version: null,

--- a/protocol/src/host/notifications/host-notifications.ts
+++ b/protocol/src/host/notifications/host-notifications.ts
@@ -1187,21 +1187,22 @@ export type HostNotificationsCloudFeedMarkAllReadRequest = z.infer<
 /**
  * `unavailable` means the relay could not reach the cloud, and NOTHING was
  * changed anywhere - the host deliberately keeps no local shadow of the cloud
- * feed to mutate optimistically. The client keeps showing the rows it has and
- * surfaces the degraded state; it must not treat the mutation as applied.
+ * feed to mutate optimistically. `unsupported` means an older cloud server
+ * accepted the envelope but could not acknowledge this optional operation; a
+ * client may use a released compatibility path. Neither is an applied mutation.
  */
 export const hostNotificationsCloudFeedMutationResponseSchema = z
   .object({
-    status: z.enum(["applied", "unavailable"]),
-    /** The feed version after the mutation; `null` when unavailable. */
+    status: z.enum(["applied", "unavailable", "unsupported"]),
+    /** The feed version after the mutation; `null` when it was not applied. */
     version: z.number().int().nonnegative().nullable(),
   })
   .superRefine((value, context) => {
-    if ((value.status === "unavailable") === (value.version === null)) return;
+    if ((value.status === "applied") === (value.version !== null)) return;
     context.addIssue({
       code: "custom",
       path: ["version"],
-      message: "version must be null exactly when status is unavailable",
+      message: "version must be non-null exactly when status is applied",
     });
   });
 export type HostNotificationsCloudFeedMutationResponse = z.infer<

--- a/protocol/src/host/notifications/host-notifications.ts
+++ b/protocol/src/host/notifications/host-notifications.ts
@@ -1187,11 +1187,32 @@ export type HostNotificationsCloudFeedMarkAllReadRequest = z.infer<
 /**
  * `unavailable` means the relay could not reach the cloud, and NOTHING was
  * changed anywhere - the host deliberately keeps no local shadow of the cloud
- * feed to mutate optimistically. `unsupported` means an older cloud server
- * accepted the envelope but could not acknowledge this optional operation; a
- * client may use a released compatibility path. Neither is an applied mutation.
+ * feed to mutate optimistically. Neither is an applied mutation.
  */
 export const hostNotificationsCloudFeedMutationResponseSchema = z
+  .object({
+    status: z.enum(["applied", "unavailable"]),
+    /** The feed version after the mutation; `null` when unavailable. */
+    version: z.number().int().nonnegative().nullable(),
+  })
+  .superRefine((value, context) => {
+    if ((value.status === "applied") === (value.version !== null)) return;
+    context.addIssue({
+      code: "custom",
+      path: ["version"],
+      message: "version must be non-null exactly when status is applied",
+    });
+  });
+export type HostNotificationsCloudFeedMutationResponse = z.infer<
+  typeof hostNotificationsCloudFeedMutationResponseSchema
+>;
+
+/**
+ * The atomic bulk operation is additive. `unsupported` means an older cloud
+ * server accepted its envelope but could not acknowledge this new operation;
+ * the client may then use the released per-entry compatibility path.
+ */
+export const hostNotificationsCloudFeedMarkAllReadResponseSchema = z
   .object({
     status: z.enum(["applied", "unavailable", "unsupported"]),
     /** The feed version after the mutation; `null` when it was not applied. */
@@ -1205,8 +1226,8 @@ export const hostNotificationsCloudFeedMutationResponseSchema = z
       message: "version must be non-null exactly when status is applied",
     });
   });
-export type HostNotificationsCloudFeedMutationResponse = z.infer<
-  typeof hostNotificationsCloudFeedMutationResponseSchema
+export type HostNotificationsCloudFeedMarkAllReadResponse = z.infer<
+  typeof hostNotificationsCloudFeedMarkAllReadResponseSchema
 >;
 
 export const hostNotificationsCloudFeedMarkRead = defineRpcContract({
@@ -1234,7 +1255,7 @@ export const hostNotificationsCloudFeedMarkAllRead = defineRpcContract({
   method: "host.notifications.cloudFeed.markAllRead",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: hostNotificationsCloudFeedMarkAllReadRequestSchema,
-  responseSchema: hostNotificationsCloudFeedMutationResponseSchema,
+  responseSchema: hostNotificationsCloudFeedMarkAllReadResponseSchema,
 });
 
 export const hostNotificationsCloudFeedClearAll = defineRpcContract({

--- a/protocol/src/host/notifications/host-notifications.ts
+++ b/protocol/src/host/notifications/host-notifications.ts
@@ -1174,6 +1174,17 @@ export type HostNotificationsCloudFeedClearAllRequest = z.infer<
 >;
 
 /**
+ * Mark every notification read in the cloud snapshot the user was looking at.
+ * The shape matches clear-all because both operations are bounded by observed
+ * feed membership rather than a host timestamp.
+ */
+export const hostNotificationsCloudFeedMarkAllReadRequestSchema =
+  hostNotificationsCloudFeedClearAllRequestSchema;
+export type HostNotificationsCloudFeedMarkAllReadRequest = z.infer<
+  typeof hostNotificationsCloudFeedMarkAllReadRequestSchema
+>;
+
+/**
  * `unavailable` means the relay could not reach the cloud, and NOTHING was
  * changed anywhere - the host deliberately keeps no local shadow of the cloud
  * feed to mutate optimistically. The client keeps showing the rows it has and
@@ -1215,6 +1226,13 @@ export const hostNotificationsCloudFeedClear = defineRpcContract({
   method: "host.notifications.cloudFeed.clear",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: hostNotificationsCloudFeedEntryRequestSchema,
+  responseSchema: hostNotificationsCloudFeedMutationResponseSchema,
+});
+
+export const hostNotificationsCloudFeedMarkAllRead = defineRpcContract({
+  method: "host.notifications.cloudFeed.markAllRead",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: hostNotificationsCloudFeedMarkAllReadRequestSchema,
   responseSchema: hostNotificationsCloudFeedMutationResponseSchema,
 });
 

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -347,6 +347,7 @@ import {
   hostNotificationsFeedSubscribeV11,
   hostNotificationsCloudFeedSubscribeV10,
   hostNotificationsCloudFeedMarkRead,
+  hostNotificationsCloudFeedMarkAllRead,
   hostNotificationsCloudFeedResolve,
   hostNotificationsCloudFeedClear,
   hostNotificationsCloudFeedClearAll,
@@ -3370,6 +3371,19 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
       versions: {
         0: {
           contract: hostNotificationsCloudFeedResolve,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+  },
+  "host.notifications.cloudFeed.markAllRead": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: hostNotificationsCloudFeedMarkAllRead,
           upgradeFromPreviousVersion: null,
         },
       },


### PR DESCRIPTION
## Summary
- add the cloud notification `markAllRead` protocol and host client operation
- update the GUI to use a single optimistic bulk mutation
- add regression coverage for unrenderable notification entries

## Verification
- `bun run --filter @traycer/protocol test`
- `bun run --filter @traycer/gui-app test`