### PR TITLE
fix(worktree): retry generated branch collisions through git

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
@@ -388,7 +388,15 @@ describe("<SetupCardSegment /> single-repo dropdown (two steps)", () => {
       epicId: EPIC_ID,
       ownerId: OWNER_ID,
       ownerKind: "chat",
-      entries: [folderIntent],
+      entries: [
+        {
+          ...folderIntent,
+          branch: {
+            ...folderIntent.branch,
+            collision: "fail",
+          },
+        },
+      ],
     });
     expect(retryMutate).not.toHaveBeenCalled();
   });

--- a/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
@@ -36,6 +36,7 @@ import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useTerminalListFor } from "@/hooks/terminal/use-terminal-list-for-query";
 import { useWorktreeRetrySetupFor } from "@/hooks/worktree/use-worktree-retry-setup-mutation";
 import { useWorktreeCreateForClient } from "@/hooks/worktree/use-worktree-create-mutation";
+import { worktreeCreateEntries } from "@/lib/worktree/worktree-create-request";
 import { isVisibleRawTerminalSession } from "@/lib/terminals/terminal-session-filters";
 import { cn } from "@/lib/utils";
 import { LiveElapsed } from "./segment-elapsed";
@@ -198,7 +199,7 @@ export function SetupCardSegment(props: {
           epicId: aggregate.epicId,
           ownerId: aggregate.ownerId,
           ownerKind: aggregate.ownerKind,
-          entries: [workspace.retryFolderIntent],
+          entries: worktreeCreateEntries([workspace.retryFolderIntent]),
         },
         {
           // A failed entry does NOT reject the RPC - it rides `perEntry` on a

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/new-worktree-form.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/new-worktree-form.test.tsx
@@ -591,6 +591,22 @@ describe("NewWorktreeForm — new-branch name", () => {
     });
   });
 
