### PR TITLE
test(desktop): observe causal boundaries instead of inferring them from time

### DIFF
--- a/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
@@ -398,45 +398,52 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
    * `fs.watch` delivery itself has no upper bound, and the debounce only
    * starts once the watcher callback runs.
    */
-  it("unsubscribing stops delivery while the watcher keeps notifying others", async () => {
-    const store = makeStore();
+  it(
+    "unsubscribing stops delivery while the watcher keeps notifying others",
+    async () => {
+      const store = makeStore();
 
-    let firstCount = 0;
-    const unsubscribeFirst = store.subscribe(() => {
-      firstCount += 1;
-    });
+      let firstCount = 0;
+      const unsubscribeFirst = store.subscribe(() => {
+        firstCount += 1;
+      });
 
-    // Establish that the registration is genuinely live, rather than
-    // inferring it from the absence of a call.
-    await store.signIn({ token: "tok-1", refreshToken: "rt-1" }, IDENTITY);
-    await vi.waitFor(
-      () => {
-        expect(firstCount).toBeGreaterThanOrEqual(1);
-      },
-      { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
-    );
+      // Establish that the registration is genuinely live, rather than
+      // inferring it from the absence of a call.
+      await store.signIn({ token: "tok-1", refreshToken: "rt-1" }, IDENTITY);
+      await vi.waitFor(
+        () => {
+          expect(firstCount).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+      );
 
-    unsubscribeFirst();
-    const countAtUnsubscribe = firstCount;
+      unsubscribeFirst();
+      const countAtUnsubscribe = firstCount;
 
-    let probeCount = 0;
-    const unsubscribeProbe = store.subscribe(() => {
-      probeCount += 1;
-    });
+      let probeCount = 0;
+      const unsubscribeProbe = store.subscribe(() => {
+        probeCount += 1;
+      });
 
-    await store.rotate({ userId: IDENTITY.id, token: "tok-1" });
-    await vi.waitFor(
-      () => {
-        expect(probeCount).toBeGreaterThanOrEqual(1);
-      },
-      { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
-    );
+      await store.rotate({ userId: IDENTITY.id, token: "tok-1" });
+      await vi.waitFor(
+        () => {
+          expect(probeCount).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+      );
 
-    // The probe proves an event completed the full path after the first
-    // listener unsubscribed, so an unchanged count is a real guarantee.
-    expect(firstCount).toBe(countAtUnsubscribe);
-    unsubscribeProbe();
-  });
+      // The probe proves an event completed the full path after the first
+      // listener unsubscribed, so an unchanged count is a real guarantee.
+      expect(firstCount).toBe(countAtUnsubscribe);
+      unsubscribeProbe();
+    },
+    // Two sequential WATCHER_DELIVERY_TIMEOUT_MS waits: give the test itself
+    // headroom above their sum, or Vitest's 5s default per-test timeout aborts
+    // the test before either wait's own (longer) deadline can take effect.
+    2 * WATCHER_DELIVERY_TIMEOUT_MS,
+  );
 
   it("signIn on a second instance supersedes a prior sign-out tombstone", async () => {
     const a = makeStore();
@@ -501,103 +508,115 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
       user: { ...IDENTITY },
     };
 
-    it("external write fires subscribe with present:true, userId, higher revision", async () => {
-      const store = makeStore();
-      const changes: TokenStoreChange[] = [];
-      const dispose = store.subscribe((change) => {
-        changes.push(change);
-      });
+    it(
+      "external write fires subscribe with present:true, userId, higher revision",
+      async () => {
+        const store = makeStore();
+        const changes: TokenStoreChange[] = [];
+        const dispose = store.subscribe((change) => {
+          changes.push(change);
+        });
 
-      await writeCredentialsFile(credentialsPath(), EXTERNAL, 0);
+        await writeCredentialsFile(credentialsPath(), EXTERNAL, 0);
 
-      await vi.waitFor(
-        () => {
-          expect(changes.length).toBeGreaterThanOrEqual(1);
-        },
-        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
-      );
-      const last = changes[changes.length - 1];
-      expect(last).toEqual({
-        present: true,
-        userId: IDENTITY.id,
-        revision: expect.any(Number),
-      });
-      expect(last.revision).toBeGreaterThanOrEqual(1);
-      dispose();
-    });
+        await vi.waitFor(
+          () => {
+            expect(changes.length).toBeGreaterThanOrEqual(1);
+          },
+          { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+        );
+        const last = changes[changes.length - 1];
+        expect(last).toEqual({
+          present: true,
+          userId: IDENTITY.id,
+          revision: expect.any(Number),
+        });
+        expect(last.revision).toBeGreaterThanOrEqual(1);
+        dispose();
+      },
+      WATCHER_DELIVERY_TIMEOUT_MS,
+    );
 
-    it("external delete fires present:false", async () => {
-      const store = makeStore();
-      await store.signIn({ token: "tok-1", refreshToken: "rt-1" }, IDENTITY);
-      // Drain the self-write emit from signIn before asserting on the delete.
-      await vi.waitFor(
-        async () => {
-          expect(await store.get()).not.toBeNull();
-        },
-        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
-      );
+    it(
+      "external delete fires present:false",
+      async () => {
+        const store = makeStore();
+        await store.signIn({ token: "tok-1", refreshToken: "rt-1" }, IDENTITY);
+        // Drain the self-write emit from signIn before asserting on the delete.
+        await vi.waitFor(
+          async () => {
+            expect(await store.get()).not.toBeNull();
+          },
+          { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+        );
 
-      const changes: TokenStoreChange[] = [];
-      const dispose = store.subscribe((change) => {
-        changes.push(change);
-      });
+        const changes: TokenStoreChange[] = [];
+        const dispose = store.subscribe((change) => {
+          changes.push(change);
+        });
 
-      await deleteCredentialsFile(credentialsPath());
+        await deleteCredentialsFile(credentialsPath());
 
-      await vi.waitFor(
-        () => {
-          expect(changes.some((c) => c.present === false)).toBe(true);
-        },
-        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
-      );
-      const lastDelete = changes.filter((c) => c.present === false).at(-1);
-      expect(lastDelete).toEqual({
-        present: false,
-        userId: null,
-        revision: expect.any(Number),
-      });
-      dispose();
-    });
+        await vi.waitFor(
+          () => {
+            expect(changes.some((c) => c.present === false)).toBe(true);
+          },
+          { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+        );
+        const lastDelete = changes.filter((c) => c.present === false).at(-1);
+        expect(lastDelete).toEqual({
+          present: false,
+          userId: null,
+          revision: expect.any(Number),
+        });
+        dispose();
+      },
+      2 * WATCHER_DELIVERY_TIMEOUT_MS,
+    );
 
-    it("debounce coalesces a burst of external writes into one emit", async () => {
-      const store = makeStore();
-      const changes: TokenStoreChange[] = [];
-      const dispose = store.subscribe((change) => {
-        changes.push(change);
-      });
+    it(
+      "debounce coalesces a burst of external writes into one emit",
+      async () => {
+        const store = makeStore();
+        const changes: TokenStoreChange[] = [];
+        const dispose = store.subscribe((change) => {
+          changes.push(change);
+        });
 
-      // Burst of rapid renames through the protocol write primitive.
-      await Promise.all([
-        writeCredentialsFile(
-          credentialsPath(),
-          { ...EXTERNAL, token: "burst-1" },
-          0,
-        ),
-        writeCredentialsFile(
-          credentialsPath(),
-          { ...EXTERNAL, token: "burst-2" },
-          0,
-        ),
-        writeCredentialsFile(
-          credentialsPath(),
-          { ...EXTERNAL, token: "burst-3" },
-          0,
-        ),
-      ]);
+        // Burst of rapid renames through the protocol write primitive.
+        await Promise.all([
+          writeCredentialsFile(
+            credentialsPath(),
+            { ...EXTERNAL, token: "burst-1" },
+            0,
+          ),
+          writeCredentialsFile(
+            credentialsPath(),
+            { ...EXTERNAL, token: "burst-2" },
+            0,
+          ),
+          writeCredentialsFile(
+            credentialsPath(),
+            { ...EXTERNAL, token: "burst-3" },
+            0,
+          ),
+        ]);
 
-      await vi.waitFor(
-        () => {
-          expect(changes.length).toBeGreaterThanOrEqual(1);
-        },
-        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
-      );
-      // Give the debounce window a little more time to prove no late extras.
-      await new Promise<void>((resolve) => setTimeout(resolve, 120));
-      // A burst must not produce one event per write; coalesce toward one.
-      expect(changes.length).toBeLessThan(3);
-      expect(changes.at(-1)?.present).toBe(true);
-      expect(changes.at(-1)?.userId).toBe(IDENTITY.id);
-      dispose();
-    });
+        await vi.waitFor(
+          () => {
+            expect(changes.length).toBeGreaterThanOrEqual(1);
+          },
+          { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+        );
+        // Give the debounce window a little more time to prove no late extras.
+        await new Promise<void>((resolve) => setTimeout(resolve, 120));
+        // A burst must not produce one event per write; coalesce toward one.
+        expect(changes.length).toBeLessThan(3);
+        expect(changes.at(-1)?.present).toBe(true);
+        expect(changes.at(-1)?.userId).toBe(IDENTITY.id);
+        dispose();
+      },
+      WATCHER_DELIVERY_TIMEOUT_MS,
+    );
   });
 });

--- a/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
@@ -431,15 +431,20 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
       unsubscribeFirst();
       const countAtUnsubscribe = firstCount;
 
-      let probeCount = 0;
-      const unsubscribeProbe = store.subscribe(() => {
-        probeCount += 1;
+      // The second mutation is a delete, not another rotate: its
+      // `present: false` payload cannot be satisfied by a notification the
+      // first (still in-flight) signIn write already queued, which the probe
+      // subscribing after unsubscribeFirst could otherwise observe and
+      // mistake for acknowledgement of this mutation.
+      const probeChanges: TokenStoreChange[] = [];
+      const unsubscribeProbe = store.subscribe((change) => {
+        probeChanges.push(change);
       });
 
-      await store.rotate({ userId: IDENTITY.id, token: "tok-1" });
+      await store.delete();
       await vi.waitFor(
         () => {
-          expect(probeCount).toBeGreaterThanOrEqual(1);
+          expect(probeChanges.some((c) => c.present === false)).toBe(true);
         },
         { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
       );

--- a/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
@@ -34,6 +34,20 @@ const IDENTITY = {
   name: "Ada",
 } as const;
 
+/**
+ * Waits that cross a REAL `fs.watch` need a regression-scale bound, not the
+ * implicit 1000 ms `vi.waitFor` default. OS event delivery is unbounded, and
+ * the store's own 50 ms debounce only starts once the watcher callback runs,
+ * so the default is a wall-clock bet on a loaded machine - and it loses. CI
+ * observed `external write fires subscribe...` failing at 1017 ms, and 12
+ * parallel local copies of this file reproduce it.
+ *
+ * A watcher that genuinely never delivers still fails here in seconds, while
+ * ordinary scheduler latency no longer does. Only real-delivery waits use
+ * this; mock-driven waits elsewhere keep the default deliberately.
+ */
+const WATCHER_DELIVERY_TIMEOUT_MS = 10_000;
+
 vi.mock("electron", () => ({
   app: {
     getPath: (): string => join(tmpdir(), "traycer-file-token-store-userdata"),
@@ -365,16 +379,63 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
     expect((await b.get())?.token).toBe(live?.token);
   });
 
-  it("subscribe is a live registration that never fires (§4 stub)", async () => {
+  /**
+   * Replaces a test that asserted `subscribe` "never fires". It does fire:
+   * the watcher is installed in the constructor and deliberately notifies on
+   * SELF-writes as well as external ones (see the contract note on
+   * `FileTokenStore` and on `subscribe` itself), so the old assertion only
+   * held while the 50 ms debounce had not yet elapsed - i.e. it was a race
+   * that a fast machine won. CI lost it: `expected 1 to be +0`. The suite
+   * already knew better one screen down, where a sibling test drains "the
+   * self-write emit from signIn" before asserting on a delete.
+   *
+   * What is actually worth pinning is the unsubscribe contract, and it is
+   * pinned without any sleep: a SECOND live listener acts as a positive
+   * acknowledgement that a post-unsubscribe write travelled the whole real
+   * path (fs.watch delivery -> debounce -> read -> fan-out). Once the probe
+   * has observed that event, the unsubscribed listener demonstrably had its
+   * chance and did not fire. Sleeping past 50 ms instead would not work:
+   * `fs.watch` delivery itself has no upper bound, and the debounce only
+   * starts once the watcher callback runs.
+   */
+  it("unsubscribing stops delivery while the watcher keeps notifying others", async () => {
     const store = makeStore();
-    let fired = 0;
-    const dispose = store.subscribe(() => {
-      fired += 1;
+
+    let firstCount = 0;
+    const unsubscribeFirst = store.subscribe(() => {
+      firstCount += 1;
     });
+
+    // Establish that the registration is genuinely live, rather than
+    // inferring it from the absence of a call.
     await store.signIn({ token: "tok-1", refreshToken: "rt-1" }, IDENTITY);
+    await vi.waitFor(
+      () => {
+        expect(firstCount).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+    );
+
+    unsubscribeFirst();
+    const countAtUnsubscribe = firstCount;
+
+    let probeCount = 0;
+    const unsubscribeProbe = store.subscribe(() => {
+      probeCount += 1;
+    });
+
     await store.rotate({ userId: IDENTITY.id, token: "tok-1" });
-    dispose();
-    expect(fired).toBe(0);
+    await vi.waitFor(
+      () => {
+        expect(probeCount).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+    );
+
+    // The probe proves an event completed the full path after the first
+    // listener unsubscribed, so an unchanged count is a real guarantee.
+    expect(firstCount).toBe(countAtUnsubscribe);
+    unsubscribeProbe();
   });
 
   it("signIn on a second instance supersedes a prior sign-out tombstone", async () => {
@@ -449,9 +510,12 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
 
       await writeCredentialsFile(credentialsPath(), EXTERNAL, 0);
 
-      await vi.waitFor(() => {
-        expect(changes.length).toBeGreaterThanOrEqual(1);
-      });
+      await vi.waitFor(
+        () => {
+          expect(changes.length).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+      );
       const last = changes[changes.length - 1];
       expect(last).toEqual({
         present: true,
@@ -466,9 +530,12 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
       const store = makeStore();
       await store.signIn({ token: "tok-1", refreshToken: "rt-1" }, IDENTITY);
       // Drain the self-write emit from signIn before asserting on the delete.
-      await vi.waitFor(async () => {
-        expect(await store.get()).not.toBeNull();
-      });
+      await vi.waitFor(
+        async () => {
+          expect(await store.get()).not.toBeNull();
+        },
+        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+      );
 
       const changes: TokenStoreChange[] = [];
       const dispose = store.subscribe((change) => {
@@ -477,9 +544,12 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
 
       await deleteCredentialsFile(credentialsPath());
 
-      await vi.waitFor(() => {
-        expect(changes.some((c) => c.present === false)).toBe(true);
-      });
+      await vi.waitFor(
+        () => {
+          expect(changes.some((c) => c.present === false)).toBe(true);
+        },
+        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+      );
       const lastDelete = changes.filter((c) => c.present === false).at(-1);
       expect(lastDelete).toEqual({
         present: false,
@@ -515,9 +585,12 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
         ),
       ]);
 
-      await vi.waitFor(() => {
-        expect(changes.length).toBeGreaterThanOrEqual(1);
-      });
+      await vi.waitFor(
+        () => {
+          expect(changes.length).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: WATCHER_DELIVERY_TIMEOUT_MS },
+      );
       // Give the debounce window a little more time to prove no late extras.
       await new Promise<void>((resolve) => setTimeout(resolve, 120));
       // A burst must not produce one event per write; coalesce toward one.

--- a/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
@@ -48,6 +48,16 @@ const IDENTITY = {
  */
 const WATCHER_DELIVERY_TIMEOUT_MS = 10_000;
 
+/**
+ * Per-test timeouts below are `N * WATCHER_DELIVERY_TIMEOUT_MS +
+ * TEST_TIMEOUT_BUFFER_MS`, not a bare sum: the enclosing Vitest timer starts
+ * before the `signIn`/`rotate`/write calls that precede each `vi.waitFor`,
+ * so a sum-only budget leaves zero room for those calls, their assertions,
+ * or (for the debounce test) the extra 120 ms post-wait sleep. Sized well
+ * above that fixed overhead rather than tuned to the minimum that passes.
+ */
+const TEST_TIMEOUT_BUFFER_MS = 5_000;
+
 vi.mock("electron", () => ({
   app: {
     getPath: (): string => join(tmpdir(), "traycer-file-token-store-userdata"),
@@ -442,7 +452,7 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
     // Two sequential WATCHER_DELIVERY_TIMEOUT_MS waits: give the test itself
     // headroom above their sum, or Vitest's 5s default per-test timeout aborts
     // the test before either wait's own (longer) deadline can take effect.
-    2 * WATCHER_DELIVERY_TIMEOUT_MS,
+    2 * WATCHER_DELIVERY_TIMEOUT_MS + TEST_TIMEOUT_BUFFER_MS,
   );
 
   it("signIn on a second instance supersedes a prior sign-out tombstone", async () => {
@@ -534,7 +544,7 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
         expect(last.revision).toBeGreaterThanOrEqual(1);
         dispose();
       },
-      WATCHER_DELIVERY_TIMEOUT_MS,
+      WATCHER_DELIVERY_TIMEOUT_MS + TEST_TIMEOUT_BUFFER_MS,
     );
 
     it(
@@ -571,7 +581,7 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
         });
         dispose();
       },
-      2 * WATCHER_DELIVERY_TIMEOUT_MS,
+      2 * WATCHER_DELIVERY_TIMEOUT_MS + TEST_TIMEOUT_BUFFER_MS,
     );
 
     it(
@@ -616,7 +626,7 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
         expect(changes.at(-1)?.userId).toBe(IDENTITY.id);
         dispose();
       },
-      WATCHER_DELIVERY_TIMEOUT_MS,
+      WATCHER_DELIVERY_TIMEOUT_MS + TEST_TIMEOUT_BUFFER_MS,
     );
   });
 });

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -1201,6 +1201,14 @@ describe("two lanes: mutation vs download independence", () => {
     writeStagedRecord("production", "1.8.0", null);
 
     const downloadGate = deferred<unknown>();
+    // Signals that the preflight download has actually been ENTERED. The
+    // property under test is "convergeReady is not blocked while apply sits
+    // in its preflight download", so apply must provably be sitting there
+    // before convergeReady starts. `flushMicrotasks()` cannot establish that:
+    // it is three promise turns, while `applyStaged` first crosses real fs
+    // reads. Losing that race makes this test either time out or - worse -
+    // pass without ever exercising the concurrency it claims to prove.
+    const downloadStarted = deferred<void>();
     let ensureCalled = false;
     vi.mocked(runBundledTraycerCliJson).mockImplementation(async (args) => {
       if (args.includes("available")) {
@@ -1210,6 +1218,7 @@ describe("two lanes: mutation vs download independence", () => {
     });
     vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
       if (opts.args.includes("download")) {
+        downloadStarted.resolve(undefined);
         await downloadGate.promise;
         return { data: {} };
       }
@@ -1228,7 +1237,7 @@ describe("two lanes: mutation vs download independence", () => {
     });
 
     const applyPromise = controller.applyStaged("manual", false);
-    await flushMicrotasks();
+    await downloadStarted.promise;
 
     const convergePromise = controller.convergeReady(false);
     // The download is still gated (unresolved) while convergeReady reaches
@@ -1262,6 +1271,9 @@ describe("two lanes: mutation vs download independence", () => {
     writeStagedRecord("production", "1.8.0", null);
 
     const downloadGate = deferred<unknown>();
+    // See the sibling applyStaged test: the preflight download must provably
+    // have been entered before convergeReady starts, or this proves nothing.
+    const downloadStarted = deferred<void>();
     let ensureCalled = false;
     vi.mocked(runBundledTraycerCliJson).mockImplementation(async (args) => {
       if (args.includes("available")) {
@@ -1271,6 +1283,7 @@ describe("two lanes: mutation vs download independence", () => {
     });
     vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
       if (opts.args.includes("download")) {
+        downloadStarted.resolve(undefined);
         await downloadGate.promise;
         return { data: {} };
       }
@@ -1289,7 +1302,7 @@ describe("two lanes: mutation vs download independence", () => {
     });
 
     const activatePromise = controller.activateInstalled(false);
-    await flushMicrotasks();
+    await downloadStarted.promise;
 
     const convergePromise = controller.convergeReady(false);
     await vi.waitFor(() => {
@@ -3000,12 +3013,26 @@ describe("platform matrix", () => {
       }
       return { removedInstallDir: true, serviceUninstalled: true };
     });
+    // Signals that the download is genuinely in flight WITH its abort
+    // listener attached. Without this handshake the test has no in-flight
+    // child to abort: `flushMicrotasks()` is three promise turns, while
+    // `stageLatest` first crosses real fs reads (isHostRemovedByUser, the
+    // staged-record read) before the download child and its AbortController
+    // exist. Removal could therefore win outright, leaving `observedAbort`
+    // false forever - which is a 1 s `vi.waitFor` timeout, not a bug in the
+    // behaviour under test. Raising that deadline would only wait longer on
+    // a precondition that never became true.
+    const downloadStarted = deferred<void>();
     vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
       if (opts.args.includes("download")) {
         const aborted = new Promise<void>((resolve) => {
-          if (opts.signal === null) return;
+          if (opts.signal === null) {
+            downloadStarted.resolve(undefined);
+            return;
+          }
           if (opts.signal.aborted) {
             observedAbort = true;
+            downloadStarted.resolve(undefined);
             resolve();
             return;
           }
@@ -3017,6 +3044,9 @@ describe("platform matrix", () => {
             },
             { once: true },
           );
+          // Resolved only after the listener is attached, so an abort that
+          // arrives next tick is guaranteed to be observed.
+          downloadStarted.resolve(undefined);
         });
         await aborted;
         await downloadGate.promise;
@@ -3026,7 +3056,7 @@ describe("platform matrix", () => {
     });
 
     const stagePromise = controller.stageLatest();
-    await flushMicrotasks();
+    await downloadStarted.promise;
 
     const removal = controller.removeTraycer();
     await vi.waitFor(() => {


### PR DESCRIPTION
Fixes the two tests behind the rare `test (desktop darwin + packaging)` failures, plus a latent variant of the second. All three share one defect: **asynchronous state inferred from elapsed time or turn count, instead of observed at the boundary that actually orders the work.**

Test-only. No production code changes.

> Note on scope: the `isHostRemovedByUser()` cache race found during the same investigation is deliberately **not** here — it is product code and is being handled separately.

---

## 1. `subscribe is a live registration that never fires (§4 stub)`

Observed in CI: `AssertionError: expected 1 to be +0` (`file-token-store.test.ts:377`).

The premise is false. The watcher is installed in the constructor and **deliberately notifies on self-writes as well as external ones** — stated in the contract note on `FileTokenStore` and again on `subscribe`. The old assertion only held while the 50 ms debounce had not yet elapsed, so it was a race a fast machine wins. Measured directly, listener still attached:

```
immediate = 0     ← right after signIn + rotate (debounce pending)
afterDebounce = 1 ← once it elapses, the listener fires
afterDispose = 1  ← unsubscribe genuinely stops delivery
```

The suite already knew this **one screen away**, where a sibling test drains *"the self-write emit from signIn"* before asserting on a delete. The file contradicted itself; this test was stale residue from a staged rollout, not a spec requirement.

**Replaced with the contract actually worth pinning, and pinned without sleeping.** A second live listener acts as a positive acknowledgement that a post-unsubscribe write travelled the whole real path — `fs.watch` delivery → debounce → read → fan-out. Once the probe observes that event, the unsubscribed listener demonstrably had its chance and did not fire.

Sleeping past 50 ms would **not** be equivalent: `fs.watch` delivery has no upper bound, and the debounce only starts once the watcher callback runs. That would just be a longer stopwatch.

## 2. Three `vi.waitFor` sites missing a happens-before edge

`P3: removeTraycer…` (the second CI failure, at 1017 ms) plus two latent siblings used `flushMicrotasks()` — exactly three promise turns — where a real handshake was needed. `stageLatest` / `applyStaged` / `activateInstalled` each cross real fs reads before the download child and its `AbortController` exist.

I instrumented it rather than argue it:

```
startedAfterFlushMicrotasks = false
```

The download had **not** begun when the test proceeded to trigger removal — so the abort P3 waits for could target a child that did not exist yet, leaving `observedAbort` false forever.

For the two lane tests this is **worse than a flake**. They claim a preflight download reconcile does not hold the exclusive mutation lane; without the handshake they can pass *without ever exercising that concurrency* — a silent coverage hole in a concurrency invariant.

Each mock now resolves a `downloadStarted` deferred when the download is entered (for P3, only **after** the abort listener is attached, so an abort arriving next tick is still observed), and the test awaits it. **Deliberately not a longer deadline** — the condition was never going to become true, so more time would not have helped.

## 3. Explicit bound for the four real-`fs.watch` waits

These are the only waits in the suite depending on unbounded OS delivery. The implicit 1000 ms `vi.waitFor` default is a wall-clock bet, and CI lost it at **1017 ms** on `external write fires subscribe…`. Now 10 s: regression-scale, not jitter-scale — a watcher that genuinely never delivers still fails in seconds, while scheduler latency no longer does.

## What is deliberately untouched

The other **19** `vi.waitFor` sites. I audited all 23. They follow a real `await` and bridge fire-and-forget continuations, several with comments explaining why polling beat a microtask flush — and four already use `waitFor` correctly **as** the start handshake (`host-controller.test.ts` L2472, L2541, L4457/4461; `traycer-cli-envelope.test.ts` L629). That is the pattern adopted here, so this PR imports an existing convention rather than inventing one. A blanket timeout raise across all sites would be the "widen the bound" move this change exists to avoid.

## Verification

- **12 parallel copies** of the file-token-store suite reproduced the 1017 ms watcher failure **before** this change; **12/12 green after**.
- Both touched suites pass: **173 tests**.
- P3's ordering race did **not** reproduce locally, before or after — consistent with an independent reviewer's 24/24 local pass. That fix therefore rests on the instrumented precondition evidence above rather than on a reproduced failure, and I would rather state that plainly than imply a repro I do not have.