### PR TITLE
feat(gui): usage dashboard feedback — ECharts area chart, readable axis, by-chat table

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -129,6 +129,7 @@
         "date-fns": "catalog:",
         "diff": "catalog:",
         "dompurify": "catalog:",
+        "echarts": "catalog:",
         "fflate": "catalog:",
         "fuse.js": "catalog:",
         "hast-util-sanitize": "catalog:",
@@ -364,6 +365,7 @@
     "date-fns": "^4.4.0",
     "diff": "^9.0.0",
     "dompurify": "^3.4.12",
+    "echarts": "^6.1.0",
     "electron": "^42.8.1",
     "electron-builder": "^26.15.3",
     "electron-log": "^5.4.4",
@@ -2030,6 +2032,8 @@
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
+    "echarts": ["echarts@6.1.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.1.0" } }, "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "ejs": ["ejs@5.0.1", "", { "bin": { "ejs": "bin/cli.js" } }, "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A=="],
@@ -3672,6 +3676,8 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "zrender": ["zrender@6.1.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ=="],
+
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
@@ -4106,6 +4112,8 @@
 
     "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "echarts/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+
     "electron/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -4301,6 +4309,8 @@
     "yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/clients/gui-app/__tests__/test-browser-apis.ts
+++ b/clients/gui-app/__tests__/test-browser-apis.ts
@@ -47,6 +47,55 @@ vi.mock("@pierre/diffs/worker/worker.js?worker", () => ({
   },
 }));
 
+// ECharts (the usage charts' renderer) cannot run under jsdom: zrender
+// measures text through a real canvas context, which jsdom does not
+// implement (see the getContext stub below). Mock the tree-shaken entry
+// points globally so any test that mounts a usage surface gets a recording
+// fake instead of a crash; chart tests read the captured options back
+// through `getEChartsMockInstances`. Registered here rather than per test
+// file because the chart mounts transitively from several suites (settings
+// panel, epic dialog, summary panel).
+export interface EChartsMockInstance {
+  readonly dom: HTMLElement;
+  readonly options: unknown[];
+  disposed: boolean;
+}
+interface EChartsMockGlobal {
+  __traycerEChartsMockInstances?: EChartsMockInstance[];
+}
+export function getEChartsMockInstances(): readonly EChartsMockInstance[] {
+  return (globalThis as EChartsMockGlobal).__traycerEChartsMockInstances ?? [];
+}
+export function clearEChartsMockInstances(): void {
+  (globalThis as EChartsMockGlobal).__traycerEChartsMockInstances = [];
+}
+vi.mock("echarts/core", () => ({
+  use: (): void => undefined,
+  init: (dom: HTMLElement) => {
+    const record: EChartsMockInstance = { dom, options: [], disposed: false };
+    const target = globalThis as EChartsMockGlobal;
+    target.__traycerEChartsMockInstances = [
+      ...(target.__traycerEChartsMockInstances ?? []),
+      record,
+    ];
+    return {
+      setOption: (option: unknown): void => {
+        record.options.push(option);
+      },
+      resize: (): void => undefined,
+      dispose: (): void => {
+        record.disposed = true;
+      },
+    };
+  },
+}));
+vi.mock("echarts/charts", () => ({ LineChart: {} }));
+vi.mock("echarts/components", () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+}));
+vi.mock("echarts/renderers", () => ({ SVGRenderer: {} }));
+
 // Brand icons (@lobehub/icons) render a decorative SVG `<title>BrandName</title>`
 // for accessibility. Those titles aren't visible content, but they DO satisfy
 // `getByText`, which makes any text query near a provider icon ambiguous (the