+  it("keeps a pre-policy staged branch on exact collision handling", () => {
+    branchesData = {
+      branches: [{ name: "development", isCurrent: true, isRemoteOnly: false }],
+      uncommittedFileCount: 0,
+    };
+    const onEmit = vi.fn<(intent: WorktreeFolderIntent) => void>();
+    renderForm(onEmit, STAGED_DEVELOPMENT_INTENT);
+
+    flushAutosave();
+
+    expect(onEmit).not.toHaveBeenCalled();
+    expect(screen.getByTestId("new-worktree-save-status").textContent).toBe(
+      "Saved",
+    );
+  });
+
   it("adopts an externally regenerated name and retry identity", () => {
     branchesData = {
       branches: [{ name: "development", isCurrent: true, isRemoteOnly: false }],
@@ -1647,9 +1663,12 @@ describe("NewWorktreeForm — autosave lifecycle", () => {
     expect(onEmit).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the same focused input when the saved intent echoes back", () => {
+  it("keeps a manually edited branch name when the saved intent echoes back", async () => {
     branchesData = {
-      branches: [{ name: "development", isCurrent: true, isRemoteOnly: false }],
+      branches: [
+        { name: "development", isCurrent: true, isRemoteOnly: false },
+        { name: "chore/cleanup", isCurrent: false, isRemoteOnly: false },
+      ],
       uncommittedFileCount: 0,
     };
     const onEmit = vi.fn<(intent: WorktreeFolderIntent) => void>();
@@ -1681,6 +1700,9 @@ describe("NewWorktreeForm — autosave lifecycle", () => {
     expect(screen.getByTestId("new-worktree-save-status").textContent).toBe(
       "Saved",
     );
+
+    await selectSource("chore/cleanup");
+    expect((name as HTMLInputElement).value).toBe("feat/changed");
   });
 
   it("cancels a pending save when typing returns to the staged value", () => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/new-worktree-form.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/new-worktree-form.test.tsx
@@ -330,6 +330,9 @@ function flushAutosave(): void {
 
 beforeEach(() => {
   vi.useFakeTimers();
+  vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
+    "00000000-0000-4000-8000-000000000000",
+  );
   mockVirtuosoState.captureConfiguration.mockClear();
   mockVirtuosoState.scrollIntoView.mockClear();
   mockVirtuosoState.transientUndefinedIndexes.clear();
@@ -557,9 +560,90 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "traycer/swift-otter",
           source: "development",
           carryUncommittedChanges: false,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
+  });
+
+  it("switches an edited generated branch name to exact collision handling", () => {
+    branchesData = {
+      branches: [{ name: "development", isCurrent: true, isRemoteOnly: false }],
+      uncommittedFileCount: 0,
+    };
+    const onEmit = vi.fn<(intent: WorktreeFolderIntent) => void>();
+    renderForm(onEmit, null);
+
+    fireEvent.change(screen.getByTestId("new-worktree-branch-name"), {
+      target: { value: "my-explicit-branch" },
+    });
+    flushAutosave();
+
+    const lastCall = onEmit.mock.lastCall;
+    if (lastCall === undefined) throw new Error("expected an emitted intent");
+    const [emitted] = lastCall;
+    if (emitted.kind !== "worktree")
+      throw new Error("expected worktree intent");
+    expect(emitted.branch).toMatchObject({
+      name: "my-explicit-branch",
+      collision: "fail",
+    });
+  });
+
+  it("adopts an externally regenerated name and retry identity", () => {
+    branchesData = {
+      branches: [{ name: "development", isCurrent: true, isRemoteOnly: false }],
+      uncommittedFileCount: 0,
+    };
+    const onEmit = vi.fn<(intent: WorktreeFolderIntent) => void>();
+    let currentIntent: WorktreeFolderIntent = {
+      ...STAGED_DEVELOPMENT_INTENT,
+      branch: {
+        type: "new",
+        name: "my-explicit-branch",
+        source: "development",
+        carryUncommittedChanges: false,
+        collision: "fail",
+      },
+    };
+    const subject = () => (
+      <TooltipProvider>
+        <NewWorktreeForm
+          hostClient={null}
+          workspacePath="/repo"
+          repoIdentifier={{ owner: "acme", repo: "app" }}
+          isPrimary
+          summary={SUMMARY}
+          currentIntent={currentIntent}
+          defaultNewBranchName="traycer/swift-otter"
+          onEmit={onEmit}
+        />
+      </TooltipProvider>
+    );
+    const view = render(subject());
+
+    currentIntent = {
+      ...currentIntent,
+      branch: {
+        type: "new",
+        name: "traycer/fresh-otter",
+        source: "development",
+        carryUncommittedChanges: false,
+        collision: "random",
+        retryIdentity: "external-retry-identity",
+      },
+    };
+    view.rerender(subject());
+
+    expect(
+      screen.getByTestId<HTMLInputElement>("new-worktree-branch-name").value,
+    ).toBe("traycer/fresh-otter");
+    expect(screen.getByTestId("new-worktree-save-status").textContent).toBe(
+      "Saved",
+    );
+    flushAutosave();
+    expect(onEmit).not.toHaveBeenCalled();
   });
 
   it("working tree source: clearing the name pauses autosave and Enter is inert", () => {
@@ -602,6 +686,8 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "traycer/swift-otter",
           source: "development",
           carryUncommittedChanges: true,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
@@ -628,6 +714,8 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "traycer/swift-otter",
           source: "development",
           carryUncommittedChanges: false,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
@@ -661,6 +749,8 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "release-9",
           source: "origin/release-9",
           carryUncommittedChanges: false,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
@@ -700,6 +790,8 @@ describe("NewWorktreeForm — new-branch name", () => {
         name: "release-9",
         source: "origin/release-9",
         carryUncommittedChanges: false,
+        collision: "random",
+        retryIdentity: "00000000-0000-4000-8000-000000000000",
       },
     });
   });
@@ -792,6 +884,8 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "traycer/swift-otter",
           source: "chore/cleanup",
           carryUncommittedChanges: false,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
@@ -845,6 +939,7 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "feat/forked",
           source: "chore/cleanup",
           carryUncommittedChanges: false,
+          collision: "fail",
         },
       },
     ]);
@@ -887,6 +982,8 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "traycer/swift-otter",
           source: "existing_branch_1",
           carryUncommittedChanges: false,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
@@ -920,6 +1017,8 @@ describe("NewWorktreeForm — new-branch name", () => {
           name: "traycer/swift-otter",
           source: "chore/cleanup",
           carryUncommittedChanges: false,
+          collision: "random",
+          retryIdentity: "00000000-0000-4000-8000-000000000000",
         },
       },
     ]);
@@ -1650,6 +1749,7 @@ describe("NewWorktreeForm — autosave lifecycle", () => {
       name: "feat/only-this",
       source: "development",
       carryUncommittedChanges: false,
+      collision: "fail",
     });
   });
 

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/worktree-intent-merge.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/worktree-intent-merge.test.ts
@@ -175,6 +175,11 @@ describe("worktree intent merge", () => {
         : null,
     ).toBe("main");
     expect(updated?.kind === "worktree" ? updated.scripts : null).toBeNull();
+    expect(
+      updated?.kind === "worktree" && updated.branch.type === "new"
+        ? updated.branch.collision
+        : null,
+    ).toBe("random");
     // Sibling folders are untouched.
     expect(other?.kind === "worktree" ? other.branch.name : null).toBe(
       "traycer/second",

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -43,6 +43,7 @@ import {
 import { useWorktreeSetEntryModeForClient } from "@/hooks/worktree/use-worktree-set-entry-mode-mutation";
 import { useWorktreeImportForClient } from "@/hooks/worktree/use-worktree-import-mutation";
 import { useWorktreeCreateForClient } from "@/hooks/worktree/use-worktree-create-mutation";
+import { worktreeCreateEntries } from "@/lib/worktree/worktree-create-request";
 import {
   useWorkspaceBindingRemoveEntryForClient,
   usePendingRemoveBindingEntryPaths,
@@ -1829,7 +1830,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         epicId: surface.epicId,
         ownerId: surface.ownerId,
         ownerKind,
-        entries: [...stagedEntries],
+        entries: worktreeCreateEntries(stagedEntries),
       },
       {
         onSuccess: (result) => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
@@ -667,14 +667,20 @@ function stagedNewBranch(
 function newBranchCollisionState(
   branch: NewWorktreeBranch | null,
 ): Pick<NewBranchNameState, "collision" | "retryIdentity"> {
-  if (branch?.collision === "random") {
+  if (!branch) {
+    return {
+      collision: "random",
+      retryIdentity: createWorktreeRetryIdentity(),
+    };
+  }
+  if (branch.collision === "random") {
     return {
       collision: "random",
       retryIdentity: branch.retryIdentity,
     };
   }
   return {
-    collision: branch?.collision ?? "random",
+    collision: branch.collision ?? "fail",
     retryIdentity: createWorktreeRetryIdentity(),
   };
 }
@@ -683,13 +689,14 @@ function newBranchNameState(input: {
   readonly currentIntent: WorktreeFolderIntent | null;
   readonly fallbackName: string;
   readonly forSource: string | null;
+  readonly edited: boolean;
   readonly stagedIntentKey: string | null;
 }): NewBranchNameState {
   const branch = stagedNewBranch(input.currentIntent);
   return {
     value: branch?.name ?? input.fallbackName,
     forSource: input.forSource,
-    edited: false,
+    edited: input.edited,
     ...newBranchCollisionState(branch),
     stagedIntentKey: input.stagedIntentKey,
   };
@@ -749,6 +756,7 @@ function useNewWorktreeFormState(
         defaultNewBranchName,
       ),
       forSource: selectedSourceId,
+      edited: false,
       stagedIntentKey,
     }),
   );
@@ -758,6 +766,7 @@ function useNewWorktreeFormState(
         currentIntent,
         fallbackName: nameState.value,
         forSource: selectedSourceId,
+        edited: nameState.edited,
         stagedIntentKey,
       }),
     );
@@ -775,6 +784,7 @@ function useNewWorktreeFormState(
           defaultNewBranchName,
         ),
         forSource: selectedSourceId,
+        edited: false,
         stagedIntentKey,
       }),
     );

--- a/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
@@ -39,6 +39,7 @@ import {
   type UnifiedPickerSourceOption,
 } from "@/components/home/worktree/worktree-unified-picker-model";
 import { promotePickerRow } from "./promote-picker-row";
+import { createWorktreeRetryIdentity } from "@/lib/worktree/worktree-retry-identity";
 
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 type RepoIdentifier = WorktreeFolderIntent["repoIdentifier"];
@@ -111,19 +112,34 @@ export function NewWorktreeForm(props: NewWorktreeFormProps) {
     () =>
       selectedSource === null
         ? null
-        : newWorktreeIntent({
-            workspacePath: props.workspacePath,
-            repoIdentifier: props.repoIdentifier,
-            isPrimary: props.isPrimary,
-            source: selectedSource,
-            branchName: trimmed,
-          }),
+        : newWorktreeIntent(
+            form.branchCollision === "random"
+              ? {
+                  workspacePath: props.workspacePath,
+                  repoIdentifier: props.repoIdentifier,
+                  isPrimary: props.isPrimary,
+                  source: selectedSource,
+                  branchName: trimmed,
+                  collision: "random",
+                  retryIdentity: form.branchRetryIdentity,
+                }
+              : {
+                  workspacePath: props.workspacePath,
+                  repoIdentifier: props.repoIdentifier,
+                  isPrimary: props.isPrimary,
+                  source: selectedSource,
+                  branchName: trimmed,
+                  collision: "fail",
+                },
+          ),
     [
       props.isPrimary,
       props.repoIdentifier,
       props.workspacePath,
       selectedSource,
       trimmed,
+      form.branchCollision,
+      form.branchRetryIdentity,
     ],
   );
   const preservesExistingBranchCheckout =
