### PR TITLE
fix(desktop): stop the removal sentinel's initial load overwriting a completed mark

### DIFF
--- a/clients/desktop/src/electron-main/host/__tests__/host-removal-state-load-race.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-removal-state-load-race.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HostRemovalState } from "../../../ipc-contracts/host-management-types";
+
+/**
+ * **The initial load must never overwrite a completed mutation** (the
+ * remove-vs-preflight cache race).
+ *
+ * `isHostRemovedByUser()` lazily loads the sentinel from disk on first call.
+ * That load is async, and `markHostRemovedByUser()` /
+ * `clearHostRemovedByUser()` can start AND fully complete while it is still
+ * in flight - `removeTraycer` and the launch-time converge preflight run
+ * concurrently by design, so this is a real interleaving, not a theoretical
+ * one. The load's result is then a PRE-mutation snapshot of the file; caching
+ * it unconditionally overwrites the value the mutation just confirmed to
+ * disk, and every subsequent gate (`convergeReady`, `respawn`,
+ * `recoverIfDown`, `applyStaged`) reads the stale answer from cache until the
+ * process restarts. For `mark` that means the app can silently reinstall the
+ * host the user just removed - exactly what the sentinel exists to prevent.
+ *
+ * The store is faked HERE (unlike the sibling sentinel-contract suite, which
+ * deliberately uses the real writer): disk-load timing is the
+ * nondeterministic boundary under test, and only a controllable load can hold
+ * the initial read open while a mutation completes. The fake preserves the
+ * real store's contract - `load()` never rejects, `save()` mutates the
+ * backing value, mark's readback load sees the post-save value.
+ */
+
+type Deferred = {
+  readonly promise: Promise<HostRemovalState>;
+  readonly resolve: (value: HostRemovalState) => void;
+};
+
+function deferred(): Deferred {
+  let resolve: (value: HostRemovalState) => void = () => undefined;
+  const promise = new Promise<HostRemovalState>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+// Mutable fake-store state, reset per test. `deferredLoads` holds loads that
+// were captured instead of resolving immediately; each entry also snapshots
+// the disk value AT CALL TIME, which is what a real slow read would return.
+let diskValue: HostRemovalState;
+let loadCalls: number;
+let deferNextLoad: boolean;
+let capturedLoads: Array<{ gate: Deferred; snapshot: HostRemovalState }>;
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/unused-by-faked-store"),
+    isPackaged: false,
+    getAppPath: vi.fn(() => "/tmp"),
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    transports: { file: { level: "info" }, console: { level: "info" } },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../app/json-file-store", () => ({
+  createJsonFileStore: () => ({
+    load: (): Promise<HostRemovalState> => {
+      loadCalls += 1;
+      if (deferNextLoad) {
+        deferNextLoad = false;
+        const entry = { gate: deferred(), snapshot: { ...diskValue } };
+        capturedLoads.push(entry);
+        return entry.gate.promise;
+      }
+      return Promise.resolve({ ...diskValue });
+    },
+    save: (value: HostRemovalState): Promise<void> => {
+      diskValue = { ...value };
+      return Promise.resolve();
+    },
+    saveStrict: (value: HostRemovalState): Promise<void> => {
+      diskValue = { ...value };
+      return Promise.resolve();
+    },
+    flush: (): Promise<void> => Promise.resolve(),
+  }),
+}));
+
+const {
+  __resetHostRemovalStateForTest,
+  clearHostRemovedByUser,
+  isHostRemovedByUser,
+  markHostRemovedByUser,
+} = await import("../host-removal-state");
+
+/** Release captured load N with the disk snapshot it would really have read. */
+function releaseCapturedLoad(index: number): void {
+  const entry = capturedLoads[index];
+  entry.gate.resolve(entry.snapshot);
+}
+
+describe("host-removal-state: initial load vs completed mutation", () => {
+  beforeEach(() => {
+    diskValue = { removedByUser: false };
+    loadCalls = 0;
+    deferNextLoad = false;
+    capturedLoads = [];
+    __resetHostRemovalStateForTest();
+  });
+
+  afterEach(() => {
+    __resetHostRemovalStateForTest();
+  });
+
+  it("a stale initial load cannot overwrite a completed mark", async () => {
+    // 1. First read begins; its disk load is held open (snapshot: false).
+    deferNextLoad = true;
+    const firstRead = isHostRemovedByUser();
+
+    // 2. The user's removal completes fully while that load is in flight:
+    //    persisted, readback-confirmed, cache installed.
+    await markHostRemovedByUser();
+
+    // 3. The slow load finally resolves with its pre-mark snapshot.
+    releaseCapturedLoad(0);
+
+    // The in-flight read must yield the post-mutation truth, not its stale
+    // snapshot...
+    await expect(firstRead).resolves.toBe(true);
+    // ...and, decisive for the product: later gates must keep seeing it.
+    // Before the adopt-once guard, the stale snapshot overwrote the cache
+    // here and every converge/respawn gate read `false` until restart.
+    await expect(isHostRemovedByUser()).resolves.toBe(true);
+  });
+
+  it("a stale initial load cannot resurrect a cleared sentinel", async () => {
+    // Device starts in the removed state.
+    diskValue = { removedByUser: true };
+
+    deferNextLoad = true;
+    const firstRead = isHostRemovedByUser();
+
+    // Reinstall clears the sentinel while the load is in flight.
+    await clearHostRemovedByUser();
+
+    releaseCapturedLoad(0);
+
+    await expect(firstRead).resolves.toBe(false);
+    await expect(isHostRemovedByUser()).resolves.toBe(false);
+  });
+
+  it("concurrent first reads share one disk load", async () => {
+    deferNextLoad = true;
+    const a = isHostRemovedByUser();
+    const b = isHostRemovedByUser();
+
+    releaseCapturedLoad(0);
+
+    await expect(a).resolves.toBe(false);
+    await expect(b).resolves.toBe(false);
+    expect(loadCalls).toBe(1);
+  });
+
+  it("plain first read still adopts the disk value", async () => {
+    diskValue = { removedByUser: true };
+    await expect(isHostRemovedByUser()).resolves.toBe(true);
+    // Cached now: no further loads.
+    await expect(isHostRemovedByUser()).resolves.toBe(true);
+    expect(loadCalls).toBe(1);
+  });
+});

