### PR TITLE
fix(gui-app): keep multi-line pastes inside composer code blocks

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
@@ -552,6 +552,57 @@ describe("composer rich clipboard paste", () => {
     });
   });
 
+  it("keeps every line of a multi-line plain text paste inside a code block", () => {
+    const editor = makeCodeBlockEditor("existing\n");
+
+    pastePlainText(editor, "line one\nline two\nline three");
+
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: null },
+          content: [
+            { type: "text", text: "existing\nline one\nline two\nline three" },
+          ],
+        },
+        { type: "paragraph" },
+      ],
+    });
+  });
+
+  it("keeps markdown-looking text literal inside a code block, with CRLF normalized", () => {
+    const editor = makeCodeBlockEditor("");
+
+    pastePlainText(editor, "# Title\r\n- first\r\n**bold**");
+
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+    expect(editor.state.doc.firstChild?.textContent).toBe(
+      "# Title\n- first\n**bold**",
+    );
+  });
+
+  it("degrades an HTML-flavored paste inside a code block to its plain text sibling", () => {
+    const editor = makeCodeBlockEditor("");
+
+    fireEvent.paste(editor.view.dom, {
+      clipboardData: {
+        files: [],
+        items: [],
+        types: ["text/html", "text/plain"],
+        getData: (type: string) => {
+          if (type === "text/html") return "<p>one</p><p>two</p>";
+          if (type === "text/plain") return "one\ntwo";
+          return "";
+        },
+      },
+    });
+
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+    expect(editor.state.doc.firstChild?.textContent).toBe("one\ntwo");
+  });
+
   it("converts a leading slash command paste into a chip with literal args", () => {
     const editor = makeEditor(KNOWN_SLASH_NAMES);
 
@@ -725,6 +776,25 @@ describe("composer rich clipboard paste", () => {
     expect(editor.state.doc.textContent).toBe("/plan review the diff");
   });
 });
+
+// A composer opening with a code block, caret at the end of its text — the
+// state right after typing ``` and some content. The caret is positioned
+// explicitly inside the code block because the schema keeps a trailing
+// paragraph after it.
+function makeCodeBlockEditor(text: string): Editor {
+  const editor = makeEditor(KNOWN_SLASH_NAMES);
+  editor.commands.setContent({
+    type: "doc",
+    content: [
+      {
+        type: "codeBlock",
+        content: text.length > 0 ? [{ type: "text", text }] : [],
+      },
+    ],
+  });
+  editor.commands.setTextSelection(1 + text.length);
+  return editor;
+}
 
 function pastePlainText(editor: Editor, text: string): void {
   fireEvent.paste(editor.view.dom, {

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
@@ -202,6 +202,23 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
               // through to normal text/markdown paste below.
               if (hasClaimableFileTransfer(clipboardData)) return true;
 
+              // Inside a code block, every textual flavor degrades to the
+              // clipboard's literal plain text — the in-code paste behavior
+              // ProseMirror itself would apply if this handler didn't claim
+              // the event. The branches below parse the paste into block
+              // nodes (markdown/HTML), and `replaceSelection` can fit only
+              // the first line's text inside the code block; the remaining
+              // blocks get hoisted out below it.
+              if (view.state.selection.$from.parent.type.spec.code === true) {
+                const codeText = clipboardData.getData("text/plain");
+                if (codeText.length === 0) return false;
+                const tr = view.state.tr.insertText(
+                  codeText.replace(/\r\n?/g, "\n"),
+                );
+                view.dispatch(tr.scrollIntoView());
+                return true;
+              }
+
               const composerContent =
                 readComposerContentFromClipboardData(clipboardData);
               if (composerContent !== null) {


### PR DESCRIPTION
## Problem

Pasting multi-line text inside a triple-backtick code block in the composer kept only the first line in the code block; every remaining line was inserted as a normal paragraph below it.

## Root cause

The composer's `chatPasteHandler` plugin claims every paste event, so ProseMirror's built-in in-code paste behavior (insert the clipboard's literal plain text) never runs. The handler parsed the pasted text as markdown into multiple block nodes and inserted them with `replaceSelection` — ProseMirror can only fit the first block's text inside a code block, and hoists the remaining blocks out below it. Tiptap's own CodeBlock paste plugin doesn't cover this either: it deliberately backs off when the selection is already inside a code block.

## Fix

When the caret's parent node is a code node (`$from.parent.type.spec.code`), insert the clipboard's `text/plain` verbatim (CRLF-normalized) and skip the markdown/HTML/composer-flavor branches — mirroring ProseMirror's native in-code paste path. HTML-flavored pastes (e.g. copies from VS Code or a webpage) degrade to their plain-text sibling inside a code block.

## Tests

- multi-line plain text pasted inside a code block keeps every line in the block
- markdown-looking text (`# Title`, `- first`, `**bold**`) stays literal, with CRLF normalized to `\n`
- an HTML-flavored paste inside a code block falls back to its `text/plain` sibling

All 30 tests in `composer-rich-paste.test.tsx` and the full composer suite (415 tests) pass.