@@ -134,11 +150,12 @@ export function NewWorktreeForm(props: NewWorktreeFormProps) {
     preservesExistingBranchCheckout ||
     (draftIntent?.kind === "worktree" &&
       props.currentIntent?.kind === "worktree" &&
-      matchesStagedBranch(
-        props.currentIntent.branch,
-        draftIntent.branch.name,
-        selectedSource,
-      ));
+      matchesStagedBranch(props.currentIntent.branch, {
+        trimmedName: draftIntent.branch.name,
+        source: selectedSource,
+        collision: form.branchCollision,
+        retryIdentity: form.branchRetryIdentity,
+      }));
   const { flush } = useNewWorktreeAutosave({
     draftIntent,
     isSaved,
@@ -618,10 +635,82 @@ function sourceBranchRowKey(
 interface NewWorktreeFormState {
   readonly selectedSource: UnifiedPickerSourceOption | null;
   readonly branchName: string;
+  readonly branchCollision: "fail" | "random";
+  readonly branchRetryIdentity: string;
   readonly hasUserEdited: boolean;
   readonly hasUnresolvedExplicitSource: boolean;
   readonly setBranchName: (next: string) => void;
   readonly selectSource: (next: string) => void;
+}
+
+type NewWorktreeBranch = Extract<
+  Extract<WorktreeFolderIntent, { readonly kind: "worktree" }>["branch"],
+  { readonly type: "new" }
+>;
+
+interface NewBranchNameState {
+  readonly value: string;
+  readonly forSource: string | null;
+  readonly edited: boolean;
+  readonly collision: "fail" | "random";
+  readonly retryIdentity: string;
+  readonly stagedIntentKey: string | null;
+}
+
+function stagedNewBranch(
+  intent: WorktreeFolderIntent | null,
+): NewWorktreeBranch | null {
+  if (intent?.kind !== "worktree" || intent.branch.type !== "new") return null;
+  return intent.branch;
+}
+
+function newBranchCollisionState(
+  branch: NewWorktreeBranch | null,
+): Pick<NewBranchNameState, "collision" | "retryIdentity"> {
+  if (branch?.collision === "random") {
+    return {
+      collision: "random",
+      retryIdentity: branch.retryIdentity,
+    };
+  }
+  return {
+    collision: branch?.collision ?? "random",
+    retryIdentity: createWorktreeRetryIdentity(),
+  };
+}
+
+function newBranchNameState(input: {
+  readonly currentIntent: WorktreeFolderIntent | null;
+  readonly fallbackName: string;
+  readonly forSource: string | null;
+  readonly stagedIntentKey: string | null;
+}): NewBranchNameState {
+  const branch = stagedNewBranch(input.currentIntent);
+  return {
+    value: branch?.name ?? input.fallbackName,
+    forSource: input.forSource,
+    edited: false,
+    ...newBranchCollisionState(branch),
+    stagedIntentKey: input.stagedIntentKey,
+  };
+}
+
+function selectedSourceNameState(input: {
+  readonly previous: NewBranchNameState;
+  readonly source: UnifiedPickerSourceOption | undefined;
+  readonly defaultNewBranchName: string;
+}): NewBranchNameState {
+  if (input.previous.edited || input.previous.forSource === input.source?.id) {
+    return input.previous;
+  }
+  return {
+    value: input.source?.defaultNewBranchName ?? input.defaultNewBranchName,
+    forSource: input.source?.id ?? null,
+    edited: false,
+    collision: "random",
+    retryIdentity: createWorktreeRetryIdentity(),
+    stagedIntentKey: input.previous.stagedIntentKey,
+  };
 }
 
 /**
@@ -649,49 +738,69 @@ function useNewWorktreeFormState(
   const selectedSourceId = selectedSource?.id ?? null;
   const hasUnresolvedExplicitSource =
     sourceId !== null && selectedSource === null;
+  const stagedIntentKey = newBranchIntentKey(currentIntent);
 
-  const [nameState, setNameState] = useState(() => ({
-    value: initialNewBranchName(
+  const [nameState, setNameState] = useState(() =>
+    newBranchNameState({
       currentIntent,
-      selectedSource,
-      defaultNewBranchName,
-    ),
-    forSource: selectedSourceId,
-    edited: false,
-  }));
-  if (
-    !hasUnresolvedExplicitSource &&
-    !nameState.edited &&
-    nameState.forSource !== selectedSourceId
-  ) {
-    setNameState({
-      value: initialNewBranchName(
+      fallbackName: initialNewBranchName(
         currentIntent,
         selectedSource,
         defaultNewBranchName,
       ),
       forSource: selectedSourceId,
-      edited: false,
-    });
+      stagedIntentKey,
+    }),
+  );
+  if (nameState.stagedIntentKey !== stagedIntentKey) {
+    setNameState(
+      newBranchNameState({
+        currentIntent,
+        fallbackName: nameState.value,
+        forSource: selectedSourceId,
+        stagedIntentKey,
+      }),
+    );
+  } else if (
+    !hasUnresolvedExplicitSource &&
+    !nameState.edited &&
+    nameState.forSource !== selectedSourceId
+  ) {
+    setNameState(
+      newBranchNameState({
+        currentIntent,
+        fallbackName: initialNewBranchName(
+          currentIntent,
+          selectedSource,
+          defaultNewBranchName,
+        ),
+        forSource: selectedSourceId,
+        stagedIntentKey,
+      }),
+    );
   }
 
   const setBranchName = useCallback(
     (next: string) =>
-      setNameState((prev) => ({ ...prev, value: next, edited: true })),
+      setNameState((prev) => ({
+        ...prev,
+        value: next,
+        edited: true,
+        collision: "fail",
+      })),
     [],
   );
   const selectSource = useCallback(
     (next: string) => {
       setSourceId(next);
       const nextSource = sourceOptions.find((option) => option.id === next);
-      setNameState((prev) => {
-        if (prev.edited || prev.forSource === nextSource?.id) return prev;
-        return {
-          value: nextSource?.defaultNewBranchName ?? defaultNewBranchName,
-          forSource: nextSource?.id ?? null,
-          edited: false,
-        };
-      });
+      setNameState((previous) =>
+        selectedSourceNameState({
+          previous,
+          source: nextSource,
+          defaultNewBranchName,
+        }),
+      );
     },
     [defaultNewBranchName, sourceOptions],
   );
@@ -699,6 +808,8 @@ function useNewWorktreeFormState(
   return {
     selectedSource,
     branchName: nameState.value,
+    branchCollision: nameState.collision,
+    branchRetryIdentity: nameState.retryIdentity,
     hasUserEdited:
       nameState.edited ||
       (sourceId !== null && sourceId !== model.newBranchSourceId),
@@ -706,6 +817,19 @@ function useNewWorktreeFormState(
     setBranchName,
     selectSource,
   };
+}
+
+function newBranchIntentKey(
+  intent: WorktreeFolderIntent | null,
+): string | null {
+  if (intent?.kind !== "worktree" || intent.branch.type !== "new") return null;
+  return JSON.stringify([
+    intent.branch.name,
+    intent.branch.source,
+    intent.branch.carryUncommittedChanges,
+    intent.branch.collision ?? "fail",
+    intent.branch.collision === "random" ? intent.branch.retryIdentity : null,
+  ]);
 }
 
 /** The Source dropdown rows, mapped 1:1 from the model's ordered source list
@@ -771,17 +895,25 @@ function initialNewBranchName(
 
 function matchesStagedBranch(
   branch: Extract<WorktreeFolderIntent, { kind: "worktree" }>["branch"],
-  trimmedName: string,
-  source: UnifiedPickerSourceOption | null,
+  input: {
+    readonly trimmedName: string;
+    readonly source: UnifiedPickerSourceOption | null;
+    readonly collision: "fail" | "random";
+    readonly retryIdentity: string;
+  },
 ): boolean {
   if (branch.type === "new") {
     // Carry vs clean share a source name, so the carry flag is part of identity:
     // switching between them must register as a change (Select re-enables).
     return (
-      source !== null &&
-      branch.name === trimmedName &&
-      branch.source === source.name &&
-      branch.carryUncommittedChanges === source.carryUncommittedChanges
+      input.source !== null &&
+      branch.name === input.trimmedName &&
+      branch.source === input.source.name &&
+      branch.carryUncommittedChanges === input.source.carryUncommittedChanges &&
+      (branch.collision ?? "fail") === input.collision &&
+      (input.collision !== "random" ||
+        (branch.collision === "random" &&
+          branch.retryIdentity === input.retryIdentity))
     );
   }
   return false;

--- a/clients/gui-app/src/components/home/host-workspace-selector/worktree-intent-merge.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/worktree-intent-merge.ts
@@ -3,6 +3,7 @@ import type {
   WorktreeIntent,
   WorktreeFolderIntent,
 } from "@traycer/protocol/host/worktree-schemas";
+import { createWorktreeRetryIdentity } from "@/lib/worktree/worktree-retry-identity";
 
 /**
  * Updates the setup/teardown `scripts` override on the staged `worktree` entry
@@ -60,7 +61,15 @@ export function setWorktreeIntentEntryBranchName(
       entry.workspacePath === workspacePath &&
       entry.kind === "worktree" &&
       entry.branch.type === "new"
-        ? { ...entry, branch: { ...entry.branch, name } }
+        ? {
+            ...entry,
+            branch: {
+              ...entry.branch,
+              name,
+              collision: "random",
+              retryIdentity: createWorktreeRetryIdentity(),
+            },
+          }
         : entry,
     ),
   };

--- a/clients/gui-app/src/components/home/worktree/__tests__/worktree-unified-picker-model.test.ts
+++ b/clients/gui-app/src/components/home/worktree/__tests__/worktree-unified-picker-model.test.ts
@@ -384,6 +384,8 @@ describe("newWorktreeIntent", () => {
           defaultNewBranchName: "traycer/swift-otter",
         },
         branchName: "feat/new",
+        collision: "random",
+        retryIdentity: "retry-identity",
       }),
     ).toEqual({
       kind: "worktree",
@@ -396,6 +398,8 @@ describe("newWorktreeIntent", () => {
         name: "feat/new",
         source: "development",
         carryUncommittedChanges: false,
+        collision: "random",
+        retryIdentity: "retry-identity",
       },
     });
   });
@@ -415,6 +419,8 @@ describe("newWorktreeIntent", () => {
           defaultNewBranchName: "traycer/swift-otter",
         },
         branchName: "feat/new",
+        collision: "random",
+        retryIdentity: "retry-identity",
       }),
     ).toMatchObject({
       kind: "worktree",
@@ -442,6 +448,8 @@ describe("newWorktreeIntent", () => {
           defaultNewBranchName: "traycer/swift-otter",
         },
         branchName: "",
+        collision: "random",
+        retryIdentity: "retry-identity",
       }),
     ).toBeNull();
   });
@@ -461,6 +469,8 @@ describe("newWorktreeIntent", () => {
           defaultNewBranchName: "traycer/swift-otter",
         },
         branchName: "traycer/swift-otter",
+        collision: "random",
+        retryIdentity: "retry-identity",
       }),
     ).toMatchObject({
       kind: "worktree",

--- a/clients/gui-app/src/components/home/worktree/worktree-unified-picker-model.ts
+++ b/clients/gui-app/src/components/home/worktree/worktree-unified-picker-model.ts
@@ -255,13 +255,20 @@ export function worktreeImportRows(input: {
 }
 
 /** The intent emitted by the "New worktree" form for a source + branch name. */
-export function newWorktreeIntent(input: {
+type NewWorktreeIntentInput = {
   readonly workspacePath: string;
   readonly repoIdentifier: RepoIdentifier;
   readonly isPrimary: boolean;
   readonly source: UnifiedPickerSourceOption;
   readonly branchName: string;
-}): WorktreeFolderIntent | null {
+} & (
+  | { readonly collision: "fail" }
+  | { readonly collision: "random"; readonly retryIdentity: string }
+);
+
+export function newWorktreeIntent(
+  input: NewWorktreeIntentInput,
+): WorktreeFolderIntent | null {
   const branchName = input.branchName.trim();
   if (branchName.length === 0) return null;
   return {
@@ -270,11 +277,22 @@ export function newWorktreeIntent(input: {
     workspacePath: input.workspacePath,
     repoIdentifier: input.repoIdentifier,
     isPrimary: input.isPrimary,
-    branch: {
-      type: "new",
-      name: branchName,
-      source: input.source.name,
-      carryUncommittedChanges: input.source.carryUncommittedChanges,
-    },
+    branch:
+      input.collision === "random"
+        ? {
+            type: "new",
+            name: branchName,
+            source: input.source.name,
+            carryUncommittedChanges: input.source.carryUncommittedChanges,
+            collision: "random",
+            retryIdentity: input.retryIdentity,
+          }
+        : {
+            type: "new",
+            name: branchName,
+            source: input.source.name,
+            carryUncommittedChanges: input.source.carryUncommittedChanges,
+            collision: "fail",
+          },
   };
 }

--- a/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
+++ b/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
@@ -23,6 +23,7 @@ import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import { TuiForkProfileRejectedError } from "@/lib/tui-fork-profile-rejection";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import { displayTitle } from "@/lib/display-title";
+import { worktreeCreateEntries } from "@/lib/worktree/worktree-create-request";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import {
@@ -531,6 +532,7 @@ async function dispatchWorktreeIntent(
   // folders when it finds no row (the always-non-empty invariant), so there is
   // nothing to dispatch here.
   if (intent.entries.length === 0) return;
+  const entries = worktreeCreateEntries(intent.entries);
   // Send the full union in ONE `worktree.create` call and let the host's
   // `resolveIntent` route each entry by `kind` (local / import / worktree)
   // into a single sibling-preserving binding write. One call keeps entry
@@ -541,7 +543,7 @@ async function dispatchWorktreeIntent(
     epicId,
     ownerId: tuiAgentId,
     ownerKind: "terminal-agent",
-    entries: [...intent.entries],
+    entries,
   });
   // The RPC resolves per-entry: an entry the host failed - or reported
   // nothing about - has no `ok` row. Launching anyway would run the agent

--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-create-request.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-create-request.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { worktreeCreateEntries } from "../worktree-create-request";
+
+const baseEntry = {
+  kind: "worktree" as const,
+  workspacePath: "/repo",
+  repoIdentifier: null,
+  isPrimary: true,
+  scripts: null,
+  branch: {
+    type: "new" as const,
+    name: "gentle-yak",
+    source: "development",
+    carryUncommittedChanges: false,
+  },
+};
+
+describe("worktreeCreateEntries", () => {
+  it("defaults a pre-policy persisted intent to fail", () => {
+    const entry = worktreeCreateEntries([baseEntry])[0];
+    if (entry.kind !== "worktree") throw new Error("expected worktree entry");
+    expect(entry.branch).toMatchObject({
+      collision: "fail",
+    });
+  });
+
+  it("preserves random retry identity on a fresh generated intent", () => {
+    const entry = worktreeCreateEntries([
+      {
+        ...baseEntry,
+        branch: {
+          ...baseEntry.branch,
+          collision: "random",
+          retryIdentity: "retry-identity",
+        },
+      },
+    ])[0];
+    if (entry.kind !== "worktree") throw new Error("expected worktree entry");
+    expect(entry.branch).toMatchObject({
+      collision: "random",
+      retryIdentity: "retry-identity",
+    });
+  });
+});

--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-intent-seeding.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-intent-seeding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   DiskWorktreeEntry,
   WorktreeBranch,
@@ -100,6 +100,16 @@ function rememberedImport(worktreePath: string): WorktreeFolderIntent {
   };
 }
 
+beforeEach(() => {
+  vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
+    "00000000-0000-4000-8000-000000000000",
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("defaultFolderIntent", () => {
   it("forks a new branch off the working tree for a git repo", () => {
     expect(
@@ -122,6 +132,8 @@ describe("defaultFolderIntent", () => {
         name: "traycer/swift-otter",
         source: "main",
         carryUncommittedChanges: false,
+        collision: "random",
+        retryIdentity: "00000000-0000-4000-8000-000000000000",
       },
     });
   });
@@ -244,6 +256,8 @@ describe("resolveRememberedFolderIntent", () => {
         name: "traycer/fresh-name",
         source: "main",
         carryUncommittedChanges: false,
+        collision: "random",
+        retryIdentity: "00000000-0000-4000-8000-000000000000",
       },
     });
   });

--- a/clients/gui-app/src/lib/worktree/random-friendly-name.ts
+++ b/clients/gui-app/src/lib/worktree/random-friendly-name.ts
@@ -2,12 +2,11 @@
  * Picks a memorable two-word `<adjective>-<noun>` slug for a default
  * branch name when the Epic / chat title doesn't yield anything
  * meaningful. Lives client-side so the Create-new-worktree input shows
- * the same name the user would land with after a host-side collision
- * pass - `swift-otter` over `k7m9`.
+ * the friendly first candidate - `swift-otter` over `k7m9`.
  *
  * Wordlists are embedded (no network / dependency); roughly
- * `ADJECTIVES.length * NOUNS.length` ≈ 1.6k combinations before the
- * client-side collision suffix kicks in (`-2`, `-3`, …).
+ * `ADJECTIVES.length * NOUNS.length` ≈ 1.6k combinations before Git may
+ * require a retry-identity-derived random suffix.
  */
 
 const ADJECTIVES: ReadonlyArray<string> = [

--- a/clients/gui-app/src/lib/worktree/worktree-create-request.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-create-request.ts
@@ -1,0 +1,43 @@
+import type {
+  WorktreeCreateRequest,
+  WorktreeFolderIntent,
+} from "@traycer/protocol/host/worktree-schemas";
+
+/**
+ * Promotes shared/persisted folder intents into the current create RPC shape.
+ * Intents written before collision policy existed are intentionally exact-name
+ * (`fail`): only a fresh generated proposal carries the retry identity needed
+ * for random collision retries.
+ */
+export function worktreeCreateEntries(
+  entries: ReadonlyArray<WorktreeFolderIntent>,
+): WorktreeCreateRequest["entries"] {
+  return entries.map((entry): WorktreeCreateRequest["entries"][number] => {
+    if (entry.kind !== "worktree") return entry;
+    const branch = entry.branch;
+    if (branch.type === "existing") return { ...entry, branch };
+    if (branch.collision === "random") {
+      return {
+        ...entry,
+        branch: {
+          type: "new",
+          name: branch.name,
+          source: branch.source,
+          carryUncommittedChanges: branch.carryUncommittedChanges,
+          collision: "random",
+          retryIdentity: branch.retryIdentity,
+        },
+      };
+    }
+    return {
+      ...entry,
+      branch: {
+        type: "new",
+        name: branch.name,
+        source: branch.source,
+        carryUncommittedChanges: branch.carryUncommittedChanges,
+        collision: "fail",
+      },
+    };
+  });
+}

--- a/clients/gui-app/src/lib/worktree/worktree-intent-seeding.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-intent-seeding.ts
@@ -3,6 +3,7 @@ import type {
   WorktreeFolderIntent,
   WorktreeWorkspaceSummary,
 } from "@traycer/protocol/host/worktree-schemas";
+import { createWorktreeRetryIdentity } from "@/lib/worktree/worktree-retry-identity";
 
 type RepoIdentifier = WorktreeFolderIntent["repoIdentifier"];
 
@@ -48,6 +49,8 @@ export function defaultFolderIntent(
       name: folder.defaultNewBranchName,
       source: folder.currentBranch,
       carryUncommittedChanges: false,
+      collision: "random",
+      retryIdentity: createWorktreeRetryIdentity(),
     },
   };
 }
@@ -101,6 +104,8 @@ export function applySeedIntentOverride(input: {
       name: folder.defaultNewBranchName,
       source: folder.currentBranch,
       carryUncommittedChanges: true,
+      collision: "random",
+      retryIdentity: createWorktreeRetryIdentity(),
     },
   };
 }
@@ -175,6 +180,8 @@ export function resolveRememberedFolderIntent(input: {
         name: folder.defaultNewBranchName,
         source: remembered.branch.source,
         carryUncommittedChanges: false,
+        collision: "random",
+        retryIdentity: createWorktreeRetryIdentity(),
       },
     };
   }

--- a/clients/gui-app/src/lib/worktree/worktree-retry-identity.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-retry-identity.ts
@@ -1,0 +1,4 @@
+/** Stable idempotency key persisted with one generated worktree intent. */
+export function createWorktreeRetryIdentity(): string {
+  return globalThis.crypto.randomUUID();
+}

--- a/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
@@ -55,6 +55,7 @@ describe("resolveWorktreeBranchSelection", () => {
       name: "feature/x",
       source: "main",
       carryUncommittedChanges: true,
+      collision: "fail",
     });
     expect(rpcMock).not.toHaveBeenCalled();
   });
@@ -85,6 +86,7 @@ describe("resolveWorktreeBranchSelection", () => {
       name: "feature/x",
       source: "develop",
       carryUncommittedChanges: false,
+      collision: "fail",
     });
   });
 