--- a/clients/desktop/src/electron-main/host/host-removal-state.ts
+++ b/clients/desktop/src/electron-main/host/host-removal-state.ts
@@ -25,6 +25,7 @@ const DEFAULT_STATE: HostRemovalState = { removedByUser: false };
 
 let store: JsonFileStore<HostRemovalState> | null = null;
 let cached: HostRemovalState | null = null;
+let loadInFlight: Promise<HostRemovalState> | null = null;
 
 function getStore(): JsonFileStore<HostRemovalState> {
   if (store === null) {
@@ -54,10 +55,29 @@ function parseRemovalState(value: unknown): HostRemovalState {
  * device. Reads the cached value after the first load; the cache is kept in
  * lockstep with `mark` / `clear` below so a synchronous-feeling read after a
  * mutation always reflects it.
+ *
+ * The initial load ADOPTS ONCE and never overwrites. A completed `mark` /
+ * `clear` installs the authoritative value directly, and a first read's disk
+ * load can still be in flight while that happens - its result is then a
+ * pre-mutation snapshot. The previous unconditional `cached = await load()`
+ * let that stale snapshot overwrite a confirmed mark, after which every
+ * gate in the auto-provision paths read removed=false from cache while disk
+ * said true - re-enabling exactly the silent host reinstall this sentinel
+ * exists to prevent, until the next process restart. Concurrent first reads
+ * also share one in-flight load, so the adoption decision happens once.
+ * (`JsonFileStore.load` is non-throwing by contract - it falls back - so the
+ * in-flight promise cannot stick around rejected.)
  */
 export async function isHostRemovedByUser(): Promise<boolean> {
   if (cached === null) {
-    cached = await getStore().load();
+    if (loadInFlight === null) {
+      loadInFlight = getStore().load();
+    }
+    const loaded = await loadInFlight;
+    loadInFlight = null;
+    if (cached === null) {
+      cached = loaded;
+    }
   }
   return cached.removedByUser;
 }
@@ -99,4 +119,5 @@ export async function clearHostRemovedByUser(): Promise<void> {
 export function __resetHostRemovalStateForTest(): void {
   store = null;
   cached = null;
+  loadInFlight = null;
 }


### PR DESCRIPTION
## The race

`isHostRemovedByUser()` lazily loads the sentinel on first call:

```ts
if (cached === null) {
  cached = await getStore().load();   // unconditional adoption
}
```

That load is async, and `markHostRemovedByUser()` can start **and fully complete** while it is in flight — `removeTraycer` and the launch-time converge preflight run concurrently by design, so this interleaving is real, not theoretical:

1. A preflight calls `isHostRemovedByUser()`; the disk load begins (file says `false`).
2. The user's removal completes: saved, flushed, **readback-confirmed**, `cached = { removedByUser: true }`.
3. The slow load resolves with its pre-mark snapshot and executes `cached = { removedByUser: false }`.

## Why it matters

The overwrite inverts the module's whole purpose. After a confirmed removal, every auto-provision gate — `convergeReady`, `respawn`, `recoverIfDown`, the launch-time `applyStaged` reconcile — reads `removed=false` from the poisoned cache until the next process restart. That re-enables exactly the silent host reinstall this sentinel exists to prevent, on the one path where the module is otherwise scrupulous: `mark` refuses to trust memory until the write is confirmed on disk, then loses all of it to a read that merely *started* earlier. The mirror race on `clear` resurrects a cleared sentinel and refuses a requested reinstall.

## The fix

The initial load **adopts once**: it populates the cache only if no completed mutation installed the authoritative value first, and concurrent first reads share a single in-flight load so the adoption decision happens exactly once. Mutations remain the only other writers. (`JsonFileStore.load` is non-throwing by contract — it falls back — so the shared promise cannot stick around rejected.)

No behavior change on the ordinary path: a plain first read still adopts the disk value, and the byte-shape contract suite (`host-removal-state-sentinel-contract.test.ts`) passes untouched.

## Tests, ablation-verified

New `host-removal-state-load-race.test.ts` fakes the store — deliberately unlike the sibling contract suite, which uses the real writer — because disk-load *timing* is the nondeterministic boundary under test; only a controllable load can hold the first read open while a mutation completes. Four cases: the mark race, the clear race, single-flighted concurrent first reads, and the plain first read.

With the fix reverted to the old one-liner, the three guard-dependent tests go red and the plain-read case stays green — the suite brackets the behavior rather than matching the implementation.

Consumers verified: `host-controller` (removeTraycer/uninstall paths), `host-launch-converge`, `host-login-item`, plus both sentinel suites — 233 tests green.

## Provenance

Found by an adversarial cross-check agent while auditing the flaky `P3: removeTraycer…` test's preconditions (it noticed the lazy-load assignment had no guard against a concurrent completed mark). Fixed separately from the flaky-test work on purpose: this is a product defect, not a test defect.