### PR TITLE
fix(transport): publish remote hosts' negotiated manifests + split the mux handshake manifest

### DIFF
--- a/clients/shared/host-client/REMOTE-TRANSPORT.md
+++ b/clients/shared/host-client/REMOTE-TRANSPORT.md
@@ -114,7 +114,11 @@ every resume**:
 {
   "muxVersion": 1,
   "bearer": "<user JWS>",          // R4-A2: re-presented on attach AND resume
-  "manifest": { "rpc": { …ConnectionManifest… }, "stream": { …ConnectionManifest… } },
+  "manifest": {                     // see "Manifest shape" below - all three keys REQUIRED
+    "rpc": { …ConnectionManifest… },         // released floor ONLY
+    "optionalRpc": { …ConnectionManifest… }, // every non-floor method
+    "stream": { …ConnectionManifest… }
+  },
   "authz": null,                    // R4-D1 RESERVED: versioned session-grant slot (team hosts, v3)
   "resume": null                    // R4-E3 RESERVED: always null (v1 = fresh full attach)
 }
@@ -136,15 +140,38 @@ every resume**:
 
 ```jsonc
 {
-  "manifest": { "rpc": …, "stream": … },      // host's combined manifests
+  "manifest": { "rpc": …, "optionalRpc": …, "stream": … },  // same shape as OPEN
   "capabilities": ["credentialUpdate"]         // additive; e.g. in-place bearer rotation
 }
 ```
 
-Version negotiation is amortized: the client runs `checkCompatibility` (rpc) at
-`OPEN_ACK`, then per-stream `checkStreamMethodCompatibility` at each subscribe,
-reusing the exact framework helpers the local transports use. A hard
-incompatibility → session `FATAL{code:"INCOMPATIBLE"}`.
+### Manifest shape (floor / optional split)
+
+`rpc`, `optionalRpc` and `stream` are **all three required** on both frames -
+`sessionManifestsSchema` rejects a frame missing any of them, and the session
+reconnects rather than proceeding on a manifest it did not understand. An
+implementation that emits only `rpc` + `stream` (the pre-split shape) will have
+every `OPEN`/`OPEN_ACK` refused.
+
+| Key | Contents | Compat-checked? |
+|---|---|---|
+| `rpc` | the RELEASED FLOOR only | **Yes** - a mismatch is session-fatal |
+| `optionalRpc` | every non-floor method | **No** - merged in for version selection, dispatch and capability gating; a peer missing one degrades per the registry's declared strategy |
+| `stream` | all stream methods, merged | per-subscription at subscribe, never session-fatal |
+
+Split the two rpc channels with `splitConnectionManifest(registry,
+RELEASED_FLOOR_METHOD_NAMES)`. A host SHOULD narrow `optionalRpc` to methods it
+actually has a resolver for (`deriveHostManifest`) - advertising one it cannot
+serve makes a client gate the feature ON and then take a 404 instead of its
+clean `E_HOST_UNSUPPORTED` degrade. The floor is deliberately NOT filtered: a
+floor method without a resolver is a host bug, and hiding it would revive the
+fatal equal-set handshake failure.
+
+Version negotiation is amortized: the client runs `checkCompatibility` over the
+FLOOR channel at `OPEN_ACK`, then per-stream `checkStreamMethodCompatibility` at
+each subscribe, reusing the exact framework helpers the local transports use. A
+hard floor incompatibility → session `FATAL{code:"INCOMPATIBLE"}`; an optional
+method either side lacks never fatals the session.
 
 ## 5. Unary RPC (single-flight, no post-send auto-retry — audit C3)
 

--- a/clients/shared/host-client/REMOTE-TRANSPORT.md
+++ b/clients/shared/host-client/REMOTE-TRANSPORT.md
@@ -153,11 +153,11 @@ reconnects rather than proceeding on a manifest it did not understand. An
 implementation that emits only `rpc` + `stream` (the pre-split shape) will have
 every `OPEN`/`OPEN_ACK` refused.
 
-| Key | Contents | Compat-checked? |
-|---|---|---|
-| `rpc` | the RELEASED FLOOR only | **Yes** - a mismatch is session-fatal |
-| `optionalRpc` | every non-floor method | **No** - merged in for version selection, dispatch and capability gating; a peer missing one degrades per the registry's declared strategy |
-| `stream` | all stream methods, merged | per-subscription at subscribe, never session-fatal |
+| Key           | Contents                   | Compat-checked?                                                                                                                            |
+| ------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `rpc`         | the RELEASED FLOOR only    | **Yes** - a mismatch is session-fatal                                                                                                      |
+| `optionalRpc` | every non-floor method     | **No** - merged in for version selection, dispatch and capability gating; a peer missing one degrades per the registry's declared strategy |
+| `stream`      | all stream methods, merged | per-subscription at subscribe, never session-fatal                                                                                         |
 
 Split the two rpc channels with `splitConnectionManifest(registry,
 RELEASED_FLOOR_METHOD_NAMES)`. A host SHOULD narrow `optionalRpc` to methods it

--- a/clients/shared/host-transport/negotiated-manifest-registry.ts
+++ b/clients/shared/host-transport/negotiated-manifest-registry.ts
@@ -11,8 +11,20 @@
  * failing the handshake.
  *
  * So the client records each `openAck`'s merged method names here, keyed by