@@ -112,6 +114,7 @@ describe("resolveWorktreeBranchSelection", () => {
       name: "feature/x",
       source: "develop",
       carryUncommittedChanges: false,
+      collision: "fail",
     });
   });
 

--- a/clients/traycer-cli/src/commands/worktree-create.ts
+++ b/clients/traycer-cli/src/commands/worktree-create.ts
@@ -96,6 +96,7 @@ export async function resolveWorktreeBranchSelection(
     name,
     source,
     carryUncommittedChanges: opts.carryUncommittedChanges,
+    collision: "fail",
   };
 }
 

--- a/protocol/src/host/__tests__/worktree-schemas.test.ts
+++ b/protocol/src/host/__tests__/worktree-schemas.test.ts
@@ -43,6 +43,8 @@ import {
   worktreeSetRepoBranchPrefixResponseSchema,
   worktreeSubmoduleMergeFactSchema,
   worktreeSubmoduleMergeFactSchemaV12,
+  worktreeCreateRequestSchema,
+  worktreeCreatePathsRequestSchema,
 } from "@traycer/protocol/host/worktree-schemas";
 
 const V10 = { major: 1, minor: 0 } as const;
@@ -56,6 +58,114 @@ const listByWorkspacePathsRegistry =
   hostRpcRegistry["worktree.listByWorkspacePaths"];
 const listBindingsForEpicRegistry =
   hostRpcRegistry["worktree.listBindingsForEpic"];
