### PR TITLE
feat(gui-app): read never-enabled providers as an offer, not a disable

### DIFF
--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -1,9 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import { DEFAULT_PROVIDER_NATIVE_CAPABILITIES } from "@traycer/protocol/host/provider-native-schemas";
+
+const providerMocks = vi.hoisted(() => ({
+  providers: [] as ProviderCliState[],
+}));
 
 vi.mock("@/hooks/providers/use-providers-list-query", () => ({
   useProvidersList: () => ({
-    data: { providers: [] },
+    data: { providers: providerMocks.providers },
     isPending: false,
     isError: false,
     fetchStatus: "idle",
@@ -18,6 +24,50 @@ vi.mock("@/hooks/providers/use-providers-set-enabled-mutation", () => ({
 }));
 
 import { OnboardingDetectedAgents } from "@/components/onboarding/onboarding-detected-agents";
+
+function providerState(
+  providerId: ProviderCliState["providerId"],
+  enablement: Pick<ProviderCliState, "enabled" | "disabledBy">,
+): ProviderCliState {
+  return {
+    providerId,
+    enabled: enablement.enabled,
+    disabledBy: enablement.disabledBy,
+    selected: { kind: "bundled" },
+    candidates: [],
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: "Signed in",
+      detail: null,
+    },
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: false,
+    nativeCapabilities: DEFAULT_PROVIDER_NATIVE_CAPABILITIES,
+    managedInstallState: null,
+    versionVisibility: null,
+    advisory: null,
+    profiles: [],
+  };
+}
+
+function rowText(name: string): string {
+  const row = screen
+    .getAllByRole("listitem")
+    .find((item) => item.textContent.includes(name));
+  if (row === undefined) throw new Error(`No onboarding row for ${name}.`);
+  return row.textContent;
+}
+
+afterEach(() => {
+  cleanup();
+  providerMocks.providers = [];
+});
 
 describe("OnboardingDetectedAgents", () => {
   it("renders providers in the shared provider order", () => {
@@ -62,5 +112,50 @@ describe("OnboardingDetectedAgents", () => {
         return longestMatch(text);
       }),
     ).toEqual(expectedNames);
+  });
+
+  // Onboarding is where the seeded set gets confirmed: the host turns on the
+  // floor plus anything it detected, and everything else arrives off with no
+  // `disabledBy`. Those rows are an OFFER, so they may not be labelled with a
+  // decision nobody made - only a provider a person switched off says
+  // "Disabled".
+  it("offers a never-enabled provider instead of calling it disabled", () => {
+    providerMocks.providers = [
+      providerState("codex", { enabled: true, disabledBy: null }),
+      providerState("grok", { enabled: false, disabledBy: null }),
+      providerState("qwen", {
+        enabled: false,
+        disabledBy: {
+          userId: "4b1b3f3b-1d55-4a1c-9a2a-d0c6ab6e6c33",
+          handle: "pranshu",
+          at: 1,
+        },
+      }),
+    ];
+
+    render(<OnboardingDetectedAgents />);
+
+    expect(rowText("Codex")).toContain("Signed in");
+    expect(rowText("Grok")).toContain("Not enabled - turn on to use");
+    expect(rowText("Grok")).not.toContain("Disabled");
+    expect(rowText("Qwen Code")).toContain("Disabled");
+  });
+
+  it("keeps the enable switch reachable on every off provider", () => {
+    providerMocks.providers = [
+      providerState("codex", { enabled: true, disabledBy: null }),
+      providerState("grok", { enabled: false, disabledBy: null }),
+    ];
+
+    render(<OnboardingDetectedAgents />);
+
+    const grokSwitch = screen.getByRole("switch", { name: "Enable Grok" });
+    if (!(grokSwitch instanceof HTMLButtonElement)) {
+      throw new Error("Expected the Grok switch to render as a button.");
+    }
+    // Two providers are known and one is on, so the at-least-one rule binds
+    // only the enabled one - the offer is always actionable.
+    expect(grokSwitch.disabled).toBe(false);
+    expect(grokSwitch.getAttribute("aria-checked")).toBe("false");
   });
 });

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -12,6 +12,7 @@ import {
   ORDERED_PROVIDERS,
   providerDisplayName,
 } from "@/lib/provider-ordering";
+import { providerEnablement } from "@/lib/providers/provider-enablement";
 import { cn } from "@/lib/utils";
 
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -49,7 +50,18 @@ function accountLineFor(state: ProviderCliState): AccountLine {
       title: null,
     };
   }
-  if (!state.enabled) return { text: "Disabled", tone: "muted", title: null };
+  // Onboarding is where the seeded set is CONFIRMED, so the two off states have
+  // to read differently here more than anywhere else. Everything the host did
+  // not seed arrives `enabled: false` with no `disabledBy`, and this row is the
+  // user's first sight of it: the line offers it, and the switch beside it
+  // accepts. Only a provider a person actually turned off says "Disabled".
+  const enablement = providerEnablement(state);
+  if (enablement === "never-enabled") {
+    return { text: "Not enabled - turn on to use", tone: "muted", title: null };
+  }
+  if (enablement === "disabled") {
+    return { text: "Disabled", tone: "muted", title: null };
+  }
   const { auth } = state;
   if (state.authPending) {
     return { text: "Checking account…", tone: "muted", title: null };

--- a/clients/gui-app/src/components/providers/__tests__/provider-pack-readiness.test.ts
+++ b/clients/gui-app/src/components/providers/__tests__/provider-pack-readiness.test.ts
@@ -276,6 +276,35 @@ describe("providerPackPreparingByHarnessId", () => {
     expect([...map.keys()]).toEqual(["claude"]);
     expect(map.get("claude")?.percent).toBe(10);
   });
+
+  // Providers default off, so the catalog is mostly disabled rows. The picker
+  // rail treats a map entry as its own reason to keep a provider visible, and
+  // `managedInstallState` is NOT cleared when a provider is switched off - so
+  // without this gate a pack left downloading or failed at disable time would
+  // put an unselectable row back in the picker.
+  it("omits disabled providers, whatever their pack state says", () => {
+    const disabled = (
+      providerId: ProviderCliState["providerId"],
+      managedInstallState: ProviderManagedInstallState,
+    ): ProviderCliState => ({
+      ...providerState(providerId, managedInstallState),
+      enabled: false,
+      disabledBy: null,
+    });
+
+    const map = providerPackPreparingByHarnessId([
+      disabled("claude-code", { status: "downloading", percent: 10 }),
+      disabled("codex", {
+        status: "error",
+        reason: "disk-full",
+        message: "ENOSPC",
+        retryAtMs: null,
+      }),
+      providerState("amp", { status: "downloading", percent: 20 }),
+    ]);
+
+    expect([...map.keys()]).toEqual(["amp"]);
+  });
 });
 
 describe("preparing labels", () => {

--- a/clients/gui-app/src/components/providers/provider-pack-readiness.ts
+++ b/clients/gui-app/src/components/providers/provider-pack-readiness.ts
@@ -149,6 +149,15 @@ export function providerPackPreparingByHarnessId(
 ): ReadonlyMap<GuiHarnessId, ProviderPackPreparing> {
   const entries = new Map<GuiHarnessId, ProviderPackPreparing>();
   for (const provider of providers) {
+    // A disabled provider is filtered out of the picker by availability alone
+    // (the host reports it unavailable and, deliberately, `requiresApiKey:
+    // false`) - EXCEPT through this map, which the rail treats as its own
+    // reason to keep a row visible. `managedInstallState` is not cleared when a
+    // provider goes off, so a pack left mid-download or in `error` when it was
+    // disabled would re-materialize that provider in the picker as a row the
+    // user cannot select and did not ask for. Enablement decides visibility;
+    // pack state only decorates a provider that is already visible.
+    if (!provider.enabled) continue;
     const preparing = providerPackPreparingForProvider(provider);
     if (preparing === null) continue;
     entries.set(providerIdToGuiHarnessId(provider.providerId), preparing);

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rail-controls.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rail-controls.test.tsx
@@ -166,7 +166,7 @@ describe("<ProviderRailControls />", () => {
     });
 
     openFilterMenu();
-    fireEvent.click(screen.getByRole("menuitemradio", { name: "Disabled" }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Not enabled" }));
 
     expect(onViewChange).toHaveBeenCalledWith({
       query: "",
@@ -198,7 +198,7 @@ describe("<ProviderRailControls />", () => {
     // screen reader gets from a filtered rail is the word "Filter".
     expect(
       screen.getByRole("button", {
-        name: "Filter providers, showing disabled",
+        name: "Filter providers, showing not enabled",
       }),
     ).toBeDefined();
   });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rail-filter.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rail-filter.test.ts
@@ -166,8 +166,10 @@ describe("providerRailStatusLabel", () => {
     expect(providerRailStatusLabel(PROVIDER_RAIL_STATUS.Enabled)).toBe(
       "Enabled",
     );
+    // Not "Disabled": the bucket is every provider that is off, and providers
+    // ship off by default, so most of it was never disabled by anyone.
     expect(providerRailStatusLabel(PROVIDER_RAIL_STATUS.Disabled)).toBe(
-      "Disabled",
+      "Not enabled",
     );
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -2089,6 +2089,178 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(providerMocks.setEnabledMutate).not.toHaveBeenCalled();
   });
 
+  // Providers ship OFF, so `enabled: false` is the resting state of most of
+  // the catalog rather than evidence of a decision. `disabledBy` is the only
+  // thing that distinguishes the two, and these three tests pin each arm to the
+  // words it may use.
+  it("calls a never-enabled provider 'Not enabled' and invites turning it on", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        providerState({
+          providerId: "traycer",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        {
+          ...providerState({
+            providerId: "codex",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+          }),
+          enabled: false,
+          disabledBy: null,
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Codex/i }));
+
+    // Through the switch's accessible name, which the `<label htmlFor>` beside
+    // it supplies - a bare text query also matches the rail filter's
+    // "Not enabled" menu item, which Radix keeps mounted while shut.
+    expect(screen.getByRole("switch", { name: "Not enabled" })).toBeDefined();
+    expect(tooltipTextNear(screen.getByRole("switch"))).toBe(
+      "Turn on to use Codex when creating an agent.",
+    );
+  });
+
+  it("still says 'Disabled' for a provider a person turned off", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        providerState({
+          providerId: "traycer",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        {
+          ...providerState({
+            providerId: "codex",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+          }),
+          enabled: false,
+          disabledBy: {
+            userId: "4b1b3f3b-1d55-4a1c-9a2a-d0c6ab6e6c33",
+            handle: "pranshu",
+            at: 1,
+          },
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Codex/i }));
+
+    expect(screen.getByRole("switch", { name: "Disabled" })).toBeDefined();
+    // No invitation: a deliberate disable is a decision, not a gap to fill.
+    expect(tooltipTextNear(screen.getByRole("switch"))).toBeNull();
+  });
+
+  // The floor the host seeds is four providers, not one, so the client rule has
+  // to keep working well clear of its own edge - a fresh install must still be
+  // able to turn any of the four off.
+  it("lets a provider be disabled while the seeded floor is enabled", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        ...(["claude-code", "codex", "opencode", "traycer"] as const).map(
+          (providerId) =>
+            providerState({
+              providerId,
+              selected: { kind: "bundled" },
+              candidates: [],
+              envOverrides: [],
+            }),
+        ),
+        {
+          ...providerState({
+            providerId: "grok",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+          }),
+          enabled: false,
+          disabledBy: null,
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Codex/i }));
+    const switchElement = screen.getByRole("switch");
+    if (!(switchElement instanceof HTMLButtonElement)) {
+      throw new Error("Expected provider switch to render as a button.");
+    }
+
+    expect(switchElement.disabled).toBe(false);
+    fireEvent.click(switchElement);
+
+    expect(providerMocks.setEnabledMutate).toHaveBeenCalledWith({
+      providerId: "codex",
+      enabled: false,
+      profileAction: null,
+    });
+  });
+
+  it("enables a never-enabled provider through the same setEnabled flow", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        providerState({
+          providerId: "traycer",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        {
+          ...providerState({
+            providerId: "grok",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+          }),
+          enabled: false,
+          disabledBy: null,
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Grok/i }));
+    fireEvent.click(screen.getByRole("switch"));
+
+    // The pack download rides this mutation host-side, so "invite to enable"
+    // must not have become a different (or no) call.
+    expect(providerMocks.setEnabledMutate).toHaveBeenCalledWith({
+      providerId: "grok",
+      enabled: true,
+      profileAction: null,
+    });
+  });
+
   it("renders capability-driven tabs and hides unsupported ones", () => {
     providerMocks.listResult.data = {
       providers: [

--- a/clients/gui-app/src/components/settings/panels/provider-rail-filter.ts
+++ b/clients/gui-app/src/components/settings/panels/provider-rail-filter.ts
@@ -27,7 +27,12 @@ export const PROVIDER_RAIL_STATUS_OPTIONS: ReadonlyArray<{
 }> = [
   { value: PROVIDER_RAIL_STATUS.All, label: "All" },
   { value: PROVIDER_RAIL_STATUS.Enabled, label: "Enabled" },
-  { value: PROVIDER_RAIL_STATUS.Disabled, label: "Disabled" },
+  // The value stays `disabled` (it is the `enabled === false` bucket, and the
+  // filter has no third axis), but the LABEL cannot: providers ship off by
+  // default, so this bucket is mostly providers nobody has ever touched. A
+  // menu item reading "Disabled" over a list of never-enabled providers claims
+  // a decision that was never made. "Not enabled" is true of both members.
+  { value: PROVIDER_RAIL_STATUS.Disabled, label: "Not enabled" },
 ];
 
 export interface ProviderRailView {

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -39,6 +39,10 @@ import {
   providerIdToGuiHarnessId,
   sortProviderStatesByProviderOrder,
 } from "@/lib/provider-ordering";
+import {
+  providerEnableInvitation,
+  providerEnablementLabel,
+} from "@/lib/providers/provider-enablement";
 import { ProviderAuthBadge, ProviderAuthLine } from "./provider-auth-display";
 import { TraycerSubscriptionSection } from "./traycer-subscription-section";
 import { ProviderRateLimitForProvider } from "./provider-rate-limit-section";
@@ -349,7 +353,10 @@ function ProvidersSettingsPanelInner({
   return (
     <SettingsPanelShell
       title="Providers"
-      description="Choose the CLI binary Traycer runs for each coding agent. Pick the bundled binary, one found on your PATH, or a custom install. Disable a provider to hide it when creating an agent."
+      // Providers ship off by default, so the enablement sentence leads with
+      // turning one ON. The old copy ("Disable a provider to hide it…") read as
+      // if everything were already on and the only move left were subtraction.
+      description="Choose the CLI binary Traycer runs for each coding agent. Pick the bundled binary, one found on your PATH, or a custom install. Enable a provider to offer it when creating an agent."
       fillHeight
       bodyClassName="max-h-[min(85vh,52rem)]"
       // No host readout here — the sidebar states the scoped host one row
@@ -695,8 +702,7 @@ function TraycerSubscriptionForProvider({
 
 function ProviderEnableSwitch(props: {
   readonly id: string;
-  readonly providerId: ProviderCliState["providerId"];
-  readonly enabled: boolean;
+  readonly state: ProviderCliState;
   readonly isPending: boolean;
   readonly enabledProviderCount: number;
   readonly onSetEnabled: (
@@ -704,24 +710,33 @@ function ProviderEnableSwitch(props: {
     enabled: boolean,
   ) => void;
 }) {
-  const { id, providerId, enabled, isPending, onSetEnabled } = props;
+  const { id, state, isPending, onSetEnabled } = props;
+  const enabled = state.enabled;
   const disablingLast = enabled && props.enabledProviderCount <= 1;
+  // The last-enabled guard wins when both apply - it is the only one that
+  // explains why the control below refuses to move. The invitation is the
+  // resting case: a provider that has never been enabled says what turning it
+  // on buys, and one a person deliberately turned off says nothing at all.
+  const tooltip = disablingLast
+    ? "At least one provider must stay enabled."
+    : providerEnableInvitation(state, PROVIDER_DISPLAY_NAMES[state.providerId]);
   return (
     <TooltipWrapper
-      label={disablingLast ? "At least one provider must stay enabled." : null}
+      label={tooltip}
       side="top"
       sideOffset={undefined}
       align={undefined}
     >
-      {/* Guard span: the Switch is `disabled` in exactly the state this
-          explains, and a disabled control emits no pointer events. */}
+      {/* Guard span: the Switch is `disabled` in exactly the last-enabled state
+          the tooltip explains, and a disabled control emits no pointer
+          events. */}
       <span className="inline-flex">
         <Switch
           id={id}
           checked={enabled}
           onCheckedChange={(next) => {
             if (isPending || (!next && disablingLast)) return;
-            onSetEnabled(providerId, next);
+            onSetEnabled(state.providerId, next);
           }}
           disabled={isPending || disablingLast}
         />
@@ -837,12 +852,11 @@ function ProviderDetail({
         </div>
         <div className="flex shrink-0 items-center gap-2 text-ui-sm">
           <label htmlFor={switchId} className="text-muted-foreground">
-            {state.enabled ? "Enabled" : "Disabled"}
+            {providerEnablementLabel(state)}
           </label>
           <ProviderEnableSwitch
             id={switchId}
-            providerId={providerId}
-            enabled={state.enabled}
+            state={state}
             isPending={setEnabled.isPending}
             enabledProviderCount={enabledProviderCount}
             onSetEnabled={(id, enabled) =>

--- a/clients/gui-app/src/lib/host-error-toast.ts
+++ b/clients/gui-app/src/lib/host-error-toast.ts
@@ -148,7 +148,11 @@ function hostErrorToastMessage(error: HostRpcError, fallback: string) {
     return "Keep at least one workspace folder linked — add another before removing this one.";
   }
   if (error.code === "PROVIDER_DISABLED") {
-    return "This provider is disabled. Enable it in Settings → Providers.";
+    // "Isn't enabled", not "is disabled": the code covers both off states and
+    // this toast has no `disabledBy` to tell them apart. Providers ship off, so
+    // the likelier reader never disabled anything - the sentence has to be true
+    // for them too, and the action is the same either way.
+    return "This provider isn't enabled. Enable it in Settings → Providers.";
   }
   return fallback;
 }

--- a/clients/gui-app/src/lib/providers/__tests__/provider-enablement.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-enablement.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  providerEnableInvitation,
+  providerEnablement,
+  providerEnablementLabel,
+} from "@/lib/providers/provider-enablement";
+
+const DISABLED_BY = {
+  userId: "d0c6ab6e-6c33-4a1c-9a2a-4b1b3f3b1d55",
+  handle: "pranshu",
+  at: 1,
+};
+
+describe("providerEnablement", () => {
+  it("reads an enabled provider as enabled regardless of a stale attribution", () => {
+    expect(providerEnablement({ enabled: true, disabledBy: null })).toBe(
+      "enabled",
+    );
+    // `disabledBy` is cleared on enable, but the client must not depend on that
+    // ordering: `enabled` is the fact, `disabledBy` only explains an off state.
+    expect(providerEnablement({ enabled: true, disabledBy: DISABLED_BY })).toBe(
+      "enabled",
+    );
+  });
+
+  it("separates never-enabled from user-disabled", () => {
+    expect(providerEnablement({ enabled: false, disabledBy: null })).toBe(
+      "never-enabled",
+    );
+    expect(
+      providerEnablement({ enabled: false, disabledBy: DISABLED_BY }),
+    ).toBe("disabled");
+  });
+});
+
+describe("providerEnablementLabel", () => {
+  it("never tells a user they disabled something they never enabled", () => {
+    expect(providerEnablementLabel({ enabled: true, disabledBy: null })).toBe(
+      "Enabled",
+    );
+    expect(providerEnablementLabel({ enabled: false, disabledBy: null })).toBe(
+      "Not enabled",
+    );
+    expect(
+      providerEnablementLabel({ enabled: false, disabledBy: DISABLED_BY }),
+    ).toBe("Disabled");
+  });
+});
+
+describe("providerEnableInvitation", () => {
+  it("invites only the never-enabled state", () => {
+    expect(
+      providerEnableInvitation({ enabled: false, disabledBy: null }, "Codex"),
+    ).toBe("Turn on to use Codex when creating an agent.");
+  });
+
+  it("stays silent for an enabled provider and for a deliberate disable", () => {
+    expect(
+      providerEnableInvitation({ enabled: true, disabledBy: null }, "Codex"),
+    ).toBeNull();
+    expect(
+      providerEnableInvitation(
+        { enabled: false, disabledBy: DISABLED_BY },
+        "Codex",
+      ),
+    ).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/providers/provider-enablement.ts
+++ b/clients/gui-app/src/lib/providers/provider-enablement.ts
@@ -1,0 +1,65 @@
+/**
+ * The tri-state hiding behind the two enablement fields on the wire.
+ *
+ * `enabled` alone is a boolean, but "off" has two meanings and they are not
+ * the same sentence to a user:
+ *
+ *   - `enabled: false` + `disabledBy: null` — the provider has never been
+ *     enabled on this host. Providers ship off by default, so this is the
+ *     resting state of most of the catalog on a fresh install. Nobody turned
+ *     it off, and copy claiming they did describes an action that never
+ *     happened.
+ *   - `enabled: false` + `disabledBy` set — a person switched it off, with the
+ *     audit record to prove it. "Disabled" is accurate here and only here.
+ *
+ * The host draws the same distinction in the availability error it reports
+ * ("Enable in Settings → Providers" vs "Disabled in Settings → Providers"), so
+ * this module exists to keep the client's own copy from drifting away from it.
+ * No new wire field carries the tri-state - the pair already says it.
+ */
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+
+export type ProviderEnablement = "enabled" | "never-enabled" | "disabled";
+
+/** Just the two fields that decide the state, so callers can pass a fixture. */
+export type ProviderEnablementInput = Pick<
+  ProviderCliState,
+  "enabled" | "disabledBy"
+>;
+
+export function providerEnablement(
+  state: ProviderEnablementInput,
+): ProviderEnablement {
+  if (state.enabled) return "enabled";
+  return state.disabledBy === null ? "never-enabled" : "disabled";
+}
+
+/**
+ * The word next to an enable switch. "Not enabled" rather than "Off" so the
+ * label and the control agree on one verb, and rather than "Disabled" so the
+ * default state stops accusing the user of a decision.
+ */
+export const PROVIDER_ENABLEMENT_LABELS: Record<ProviderEnablement, string> = {
+  enabled: "Enabled",
+  "never-enabled": "Not enabled",
+  disabled: "Disabled",
+};
+
+export function providerEnablementLabel(
+  state: ProviderEnablementInput,
+): string {
+  return PROVIDER_ENABLEMENT_LABELS[providerEnablement(state)];
+}
+
+/**
+ * The invitation shown on a never-enabled provider, and `null` for the other
+ * two states - an enabled provider needs no prompt, and a provider a person
+ * deliberately turned off should not be nagged back on.
+ */
+export function providerEnableInvitation(
+  state: ProviderEnablementInput,
+  providerLabel: string,
+): string | null {
+  if (providerEnablement(state) !== "never-enabled") return null;
+  return `Turn on to use ${providerLabel} when creating an agent.`;
+}


### PR DESCRIPTION
## Summary

Client half of the provider default-enablement change (internal sibling PR: host-side versioned overrides + boot initializer). The host now distinguishes a provider that was never enabled (`enabled: false`, `disabledBy: null`) from one a user explicitly disabled (`disabledBy` stamped). This PR makes the GUI render that tri-state honestly.

- New `clients/gui-app/src/lib/providers/provider-enablement.ts`: `providerEnablement()` → `enabled | never-enabled | disabled`, plus label/invitation helpers. `enabled: true` wins over a stale `disabledBy`.
- Settings → Providers: switch label and tooltip go through the tri-state; never-enabled reads "Not enabled" with an invitation to enable, user-disabled stays "Disabled" with no nag. Panel description now says "Enable a provider to offer it…" instead of assuming everything is already on.
- Onboarding detected-agents: account line splits "Not enabled - turn on to use" vs "Disabled"; seeded/detected providers render on purely from host state.
- Provider rail filter: label-only change "Disabled" → "Not enabled" (wire value unchanged — on fresh installs that bucket is most providers, and "Disabled" claimed a decision nobody made).
- `PROVIDER_DISABLED` toast copy neutral for both off states.

## Bug fix (found during verification)

A disabled provider whose managed pack was left `downloading`/`error` at disable time reappeared in the picker rail as an unselectable row: `railHarnessVisible()`'s preparing-map arm is an independent visibility path and the host retains `managedInstallState` on disable. Now `providerPackPreparingByHarnessId()` skips disabled providers. The per-provider helper is deliberately untouched, so Settings CLI notices, the terminal launcher, and sign-in gating still report failed installs truthfully. This becomes a live path once the host-side migration disables providers on existing installs.

## Testing

- New unit tests: tri-state helper (all arms), settings panel (labels/invitation/floor-of-4 disable-ability/enable fires `providers.setEnabled`), onboarding three-way account line, preparing-map gate, rail filter labels.
- `bun run compile` clean across all 5 projects; lint/format clean; pre-commit passed.
- Full gui-app suite: 11614/11620 — the 6 failures (scroll-restoration, reading-position) reproduce identically on a clean tree; environment issue, unrelated.