### PR TITLE
docs: make CI the contributor test gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,7 @@
 
 ## Checklist
 
-- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
-- [ ] Code is formatted (`bun run format`)
-- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
+- [ ] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
+- [ ] Separate CI test checks pass
 - [ ] Tests added/updated where it makes sense
 - [ ] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ are **not** here — the CLI provisions a signed host from GitHub Releases; see
 bun install
 bun run build
 bun run compile                 # never tsc directly
-bun run test && bun run lint && bun run format
+bun run lint && bun run format
+bun run test                    # explicit local run; CI owns the test gate
 bunx nx run @traycer-clients/traycer-cli:build   # single package
-pre-commit run --all-files      # explicit full-repo / CI-style validation
+pre-commit run --all-files      # explicit full-repo static validation
 
 make dev-desktop                # signed host from Releases + HMR desktop
 make dev-desktop VERSION=1.2.3  # pin host release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ bun install
 bun run build
 bun run compile                 # never tsc directly
 bun run lint && bun run format
-bun run test                    # explicit local run; CI owns the test gate
+make test-affected              # optional targeted run; CI owns the test gate
 bunx nx run @traycer-clients/traycer-cli:build   # single package
 pre-commit run --all-files      # explicit full-repo static validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,20 +42,25 @@ bunx nx run @traycer-clients/traycer-cli:build
 
 ## Pre-commit hooks
 
-We use [pre-commit](https://pre-commit.com) for hygiene checks (whitespace, large files, private keys, YAML/JSON, shell scripts). Install once:
+We use [pre-commit](https://pre-commit.com) for hygiene and affected workspace
+checks (build, compile, lint, and format). Install once:
 
 ```sh
 pipx install pre-commit   # or: brew install pre-commit
 pre-commit install
 ```
 
-The hooks then run on every commit; run them on demand with `pre-commit run --all-files`. Lint and format are enforced separately in CI.
+The hooks then run on every commit; run them on demand with
+`pre-commit run --all-files`. Tests are intentionally excluded from the hook
+and run as separate CI checks. Run a targeted test locally when it helps your
+development loop; the full suite does not need to run before each commit.
 
 ## Pull requests
 
 1. Fork and branch from `main`.
 2. Keep changes focused; add or update tests where it makes sense.
-3. Make sure `bun run build`, `bun run lint`, `bun run test`, and formatting all pass — CI runs the same four checks.
+3. Commit normally; pre-commit runs the affected static checks, and CI runs the
+   test suites separately.
 4. Open a PR with the template and link any related issue.
 
 ## Developer Certificate of Origin (DCO)


### PR DESCRIPTION
## Summary

- clarify that pre-commit owns build, compile, lint, and format checks
- make separate CI checks the owner of the full test suite
- remove the local full-test requirement from contributor and PR guidance

## Validation

- pre-commit hooks passed during the signed-off commit
- markdown diff and formatting checks passed
- test suites were not run locally because CI owns the test gate