+const createRegistry = hostRpcRegistry["worktree.create"];
+const createPathsRegistry = hostRpcRegistry["worktree.createPaths"];
+
+describe("worktree create collision-policy negotiation", () => {
+  const randomBranch = {
+    type: "new" as const,
+    name: "gentle-yak",
+    source: "development",
+    carryUncommittedChanges: false,
+    collision: "random" as const,
+    retryIdentity: "create-operation-123",
+  };
+
+  it("upgrades worktree.create v1.0 new branches to fail", () => {
+    const upgraded = upgradeRequestToVersion(createRegistry, V10, V11, {
+      epicId: "epic-1",
+      ownerId: "agent-1",
+      ownerKind: "terminal-agent",
+      entries: [
+        {
+          kind: "worktree",
+          workspacePath: "/repo",
+          repoIdentifier: null,
+          isPrimary: true,
+          scripts: null,
+          branch: {
+            type: "new",
+            name: "gentle-yak",
+            source: "development",
+            carryUncommittedChanges: false,
+          },
+        },
+      ],
+    });
+
+    expect(worktreeCreateRequestSchema.parse(upgraded)).toEqual(upgraded);
+    const entry = upgraded.entries[0];
+    expect(entry?.kind).toBe("worktree");
+    if (entry?.kind !== "worktree") throw new Error("expected worktree entry");
+    expect(entry.branch).toMatchObject({ collision: "fail" });
+  });
+
+  it("upgrades worktree.createPaths v1.0 new branches to fail", () => {
+    const upgraded = upgradeRequestToVersion(createPathsRegistry, V10, V11, {
+      entries: [
+        {
+          workspacePath: "/repo",
+          branch: {
+            type: "new",
+            name: "gentle-yak",
+            source: "development",
+            carryUncommittedChanges: false,
+          },
+        },
+      ],
+    });
+
+    expect(worktreeCreatePathsRequestSchema.parse(upgraded)).toEqual(upgraded);
+    expect(upgraded.entries[0]?.branch).toMatchObject({ collision: "fail" });
+  });
+
+  it("requires an explicit retry identity for random worktree.create branches", () => {
+    const request = {
+      epicId: "epic-1",
+      ownerId: "agent-1",
+      ownerKind: "terminal-agent" as const,
+      entries: [
+        {
+          kind: "worktree" as const,
+          workspacePath: "/repo",
+          repoIdentifier: null,
+          isPrimary: true,
+          scripts: null,
+          branch: randomBranch,
+        },
+      ],
+    };
+    expect(worktreeCreateRequestSchema.parse(request)).toEqual(request);
+    expect(() =>
+      worktreeCreateRequestSchema.parse({
+        ...request,
+        entries: [
+          {
+            ...request.entries[0],
+            branch: { ...randomBranch, retryIdentity: undefined },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("requires the same retry identity on random worktree.createPaths branches", () => {
+    const request = {
+      entries: [{ workspacePath: "/repo", branch: randomBranch }],
+    };
+    expect(worktreeCreatePathsRequestSchema.parse(request)).toEqual(request);
+    expect(() =>
+      worktreeCreatePathsRequestSchema.parse({
+        entries: [
+          {
+            workspacePath: "/repo",
+            branch: { ...randomBranch, retryIdentity: undefined },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});
 
 // A v1.1 selector row - every field the shipped binding listing carries,
 // without the v1.2 `isGitResolvePending` marker.
@@ -905,9 +1015,9 @@ describe("worktree.listByWorkspacePaths v1.1 <-> v1.2 negotiation", () => {
     expect(
       upgradeRequestToVersion(listByWorkspacePathsRegistry, V13, V14, request),
     ).toEqual(request);
-    expect(
-      worktreeListByWorkspacePathsRequestSchemaV14.parse(request),
-    ).toEqual(request);
+    expect(worktreeListByWorkspacePathsRequestSchemaV14.parse(request)).toEqual(
+      request,
+    );
 
     const response = {
       workspaces: [
@@ -977,9 +1087,9 @@ describe("repoBranchPrefixStateSchema", () => {
         value: "has spaces",
       }),
     ).toEqual({ status: "present", value: "has spaces" });
-    expect(
-      repoBranchPrefixStateSchema.parse({ status: "malformed" }),
-    ).toEqual({ status: "malformed" });
+    expect(repoBranchPrefixStateSchema.parse({ status: "malformed" })).toEqual({
+      status: "malformed",
+    });
   });
 
   it("rejects incomplete or unknown status shapes", () => {
@@ -1031,9 +1141,9 @@ describe("worktree.setRepoBranchPrefix schemas", () => {
 
   it("is registered off the released floor as a v1.0 method", () => {
     expect(setRepoBranchPrefixRegistry[1].latestMinor).toBe(0);
-    expect(
-      Object.keys(setRepoBranchPrefixRegistry[1].versions).sort(),
-    ).toEqual(["0"]);
+    expect(Object.keys(setRepoBranchPrefixRegistry[1].versions).sort()).toEqual(
+      ["0"],
+    );
   });
 });
 

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -401,8 +401,10 @@ import {
 import { defineRpcContract } from "@traycer/protocol/framework/index";
 import {
   worktreeCreateRequestSchema,
+  worktreeCreateRequestSchemaV10,
   worktreeCreateResponseSchema,
   worktreeCreatePathsRequestSchema,
+  worktreeCreatePathsRequestSchemaV10,
   worktreeCreatePathsResponseSchema,
   worktreeDeleteRequestSchema,
   worktreeDeleteResponseSchema,
@@ -754,15 +756,83 @@ export const worktreeListBranchesV10 = defineRpcContract({
 export const worktreeCreateV10 = defineRpcContract({
   method: "worktree.create",
   schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: worktreeCreateRequestSchemaV10,
+  responseSchema: worktreeCreateResponseSchema,
+});
+
+export const worktreeCreateV11 = defineRpcContract({
+  method: "worktree.create",
+  schemaVersion: { major: 1, minor: 1 } as const,
   requestSchema: worktreeCreateRequestSchema,
   responseSchema: worktreeCreateResponseSchema,
+});
+
+export const worktreeCreateUpgradeV10ToV11 = defineUpgradePath<
+  typeof worktreeCreateV10,
+  typeof worktreeCreateV11
+>({
+  from: worktreeCreateV10.schemaVersion,
+  to: worktreeCreateV11.schemaVersion,
+  upgradeRequest: (request) => ({
+    ...request,
+    entries: request.entries.map((entry) => {
+      if (entry.kind !== "worktree") return entry;
+      if (entry.branch.type === "existing") {
+        return { ...entry, branch: { ...entry.branch } };
+      }
+      return {
+        ...entry,
+        branch: {
+          type: "new" as const,
+          name: entry.branch.name,
+          source: entry.branch.source,
+          carryUncommittedChanges: entry.branch.carryUncommittedChanges,
+          collision: "fail" as const,
+        },
+      };
+    }),
+  }),
+  upgradeResponse: (response) => response,
 });
 
 export const worktreeCreatePathsV10 = defineRpcContract({
   method: "worktree.createPaths",
   schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: worktreeCreatePathsRequestSchemaV10,
+  responseSchema: worktreeCreatePathsResponseSchema,
+});
+
+export const worktreeCreatePathsV11 = defineRpcContract({
+  method: "worktree.createPaths",
+  schemaVersion: { major: 1, minor: 1 } as const,
   requestSchema: worktreeCreatePathsRequestSchema,
   responseSchema: worktreeCreatePathsResponseSchema,
+});
+
+export const worktreeCreatePathsUpgradeV10ToV11 = defineUpgradePath<
+  typeof worktreeCreatePathsV10,
+  typeof worktreeCreatePathsV11
+>({
+  from: worktreeCreatePathsV10.schemaVersion,
+  to: worktreeCreatePathsV11.schemaVersion,
+  upgradeRequest: (request) => ({
+    entries: request.entries.map((entry) => {
+      if (entry.branch.type === "existing") {
+        return { ...entry, branch: { ...entry.branch } };
+      }
+      return {
+        ...entry,
+        branch: {
+          type: "new" as const,
+          name: entry.branch.name,
+          source: entry.branch.source,
+          carryUncommittedChanges: entry.branch.carryUncommittedChanges,
+          collision: "fail" as const,
+        },
+      };
+    }),
+  }),
+  upgradeResponse: (response) => response,
 });
 
 export const worktreeImportV10 = defineRpcContract({
@@ -5102,11 +5172,15 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
   },
   "worktree.create": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: worktreeCreateV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: worktreeCreateV11,
+          upgradeFromPreviousVersion: worktreeCreateUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},
@@ -5114,11 +5188,15 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
   },
   "worktree.createPaths": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: worktreeCreatePathsV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: worktreeCreatePathsV11,
+          upgradeFromPreviousVersion: worktreeCreatePathsUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},

--- a/protocol/src/host/worktree-schemas.ts
+++ b/protocol/src/host/worktree-schemas.ts
@@ -149,23 +149,58 @@ export type WorkspaceScripts = z.infer<typeof workspaceScriptsSchema>;
  * Both variants carry `name` as `min(1)`: a git branch name is never empty, so
  * an empty name is structurally impossible to express on either side.
  */
-export const worktreeBranchSelectionSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("new"),
-    name: z.string().min(1),
-    // A fork source is a branch name, never empty - `min(1)` rejects a malformed
-    // empty-source request at the schema boundary (consistent with `name`).
-    source: z.string().min(1),
-    carryUncommittedChanges: z.boolean(),
-  }),
-  z.object({
-    type: z.literal("existing"),
-    name: z.string().min(1),
-  }),
-]);
-export type WorktreeBranchSelection = z.infer<
-  typeof worktreeBranchSelectionSchema
+export const worktreeBranchCollisionSchema = z.enum(["fail", "random"]);
+export type WorktreeBranchCollision = z.infer<
+  typeof worktreeBranchCollisionSchema
 >;
+
+const worktreeNewBranchBaseShape = {
+  type: z.literal("new"),
+  name: z.string().min(1),
+  // A fork source is a branch name, never empty - `min(1)` rejects a malformed
+  // empty-source request at the schema boundary (consistent with `name`).
+  source: z.string().min(1),
+  carryUncommittedChanges: z.boolean(),
+} as const;
+
+export type WorktreeBranchSelection =
+  | {
+      readonly type: "new";
+      readonly name: string;
+      readonly source: string;
+      readonly carryUncommittedChanges: boolean;
+      readonly collision?: "fail";
+    }
+  | {
+      readonly type: "new";
+      readonly name: string;
+      readonly source: string;
+      readonly carryUncommittedChanges: boolean;
+      readonly collision: "random";
+      readonly retryIdentity: string;
+    }
+  | { readonly type: "existing"; readonly name: string };
+
+export const worktreeBranchSelectionSchema: z.ZodType<WorktreeBranchSelection> =
+  z.union([
+    z.object({
+      ...worktreeNewBranchBaseShape,
+      collision: z.literal("random"),
+      // Idempotency key for one generated-name create operation. The host hashes
+      // it into retry candidates and the managed directory, so a replay can
+      // recognize only its own completed checkout without adopting existing refs.
+      retryIdentity: z.string().min(1).max(128),
+    }),
+    // Keep the released variant structurally unchanged. Persisted pre-policy
+    // intents omit collision and execute as `fail`; an explicit `fail` is also
+    // safe input because Zod objects strip unknown keys by default. The random
+    // arm must come first so its identity fields survive parsing.
+    z.object(worktreeNewBranchBaseShape),
+    z.object({
+      type: z.literal("existing"),
+      name: z.string().min(1),
+    }),
+  ]);
 
 /**
  * Setup/teardown override carried on a `kind:"worktree"` folder intent. The
@@ -496,13 +531,77 @@ const worktreeOwnerRequestFields = {
   ownerKind: worktreeBindingOwnerKindSchema,
 } as const;
 
+const worktreeBranchSelectionRequestSchemaV10 = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("new"),
+    name: z.string().min(1),
+    source: z.string().min(1),
+    carryUncommittedChanges: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("existing"),
+    name: z.string().min(1),
+  }),
+]);
+
+const worktreeBranchSelectionRequestSchemaV11 = z.union([
+  z.object({
+    ...worktreeNewBranchBaseShape,
+    collision: z.literal("fail"),
+  }),
+  z.object({
+    ...worktreeNewBranchBaseShape,
+    collision: z.literal("random"),
+    retryIdentity: z.string().min(1).max(128),
+  }),
+  z.object({
+    type: z.literal("existing"),
+    name: z.string().min(1),
+  }),
+]);
+
+const worktreeFolderIntentRequestSchemaV10 = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("local"), ...worktreeFolderIntentBaseShape }),
+  z.object({
+    kind: z.literal("import"),
+    ...worktreeFolderIntentBaseShape,
+    worktreePath: z.string(),
+  }),
+  z.object({
+    kind: z.literal("worktree"),
+    ...worktreeFolderIntentBaseShape,
+    branch: worktreeBranchSelectionRequestSchemaV10,
+    scripts: worktreeEntryScriptsSchema.nullable(),
+  }),
+]);
+
+const worktreeFolderIntentRequestSchemaV11 = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("local"), ...worktreeFolderIntentBaseShape }),
+  z.object({
+    kind: z.literal("import"),
+    ...worktreeFolderIntentBaseShape,
+    worktreePath: z.string(),
+  }),
+  z.object({
+    kind: z.literal("worktree"),
+    ...worktreeFolderIntentBaseShape,
+    branch: worktreeBranchSelectionRequestSchemaV11,
+    scripts: worktreeEntryScriptsSchema.nullable(),
+  }),
+]);
+
 // `worktree.create` takes the canonical folder-intent union directly: the
 // orchestrator resolves each entry's `kind` (and, for `worktree`, its
 // `branch.type`) into a binding. The `perEntry` channel reports per-folder
 // success/failure unchanged.
+export const worktreeCreateRequestSchemaV10 = z.object({
+  ...worktreeOwnerRequestFields,
+  entries: z.array(worktreeFolderIntentRequestSchemaV10),
+});
+
 export const worktreeCreateRequestSchema = z.object({
   ...worktreeOwnerRequestFields,
-  entries: z.array(worktreeFolderIntentSchema),
+  entries: z.array(worktreeFolderIntentRequestSchemaV11),
 });
 export type WorktreeCreateRequest = z.infer<typeof worktreeCreateRequestSchema>;
 
@@ -546,12 +645,21 @@ export type WorktreeCreateResponse = z.infer<
  * (`worktreeFolderIntentSchema`), which keeps both because that flow is driven
  * by epic/cloud metadata that is authoritative and may differ from local git.
  */
+export const worktreeCreatePathsEntrySchemaV10 = z.object({
+  workspacePath: z.string(),
+  branch: worktreeBranchSelectionRequestSchemaV10,
+});
+
 export const worktreeCreatePathsEntrySchema = z.object({
+  workspacePath: z.string(),
+  branch: worktreeBranchSelectionRequestSchemaV11,
+});
+const worktreeCreatePathsEntrySharedSchema = z.object({
   workspacePath: z.string(),
   branch: worktreeBranchSelectionSchema,
 });
 export type WorktreeCreatePathsEntry = z.infer<
-  typeof worktreeCreatePathsEntrySchema
+  typeof worktreeCreatePathsEntrySharedSchema
 >;
 
 export const worktreeCreatedPathEntrySchema = z.object({
@@ -564,6 +672,10 @@ export const worktreeCreatedPathEntrySchema = z.object({
 export type WorktreeCreatedPathEntry = z.infer<
   typeof worktreeCreatedPathEntrySchema
 >;
+
+export const worktreeCreatePathsRequestSchemaV10 = z.object({
+  entries: z.array(worktreeCreatePathsEntrySchemaV10),
+});
 
 export const worktreeCreatePathsRequestSchema = z.object({
   entries: z.array(worktreeCreatePathsEntrySchema),


### PR DESCRIPTION
## Summary
- let Git atomically arbitrate generated worktree-branch collisions
- retry generated names using a persisted identity; keep typed names exact and failing
- remove branch probing, numeric allocation, leftover adoption, and fast-forwarding

## Verification
- host focused collision/orchestration/resolver suites
- GUI focused suites
- protocol compatibility suite
- `bun run --filter @traycer/host compile`
- `bun run compile`
- affected-workspace pre-commit checks (lint, format, compile, build)