### PR TITLE
feat(protocol,gui-app): epic.readChatAttachment - chat-plane image byte channel

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -35,6 +35,10 @@ const attachmentMocks = vi.hoisted(() => ({
     Promise.resolve(new Uint8Array([1, 2, 3])),
   ),
   hasBytes: vi.fn(() => true),
+  readChatBytes: vi.fn(
+    (_hash: string): Promise<Uint8Array<ArrayBuffer> | null> =>
+      Promise.resolve(new Uint8Array([1, 2, 3])),
+  ),
 }));
 const composerPickerMocks = vi.hoisted(() => ({
   useComposerPickerItems: vi.fn(),
@@ -111,6 +115,7 @@ vi.mock("@/lib/epic-selectors", () => ({
 
 vi.mock("@/hooks/host/use-tab-host-client", () => ({
   useTabHostClient: () => null,
+  useMaybeTabHostClient: () => null,
 }));
 
 vi.mock("@/components/chat/composer/picker/use-composer-picker-items", () => ({
@@ -125,6 +130,18 @@ vi.mock(
       ...actual,
       useEpicImageFetcher: () => attachmentMocks.fetcher,
       useEpicAttachmentBytesPresence: () => attachmentMocks.hasBytes,
+    };
+  },
+);
+
+vi.mock(
+  import("@/lib/attachments/use-chat-image-fetcher"),
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      useChatImageFetcher: () => attachmentMocks.fetcher,
+      useChatAttachmentByteReader: () => attachmentMocks.readChatBytes,
     };
   },
 );
@@ -256,6 +273,11 @@ describe("<UserMessageBody /> agent messages", () => {
     );
     attachmentMocks.hasBytes.mockReset();
     attachmentMocks.hasBytes.mockReturnValue(true);
+    attachmentMocks.readChatBytes.mockReset();
+    attachmentMocks.readChatBytes.mockImplementation((_hash) =>
+      Promise.resolve(new Uint8Array([1, 2, 3])),
+    );
+
     composerPickerMocks.useComposerPickerItems.mockClear();
     useWorkspaceFoldersStore.setState({ folders: [] });
   });
@@ -779,23 +801,17 @@ describe("<UserMessageBody /> agent messages", () => {
     }
   });
 
-  it("re-inlines hash-only image bytes as b64content on copy when the epic has them", async () => {
+  // The copy path resolves bytes through the CHAT attachment reader
+  // (`useChatAttachmentByteReader`), not through a synchronous doc-map presence
+  // pre-check: chat image bytes live on the chat plane now, so presence is not
+  // answerable without a round trip and the reader's own timeout is what keeps
+  // a Cmd+C from hanging. These two tests pin that mechanism.
+  it("re-inlines hash-only image bytes as b64content on copy when the chat reader resolves them", async () => {
     const imageBytes = new Uint8Array([10, 20, 30]);
     const imageHash = "resolved-image-hash";
-    openEpicHandleMocks.hasAttachmentBytes.mockImplementation(
-      (hash: string) => hash === imageHash,
-    );
-    openEpicHandleMocks.readAttachmentBytes.mockImplementation((hash: string) =>
+    attachmentMocks.readChatBytes.mockImplementation((hash: string) =>
       Promise.resolve(hash === imageHash ? imageBytes : null),
     );
-    openEpicHandleMocks.handle = {
-      store: {
-        getState: () => ({
-          hasAttachmentBytes: openEpicHandleMocks.hasAttachmentBytes,
-          readAttachmentBytes: openEpicHandleMocks.readAttachmentBytes,
-        }),
-      },
-    };
     const clipboard = installRichClipboardMock();
     try {
       render(
@@ -815,13 +831,7 @@ describe("<UserMessageBody /> agent messages", () => {
       await waitFor(() => {
         expect(clipboard.write).toHaveBeenCalledTimes(1);
       });
-      expect(openEpicHandleMocks.hasAttachmentBytes).toHaveBeenCalledWith(
-        imageHash,
-      );
-      expect(openEpicHandleMocks.readAttachmentBytes).toHaveBeenCalledWith(
-        imageHash,
-        expect.any(AbortSignal),
-      );
+      expect(attachmentMocks.readChatBytes).toHaveBeenCalledWith(imageHash);
       const payload = clipboard.payloads[0];
       expect(payload).toBeDefined();
       const copied = parseComposerClipboardHtml(
@@ -850,24 +860,14 @@ describe("<UserMessageBody /> agent messages", () => {
       });
     } finally {
       clipboard.restore();
-      openEpicHandleMocks.handle = null;
-      openEpicHandleMocks.hasAttachmentBytes.mockReset();
-      openEpicHandleMocks.readAttachmentBytes.mockReset();
     }
   });
 
-  it("leaves a dangling hash-only image as hash-only when attachment bytes are absent", async () => {
+  it("leaves a dangling hash-only image as hash-only when the chat reader misses", async () => {
     const imageHash = "dangling-image-hash";
-    openEpicHandleMocks.hasAttachmentBytes.mockReturnValue(false);
-    openEpicHandleMocks.readAttachmentBytes.mockResolvedValue(null);
-    openEpicHandleMocks.handle = {
-      store: {
-        getState: () => ({
-          hasAttachmentBytes: openEpicHandleMocks.hasAttachmentBytes,
-          readAttachmentBytes: openEpicHandleMocks.readAttachmentBytes,
-        }),
-      },
-    };
+    // A miss - the host answered `missing` and the doc replica had nothing
+    // either, which the reader collapses to `null`.
+    attachmentMocks.readChatBytes.mockResolvedValue(null);
     const clipboard = installRichClipboardMock();
     try {
       render(
@@ -887,22 +887,16 @@ describe("<UserMessageBody /> agent messages", () => {
       await waitFor(() => {
         expect(clipboard.write).toHaveBeenCalledTimes(1);
       });
-      expect(openEpicHandleMocks.hasAttachmentBytes).toHaveBeenCalledWith(
-        imageHash,
-      );
-      expect(openEpicHandleMocks.readAttachmentBytes).not.toHaveBeenCalled();
+      expect(attachmentMocks.readChatBytes).toHaveBeenCalledWith(imageHash);
       const payload = clipboard.payloads[0];
       expect(payload).toBeDefined();
       const copied = parseComposerClipboardHtml(
         await payload["text/html"].text(),
       );
-      // Bytes absent → hash-only payload stays hash-only (no b64content).
+      // Bytes unresolvable → hash-only payload stays hash-only (no b64content).
       expect(copied).toEqual(hashOnlyImageMessageContent(imageHash));
     } finally {
       clipboard.restore();
-      openEpicHandleMocks.handle = null;
-      openEpicHandleMocks.hasAttachmentBytes.mockReset();
-      openEpicHandleMocks.readAttachmentBytes.mockReset();
     }
   });
 

--- a/clients/gui-app/src/components/chat/__tests__/user-message-attachment-gallery.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/user-message-attachment-gallery.test.tsx
@@ -2,11 +2,17 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { UserMessageAttachmentGallery } from "@/components/chat/user-message-attachment-gallery";
-import { useAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
+import { useChatAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
 
-vi.mock("@/lib/attachments/use-attachment-blob-src", () => ({
-  useAttachmentBlobSrc: vi.fn(),
-}));
+vi.mock(
+  "@/lib/attachments/use-attachment-blob-src",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/lib/attachments/use-attachment-blob-src")
+    >()),
+    useChatAttachmentBlobSrc: vi.fn(),
+  }),
+);
 
 afterEach(() => {
   cleanup();
@@ -15,7 +21,7 @@ afterEach(() => {
 
 describe("UserMessageAttachmentGallery", () => {
   it("surfaces an unavailable image in both the thumbnail and dialog", async () => {
-    vi.mocked(useAttachmentBlobSrc).mockReturnValue({
+    vi.mocked(useChatAttachmentBlobSrc).mockReturnValue({
       status: "unavailable",
       src: null,
     });

--- a/clients/gui-app/src/components/chat/chat-attachment-scope-context.ts
+++ b/clients/gui-app/src/components/chat/chat-attachment-scope-context.ts
@@ -1,0 +1,67 @@
+import { createContext, use } from "react";
+
+import type {
+  ReadChatAttachmentRequest,
+  ReadChatAttachmentResponse,
+} from "@traycer/protocol/host/epic/chat-attachment";
+
+/**
+ * Exactly the slice of the host client a chat attachment read needs: this ONE
+ * signal-bound method. Narrower than `HostClient` on purpose - the provider
+ * hands its real client straight in (a generic `requestWithSignal` instantiates
+ * to this), and a test can supply the one method instead of faking a whole
+ * client class through an `as unknown` cast.
+ */
+export interface ChatAttachmentReadClient {
+  requestWithSignal(
+    method: "epic.readChatAttachment",
+    params: ReadChatAttachmentRequest,
+    signal: AbortSignal | undefined,
+  ): Promise<ReadChatAttachmentResponse>;
+}
+
+/**
+ * Everything a chat image byte read is scoped by, resolved ONCE per chat tile.
+ *
+ * Chat image bytes live on the chat plane now, and `epic.readChatAttachment`
+ * takes the owning chat id so the serving host can apply that chat's visibility
+ * rule to a local-store hit (see `@traycer/protocol`
+ * `host/epic/chat-attachment.ts`). Every render site that shows a chat image is
+ * structurally inside exactly one chat, so the id is context rather than a prop
+ * threaded through five layers of transcript rendering with no other reason to
+ * know it.
+ *
+ * ## Why the CLIENT is in here too
+ *
+ * Because resolving it is a `useHostDirectoryList()` query subscription, and a
+ * transcript can hold a hundred image thumbnails. Resolving per thumbnail would
+ * put a query observer behind every image and force every surface that renders
+ * a chat message into a `QueryClientProvider`. The tile already knows its host -
+ * it is `<TabHostProvider>`-bound for life - so it resolves the client once and
+ * hands it down. `null` is the ordinary "not ready / signed out" value that
+ * `useTabHostClient` already returns.
+ *
+ * Deliberately its own context rather than fields borrowed off
+ * `ChatPlanActionsContext` (which happens to carry the same epic/chat pair): a
+ * byte read has nothing to do with plan actions, and hanging it there would make
+ * the plan-action provider load-bearing for image rendering.
+ *
+ * `null` outside a chat tile - the landing composer and the new-conversation
+ * modal both compose images before any chat exists, and both keep the epic-doc
+ * byte source they already used.
+ */
+export interface ChatAttachmentScopeValue {
+  readonly epicId: string;
+  readonly chatId: string;
+  /** The tile's bound host - the one asked for chat-plane bytes. */
+  readonly hostId: string;
+  /** Routed to `hostId`; `null` until the directory resolves it. */
+  readonly client: ChatAttachmentReadClient | null;
+}
+
+export const ChatAttachmentScopeContext =
+  createContext<ChatAttachmentScopeValue | null>(null);
+
+export function useChatAttachmentScope(): ChatAttachmentScopeValue | null {
+  return use(ChatAttachmentScopeContext);
+}

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -42,7 +42,6 @@ import {
 import { bytesToBase64 } from "@/lib/composer/image-base64";
 import { containsImageAtoms } from "@/lib/composer/image-atoms";
 import { stringValue } from "@/lib/composer/tiptap-json-content";
-import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { useEpicArtifact, useOpenEpicId } from "@/lib/epic-selectors";
 import { cn, formatSingleLine } from "@/lib/utils";
 import { deriveA2AReceivedCollapsibleKey } from "@/components/chat/chat-collapsible-key";
@@ -87,6 +86,7 @@ import {
 } from "@/hooks/composer/use-composer-paste";
 import { useWorkspaceMentionRoots } from "@/hooks/composer/use-workspace-mention-roots";
 import { useEpicAttachmentBytesPresence } from "@/lib/attachments/use-attachment-blob-src";
+import { useChatAttachmentByteReader } from "@/lib/attachments/use-chat-image-fetcher";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
 const NOOP: () => void = () => undefined;
@@ -1018,24 +1018,13 @@ function MessageCopyButton({
     onSuccess: null,
     onError: handleCopyError,
   });
-  const handle = useMaybeOpenEpicHandle();
-  const resolveAttachmentBytes = useCallback(
-    async (hash: string): Promise<Uint8Array | null> => {
-      if (handle === null) return null;
-      const state = handle.store.getState();
-      // Only read hashes whose bytes are already local — `readAttachmentBytes`
-      // otherwise waits indefinitely for a cross-device sync, which would hang
-      // the clipboard write. An absent hash (a dangling ref from the old
-      // edit-flow bug) stays hash-only; downstream paste validation drops it.
-      if (!state.hasAttachmentBytes(hash)) return null;
-      const bytes = await state.readAttachmentBytes(
-        hash,
-        new AbortController().signal,
-      );
-      return bytes === null ? null : new Uint8Array(bytes);
-    },
-    [handle],
-  );
+  // Chat-plane read with the reader's own bound. This replaces a
+  // `hasAttachmentBytes` pre-check that existed purely to stop
+  // `readAttachmentBytes` from waiting indefinitely and hanging the clipboard
+  // write; the bytes are no longer answerable synchronously, so the same
+  // guarantee now comes from the timeout. A hash that does not resolve stays
+  // hash-only, exactly as before, and downstream paste validation drops it.
+  const resolveAttachmentBytes = useChatAttachmentByteReader();
   const onClick = useCallback(() => {
     if (structuredContent === null) {
       copy(text);

--- a/clients/gui-app/src/components/chat/composer/chat-composer-attachments-strip.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer-attachments-strip.tsx
@@ -5,7 +5,7 @@ import {
   NO_SESSION_OBJECT_URL,
 } from "@/components/chat/composer/attachments/attachment-strip";
 import { QueueEditDraftPill } from "@/components/chat/composer/queue-edit-draft-pill";
-import { useEpicImageFetcher } from "@/lib/attachments/use-attachment-blob-src";
+import { useChatImageFetcher } from "@/lib/attachments/use-chat-image-fetcher";
 
 interface ChatComposerAttachmentsStripProps {
   readonly content: JsonContent;
@@ -17,7 +17,9 @@ interface ChatComposerAttachmentsStripProps {
 export function ChatComposerAttachmentsStrip(
   props: ChatComposerAttachmentsStripProps,
 ) {
-  const fetcher = useEpicImageFetcher();
+  // Chat-plane bytes for hash-only chips, scoped by the surrounding tile's
+  // `ChatAttachmentScopeContext` - the same chat the composer posts into.
+  const fetcher = useChatImageFetcher();
   return (
     <>
       <QueueEditDraftPill

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -78,7 +78,7 @@ import { commitProfileSelection } from "@/stores/composer/commit-selection";
 import { useTaskProfileRateLimitSwitch } from "./use-task-profile-rate-limit-switch";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { useEpicAttachmentBytesPresence } from "@/lib/attachments/use-attachment-blob-src";
-import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { useChatAttachmentByteReader } from "@/lib/attachments/use-chat-image-fetcher";
 import { recordFocusedChat } from "@/stores/chat/last-focused-chat-store";
 import { usePromptStash } from "@/hooks/composer/use-prompt-stash";
 import {
@@ -240,7 +240,6 @@ function ChatComposerImpl(props: ChatComposerProps) {
   const workspaceBlocked = !workspaceComposerCanStart(workspaceAvailability);
 
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
-  const openEpicHandle = useOpenEpicHandle();
   const hasPastedImageBytes = useEpicAttachmentBytesPresence();
   // Counts editor-ready transitions (a counter, not a boolean, so a torn-down
   // and re-created editor re-fires). The draft-reset bridge keys its
@@ -410,20 +409,13 @@ function ChatComposerImpl(props: ChatComposerProps) {
     isResolvingFilePaths,
   });
 
-  const readPromptStashImage = useCallback(
-    async (hash: string) => {
-      const state = openEpicHandle.store.getState();
-      if (!state.hasAttachmentBytes(hash)) return null;
-      // Capture deliberately survives composer unmount, so this read is not
-      // coupled to component-lifecycle cancellation.
-      const bytes = await state.readAttachmentBytes(
-        hash,
-        new AbortController().signal,
-      );
-      return bytes === null ? null : new Uint8Array(bytes);
-    },
-    [openEpicHandle],
-  );
+  // Chat-plane read with the reader's own bound, which replaces the old
+  // `hasAttachmentBytes` pre-check: the bytes may live on this host's disk or
+  // in the cloud now, so presence is no longer answerable synchronously, and
+  // the bound is what keeps a stash save from hanging on an unreachable image.
+  // A capture deliberately survives composer unmount, so this read is not
+  // coupled to component-lifecycle cancellation.
+  const readPromptStashImage = useChatAttachmentByteReader();
   const promptStashSource = useChatPromptStashSource(taskId, onCancelQueueEdit);
   // Chat writes the draft store, but restore still requires the exact ready
   // editor generation that started the restore - a remount under the same

--- a/clients/gui-app/src/components/chat/segments/__tests__/assistant-markdown-image.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/assistant-markdown-image.test.tsx
@@ -31,9 +31,15 @@ const blobSrcState = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@/lib/attachments/use-attachment-blob-src", () => ({
-  useAttachmentBlobSrc: () => blobSrcState.value,
-}));
+vi.mock(
+  "@/lib/attachments/use-attachment-blob-src",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/lib/attachments/use-attachment-blob-src")
+    >()),
+    useChatAttachmentBlobSrc: () => blobSrcState.value,
+  }),
+);
 
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";

--- a/clients/gui-app/src/components/chat/segments/__tests__/image-generation-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/image-generation-card.test.tsx
@@ -22,9 +22,15 @@ const blobSrcState = vi.hoisted((): { value: AttachmentBlobState } => ({
   },
 }));
 
-vi.mock("@/lib/attachments/use-attachment-blob-src", () => ({
-  useAttachmentBlobSrc: () => blobSrcState.value,
-}));
+vi.mock(
+  "@/lib/attachments/use-attachment-blob-src",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/lib/attachments/use-attachment-blob-src")
+    >()),
+    useChatAttachmentBlobSrc: () => blobSrcState.value,
+  }),
+);
 
 vi.mock("@/hooks/runner/use-open-external-link-mutation", () => ({
   useRunnerOpenExternalLink: () => ({ isPending: false, mutate: vi.fn() }),

--- a/clients/gui-app/src/components/chat/segments/assistant-markdown-image.tsx
+++ b/clients/gui-app/src/components/chat/segments/assistant-markdown-image.tsx
@@ -5,7 +5,7 @@ import {
   useScrollToChatBlock,
   type ScrollToChatBlock,
 } from "@/components/chat/chat-scroll-to-block";
-import { useAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
+import { useChatAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
 import type {
   AssistantMarkdownImageContext,
   AssistantMarkdownImageResolution,
@@ -436,7 +436,7 @@ function ResolvedImage(props: {
   readonly hash: string;
   readonly mediaType: string;
 }): ReactNode {
-  const image = useAttachmentBlobSrc(props.hash, props.mediaType, null);
+  const image = useChatAttachmentBlobSrc(props.hash, props.mediaType, null);
   if (image.status === "loading") {
     return (
       <AttachmentImageLoading

--- a/clients/gui-app/src/components/chat/segments/image-generation-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/image-generation-card.tsx
@@ -4,7 +4,7 @@ import type {
   ToolInputDetail,
 } from "@traycer/protocol/persistence/epic/content-blocks";
 import type { SegmentEndState } from "@/stores/composer/chat-store";
-import { useAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
+import { useChatAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
 import { CHAT_IMAGE_MAX_EDGE } from "./chat-image-size";
 import { AttachmentImageFailure } from "./attachment-image";
 import { useSanitizedSvg } from "./use-sanitized-svg";
@@ -126,7 +126,7 @@ function GeneratedImageContent(props: {
   readonly result: ImageGenerationResult;
   readonly fallbackAlt: string;
 }): ReactNode {
-  const image = useAttachmentBlobSrc(
+  const image = useChatAttachmentBlobSrc(
     props.result.attachmentHash,
     props.result.mediaType,
     null,

--- a/clients/gui-app/src/components/chat/user-message-attachment-gallery.tsx
+++ b/clients/gui-app/src/components/chat/user-message-attachment-gallery.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import {
   type AttachmentBlobSrcState,
-  useAttachmentBlobSrc,
+  useChatAttachmentBlobSrc,
 } from "@/lib/attachments/use-attachment-blob-src";
 import {
   buildImageAttachmentDisplayLabels,
@@ -79,16 +79,17 @@ function imageAttachmentRenderKey(attachment: ImageAttachment): string {
 }
 
 /**
- * Resolves the image source: persisted images (`hash`) stream their bytes from
- * the epic doc's attachments map into a shared blob URL via the content-addressed
- * cache; draft/optimistic images render their inline `dataUrl` directly. A
- * persisted hash transitions from loading to unavailable after its sync grace
- * period while remaining able to recover when bytes arrive later.
+ * Resolves the image source: persisted images (`hash`) fetch their bytes off the
+ * chat plane (this chat's tab host, epic doc as the legacy fallback) into a
+ * shared blob URL via the content-addressed cache; draft/optimistic images
+ * render their inline `dataUrl` directly. A persisted hash transitions from
+ * loading to unavailable after its grace period while remaining able to recover
+ * when bytes arrive later.
  */
 function useImageAttachmentSrc(
   attachment: ImageAttachment,
 ): AttachmentBlobSrcState {
-  return useAttachmentBlobSrc(
+  return useChatAttachmentBlobSrc(
     attachment.hash,
     attachment.mediaType,
     attachment.dataUrl,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -51,6 +51,10 @@ import {
   type ChatPlanActionsContextValue,
 } from "@/components/chat/chat-plan-actions-context";
 import {
+  ChatAttachmentScopeContext,
+  type ChatAttachmentScopeValue,
+} from "@/components/chat/chat-attachment-scope-context";
+import {
   WorkingVerbContext,
   pickWorkingVerb,
 } from "@/components/chat/working-verb";
@@ -781,6 +785,20 @@ function transcriptJumpCardKind(
 export function ChatTileSessionView(props: ChatTileSessionViewProps) {
   const view = useChatTileSessionViewModel(props);
   const hostId = useTabHostId();
+  // Chat image byte reads are scoped here, once per tile, rather than per
+  // rendered image: resolving the routed client is a directory-query
+  // subscription, and a transcript can hold a hundred thumbnails. Covers the
+  // transcript AND the composer/lower surfaces below.
+  const attachmentHostClient = useTabHostClient();
+  const attachmentScope = useMemo<ChatAttachmentScopeValue>(
+    () => ({
+      epicId: view.currentEpicId,
+      chatId: view.node.id,
+      hostId,
+      client: attachmentHostClient,
+    }),
+    [attachmentHostClient, hostId, view.currentEpicId, view.node.id],
+  );
   const systemOverlayActive = useAnySystemOverlayActive();
   const tileNavigation = useEpicTileNavigation();
   const [backgroundScrollRequest, setBackgroundScrollRequest] =
@@ -987,121 +1005,123 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
   );
 
   return (
-    <ChatDiffTargetContext.Provider value={diffOpener}>
-      <ChatScrollToBlockContext.Provider value={scrollToBlock}>
-        <div
-          data-testid="chat-tile"
-          data-node-id={view.node.id}
-          data-chat-keyboard-scroll-scope=""
-          data-active={props.isActive ? "true" : "false"}
-          className="flex h-full min-h-0 flex-col"
-        >
-          {/* A flex CONTAINER (not just an item): ChatSessionMessagesSurface's
-           * transcript root relies on `flex-1` from ITS immediate parent to
-           * get a definite height (h-full on LegendList needs a real
-           * containing block all the way up). The overlay dock below is
-           * absolutely positioned, so it does not participate in this flex
-           * layout regardless. */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
-            <ChatSessionMessagesSurface
-              snapshotLoaded={view.snapshotLoaded}
-              fatalClose={view.fatalClose}
-              onRetry={view.onChatRetry}
-              restoreContext={view.restoreContext}
-              node={view.node}
-              epicId={view.currentEpicId}
-              viewTabId={view.viewTabId}
-              tabHostId={view.tabHostId}
-              workspaceRoots={view.linkResolutionRoots}
-              messages={view.messages}
-              backgroundItems={view.lower.backgroundItems}
-              scrollRequest={backgroundScrollRequest}
-              surfaceVisible={view.surfaceVisible}
-              systemOverlayActive={systemOverlayActive}
-              getMessageActions={view.getMessageActions}
-              nextStepActions={view.nextStepActions}
-              planActions={view.planActions}
-              composerOverlayHeight={
-                lowerSurfacesElement === null ? 0 : lowerSurfacesHeight
-              }
-            />
-            {/*
-             * SurfaceActivityProvider narrows catalog/provider query subscriptions
-             * to the one focused pane+tab. A visible split partner keeps rendering
-             * its transcript and scroll state, but releases catalog/provider query
-             * observers and cannot own palette/composer-global work.
-             *
-             * Absolutely overlays the transcript (decision log #3) instead of
-             * pushing its height via flex, so streamed replies flow visually
-             * behind it; `lowerSurfacesHeight` (measured here) feeds the
-             * transcript's bottom content inset. The full-width positioning
-             * layer must remain both pointer- and paint-transparent so it
-             * cannot cover the transcript scrollbar or its edge lanes.
-             * Centered lower surfaces opt back into pointer handling and own
-             * their opaque backplates (including the bottom seam seal), so
-             * transcript content cannot show through the actual chrome.
-             */}
-            {view.snapshotLoaded ? (
-              <div
-                ref={setLowerSurfacesElement}
-                className="pointer-events-none absolute inset-x-0 bottom-0 z-10"
-                data-chat-lower-surfaces-overlay=""
-              >
-                <div className="pointer-events-none">
-                  <SurfaceActivityProvider active={view.surfaceFocused}>
-                    <ChatLowerInteractionSurfaces
-                      epicId={view.currentEpicId}
-                      viewTabId={view.viewTabId}
-                      chatId={view.node.id}
-                      hostId={hostId}
-                      runtime={view.lower.runtime}
-                      access={view.lower.access}
-                      turn={view.lower.turn}
-                      interview={view.lower.interview}
-                      approvals={view.lower.approvals}
-                      queue={view.lower.queue}
-                      composer={view.lower.composer}
-                      todo={view.todo}
-                      restoreContext={view.restoreContext}
-                      backgroundItems={view.lower.backgroundItems}
-                      backgroundStopPendingTaskIds={
-                        view.lower.backgroundStopPendingTaskIds
-                      }
-                      backgroundStopAllPending={
-                        view.lower.backgroundStopAllPending
-                      }
-                      onBackgroundItemClick={scrollToBackgroundItem}
-                    />
-                  </SurfaceActivityProvider>
+    <ChatAttachmentScopeContext.Provider value={attachmentScope}>
+      <ChatDiffTargetContext.Provider value={diffOpener}>
+        <ChatScrollToBlockContext.Provider value={scrollToBlock}>
+          <div
+            data-testid="chat-tile"
+            data-node-id={view.node.id}
+            data-chat-keyboard-scroll-scope=""
+            data-active={props.isActive ? "true" : "false"}
+            className="flex h-full min-h-0 flex-col"
+          >
+            {/* A flex CONTAINER (not just an item): ChatSessionMessagesSurface's
+             * transcript root relies on `flex-1` from ITS immediate parent to
+             * get a definite height (h-full on LegendList needs a real
+             * containing block all the way up). The overlay dock below is
+             * absolutely positioned, so it does not participate in this flex
+             * layout regardless. */}
+            <div className="relative flex min-h-0 flex-1 flex-col">
+              <ChatSessionMessagesSurface
+                snapshotLoaded={view.snapshotLoaded}
+                fatalClose={view.fatalClose}
+                onRetry={view.onChatRetry}
+                restoreContext={view.restoreContext}
+                node={view.node}
+                epicId={view.currentEpicId}
+                viewTabId={view.viewTabId}
+                tabHostId={view.tabHostId}
+                workspaceRoots={view.linkResolutionRoots}
+                messages={view.messages}
+                backgroundItems={view.lower.backgroundItems}
+                scrollRequest={backgroundScrollRequest}
+                surfaceVisible={view.surfaceVisible}
+                systemOverlayActive={systemOverlayActive}
+                getMessageActions={view.getMessageActions}
+                nextStepActions={view.nextStepActions}
+                planActions={view.planActions}
+                composerOverlayHeight={
+                  lowerSurfacesElement === null ? 0 : lowerSurfacesHeight
+                }
+              />
+              {/*
+               * SurfaceActivityProvider narrows catalog/provider query subscriptions
+               * to the one focused pane+tab. A visible split partner keeps rendering
+               * its transcript and scroll state, but releases catalog/provider query
+               * observers and cannot own palette/composer-global work.
+               *
+               * Absolutely overlays the transcript (decision log #3) instead of
+               * pushing its height via flex, so streamed replies flow visually
+               * behind it; `lowerSurfacesHeight` (measured here) feeds the
+               * transcript's bottom content inset. The full-width positioning
+               * layer must remain both pointer- and paint-transparent so it
+               * cannot cover the transcript scrollbar or its edge lanes.
+               * Centered lower surfaces opt back into pointer handling and own
+               * their opaque backplates (including the bottom seam seal), so
+               * transcript content cannot show through the actual chrome.
+               */}
+              {view.snapshotLoaded ? (
+                <div
+                  ref={setLowerSurfacesElement}
+                  className="pointer-events-none absolute inset-x-0 bottom-0 z-10"
+                  data-chat-lower-surfaces-overlay=""
+                >
+                  <div className="pointer-events-none">
+                    <SurfaceActivityProvider active={view.surfaceFocused}>
+                      <ChatLowerInteractionSurfaces
+                        epicId={view.currentEpicId}
+                        viewTabId={view.viewTabId}
+                        chatId={view.node.id}
+                        hostId={hostId}
+                        runtime={view.lower.runtime}
+                        access={view.lower.access}
+                        turn={view.lower.turn}
+                        interview={view.lower.interview}
+                        approvals={view.lower.approvals}
+                        queue={view.lower.queue}
+                        composer={view.lower.composer}
+                        todo={view.todo}
+                        restoreContext={view.restoreContext}
+                        backgroundItems={view.lower.backgroundItems}
+                        backgroundStopPendingTaskIds={
+                          view.lower.backgroundStopPendingTaskIds
+                        }
+                        backgroundStopAllPending={
+                          view.lower.backgroundStopAllPending
+                        }
+                        onBackgroundItemClick={scrollToBackgroundItem}
+                      />
+                    </SurfaceActivityProvider>
+                  </div>
                 </div>
-              </div>
-            ) : null}
+              ) : null}
+            </div>
+            <ChatTileErrorNoticeToasts handle={view.handle} />
+            <ChatTileRestoreResultToasts handle={view.handle} />
+            <RevertOnEditDialog
+              open={view.revertOnEdit.open}
+              onOpenChange={view.revertOnEdit.onOpenChange}
+              onRevert={view.revertOnEdit.onRevert}
+              onDontRevert={view.revertOnEdit.onDontRevert}
+              artifactCount={view.revertOnEdit.artifactCount}
+            />
+            <SteerSettingsConflictDialog
+              open={view.steerRestart.open}
+              onOpenChange={view.steerRestart.onOpenChange}
+              onRestart={view.steerRestart.onRestart}
+              changed={view.steerRestart.changed}
+            />
+            <ChatForkDialog
+              open={view.fork.open}
+              target={view.fork.target}
+              epicId={view.currentEpicId}
+              tabId={view.viewTabId}
+              onOpenChange={view.fork.onOpenChange}
+            />
           </div>
-          <ChatTileErrorNoticeToasts handle={view.handle} />
-          <ChatTileRestoreResultToasts handle={view.handle} />
-          <RevertOnEditDialog
-            open={view.revertOnEdit.open}
-            onOpenChange={view.revertOnEdit.onOpenChange}
-            onRevert={view.revertOnEdit.onRevert}
-            onDontRevert={view.revertOnEdit.onDontRevert}
-            artifactCount={view.revertOnEdit.artifactCount}
-          />
-          <SteerSettingsConflictDialog
-            open={view.steerRestart.open}
-            onOpenChange={view.steerRestart.onOpenChange}
-            onRestart={view.steerRestart.onRestart}
-            changed={view.steerRestart.changed}
-          />
-          <ChatForkDialog
-            open={view.fork.open}
-            target={view.fork.target}
-            epicId={view.currentEpicId}
-            tabId={view.viewTabId}
-            onOpenChange={view.fork.onOpenChange}
-          />
-        </div>
-      </ChatScrollToBlockContext.Provider>
-    </ChatDiffTargetContext.Provider>
+        </ChatScrollToBlockContext.Provider>
+      </ChatDiffTargetContext.Provider>
+    </ChatAttachmentScopeContext.Provider>
   );
 }
 

--- a/clients/gui-app/src/lib/attachments/__tests__/use-chat-image-fetcher.test.tsx
+++ b/clients/gui-app/src/lib/attachments/__tests__/use-chat-image-fetcher.test.tsx
@@ -1,0 +1,270 @@
+import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import type {
+  ReadChatAttachmentRequest,
+  ReadChatAttachmentResponse,
+} from "@traycer/protocol/host/epic/chat-attachment";
+
+import {
+  ChatAttachmentScopeContext,
+  type ChatAttachmentReadClient,
+  type ChatAttachmentScopeValue,
+} from "@/components/chat/chat-attachment-scope-context";
+import {
+  resetChatAttachmentHostSupportForTests,
+  useChatAttachmentByteReader,
+  useChatImageFetcher,
+} from "@/lib/attachments/use-chat-image-fetcher";
+
+/**
+ * The chat-plane byte chain: `epic.readChatAttachment` on the tile's host
+ * first, the epic doc replica only as the legacy fallback.
+ *
+ * The load-bearing case is a chat whose doc `attachments` map is EMPTY - which
+ * is every chat once bytes stop being written into the document - so most of
+ * these tests hold `hasAttachmentBytes` at false and assert the image resolves
+ * anyway. The second load-bearing case is the inverse: `readAttachmentBytes`
+ * waits indefinitely for a hash the replica does not hold, so the chain must
+ * never reach it without the presence guard passing first.
+ */
+
+const docMocks = vi.hoisted(() => ({
+  hasAttachmentBytes: vi.fn((_hash: string) => false),
+  readAttachmentBytes: vi.fn(
+    (_hash: string, _signal: AbortSignal): Promise<Uint8Array | null> =>
+      Promise.resolve(null),
+  ),
+  present: true,
+}));
+
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useMaybeOpenEpicHandle: () =>
+    docMocks.present
+      ? {
+          epicId: "epic-1",
+          store: {
+            getState: () => ({
+              hasAttachmentBytes: docMocks.hasAttachmentBytes,
+              readAttachmentBytes: docMocks.readAttachmentBytes,
+            }),
+          },
+        }
+      : null,
+}));
+
+const HASH = "a".repeat(64);
+const CHAT_ID = "chat-1";
+const CHAT_PLANE_BYTES = new Uint8Array([1, 2, 3]);
+const DOC_BYTES = new Uint8Array([9, 9]);
+/** base64 of CHAT_PLANE_BYTES. */
+const CHAT_PLANE_BASE64 = "AQID";
+
+const request =
+  vi.fn<
+    (
+      method: "epic.readChatAttachment",
+      params: ReadChatAttachmentRequest,
+      signal: AbortSignal | undefined,
+    ) => Promise<ReadChatAttachmentResponse>
+  >();
+
+const stubClient: ChatAttachmentReadClient = {
+  requestWithSignal: (method, params, signal) =>
+    request(method, params, signal),
+};
+
+function scopeValue(
+  hostId: string,
+  withClient: boolean,
+): ChatAttachmentScopeValue {
+  return {
+    epicId: "epic-1",
+    chatId: CHAT_ID,
+    hostId,
+    client: withClient ? stubClient : null,
+  };
+}
+
+function wrapperFor(scope: ChatAttachmentScopeValue | null) {
+  return function Wrapper({ children }: { children: ReactNode }): ReactNode {
+    return (
+      <ChatAttachmentScopeContext.Provider value={scope}>
+        {children}
+      </ChatAttachmentScopeContext.Provider>
+    );
+  };
+}
+
+function rpcError(code: "E_HOST_UNSUPPORTED" | "RPC_ERROR"): HostRpcError {
+  return new HostRpcError({
+    code,
+    message: code === "E_HOST_UNSUPPORTED" ? "unsupported" : "socket died",
+    requestId: "req-1",
+    method: "epic.readChatAttachment",
+    fatalDetails: null,
+  });
+}
+
+function fetchOnce(
+  scope: ChatAttachmentScopeValue | null,
+): Promise<Uint8Array> {
+  const { result } = renderHook(() => useChatImageFetcher(), {
+    wrapper: wrapperFor(scope),
+  });
+  return result.current(HASH, new AbortController().signal);
+}
+
+beforeEach(() => {
+  resetChatAttachmentHostSupportForTests();
+  request.mockReset();
+  docMocks.present = true;
+  docMocks.hasAttachmentBytes.mockReset();
+  docMocks.hasAttachmentBytes.mockReturnValue(false);
+  docMocks.readAttachmentBytes.mockReset();
+  docMocks.readAttachmentBytes.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useChatImageFetcher", () => {
+  it("serves a sent message's image from the host while the doc map is empty", async () => {
+    request.mockResolvedValue({
+      ok: true,
+      bytesBase64: CHAT_PLANE_BASE64,
+      mediaType: "image/png",
+    });
+
+    await expect(fetchOnce(scopeValue("host-1", true))).resolves.toEqual(
+      CHAT_PLANE_BYTES,
+    );
+
+    expect(request).toHaveBeenCalledWith(
+      "epic.readChatAttachment",
+      { epicId: "epic-1", chatId: CHAT_ID, hash: HASH },
+      expect.any(AbortSignal),
+    );
+    // The doc replica is not consulted at all on a chat-plane hit.
+    expect(docMocks.hasAttachmentBytes).not.toHaveBeenCalled();
+    expect(docMocks.readAttachmentBytes).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the doc replica when the host answers missing", async () => {
+    request.mockResolvedValue({ ok: false, reason: "missing" });
+    docMocks.hasAttachmentBytes.mockReturnValue(true);
+    docMocks.readAttachmentBytes.mockResolvedValue(DOC_BYTES);
+
+    await expect(fetchOnce(scopeValue("host-1", true))).resolves.toEqual(
+      DOC_BYTES,
+    );
+    expect(docMocks.readAttachmentBytes).toHaveBeenCalledWith(
+      HASH,
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("never calls the indefinitely-waiting doc read without a presence hit", async () => {
+    request.mockResolvedValue({ ok: false, reason: "missing" });
+    docMocks.hasAttachmentBytes.mockReturnValue(false);
+
+    await expect(fetchOnce(scopeValue("host-1", true))).rejects.toThrow(
+      /unavailable/,
+    );
+    expect(docMocks.hasAttachmentBytes).toHaveBeenCalledWith(HASH);
+    expect(docMocks.readAttachmentBytes).not.toHaveBeenCalled();
+  });
+
+  it("propagates a transient RPC failure so the blob cache retries it", async () => {
+    request.mockRejectedValue(rpcError("RPC_ERROR"));
+    docMocks.hasAttachmentBytes.mockReturnValue(true);
+    docMocks.readAttachmentBytes.mockResolvedValue(DOC_BYTES);
+
+    await expect(fetchOnce(scopeValue("host-1", true))).rejects.toThrow(
+      "socket died",
+    );
+    // A dropped socket is not "these bytes moved to the doc" - the fallback
+    // must not silently absorb it into a legacy read.
+    expect(docMocks.readAttachmentBytes).not.toHaveBeenCalled();
+  });
+
+  it("skips the RPC leg permanently for a host that answers E_HOST_UNSUPPORTED", async () => {
+    request.mockRejectedValue(rpcError("E_HOST_UNSUPPORTED"));
+    docMocks.hasAttachmentBytes.mockReturnValue(true);
+    docMocks.readAttachmentBytes.mockResolvedValue(DOC_BYTES);
+
+    await expect(fetchOnce(scopeValue("host-1", true))).resolves.toEqual(
+      DOC_BYTES,
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+
+    // Second image, same host: the verdict is cached per host, not re-probed.
+    await expect(fetchOnce(scopeValue("host-1", true))).resolves.toEqual(
+      DOC_BYTES,
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+
+    // A different host is a different build - it gets its own probe.
+    await expect(fetchOnce(scopeValue("host-2", true))).resolves.toEqual(
+      DOC_BYTES,
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the RPC leg entirely with no chat scope", async () => {
+    docMocks.hasAttachmentBytes.mockReturnValue(true);
+    docMocks.readAttachmentBytes.mockResolvedValue(DOC_BYTES);
+
+    await expect(fetchOnce(null)).resolves.toEqual(DOC_BYTES);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("skips the RPC leg when the tile's host client is not resolved", async () => {
+    docMocks.hasAttachmentBytes.mockReturnValue(true);
+    docMocks.readAttachmentBytes.mockResolvedValue(DOC_BYTES);
+
+    await expect(fetchOnce(scopeValue("host-1", false))).resolves.toEqual(
+      DOC_BYTES,
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("treats an undecodable body as a retryable failure, not a miss", async () => {
+    request.mockResolvedValue({
+      ok: true,
+      bytesBase64: "!!!not base64!!!",
+      mediaType: "image/png",
+    });
+
+    await expect(fetchOnce(scopeValue("host-1", true))).rejects.toThrow(
+      /undecodable/,
+    );
+  });
+});
+
+describe("useChatAttachmentByteReader", () => {
+  it("answers bytes through the same chain", async () => {
+    request.mockResolvedValue({
+      ok: true,
+      bytesBase64: CHAT_PLANE_BASE64,
+      mediaType: "image/png",
+    });
+    const { result } = renderHook(() => useChatAttachmentByteReader(), {
+      wrapper: wrapperFor(scopeValue("host-1", true)),
+    });
+
+    await expect(result.current(HASH)).resolves.toEqual(CHAT_PLANE_BYTES);
+  });
+
+  it("answers null instead of throwing so a copy keeps its hash-only node", async () => {
+    request.mockResolvedValue({ ok: false, reason: "missing" });
+    const { result } = renderHook(() => useChatAttachmentByteReader(), {
+      wrapper: wrapperFor(scopeValue("host-1", true)),
+    });
+
+    await expect(result.current(HASH)).resolves.toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/attachments/use-attachment-blob-src.ts
+++ b/clients/gui-app/src/lib/attachments/use-attachment-blob-src.ts
@@ -10,6 +10,7 @@ import {
   IMAGE_UNAVAILABLE_GRACE_MS,
   useImageBlobUrlState,
 } from "@/lib/attachments/use-image-blob-url";
+import { useChatImageFetcher } from "@/lib/attachments/use-chat-image-fetcher";
 
 export type AttachmentBlobSrcState =
   | { readonly status: "loading"; readonly src: null }
@@ -53,13 +54,16 @@ export function useEpicAttachmentBytesPresence():
 }
 
 /**
- * Resolves an image attachment's `src`: persisted images (`hash`) stream their
- * bytes from the epic doc's attachments map into a shared blob URL via the
- * content-addressed cache; draft/optimistic images use their inline `dataUrl`.
- * Persisted images become unavailable after the sync grace window, but the
- * underlying acquisition remains recoverable when bytes arrive later. Used by
- * the sent-message renderer (the composer chip resolves images via the strip's
- * injected fetcher instead).
+ * Resolves an ARTIFACT image attachment's `src`: persisted images (`hash`)
+ * stream their bytes from the epic doc's attachments map into a shared blob URL
+ * via the content-addressed cache; draft/optimistic images use their inline
+ * `dataUrl`. Persisted images become unavailable after the sync grace window,
+ * but the underlying acquisition remains recoverable when bytes arrive later.
+ *
+ * Artifact-referenced images stay doc-resident by design - an artifact is
+ * epic-shared by nature, so doc replication IS its access model - which is why
+ * this keeps the epic byte source while every CHAT render site moved to
+ * `useChatAttachmentBlobSrc` below.
  */
 export function useAttachmentBlobSrc(
   hash: string | null,
@@ -67,6 +71,32 @@ export function useAttachmentBlobSrc(
   dataUrl: string | null,
 ): AttachmentBlobSrcState {
   const fetcher = useEpicImageFetcher();
+  return useResolvedAttachmentBlobSrc(hash, mediaType, dataUrl, fetcher);
+}
+
+/**
+ * The same resolution, for an image rendered inside a CHAT: bytes come off the
+ * chat plane (`epic.readChatAttachment` on the tile's host) with the epic doc
+ * as the legacy fallback. The chat scope comes from
+ * `ChatAttachmentScopeContext`; see `use-chat-image-fetcher.ts` for the chain
+ * and why the chat id is part of it. Outside a chat tile there is no scope, and
+ * this degrades to the doc-replica read those surfaces already used.
+ */
+export function useChatAttachmentBlobSrc(
+  hash: string | null,
+  mediaType: string,
+  dataUrl: string | null,
+): AttachmentBlobSrcState {
+  const fetcher = useChatImageFetcher();
+  return useResolvedAttachmentBlobSrc(hash, mediaType, dataUrl, fetcher);
+}
+
+function useResolvedAttachmentBlobSrc(
+  hash: string | null,
+  mediaType: string,
+  dataUrl: string | null,
+  fetcher: ImageBytesFetcher,
+): AttachmentBlobSrcState {
   const blob = useImageBlobUrlState(
     hash,
     mediaType,

--- a/clients/gui-app/src/lib/attachments/use-chat-image-fetcher.ts
+++ b/clients/gui-app/src/lib/attachments/use-chat-image-fetcher.ts
@@ -1,0 +1,195 @@
+import { useCallback } from "react";
+
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+
+import {
+  useChatAttachmentScope,
+  type ChatAttachmentScopeValue,
+} from "@/components/chat/chat-attachment-scope-context";
+import type { ImageBytesFetcher } from "@/lib/attachments/image-blob-cache";
+import { base64ToBytes } from "@/lib/composer/image-base64";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
+
+/** A view guaranteed to be backed by a plain `ArrayBuffer` (not shared). */
+type ImageBytes = Uint8Array<ArrayBuffer>;
+
+/**
+ * How long a one-shot byte read (clipboard re-inline, prompt stash) waits before
+ * giving up and treating the image as unresolvable.
+ *
+ * These two callers are not renderers: nothing paints while they run, and both
+ * have a defined "couldn't get it" behavior (drop the image from the clipboard
+ * write / fail the stash save). An unbounded wait would hang a Cmd+C instead,
+ * which is what the old `hasAttachmentBytes` pre-check existed to avoid - the
+ * bound replaces that pre-check rather than being added on top of it.
+ */
+export const CHAT_ATTACHMENT_READ_TIMEOUT_MS = 8_000;
+
+/**
+ * Hosts that have answered `E_HOST_UNSUPPORTED` for `epic.readChatAttachment`.
+ *
+ * Per host, not per image, and remembered for the session: the answer is a
+ * property of the host BUILD, so re-probing it once per image would spend a
+ * round trip per thumbnail to re-learn a constant. A host in this set falls
+ * straight through to the epic doc-replica read - which is that host's only
+ * byte source, so the "degraded" path is exactly its current behavior.
+ */
+const hostsWithoutChatAttachmentRead = new Set<string>();
+
+/**
+ * Test-only: forgets every remembered `E_HOST_UNSUPPORTED` verdict. The set is
+ * module-global and deliberately session-lived, so a suite that exercises the
+ * unsupported path would otherwise poison every later test in the same file.
+ */
+export function resetChatAttachmentHostSupportForTests(): void {
+  hostsWithoutChatAttachmentRead.clear();
+}
+
+function isHostUnsupported(error: unknown): boolean {
+  return error instanceof HostRpcError && error.code === "E_HOST_UNSUPPORTED";
+}
+
+/**
+ * The chat-plane leg: ask this tile's host for one attachment's bytes.
+ *
+ * Returns `null` for every "these bytes are not obtainable here" answer - the
+ * host said `missing`, the host predates the method, or there is no chat scope /
+ * no reachable host - so the caller can fall through to the doc replica. It
+ * THROWS for transient failures, which is what keeps the image blob cache's
+ * retry ladder alive for a blob that is one publish away.
+ */
+async function readChatAttachmentFromHost(
+  scope: ChatAttachmentScopeValue | null,
+  hash: string,
+  signal: AbortSignal,
+): Promise<ImageBytes | null> {
+  if (scope === null || scope.client === null) return null;
+  if (hostsWithoutChatAttachmentRead.has(scope.hostId)) return null;
+  try {
+    const response = await scope.client.requestWithSignal(
+      "epic.readChatAttachment",
+      { epicId: scope.epicId, chatId: scope.chatId, hash },
+      signal,
+    );
+    if (!response.ok) return null;
+    const bytes = base64ToBytes(response.bytesBase64);
+    if (bytes === null) {
+      // A malformed base64 body is a wire bug, not an absent image: throwing
+      // keeps it retryable and keeps it OUT of the "stored on the originating
+      // device" marker, which would report a transport fault as a data loss.
+      throw new Error(`Chat attachment ${hash} had an undecodable body`);
+    }
+    return bytes;
+  } catch (error: unknown) {
+    if (isHostUnsupported(error)) {
+      hostsWithoutChatAttachmentRead.add(scope.hostId);
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * The legacy leg: the epic Y.Doc's content-addressed `attachments` map.
+ *
+ * Guarded by `hasAttachmentBytes`, and the guard is not optional.
+ * `readAttachmentBytes` waits INDEFINITELY for a hash the local replica does
+ * not hold - it is built for a doc-resident image that is still syncing - so
+ * calling it unguarded here would park the chain forever on exactly the case
+ * the chat-plane leg above is supposed to own, and the blob cache would never
+ * retry the leg that could actually succeed.
+ */
+async function readAttachmentFromEpicDoc(
+  handle: OpenEpicStoreHandle | null,
+  hash: string,
+  signal: AbortSignal,
+): Promise<ImageBytes | null> {
+  if (handle === null) return null;
+  const state = handle.store.getState();
+  if (!state.hasAttachmentBytes(hash)) return null;
+  const bytes = await state.readAttachmentBytes(hash, signal);
+  return bytes === null ? null : new Uint8Array(bytes);
+}
+
+/**
+ * The byte source for images rendered INSIDE a chat.
+ *
+ * Resolution order, and each leg is here for a different era of the same image:
+ *
+ * 1. `imageBlobCache` - not in this function. The cache wraps the fetcher
+ *    (`use-image-blob-url.ts`), so a hash already resolved anywhere in the app
+ *    never reaches this code at all.
+ * 2. `epic.readChatAttachment` on the tile's host - the chat plane, where chat
+ *    image bytes now live. That host serves it from its own per-epic disk store
+ *    when it has the file, else as a bearer pass-through to the blob the owning
+ *    host published, where the server applies the chat's ACL.
+ * 3. The epic doc's `attachments` map - legacy hashes written before the move,
+ *    and artifact-plane hashes that a chat message happens to reference. Behind
+ *    a presence check; see `readAttachmentFromEpicDoc`.
+ *
+ * With no chat scope (a chat-shaped surface rendered outside a tile) leg 2 is
+ * skipped, which is exactly where those surfaces already were.
+ *
+ * Referentially stable per (scope, epic handle) so it can be handed to
+ * `useImageBlobUrl` / `AttachmentStrip` without re-acquiring every render.
+ */
+export function useChatImageFetcher(): ImageBytesFetcher {
+  const scope = useChatAttachmentScope();
+  const handle = useMaybeOpenEpicHandle();
+  return useCallback<ImageBytesFetcher>(
+    async (hash, signal) => {
+      const fromChatPlane = await readChatAttachmentFromHost(
+        scope,
+        hash,
+        signal,
+      );
+      if (fromChatPlane !== null) return fromChatPlane;
+      const fromDoc = await readAttachmentFromEpicDoc(handle, hash, signal);
+      if (fromDoc !== null) return fromDoc;
+      throw new Error(`Image attachment ${hash} unavailable`);
+    },
+    [scope, handle],
+  );
+}
+
+export type ChatAttachmentByteReader = (
+  hash: string,
+) => Promise<ImageBytes | null>;
+
+/**
+ * The same resolution chain as `useChatImageFetcher`, as a one-shot read that
+ * answers `null` instead of throwing and gives up after
+ * `CHAT_ATTACHMENT_READ_TIMEOUT_MS`.
+ *
+ * For the two non-rendering consumers - the clipboard re-inline on a copied
+ * user message and the prompt stash's hash resolution. Both used to pre-check
+ * `hasAttachmentBytes` and read the doc directly; both now go through the host,
+ * so both need a bound instead of a pre-check. `null` keeps their existing skip
+ * behavior verbatim: the clipboard write leaves the image as a bare hash, and
+ * the stash reports the image as unavailable.
+ *
+ * Deliberately NOT routed through `imageBlobCache`: that cache hands back a
+ * blob URL, not bytes, and its entries are reference-counted against mounted
+ * renderers. A copy is neither.
+ */
+export function useChatAttachmentByteReader(): ChatAttachmentByteReader {
+  const fetcher = useChatImageFetcher();
+  return useCallback<ChatAttachmentByteReader>(
+    async (hash) => {
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => controller.abort(),
+        CHAT_ATTACHMENT_READ_TIMEOUT_MS,
+      );
+      try {
+        return await fetcher(hash, controller.signal);
+      } catch {
+        return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    [fetcher],
+  );
+}

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -832,6 +832,12 @@ export const HOST_METHOD_POLL_TABLE = {
   "epic.readCloudChatPart": { ...LATEST_SCHEDULING, poll: null },
   "epic.listCloudChatPayloads": { ...LATEST_SCHEDULING, poll: null },
   "epic.readCloudChatPayload": { ...LATEST_SCHEDULING, poll: null },
+  // One chat image attachment's bytes. Not polled, and it must not be: the
+  // answer is content-addressed, so a hash that resolved once resolves to the
+  // same bytes forever and a hash that missed is re-driven by the image blob
+  // cache's own retry ladder (`use-image-blob-url.ts`), not by a cadence. An
+  // interval here would re-fetch megabytes to re-learn a constant.
+  "epic.readChatAttachment": { ...LATEST_SCHEDULING, poll: null },
   // Not polled, and this is a deliberate freshness choice rather than a copy of
   // the row above it. The answer is "which cloud row does this local chat
   // publish into", which changes exactly once in a chat's life - when a fork

--- a/protocol/src/host/epic/chat-attachment.ts
+++ b/protocol/src/host/epic/chat-attachment.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+
+import { assetMediaTypeSchema } from "@traycer/protocol/host/asset-stream-schemas";
+
+/**
+ * Host <-> client wire shape for reading ONE chat image attachment's bytes.
+ *
+ * ## Why this exists at all
+ *
+ * Chat image bytes used to live in the epic Y.Doc's content-addressed
+ * `attachments` map, which every epic participant's host replicates whole. That
+ * is the wrong home for two reasons that are not fixable in place: a Yjs
+ * document replicates all-or-nothing, so a PRIVATE chat's pasted image is
+ * readable by anyone with epic access; and the referencing messages themselves
+ * left the doc for the per-host chat store, so the bytes and their referencer
+ * no longer share a reachability set.
+ *
+ * The bytes now follow their referencer onto the chat plane - a per-epic disk
+ * store on the owning host, published as `image-attachment` chat blobs - and
+ * this method is how a viewer gets them back. The viewer's TAB host resolves it:
+ * its own local disk store first (the owning-host case, and the live cross-host
+ * case), else a bearer pass-through to the cloud blob the owning host published,
+ * where the server applies the same per-chat ACL it applies to every other chat
+ * read.
+ *
+ * ## `chatId` is REQUIRED, and it is the whole privacy argument
+ *
+ * A hash is a content address, not a capability. If this method took `(epicId,
+ * hash)` the host would have no way to decide whether THIS caller may see THESE
+ * bytes, and answering from the local disk store would hand any epic participant
+ * the contents of any private chat that happens to live on that host - the exact
+ * doc-map hole this move exists to close, rebuilt behind an RPC.
+ *
+ * With the chat id in hand the host gates the LOCAL read the same way it gates
+ * live viewing of the same chat (owner, or a cloud-confirmed `task`-visible chat
+ * read with the subscriber's own bearer), and the cloud leg is gated server-side
+ * by the identity it is already fetching under. The client always knows the
+ * owning chat - every render site reaches this from a message inside one - so
+ * requiring it costs nothing and is not a field a caller can meaningfully forge:
+ * a wrong chat id fails the gate rather than widening it.
+ *
+ * ## Optional capability
+ *
+ * Registered `degrade: { kind: "unsupported" }` and NOT on the released floor -
+ * a new method NAME is handshake-fatal against a released peer. A host that
+ * predates this surface answers `E_HOST_UNSUPPORTED`, and the client's contract
+ * is to fall back to the epic doc-replica read it used before this method
+ * existed, which is exactly that host's own behavior today. There is no
+ * user-visible degradation to render, so nothing renders one.
+ *
+ * ## Transport: unary base64, not the asset stream
+ *
+ * Chat images are capped at 5 MiB at paste time, and whole-body mux chunking
+ * removed the 1 MiB remote-frame ceiling that motivated the asset stream for
+ * 20 MiB workspace files. Unary keeps the client's resolution chain one shape
+ * (cache -> this -> doc replica) instead of splicing a four-frame stream into
+ * the middle of it. Precedent and rationale for the base64 field itself:
+ * `epic.readCloudChatPayload` in `cloud-chat.ts` - a byte channel that a JS
+ * string round trip would silently corrupt.
+ */
+
+/** Lowercase hex sha256 - the only form a content address is written in. */
+const sha256HexSchema = z.string().regex(/^[0-9a-f]{64}$/);
+
+export const readChatAttachmentRequestSchema = z.object({
+  epicId: z.string().min(1),
+  /**
+   * The chat that REFERENCES the attachment - the authorization subject, not a
+   * lookup key. See the visibility argument above: without it the host cannot
+   * gate a local-store hit, and a content address alone would leak private-chat
+   * bytes to any epic participant.
+   */
+  chatId: z.string().min(1),
+  /** Content address of the image bytes. */
+  hash: sha256HexSchema,
+});
+export type ReadChatAttachmentRequest = z.infer<
+  typeof readChatAttachmentRequestSchema
+>;
+
+export const readChatAttachmentFoundSchema = z.object({
+  ok: z.literal(true),
+  /** Base64 of the RAW image bytes - what `hash` is over. */
+  bytesBase64: z.string(),
+  /**
+   * HOST-AUTHORITATIVE, derived from the delivered bytes' magic bytes - never
+   * echoed from a client-declared media type and never inferred from a file
+   * extension. Same rule and same enum as the asset-stream header
+   * (`assetMediaTypeSchema`), reused rather than re-declared so the set of
+   * formats a renderer must handle cannot drift between the two byte channels.
+   */
+  mediaType: assetMediaTypeSchema,
+});
+export type ReadChatAttachmentFound = z.infer<
+  typeof readChatAttachmentFoundSchema
+>;
+
+/**
+ * The bytes are not obtainable, and this is DATA rather than a throw.
+ *
+ * One reason arm, deliberately. "Not on this host's disk", "never published",
+ * "published but this viewer may not read that chat" and "this chat does not
+ * exist" all collapse to `missing`, mirroring the posture the server already
+ * takes on every chat read (`requireReadableChat`: a chat you may not see is
+ * NOT FOUND, never forbidden). Distinguishing a refusal from an absence would
+ * turn this into an existence oracle over other people's private chats -
+ * answerable by anyone who can guess a `(chatId, hash)` pair - which is the
+ * same leak the `chatId` requirement above exists to prevent, just moved into
+ * the response.
+ *
+ * TRANSIENT failures are NOT this. A dropped socket, a cloud 5xx, an unreadable
+ * disk - those ride the RPC error channel and throw, so the client's blob cache
+ * retries them instead of caching a permanent "unavailable" for bytes that are
+ * one good request away. `missing` is the answer a client should render the
+ * "stored on the originating device" marker for.
+ */
+export const readChatAttachmentMissingSchema = z.object({
+  ok: z.literal(false),
+  reason: z.literal("missing"),
+});
+export type ReadChatAttachmentMissing = z.infer<
+  typeof readChatAttachmentMissingSchema
+>;
+
+export const readChatAttachmentResponseSchema = z.discriminatedUnion("ok", [
+  readChatAttachmentFoundSchema,
+  readChatAttachmentMissingSchema,
+]);
+export type ReadChatAttachmentResponse = z.infer<
+  typeof readChatAttachmentResponseSchema
+>;

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -128,6 +128,10 @@ import {
   listChatRecordsRequestSchema,
   listChatRecordsResponseSchema,
 } from "@traycer/protocol/host/epic/chat-records";
+import {
+  readChatAttachmentRequestSchema,
+  readChatAttachmentResponseSchema,
+} from "@traycer/protocol/host/epic/chat-attachment";
 
 // `epic.listTasks@1.0` - frozen pre-pinning host entry point for the CloudData
 // task-list query. Both request and response preserve the released wire shape.
@@ -729,6 +733,20 @@ export const epicListChatRecordsV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: listChatRecordsRequestSchema,
   responseSchema: listChatRecordsResponseSchema,
+});
+
+// One chat image attachment's bytes, resolved by the VIEWER's tab host (local
+// disk store first, cloud blob pass-through second). Optional and off the
+// released floor like every other read above it: a host that predates it
+// answers `E_HOST_UNSUPPORTED` and the client falls back to the epic
+// doc-replica read, which is that host's only byte source anyway - so the
+// degrade arm is today's behavior, not a degraded one. See
+// `chat-attachment.ts` for why `chatId` is a required request field.
+export const epicReadChatAttachmentV10 = defineRpcContract({
+  method: "epic.readChatAttachment",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: readChatAttachmentRequestSchema,
+  responseSchema: readChatAttachmentResponseSchema,
 });
 
 export { epicSubscribeV10, epicSubscribeV11 };

--- a/protocol/src/host/epic/index.ts
+++ b/protocol/src/host/epic/index.ts
@@ -1,4 +1,5 @@
 export * from "./unary-schemas";
+export * from "./chat-attachment";
 export * from "./chat-publication-identity";
 export * from "./chat-backup-status";
 export * from "./chat-records";

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -293,6 +293,7 @@ import {
   epicListCloudChatsV10,
   epicListCollaboratorsV10,
   epicListCommentThreadsV10,
+  epicReadChatAttachmentV10,
   epicReadCloudChatPartV10,
   epicReadCloudChatPayloadV10,
   epicResolveCloudChatHeadV10,
@@ -5995,6 +5996,27 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
       versions: {
         0: {
           contract: epicListChatRecordsV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
+  },
+  // One chat image attachment's bytes off the CHAT plane, resolved by the
+  // viewer's tab host (its own disk store, else a bearer pass-through to the
+  // published cloud blob). Optional for the usual reason - a new method name is
+  // handshake-fatal against a released peer - and the degrade needs no surface
+  // at all: a host without it is a host whose images only ever lived in the
+  // epic doc, and the client's doc-replica fallback is exactly what it already
+  // did. `chatId` rides the request so a LOCAL hit can be gated by the same
+  // per-chat visibility rule as live viewing; see `epic/chat-attachment.ts`.
+  "epic.readChatAttachment": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicReadChatAttachmentV10,
           upgradeFromPreviousVersion: null,
         },
       },


### PR DESCRIPTION
## What

New optional unary `epic.readChatAttachment@1.0` plus the gui-app fetch chain for chat image attachments. Part of the chat-attachments-off-the-doc train: bytes move from the epic Y.Doc's `attachments` map (whole-doc replication — a private chat's pasted image is readable by anyone with epic access) onto the owning host's chat storage plane.

## Protocol

- `(epicId, chatId, hash)` request — `chatId` is the authorization subject; the contract doc explains why a bare content address would rebuild the doc-map privacy hole behind an RPC.
- `{ok: true, bytesBase64, mediaType}` (host-authoritative magic-byte sniff, asset-stream enum reused) or `{ok: false, reason: "missing"}` — one refusal arm by design, so the response cannot become an existence oracle; transients ride the RPC error channel.
- Registered `degrade: {kind: "unsupported"}`, off the released floor. Old hosts answer `E_HOST_UNSUPPORTED`; the client falls back to today's doc-replica read.

## Client

- Chat render sites (gallery, assistant markdown images, generation cards, composer chips) resolve through a chat-scoped fetcher: blob cache → tab-host RPC → presence-guarded doc-replica fallback. `chatId` threads via a new chat-attachment scope context.
- Unsupported-host verdicts cached per host (no per-image re-probing).
- Clipboard re-inline and prompt stash fetch through the same chain with bounded timeouts.
- Artifact images stay on the doc-replica path (they're epic-shared by design).

Host/server half: internal PR (same train, lands together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