--- a/clients/gui-app/__tests__/test-browser-apis.ts
+++ b/clients/gui-app/__tests__/test-browser-apis.ts
@@ -58,12 +58,25 @@ vi.mock("@pierre/diffs/worker/worker.js?worker", () => ({
 export interface EChartsMockInstance {
   readonly dom: HTMLElement;
   readonly options: unknown[];
+  /** Every `setOption` call's second argument, index-aligned with `options`. */
+  readonly setOptionOpts: unknown[];
   disposed: boolean;
 }
 interface EChartsMockGlobal {
   __traycerEChartsMockInstances?: EChartsMockInstance[];
 }
+/**
+ * LIVE chart instances only. The record list is append-only and shared
+ * across a file's tests, and every consumer reaches for `.at(-1)` - so
+ * without this filter a test could read an option belonging to a chart
+ * that a previous test already unmounted, and pass on stale data.
+ * {@link getAllEChartsMockInstances} keeps the unfiltered list for
+ * lifecycle assertions (e.g. "did unmount dispose it").
+ */
 export function getEChartsMockInstances(): readonly EChartsMockInstance[] {
+  return getAllEChartsMockInstances().filter((record) => !record.disposed);
+}
+export function getAllEChartsMockInstances(): readonly EChartsMockInstance[] {
   return (globalThis as EChartsMockGlobal).__traycerEChartsMockInstances ?? [];
 }
 export function clearEChartsMockInstances(): void {
@@ -72,15 +85,21 @@ export function clearEChartsMockInstances(): void {
 vi.mock("echarts/core", () => ({
   use: (): void => undefined,
   init: (dom: HTMLElement) => {
-    const record: EChartsMockInstance = { dom, options: [], disposed: false };
+    const record: EChartsMockInstance = {
+      dom,
+      options: [],
+      setOptionOpts: [],
+      disposed: false,
+    };
     const target = globalThis as EChartsMockGlobal;
     target.__traycerEChartsMockInstances = [
       ...(target.__traycerEChartsMockInstances ?? []),
       record,
     ];
     return {
-      setOption: (option: unknown): void => {
+      setOption: (option: unknown, opts: unknown): void => {
         record.options.push(option);
+        record.setOptionOpts.push(opts);
       },
       resize: (): void => undefined,
       dispose: (): void => {

--- a/clients/gui-app/package.json
+++ b/clients/gui-app/package.json
@@ -73,6 +73,7 @@
     "culori": "catalog:",
     "date-fns": "catalog:",
     "diff": "catalog:",
+    "echarts": "catalog:",
     "dompurify": "catalog:",
     "fflate": "catalog:",
     "fuse.js": "catalog:",

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -19,6 +19,23 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { EpicUsageDialog } from "@/components/epic-canvas/panels/epic-usage-dialog";
+import type { UsageChartOption } from "@/lib/usage-analytics/usage-chart-option";
+import { getEChartsMockInstances } from "../../../../../__tests__/test-browser-apis";
+
+/**
+ * How many per-day points the mounted trend chart was actually given -
+ * read from the option the mocked ECharts instance received, the area
+ * chart's equivalent of counting the old per-day bar columns.
+ */
+function chartDayCount(): number {
+  const option = getEChartsMockInstances().at(-1)?.options.at(-1);
+  if (option === undefined) throw new Error("no ECharts option captured");
+  const { xAxis } = option as UsageChartOption;
+  const axis = Array.isArray(xAxis) ? xAxis[0] : xAxis;
+  const data = axis !== undefined && "data" in axis ? axis.data : undefined;
+  if (!Array.isArray(data)) throw new Error("x-axis carries no day labels");
+  return data.length;
+}
 
 type UsageSummaryRequest = RequestOfMethod<
   HostRpcRegistry,
@@ -233,7 +250,7 @@ describe("<EpicUsageDialog />", () => {
   it("bounds the trend for a long-lived epic, and says so rather than capping silently", async () => {
     // `window: "epic"` resolves `windowDays` from the epic's own fact span,
     // so a near-epoch `occurredAt` (a valid non-negative integer on the
-    // wire) asks for ~20k columns - each a tooltip-wrapped button.
+    // wire) asks for ~20k per-day points.
     renderDialog(() => {
       const response = usageSummaryResponse();
       return {
@@ -249,7 +266,7 @@ describe("<EpicUsageDialog />", () => {
     await waitFor(() => {
       expect(screen.getByTestId("usage-daily-chart")).toBeTruthy();
     });
-    expect(screen.getAllByTestId("usage-daily-chart-column")).toHaveLength(90);
+    expect(chartDayCount()).toBe(90);
     expect(
       screen.getByTestId("epic-usage-trend-capped-note").textContent,
     ).toContain("Trend shows the last 90 days");
@@ -261,7 +278,7 @@ describe("<EpicUsageDialog />", () => {
     await waitFor(() => {
       expect(screen.getByTestId("usage-daily-chart")).toBeTruthy();
     });
-    expect(screen.getAllByTestId("usage-daily-chart-column")).toHaveLength(30);
+    expect(chartDayCount()).toBe(30);
     expect(screen.queryByTestId("epic-usage-trend-capped-note")).toBeNull();
   });
 

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
@@ -50,7 +50,9 @@ describe("<UsageActivityHeatmap />", () => {
         <UsageActivityHeatmap calendar={calendar} metric="cost" />
       </TooltipProvider>,
     );
-    const tiles = screen.getAllByTestId("usage-activity-day");
+    // Role query, not a test id: each tile is a real button whose
+    // accessible name carries the day and its value.
+    const tiles = screen.getAllByRole("button");
     expect(tiles).toHaveLength(7);
     const active = tiles.find(
       (tile) => tile.getAttribute("data-day") === "2026-08-03",
@@ -71,8 +73,7 @@ describe("<UsageActivityHeatmap />", () => {
         <UsageActivityHeatmap calendar={calendar} metric="cost" />
       </TooltipProvider>,
     );
-    const stats = screen.getByTestId("usage-activity-stats");
-    expect(within(stats).getByText("Aug 3, 2026")).toBeTruthy();
-    expect(within(stats).getByText("Aug 2026")).toBeTruthy();
+    expect(screen.getByText("Aug 3, 2026")).toBeTruthy();
+    expect(screen.getByText("Aug 2026")).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
@@ -5,7 +5,37 @@ import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activit
 import { buildUsageActivityCalendar } from "@/lib/usage-analytics/usage-activity";
 import type { UsageBucket } from "@/lib/usage-analytics/usage-chart-data";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  restoreScrollWidth?.();
+  restoreScrollWidth = null;
+});
+
+/**
+ * jsdom does no layout, so `scrollWidth` is 0 everywhere and an
+ * "anchored to the end" assertion would pass against a scroller that was
+ * never touched. Stub a real content width so the assertion can only pass
+ * if the component actually drove `scrollLeft`.
+ */
+const YEAR_GRID_WIDTH = 650;
+let restoreScrollWidth: (() => void) | null = null;
+function stubScrollWidth(): void {
+  const original = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollWidth",
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get: () => YEAR_GRID_WIDTH,
+  });
+  restoreScrollWidth = () => {
+    if (original === undefined) {
+      delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth;
+      return;
+    }
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", original);
+  };
+}
 
 function bucket(day: string, knownCostUsd: number): UsageBucket {
   return {
@@ -65,6 +95,20 @@ describe("<UsageActivityHeatmap />", () => {
     );
     expect(empty?.getAttribute("data-level")).toBe("0");
     expect(empty?.getAttribute("aria-label")).toBe("2026-08-02: No usage");
+  });
+
+  it("opens on the most recent weeks, not the oldest", () => {
+    // The year grid is wider than a narrow Settings pane. A fresh scroller
+    // sits at scrollLeft 0 - the OLDEST weeks - so the current period, the
+    // reason to open this at all, would hide behind a scrollbar.
+    stubScrollWidth();
+    render(
+      <TooltipProvider>
+        <UsageActivityHeatmap calendar={calendar} metric="cost" />
+      </TooltipProvider>,
+    );
+    const scroller = screen.getByTestId("usage-activity-scroller");
+    expect(scroller.scrollLeft).toBe(YEAR_GRID_WIDTH);
   });
 
   it("shows the stat row computed from the same calendar", () => {

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
@@ -74,27 +74,41 @@ describe("<UsageActivityHeatmap />", () => {
     "cost",
   );
 
-  it("renders one focusable tile per day with its intensity level", () => {
+  it("renders one tile per day at its intensity level", () => {
     render(
       <TooltipProvider>
         <UsageActivityHeatmap calendar={calendar} metric="cost" />
       </TooltipProvider>,
     );
-    // Role query, not a test id: each tile is a real button whose
-    // accessible name carries the day and its value.
-    const tiles = screen.getAllByRole("button");
+    const tiles = screen.getAllByTestId("usage-activity-day");
     expect(tiles).toHaveLength(7);
     const active = tiles.find(
       (tile) => tile.getAttribute("data-day") === "2026-08-03",
     );
     expect(active?.getAttribute("data-level")).toBe("4");
-    // Identity is not color-alone: every tile names its day and exact value.
-    expect(active?.getAttribute("aria-label")).toBe("2026-08-03: $5.00");
     const empty = tiles.find(
       (tile) => tile.getAttribute("data-day") === "2026-08-02",
     );
     expect(empty?.getAttribute("data-level")).toBe("0");
-    expect(empty?.getAttribute("aria-label")).toBe("2026-08-02: No usage");
+  });
+
+  it("keeps 365 marks out of the tab order and states the values in a table instead", () => {
+    // Each tile as a tab stop made the calendar a keyboard trap: the first
+    // Tab landed a year back (DOM is oldest-first, the scroller is anchored
+    // right), dragged the scroll position with it, and the stats below were
+    // hundreds of presses away.
+    render(
+      <TooltipProvider>
+        <UsageActivityHeatmap calendar={calendar} metric="cost" />
+      </TooltipProvider>,
+    );
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    const table = screen.getByTestId("usage-activity-data-table");
+    // Only days WITH usage earn a row - a year of "No usage" is noise.
+    const rows = within(table).getAllByRole("row").slice(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.textContent).toContain("2026-08-03");
+    expect(rows[0]?.textContent).toContain("$5.00");
   });
 
   it("opens on the most recent weeks, not the oldest", () => {

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
+import { buildUsageActivityCalendar } from "@/lib/usage-analytics/usage-activity";
+import type { UsageBucket } from "@/lib/usage-analytics/usage-chart-data";
+
+afterEach(cleanup);
+
+function bucket(day: string, knownCostUsd: number): UsageBucket {
+  return {
+    day,
+    harnessId: "claude",
+    model: "claude-sonnet-5",
+    factCount: 1,
+    tokens: {
+      uncachedInputTokens: 10,
+      cacheReadInputTokens: 0,
+      cacheCreationTokens: 0,
+      outputTokens: 0,
+    },
+    knownCostUsd,
+    knownCacheSavingsUsd: 0,
+    knownReasoningTokens: 0,
+    costProvenance: "providerReported",
+  };
+}
+
+// 2026-08-02 (Sunday) .. 2026-08-08 (Saturday): one full week.
+const DAYS = [
+  "2026-08-02",
+  "2026-08-03",
+  "2026-08-04",
+  "2026-08-05",
+  "2026-08-06",
+  "2026-08-07",
+  "2026-08-08",
+];
+
+describe("<UsageActivityHeatmap />", () => {
+  const calendar = buildUsageActivityCalendar(
+    DAYS,
+    [bucket("2026-08-03", 5)],
+    "cost",
+  );
+
+  it("renders one focusable tile per day with its intensity level", () => {
+    render(
+      <TooltipProvider>
+        <UsageActivityHeatmap calendar={calendar} metric="cost" />
+      </TooltipProvider>,
+    );
+    const tiles = screen.getAllByTestId("usage-activity-day");
+    expect(tiles).toHaveLength(7);
+    const active = tiles.find(
+      (tile) => tile.getAttribute("data-day") === "2026-08-03",
+    );
+    expect(active?.getAttribute("data-level")).toBe("4");
+    // Identity is not color-alone: every tile names its day and exact value.
+    expect(active?.getAttribute("aria-label")).toBe("2026-08-03: $5.00");
+    const empty = tiles.find(
+      (tile) => tile.getAttribute("data-day") === "2026-08-02",
+    );
+    expect(empty?.getAttribute("data-level")).toBe("0");
+    expect(empty?.getAttribute("aria-label")).toBe("2026-08-02: No usage");
+  });
+
+  it("shows the stat row computed from the same calendar", () => {
+    render(
+      <TooltipProvider>
+        <UsageActivityHeatmap calendar={calendar} metric="cost" />
+      </TooltipProvider>,
+    );
+    const stats = screen.getByTestId("usage-activity-stats");
+    expect(within(stats).getByText("Aug 3, 2026")).toBeTruthy();
+    expect(within(stats).getByText("Aug 2026")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-chat-breakdown.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-chat-breakdown.test.tsx
@@ -46,7 +46,7 @@ describe("UsageChatBreakdown", () => {
         ]}
       />,
     );
-    const rows = screen.getAllByRole("listitem");
+    const rows = screen.getAllByRole("row").slice(1);
     expect(rows.map((row) => row.textContent)).toEqual([
       expect.stringContaining("Fix the flaky test"),
       expect.stringContaining("Subagent: verify the fix"),
@@ -55,7 +55,7 @@ describe("UsageChatBreakdown", () => {
 
   it("falls back to the raw chatId when the chat is not in the open tree (e.g. swept)", () => {
     render(<UsageChatBreakdown rows={[bucket({ chatId: "chat-unknown" })]} />);
-    const rows = screen.getAllByRole("listitem");
+    const rows = screen.getAllByRole("row").slice(1);
     expect(rows.map((row) => row.textContent)).toEqual([
       expect.stringContaining("chat-unknown"),
     ]);
@@ -70,15 +70,24 @@ describe("UsageChatBreakdown", () => {
         ]}
       />,
     );
-    const rows = screen.getAllByRole("listitem");
+    const rows = screen.getAllByRole("row").slice(1);
     expect(rows.map((row) => row.textContent)).toEqual([
       expect.stringContaining("Fix the flaky test"),
       expect.stringContaining("Subagent: verify the fix"),
     ]);
   });
 
-  it("shows an explicit empty state rather than a bare empty list", () => {
+  it("shows an explicit empty state rather than a bare empty table", () => {
     render(<UsageChatBreakdown rows={[]} />);
     expect(screen.getByTestId("usage-chat-breakdown-empty")).not.toBeNull();
+  });
+
+  it("renders as a real table with named columns", () => {
+    render(<UsageChatBreakdown rows={[bucket({ chatId: "chat-1" })]} />);
+    const table = screen.getByRole("table");
+    expect(table.getAttribute("data-testid")).toBe("usage-chat-breakdown");
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Chat / agent", "Tokens", "Cost"]);
   });
 });

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-daily-chart.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-daily-chart.test.tsx
@@ -1,15 +1,44 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { LineSeriesOption } from "echarts/charts";
+import {
+  clearEChartsMockInstances,
+  getEChartsMockInstances,
+} from "../../../../__tests__/test-browser-apis";
 import { UsageDailyChart } from "@/components/usage-analytics/usage-daily-chart";
 import {
   buildUsageChartColumns,
   type UsageBucket,
 } from "@/lib/usage-analytics/usage-chart-data";
+import type { UsageChartOption } from "@/lib/usage-analytics/usage-chart-option";
 import { buildUsageSeriesScale } from "@/lib/usage-analytics/usage-series-scale";
+
+beforeEach(() => {
+  clearEChartsMockInstances();
+});
 
 afterEach(() => {
   cleanup();
 });
+
+/** The option the mocked chart instance most recently received. */
+function latestChartOption(): UsageChartOption {
+  const instance = getEChartsMockInstances().at(-1);
+  const option = instance?.options.at(-1);
+  if (option === undefined) throw new Error("no ECharts option captured");
+  return option as UsageChartOption;
+}
+
+function seriesByName(
+  option: UsageChartOption,
+  name: string,
+): LineSeriesOption {
+  const raw = option.series ?? [];
+  const list = Array.isArray(raw) ? raw : [raw];
+  const found = list.find((entry) => entry.name === name);
+  if (found === undefined) throw new Error(`series ${name} not in option`);
+  return found;
+}
 
 function bucket(overrides: Partial<UsageBucket>): UsageBucket {
   return {
@@ -61,6 +90,12 @@ describe("<UsageDailyChart /> legend filter", () => {
         .getByRole("button", { name: "claude" })
         .getAttribute("aria-pressed"),
     ).toBe("true");
+    // The chip updating is not enough - the chart must actually receive an
+    // option with the hidden series zeroed (still PRESENT, so the slot and
+    // color never shift) and the other series untouched.
+    const option = latestChartOption();
+    expect(seriesByName(option, "codex").data).toEqual([0]);
+    expect(seriesByName(option, "claude").data).toEqual([3]);
   });
 
   it("keeps the legend reachable when a refetch narrows the window to the hidden series", () => {

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-daily-chart.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-daily-chart.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { LineSeriesOption } from "echarts/charts";
 import {
@@ -132,6 +138,36 @@ describe("<UsageDailyChart /> legend filter", () => {
     // Nothing is filtered any more, so the single-series suppression applies
     // again - the legend going away IS the proof the series came back.
     expect(screen.queryByTestId("usage-daily-chart-legend")).toBeNull();
+  });
+
+  it("exposes every plotted value without a pointer, via a screen-reader table", () => {
+    // The bar version made each day a focusable button; ECharts draws one
+    // opaque graphic whose values live only in a pointer-triggered tooltip.
+    // In the epic dialog the companion table is grouped by CHAT, so this is
+    // the only non-pointer path to the per-day numbers there.
+    render(<UsageDailyChart columns={columns} scale={scale} metric="cost" />);
+    const table = screen.getByTestId("usage-daily-chart-data-table");
+    expect(
+      within(table)
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent),
+    ).toEqual(["Day", "claude", "codex"]);
+    const row = within(table).getByRole("row", { name: /Aug 1/ });
+    expect(row.textContent).toContain("$3.00");
+    expect(row.textContent).toContain("$5.00");
+  });
+
+  it("drops a filtered series from the accessible table too", () => {
+    render(<UsageDailyChart columns={columns} scale={scale} metric="cost" />);
+    fireEvent.click(screen.getByRole("button", { name: "codex" }));
+    const table = screen.getByTestId("usage-daily-chart-data-table");
+    // The table is the same view by another means - it must not contradict
+    // what the chart draws.
+    expect(
+      within(table)
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent),
+    ).toEqual(["Day", "claude"]);
   });
 
   it("hides the legend for a single series that is not filtered out", () => {

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
@@ -186,6 +186,64 @@ describe("<UsageSummaryPanel /> activity section", () => {
     expect(seen).toContain(90);
   });
 
+  it("does NOT shrink the calendar for a transient year-read failure", async () => {
+    // The 90-day fallback exists for ONE failure: an old host's window cap.
+    // A transient error on the year read followed by a lucky 90-day success
+    // must surface as an error, not quietly present a quarter of the
+    // calendar as if it were the whole thing.
+    const seen: number[] = [];
+    renderPanel({
+      response: (request) => {
+        seen.push(request.windowDays);
+        if (request.windowDays === 365) {
+          throw new Error("socket hang up");
+        }
+        return response({
+          servedBy: "cloud",
+          hostBuckets: [hostBucket("host-a", 3)],
+        });
+      },
+      hostNames: new Map([["host-a", "Studio Mac"]]),
+    });
+
+    await screen.findByTestId("usage-cost-figure");
+    const section = await screen.findByTestId("usage-activity-section");
+    expect(await within(section).findByTestId("usage-error-card")).toBeTruthy();
+    expect(screen.queryByTestId("usage-activity-heatmap")).toBeNull();
+    // And the narrower read never even fired.
+    expect(seen).not.toContain(90);
+  });
+
+  it("offers hosts that only the FALLBACK calendar read knows about", async () => {
+    // An old host that rejects the year can still surface a host (active
+    // e.g. 60 days ago) that neither the directory nor the 30-day window
+    // knows - the filter has to learn it from the fallback response too.
+    const user = userEvent.setup();
+    renderPanel({
+      response: (request) => {
+        if (request.windowDays === 365) {
+          throw new Error(
+            "windowDays must be an integer between 1 and 90, got 365",
+          );
+        }
+        return response({
+          servedBy: "cloud",
+          hostBuckets:
+            request.windowDays === 90
+              ? [hostBucket("host-a", 3), hostBucket("host-sixty-days", 2)]
+              : [hostBucket("host-a", 3)],
+        });
+      },
+      hostNames: new Map(),
+    });
+
+    await screen.findByTestId("usage-activity-heatmap");
+    await user.click(await screen.findByTestId("usage-host-filter"));
+    expect(
+      await screen.findByTestId("usage-host-filter-option-host-sixty-days"),
+    ).toBeTruthy();
+  });
+
   it("shows an error with a retry only once BOTH activity reads fail", async () => {
     // The page's own Retry refetches the window query alone, so a dropped
     // activity error would leave the section silently absent with no way

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
@@ -290,6 +290,30 @@ describe("<UsageSummaryPanel /> host scope", () => {
     expect(screen.queryByTestId("usage-served-by-local-note")).toBeNull();
   });
 
+  it("offers hosts that only the year-long activity read knows about", async () => {
+    // The calendar spans a year; the picker's own read spans 30 days. A
+    // host active months ago, absent from the directory, showed up in the
+    // All-hosts calendar with no way to isolate it.
+    const user = userEvent.setup();
+    renderPanel({
+      response: (request) =>
+        response({
+          servedBy: "cloud",
+          hostBuckets:
+            request.windowDays === 365
+              ? [hostBucket("host-a", 3), hostBucket("host-dormant", 9)]
+              : [hostBucket("host-a", 3)],
+        }),
+      hostNames: new Map(),
+    });
+
+    await screen.findByTestId("usage-cost-figure");
+    await user.click(await screen.findByTestId("usage-host-filter"));
+    expect(
+      await screen.findByTestId("usage-host-filter-option-host-dormant"),
+    ).toBeTruthy();
+  });
+
   it("keeps every discovered host in the picker after narrowing to one", async () => {
     // The shared aggregator filters facts by `hostId` BEFORE grouping, so a
     // filtered response's `hostBuckets` names only the selected host. With an

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
@@ -161,15 +161,40 @@ function renderPanel(input: {
 }
 
 describe("<UsageSummaryPanel /> activity section", () => {
-  it("surfaces a failed activity read with its own retry, never a silent gap", async () => {
-    // The 365-day activity read is a SECOND request. When only it fails,
-    // the page's own Retry refetches the window query alone - so dropping
-    // this error left the section silently absent with no way back.
-    let activityAttempts = 0;
-    const { requests } = renderPanel({
+  it("falls back to a shorter calendar when the host is too old for the year window", async () => {
+    // Hosts update independently of the app: one released before this
+    // feature caps windowDays at 90 and rejects the year outright. That
+    // must degrade to a shorter calendar, not an error.
+    const seen: number[] = [];
+    renderPanel({
       response: (request) => {
+        seen.push(request.windowDays);
         if (request.windowDays === 365) {
-          activityAttempts += 1;
+          throw new Error("windowDays must be an integer between 1 and 90");
+        }
+        return response({
+          servedBy: "cloud",
+          hostBuckets: [hostBucket("host-a", 3)],
+        });
+      },
+      hostNames: new Map([["host-a", "Studio Mac"]]),
+    });
+
+    await screen.findByTestId("usage-cost-figure");
+    expect(await screen.findByTestId("usage-activity-heatmap")).toBeTruthy();
+    expect(screen.queryByTestId("usage-error-card")).toBeNull();
+    expect(seen).toContain(90);
+  });
+
+  it("shows an error with a retry only once BOTH activity reads fail", async () => {
+    // The page's own Retry refetches the window query alone, so a dropped
+    // activity error would leave the section silently absent with no way
+    // back.
+    let attempts = 0;
+    renderPanel({
+      response: (request) => {
+        if (request.windowDays === 365 || request.windowDays === 90) {
+          attempts += 1;
           throw new Error("activity read failed");
         }
         return response({
@@ -184,22 +209,15 @@ describe("<UsageSummaryPanel /> activity section", () => {
     // blank a working page.
     await screen.findByTestId("usage-cost-figure");
     const section = await screen.findByTestId("usage-activity-section");
-    const card = within(section).getByTestId("usage-error-card");
+    const card = await within(section).findByTestId("usage-error-card");
     expect(card).toBeTruthy();
     expect(screen.queryByTestId("usage-activity-heatmap")).toBeNull();
 
-    // And its Retry refetches the ACTIVITY query, not the window one.
-    const attemptsBefore = activityAttempts;
-    const windowRequestsBefore = requests.filter(
-      (request) => request.windowDays !== 365,
-    ).length;
+    const before = attempts;
     await userEvent.click(within(card).getByRole("button", { name: /retry/i }));
     await waitFor(() => {
-      expect(activityAttempts).toBeGreaterThan(attemptsBefore);
+      expect(attempts).toBeGreaterThan(before);
     });
-    expect(
-      requests.filter((request) => request.windowDays !== 365).length,
-    ).toBe(windowRequestsBefore);
   });
 });
 

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-host-scope.test.tsx
@@ -160,6 +160,49 @@ function renderPanel(input: {
   return { requests };
 }
 
+describe("<UsageSummaryPanel /> activity section", () => {
+  it("surfaces a failed activity read with its own retry, never a silent gap", async () => {
+    // The 365-day activity read is a SECOND request. When only it fails,
+    // the page's own Retry refetches the window query alone - so dropping
+    // this error left the section silently absent with no way back.
+    let activityAttempts = 0;
+    const { requests } = renderPanel({
+      response: (request) => {
+        if (request.windowDays === 365) {
+          activityAttempts += 1;
+          throw new Error("activity read failed");
+        }
+        return response({
+          servedBy: "cloud",
+          hostBuckets: [hostBucket("host-a", 3)],
+        });
+      },
+      hostNames: new Map([["host-a", "Studio Mac"]]),
+    });
+
+    // The dashboard itself still renders - one failed section must not
+    // blank a working page.
+    await screen.findByTestId("usage-cost-figure");
+    const section = await screen.findByTestId("usage-activity-section");
+    const card = within(section).getByTestId("usage-error-card");
+    expect(card).toBeTruthy();
+    expect(screen.queryByTestId("usage-activity-heatmap")).toBeNull();
+
+    // And its Retry refetches the ACTIVITY query, not the window one.
+    const attemptsBefore = activityAttempts;
+    const windowRequestsBefore = requests.filter(
+      (request) => request.windowDays !== 365,
+    ).length;
+    await userEvent.click(within(card).getByRole("button", { name: /retry/i }));
+    await waitFor(() => {
+      expect(activityAttempts).toBeGreaterThan(attemptsBefore);
+    });
+    expect(
+      requests.filter((request) => request.windowDays !== 365).length,
+    ).toBe(windowRequestsBefore);
+  });
+});
+
 describe("<UsageSummaryPanel /> host scope", () => {
   it("defaults to All hosts - the request carries no host filter at all", async () => {
     const { requests } = renderPanel({

--- a/clients/gui-app/src/components/usage-analytics/echarts-container.tsx
+++ b/clients/gui-app/src/components/usage-analytics/echarts-container.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { LineChart } from "echarts/charts";
+import { GridComponent, TooltipComponent } from "echarts/components";
+import * as echarts from "echarts/core";
+import { SVGRenderer } from "echarts/renderers";
+import type { EChartsType } from "echarts/core";
+import type { UsageChartOption } from "@/lib/usage-analytics/usage-chart-option";
+
+// Tree-shaken registration: only the pieces the usage chart draws with. The
+// SVG renderer is load-bearing, not a preference - the palette reaches the
+// chart as CSS `var(...)` strings that only resolve because they end up in
+// DOM attributes (see `buildUsageChartOption`).
+echarts.use([LineChart, GridComponent, TooltipComponent, SVGRenderer]);
+
+export interface EChartsContainerProps {
+  readonly option: UsageChartOption;
+  readonly className: string;
+  /** The chart is a single opaque graphic to assistive tech - name it. */
+  readonly ariaLabel: string;
+  readonly testId: string;
+}
+
+/**
+ * Imperative ECharts lifecycle behind a plain div: init once, `setOption`
+ * per option change, resize with the container, dispose on unmount. Every
+ * usage surface renders charts through this one wrapper so the
+ * renderer/theming decisions live in exactly one place.
+ */
+export function EChartsContainer(props: EChartsContainerProps): ReactNode {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container === null) return;
+    const chart = echarts.init(container, null, { renderer: "svg" });
+    chartRef.current = chart;
+    // The container mounts before layout settles (and at 0×0 inside a
+    // just-opening dialog); the observer's initial callback delivers the
+    // real size, and later ones track panel/window resizes.
+    const observer = new ResizeObserver(() => {
+      chart.resize();
+    });
+    observer.observe(container);
+    return () => {
+      observer.disconnect();
+      chartRef.current = null;
+      chart.dispose();
+    };
+  }, []);
+
+  // Runs after the init effect on mount (declaration order), then alone on
+  // every option change. `notMerge` so a window/metric switch REPLACES the
+  // option - merged leftovers from the previous shape (an extra series, a
+  // stale formatter closure) are exactly the bugs merging invites.
+  useEffect(() => {
+    chartRef.current?.setOption(props.option, { notMerge: true });
+  }, [props.option]);
+
+  return (
+    <div
+      ref={containerRef}
+      role="img"
+      aria-label={props.ariaLabel}
+      data-testid={props.testId}
+      className={props.className}
+    />
+  );
+}

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -95,9 +95,10 @@ function MonthLabelRow(props: {
   );
   return (
     // Same 12px column rhythm as the tile grid (10px tile + 2px gap), and
-    // the same leading gutter as the weekday label column, so each label
-    // lands exactly over its month's first week.
-    <div className="flex gap-0.5 pl-[1.375rem] text-ui-xs text-muted-foreground">
+    // the same leading gutter the grid itself sits behind - the 10px
+    // weekday column plus the 6px gap between it and the tiles, i.e. 16px
+    // - so each label lands exactly over its month's first week.
+    <div className="flex gap-0.5 pl-4 text-ui-xs text-muted-foreground">
       {weeks.map((week, weekIndex) => (
         <span key={week.firstDay} className="w-2.5 shrink-0 overflow-visible">
           <span className="block w-8">{byWeek.get(weekIndex) ?? ""}</span>

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -52,12 +52,28 @@ export function UsageActivityHeatmap(props: {
   readonly metric: UsageMetric;
 }): ReactNode {
   const { calendar, metric } = props;
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  // A year grid is wider than a narrow Settings pane, and a fresh scroller
+  // starts at the OLDEST week - so the current period, the whole point of
+  // opening this, would sit off-screen behind a scrollbar the reader has
+  // to discover. Anchor to the newest week instead. Re-runs when the week
+  // count changes (window/host filter), since that resizes the content.
+  const weekCount = calendar.weeks.length;
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (scroller === null) return;
+    scroller.scrollLeft = scroller.scrollWidth;
+  }, [weekCount]);
   return (
     <div
       className="flex w-full flex-col gap-3"
       data-testid="usage-activity-heatmap"
     >
-      <div className="w-full overflow-x-auto">
+      <div
+        ref={scrollerRef}
+        className="w-full overflow-x-auto"
+        data-testid="usage-activity-scroller"
+      >
         <div className="flex min-w-max flex-col gap-1">
           <MonthLabelRow calendar={calendar} />
           <div className="flex gap-1.5">

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -1,0 +1,203 @@
+import type { ReactNode } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type {
+  UsageActivityCalendar,
+  UsageActivityCell,
+} from "@/lib/usage-analytics/usage-activity";
+import { formatMetricValue } from "@/lib/usage-analytics/format-metric-value";
+import type { UsageMetric } from "@/lib/usage-analytics/usage-chart-data";
+
+const WEEKDAY_ROW_LABELS: ReadonlyArray<{
+  readonly row: number;
+  readonly label: string;
+}> = [
+  { row: 1, label: "M" },
+  { row: 3, label: "W" },
+  { row: 5, label: "F" },
+];
+
+const LEVELS = [0, 1, 2, 3, 4] as const;
+
+const WEEKDAY_KEYS = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+/** Pairs each fixed weekday slot with its cell so render keys are the weekday, not an array index. */
+function zipWeekdays(
+  cells: ReadonlyArray<UsageActivityCell | null>,
+): ReadonlyArray<{
+  readonly weekdayKey: string;
+  readonly cell: UsageActivityCell | null;
+}> {
+  return WEEKDAY_KEYS.map((weekdayKey, slot) => ({
+    weekdayKey,
+    cell: cells[slot] ?? null,
+  }));
+}
+
+/**
+ * GitHub-style activity calendar: one column per week (Sunday-first rows),
+ * one tile per day, intensity = the day's metric value quantized to
+ * quartiles (`buildUsageActivityCalendar`). Colors come from the
+ * `--usage-heat-N` sequential ramp (one hue, light→dark, its own dark-mode
+ * steps) scoped under `.usage-chart-root` beside the categorical palette.
+ * Tiles are marks, not layout, so their fixed pixel size is fine; the grid
+ * itself scrolls horizontally rather than squeezing tiles unreadable.
+ */
+export function UsageActivityHeatmap(props: {
+  readonly calendar: UsageActivityCalendar;
+  readonly metric: UsageMetric;
+}): ReactNode {
+  const { calendar, metric } = props;
+  return (
+    <div
+      className="flex w-full flex-col gap-3"
+      data-testid="usage-activity-heatmap"
+    >
+      <div className="w-full overflow-x-auto">
+        <div className="flex min-w-max flex-col gap-1">
+          <MonthLabelRow calendar={calendar} />
+          <div className="flex gap-1.5">
+            <WeekdayLabelColumn />
+            <div className="flex gap-0.5" data-testid="usage-activity-grid">
+              {calendar.weeks.map((week) => (
+                <div key={week.firstDay} className="flex flex-col gap-0.5">
+                  {zipWeekdays(week.cells).map(({ weekdayKey, cell }) =>
+                    cell === null ? (
+                      <span key={weekdayKey} className="size-2.5" aria-hidden />
+                    ) : (
+                      <DayTile key={weekdayKey} cell={cell} metric={metric} />
+                    ),
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ActivityStats stats={calendar.stats} />
+        <LevelLegend />
+      </div>
+    </div>
+  );
+}
+
+function MonthLabelRow(props: {
+  readonly calendar: UsageActivityCalendar;
+}): ReactNode {
+  const { weeks, monthLabels } = props.calendar;
+  const byWeek = new Map(
+    monthLabels.map((label) => [label.weekIndex, label.label]),
+  );
+  return (
+    // Same 12px column rhythm as the tile grid (10px tile + 2px gap), and
+    // the same leading gutter as the weekday label column, so each label
+    // lands exactly over its month's first week.
+    <div className="flex gap-0.5 pl-[1.375rem] text-ui-xs text-muted-foreground">
+      {weeks.map((week, weekIndex) => (
+        <span key={week.firstDay} className="w-2.5 shrink-0 overflow-visible">
+          <span className="block w-8">{byWeek.get(weekIndex) ?? ""}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function WeekdayLabelColumn(): ReactNode {
+  return (
+    <div
+      className="grid shrink-0 grid-rows-7 gap-0.5 text-ui-xs text-muted-foreground"
+      aria-hidden
+    >
+      {Array.from({ length: 7 }, (_, row) => (
+        <span key={row} className="flex size-2.5 items-center justify-end pr-1">
+          {WEEKDAY_ROW_LABELS.find((entry) => entry.row === row)?.label ?? ""}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function DayTile(props: {
+  readonly cell: UsageActivityCell;
+  readonly metric: UsageMetric;
+}): ReactNode {
+  const { cell, metric } = props;
+  const valueLabel =
+    cell.value > 0 ? formatMetricValue(cell.value, metric) : "No usage";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${cell.day}: ${valueLabel}`}
+          data-testid="usage-activity-day"
+          data-day={cell.day}
+          data-level={cell.level}
+          className="size-2.5 rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          style={{ backgroundColor: `var(--usage-heat-${String(cell.level)})` }}
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>
+          <span className="font-medium">{cell.day}</span>
+          {" · "}
+          {valueLabel}
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function ActivityStats(props: {
+  readonly stats: UsageActivityCalendar["stats"];
+}): ReactNode {
+  const { stats } = props;
+  const entries: ReadonlyArray<{
+    readonly label: string;
+    readonly value: string;
+  }> = [
+    { label: "Most active month", value: stats.mostActiveMonth ?? "—" },
+    { label: "Most active day", value: stats.mostActiveDay ?? "—" },
+    { label: "Longest streak", value: `${String(stats.longestStreakDays)}d` },
+    { label: "Current streak", value: `${String(stats.currentStreakDays)}d` },
+  ];
+  return (
+    <dl
+      className="flex flex-wrap gap-x-6 gap-y-1"
+      data-testid="usage-activity-stats"
+    >
+      {entries.map((entry) => (
+        <div key={entry.label} className="flex flex-col">
+          <dt className="text-ui-xs text-muted-foreground">{entry.label}</dt>
+          <dd className="text-ui-sm font-medium text-foreground">
+            {entry.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function LevelLegend(): ReactNode {
+  return (
+    <div
+      className="flex items-center gap-1 text-ui-xs text-muted-foreground"
+      aria-hidden
+    >
+      Fewer
+      {LEVELS.map((level) => (
+        <span
+          key={level}
+          className={cn("size-2.5 rounded-[2px]")}
+          style={{ backgroundColor: `var(--usage-heat-${String(level)})` }}
+        />
+      ))}
+      More
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -69,8 +69,11 @@ export function UsageActivityHeatmap(props: {
       className="flex w-full flex-col gap-3"
       data-testid="usage-activity-heatmap"
     >
+      {/* The grid is decorative for assistive tech - the data table below
+          carries the same values in a navigable form. */}
       <div
         ref={scrollerRef}
+        aria-hidden
         className="w-full overflow-x-auto"
         data-testid="usage-activity-scroller"
       >
@@ -94,6 +97,7 @@ export function UsageActivityHeatmap(props: {
           </div>
         </div>
       </div>
+      <UsageActivityDataTable calendar={calendar} metric={metric} />
       <div className="flex flex-wrap items-center justify-between gap-3">
         <ActivityStats stats={calendar.stats} />
         <LevelLegend />
@@ -139,6 +143,16 @@ function WeekdayLabelColumn(): ReactNode {
   );
 }
 
+/**
+ * A tile is a MARK, not a control: it carries no action, and making each
+ * of 365 a tab stop turned the calendar into a keyboard trap - the first
+ * Tab landed on an off-screen date a year back (the DOM is oldest-first,
+ * the scroller is anchored right), yanked the scroll position with it, and
+ * reaching the stats below took hundreds more presses. So the grid is
+ * hidden from assistive tech entirely and {@link UsageActivityDataTable}
+ * carries the same values in a form that is actually navigable. The
+ * tooltip stays for pointer users.
+ */
 function DayTile(props: {
   readonly cell: UsageActivityCell;
   readonly metric: UsageMetric;
@@ -149,13 +163,11 @@ function DayTile(props: {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          type="button"
-          aria-label={`${cell.day}: ${valueLabel}`}
+        <span
           data-testid="usage-activity-day"
           data-day={cell.day}
           data-level={cell.level}
-          className="size-2.5 rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="size-2.5 rounded-[2px]"
           style={{ backgroundColor: `var(--usage-heat-${String(cell.level)})` }}
         />
       </TooltipTrigger>
@@ -167,6 +179,40 @@ function DayTile(props: {
         </p>
       </TooltipContent>
     </Tooltip>
+  );
+}
+
+/**
+ * The calendar's values for anyone not using a pointer: one row per day
+ * that had usage. Days with none are omitted - a year of "No usage" rows
+ * is noise, and their absence is itself the information.
+ */
+function UsageActivityDataTable(props: {
+  readonly calendar: UsageActivityCalendar;
+  readonly metric: UsageMetric;
+}): ReactNode {
+  const active = props.calendar.weeks
+    .flatMap((week) => week.cells)
+    .filter((cell) => cell !== null)
+    .filter((cell) => cell.value > 0);
+  return (
+    <table className="sr-only" data-testid="usage-activity-data-table">
+      <caption>Daily usage</caption>
+      <thead>
+        <tr>
+          <th scope="col">Day</th>
+          <th scope="col">Usage</th>
+        </tr>
+      </thead>
+      <tbody>
+        {active.map((cell) => (
+          <tr key={cell.day}>
+            <th scope="row">{cell.day}</th>
+            <td>{formatMetricValue(cell.value, props.metric)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -158,8 +158,6 @@ function DayTile(props: {
   readonly metric: UsageMetric;
 }): ReactNode {
   const { cell, metric } = props;
-  const valueLabel =
-    cell.value > 0 ? formatMetricValue(cell.value, metric) : "No usage";
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -175,7 +173,7 @@ function DayTile(props: {
         <p>
           <span className="font-medium">{cell.day}</span>
           {" · "}
-          {valueLabel}
+          {activityValueLabel(cell, metric)}
         </p>
       </TooltipContent>
     </Tooltip>
@@ -183,9 +181,27 @@ function DayTile(props: {
 }
 
 /**
+ * What a day reads as. A day can hold real turns whose cost was never
+ * available: under the Cost metric its value is 0, and calling that
+ * "No usage" would report work as inactivity. It says how many turns ran
+ * and that they are not counted - the same words the headline footnote
+ * uses, and never the banned vocabulary (see the pricing artifact's
+ * product framing).
+ */
+function activityValueLabel(
+  cell: UsageActivityCell,
+  metric: UsageMetric,
+): string {
+  if (cell.value > 0) return formatMetricValue(cell.value, metric);
+  if (cell.factCount === 0) return "No usage";
+  const turnWord = cell.factCount === 1 ? "turn" : "turns";
+  return `${String(cell.factCount)} ${turnWord} · not counted`;
+}
+
+/**
  * The calendar's values for anyone not using a pointer: one row per day
- * that had usage. Days with none are omitted - a year of "No usage" rows
- * is noise, and their absence is itself the information.
+ * that saw activity. Days with none are omitted - a year of "No usage"
+ * rows is noise, and their absence is itself the information.
  */
 function UsageActivityDataTable(props: {
   readonly calendar: UsageActivityCalendar;
@@ -194,7 +210,8 @@ function UsageActivityDataTable(props: {
   const active = props.calendar.weeks
     .flatMap((week) => week.cells)
     .filter((cell) => cell !== null)
-    .filter((cell) => cell.value > 0);
+    // Presence, not value: a day of unpriced work belongs here too.
+    .filter((cell) => cell.factCount > 0);
   return (
     <table className="sr-only" data-testid="usage-activity-data-table">
       <caption>Daily usage</caption>
@@ -208,7 +225,7 @@ function UsageActivityDataTable(props: {
         {active.map((cell) => (
           <tr key={cell.day}>
             <th scope="row">{cell.day}</th>
-            <td>{formatMetricValue(cell.value, props.metric)}</td>
+            <td>{activityValueLabel(cell, props.metric)}</td>
           </tr>
         ))}
       </tbody>

--- a/clients/gui-app/src/components/usage-analytics/usage-chat-breakdown.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-chat-breakdown.tsx
@@ -11,12 +11,14 @@ export interface UsageChatBreakdownProps {
 }
 
 /**
- * By-chat/agent breakdown for the epic-scoped panel. Titles are joined
- * CLIENT-SIDE from the open epic's own tree projection (`useEpicTreeNode`) -
- * the summary only carries `chatId`, and this is the one place in the app
- * that already knows every node's title, chat or A2A child agent alike (an
- * A2A child agent is its own chat, so this list doubles as the by-agent
- * view with no separate wire shape).
+ * By-chat/agent breakdown for the epic-scoped panel, as a real table
+ * (2026-08-11 feedback round) with the same column styling as
+ * `UsageBreakdownTable`. Titles are joined CLIENT-SIDE from the open epic's
+ * own tree projection (`useEpicTreeNode`) - the summary only carries
+ * `chatId`, and this is the one place in the app that already knows every
+ * node's title, chat or A2A child agent alike (an A2A child agent is its
+ * own chat, so this list doubles as the by-agent view with no separate wire
+ * shape).
  */
 export function UsageChatBreakdown(props: UsageChatBreakdownProps): ReactNode {
   if (props.rows.length === 0) {
@@ -33,11 +35,29 @@ export function UsageChatBreakdown(props: UsageChatBreakdownProps): ReactNode {
     (a, b) => b.knownCostUsd - a.knownCostUsd,
   );
   return (
-    <ul className="flex flex-col gap-1.5" data-testid="usage-chat-breakdown">
-      {sorted.map((row) => (
-        <UsageChatBreakdownRow key={row.chatId} row={row} />
-      ))}
-    </ul>
+    <table
+      className="w-full border-collapse text-ui-sm"
+      data-testid="usage-chat-breakdown"
+    >
+      <thead>
+        <tr className="border-b border-border/60 text-left text-ui-xs text-muted-foreground">
+          <th scope="col" className="py-1.5 pr-3 font-medium">
+            Chat / agent
+          </th>
+          <th scope="col" className="py-1.5 pr-3 text-right font-medium">
+            Tokens
+          </th>
+          <th scope="col" className="py-1.5 text-right font-medium">
+            Cost
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((row) => (
+          <UsageChatBreakdownRow key={row.chatId} row={row} />
+        ))}
+      </tbody>
+    </table>
   );
 }
 
@@ -49,20 +69,21 @@ function UsageChatBreakdownRow(props: {
   const title = node?.title ?? row.chatId;
   const tokens = sumTokenTotals(row.tokens);
   return (
-    <li
-      className="flex items-center gap-3 text-ui-sm"
+    <tr
+      className="border-b border-border/40 last:border-b-0"
       data-testid={`usage-chat-breakdown-row-${row.chatId}`}
     >
-      <span className="min-w-0 flex-1 truncate text-foreground">{title}</span>
-      <span className="shrink-0 tabular-nums text-ui-xs text-muted-foreground">
+      {/* `wrap-anywhere`, matching the other breakdown tables' identifier
+          cells: a fallback chatId (or a long unbroken title) must not set
+          the auto-layout table's minimum width and push Tokens/Cost out of
+          the dialog, and truncating would hide the identifier instead. */}
+      <td className="py-1.5 pr-3 wrap-anywhere text-foreground">{title}</td>
+      <td className="py-1.5 pr-3 text-right tabular-nums text-muted-foreground">
         {tokens.toLocaleString()}
-      </span>
-      {/* `min-w-16`, not `w-16`: the column still aligns at the common
-          case's width, but a wider figure ("$1,234.56") grows instead of
-          overflowing its box. */}
-      <span className="min-w-16 shrink-0 text-right tabular-nums font-medium text-foreground">
+      </td>
+      <td className="py-1.5 text-right tabular-nums font-medium text-foreground">
         {formatUsd(row.knownCostUsd)}
-      </span>
-    </li>
+      </td>
+    </tr>
   );
 }

--- a/clients/gui-app/src/components/usage-analytics/usage-daily-chart.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-daily-chart.tsx
@@ -1,24 +1,13 @@
-import { useState, type ReactNode } from "react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { useMemo, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import {
   applyUsageSeriesVisibility,
   type UsageChartColumn,
   type UsageMetric,
 } from "@/lib/usage-analytics/usage-chart-data";
+import { buildUsageChartOption } from "@/lib/usage-analytics/usage-chart-option";
 import type { UsageSeriesScale } from "@/lib/usage-analytics/usage-series-scale";
-import {
-  formatDayLabel,
-  formatMetricValue,
-  niceCeil,
-} from "@/lib/usage-analytics/format-metric-value";
-
-const MAX_X_AXIS_LABELS = 9;
-const Y_AXIS_TICK_FRACTIONS = [1, 0.5, 0] as const;
+import { EChartsContainer } from "@/components/usage-analytics/echarts-container";
 
 export interface UsageDailyChartProps {
   readonly columns: readonly UsageChartColumn[];
@@ -27,28 +16,33 @@ export interface UsageDailyChartProps {
 }
 
 /**
- * Per-day stacked bar chart, one bar per calendar day, segmented by harness.
- * Mark specs and spacing follow the dataviz skill: 2px surface gaps between
- * stacked segments, 4px rounded top cap on the outer segment only, no bar
- * over 24px thick. The three/one WARN-band contrast slots in the palette
- * (`usage-analytics-chart.css`) get their relief from the tooltip (hover
- * AND keyboard focus, via the shared `Tooltip` primitive) plus the
- * breakdown table beneath the chart - every value stays reachable without
- * landing exactly on a segment.
+ * Per-day stacked AREA chart, one point per calendar day, one band per
+ * harness, drawn by ECharts (2026-08-11 feedback round: the hand-rolled
+ * bars truncated every x-axis label past ~10 days, and the team asked for
+ * the area-chart look). Data flow is unchanged from the bar era:
+ * `columns`/`scale` in, the legend-chip filter zeroes hidden series via
+ * `applyUsageSeriesVisibility`, and `buildUsageChartOption` maps the result
+ * onto an ECharts option. Exact values stay reachable without a pointer
+ * through the breakdown tables beneath the chart - that has been their
+ * documented relief-channel role since the bar version.
  */
 export function UsageDailyChart(props: UsageDailyChartProps): ReactNode {
   const { columns, scale, metric } = props;
   // Self-contained: which series the legend chips have hidden. Toggling never
   // changes `scale.order` or its color assignment (see
-  // `applyUsageSeriesVisibility`'s doc comment) - only which segments render.
+  // `applyUsageSeriesVisibility`'s doc comment) - only which bands render.
   const [hiddenSeries, setHiddenSeries] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
-  const visibleColumns = applyUsageSeriesVisibility(columns, hiddenSeries);
-  const maxTotal = niceCeil(
-    Math.max(0, ...visibleColumns.map((column) => column.total)),
+  const option = useMemo(
+    () =>
+      buildUsageChartOption({
+        columns: applyUsageSeriesVisibility(columns, hiddenSeries),
+        scale,
+        metric,
+      }),
+    [columns, hiddenSeries, scale, metric],
   );
-  const tickEvery = Math.max(1, Math.ceil(columns.length / MAX_X_AXIS_LABELS));
   const toggleSeries = (seriesKey: string) => {
     setHiddenSeries((prev) => {
       const next = new Set(prev);
@@ -66,27 +60,18 @@ export function UsageDailyChart(props: UsageDailyChartProps): ReactNode {
       className="usage-chart-root flex w-full flex-col gap-2"
       data-testid="usage-daily-chart"
     >
-      <div className="flex h-[clamp(11rem,26vh,16rem)] w-full gap-3">
-        <YAxis maxValue={maxTotal} metric={metric} />
-        <div className="flex min-w-0 flex-1 items-stretch gap-px border-l border-b border-border/60 pl-1">
-          {visibleColumns.map((column) => (
-            <DayColumn
-              key={column.day}
-              column={column}
-              scale={scale}
-              metric={metric}
-              maxValue={maxTotal}
-            />
-          ))}
-        </div>
-      </div>
-      <XAxis days={columns.map((column) => column.day)} tickEvery={tickEvery} />
+      <EChartsContainer
+        option={option}
+        className="h-[clamp(11rem,26vh,16rem)] w-full"
+        ariaLabel="Daily usage chart"
+        testId="usage-daily-chart-canvas"
+      />
       {/* The `>= 2` gate keeps a one-chip legend off a single-series chart,
           where filtering is meaningless. It must not apply when that lone
           series is HIDDEN, though: `hiddenSeries` outlives a prop change, so
           a refetch that narrows the window to only the hidden harness would
-          otherwise zero every bar (see `applyUsageSeriesVisibility`) while
-          removing the only control that can bring it back. */}
+          otherwise zero the whole chart (see `applyUsageSeriesVisibility`)
+          while removing the only control that can bring it back. */}
       {scale.order.length >= 2 ||
       scale.order.some((seriesKey) => hiddenSeries.has(seriesKey)) ? (
         <UsageChartLegend
@@ -99,145 +84,12 @@ export function UsageDailyChart(props: UsageDailyChartProps): ReactNode {
   );
 }
 
-function YAxis(props: {
-  readonly maxValue: number;
-  readonly metric: UsageMetric;
-}): ReactNode {
-  return (
-    <div
-      className="flex w-12 shrink-0 flex-col justify-between py-0.5 text-right text-ui-xs text-muted-foreground"
-      aria-hidden
-    >
-      {Y_AXIS_TICK_FRACTIONS.map((fraction) => (
-        <span key={fraction} className="tabular-nums">
-          {formatMetricValue(props.maxValue * fraction, props.metric)}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function XAxis(props: {
-  readonly days: readonly string[];
-  readonly tickEvery: number;
-}): ReactNode {
-  return (
-    <div className="flex w-full gap-px pl-[3.25rem]">
-      {props.days.map((day, index) => (
-        <span
-          key={day}
-          className="min-w-0 flex-1 truncate text-center text-ui-xs text-muted-foreground"
-        >
-          {index % props.tickEvery === 0 ? formatDayLabel(day) : ""}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function DayColumn(props: {
-  readonly column: UsageChartColumn;
-  readonly scale: UsageSeriesScale;
-  readonly metric: UsageMetric;
-  readonly maxValue: number;
-}): ReactNode {
-  const { column, scale, metric, maxValue } = props;
-  // Stacking order: `scale.order` is bottom-up (matches the legend/table
-  // order), but the DOM renders top-to-bottom inside a `flex-col
-  // justify-end` column, so the LAST non-zero segment lands at the bottom
-  // (the baseline, square) and the FIRST lands at the top (the outer edge,
-  // rounded) - reversing here keeps that one rule in one place instead of
-  // recomputing "which end is this" per segment.
-  const nonZeroSegments = [...column.segments]
-    .filter((segment) => segment.value > 0)
-    .reverse();
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          // The bars inside are decorative, so without this the control has
-          // no accessible name at all - and a tooltip wired up as a
-          // DESCRIPTION is announced inconsistently on a control that has
-          // none.
-          aria-label={formatDayLabel(column.day)}
-          data-testid="usage-daily-chart-column"
-          data-day={column.day}
-          className="group flex min-w-0 flex-1 flex-col justify-end rounded-t-[4px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          {nonZeroSegments.length === 0 ? (
-            <span className="block h-px w-full bg-border/60" />
-          ) : (
-            nonZeroSegments.map((segment, index) => (
-              <span
-                key={segment.seriesKey}
-                className={cn(
-                  "block w-full transition-opacity group-hover:opacity-80",
-                  index === 0 && "rounded-t-[4px]",
-                )}
-                style={{
-                  height: `${String(maxValue > 0 ? (segment.value / maxValue) * 100 : 0)}%`,
-                  backgroundColor: scale.colorVar(segment.seriesKey),
-                  marginBottom:
-                    index === nonZeroSegments.length - 1 ? 0 : "2px",
-                }}
-              />
-            ))
-          )}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <DayTooltipBody column={column} scale={scale} metric={metric} />
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-function DayTooltipBody(props: {
-  readonly column: UsageChartColumn;
-  readonly scale: UsageSeriesScale;
-  readonly metric: UsageMetric;
-}): ReactNode {
-  const { column, scale, metric } = props;
-  const nonZero = column.segments.filter((segment) => segment.value > 0);
-  return (
-    <div className="flex flex-col gap-1">
-      <p className="font-medium">{formatDayLabel(column.day)}</p>
-      {nonZero.length === 0 ? (
-        <p className="text-muted-foreground">No usage</p>
-      ) : (
-        <ul className="flex flex-col gap-0.5">
-          {nonZero.map((segment) => (
-            <li
-              key={segment.seriesKey}
-              className="flex items-center justify-between gap-3"
-            >
-              <span className="flex items-center gap-1.5">
-                <span
-                  aria-hidden
-                  className="h-2 w-2 shrink-0 rounded-full"
-                  style={{ backgroundColor: scale.colorVar(segment.seriesKey) }}
-                />
-                {scale.labelFor(segment.seriesKey)}
-              </span>
-              <span className="tabular-nums font-medium">
-                {formatMetricValue(segment.value, metric)}
-              </span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
 /**
  * Legend chips double as the chart's series filter: clicking one hides its
- * segments from every bar (see `applyUsageSeriesVisibility`) without
- * changing `scale.order` or any chip's color, so a filtered-out series can
- * always be brought back in the same slot. `aria-pressed` carries the
- * on/off state for assistive tech since the visual cue is opacity alone.
+ * band from the chart (see `applyUsageSeriesVisibility`) without changing
+ * `scale.order` or any chip's color, so a filtered-out series can always be
+ * brought back in the same slot. `aria-pressed` carries the on/off state
+ * for assistive tech since the visual cue is opacity alone.
  */
 function UsageChartLegend(props: {
   readonly scale: UsageSeriesScale;
@@ -246,7 +98,7 @@ function UsageChartLegend(props: {
 }): ReactNode {
   return (
     <ul
-      className="flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.25rem] text-ui-xs text-muted-foreground"
+      className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-ui-xs text-muted-foreground"
       data-testid="usage-daily-chart-legend"
     >
       {props.scale.order.map((seriesKey) => {

--- a/clients/gui-app/src/components/usage-analytics/usage-daily-chart.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-daily-chart.tsx
@@ -6,6 +6,10 @@ import {
   type UsageMetric,
 } from "@/lib/usage-analytics/usage-chart-data";
 import { buildUsageChartOption } from "@/lib/usage-analytics/usage-chart-option";
+import {
+  formatDayLabel,
+  formatMetricValue,
+} from "@/lib/usage-analytics/format-metric-value";
 import type { UsageSeriesScale } from "@/lib/usage-analytics/usage-series-scale";
 import { EChartsContainer } from "@/components/usage-analytics/echarts-container";
 
@@ -34,14 +38,19 @@ export function UsageDailyChart(props: UsageDailyChartProps): ReactNode {
   const [hiddenSeries, setHiddenSeries] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  const visibleColumns = useMemo(
+    () => applyUsageSeriesVisibility(columns, hiddenSeries),
+    [columns, hiddenSeries],
+  );
   const option = useMemo(
     () =>
       buildUsageChartOption({
-        columns: applyUsageSeriesVisibility(columns, hiddenSeries),
+        columns: visibleColumns,
         scale,
         metric,
+        hiddenSeries,
       }),
-    [columns, hiddenSeries, scale, metric],
+    [visibleColumns, hiddenSeries, scale, metric],
   );
   const toggleSeries = (seriesKey: string) => {
     setHiddenSeries((prev) => {
@@ -66,6 +75,12 @@ export function UsageDailyChart(props: UsageDailyChartProps): ReactNode {
         ariaLabel="Daily usage chart"
         testId="usage-daily-chart-canvas"
       />
+      <UsageDailyChartDataTable
+        columns={visibleColumns}
+        scale={scale}
+        metric={metric}
+        hiddenSeries={hiddenSeries}
+      />
       {/* The `>= 2` gate keeps a one-chip legend off a single-series chart,
           where filtering is meaningless. It must not apply when that lone
           series is HIDDEN, though: `hiddenSeries` outlives a prop change, so
@@ -81,6 +96,62 @@ export function UsageDailyChart(props: UsageDailyChartProps): ReactNode {
         />
       ) : null}
     </div>
+  );
+}
+
+/**
+ * The chart's values as a real table, visually hidden but fully in the
+ * accessibility tree and reachable by keyboard.
+ *
+ * The bar version made every day a focusable button, so tabbing through the
+ * chart read out each day's total; ECharts draws one opaque graphic whose
+ * per-day values live only in a POINTER-triggered tooltip. The Settings
+ * dashboard has a by-day breakdown table underneath, but the epic dialog's
+ * table is grouped by chat, so without this there is no non-pointer path to
+ * the plotted values there at all.
+ *
+ * Hidden series are omitted, matching what the chart draws - the table is
+ * the same view by another means, not a second, contradictory dataset.
+ */
+function UsageDailyChartDataTable(props: {
+  readonly columns: readonly UsageChartColumn[];
+  readonly scale: UsageSeriesScale;
+  readonly metric: UsageMetric;
+  readonly hiddenSeries: ReadonlySet<string>;
+}): ReactNode {
+  const { columns, scale, metric, hiddenSeries } = props;
+  const visibleKeys = scale.order.filter((key) => !hiddenSeries.has(key));
+  return (
+    <table className="sr-only" data-testid="usage-daily-chart-data-table">
+      <caption>Daily usage by harness</caption>
+      <thead>
+        <tr>
+          <th scope="col">Day</th>
+          {visibleKeys.map((seriesKey) => (
+            <th key={seriesKey} scope="col">
+              {scale.labelFor(seriesKey)}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {columns.map((column) => (
+          <tr key={column.day}>
+            <th scope="row">{formatDayLabel(column.day)}</th>
+            {visibleKeys.map((seriesKey) => (
+              <td key={seriesKey}>
+                {formatMetricValue(
+                  column.segments.find(
+                    (segment) => segment.seriesKey === seriesKey,
+                  )?.value ?? 0,
+                  metric,
+                )}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/clients/gui-app/src/components/usage-analytics/usage-stat-tiles.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-stat-tiles.tsx
@@ -75,9 +75,9 @@ export function UsageStatTiles(props: UsageStatTilesProps): ReactNode {
         label="Cache savings"
         value={formatUsd(tiles.cacheSavings.knownCacheSavingsUsd)}
         detail={
-          tiles.cacheSavings.multipleOfRawCost === null
-            ? null
-            : `${tiles.cacheSavings.multipleOfRawCost.toFixed(1)}x raw cost`
+          tiles.cacheSavings.knownCacheSavingsUsd > 0
+            ? "estimated at published rates"
+            : null
         }
       />
     </div>

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -41,6 +41,11 @@ import { UsageCostFigure } from "@/components/usage-analytics/usage-cost-figure"
 import { UsageErrorCard } from "@/components/usage-analytics/usage-error-card";
 import { UsageHostFilter } from "@/components/usage-analytics/usage-host-filter";
 import { UsageHostSplit } from "@/components/usage-analytics/usage-host-split";
+import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
+import {
+  buildUsageActivityCalendar,
+  USAGE_ACTIVITY_WINDOW_DAYS,
+} from "@/lib/usage-analytics/usage-activity";
 import {
   buildUsageHostFilterOptions,
   buildUsageHostSplitRows,
@@ -95,12 +100,31 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
     () => buildUsageSummaryRequest({ windowDays, epicId: null, hostId }),
     [windowDays, hostId],
   );
+  // The activity heatmap's own fixed-year read (ticket 15) - independent of
+  // the 7/30/90 picker (an activity calendar over one month is all padding)
+  // but scoped by the same host filter, so narrowing to a machine narrows
+  // the calendar too.
+  const activityRequest = useMemo(
+    () =>
+      buildUsageSummaryRequest({
+        windowDays: USAGE_ACTIVITY_WINDOW_DAYS,
+        epicId: null,
+        hostId,
+      }),
+    [hostId],
+  );
   // Enabled unconditionally: this panel only mounts once its caller has
   // already confirmed `host.usage.summary` is supported (see
   // `UsageSettingsPanelBody`'s early return). No polling here - unlike the
   // ambient epic cost badge, this is an actively-viewed screen with its own
   // refetch triggers (window/metric change, manual Retry).
   const query = useUsageSummaryForClient(props.client, request, true, false);
+  const activityQuery = useUsageSummaryForClient(
+    props.client,
+    activityRequest,
+    true,
+    false,
+  );
   const days = useMemo(() => daysForResponse(query.data), [query.data]);
   const dateRangeLabel = formatDateRangeLabel(days);
 
@@ -182,6 +206,7 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
       </div>
       <UsageSummaryPanelBody
         query={query}
+        activityData={activityQuery.data}
         metric={metric}
         days={days}
         breakdownGroupBy={breakdownGroupBy}
@@ -250,6 +275,13 @@ function daysForResponse(
 
 function UsageSummaryPanelBody(props: {
   readonly query: UsageSummaryQueryResult;
+  /**
+   * The fixed-year activity read, already unwrapped: this section is
+   * SECONDARY, so it renders only once data exists and simply stays absent
+   * while loading or errored - the page's loading/error surfaces belong to
+   * the primary window query alone.
+   */
+  readonly activityData: UsageSummaryResponse | undefined;
   readonly metric: UsageMetric;
   readonly days: readonly string[];
   readonly breakdownGroupBy: UsageBreakdownGroupBy;
@@ -260,6 +292,7 @@ function UsageSummaryPanelBody(props: {
 }): ReactNode {
   const {
     query,
+    activityData,
     metric,
     days,
     breakdownGroupBy,
@@ -350,6 +383,23 @@ function UsageSummaryPanelBody(props: {
         )}
       </div>
       <UsageDailyChart columns={columns} scale={scale} metric={metric} />
+      {activityData === undefined ? null : (
+        <div className="flex flex-col gap-2">
+          <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
+          <UsageActivityHeatmap
+            calendar={buildUsageActivityCalendar(
+              lastNCalendarDays(
+                USAGE_ACTIVITY_WINDOW_DAYS,
+                activityData.summary.window.timezone,
+                activityData.summary.window.endAtExclusive - 1,
+              ),
+              activityData.summary.buckets,
+              metric,
+            )}
+            metric={metric}
+          />
+        </div>
+      )}
       <div>
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <h3 className="text-ui-sm font-medium text-foreground">Breakdown</h3>

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -44,6 +44,7 @@ import { UsageHostSplit } from "@/components/usage-analytics/usage-host-split";
 import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
 import {
   buildUsageActivityCalendar,
+  USAGE_ACTIVITY_FALLBACK_WINDOW_DAYS,
   USAGE_ACTIVITY_WINDOW_DAYS,
 } from "@/lib/usage-analytics/usage-activity";
 import {
@@ -123,6 +124,26 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
     props.client,
     activityRequest,
     true,
+    false,
+  );
+  // Hosts update independently of the app: one released before ticket 15
+  // caps `windowDays` at 90 and rejects the year outright. Only then does
+  // this narrower read run, so the calendar degrades to a shorter span
+  // instead of the section showing an error for a host that can never
+  // answer it.
+  const activityFallbackRequest = useMemo(
+    () =>
+      buildUsageSummaryRequest({
+        windowDays: USAGE_ACTIVITY_FALLBACK_WINDOW_DAYS,
+        epicId: null,
+        hostId,
+      }),
+    [hostId],
+  );
+  const activityFallbackQuery = useUsageSummaryForClient(
+    props.client,
+    activityFallbackRequest,
+    activityQuery.error !== null,
     false,
   );
   const days = useMemo(() => daysForResponse(query.data), [query.data]);
@@ -217,6 +238,7 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
       <UsageSummaryPanelBody
         query={query}
         activityQuery={activityQuery}
+        activityFallbackQuery={activityFallbackQuery}
         metric={metric}
         days={days}
         breakdownGroupBy={breakdownGroupBy}
@@ -308,6 +330,8 @@ function UsageSummaryPanelBody(props: {
    * back. It stays SECONDARY (its own inline error, never the page's).
    */
   readonly activityQuery: UsageSummaryQueryResult;
+  /** The narrower read that runs only once {@link activityQuery} has failed. */
+  readonly activityFallbackQuery: UsageSummaryQueryResult;
   readonly metric: UsageMetric;
   readonly days: readonly string[];
   readonly breakdownGroupBy: UsageBreakdownGroupBy;
@@ -319,6 +343,7 @@ function UsageSummaryPanelBody(props: {
   const {
     query,
     activityQuery,
+    activityFallbackQuery,
     metric,
     days,
     breakdownGroupBy,
@@ -409,7 +434,11 @@ function UsageSummaryPanelBody(props: {
         )}
       </div>
       <UsageDailyChart columns={columns} scale={scale} metric={metric} />
-      <UsageActivitySection query={activityQuery} metric={metric} />
+      <UsageActivitySection
+        query={activityQuery}
+        fallbackQuery={activityFallbackQuery}
+        metric={metric}
+      />
       <div>
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <h3 className="text-ui-sm font-medium text-foreground">Breakdown</h3>
@@ -443,10 +472,35 @@ function UsageSummaryPanelBody(props: {
  */
 function UsageActivitySection(props: {
   readonly query: UsageSummaryQueryResult;
+  readonly fallbackQuery: UsageSummaryQueryResult;
   readonly metric: UsageMetric;
 }): ReactNode {
-  const { query, metric } = props;
-  if (query.error !== null) {
+  const { query, fallbackQuery, metric } = props;
+  // A host too old for the year window answers the narrower read instead -
+  // a shorter calendar, not an error.
+  const data = query.data ?? fallbackQuery.data;
+  if (data !== undefined) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="usage-activity-section">
+        <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
+        <UsageActivityHeatmap
+          calendar={buildUsageActivityCalendar(
+            lastNCalendarDays(
+              data.summary.window.windowDays,
+              data.summary.window.timezone,
+              data.summary.window.endAtExclusive - 1,
+            ),
+            data.summary.buckets,
+            metric,
+          )}
+          metric={metric}
+        />
+      </div>
+    );
+  }
+  // Both reads failed (or the fallback is still in flight after the first
+  // failed): only now is there nothing to show.
+  if (query.error !== null && fallbackQuery.error !== null) {
     return (
       <div className="flex flex-col gap-2" data-testid="usage-activity-section">
         <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
@@ -454,28 +508,11 @@ function UsageActivitySection(props: {
           error={query.error}
           onRetry={() => {
             void query.refetch();
+            void fallbackQuery.refetch();
           }}
         />
       </div>
     );
   }
-  if (query.data === undefined) return null;
-  const { window, buckets } = query.data.summary;
-  return (
-    <div className="flex flex-col gap-2" data-testid="usage-activity-section">
-      <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
-      <UsageActivityHeatmap
-        calendar={buildUsageActivityCalendar(
-          lastNCalendarDays(
-            USAGE_ACTIVITY_WINDOW_DAYS,
-            window.timezone,
-            window.endAtExclusive - 1,
-          ),
-          buckets,
-          metric,
-        )}
-        metric={metric}
-      />
-    </div>
-  );
+  return null;
 }

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -153,10 +153,20 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
   if (pinnedToHostName !== null && hostId !== null) {
     setHostId(null);
   }
+  // Hosts named by EITHER read. The activity calendar spans a year while
+  // the picker's own read spans 7/30/90 days, so a host that was active
+  // months ago - and that the local directory can no longer name - shows up
+  // in the All-hosts calendar with no way to isolate it. Both responses are
+  // evidence about which hosts exist, so both feed the filter.
   const responseHostIds = useMemo(
     () =>
-      (query.data?.summary.hostBuckets ?? []).map((bucket) => bucket.hostId),
-    [query.data],
+      unionHostIds(
+        (query.data?.summary.hostBuckets ?? []).map((bucket) => bucket.hostId),
+        (activityQuery.data?.summary.hostBuckets ?? []).map(
+          (bucket) => bucket.hostId,
+        ),
+      ),
+    [query.data, activityQuery.data],
   );
   // Host ids learned from the last UNFILTERED response.
   //
@@ -217,6 +227,21 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
         }
       />
     </div>
+  );
+}
+
+/**
+ * Merged host ids from the two reads, sorted so the result is a function of
+ * WHICH hosts appeared rather than of which response happened to arrive
+ * first - {@link sameHostIds} compares position-wise, and an unsorted union
+ * would flip-flop as the two queries settle.
+ */
+function unionHostIds(
+  a: readonly string[],
+  b: readonly string[],
+): readonly string[] {
+  return [...new Set([...a, ...b])].sort((left, right) =>
+    left.localeCompare(right),
   );
 }
 

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -206,7 +206,7 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
       </div>
       <UsageSummaryPanelBody
         query={query}
-        activityData={activityQuery.data}
+        activityQuery={activityQuery}
         metric={metric}
         days={days}
         breakdownGroupBy={breakdownGroupBy}
@@ -276,12 +276,13 @@ function daysForResponse(
 function UsageSummaryPanelBody(props: {
   readonly query: UsageSummaryQueryResult;
   /**
-   * The fixed-year activity read, already unwrapped: this section is
-   * SECONDARY, so it renders only once data exists and simply stays absent
-   * while loading or errored - the page's loading/error surfaces belong to
-   * the primary window query alone.
+   * The fixed-year activity read. The WHOLE result, not just its data: the
+   * page-level Retry refetches the primary window query only, so handing
+   * this one's `data` alone would drop a failed activity read on the floor
+   * - the section would silently vanish with no explanation and no way
+   * back. It stays SECONDARY (its own inline error, never the page's).
    */
-  readonly activityData: UsageSummaryResponse | undefined;
+  readonly activityQuery: UsageSummaryQueryResult;
   readonly metric: UsageMetric;
   readonly days: readonly string[];
   readonly breakdownGroupBy: UsageBreakdownGroupBy;
@@ -292,7 +293,7 @@ function UsageSummaryPanelBody(props: {
 }): ReactNode {
   const {
     query,
-    activityData,
+    activityQuery,
     metric,
     days,
     breakdownGroupBy,
@@ -383,23 +384,7 @@ function UsageSummaryPanelBody(props: {
         )}
       </div>
       <UsageDailyChart columns={columns} scale={scale} metric={metric} />
-      {activityData === undefined ? null : (
-        <div className="flex flex-col gap-2">
-          <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
-          <UsageActivityHeatmap
-            calendar={buildUsageActivityCalendar(
-              lastNCalendarDays(
-                USAGE_ACTIVITY_WINDOW_DAYS,
-                activityData.summary.window.timezone,
-                activityData.summary.window.endAtExclusive - 1,
-              ),
-              activityData.summary.buckets,
-              metric,
-            )}
-            metric={metric}
-          />
-        </div>
-      )}
+      <UsageActivitySection query={activityQuery} metric={metric} />
       <div>
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <h3 className="text-ui-sm font-medium text-foreground">Breakdown</h3>
@@ -418,6 +403,54 @@ function UsageSummaryPanelBody(props: {
           />
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * The activity calendar and its own loading/error handling.
+ *
+ * Deliberately NOT folded into the page's loading and error states: this
+ * read is a second, independent request, and a failed year-long calendar
+ * must not blank a working dashboard. But it must not vanish silently
+ * either - the page's Retry only refetches the primary window query, so
+ * this section carries its own error card and its own refetch.
+ */
+function UsageActivitySection(props: {
+  readonly query: UsageSummaryQueryResult;
+  readonly metric: UsageMetric;
+}): ReactNode {
+  const { query, metric } = props;
+  if (query.error !== null) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="usage-activity-section">
+        <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
+        <UsageErrorCard
+          error={query.error}
+          onRetry={() => {
+            void query.refetch();
+          }}
+        />
+      </div>
+    );
+  }
+  if (query.data === undefined) return null;
+  const { window, buckets } = query.data.summary;
+  return (
+    <div className="flex flex-col gap-2" data-testid="usage-activity-section">
+      <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>
+      <UsageActivityHeatmap
+        calendar={buildUsageActivityCalendar(
+          lastNCalendarDays(
+            USAGE_ACTIVITY_WINDOW_DAYS,
+            window.timezone,
+            window.endAtExclusive - 1,
+          ),
+          buckets,
+          metric,
+        )}
+        metric={metric}
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -44,6 +44,7 @@ import { UsageHostSplit } from "@/components/usage-analytics/usage-host-split";
 import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
 import {
   buildUsageActivityCalendar,
+  isWindowTooWideError,
   USAGE_ACTIVITY_FALLBACK_WINDOW_DAYS,
   USAGE_ACTIVITY_WINDOW_DAYS,
 } from "@/lib/usage-analytics/usage-activity";
@@ -127,10 +128,10 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
     false,
   );
   // Hosts update independently of the app: one released before ticket 15
-  // caps `windowDays` at 90 and rejects the year outright. Only then does
-  // this narrower read run, so the calendar degrades to a shorter span
-  // instead of the section showing an error for a host that can never
-  // answer it.
+  // caps `windowDays` at 90 and rejects the year outright. ONLY that
+  // classified rejection arms this narrower read - a transient failure on
+  // the year read must surface as an error, not be quietly replaced by a
+  // quarter of the calendar that happened to succeed.
   const activityFallbackRequest = useMemo(
     () =>
       buildUsageSummaryRequest({
@@ -143,7 +144,7 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
   const activityFallbackQuery = useUsageSummaryForClient(
     props.client,
     activityFallbackRequest,
-    activityQuery.error !== null,
+    isWindowTooWideError(activityQuery.error),
     false,
   );
   const days = useMemo(() => daysForResponse(query.data), [query.data]);
@@ -182,12 +183,16 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
   const responseHostIds = useMemo(
     () =>
       unionHostIds(
-        (query.data?.summary.hostBuckets ?? []).map((bucket) => bucket.hostId),
-        (activityQuery.data?.summary.hostBuckets ?? []).map(
-          (bucket) => bucket.hostId,
-        ),
+        [
+          ...(query.data?.summary.hostBuckets ?? []),
+          ...(activityQuery.data?.summary.hostBuckets ?? []),
+          // The fallback calendar is a real read too: an old host that
+          // rejected the year can still surface a host (active e.g. 60 days
+          // ago) that neither the directory nor the 30-day window knows.
+          ...(activityFallbackQuery.data?.summary.hostBuckets ?? []),
+        ].map((bucket) => bucket.hostId),
       ),
-    [query.data, activityQuery.data],
+    [query.data, activityQuery.data, activityFallbackQuery.data],
   );
   // Host ids learned from the last UNFILTERED response.
   //
@@ -258,13 +263,8 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
  * first - {@link sameHostIds} compares position-wise, and an unsorted union
  * would flip-flop as the two queries settle.
  */
-function unionHostIds(
-  a: readonly string[],
-  b: readonly string[],
-): readonly string[] {
-  return [...new Set([...a, ...b])].sort((left, right) =>
-    left.localeCompare(right),
-  );
+function unionHostIds(ids: readonly string[]): readonly string[] {
+  return [...new Set(ids)].sort((left, right) => left.localeCompare(right));
 }
 
 /**
@@ -477,7 +477,9 @@ function UsageActivitySection(props: {
 }): ReactNode {
   const { query, fallbackQuery, metric } = props;
   // A host too old for the year window answers the narrower read instead -
-  // a shorter calendar, not an error.
+  // a shorter calendar, not an error. The fallback query is only ever
+  // ENABLED for that classified rejection (see `isWindowTooWideError`), so
+  // its data can't paper over an unrelated year-read failure.
   const data = query.data ?? fallbackQuery.data;
   if (data !== undefined) {
     return (
@@ -498,9 +500,14 @@ function UsageActivitySection(props: {
       </div>
     );
   }
-  // Both reads failed (or the fallback is still in flight after the first
-  // failed): only now is there nothing to show.
-  if (query.error !== null && fallbackQuery.error !== null) {
+  // The year read failed for a reason the fallback does not exist for, or
+  // the fallback itself failed too - either way the section owes the
+  // reader an explanation and a way back, never a silent gap.
+  const windowTooWide = isWindowTooWideError(query.error);
+  if (
+    query.error !== null &&
+    (!windowTooWide || fallbackQuery.error !== null)
+  ) {
     return (
       <div className="flex flex-col gap-2" data-testid="usage-activity-section">
         <h3 className="text-ui-sm font-medium text-foreground">Activity</h3>

--- a/clients/gui-app/src/hooks/usage-analytics/use-usage-summary-query.ts
+++ b/clients/gui-app/src/hooks/usage-analytics/use-usage-summary-query.ts
@@ -9,7 +9,13 @@ import type { HostRpcRegistry } from "@/lib/host";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { getViewerTimeZone } from "@/lib/usage-analytics/viewer-timezone";
 
-export type UsageSummaryWindowDays = 7 | 30 | 90;
+/**
+ * The window picker offers 7/30/90; 365 is the activity heatmap's fixed
+ * year window (ticket 15), never a picker option. The wire itself accepts
+ * any positive integer (`windowDays: z.number().int().positive()`), so this
+ * union is a GUI discipline, not a protocol bound.
+ */
+export type UsageSummaryWindowDays = 7 | 30 | 90 | 365;
 
 export type UsageSummaryRequest = RequestOfMethod<
   HostRpcRegistry,

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/format-metric-value.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/format-metric-value.test.ts
@@ -3,7 +3,6 @@ import {
   formatDateRangeLabel,
   formatDayLabel,
   formatMetricValue,
-  niceCeil,
 } from "@/lib/usage-analytics/format-metric-value";
 
 describe("formatMetricValue", () => {
@@ -55,16 +54,5 @@ describe("formatDateRangeLabel", () => {
 
   it("renders nothing for an empty day list", () => {
     expect(formatDateRangeLabel([])).toBe("");
-  });
-});
-
-describe("niceCeil", () => {
-  it("rounds up to the nearest clean 1/2/5/10 step", () => {
-    expect(niceCeil(0)).toBe(0);
-    expect(niceCeil(0.8)).toBe(1);
-    expect(niceCeil(1.4)).toBe(2);
-    expect(niceCeil(3)).toBe(5);
-    expect(niceCeil(7)).toBe(10);
-    expect(niceCeil(42)).toBe(50);
   });
 });

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { buildUsageActivityCalendar } from "@/lib/usage-analytics/usage-activity";
 import type { UsageBucket } from "@/lib/usage-analytics/usage-chart-data";
 
-function bucket(day: string, knownCostUsd: number): UsageBucket {
+function bucket(
+  day: string,
+  knownCostUsd: number,
+  overrides: Partial<UsageBucket>,
+): UsageBucket {
   return {
     day,
     harnessId: "claude",
@@ -18,7 +22,7 @@ function bucket(day: string, knownCostUsd: number): UsageBucket {
     knownCacheSavingsUsd: 0,
     knownReasoningTokens: 0,
     costProvenance: "providerReported",
-    ...{},
+    ...overrides,
   };
 }
 
@@ -40,7 +44,7 @@ describe("buildUsageActivityCalendar", () => {
     const days = dayRange("2026-08-02", "2026-08-08");
     const calendar = buildUsageActivityCalendar(
       days,
-      [bucket("2026-08-03", 5)],
+      [bucket("2026-08-03", 5, {})],
       "cost",
     );
     expect(calendar.weeks).toHaveLength(1);
@@ -65,12 +69,12 @@ describe("buildUsageActivityCalendar", () => {
     const calendar = buildUsageActivityCalendar(
       days,
       [
-        bucket("2026-08-02", 1),
-        bucket("2026-08-03", 2),
-        bucket("2026-08-04", 3),
+        bucket("2026-08-02", 1, {}),
+        bucket("2026-08-03", 2, {}),
+        bucket("2026-08-04", 3, {}),
         // The whale day: a linear-to-max scale would push every other day
         // into the faintest step.
-        bucket("2026-08-05", 1000),
+        bucket("2026-08-05", 1000, {}),
       ],
       "cost",
     );
@@ -88,7 +92,7 @@ describe("buildUsageActivityCalendar", () => {
     const days = dayRange("2026-08-02", "2026-08-04");
     const calendar = buildUsageActivityCalendar(
       days,
-      [bucket("2026-08-02", 2), bucket("2026-08-03", 2)],
+      [bucket("2026-08-02", 2, {}), bucket("2026-08-03", 2, {})],
       "cost",
     );
     const levels = (calendar.weeks[0]?.cells ?? [])
@@ -116,12 +120,12 @@ describe("buildUsageActivityCalendar", () => {
     const calendar = buildUsageActivityCalendar(
       days,
       [
-        bucket("2026-08-02", 1),
-        bucket("2026-08-03", 1),
-        bucket("2026-08-04", 1),
+        bucket("2026-08-02", 1, {}),
+        bucket("2026-08-03", 1, {}),
+        bucket("2026-08-04", 1, {}),
         // gap on 08-05
-        bucket("2026-08-06", 1),
-        bucket("2026-08-07", 1),
+        bucket("2026-08-06", 1, {}),
+        bucket("2026-08-07", 1, {}),
       ],
       "cost",
     );
@@ -130,11 +134,39 @@ describe("buildUsageActivityCalendar", () => {
     expect(calendar.stats.mostActiveMonth).toBe("Aug 2026");
   });
 
+  it("counts a day of unpriced work as activity, not as an empty day", () => {
+    // Cost is the selected metric and this day's usage was never priced, so
+    // its value is 0 - but the turns happened. Reporting that as inactivity
+    // would break the streak and drop the day from the accessible table.
+    const days = dayRange("2026-08-02", "2026-08-05");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [
+        bucket("2026-08-02", 4, {}),
+        bucket("2026-08-03", 0, { costProvenance: "unpriced", factCount: 2 }),
+        bucket("2026-08-04", 6, {}),
+      ],
+      "cost",
+    );
+    const byDay = new Map(
+      (calendar.weeks[0]?.cells ?? [])
+        .filter((cell) => cell !== null)
+        .map((cell) => [cell.day, cell]),
+    );
+    const unpriced = byDay.get("2026-08-03");
+    expect(unpriced?.value).toBe(0);
+    expect(unpriced?.factCount).toBe(2);
+    // Faintest visible step, never the empty one.
+    expect(unpriced?.level).toBe(1);
+    // And the streak runs straight through it.
+    expect(calendar.stats.longestStreakDays).toBe(3);
+  });
+
   it("names the most active day by value", () => {
     const days = dayRange("2026-08-02", "2026-08-04");
     const calendar = buildUsageActivityCalendar(
       days,
-      [bucket("2026-08-02", 1), bucket("2026-08-03", 9)],
+      [bucket("2026-08-02", 1, {}), bucket("2026-08-03", 9, {})],
       "cost",
     );
     expect(calendar.stats.mostActiveDay).toBe("Aug 3, 2026");

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { buildUsageActivityCalendar } from "@/lib/usage-analytics/usage-activity";
+import type { UsageBucket } from "@/lib/usage-analytics/usage-chart-data";
+
+function bucket(day: string, knownCostUsd: number): UsageBucket {
+  return {
+    day,
+    harnessId: "claude",
+    model: "claude-sonnet-5",
+    factCount: 1,
+    tokens: {
+      uncachedInputTokens: 10,
+      cacheReadInputTokens: 0,
+      cacheCreationTokens: 0,
+      outputTokens: 0,
+    },
+    knownCostUsd,
+    knownCacheSavingsUsd: 0,
+    knownReasoningTokens: 0,
+    costProvenance: "providerReported",
+    ...{},
+  };
+}
+
+/** Oldest-first calendar days, inclusive - fixture stand-in for `lastNCalendarDays`. */
+function dayRange(from: string, to: string): string[] {
+  const days: string[] = [];
+  const cursor = new Date(`${from}T00:00:00Z`);
+  const end = new Date(`${to}T00:00:00Z`);
+  while (cursor.getTime() <= end.getTime()) {
+    days.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return days;
+}
+
+describe("buildUsageActivityCalendar", () => {
+  it("gives every day a tile - zero-usage days get level 0, not a hole", () => {
+    // 2026-08-02 is a Sunday.
+    const days = dayRange("2026-08-02", "2026-08-08");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [bucket("2026-08-03", 5)],
+      "cost",
+    );
+    expect(calendar.weeks).toHaveLength(1);
+    const cells = calendar.weeks[0]?.cells ?? [];
+    expect(cells.filter((cell) => cell !== null)).toHaveLength(7);
+    expect(
+      cells.filter((cell) => cell !== null && cell.level === 0),
+    ).toHaveLength(6);
+  });
+
+  it("pads a mid-week window start so weekday rows stay aligned", () => {
+    // 2026-08-05 is a Wednesday - rows 0-2 of the first week are padding.
+    const days = dayRange("2026-08-05", "2026-08-08");
+    const calendar = buildUsageActivityCalendar(days, [], "cost");
+    const first = calendar.weeks[0]?.cells ?? [];
+    expect(first.slice(0, 3)).toEqual([null, null, null]);
+    expect(first[3]?.day).toBe("2026-08-05");
+  });
+
+  it("quantizes nonzero days by quartile and washes nothing out under a long tail", () => {
+    const days = dayRange("2026-08-02", "2026-08-08");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [
+        bucket("2026-08-02", 1),
+        bucket("2026-08-03", 2),
+        bucket("2026-08-04", 3),
+        // The whale day: a linear-to-max scale would push every other day
+        // into the faintest step.
+        bucket("2026-08-05", 1000),
+      ],
+      "cost",
+    );
+    const byDay = new Map(
+      (calendar.weeks[0]?.cells ?? [])
+        .filter((cell) => cell !== null)
+        .map((cell) => [cell.day, cell.level]),
+    );
+    expect(byDay.get("2026-08-05")).toBe(4);
+    expect(byDay.get("2026-08-02")).toBeGreaterThanOrEqual(1);
+    expect(byDay.get("2026-08-04")).toBeGreaterThanOrEqual(2);
+  });
+
+  it("reads a uniform history as full intensity, not the faintest step", () => {
+    const days = dayRange("2026-08-02", "2026-08-04");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [bucket("2026-08-02", 2), bucket("2026-08-03", 2)],
+      "cost",
+    );
+    const levels = (calendar.weeks[0]?.cells ?? [])
+      .filter((cell) => cell !== null && cell.value > 0)
+      .map((cell) => cell?.level);
+    expect(levels).toEqual([4, 4]);
+  });
+
+  it("labels months where they begin, never the window's partial first month", () => {
+    const days = dayRange("2026-06-15", "2026-08-11");
+    const calendar = buildUsageActivityCalendar(days, [], "cost");
+    expect(calendar.monthLabels.map((label) => label.label)).toEqual([
+      "Jul",
+      "Aug",
+    ]);
+    for (const label of calendar.monthLabels) {
+      expect(label.weekIndex).toBeGreaterThan(0);
+      expect(label.weekIndex).toBeLessThan(calendar.weeks.length);
+    }
+  });
+
+  it("computes streaks - and an inactive today does not zero the current streak", () => {
+    // Window ends today (2026-08-08); today has no usage yet.
+    const days = dayRange("2026-08-01", "2026-08-08");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [
+        bucket("2026-08-02", 1),
+        bucket("2026-08-03", 1),
+        bucket("2026-08-04", 1),
+        // gap on 08-05
+        bucket("2026-08-06", 1),
+        bucket("2026-08-07", 1),
+      ],
+      "cost",
+    );
+    expect(calendar.stats.longestStreakDays).toBe(3);
+    expect(calendar.stats.currentStreakDays).toBe(2);
+    expect(calendar.stats.mostActiveMonth).toBe("Aug 2026");
+  });
+
+  it("names the most active day by value", () => {
+    const days = dayRange("2026-08-02", "2026-08-04");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [bucket("2026-08-02", 1), bucket("2026-08-03", 9)],
+      "cost",
+    );
+    expect(calendar.stats.mostActiveDay).toBe("Aug 3, 2026");
+  });
+});

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildUsageActivityCalendar } from "@/lib/usage-analytics/usage-activity";
+import {
+  buildUsageActivityCalendar,
+  isWindowTooWideError,
+} from "@/lib/usage-analytics/usage-activity";
 import type { UsageBucket } from "@/lib/usage-analytics/usage-chart-data";
 
 function bucket(
@@ -162,6 +165,23 @@ describe("buildUsageActivityCalendar", () => {
     expect(calendar.stats.longestStreakDays).toBe(3);
   });
 
+  it("names a most-active month even when every active day is unpriced", () => {
+    // All-unpriced year under the Cost metric: every month sums to $0, but
+    // the tiles/streaks/table all recognize the work - "—" beside them
+    // reads as a contradiction. Fact counts break the all-zero tie.
+    const days = dayRange("2026-07-28", "2026-08-05");
+    const calendar = buildUsageActivityCalendar(
+      days,
+      [
+        bucket("2026-07-29", 0, { costProvenance: "unpriced", factCount: 1 }),
+        bucket("2026-08-02", 0, { costProvenance: "unpriced", factCount: 3 }),
+        bucket("2026-08-03", 0, { costProvenance: "unpriced", factCount: 2 }),
+      ],
+      "cost",
+    );
+    expect(calendar.stats.mostActiveMonth).toBe("Aug 2026");
+  });
+
   it("names the most active day by value", () => {
     const days = dayRange("2026-08-02", "2026-08-04");
     const calendar = buildUsageActivityCalendar(
@@ -170,5 +190,18 @@ describe("buildUsageActivityCalendar", () => {
       "cost",
     );
     expect(calendar.stats.mostActiveDay).toBe("Aug 3, 2026");
+  });
+});
+
+describe("isWindowTooWideError", () => {
+  it("recognizes the legacy validator's rejection and nothing else", () => {
+    expect(
+      isWindowTooWideError({
+        message: "windowDays must be an integer between 1 and 90, got 365",
+      }),
+    ).toBe(true);
+    // A transient failure is NOT a reason to quietly shrink the calendar.
+    expect(isWindowTooWideError({ message: "socket hang up" })).toBe(false);
+    expect(isWindowTooWideError(null)).toBe(false);
   });
 });

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-chart-option.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-chart-option.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type { LineSeriesOption } from "echarts/charts";
+import {
+  buildUsageChartColumns,
+  applyUsageSeriesVisibility,
+} from "@/lib/usage-analytics/usage-chart-data";
+import type { UsageBucket } from "@/lib/usage-analytics/usage-chart-data";
+import {
+  buildUsageChartOption,
+  buildUsageTooltipHtml,
+  type UsageChartOption,
+} from "@/lib/usage-analytics/usage-chart-option";
+import { buildUsageSeriesScale } from "@/lib/usage-analytics/usage-series-scale";
+
+function bucket(overrides: Partial<UsageBucket>): UsageBucket {
+  return {
+    day: "2026-08-01",
+    harnessId: "claude",
+    model: "claude-sonnet-5",
+    factCount: 1,
+    tokens: {
+      uncachedInputTokens: 10,
+      cacheReadInputTokens: 0,
+      cacheCreationTokens: 0,
+      outputTokens: 0,
+    },
+    knownCostUsd: 1,
+    knownCacheSavingsUsd: 0,
+    knownReasoningTokens: 0,
+    costProvenance: "providerReported",
+    ...overrides,
+  };
+}
+
+function seriesList(option: UsageChartOption): readonly LineSeriesOption[] {
+  const { series } = option;
+  if (series === undefined) return [];
+  return Array.isArray(series) ? series : [series];
+}
+
+const scale = buildUsageSeriesScale(["claude", "codex"]);
+const days = ["2026-08-01", "2026-08-02"] as const;
+const columns = buildUsageChartColumns(
+  [...days],
+  [
+    bucket({ day: "2026-08-01", harnessId: "claude", knownCostUsd: 3 }),
+    bucket({ day: "2026-08-02", harnessId: "codex", knownCostUsd: 5 }),
+  ],
+  scale,
+  "cost",
+);
+
+describe("buildUsageChartOption", () => {
+  const option = buildUsageChartOption({ columns, scale, metric: "cost" });
+
+  it("emits one stacked area series per scale slot, in slot order", () => {
+    const series = seriesList(option);
+    expect(series.map((entry) => entry.name)).toEqual(["claude", "codex"]);
+    // One shared stack id is what turns adjacent lines into stacked areas.
+    expect(new Set(series.map((entry) => entry.stack)).size).toBe(1);
+    for (const entry of series) {
+      expect(entry.type).toBe("line");
+      expect(entry.areaStyle).toBeDefined();
+    }
+  });
+
+  it("maps per-day segment values into each series, keeping explicit zeros", () => {
+    const series = seriesList(option);
+    expect(series[0]?.data).toEqual([3, 0]);
+    expect(series[1]?.data).toEqual([0, 5]);
+  });
+
+  it("colors every series with a var() reference, never a resolved value", () => {
+    // The SVG renderer writes these strings into DOM attributes where the
+    // `.usage-chart-root` scoped palette (and its `.dark` override) resolves
+    // them live - a resolved hex here would freeze the mount-time theme.
+    for (const entry of seriesList(option)) {
+      expect(entry.color).toMatch(/^var\(--usage-series-/);
+    }
+  });
+
+  it("labels the x-axis with formatted day labels", () => {
+    const { xAxis } = option;
+    const axis = Array.isArray(xAxis) ? xAxis[0] : xAxis;
+    expect(axis).toMatchObject({ data: ["Aug 1", "Aug 2"] });
+  });
+
+  it("shows point symbols only when a single day leaves nothing else visible", () => {
+    expect(
+      seriesList(option).every((entry) => entry.showSymbol === false),
+    ).toBe(true);
+    const single = buildUsageChartOption({
+      columns: columns.slice(0, 1),
+      scale,
+      metric: "cost",
+    });
+    expect(seriesList(single).every((entry) => entry.showSymbol === true)).toBe(
+      true,
+    );
+  });
+
+  it("keeps a hidden series present as zeros so slots and colors never shift", () => {
+    const filtered = buildUsageChartOption({
+      columns: applyUsageSeriesVisibility(columns, new Set(["codex"])),
+      scale,
+      metric: "cost",
+    });
+    const series = seriesList(filtered);
+    expect(series.map((entry) => entry.name)).toEqual(["claude", "codex"]);
+    expect(series[1]?.data).toEqual([0, 0]);
+  });
+});
+
+describe("buildUsageTooltipHtml", () => {
+  it("drops zero-value entries and formats the rest for the metric", () => {
+    const html = buildUsageTooltipHtml(
+      "Aug 1",
+      [
+        { label: "claude", colorVar: "var(--usage-series-1)", value: 3 },
+        { label: "codex", colorVar: "var(--usage-series-2)", value: 0 },
+      ],
+      "cost",
+    );
+    expect(html).toContain("Aug 1");
+    expect(html).toContain("claude");
+    expect(html).toContain("$3.00");
+    expect(html).not.toContain("codex");
+  });
+
+  it("says no-usage instead of rendering an empty body", () => {
+    const html = buildUsageTooltipHtml("Aug 1", [], "cost");
+    expect(html).toContain("No usage");
+  });
+
+  it("escapes wire-provided labels - the tooltip is injected as innerHTML", () => {
+    const html = buildUsageTooltipHtml(
+      "Aug 1",
+      [{ label: "<img src=x>", colorVar: "red", value: 1 }],
+      "tokens",
+    );
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img src=x&gt;");
+  });
+});

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-chart-option.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-chart-option.test.ts
@@ -51,7 +51,12 @@ const columns = buildUsageChartColumns(
 );
 
 describe("buildUsageChartOption", () => {
-  const option = buildUsageChartOption({ columns, scale, metric: "cost" });
+  const option = buildUsageChartOption({
+    columns,
+    scale,
+    metric: "cost",
+    hiddenSeries: new Set(),
+  });
 
   it("emits one stacked area series per scale slot, in slot order", () => {
     const series = seriesList(option);
@@ -106,6 +111,7 @@ describe("buildUsageChartOption", () => {
       columns: columns.slice(0, 1),
       scale,
       metric: "cost",
+      hiddenSeries: new Set(),
     });
     expect(seriesList(single).every((entry) => entry.showSymbol === true)).toBe(
       true,
@@ -117,10 +123,34 @@ describe("buildUsageChartOption", () => {
       columns: applyUsageSeriesVisibility(columns, new Set(["codex"])),
       scale,
       metric: "cost",
+      hiddenSeries: new Set(["codex"]),
     });
     const series = seriesList(filtered);
     expect(series.map((entry) => entry.name)).toEqual(["claude", "codex"]);
     expect(series[1]?.data).toEqual([0, 0]);
+  });
+
+  it("draws nothing for a hidden series - zeroed values alone still stroke a line", () => {
+    // A stacked line at zero rides the baseline (or the series below it) and
+    // stays visible with its 2px stroke, so filtering it out of the legend
+    // has to suppress the stroke/area/symbol too, not just the values.
+    const filtered = buildUsageChartOption({
+      columns: applyUsageSeriesVisibility(columns, new Set(["codex"])),
+      scale,
+      metric: "cost",
+      hiddenSeries: new Set(["codex"]),
+    });
+    const codex = seriesList(filtered).find((entry) => entry.name === "codex");
+    expect(codex?.lineStyle?.width).toBe(0);
+    expect(codex?.areaStyle?.opacity).toBe(0);
+    expect(codex?.showSymbol).toBe(false);
+    expect(codex?.emphasis?.lineStyle?.width).toBe(0);
+    // The visible series keeps its full treatment.
+    const claude = seriesList(filtered).find(
+      (entry) => entry.name === "claude",
+    );
+    expect(claude?.lineStyle?.width).toBe(2);
+    expect(claude?.areaStyle?.opacity).toBe(0.3);
   });
 });
 

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-chart-option.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-chart-option.test.ts
@@ -79,6 +79,19 @@ describe("buildUsageChartOption", () => {
     }
   });
 
+  it("pins explicit emphasis colors so hover never runs the default color lift", () => {
+    // Regression: with no explicit emphasis color, ECharts "lifts" the
+    // series color on hover by parsing it - `var(...)` doesn't parse, the
+    // lift returns undefined, and the whole chart blanked out under the
+    // axis pointer (2026-08-11 live report).
+    for (const entry of seriesList(option)) {
+      const emphasis = entry.emphasis;
+      expect(emphasis?.lineStyle?.color).toMatch(/^var\(--usage-series-/);
+      expect(emphasis?.areaStyle?.color).toMatch(/^var\(--usage-series-/);
+      expect(emphasis?.itemStyle?.color).toMatch(/^var\(--usage-series-/);
+    }
+  });
+
   it("labels the x-axis with formatted day labels", () => {
     const { xAxis } = option;
     const axis = Array.isArray(xAxis) ? xAxis[0] : xAxis;

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-stat-tiles.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-stat-tiles.test.ts
@@ -119,28 +119,14 @@ describe("buildUsageStatTiles", () => {
     ).toBe(42);
   });
 
-  it("computes the cache-savings multiple against the raw (pre-savings) cost", () => {
+  it("carries savings as a standalone figure - no raw-cost ratio field", () => {
+    // Ticket 18: catalog-derived savings added to provider-reported cost
+    // mixes bases, so the "Nx raw cost" counterfactual was dropped whole.
     const tiles = buildUsageStatTiles(
       totals({ knownCostUsd: 4, knownCacheSavingsUsd: 1 }),
       [],
     );
-    // raw = 4 + 1 = 5; multiple = 5 / 4
-    expect(tiles.cacheSavings.multipleOfRawCost).toBeCloseTo(1.25, 10);
-  });
-
-  it("reports no multiple when there is nothing known to divide", () => {
-    expect(
-      buildUsageStatTiles(
-        totals({ knownCostUsd: 0, knownCacheSavingsUsd: 0 }),
-        [],
-      ).cacheSavings.multipleOfRawCost,
-    ).toBeNull();
-    expect(
-      buildUsageStatTiles(
-        totals({ knownCostUsd: 0, knownCacheSavingsUsd: 3 }),
-        [],
-      ).cacheSavings.multipleOfRawCost,
-    ).toBeNull();
+    expect(tiles.cacheSavings).toEqual({ knownCacheSavingsUsd: 1 });
   });
 });
 

--- a/clients/gui-app/src/lib/usage-analytics/format-metric-value.ts
+++ b/clients/gui-app/src/lib/usage-analytics/format-metric-value.ts
@@ -69,14 +69,3 @@ export function formatDateRangeLabel(days: readonly string[]): string {
     ? `${from} – ${to}, ${lastYear}`
     : `${from}, ${firstYear} – ${to}, ${lastYear}`;
 }
-
-const NICE_STEPS = [1, 2, 5, 10] as const;
-
-/** Rounds up to a clean 1/2/5/10 step for y-axis ticks. */
-export function niceCeil(value: number): number {
-  if (value <= 0) return 0;
-  const magnitude = 10 ** Math.floor(Math.log10(value));
-  const normalized = value / magnitude;
-  const step = NICE_STEPS.find((candidate) => normalized <= candidate) ?? 10;
-  return step * magnitude;
-}

--- a/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
@@ -226,16 +226,18 @@ function currentStreak(cells: readonly UsageActivityCell[]): number {
 }
 
 function buildStats(cells: readonly UsageActivityCell[]): UsageActivityStats {
-  const byMonth = new Map<string, number>();
+  const byMonth = new Map<string, { value: number; factCount: number }>();
   let bestDay: UsageActivityCell | null = null;
   let longest = 0;
   let run = 0;
   for (const cell of cells) {
     if (cell.factCount > 0) {
-      byMonth.set(
-        cell.day.slice(0, 7),
-        (byMonth.get(cell.day.slice(0, 7)) ?? 0) + cell.value,
-      );
+      const month = cell.day.slice(0, 7);
+      const prior = byMonth.get(month) ?? { value: 0, factCount: 0 };
+      byMonth.set(month, {
+        value: prior.value + cell.value,
+        factCount: prior.factCount + cell.factCount,
+      });
       if (bestDay === null || cell.value > bestDay.value) bestDay = cell;
       run += 1;
       if (run > longest) longest = run;
@@ -244,11 +246,20 @@ function buildStats(cells: readonly UsageActivityCell[]): UsageActivityStats {
     }
   }
   const current = currentStreak(cells);
+  // Value first; fact counts break the all-zero case. An all-unpriced year
+  // (every active month sums to $0 under the Cost metric) must still name
+  // its busiest month - the tiles, streaks and table all recognize that
+  // work, and "—" beside them reads as a contradiction.
   let mostActiveMonth: string | null = null;
-  let bestMonthValue = 0;
-  for (const [month, value] of byMonth) {
-    if (value > bestMonthValue) {
-      bestMonthValue = value;
+  let bestMonth = { value: 0, factCount: 0 };
+  for (const [month, totals] of byMonth) {
+    const wins =
+      totals.value > bestMonth.value ||
+      (bestMonth.value === 0 &&
+        totals.value === 0 &&
+        totals.factCount > bestMonth.factCount);
+    if (wins) {
+      bestMonth = totals;
       mostActiveMonth = month;
     }
   }
@@ -283,3 +294,22 @@ export const USAGE_ACTIVITY_WINDOW_DAYS = 365;
  * section degrades to a shorter calendar instead of an error card.
  */
 export const USAGE_ACTIVITY_FALLBACK_WINDOW_DAYS = 90;
+
+/**
+ * Recognizes the ONE failure the 90-day fallback exists for: a host whose
+ * shared validator still caps `windowDays` (pre-ticket-15 releases cap at
+ * 90) rejecting the year read. Matched on the validator's message shape
+ * because the rejection reaches the client as a generic RPC error - and
+ * deliberately NOT on "any error at all": a transient transport failure on
+ * the year read followed by a lucky 90-day success would otherwise
+ * silently present a quarter of the calendar as if it were the whole
+ * thing. Other errors surface through the section's error card instead.
+ */
+export function isWindowTooWideError(
+  error: { readonly message: string } | null,
+): boolean {
+  return (
+    error !== null &&
+    /windowDays must be an integer between 1 and \d+/i.test(error.message)
+  );
+}

--- a/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
@@ -272,3 +272,14 @@ function buildStats(cells: readonly UsageActivityCell[]): UsageActivityStats {
  * the panel and tests share the constant.
  */
 export const USAGE_ACTIVITY_WINDOW_DAYS = 365;
+
+/**
+ * What the calendar falls back to when a host refuses the year.
+ *
+ * Hosts update independently of the app, and every host released before
+ * ticket 15 caps `windowDays` at 90 - so a year request there fails
+ * outright ("windowDays must be an integer between 1 and 90"). 90 is that
+ * ceiling, so this is the widest calendar such a host can answer, and the
+ * section degrades to a shorter calendar instead of an error card.
+ */
+export const USAGE_ACTIVITY_FALLBACK_WINDOW_DAYS = 90;

--- a/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
@@ -4,10 +4,18 @@ import {
   type UsageMetric,
 } from "@/lib/usage-analytics/usage-chart-data";
 
-/** One calendar tile. `level` 0 = no usage, 1-4 = intensity quartile. */
+/** One calendar tile. `level` 0 = no activity, 1-4 = intensity quartile. */
 export interface UsageActivityCell {
   readonly day: string;
   readonly value: number;
+  /**
+   * Turns recorded that day, independent of `value`. A day can hold real
+   * work whose cost could not be priced: under the Cost metric its `value`
+   * is 0, and treating that as an empty day would report unpriced work as
+   * inactivity - breaking streaks and dropping it from the table. Presence
+   * is a fact about the data; `value` only sets the intensity.
+   */
+  readonly factCount: number;
   readonly level: 0 | 1 | 2 | 3 | 4;
 }
 
@@ -71,22 +79,28 @@ export function buildUsageActivityCalendar(
   metric: UsageMetric,
 ): UsageActivityCalendar {
   const valueByDay = new Map<string, number>();
+  const factsByDay = new Map<string, number>();
   for (const bucket of buckets) {
     valueByDay.set(
       bucket.day,
       (valueByDay.get(bucket.day) ?? 0) + bucketMetricValue(bucket, metric),
     );
+    factsByDay.set(
+      bucket.day,
+      (factsByDay.get(bucket.day) ?? 0) + bucket.factCount,
+    );
   }
-  const cells = days.map((day) => {
-    const value = valueByDay.get(day) ?? 0;
-    return { day, value };
-  });
+  const cells = days.map((day) => ({
+    day,
+    value: valueByDay.get(day) ?? 0,
+    factCount: factsByDay.get(day) ?? 0,
+  }));
   const thresholds = quartileThresholds(
     cells.map((cell) => cell.value).filter((value) => value > 0),
   );
   const leveled: UsageActivityCell[] = cells.map((cell) => ({
     ...cell,
-    level: levelFor(cell.value, thresholds),
+    level: levelFor(cell.value, cell.factCount, thresholds),
   }));
   return {
     weeks: intoWeeks(leveled),
@@ -117,13 +131,17 @@ function quartileThresholds(
 
 /**
  * Descending comparisons so a degenerate distribution (every active day
- * equal) reads as full intensity, not the faintest step.
+ * equal) reads as full intensity, not the faintest step. A day that has
+ * turns but no measurable value (unpriced work under the Cost metric)
+ * still gets the faintest STEP rather than the empty one - it happened.
  */
 function levelFor(
   value: number,
+  factCount: number,
   thresholds: readonly [number, number, number] | null,
 ): 0 | 1 | 2 | 3 | 4 {
-  if (value <= 0 || thresholds === null) return 0;
+  if (value <= 0) return factCount > 0 ? 1 : 0;
+  if (thresholds === null) return 0;
   const [q1, q2, q3] = thresholds;
   if (value >= q3) return 4;
   if (value >= q2) return 3;
@@ -196,7 +214,7 @@ function currentStreak(cells: readonly UsageActivityCell[]): number {
   let current = 0;
   for (let i = cells.length - 1; i >= 0; i--) {
     const cell = cells[i];
-    if (cell.value > 0) {
+    if (cell.factCount > 0) {
       current += 1;
     } else if (i === cells.length - 1) {
       continue;
@@ -213,7 +231,7 @@ function buildStats(cells: readonly UsageActivityCell[]): UsageActivityStats {
   let longest = 0;
   let run = 0;
   for (const cell of cells) {
-    if (cell.value > 0) {
+    if (cell.factCount > 0) {
       byMonth.set(
         cell.day.slice(0, 7),
         (byMonth.get(cell.day.slice(0, 7)) ?? 0) + cell.value,

--- a/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
@@ -1,0 +1,256 @@
+import {
+  bucketMetricValue,
+  type UsageBucket,
+  type UsageMetric,
+} from "@/lib/usage-analytics/usage-chart-data";
+
+/** One calendar tile. `level` 0 = no usage, 1-4 = intensity quartile. */
+export interface UsageActivityCell {
+  readonly day: string;
+  readonly value: number;
+  readonly level: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface UsageActivityWeek {
+  /** The week's earliest in-window day - a stable render key for the column. */
+  readonly firstDay: string;
+  /**
+   * Always 7 slots, Sunday-first; `null` pads the partial first and last
+   * weeks so every column renders the same 7-row shape.
+   */
+  readonly cells: ReadonlyArray<UsageActivityCell | null>;
+}
+
+export interface UsageActivityMonthLabel {
+  /** Which week column the label sits above. */
+  readonly weekIndex: number;
+  readonly label: string;
+}
+
+export interface UsageActivityCalendar {
+  readonly weeks: readonly UsageActivityWeek[];
+  readonly monthLabels: readonly UsageActivityMonthLabel[];
+  readonly stats: UsageActivityStats;
+}
+
+export interface UsageActivityStats {
+  /** "Mar 2026" - carries the year because a 365-day span repeats month names. */
+  readonly mostActiveMonth: string | null;
+  /** "Nov 30, 2025" */
+  readonly mostActiveDay: string | null;
+  readonly longestStreakDays: number;
+  readonly currentStreakDays: number;
+}
+
+const MONTH_ABBR = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/**
+ * Folds the summary's day×harness×model buckets into one calendar of
+ * per-day tiles for the activity heatmap. `days` must be the response
+ * window's own oldest-first calendar-day list (`lastNCalendarDays` over the
+ * RESPONSE window, same discipline as the daily chart - never a client
+ * clock), so a day with no usage still gets a level-0 tile instead of
+ * compressing the grid.
+ */
+export function buildUsageActivityCalendar(
+  days: readonly string[],
+  buckets: readonly UsageBucket[],
+  metric: UsageMetric,
+): UsageActivityCalendar {
+  const valueByDay = new Map<string, number>();
+  for (const bucket of buckets) {
+    valueByDay.set(
+      bucket.day,
+      (valueByDay.get(bucket.day) ?? 0) + bucketMetricValue(bucket, metric),
+    );
+  }
+  const cells = days.map((day) => {
+    const value = valueByDay.get(day) ?? 0;
+    return { day, value };
+  });
+  const thresholds = quartileThresholds(
+    cells.map((cell) => cell.value).filter((value) => value > 0),
+  );
+  const leveled: UsageActivityCell[] = cells.map((cell) => ({
+    ...cell,
+    level: levelFor(cell.value, thresholds),
+  }));
+  return {
+    weeks: intoWeeks(leveled),
+    monthLabels: monthLabelsFor(leveled),
+    stats: buildStats(leveled),
+  };
+}
+
+/**
+ * Quartiles over the NONZERO day values (GitHub's approach): a single
+ * enormous day must not wash every ordinary day down to the faintest step,
+ * which a linear-to-max scale does to any long-tailed usage history.
+ */
+function quartileThresholds(
+  nonZeroValues: readonly number[],
+): readonly [number, number, number] | null {
+  if (nonZeroValues.length === 0) return null;
+  const sorted = [...nonZeroValues].sort((a, b) => a - b);
+  const at = (fraction: number): number => {
+    const index = Math.min(
+      sorted.length - 1,
+      Math.floor(fraction * sorted.length),
+    );
+    return sorted[index] ?? 0;
+  };
+  return [at(0.25), at(0.5), at(0.75)];
+}
+
+/**
+ * Descending comparisons so a degenerate distribution (every active day
+ * equal) reads as full intensity, not the faintest step.
+ */
+function levelFor(
+  value: number,
+  thresholds: readonly [number, number, number] | null,
+): 0 | 1 | 2 | 3 | 4 {
+  if (value <= 0 || thresholds === null) return 0;
+  const [q1, q2, q3] = thresholds;
+  if (value >= q3) return 4;
+  if (value >= q2) return 3;
+  if (value >= q1) return 2;
+  return 1;
+}
+
+/** Sunday-first weekday index from a `YYYY-MM-DD` string, without `Date`'s local-zone re-interpretation. */
+function weekdayIndex(day: string): number {
+  const [year, month, date] = day.split("-").map(Number);
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(date)) {
+    return 0;
+  }
+  // Date.UTC interprets the calendar tuple without any timezone - the day
+  // string is already viewer-zone bucketed, so this never shifts a day.
+  return new Date(Date.UTC(year, month - 1, date)).getUTCDay();
+}
+
+function intoWeeks(
+  cells: readonly UsageActivityCell[],
+): readonly UsageActivityWeek[] {
+  const weeks: Array<{
+    firstDay: string;
+    cells: Array<UsageActivityCell | null>;
+  }> = [];
+  let current: Array<UsageActivityCell | null> | null = null;
+  for (const cell of cells) {
+    const weekday = weekdayIndex(cell.day);
+    if (current === null || weekday === 0) {
+      current = new Array<UsageActivityCell | null>(7).fill(null);
+      weeks.push({ firstDay: cell.day, cells: current });
+    }
+    current[weekday] = cell;
+  }
+  return weeks;
+}
+
+/**
+ * A label sits above the column where a month BEGINS. The window's first
+ * month gets none - its start lies outside the window, and its stub column
+ * would collide with the first real transition's label anyway. Transitions
+ * are ≥4 weeks apart by construction, so labels never overlap.
+ */
+function monthLabelsFor(
+  cells: readonly UsageActivityCell[],
+): readonly UsageActivityMonthLabel[] {
+  const labels: UsageActivityMonthLabel[] = [];
+  let weekIndex = -1;
+  let lastMonth: string | null = null;
+  for (const cell of cells) {
+    const weekday = weekdayIndex(cell.day);
+    if (weekIndex === -1 || weekday === 0) weekIndex += 1;
+    const month = cell.day.slice(0, 7);
+    if (lastMonth !== null && month !== lastMonth) {
+      labels.push({
+        weekIndex,
+        label: MONTH_ABBR.at(Number(month.slice(5, 7)) - 1) ?? month,
+      });
+    }
+    lastMonth = month;
+  }
+  return labels;
+}
+
+/**
+ * Counts back from the newest day, but an inactive TODAY (the last cell -
+ * the day is not over yet) doesn't zero the streak.
+ */
+function currentStreak(cells: readonly UsageActivityCell[]): number {
+  let current = 0;
+  for (let i = cells.length - 1; i >= 0; i--) {
+    const cell = cells[i];
+    if (cell.value > 0) {
+      current += 1;
+    } else if (i === cells.length - 1) {
+      continue;
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+function buildStats(cells: readonly UsageActivityCell[]): UsageActivityStats {
+  const byMonth = new Map<string, number>();
+  let bestDay: UsageActivityCell | null = null;
+  let longest = 0;
+  let run = 0;
+  for (const cell of cells) {
+    if (cell.value > 0) {
+      byMonth.set(
+        cell.day.slice(0, 7),
+        (byMonth.get(cell.day.slice(0, 7)) ?? 0) + cell.value,
+      );
+      if (bestDay === null || cell.value > bestDay.value) bestDay = cell;
+      run += 1;
+      if (run > longest) longest = run;
+    } else {
+      run = 0;
+    }
+  }
+  const current = currentStreak(cells);
+  let mostActiveMonth: string | null = null;
+  let bestMonthValue = 0;
+  for (const [month, value] of byMonth) {
+    if (value > bestMonthValue) {
+      bestMonthValue = value;
+      mostActiveMonth = month;
+    }
+  }
+  return {
+    mostActiveMonth:
+      mostActiveMonth === null
+        ? null
+        : `${MONTH_ABBR.at(Number(mostActiveMonth.slice(5, 7)) - 1) ?? ""} ${mostActiveMonth.slice(0, 4)}`,
+    mostActiveDay:
+      bestDay === null
+        ? null
+        : `${MONTH_ABBR.at(Number(bestDay.day.slice(5, 7)) - 1) ?? ""} ${String(Number(bestDay.day.slice(8, 10)))}, ${bestDay.day.slice(0, 4)}`,
+    longestStreakDays: longest,
+    currentStreakDays: current,
+  };
+}
+
+/**
+ * The heatmap reads a fixed year of days regardless of the page's 7/30/90
+ * picker - an activity calendar over one month is all padding. Exported so
+ * the panel and tests share the constant.
+ */
+export const USAGE_ACTIVITY_WINDOW_DAYS = 365;

--- a/clients/gui-app/src/lib/usage-analytics/usage-chart-option.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-chart-option.ts
@@ -1,0 +1,158 @@
+import type { LineSeriesOption } from "echarts/charts";
+import type {
+  GridComponentOption,
+  TooltipComponentOption,
+} from "echarts/components";
+import type { ComposeOption } from "echarts/core";
+import {
+  formatDayLabel,
+  formatMetricValue,
+} from "@/lib/usage-analytics/format-metric-value";
+import type {
+  UsageChartColumn,
+  UsageMetric,
+} from "@/lib/usage-analytics/usage-chart-data";
+import type { UsageSeriesScale } from "@/lib/usage-analytics/usage-series-scale";
+
+export type UsageChartOption = ComposeOption<
+  LineSeriesOption | GridComponentOption | TooltipComponentOption
+>;
+
+/**
+ * Every color in the option is a `var(--usage-series-N)` / theme-token
+ * REFERENCE, never a resolved value: the chart renders through ECharts' SVG
+ * renderer, which writes these strings into DOM attributes and inline
+ * styles where Chromium resolves them live against `.usage-chart-root`'s
+ * scoped palette (and its `.dark` override). Resolving at build time would
+ * freeze the first theme's colors into the option and miss a live theme
+ * switch. This is why the canvas renderer is not an option here.
+ */
+export function buildUsageChartOption(input: {
+  readonly columns: readonly UsageChartColumn[];
+  readonly scale: UsageSeriesScale;
+  readonly metric: UsageMetric;
+}): UsageChartOption {
+  const { columns, scale, metric } = input;
+  // A one-point line with hidden symbols renders zero visible pixels - an
+  // epic whose whole life fits in one day would show an empty chart. The
+  // dot only appears when it is the ONLY mark available.
+  const showSymbol = columns.length === 1;
+  return {
+    animationDuration: 300,
+    grid: { left: 4, right: 12, top: 12, bottom: 4, containLabel: true },
+    xAxis: {
+      type: "category",
+      // The area should span the full plot, not start half a slot in - and
+      // labels are thinned by ECharts (`hideOverlap`), never truncated,
+      // which is the fix for the "Jul …" feedback.
+      boundaryGap: false,
+      data: columns.map((column) => formatDayLabel(column.day)),
+      axisLabel: {
+        color: "var(--muted-foreground)",
+        fontSize: 11,
+        hideOverlap: true,
+      },
+      axisLine: { lineStyle: { color: "var(--border)" } },
+      axisTick: { show: false },
+    },
+    yAxis: {
+      type: "value",
+      axisLabel: {
+        color: "var(--muted-foreground)",
+        fontSize: 11,
+        formatter: (value: number) => formatMetricValue(value, metric),
+      },
+      splitLine: { lineStyle: { color: "var(--border)", opacity: 0.5 } },
+    },
+    tooltip: {
+      trigger: "axis",
+      axisPointer: { type: "line", lineStyle: { color: "var(--border)" } },
+      backgroundColor: "var(--popover)",
+      borderColor: "var(--border)",
+      textStyle: { color: "var(--popover-foreground)", fontSize: 12 },
+      formatter: (params) => {
+        const list = Array.isArray(params) ? params : [params];
+        const day = list[0]?.name ?? "";
+        return buildUsageTooltipHtml(
+          day,
+          list.map((param) => ({
+            label: param.seriesName ?? "",
+            colorVar:
+              typeof param.color === "string" ? param.color : "currentColor",
+            value: typeof param.value === "number" ? param.value : 0,
+          })),
+          metric,
+        );
+      },
+    },
+    series: scale.order.map((seriesKey) => ({
+      name: scale.labelFor(seriesKey),
+      type: "line",
+      // One shared stack id turns adjacent lines into a stacked area - the
+      // same accumulate-by-slot semantics the bars had.
+      stack: "usage",
+      smooth: true,
+      showSymbol,
+      symbolSize: 6,
+      color: scale.colorVar(seriesKey),
+      lineStyle: { width: 2 },
+      areaStyle: { opacity: 0.3 },
+      emphasis: { focus: "none" },
+      data: columns.map(
+        (column) =>
+          column.segments.find((segment) => segment.seriesKey === seriesKey)
+            ?.value ?? 0,
+      ),
+    })),
+  };
+}
+
+export interface UsageTooltipEntry {
+  readonly label: string;
+  readonly colorVar: string;
+  readonly value: number;
+}
+
+/**
+ * The axis tooltip's body. Zero-value entries are dropped - a series the
+ * legend filter zeroed out (or that simply had no usage that day) must not
+ * pad the list, matching the old per-bar tooltip's behavior. The tooltip
+ * element mounts INSIDE the chart container, so `var(--usage-series-N)`
+ * marker colors resolve against the same scoped palette as the areas.
+ */
+export function buildUsageTooltipHtml(
+  day: string,
+  entries: readonly UsageTooltipEntry[],
+  metric: UsageMetric,
+): string {
+  const nonZero = entries.filter((entry) => entry.value > 0);
+  const header = `<div style="font-weight:500;margin-bottom:2px">${escapeHtml(day)}</div>`;
+  if (nonZero.length === 0) {
+    return `${header}<div style="opacity:0.7">No usage</div>`;
+  }
+  const rows = nonZero
+    .map(
+      (entry) =>
+        `<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">` +
+        `<span style="display:inline-flex;align-items:center;gap:6px">` +
+        `<span style="width:8px;height:8px;border-radius:9999px;background:${escapeHtml(entry.colorVar)}"></span>` +
+        `${escapeHtml(entry.label)}</span>` +
+        `<span style="font-variant-numeric:tabular-nums;font-weight:500">${escapeHtml(formatMetricValue(entry.value, metric))}</span>` +
+        `</div>`,
+    )
+    .join("");
+  return `${header}${rows}`;
+}
+
+/**
+ * Series labels are wire-provided harness ids and the tooltip is injected
+ * as `innerHTML` by ECharts - escape rather than trust the 64-char id
+ * grammar to stay markup-free forever.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/clients/gui-app/src/lib/usage-analytics/usage-chart-option.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-chart-option.ts
@@ -31,8 +31,16 @@ export function buildUsageChartOption(input: {
   readonly columns: readonly UsageChartColumn[];
   readonly scale: UsageSeriesScale;
   readonly metric: UsageMetric;
+  /**
+   * Legend-filtered series keys. Zeroing a series' VALUES is not enough to
+   * hide it: a stacked line at zero still draws its 2px stroke, so a
+   * filtered harness stays visible riding the baseline or the series
+   * below it. The series stays in the option (slot order and color
+   * assignment never shift) but renders nothing.
+   */
+  readonly hiddenSeries: ReadonlySet<string>;
 }): UsageChartOption {
-  const { columns, scale, metric } = input;
+  const { columns, scale, metric, hiddenSeries } = input;
   // A one-point line with hidden symbols renders zero visible pixels - an
   // epic whose whole life fits in one day would show an empty chart. The
   // dot only appears when it is the ONLY mark available.
@@ -87,6 +95,7 @@ export function buildUsageChartOption(input: {
     },
     series: scale.order.map((seriesKey) => {
       const colorVar = scale.colorVar(seriesKey);
+      const hidden = hiddenSeries.has(seriesKey);
       return {
         name: scale.labelFor(seriesKey),
         type: "line" as const,
@@ -94,11 +103,11 @@ export function buildUsageChartOption(input: {
         // same accumulate-by-slot semantics the bars had.
         stack: "usage",
         smooth: true,
-        showSymbol,
+        showSymbol: showSymbol && !hidden,
         symbolSize: 6,
         color: colorVar,
-        lineStyle: { width: 2 },
-        areaStyle: { opacity: 0.3 },
+        lineStyle: { width: hidden ? 0 : 2 },
+        areaStyle: { opacity: hidden ? 0 : 0.3 },
         // Every emphasis color is pinned to the series' own var() reference.
         // This is not decorative: with no explicit emphasis color, ECharts
         // applies its default hover "color lift" (states.js -> zrender
@@ -109,8 +118,8 @@ export function buildUsageChartOption(input: {
         // skip that lift branch entirely.
         emphasis: {
           focus: "none" as const,
-          lineStyle: { color: colorVar, width: 2 },
-          areaStyle: { color: colorVar, opacity: 0.3 },
+          lineStyle: { color: colorVar, width: hidden ? 0 : 2 },
+          areaStyle: { color: colorVar, opacity: hidden ? 0 : 0.3 },
           itemStyle: { color: colorVar },
         },
         data: columns.map(

--- a/clients/gui-app/src/lib/usage-analytics/usage-chart-option.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-chart-option.ts
@@ -85,25 +85,41 @@ export function buildUsageChartOption(input: {
         );
       },
     },
-    series: scale.order.map((seriesKey) => ({
-      name: scale.labelFor(seriesKey),
-      type: "line",
-      // One shared stack id turns adjacent lines into a stacked area - the
-      // same accumulate-by-slot semantics the bars had.
-      stack: "usage",
-      smooth: true,
-      showSymbol,
-      symbolSize: 6,
-      color: scale.colorVar(seriesKey),
-      lineStyle: { width: 2 },
-      areaStyle: { opacity: 0.3 },
-      emphasis: { focus: "none" },
-      data: columns.map(
-        (column) =>
-          column.segments.find((segment) => segment.seriesKey === seriesKey)
-            ?.value ?? 0,
-      ),
-    })),
+    series: scale.order.map((seriesKey) => {
+      const colorVar = scale.colorVar(seriesKey);
+      return {
+        name: scale.labelFor(seriesKey),
+        type: "line" as const,
+        // One shared stack id turns adjacent lines into a stacked area - the
+        // same accumulate-by-slot semantics the bars had.
+        stack: "usage",
+        smooth: true,
+        showSymbol,
+        symbolSize: 6,
+        color: colorVar,
+        lineStyle: { width: 2 },
+        areaStyle: { opacity: 0.3 },
+        // Every emphasis color is pinned to the series' own var() reference.
+        // This is not decorative: with no explicit emphasis color, ECharts
+        // applies its default hover "color lift" (states.js -> zrender
+        // `liftColor`), which parses the color to brighten it - `var(...)`
+        // strings don't parse, `lift` returns undefined, and the whole
+        // band/line renders as fill:none for as long as the axis pointer
+        // hovers the chart. Explicit colors make `hasFillOrStroke` true and
+        // skip that lift branch entirely.
+        emphasis: {
+          focus: "none" as const,
+          lineStyle: { color: colorVar, width: 2 },
+          areaStyle: { color: colorVar, opacity: 0.3 },
+          itemStyle: { color: colorVar },
+        },
+        data: columns.map(
+          (column) =>
+            column.segments.find((segment) => segment.seriesKey === seriesKey)
+              ?.value ?? 0,
+        ),
+      };
+    }),
   };
 }
 

--- a/clients/gui-app/src/lib/usage-analytics/usage-stat-tiles.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-stat-tiles.ts
@@ -26,15 +26,14 @@ export interface UsageOutputTile {
   readonly reasoningTokens: number | null;
 }
 
+/**
+ * Savings stands ALONE as a catalog-rate estimate (ticket 18). The earlier
+ * "Nx raw cost" ratio added catalog-derived savings to costs that can be
+ * provider-REPORTED - two different bases (call populations, tiers), so the
+ * ratio was not a coherent counterfactual (billing-bug pressure test).
+ */
 export interface UsageCacheSavingsTile {
   readonly knownCacheSavingsUsd: number;
-  /**
-   * How many times more the window's KNOWN priced cost would have been
-   * without caching (`(knownCostUsd + knownCacheSavingsUsd) / knownCostUsd`).
-   * `null` when there is no known cost to divide by, or no savings to show -
-   * never a fabricated ratio.
-   */
-  readonly multipleOfRawCost: number | null;
 }
 
 export interface UsageStatTiles {
@@ -74,7 +73,6 @@ export function buildUsageStatTiles(
   const activeDays = countActiveDays(buckets);
   const observedInput =
     tokens.uncachedInputTokens + tokens.cacheReadInputTokens;
-  const rawCostUsd = totals.knownCostUsd + totals.knownCacheSavingsUsd;
 
   return {
     processedTokens: {
@@ -99,10 +97,6 @@ export function buildUsageStatTiles(
     },
     cacheSavings: {
       knownCacheSavingsUsd: totals.knownCacheSavingsUsd,
-      multipleOfRawCost:
-        totals.knownCacheSavingsUsd > 0 && totals.knownCostUsd > 0
-          ? rawCostUsd / totals.knownCostUsd
-          : null,
     },
   };
 }

--- a/clients/gui-app/src/styles/usage-analytics-chart.css
+++ b/clients/gui-app/src/styles/usage-analytics-chart.css
@@ -34,6 +34,15 @@
   --usage-series-7: #4a3aa7; /* violet */
   --usage-series-8: #e34948; /* red */
   --usage-series-other: var(--muted-foreground);
+  /* Sequential ramp for the activity heatmap (dataviz skill blue ramp,
+     steps 150/300/450/650 light): one hue, light→dark, monotonic
+     lightness; level 0 is the neutral no-usage tile. Dark mode below picks
+     its OWN steps (650→250, dark→bright) rather than flipping these. */
+  --usage-heat-0: var(--muted);
+  --usage-heat-1: #b7d3f6;
+  --usage-heat-2: #6da7ec;
+  --usage-heat-3: #2a78d6;
+  --usage-heat-4: #104281;
 }
 
 .dark .usage-chart-root {
@@ -46,4 +55,9 @@
   --usage-series-7: #9085e9;
   --usage-series-8: #e66767;
   --usage-series-other: var(--muted-foreground);
+  --usage-heat-0: var(--muted);
+  --usage-heat-1: #104281;
+  --usage-heat-2: #256abf;
+  --usage-heat-3: #5598e7;
+  --usage-heat-4: #86b6ef;
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "date-fns": "^4.4.0",
     "diff": "^9.0.0",
     "dompurify": "^3.4.12",
+    "echarts": "^6.1.0",
     "electron": "^42.8.1",
     "electron-builder": "^26.15.3",
     "electron-log": "^5.4.4",


### PR DESCRIPTION
Dashboard feedback round on the usage surfaces (follow-up to #1102):

- **ECharts stacked area chart** replaces the hand-rolled stacked bars on the usage daily chart (Settings dashboard + epic Usage dialog). Tree-shaken `echarts` (core + LineChart + Grid/Tooltip components + **SVG renderer**). The SVG renderer is load-bearing: the harness palette reaches the chart as `var(--usage-series-N)` strings that Chromium resolves against the `.usage-chart-root` scoped palette (and its `.dark` override), so live theme switching needs no resolve-at-mount plumbing — verified against zrender 6.1's SVG path, which writes fill/stroke strings into DOM attributes verbatim.
- **Readable x-axis**: the old axis gave each day label exactly one column-width (`flex-1 truncate`), clipping every label past ~10 days to "Jul …". ECharts thins labels (`hideOverlap`) instead of truncating.
- **Legend semantics preserved**: the chip filter still zeroes hidden series in place (slots/colors never shift), tested end-to-end against the option the chart instance actually receives.
- **By-chat/agent breakdown is now a real table** (Chat / agent, Tokens, Cost) matching the other breakdown tables' styling.
- Tests: pure option-builder unit suite; jsdom suites run against a recording `echarts/core` mock registered in the shared setup file (zrender needs a real canvas for text measurement).

No wire changes; no protocol changes. `echarts@6.1.0` added via the root catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