- * host id, and UI layers read it through a subscription. Three properties make
- * this safe to consult from render:
+ * host id, and UI layers read it through a subscription. BOTH transports must
+ * publish - this registry is the one place "does host X have method Y" is
+ * answered, and a transport that skips it makes every optional-method gate
+ * fail closed forever for its hosts (the exact defect that shipped when the
+ * remote transport initially didn't publish):
+ *
+ * - `WsRpcClient` (local): records on every unary ack - per-call re-handshake
+ *   is the refresh cadence.
+ * - `RemoteSession` (remote mux): records at each session-open ack - the
+ *   re-attach after a socket drop is the refresh cadence, since the session
+ *   is long-lived. The host advertises its MERGED (floor + optional) rpc
+ *   manifest on both paths.
+ *
+ * Three properties make this safe to consult from render:
  *
  * - **Fail-closed.** A host with no recorded handshake reads `null` ("not yet
  *   known"), never `false`. Callers hide an optional affordance until a

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   defineVersionedRpcRegistry,
@@ -32,6 +32,10 @@ import {
   HostTransportFailureError,
   RetryableTransportError,
 } from "../../host-messenger";
+import {
+  getNegotiatedHostMethods,
+  resetNegotiatedManifests,
+} from "../../negotiated-manifest-registry";
 import type { StreamAuthRevalidator } from "@traycer-clients/shared/auth/bearer-revalidator";
 import type {
   IStreamWebSocketFactory,
@@ -165,6 +169,14 @@ class FakeRelayHost {
   /** Params carried by every logical subscribe, including reconnect replay. */
   readonly subscribeParams: unknown[] = [];
   streamManifest = buildStreamManifest(emptyStreamRegistry);
+  /**
+   * The OPTIONAL rpc manifest the fake host advertises in `openAck`. Floor
+   * stays empty (matching the empty client registries here); optional
+   * methods are the interesting surface - they must publish to the
+   * negotiated-manifest registry and must NEVER fatal the session, however
+   * unknown to the client they are.
+   */
+  optionalRpcManifest: Record<string, { major: number; minor: number }> = {};
   /** Unexpected harness-side failures; asserted empty by the tests. */
   readonly errors: unknown[] = [];
   decideOpen: (bearer: string, openIndex: number) => OpenDecision = () => ({
@@ -311,7 +323,11 @@ class FakeRelayHost {
         streamId: SESSION_CONTROL_STREAM_ID,
         qos: QosClass.INTERACTIVE,
         json: {
-          manifest: { rpc: {}, stream: this.streamManifest },
+          manifest: {
+            rpc: {},
+            optionalRpc: this.optionalRpcManifest,
+            stream: this.streamManifest,
+          },
           capabilities: [],
         },
         binary: null,
@@ -1006,4 +1022,79 @@ describe("RemoteSession dial-failure logging", () => {
       session.close();
     }
   });
+});
+
+describe("RemoteSession negotiated-manifest publication", () => {
+  // The registry is module-level by design (a host's manifest is a property
+  // of the host process, not of one messenger), so these tests reset it.
+  beforeEach(() => {
+    resetNegotiatedManifests();
+  });
+
+  it(
+    "publishes the openAck's merged rpc manifest at the ready boundary - optional methods included",
+    async () => {
+      const relay = new FakeRelayHost();
+      // Methods the CLIENT's registry does not know: exactly the shape of an
+      // optional (non-floor) method a newer host advertises - the case that
+      // silently failed closed when the remote path did not publish.
+      relay.optionalRpcManifest = {
+        "host.usage.summary": { major: 1, minor: 0 },
+        "workspace.writeFile": { major: 2, minor: 1 },
+      };
+      const lease = new MutableBearerLease("token", "user-1");
+      const session = buildSession(relay, lease, null);
+      // Fail-closed before any handshake: unknown, never false.
+      expect(getNegotiatedHostMethods("host-1")).toBeNull();
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+        expect(getNegotiatedHostMethods("host-1")).toEqual(
+          new Set(["host.usage.summary", "workspace.writeFile"]),
+        );
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+
+  it(
+    "refreshes the published set on re-attach - a host upgraded under a live session self-corrects",
+    async () => {
+      const relay = new FakeRelayHost();
+      relay.optionalRpcManifest = {
+        "host.usage.summary": { major: 1, minor: 0 },
+      };
+      const lease = new MutableBearerLease("token", "user-1");
+      const session = buildSession(relay, lease, null);
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+        expect(getNegotiatedHostMethods("host-1")).toEqual(
+          new Set(["host.usage.summary"]),
+        );
+        // The host restarts on a newer binary advertising one more optional
+        // method; the client's re-attach after the drop must overwrite the
+        // stale entry without an app restart.
+        relay.optionalRpcManifest = {
+          "host.usage.summary": { major: 1, minor: 0 },
+          "host.newly.added": { major: 1, minor: 0 },
+        };
+        relay.dropCurrentConnection();
+        await vi.waitFor(
+          () =>
+            expect(getNegotiatedHostMethods("host-1")).toEqual(
+              new Set(["host.usage.summary", "host.newly.added"]),
+            ),
+          WAIT,
+        );
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 });

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
+  defineFallbackMethodDegrade,
   defineFloorAwareVersionedRpcRegistry,
   defineRpcContract,
+  defineUpgradePath,
   defineVersionedRpcRegistry,
   type FatalErrorDetails,
   type VersionedRpcRegistry,
@@ -180,6 +182,23 @@ class FakeRelayHost {
    * unknown to the client they are.
    */
   optionalRpcManifest: Record<string, { major: number; minor: number }> = {};
+  /** The FLOOR rpc manifest advertised in `openAck` (compat-checked). */
+  floorRpcManifest: Record<string, { major: number; minor: number }> = {};
+  /**
+   * When false the `openAck` omits `optionalRpc` entirely - the shape a peer
+   * built before the floor/optional split would send. `sessionManifestsSchema`
+   * requires the field, so this exercises the parse-rejection path rather
+   * than a silently half-understood manifest.
+   */
+  sendOptionalRpc = true;
+  /** Every REQUEST frame the client sent: method + on-wire version + params. */
+  readonly unaryRequests: {
+    method: string;
+    schemaVersion: unknown;
+    params: unknown;
+  }[] = [];
+  /** Answers the next REQUEST with this result payload. */
+  unaryResult: unknown = { ready: true };
   /** Unexpected harness-side failures; asserted empty by the tests. */
   readonly errors: unknown[] = [];
   decideOpen: (bearer: string, openIndex: number) => OpenDecision = () => ({
@@ -307,6 +326,27 @@ class FakeRelayHost {
       this.subscribeParams.push(message.json?.params);
       return;
     }
+    if (message.type === MuxFrameType.REQUEST) {
+      const json = message.json ?? {};
+      this.unaryRequests.push({
+        method: typeof json.method === "string" ? json.method : "",
+        schemaVersion: json.schemaVersion,
+        params: json.params,
+      });
+      await this.sendMux(connection, {
+        type: MuxFrameType.RESPONSE,
+        streamId: message.streamId,
+        qos: QosClass.INTERACTIVE,
+        json: {
+          requestId: typeof json.requestId === "string" ? json.requestId : "",
+          method: typeof json.method === "string" ? json.method : "",
+          result: this.unaryResult,
+          error: null,
+        },
+        binary: null,
+      });
+      return;
+    }
     if (
       message.streamId !== SESSION_CONTROL_STREAM_ID ||
       message.type !== MuxFrameType.OPEN
@@ -326,11 +366,13 @@ class FakeRelayHost {
         streamId: SESSION_CONTROL_STREAM_ID,
         qos: QosClass.INTERACTIVE,
         json: {
-          manifest: {
-            rpc: {},
-            optionalRpc: this.optionalRpcManifest,
-            stream: this.streamManifest,
-          },
+          manifest: this.sendOptionalRpc
+            ? {
+                rpc: this.floorRpcManifest,
+                optionalRpc: this.optionalRpcManifest,
+                stream: this.streamManifest,
+              }
+            : { rpc: this.floorRpcManifest, stream: this.streamManifest },
           capabilities: [],
         },
         binary: null,
@@ -1157,6 +1199,159 @@ describe("RemoteSession absent optional method", () => {
             ?.hostShouldUpgrade,
         ).toBe(true);
         expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+});
+
+describe("RemoteSession fallback degrade version anchoring", () => {
+  // `degrade.to` names version 1.0 while the target's canonical is 1.1. The
+  // request handed to the fallback is ALREADY adapted to 1.0, so dispatching
+  // it at canonical would validate `{}` against 1.1's `{verbose}` schema and
+  // transform the response with the wrong contract. Re-entering the public
+  // `sendUnary` would do exactly that - hence the version-preserving internal
+  // dispatch this pins.
+  const statusV10 = defineRpcContract({
+    method: "host.status",
+    schemaVersion: { major: 1, minor: 0 } as const,
+    requestSchema: z.object({}),
+    responseSchema: z.object({ ready: z.boolean() }),
+  });
+  const statusV11 = defineRpcContract({
+    method: "host.status",
+    schemaVersion: { major: 1, minor: 1 } as const,
+    requestSchema: z.object({ verbose: z.boolean() }),
+    responseSchema: z.object({ ready: z.boolean(), detail: z.string() }),
+  });
+  const skewFallbackV10 = defineRpcContract({
+    method: "host.syntheticSkewFallback",
+    schemaVersion: { major: 1, minor: 0 } as const,
+    requestSchema: z.object({ label: z.string() }),
+    // `detailSeen` is the DISCRIMINATOR: `detail` exists only on the 1.1
+    // response, so it is true exactly when the response was decoded (and
+    // upgraded) at canonical instead of at the declared 1.0.
+    responseSchema: z.object({ summary: z.string(), detailSeen: z.boolean() }),
+  });
+  const upgradeStatus = defineUpgradePath<typeof statusV10, typeof statusV11>({
+    from: statusV10.schemaVersion,
+    to: statusV11.schemaVersion,
+    upgradeRequest: () => ({ verbose: false }),
+    upgradeResponse: (response) => ({
+      ready: response.ready,
+      detail: "upgraded",
+    }),
+  });
+  const skewRegistry: VersionedRpcRegistry =
+    defineFloorAwareVersionedRpcRegistry(["host.status"] as const, {
+      "host.status": {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: statusV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: statusV11,
+              upgradeFromPreviousVersion: upgradeStatus,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+      "host.syntheticSkewFallback": {
+        degrade: defineFallbackMethodDegrade<
+          typeof skewFallbackV10,
+          typeof statusV10,
+          "host.status"
+        >({
+          kind: "fallback",
+          to: { method: "host.status", major: 1, minor: 0 },
+          adaptRequest: () => ({}),
+          adaptResponse: (response) => ({
+            summary: response.ready ? "ready" : "not-ready",
+            detailSeen: Object.prototype.hasOwnProperty.call(
+              response,
+              "detail",
+            ),
+          }),
+        }),
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: skewFallbackV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    });
+
+  it(
+    "dispatches the fallback at degrade.to, not the target's canonical version",
+    async () => {
+      const relay = new FakeRelayHost();
+      // The host has the older 1.0 target on its FLOOR and NOT the
+      // fallback's own (optional) method.
+      relay.floorRpcManifest = { "host.status": { major: 1, minor: 0 } };
+      relay.unaryResult = { ready: true };
+      const lease = new MutableBearerLease("token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        rpcRegistry: skewRegistry,
+      });
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+        const result: unknown = await session.sendUnary(
+          "host.syntheticSkewFallback",
+          { label: "x" },
+        );
+        // adaptResponse ran over the DECLARED 1.0 response shape: no `detail`
+        // key, i.e. no canonical-version upgrade was applied on the way back.
+        expect(result).toEqual({ summary: "ready", detailSeen: false });
+        // ONE request, sent as host.status anchored at the DECLARED 1.0 -
+        // canonical 1.1 here would have rejected the adapted `{}` payload.
+        expect(relay.unaryRequests).toHaveLength(1);
+        expect(relay.unaryRequests[0]?.method).toBe("host.status");
+        expect(relay.unaryRequests[0]?.schemaVersion).toEqual({
+          major: 1,
+          minor: 0,
+        });
+        expect(relay.unaryRequests[0]?.params).toEqual({});
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+});
+
+describe("RemoteSession openAck without optionalRpc", () => {
+  // The registry is module-level, so a sibling suite's successful handshake
+  // would otherwise leave this host's entry populated.
+  beforeEach(() => {
+    resetNegotiatedManifests();
+  });
+
+  it(
+    "refuses a manifest missing the required optionalRpc rather than half-reading it",
+    async () => {
+      const relay = new FakeRelayHost();
+      // The pre-split frame shape. `sessionManifestsSchema` requires
+      // `optionalRpc`, so this is rejected at parse - it never reaches the
+      // floor compat check, and the merged legacy set is never mistaken for a
+      // floor. The session stays un-ready and retries rather than proceeding
+      // on a manifest it did not understand.
+      relay.sendOptionalRpc = false;
+      const lease = new MutableBearerLease("token", "user-1");
+      const session = buildSession(relay, lease, null);
+      try {
+        session.start();
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        expect(session.isReady()).toBe(false);
+        expect(getNegotiatedHostMethods("host-1")).toBeNull();
+        expect(session.isClosed()).toBe(false);
       } finally {
         session.close();
       }

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
+  defineFloorAwareVersionedRpcRegistry,
+  defineRpcContract,
   defineVersionedRpcRegistry,
   type FatalErrorDetails,
   type VersionedRpcRegistry,
@@ -29,6 +31,7 @@ import {
 } from "@traycer/protocol/host-transport/mux";
 import { MutableBearerLease } from "@traycer-clients/shared/auth/bearer-source";
 import {
+  HostRpcError,
   HostTransportFailureError,
   RetryableTransportError,
 } from "../../host-messenger";
@@ -1090,6 +1093,69 @@ describe("RemoteSession negotiated-manifest publication", () => {
             ),
           WAIT,
         );
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+});
+
+describe("RemoteSession absent optional method", () => {
+  // A method the client knows and the host never advertised. Before the
+  // floor/optional split this was unreachable - the handshake fataled on the
+  // skew - so the remote path had no degrade at all and would have answered a
+  // generic RPC_ERROR. Callers key off E_HOST_UNSUPPORTED (the run-settings
+  // write queue suppresses exactly that code to fall back to legacy
+  // persist-on-next-send), so a generic error reads as a real failure.
+  const unsupportedV10 = defineRpcContract({
+    method: "host.syntheticUnsupported",
+    schemaVersion: { major: 1, minor: 0 } as const,
+    requestSchema: z.object({}),
+    responseSchema: z.object({ ok: z.boolean() }),
+  });
+  // Typed as the erased `VersionedRpcRegistry` at the declaration (same shape
+  // as `emptyRpcRegistry` above) so the session can take it directly - the
+  // repo bans chained/`as unknown` assertions, and none is needed here.
+  const unsupportedRegistry: VersionedRpcRegistry =
+    defineFloorAwareVersionedRpcRegistry([] as const, {
+      "host.syntheticUnsupported": {
+        degrade: { kind: "unsupported" },
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: unsupportedV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    });
+
+  it(
+    "applies the declared unsupported degrade instead of a generic RPC_ERROR",
+    async () => {
+      const relay = new FakeRelayHost();
+      const lease = new MutableBearerLease("token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        rpcRegistry: unsupportedRegistry,
+      });
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+        const error: unknown = await session
+          .sendUnary("host.syntheticUnsupported", {})
+          .then(
+            () => null,
+            (reason: unknown) => reason,
+          );
+        expect(error).toBeInstanceOf(HostRpcError);
+        expect((error as HostRpcError).code).toBe("E_HOST_UNSUPPORTED");
+        expect(
+          (error as HostRpcError).fatalDetails?.upgradeGuidance
+            ?.hostShouldUpgrade,
+        ).toBe(true);
         expect(relay.errors).toEqual([]);
       } finally {
         session.close();

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -7,7 +7,11 @@ import {
   type SchemaVersion,
   type VersionedRpcRegistry,
 } from "@traycer/protocol/framework/index";
-import { canonicalForMethodVersionLine } from "@traycer/protocol/framework/compat-helpers";
+import {
+  mergeConnectionManifests,
+  splitConnectionManifest,
+} from "@traycer/protocol/framework/capability-manifest";
+import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
 import {
   buildStreamManifest,
   checkStreamMethodCompatibility,
@@ -57,6 +61,7 @@ import {
   RECONNECT_MAX_BACKOFF_MS,
 } from "./config";
 import { DialFailureLog } from "./dial-failure-log";
+import { recordNegotiatedHostMethods } from "../negotiated-manifest-registry";
 import {
   CURRENT_MUX_VERSION,
   MuxFrameType,
@@ -248,6 +253,13 @@ interface ActiveConnection {
   readonly reassembler: ChunkReassembler;
   readonly inboundCredits: InboundCreditTracker;
   hostManifest: SessionManifests | null;
+  /**
+   * `hostManifest.rpc` + `hostManifest.optionalRpc`, merged once at ack.
+   * Version selection and dispatch read THIS (an optional method must
+   * dispatch like any other); only the session-level compatibility check
+   * reads the raw floor.
+   */
+  hostRpcMerged: ConnectionManifest | null;
   credentialUpdateSupported: boolean;
   hostAttached: boolean;
 }
@@ -260,6 +272,8 @@ export class RemoteSession<
 {
   private readonly options: RemoteSessionOptions<RpcRegistry, StreamRegistry>;
   private readonly clientManifests: SessionManifests;
+  /** `clientManifests.rpc` + `.optionalRpc` merged - the dispatch view. */
+  private readonly clientRpcMerged: ConnectionManifest;
 
   private phase: SessionPhase = "idle";
   private connectGeneration = 0;
@@ -311,10 +325,23 @@ export class RemoteSession<
 
   constructor(options: RemoteSessionOptions<RpcRegistry, StreamRegistry>) {
     this.options = options;
+    // The same floor/optional split the local `WsRpcClient` advertises, from
+    // the same released-floor list - the remote handshake's compatibility
+    // check runs over the floor ONLY, so a peer that lacks an optional
+    // method degrades instead of fataling the session.
+    const rpcSplit = splitConnectionManifest(
+      options.rpcRegistry,
+      RELEASED_FLOOR_METHOD_NAMES,
+    );
     this.clientManifests = {
-      rpc: buildRpcManifest(options.rpcRegistry),
+      rpc: rpcSplit.manifest,
+      optionalRpc: rpcSplit.optionalManifest,
       stream: buildStreamManifest(options.streamRegistry),
     };
+    this.clientRpcMerged = mergeConnectionManifests(
+      rpcSplit.manifest,
+      rpcSplit.optionalManifest,
+    );
     this.dialFailures = new DialFailureLog({
       label: `remote session (host ${options.hostId})`,
       now: () => Date.now(),
@@ -446,8 +473,8 @@ export class RemoteSession<
       );
     }
 
-    const clientCanonical = this.clientManifests.rpc[method];
-    const hostCanonical = hostManifest.rpc[method];
+    const clientCanonical = this.clientRpcMerged[method];
+    const hostCanonical = connection.hostRpcMerged?.[method];
     if (clientCanonical === undefined || hostCanonical === undefined) {
       return Promise.reject(
         new HostRpcError({
@@ -761,6 +788,7 @@ export class RemoteSession<
       reassembler: new ChunkReassembler(),
       inboundCredits: new InboundCreditTracker(),
       hostManifest: null,
+      hostRpcMerged: null,
       credentialUpdateSupported: false,
       hostAttached: true,
     };
@@ -978,6 +1006,24 @@ export class RemoteSession<
       this.handleConnectionLost(generation, "malformed-openAck");
       return;
     }
+    const hostRpcMerged = mergeConnectionManifests(
+      parsed.data.manifest.rpc,
+      parsed.data.manifest.optionalRpc,
+    );
+    // Publish what this host advertised so UI layers can gate an optional
+    // (non-floor) affordance without calling the method - the exact mirror of
+    // `WsRpcClient`'s publish on the local path, and recorded BEFORE the
+    // compatibility check for the same reason: an incompatible pairing still
+    // tells us truthfully which methods the host has. A long-lived session
+    // refreshes this on every re-attach, which is when a host upgraded
+    // underneath us re-handshakes.
+    recordNegotiatedHostMethods(
+      this.options.hostId,
+      Object.keys(hostRpcMerged),
+    );
+    // Floor vs floor ONLY - optional methods are deliberately outside the
+    // session-fatal surface (see `SessionManifests`); a peer lacking one
+    // degrades per-call/per-gate instead.
     const compat = checkCompatibility(
       this.options.rpcRegistry,
       this.clientManifests.rpc,
@@ -989,6 +1035,7 @@ export class RemoteSession<
       return;
     }
     connection.hostManifest = parsed.data.manifest;
+    connection.hostRpcMerged = hostRpcMerged;
     connection.credentialUpdateSupported = parsed.data.capabilities.includes(
       SESSION_CAPABILITY_CREDENTIAL_UPDATE,
     );
@@ -1743,14 +1790,6 @@ const MAX_NO_PROGRESS_UNAUTHORIZED_RECONNECTS = 3;
  * stream transport's `REVALIDATE_TIMEOUT_MS`.
  */
 const UNAUTHORIZED_REVALIDATE_TIMEOUT_MS = 10_000;
-
-function buildRpcManifest(registry: VersionedRpcRegistry): ConnectionManifest {
-  const manifest: Record<string, SchemaVersion> = {};
-  for (const method of Object.keys(registry)) {
-    manifest[method] = canonicalForMethodVersionLine(registry[method], method);
-  }
-  return manifest;
-}
 
 function indexMethodRegistry(
   registry: VersionedRpcRegistry,

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -489,6 +489,7 @@ export class RemoteSession<
       // legacy persist-on-next-send). A generic `RPC_ERROR` would surface as
       // a real failure instead.
       return this.executeUnavailableMethodDegrade(
+        connection,
         method,
         methodRegistry,
         clientCanonical,
@@ -498,6 +499,35 @@ export class RemoteSession<
       );
     }
 
+    return this.dispatchNegotiatedUnary(
+      connection,
+      method,
+      methodRegistry,
+      clientCanonical,
+      hostCanonical,
+      params,
+      requestId,
+    ) as Promise<ResponseOfMethod<RpcRegistry, Method>>;
+  }
+
+  /**
+   * Sends an ALREADY-negotiated method at EXPLICIT versions.
+   *
+   * The versions are parameters rather than re-derived from the manifests
+   * because a degrade fallback targets the version its declaration names
+   * (`degrade.to`), which is not necessarily the target method's canonical
+   * version - re-deriving would validate the already-adapted request, and
+   * transform the response, against the wrong contract.
+   */
+  private dispatchNegotiatedUnary(
+    connection: ActiveConnection,
+    method: string,
+    methodRegistry: MethodVersionRegistry,
+    clientCanonical: SchemaVersion,
+    hostCanonical: SchemaVersion,
+    params: unknown,
+    requestId: string,
+  ): Promise<unknown> {
     let prepared: { onWireVersion: SchemaVersion; onWirePayload: unknown };
     try {
       prepared = prepareRequestPayload(
@@ -513,8 +543,8 @@ export class RemoteSession<
     }
 
     const streamId = this.allocateStreamId();
-    return new Promise<ResponseOfMethod<RpcRegistry, Method>>(
-      (resolve, reject) => {
+    return new Promise<unknown>((resolve, reject) => {
+      {
         const timer = setTimeout(() => {
           this.rejectUnary(streamId, unaryTimeoutError(requestId, method));
         }, UNARY_RESPONSE_TIMEOUT_MS);
@@ -524,8 +554,7 @@ export class RemoteSession<
           clientCanonical,
           hostCanonical,
           methodRegistry,
-          resolve: (result) =>
-            resolve(result as ResponseOfMethod<RpcRegistry, Method>),
+          resolve,
           reject,
           timer,
         });
@@ -547,8 +576,8 @@ export class RemoteSession<
           this.clearPendingUnary(streamId);
           reject(asHostRpcError(cause, requestId, method));
         }
-      },
-    );
+      }
+    });
   }
 
   /** Opens a logical subscribe stream (interactive class; see §3 QoS note). */
@@ -1009,6 +1038,7 @@ export class RemoteSession<
   private executeUnavailableMethodDegrade<
     Method extends keyof RpcRegistry & string,
   >(
+    connection: ActiveConnection,
     method: Method,
     methodRegistry: MethodVersionRegistry,
     clientCanonical: SchemaVersion | undefined,
@@ -1025,14 +1055,21 @@ export class RemoteSession<
       hostManifest: hostRpcMerged,
       params,
       requestId,
-      // The fallback target is an ordinary negotiated method, so it re-enters
-      // the normal unary path (single-flight, scheduler, timeout) rather than
-      // a bespoke send - it cannot recurse, because a floor method the host
-      // advertises never lands back in this degrade.
+      // Dispatched at the versions the DECLARATION names, not the target's
+      // canonical pair: `degrade.to` may anchor an older version, and the
+      // request handed over here is already adapted to it. Re-entering
+      // `sendUnary` would re-derive canonical versions and validate the
+      // adapted payload - and transform the response - against the wrong
+      // contract. Same anchoring the local transport's fallback tests pin.
       execute: (input) =>
-        this.sendUnary(
-          input.method as Method,
-          input.params as RequestOfMethod<RpcRegistry, Method>,
+        this.dispatchNegotiatedUnary(
+          connection,
+          input.method,
+          input.methodRegistry,
+          input.clientCanonical,
+          input.hostCanonical,
+          input.params,
+          requestId,
         ),
     }) as Promise<ResponseOfMethod<RpcRegistry, Method>>;
   }

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -62,6 +62,7 @@ import {
 } from "./config";
 import { DialFailureLog } from "./dial-failure-log";
 import { recordNegotiatedHostMethods } from "../negotiated-manifest-registry";
+import { resolveUnavailableMethodDegrade } from "../unavailable-method-degrade";
 import {
   CURRENT_MUX_VERSION,
   MuxFrameType,
@@ -475,21 +476,27 @@ export class RemoteSession<
 
     const clientCanonical = this.clientRpcMerged[method];
     const hostCanonical = connection.hostRpcMerged?.[method];
-    if (clientCanonical === undefined || hostCanonical === undefined) {
-      return Promise.reject(
-        new HostRpcError({
-          code: "RPC_ERROR",
-          message: `Method '${method}' is not in both manifests`,
-          requestId,
-          method,
-          fatalDetails: null,
-        }),
-      );
-    }
     const methodRegistry = indexMethodRegistry(
       this.options.rpcRegistry,
       method,
     );
+    if (clientCanonical === undefined || hostCanonical === undefined) {
+      // Now that optional methods no longer fatal the handshake, "this host
+      // doesn't have that method" is a NORMAL runtime outcome here, and it
+      // must honor the registry's declared degrade exactly as `WsRpcClient`
+      // does - callers key off the resulting `E_HOST_UNSUPPORTED` (e.g. the
+      // run-settings write queue suppresses only that code to fall back to
+      // legacy persist-on-next-send). A generic `RPC_ERROR` would surface as
+      // a real failure instead.
+      return this.executeUnavailableMethodDegrade(
+        method,
+        methodRegistry,
+        clientCanonical,
+        connection.hostRpcMerged ?? {},
+        params,
+        requestId,
+      );
+    }
 
     let prepared: { onWireVersion: SchemaVersion; onWirePayload: unknown };
     try {
@@ -991,6 +998,43 @@ export class RemoteSession<
       this.maybeReachReadyBoundary();
     }
     void connection;
+  }
+
+  /**
+   * A method this host never advertised. Applies the registry's DECLARED
+   * degrade through the shared policy (see `unavailable-method-degrade.ts`) -
+   * `E_HOST_UNSUPPORTED` for an `unsupported` declaration, or the declared
+   * floor fallback dispatched back through this same session.
+   */
+  private executeUnavailableMethodDegrade<
+    Method extends keyof RpcRegistry & string,
+  >(
+    method: Method,
+    methodRegistry: MethodVersionRegistry,
+    clientCanonical: SchemaVersion | undefined,
+    hostRpcMerged: ConnectionManifest,
+    params: RequestOfMethod<RpcRegistry, Method>,
+    requestId: string,
+  ): Promise<ResponseOfMethod<RpcRegistry, Method>> {
+    return resolveUnavailableMethodDegrade({
+      registry: this.options.rpcRegistry,
+      method,
+      methodRegistry,
+      clientCanonical,
+      clientManifest: this.clientRpcMerged,
+      hostManifest: hostRpcMerged,
+      params,
+      requestId,
+      // The fallback target is an ordinary negotiated method, so it re-enters
+      // the normal unary path (single-flight, scheduler, timeout) rather than
+      // a bespoke send - it cannot recurse, because a floor method the host
+      // advertises never lands back in this degrade.
+      execute: (input) =>
+        this.sendUnary(
+          input.method as Method,
+          input.params as RequestOfMethod<RpcRegistry, Method>,
+        ),
+    }) as Promise<ResponseOfMethod<RpcRegistry, Method>>;
   }
 
   private handleOpenAck(

--- a/clients/shared/host-transport/unavailable-method-degrade.ts
+++ b/clients/shared/host-transport/unavailable-method-degrade.ts
@@ -1,0 +1,150 @@
+import type {
+  ConnectionManifest,
+  MethodDegradeDeclaration,
+  MethodVersionRegistry,
+  SchemaVersion,
+  VersionedRpcRegistry,
+} from "@traycer/protocol/framework/index";
+import { HostRpcError } from "./host-messenger";
+
+/**
+ * The ONE implementation of "this host does not advertise that method", shared
+ * by both transports.
+ *
+ * A method kept off the released floor is negotiated away by a peer that
+ * lacks it, so every transport must answer the same way: apply the registry's
+ * DECLARED degrade rather than inventing an error. Callers key off that
+ * outcome - `E_HOST_UNSUPPORTED` specifically, which surfaces as "this
+ * feature needs a newer host" and which several call sites suppress to fall
+ * back to legacy behavior (e.g. the run-settings write queue's
+ * persist-on-next-send). A generic `RPC_ERROR` here reads as a real failure
+ * and breaks those fallbacks.
+ *
+ * It lives here rather than inside either transport because the remote mux
+ * session originally had no degrade path at all: its handshake fataled on any
+ * method-set skew, so "host lacks an optional method" was unreachable, and
+ * when the floor/optional split made it reachable the behavior had to be
+ * written twice or shared once. Shared once - a third transport inherits it.
+ *
+ * Transport-specific execution (framing, timeouts, session plumbing) is
+ * injected as {@link UnavailableMethodDegradeOptions.execute}; everything
+ * else - which degrade applies, whether a fallback target is usable, and how
+ * the fallback's request/response are adapted - is identical by construction.
+ */
+export interface UnavailableMethodDegradeOptions<
+  Registry extends VersionedRpcRegistry,
+> {
+  readonly registry: Registry;
+  readonly method: string;
+  readonly methodRegistry: MethodVersionRegistry;
+  /** The client's canonical version, or `undefined` when it has none either. */
+  readonly clientCanonical: SchemaVersion | undefined;
+  readonly clientManifest: ConnectionManifest;
+  readonly hostManifest: ConnectionManifest;
+  readonly params: unknown;
+  readonly requestId: string;
+  /** Transport-specific dispatch of an ALREADY-negotiated method. */
+  readonly execute: (input: {
+    readonly method: string;
+    readonly methodRegistry: MethodVersionRegistry;
+    readonly clientCanonical: SchemaVersion;
+    readonly hostCanonical: SchemaVersion;
+    readonly params: unknown;
+  }) => Promise<unknown>;
+}
+
+/** The error a caller must see for "host too old for this method". */
+export function unsupportedHostMethodError(
+  method: string,
+  requestId: string,
+): HostRpcError {
+  const reason = `This host does not support '${method}'. Upgrade the host to use this feature.`;
+  return new HostRpcError({
+    code: "E_HOST_UNSUPPORTED",
+    message: reason,
+    requestId,
+    method,
+    fatalDetails: {
+      code: "E_HOST_UNSUPPORTED",
+      reason,
+      incompatibleMethods: null,
+      // The host is the side that must move: the client already has the
+      // method. Consumers read this to word the upgrade prompt.
+      upgradeGuidance: {
+        clientShouldUpgrade: false,
+        hostShouldUpgrade: true,
+      },
+    },
+  });
+}
+
+/**
+ * Resolves a call to a method the host did not advertise, per the registry's
+ * declared degrade. Throws `E_HOST_UNSUPPORTED` for an `unsupported` degrade
+ * (or none declared beyond that), and otherwise routes through the declared
+ * floor fallback.
+ */
+export async function resolveUnavailableMethodDegrade<
+  Registry extends VersionedRpcRegistry,
+>(options: UnavailableMethodDegradeOptions<Registry>): Promise<unknown> {
+  const { method, requestId } = options;
+  if (options.clientCanonical === undefined) {
+    throw new HostRpcError({
+      code: "RPC_ERROR",
+      message: `Client registry has no canonical manifest entry for method '${method}'`,
+      requestId,
+      method,
+      fatalDetails: null,
+    });
+  }
+
+  const degrade: MethodDegradeDeclaration | undefined =
+    options.methodRegistry.degrade;
+  if (degrade === undefined) {
+    throw new HostRpcError({
+      code: "RPC_ERROR",
+      message: `Host does not advertise method '${method}', and the client registry declares no degrade strategy`,
+      requestId,
+      method,
+      fatalDetails: null,
+    });
+  }
+  if (degrade.kind !== "fallback") {
+    throw unsupportedHostMethodError(method, requestId);
+  }
+
+  const targetMethod = degrade.to.method;
+  const targetRegistry = options.registry[targetMethod];
+  if (targetRegistry === undefined) {
+    throw new HostRpcError({
+      code: "RPC_ERROR",
+      message: `Fallback for method '${method}' targets unknown method '${targetMethod}'`,
+      requestId,
+      method,
+      fatalDetails: null,
+    });
+  }
+
+  const targetHostCanonical = options.hostManifest[targetMethod];
+  if (
+    options.clientManifest[targetMethod] === undefined ||
+    targetHostCanonical === undefined
+  ) {
+    throw new HostRpcError({
+      code: "RPC_ERROR",
+      message: `Fallback for method '${method}' targets unavailable floor method '${targetMethod}'`,
+      requestId,
+      method,
+      fatalDetails: null,
+    });
+  }
+
+  const fallbackResult = await options.execute({
+    method: targetMethod,
+    methodRegistry: targetRegistry as MethodVersionRegistry,
+    clientCanonical: { major: degrade.to.major, minor: degrade.to.minor },
+    hostCanonical: targetHostCanonical,
+    params: degrade.adaptRequest(options.params as never),
+  });
+  return degrade.adaptResponse(fallbackResult as never);
+}

--- a/clients/shared/host-transport/ws-rpc-client.ts
+++ b/clients/shared/host-transport/ws-rpc-client.ts
@@ -47,6 +47,7 @@ import {
 } from "@traycer/protocol/framework/index";
 import type { TimerHandle } from "./timer-handle";
 import { recordNegotiatedHostMethods } from "./negotiated-manifest-registry";
+import { resolveUnavailableMethodDegrade } from "./unavailable-method-degrade";
 
 /**
  * Minimal endpoint shape the transport layer needs to dial a host. The
@@ -500,134 +501,29 @@ async function executeUnavailableMethodDegrade<
   requestId: string,
   responseTimeoutMs: number,
 ): Promise<ResponseOfMethod<Registry, Method>> {
-  if (clientCanonical === undefined) {
-    throw new HostRpcError({
-      code: "RPC_ERROR",
-      message: `Client registry has no canonical manifest entry for method '${method}'`,
-      requestId,
-      method,
-      fatalDetails: null,
-    });
-  }
-
-  const degrade = methodRegistry.degrade;
-  if (degrade === undefined) {
-    throw new HostRpcError({
-      code: "RPC_ERROR",
-      message: `Host does not advertise method '${method}', and the client registry declares no degrade strategy`,
-      requestId,
-      method,
-      fatalDetails: null,
-    });
-  }
-
-  if (degrade.kind === "unsupported") {
-    throw unsupportedHostMethodError(method, requestId);
-  }
-
-  return executeFallbackMethodDegrade(
+  // Degrade POLICY is shared with the remote mux transport (see
+  // `unavailable-method-degrade.ts`); only the dispatch below is ws-specific.
+  return (await resolveUnavailableMethodDegrade({
     registry,
-    session,
     method,
-    degrade,
+    methodRegistry,
+    clientCanonical,
     clientManifest,
     hostManifest,
     params,
     requestId,
-    responseTimeoutMs,
-  );
-}
-
-async function executeFallbackMethodDegrade<
-  Registry extends VersionedRpcRegistry,
-  Method extends keyof Registry & string,
->(
-  registry: Registry,
-  session: Session,
-  method: Method,
-  degrade: MethodDegradeDeclaration,
-  clientManifest: ConnectionManifest,
-  hostManifest: ConnectionManifest,
-  params: RequestOfMethod<Registry, Method>,
-  requestId: string,
-  responseTimeoutMs: number,
-): Promise<ResponseOfMethod<Registry, Method>> {
-  if (degrade.kind !== "fallback") {
-    throw unsupportedHostMethodError(method, requestId);
-  }
-
-  const targetMethod = degrade.to.method;
-  if (!hasRegistryMethod(registry, targetMethod)) {
-    throw new HostRpcError({
-      code: "RPC_ERROR",
-      message: `Fallback for method '${method}' targets unknown method '${targetMethod}'`,
-      requestId,
-      method,
-      fatalDetails: null,
-    });
-  }
-
-  const targetClientCanonical = {
-    major: degrade.to.major,
-    minor: degrade.to.minor,
-  };
-  const targetHostCanonical = hostManifest[targetMethod];
-  if (
-    clientManifest[targetMethod] === undefined ||
-    targetHostCanonical === undefined
-  ) {
-    throw new HostRpcError({
-      code: "RPC_ERROR",
-      message: `Fallback for method '${method}' targets unavailable floor method '${targetMethod}'`,
-      requestId,
-      method,
-      fatalDetails: null,
-    });
-  }
-
-  const fallbackParams = degrade.adaptRequest(params);
-  const fallbackResult = await executeAvailableMethodRequest<unknown, unknown>(
-    session,
-    registry[targetMethod] as MethodVersionRegistry,
-    targetMethod,
-    targetClientCanonical,
-    targetHostCanonical,
-    fallbackParams,
-    requestId,
-    responseTimeoutMs,
-  );
-  return degrade.adaptResponse(fallbackResult) as ResponseOfMethod<
-    Registry,
-    Method
-  >;
-}
-
-function unsupportedHostMethodError(
-  method: string,
-  requestId: string,
-): HostRpcError {
-  return new HostRpcError({
-    code: "E_HOST_UNSUPPORTED",
-    message: `This host does not support '${method}'. Upgrade the host to use this feature.`,
-    requestId,
-    method,
-    fatalDetails: {
-      code: "E_HOST_UNSUPPORTED",
-      reason: `This host does not support '${method}'. Upgrade the host to use this feature.`,
-      incompatibleMethods: null,
-      upgradeGuidance: {
-        clientShouldUpgrade: false,
-        hostShouldUpgrade: true,
-      },
-    },
-  });
-}
-
-function hasRegistryMethod<Registry extends VersionedRpcRegistry>(
-  registry: Registry,
-  method: string,
-): method is keyof Registry & string {
-  return Object.prototype.hasOwnProperty.call(registry, method);
+    execute: (input) =>
+      executeAvailableMethodRequest<unknown, unknown>(
+        session,
+        input.methodRegistry,
+        input.method,
+        input.clientCanonical,
+        input.hostCanonical,
+        input.params,
+        requestId,
+        responseTimeoutMs,
+      ),
+  })) as ResponseOfMethod<Registry, Method>;
 }
 
 interface PreparedRequest<Payload> {

--- a/clients/shared/host-transport/ws-rpc-client.ts
+++ b/clients/shared/host-transport/ws-rpc-client.ts
@@ -1,5 +1,4 @@
 import type {
-  MethodDegradeDeclaration,
   MethodVersionRegistry,
   SchemaVersion,
   SplitConnectionManifest,

--- a/protocol/src/host-transport/mux.ts
+++ b/protocol/src/host-transport/mux.ts
@@ -138,12 +138,32 @@ export interface SessionOpenPayload {
   readonly resume: null;
 }
 
+/**
+ * The manifests each side advertises at session open - the same
+ * floor/optional split the local ws OPEN frame carries, with the same
+ * semantics:
+ *
+ * - `rpc` is the RELEASED FLOOR - the frozen method set both sides must
+ *   serve. It is the ONLY surface the session-level compatibility check
+ *   runs over; a floor mismatch is fatal to the session.
+ * - `optionalRpc` holds every non-floor method. It is merged with `rpc` for
+ *   version selection, dispatch, and UI capability gating, and is NEVER
+ *   compat-checked: a peer missing an optional method degrades (the feature
+ *   hides or the call fails typed), it does not kill the session. Without
+ *   this split, any version skew between client and host would fatal the
+ *   whole remote session - exactly what keeping methods off the floor is
+ *   meant to prevent.
+ * - `stream` stays a single merged map: stream methods are checked
+ *   per-subscription at open (a missing method fails that one stream, not
+ *   the session), so a session-level floor for them adds nothing.
+ */
 export interface SessionManifests {
   readonly rpc: ConnectionManifest;
+  readonly optionalRpc: ConnectionManifest;
   readonly stream: ConnectionManifest;
 }
 
-/** Host ack of `open`: its own combined manifest + additive capabilities. */
+/** Host ack of `open`: its own split manifests + additive capabilities. */
 export interface SessionOpenAckPayload {
   readonly manifest: SessionManifests;
   readonly capabilities: readonly string[];
@@ -210,6 +230,7 @@ export interface CredentialUpdatePayload {
 
 const sessionManifestsSchema: z.ZodType<SessionManifests> = z.object({
   rpc: connectionManifestSchema,
+  optionalRpc: connectionManifestSchema,
   stream: connectionManifestSchema,
 });
 

--- a/protocol/src/host-transport/mux.ts
+++ b/protocol/src/host-transport/mux.ts
@@ -156,6 +156,17 @@ export interface SessionOpenPayload {
  * - `stream` stays a single merged map: stream methods are checked
  *   per-subscription at open (a missing method fails that one stream, not
  *   the session), so a session-level floor for them adds nothing.
+ *
+ * `optionalRpc` is deliberately REQUIRED, not `.default({})`. Tolerating its
+ * absence would only move the failure: a pre-split peer sends its floor and
+ * optional methods MERGED in `rpc`, so the floor check would then compare a
+ * merged set against a floor set and fatal the session anyway - with a
+ * confusing compat error instead of an honest "malformed frame". The mux is
+ * unreleased, so no such peer exists; when it ships, a future frame-shape
+ * change gets the same treatment this split did - evolve the shape while it
+ * is still pre-release, or version the frame. See
+ * `remote-session.test.ts` > "RemoteSession openAck without optionalRpc",
+ * which pins the rejection.
  */
 export interface SessionManifests {
   readonly rpc: ConnectionManifest;


### PR DESCRIPTION
## Summary

Two defects in the remote transport, one root cause: the negotiated manifest was treated as compat-check input only.

**1. Optional-method gates failed closed forever on remote hosts.** `recordNegotiatedHostMethods` had exactly one caller — the local `WsRpcClient`. `RemoteSession` consumed the `openAck` manifest for its compat mirror and dropped it, so `useHostSupportsMethod` never had an answer for a remote host and every optional-method-gated feature silently hid itself (usage summary, `workspace.writeFile`, chat archive, …). It now publishes at every ready boundary — before the compat check, mirroring the local path — and refreshes on re-attach.

**2. Latent and worse: any build skew fataled the whole remote session.** The mux handshake exchanged single MERGED manifests, and the session-level compatibility check fatals on any method present on only one side. A remote client and host on different builds — one optional method apart — would have killed the entire session instead of degrading. Same-build dev setups masked it; the first regression test here exposed it.

The remote mux handshake is now isomorphic to the released local ws `OPEN` semantics:

| Field | Role |
|---|---|
| `SessionManifests.rpc` | released floor — the **only** compat-checked surface (mismatch is fatal, correctly) |
| `SessionManifests.optionalRpc` | merged in for version selection, dispatch, and UI capability gating; missing ⇒ degrade, never fatal |
| `SessionManifests.stream` | stays merged — stream checks are already per-subscription and non-fatal to the session |

The remote feature is unreleased, so the wire shape change needs no bridges or version dance.

## Related issue

n/a — found while investigating why an optional-method-gated panel never rendered on a remote host.

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

Two new regression tests drive the real handshake (real Noise-NK, real mux frames) against a host advertising optional methods the client does not know: the session must reach ready **and** those methods must publish to the registry. Both halves were red before this change — the first red run doubled as the ablation. Verification: 286 client transport / 7 protocol mux tests green, OSS compile clean.

Pairs with the host-side change in the internal repo (advertises the split in `openAck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)