### PR TITLE
fix(gui-app): smooth notification mark-all-read updates

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -7,6 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { domMax, LazyMotion } from "motion/react";
 import type { ReactNode } from "react";
 import type { Mock } from "vitest";
 import type { ProviderId } from "@/components/home/data/landing-options";
@@ -3703,6 +3704,30 @@ describe("chat row archive", () => {
     const row = screen.getByTestId("epic-sidebar-item-chat-root");
     expect(within(row).getByTestId("chat-row-archived-label")).toBeTruthy();
     expect(leadingStatusKinds("chat-root")).toEqual(["done"]);
+  });
+
+  it("keeps the final archived row mounted while its tree branch exits", () => {
+    seedGuiChatTree();
+    testState.archivedIds = ["chat-root"];
+    testState.indicatorChats = {
+      "chat-root": indicator({ unreadDone: true }),
+    };
+    const panel = () => (
+      <LazyMotion features={domMax}>
+        <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />
+      </LazyMotion>
+    );
+    const view = render(panel());
+
+    expect(screen.getByTestId("epic-sidebar-item-chat-root")).toBeTruthy();
+
+    testState.indicatorChats = {};
+    view.rerender(panel());
+
+    // The archived-empty branch waits until Motion finishes the tree branch's
+    // exit, so the final row cannot disappear in the same render.
+    expect(screen.getByTestId("epic-sidebar-item-chat-root")).toBeTruthy();
+    expect(screen.queryByTestId("epic-chat-sidebar-archived-empty")).toBeNull();
   });
 
   it("clears archived row styling when the unarchive projection arrives", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -498,6 +498,7 @@ function useChatVisibleIds(epicId: string): ReadonlySet<string> | null {
 // eslint-disable-next-line complexity
 export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
   const { epicId, tabId } = props;
+  const shouldReduceMotion = useReducedMotion() === true;
   const panelId: RootCreatePanelId = "chats";
   const sort = useChatSort(epicId);
   const comparator = useMemo<NodeComparator | null>(
@@ -727,60 +728,92 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
         testId="epic-chat-sidebar-filter-empty"
       />
     );
-  } else if (archiveHidEverything) {
-    panelContent = (
-      <SidebarPanelEmptyState
-        icon={Archive}
-        title={archiveEmptyState.title}
-        description={archiveEmptyState.description}
-        testId="epic-chat-sidebar-archived-empty"
-      />
-    );
   } else {
     panelContent = (
-      <ul role="tree" aria-label="Epic agents tree" className="space-y-0.5">
-        {/* Clearing an archived row's last notification indicator removes its
-        visibility exception. Keep that product behavior, but make the exit
-        legible instead of dropping the row in the same frame as the popover. */}
-        <AnimatePresence initial={false}>
-          {rootIds.map((nodeId) => (
-            <ChatNode
-              key={nodeId}
-              epicId={epicId}
-              tabId={tabId}
-              nodeId={nodeId}
-              depth={0}
-              expansion={expansion}
-              canEdit={canEdit}
-              canMutate={canMutate}
-              isDisconnected={isDisconnected}
-              treeFilter={CHATS_TREE_FILTER}
-              selectionMode={selectionMode}
-              selectedIds={selectedIds}
-              onToggleSelection={toggleSelection}
+      <AnimatePresence initial={false} mode="wait">
+        {archiveHidEverything ? (
+          <m.div
+            key="archived-empty"
+            className="flex min-h-0 flex-1 flex-col"
+            initial={shouldReduceMotion ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.16 }}
+          >
+            <SidebarPanelEmptyState
+              icon={Archive}
+              title={archiveEmptyState.title}
+              description={archiveEmptyState.description}
+              testId="epic-chat-sidebar-archived-empty"
             />
-          ))}
-        </AnimatePresence>
-        {renderedLocalRootPending !== null && (
-          <PendingCreateRow depth={0} name={renderedLocalRootPending.name} />
+          </m.div>
+        ) : (
+          <m.div
+            key="tree"
+            className="flex min-h-0 flex-1 flex-col"
+            exit={shouldReduceMotion ? undefined : { opacity: 0, x: -8 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.16 }}
+          >
+            <ul
+              role="tree"
+              aria-label="Epic agents tree"
+              className="space-y-0.5"
+            >
+              {/* Clearing an archived row's last notification indicator removes
+              its visibility exception. Keep the tree branch mounted through
+              that final-row exit before revealing the archived empty state. */}
+              <AnimatePresence initial={false}>
+                {rootIds.map((nodeId) => (
+                  <ChatNode
+                    key={nodeId}
+                    epicId={epicId}
+                    tabId={tabId}
+                    nodeId={nodeId}
+                    depth={0}
+                    expansion={expansion}
+                    canEdit={canEdit}
+                    canMutate={canMutate}
+                    isDisconnected={isDisconnected}
+                    treeFilter={CHATS_TREE_FILTER}
+                    selectionMode={selectionMode}
+                    selectedIds={selectedIds}
+                    onToggleSelection={toggleSelection}
+                  />
+                ))}
+              </AnimatePresence>
+              {renderedLocalRootPending !== null && (
+                <PendingCreateRow
+                  depth={0}
+                  name={renderedLocalRootPending.name}
+                />
+              )}
+              {renderedAcknowledgedRootPending !== null && (
+                <PendingCreateRow
+                  depth={0}
+                  name={renderedAcknowledgedRootPending.name}
+                />
+              )}
+              {renderedPreAckRootCreates.map(
+                (entry: { tempId: string; name: string }) => (
+                  <PendingCreateRow
+                    key={entry.tempId}
+                    depth={0}
+                    name={entry.name}
+                  />
+                ),
+              )}
+              {renderedPendingRootCreates.map(
+                (entry: { id: string; name: string }) => (
+                  <PendingCreateRow
+                    key={entry.id}
+                    depth={0}
+                    name={entry.name}
+                  />
+                ),
+              )}
+            </ul>
+          </m.div>
         )}
-        {renderedAcknowledgedRootPending !== null && (
-          <PendingCreateRow
-            depth={0}
-            name={renderedAcknowledgedRootPending.name}
-          />
-        )}
-        {renderedPreAckRootCreates.map(
-          (entry: { tempId: string; name: string }) => (
-            <PendingCreateRow key={entry.tempId} depth={0} name={entry.name} />
-          ),
-        )}
-        {renderedPendingRootCreates.map(
-          (entry: { id: string; name: string }) => (
-            <PendingCreateRow key={entry.id} depth={0} name={entry.name} />
-          ),
-        )}
-      </ul>
+      </AnimatePresence>
     );
   }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -3,6 +3,7 @@
  * with expansion, rename, delete, and drag-drop behaviors.
  */
 import { useDraggable } from "@dnd-kit/core";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import type { RoleClaim } from "@traycer/protocol/persistence/epic/role-claims";
 import { v4 as uuidv4 } from "uuid";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
@@ -738,23 +739,28 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
   } else {
     panelContent = (
       <ul role="tree" aria-label="Epic agents tree" className="space-y-0.5">
-        {rootIds.map((nodeId) => (
-          <ChatNode
-            key={nodeId}
-            epicId={epicId}
-            tabId={tabId}
-            nodeId={nodeId}
-            depth={0}
-            expansion={expansion}
-            canEdit={canEdit}
-            canMutate={canMutate}
-            isDisconnected={isDisconnected}
-            treeFilter={CHATS_TREE_FILTER}
-            selectionMode={selectionMode}
-            selectedIds={selectedIds}
-            onToggleSelection={toggleSelection}
-          />
-        ))}
+        {/* Clearing an archived row's last notification indicator removes its
+        visibility exception. Keep that product behavior, but make the exit
+        legible instead of dropping the row in the same frame as the popover. */}
+        <AnimatePresence initial={false}>
+          {rootIds.map((nodeId) => (
+            <ChatNode
+              key={nodeId}
+              epicId={epicId}
+              tabId={tabId}
+              nodeId={nodeId}
+              depth={0}
+              expansion={expansion}
+              canEdit={canEdit}
+              canMutate={canMutate}
+              isDisconnected={isDisconnected}
+              treeFilter={CHATS_TREE_FILTER}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelection={toggleSelection}
+            />
+          ))}
+        </AnimatePresence>
         {renderedLocalRootPending !== null && (
           <PendingCreateRow depth={0} name={renderedLocalRootPending.name} />
         )}
@@ -1271,6 +1277,7 @@ function ChatNodeShellArchivable(props: ChatNodeShellProps) {
 function ChatNodeShellBody(
   props: ChatNodeShellProps & { readonly decision: ChatRowArchiveDecision },
 ) {
+  const shouldReduceMotion = useReducedMotion() === true;
   const {
     epicId,
     tabId,
@@ -1345,7 +1352,10 @@ function ChatNodeShellBody(
   });
 
   return (
-    <li
+    <m.li
+      layout={shouldReduceMotion ? false : "position"}
+      exit={shouldReduceMotion ? undefined : { opacity: 0, x: -8 }}
+      transition={{ duration: 0.16, ease: "easeOut" }}
       role="treeitem"
       aria-selected={isActive}
       aria-expanded={hasChildren ? expanded : undefined}
@@ -1445,7 +1455,7 @@ function ChatNodeShellBody(
         isPending={deletePending}
         onConfirm={onConfirmDelete}
       />
-    </li>
+    </m.li>
   );
 }
 
@@ -1482,23 +1492,25 @@ function ChatNodeChildren(props: ChatNodeChildrenProps) {
   return (
     <ul role="group" className="relative space-y-0.5">
       <TreeGroupGuide parentDepth={props.depth} />
-      {props.childIds.map((childId) => (
-        <ChatNode
-          key={childId}
-          epicId={props.epicId}
-          tabId={props.tabId}
-          nodeId={childId}
-          depth={props.depth + 1}
-          expansion={props.expansion}
-          canEdit={props.canEdit}
-          canMutate={props.canMutate}
-          isDisconnected={props.isDisconnected}
-          treeFilter={props.treeFilter}
-          selectionMode={props.selectionMode}
-          selectedIds={props.selectedIds}
-          onToggleSelection={props.onToggleSelection}
-        />
-      ))}
+      <AnimatePresence initial={false}>
+        {props.childIds.map((childId) => (
+          <ChatNode
+            key={childId}
+            epicId={props.epicId}
+            tabId={props.tabId}
+            nodeId={childId}
+            depth={props.depth + 1}
+            expansion={props.expansion}
+            canEdit={props.canEdit}
+            canMutate={props.canMutate}
+            isDisconnected={props.isDisconnected}
+            treeFilter={props.treeFilter}
+            selectionMode={props.selectionMode}
+            selectedIds={props.selectedIds}
+            onToggleSelection={props.onToggleSelection}
+          />
+        ))}
+      </AnimatePresence>
     </ul>
   );
 }

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -1992,6 +1992,9 @@ describe("NotificationsPopover", () => {
       throw new Error("expected dismissed row in Recent");
     }
     expect(live.dataset.notificationRead).toBe("true");
+    expect(
+      within(live).getByTestId("notification-relocation-highlight"),
+    ).not.toBeNull();
     expect(within(live).queryByTestId("notification-dismiss")).toBeNull();
     const dismissed =
       useHostNotificationsStore.getState().byId["prompt-dismiss"];

--- a/clients/gui-app/src/components/notifications/notification-row.tsx
+++ b/clients/gui-app/src/components/notifications/notification-row.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { m, useReducedMotion } from "motion/react";
 import {
   Bell,
   Check,
@@ -33,6 +34,8 @@ import {
 
 interface NotificationRowProps {
   readonly feedId: string;
+  /** Briefly identifies a row that just moved from Attention into Recent. */
+  readonly highlightRelocation: boolean;
   readonly onActivate: (row: MergedNotificationRow) => void;
   readonly onAcknowledge: (row: MergedNotificationRow) => void;
   /** Dismiss an unresolved `needs_action` Attention row (stamps `resolvedAt`).
@@ -80,6 +83,7 @@ export function NotificationRow(props: NotificationRowProps): ReactNode {
   // Hooks must remain unconditional while an exact-removal frame makes this
   // row disappear between renders.
   const originHost = useHostDirectoryEntry(row?.originHostId ?? "");
+  const shouldReduceMotion = useReducedMotion() === true;
   if (row === null) return null;
   const isRead = row.readAt !== null;
   const isNavigable = row.payload !== null;
@@ -92,7 +96,16 @@ export function NotificationRow(props: NotificationRowProps): ReactNode {
   const Icon = glyph.icon;
 
   return (
-    <li
+    <m.li
+      layout={shouldReduceMotion ? false : "position"}
+      layoutId={
+        shouldReduceMotion ? undefined : `notification-row-${row.feedId}`
+      }
+      exit={shouldReduceMotion ? undefined : { opacity: 0 }}
+      transition={{
+        layout: { duration: 0.24, ease: "easeOut" },
+        opacity: { duration: 0.12, ease: "easeOut" },
+      }}
       // hover:/has-[:focus-visible]: give the whole row a subtle tint
       // whenever any of its interactive controls is hovered or keyboard-
       // focused, so the user can see what they're targeting - distinct from
@@ -107,6 +120,16 @@ export function NotificationRow(props: NotificationRowProps): ReactNode {
         originUnavailable ? "unavailable" : "available"
       }
     >
+      {props.highlightRelocation && !shouldReduceMotion ? (
+        <m.span
+          aria-hidden
+          data-testid="notification-relocation-highlight"
+          className="pointer-events-none absolute inset-0 bg-primary/15"
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 0 }}
+          transition={{ duration: 0.9, ease: "easeOut" }}
+        />
+      ) : null}
       {!isRead ? (
         <span
           aria-hidden
@@ -152,7 +175,7 @@ export function NotificationRow(props: NotificationRowProps): ReactNode {
           onResolve={props.onResolve}
         />
       </div>
-    </li>
+    </m.li>
   );
 }
 

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -1,11 +1,19 @@
 import {
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
   type ReactNode,
   type RefObject,
 } from "react";
+import {
+  AnimatePresence,
+  LayoutGroup,
+  m,
+  useReducedMotion,
+} from "motion/react";
 import { BellOff, CheckCheck, Settings, Trash2 } from "lucide-react";
 import type { StreamMethodSupport } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { Button } from "@/components/ui/button";
@@ -469,52 +477,19 @@ export function NotificationsPopover(
             </button>
           )}
           <NotificationsFeedContent isEmpty={isEmpty} presentation={feedStatus}>
-            <>
-              {isAttentionSectionVisible({
-                loadedAttentionCount: attentionIds.length,
-                canLoadMoreAttention: actions.canLoadMoreAttention,
-              }) ? (
-                <section className="px-4 pt-3">
-                  <SectionLabel>Needs attention</SectionLabel>
-                  {/* -mx-4 breaks the row list out of the section's inset so
-                  each row's bottom divider reaches the popover's true edges;
-                  rows restore the same visual inset as their own content
-                  padding (see notification-row.tsx). */}
-                  <ul className="-mx-4 flex flex-col">
-                    {attentionIds.map((id) => (
-                      <NotificationRow
-                        key={id}
-                        feedId={id}
-                        onActivate={handleActivate}
-                        onAcknowledge={handleAcknowledge}
-                        onResolve={handleResolve}
-                      />
-                    ))}
-                  </ul>
-                  {actions.canLoadMoreAttention ? (
-                    <LoadMoreButton
-                      label="Load more attention"
-                      isLoading={actions.isLoadingMoreAttention}
-                      hasError={actions.hasAttentionLoadError}
-                      onClick={() => actions.loadMoreAttention()}
-                      testId="notifications-load-more-attention"
-                    />
-                  ) : null}
-                </section>
-              ) : null}
-
-              <section className="px-4 pt-3 pb-2">
-                <SectionLabel>Recent activity</SectionLabel>
-                <RecentSectionBody
-                  recentIds={recentIds}
-                  isFilteredEmpty={isRecentFilteredEmpty}
-                  onActivate={handleActivate}
-                  onAcknowledge={handleAcknowledge}
-                  onResolve={handleResolve}
-                  onResetFilters={resetFilters}
-                />
-              </section>
-            </>
+            <NotificationsFeedSections
+              attentionIds={attentionIds}
+              recentIds={recentIds}
+              canLoadMoreAttention={actions.canLoadMoreAttention}
+              isLoadingMoreAttention={actions.isLoadingMoreAttention}
+              hasAttentionLoadError={actions.hasAttentionLoadError}
+              isRecentFilteredEmpty={isRecentFilteredEmpty}
+              onLoadMoreAttention={() => actions.loadMoreAttention()}
+              onActivate={handleActivate}
+              onAcknowledge={handleAcknowledge}
+              onResolve={handleResolve}
+              onResetFilters={resetFilters}
+            />
           </NotificationsFeedContent>
         </div>
 
@@ -541,6 +516,94 @@ export function NotificationsPopover(
         onConfirm={handleConfirmClearAll}
       />
     </TooltipProvider>
+  );
+}
+
+interface NotificationsFeedSectionsProps {
+  readonly attentionIds: ReadonlyArray<string>;
+  readonly recentIds: ReadonlyArray<string>;
+  readonly canLoadMoreAttention: boolean;
+  readonly isLoadingMoreAttention: boolean;
+  readonly hasAttentionLoadError: boolean;
+  readonly isRecentFilteredEmpty: boolean;
+  readonly onLoadMoreAttention: () => void;
+  readonly onActivate: (row: MergedNotificationRow) => void;
+  readonly onAcknowledge: (row: MergedNotificationRow) => void;
+  readonly onResolve: (row: MergedNotificationRow) => void;
+  readonly onResetFilters: () => void;
+}
+
+function NotificationsFeedSections(
+  props: NotificationsFeedSectionsProps,
+): ReactNode {
+  const relocatedIds = useRelocatedNotificationIds(
+    props.attentionIds,
+    props.recentIds,
+  );
+  const shouldReduceMotion = useReducedMotion() === true;
+  return (
+    <LayoutGroup id="notifications-feed">
+      <AnimatePresence initial={false}>
+        {isAttentionSectionVisible({
+          loadedAttentionCount: props.attentionIds.length,
+          canLoadMoreAttention: props.canLoadMoreAttention,
+        }) ? (
+          <m.section
+            key="attention-section"
+            layout={shouldReduceMotion ? false : "position"}
+            exit={shouldReduceMotion ? undefined : { height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="overflow-hidden px-4 pt-3"
+          >
+            <SectionLabel>Needs attention</SectionLabel>
+            {/* -mx-4 breaks the row list out of the section's inset so each
+            row's bottom divider reaches the popover's true edges; rows
+            restore the same visual inset as their own content padding (see
+            notification-row.tsx). */}
+            <ul className="-mx-4 flex flex-col">
+              <AnimatePresence initial={false}>
+                {props.attentionIds.map((id) => (
+                  <NotificationRow
+                    key={id}
+                    feedId={id}
+                    highlightRelocation={false}
+                    onActivate={props.onActivate}
+                    onAcknowledge={props.onAcknowledge}
+                    onResolve={props.onResolve}
+                  />
+                ))}
+              </AnimatePresence>
+            </ul>
+            {props.canLoadMoreAttention ? (
+              <LoadMoreButton
+                label="Load more attention"
+                isLoading={props.isLoadingMoreAttention}
+                hasError={props.hasAttentionLoadError}
+                onClick={props.onLoadMoreAttention}
+                testId="notifications-load-more-attention"
+              />
+            ) : null}
+          </m.section>
+        ) : null}
+      </AnimatePresence>
+
+      <m.section
+        layout={shouldReduceMotion ? false : "position"}
+        transition={{ layout: { duration: 0.24, ease: "easeOut" } }}
+        className="px-4 pt-3 pb-2"
+      >
+        <SectionLabel>Recent activity</SectionLabel>
+        <RecentSectionBody
+          recentIds={props.recentIds}
+          relocatedIds={relocatedIds}
+          isFilteredEmpty={props.isRecentFilteredEmpty}
+          onActivate={props.onActivate}
+          onAcknowledge={props.onAcknowledge}
+          onResolve={props.onResolve}
+          onResetFilters={props.onResetFilters}
+        />
+      </m.section>
+    </LayoutGroup>
   );
 }
 
@@ -829,6 +892,7 @@ function OriginUnavailableBanner(): ReactNode {
 
 interface RecentSectionBodyProps {
   readonly recentIds: ReadonlyArray<string>;
+  readonly relocatedIds: ReadonlySet<string>;
   readonly isFilteredEmpty: boolean;
   readonly onActivate: (row: MergedNotificationRow) => void;
   readonly onAcknowledge: (row: MergedNotificationRow) => void;
@@ -841,6 +905,7 @@ function RecentSectionBody(props: RecentSectionBodyProps): ReactNode {
     return (
       <RecentRowList
         ids={props.recentIds}
+        relocatedIds={props.relocatedIds}
         onActivate={props.onActivate}
         onAcknowledge={props.onAcknowledge}
         onResolve={props.onResolve}
@@ -862,6 +927,7 @@ function RecentSectionBody(props: RecentSectionBodyProps): ReactNode {
 
 interface RecentRowListProps {
   readonly ids: ReadonlyArray<string>;
+  readonly relocatedIds: ReadonlySet<string>;
   readonly onActivate: (row: MergedNotificationRow) => void;
   readonly onAcknowledge: (row: MergedNotificationRow) => void;
   readonly onResolve: (row: MergedNotificationRow) => void;
@@ -880,6 +946,7 @@ function RecentRowList(props: RecentRowListProps): ReactNode {
         <RecentRow
           key={id}
           feedId={id}
+          highlightRelocation={props.relocatedIds.has(id)}
           previousFeedId={index === 0 ? null : props.ids[index - 1]}
           now={now}
           onActivate={props.onActivate}
@@ -893,6 +960,7 @@ function RecentRowList(props: RecentRowListProps): ReactNode {
 
 interface RecentRowProps {
   readonly feedId: string;
+  readonly highlightRelocation: boolean;
   readonly previousFeedId: string | null;
   readonly now: number;
   readonly onActivate: (row: MergedNotificationRow) => void;
@@ -921,12 +989,36 @@ function RecentRow(props: RecentRowProps): ReactNode {
       )}
       <NotificationRow
         feedId={props.feedId}
+        highlightRelocation={props.highlightRelocation}
         onActivate={props.onActivate}
         onAcknowledge={props.onAcknowledge}
         onResolve={props.onResolve}
       />
     </>
   );
+}
+
+function useRelocatedNotificationIds(
+  attentionIds: ReadonlyArray<string>,
+  recentIds: ReadonlyArray<string>,
+): ReadonlySet<string> {
+  const previousAttentionIds = useRef(attentionIds);
+  const [relocatedIds, setRelocatedIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  useEffect(() => {
+    const currentAttentionIds = new Set(attentionIds);
+    const currentRecentIds = new Set(recentIds);
+    setRelocatedIds(
+      new Set(
+        previousAttentionIds.current.filter(
+          (id) => !currentAttentionIds.has(id) && currentRecentIds.has(id),
+        ),
+      ),
+    );
+    previousAttentionIds.current = attentionIds;
+  }, [attentionIds, recentIds]);
+  return relocatedIds;
 }
 
 function SectionLabel(props: { readonly children: ReactNode }): ReactNode {

--- a/clients/gui-app/src/stores/notifications/__tests__/cloud-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/cloud-notifications-store.test.ts
@@ -421,6 +421,24 @@ describe("cloud notifications store", () => {
     ]);
   });
 
+  it("preserves summary-only attention after optimistic mark-all-read", () => {
+    const failure = cloudFailureRow("entry-failure", 10);
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [failure],
+      // The relay summary also covers one unrenderable unresolved prompt.
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 2 },
+      version: 1,
+    });
+
+    useCloudNotificationsStore.getState().markAllReadLocally(30);
+
+    expect(useCloudNotificationsStore.getState().summary).toEqual({
+      totalCount: 2,
+      unreadCount: 0,
+      attentionCount: 1,
+    });
+  });
+
   it("decrements optimistic attention only for failures during entity-read fan-out", () => {
     const failure = cloudFailureRow("entry-failure", 10);
     const informational = cloudRow("entry-info", 20, "host-a");

--- a/clients/gui-app/src/stores/notifications/__tests__/cloud-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/cloud-notifications-store.test.ts
@@ -69,6 +69,50 @@ function cloudRow(
   };
 }
 
+function cloudFailureRow(
+  entryId: string,
+  createdAt: number,
+): HostNotificationsCloudFeedRow {
+  const row = cloudRow(entryId, createdAt, "host-a");
+  return {
+    ...row,
+    entry: {
+      ...row.entry,
+      severity: "failure",
+    },
+  };
+}
+
+function cloudPromptRow(
+  entryId: string,
+  createdAt: number,
+): HostNotificationsCloudFeedRow {
+  return {
+    entryId,
+    originHostId: "host-a",
+    coalesceKey: `approval.requested:${entryId}`,
+    entry: {
+      id: entryId,
+      updatedAt: createdAt,
+      readAt: null,
+      kind: "approval.requested",
+      sourceRef: entryId,
+      severity: "needs_action",
+      outcome: null,
+      resolvedAt: null,
+      epicId: "epic-1",
+      chatId: "chat-1",
+      payload: {
+        kind: "approval",
+        epicId: "epic-1",
+        chatId: "chat-1",
+        approvalId: entryId,
+      },
+    },
+    presentation: { epicTitle: "Epic", chatTitle: "Chat" },
+  };
+}
+
 class ControlledSession implements IStreamSession {
   private statusChangeHandler: StatusChangeHandler | null = null;
   private serverFrameHandler: ServerFrameHandler | null = null;
@@ -332,6 +376,69 @@ describe("cloud notifications store", () => {
     expect(cloud.connectionState).toBe("reconnecting");
     expect(cloud.rows).toEqual({ [cloudNotificationFeedId("entry-a")]: row });
     expect(cloud.version).toBe(4);
+  });
+
+  it("removes an unread failure from both optimistic summary counts when marked read", () => {
+    const failure = cloudFailureRow("entry-failure", 10);
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [failure],
+      summary: { totalCount: 1, unreadCount: 1, attentionCount: 1 },
+      version: 1,
+    });
+
+    useCloudNotificationsStore.getState().markReadLocally(failure.entryId, 20);
+
+    const cloud = useCloudNotificationsStore.getState();
+    expect(
+      cloud.rows[cloudNotificationFeedId(failure.entryId)]?.entry.readAt,
+    ).toBe(20);
+    expect(cloud.summary).toEqual({
+      totalCount: 1,
+      unreadCount: 0,
+      attentionCount: 0,
+    });
+  });
+
+  it("keeps unresolved needs-action rows in attention after optimistic mark-all-read", () => {
+    const failure = cloudFailureRow("entry-failure", 10);
+    const prompt = cloudPromptRow("entry-prompt", 20);
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [failure, prompt],
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 2 },
+      version: 1,
+    });
+
+    useCloudNotificationsStore.getState().markAllReadLocally(30);
+
+    const cloud = useCloudNotificationsStore.getState();
+    expect(cloud.summary).toEqual({
+      totalCount: 2,
+      unreadCount: 0,
+      attentionCount: 1,
+    });
+    expect(Object.values(cloud.rows).map((row) => row?.entry.readAt)).toEqual([
+      30, 30,
+    ]);
+  });
+
+  it("decrements optimistic attention only for failures during entity-read fan-out", () => {
+    const failure = cloudFailureRow("entry-failure", 10);
+    const informational = cloudRow("entry-info", 20, "host-a");
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [failure, informational],
+      summary: { totalCount: 2, unreadCount: 2, attentionCount: 1 },
+      version: 1,
+    });
+
+    useCloudNotificationsStore
+      .getState()
+      .beginEntityRead([failure.entryId, informational.entryId], 30);
+
+    expect(useCloudNotificationsStore.getState().summary).toEqual({
+      totalCount: 2,
+      unreadCount: 0,
+      attentionCount: 0,
+    });
   });
 
   it("opens the distinct cloud method and creates a fresh session after terminal failure", () => {

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-projection.test.tsx
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications-projection.test.tsx
@@ -221,6 +221,36 @@ function cloudDone(
   };
 }
 
+function cloudFailure(
+  entryId: string,
+  createdAt: number,
+  readAt: number | null,
+): HostNotificationsCloudFeedRow {
+  return {
+    entryId,
+    originHostId: "host-cloud",
+    coalesceKey: "agent.stopped:chat-cloud",
+    entry: {
+      id: entryId,
+      updatedAt: createdAt,
+      readAt,
+      kind: "agent.stopped",
+      sourceRef: entryId,
+      severity: "failure",
+      outcome: "errored",
+      epicId: "epic-cloud",
+      chatId: "chat-cloud",
+      payload: {
+        kind: "chat",
+        epicId: "epic-cloud",
+        chatId: "chat-cloud",
+        outcome: "errored",
+      },
+    },
+    presentation: { epicTitle: "Cloud epic", chatTitle: "Cloud chat" },
+  };
+}
+
 function appLocalEntry(
   id: string,
   updatedAt: number,
@@ -604,6 +634,23 @@ describe("cloud feed projection authority", () => {
     expect(result.current.unreadCount).toBe(1);
     expect(result.current.bell).toEqual({ kind: "quietDot" });
     expect(result.current.hostState.isPartial).toBe(false);
+  });
+
+  it("never keeps the attention bell after optimistically marking every cloud failure read", () => {
+    const failure = cloudFailure("entry-failure", 7, null);
+    useCloudNotificationsStore.getState().applySnapshot({
+      rows: [failure],
+      summary: { totalCount: 1, unreadCount: 1, attentionCount: 1 },
+      version: 7,
+    });
+    const { result } = renderHook(() => useNotificationBellState());
+    expect(result.current).toEqual({ kind: "attention", count: 1 });
+
+    act(() => {
+      useCloudNotificationsStore.getState().markAllReadLocally(8);
+    });
+
+    expect(result.current).toEqual({ kind: "clear" });
   });
 
   it("keys a row by entryId alone - originHostId is display metadata, not identity", () => {

--- a/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
@@ -178,6 +178,27 @@ function rowKey(row: Pick<HostNotificationsCloudFeedRow, "entryId">): string {
   return cloudNotificationFeedId(row.entryId);
 }
 
+function isUnreadFailure(row: HostNotificationsCloudFeedRow): boolean {
+  return row.entry.severity === "failure" && row.entry.readAt === null;
+}
+
+function loadedBlockingAttentionCount(
+  rows: Readonly<Partial<Record<string, HostNotificationsCloudFeedRow>>>,
+): number {
+  let count = 0;
+  for (const row of Object.values(rows)) {
+    if (
+      row !== undefined &&
+      row.entry.severity === "needs_action" &&
+      "resolvedAt" in row.entry &&
+      row.entry.resolvedAt === null
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 export const useCloudNotificationsStore = create<CloudNotificationsState>()(
   (set) => ({
     rows: {},
@@ -221,6 +242,7 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
         const key = cloudNotificationFeedId(entryId);
         const row = state.rows[key];
         if (row === undefined || row.entry.readAt !== null) return state;
+        const attentionDelta = isUnreadFailure(row) ? 1 : 0;
         return {
           rows: {
             ...state.rows,
@@ -232,6 +254,10 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
               : {
                   ...state.summary,
                   unreadCount: Math.max(0, state.summary.unreadCount - 1),
+                  attentionCount: Math.max(
+                    0,
+                    state.summary.attentionCount - attentionDelta,
+                  ),
                 },
         };
       }),
@@ -247,7 +273,16 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
           summary:
             state.summary === null
               ? null
-              : { ...state.summary, unreadCount: 0 },
+              : {
+                  ...state.summary,
+                  unreadCount: 0,
+                  // Mark-all-read removes every failure contribution,
+                  // including raw-feed rows this client cannot render. An
+                  // unresolved prompt remains blocking even after it is read;
+                  // loaded rows provide the residual until the next
+                  // authoritative summary reconciles this approximation.
+                  attentionCount: loadedBlockingAttentionCount(rows),
+                },
         };
       }),
     beginEntityRead: (entryIds, readAt) =>
@@ -255,6 +290,7 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
         const retries = { ...state.entityReadRetries };
         const rows = { ...state.rows };
         let flipped = 0;
+        let attentionFlipped = 0;
         for (const entryId of entryIds) {
           retries[entryId] = {
             attempts: retries[entryId]?.attempts ?? 0,
@@ -263,6 +299,7 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
           const key = cloudNotificationFeedId(entryId);
           const row = rows[key];
           if (row === undefined || row.entry.readAt !== null) continue;
+          if (isUnreadFailure(row)) attentionFlipped += 1;
           rows[key] = { ...row, entry: { ...row.entry, readAt } };
           flipped += 1;
         }
@@ -275,6 +312,10 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
               : {
                   ...state.summary,
                   unreadCount: Math.max(0, state.summary.unreadCount - flipped),
+                  attentionCount: Math.max(
+                    0,
+                    state.summary.attentionCount - attentionFlipped,
+                  ),
                 },
         };
       }),

--- a/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
@@ -199,6 +199,16 @@ function loadedBlockingAttentionCount(
   return count;
 }
 
+function loadedUnreadFailureCount(
+  rows: Readonly<Partial<Record<string, HostNotificationsCloudFeedRow>>>,
+): number {
+  let count = 0;
+  for (const row of Object.values(rows)) {
+    if (row !== undefined && isUnreadFailure(row)) count += 1;
+  }
+  return count;
+}
+
 export const useCloudNotificationsStore = create<CloudNotificationsState>()(
   (set) => ({
     rows: {},
@@ -263,6 +273,7 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
       }),
     markAllReadLocally: (readAt) =>
       set((state) => {
+        const unreadFailureCount = loadedUnreadFailureCount(state.rows);
         const rows = { ...state.rows };
         for (const [key, row] of Object.entries(rows)) {
           if (row === undefined || row.entry.readAt !== null) continue;
@@ -276,12 +287,15 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
               : {
                   ...state.summary,
                   unreadCount: 0,
-                  // Mark-all-read removes every failure contribution,
-                  // including raw-feed rows this client cannot render. An
-                  // unresolved prompt remains blocking even after it is read;
-                  // loaded rows provide the residual until the next
-                  // authoritative summary reconciles this approximation.
-                  attentionCount: loadedBlockingAttentionCount(rows),
+                  // Summary counts include visible cloud rows this relay could
+                  // not render. Their attention may be an unresolved prompt,
+                  // which mark-all must never hide, so only subtract failures
+                  // this client can prove it marked read. The next snapshot
+                  // removes any residual summary-only failure contribution.
+                  attentionCount: Math.max(
+                    loadedBlockingAttentionCount(rows),
+                    state.summary.attentionCount - unreadFailureCount,
+                  ),
                 },
         };
       }),


### PR DESCRIPTION
## Summary

- keep optimistic unread and attention summaries synchronized so the bell clears immediately
- animate notification relocation and section collapse while respecting reduced-motion preferences
- animate archived sidebar rows when clearing their final indicator removes them
- add regression coverage for individual, bulk, and entity-level optimistic updates

## Related issue

N/A

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)