### PR TITLE
feat(protocol,gui-app): let host.service.status answer externally-managed

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
@@ -487,6 +487,59 @@ describe("<HostSettingsPanel /> Overview update-install degrade", () => {
   });
 });
 
+describe("<HostSettingsPanel /> Overview OS service externally-managed outcome", () => {
+  // The OUTCOME axis, distinct from `ok` + `state: "externally-managed"`: the
+  // host refused to consult the CLI because an external supervisor owns its
+  // service lifecycle, so there is no label or manifest line to show and both
+  // verbs are withheld rather than offered-and-refused.
+  it("withholds both service verbs and names the external supervisor", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      overrideHandlers: {
+        "host.service.status": () =>
+          Promise.resolve({ outcome: "externally-managed" as const }),
+      },
+    });
+    // The service methods too: a host that has not negotiated them has no
+    // service section at all, which would make every absence below vacuous.
+    recordNegotiatedHostMethods("host-a", [
+      ...ALL_OVERVIEW_METHODS,
+      "host.service.status",
+      "host.service.register",
+      "host.service.deregister",
+    ]);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: false, gcTime: 0 } },
+          })
+        }
+      >
+        <RunnerHostProvider runnerHost={makeRunnerHost()}>
+          <HostSettingsPanel />
+        </RunnerHostProvider>
+      </QueryClientProvider>,
+    );
+
+    await openHostOverviewAdvanced();
+    const description = await screen.findByTestId(
+      "host-overview-service-description",
+    );
+    await waitFor(() => {
+      expect(description.textContent).toContain(
+        "managed by an external supervisor",
+      );
+    });
+    expect(screen.queryByTestId("host-overview-service-register")).toBeNull();
+    expect(screen.queryByTestId("host-overview-service-deregister")).toBeNull();
+    expect(screen.queryByTestId("host-overview-service-manifest")).toBeNull();
+  });
+});
+
 describe("<HostSettingsPanel /> Overview doctor structured failure", () => {
   it("cli-unavailable renders the structured Doctor message, not an error toast", async () => {
     const fixture = buildOverviewHostFixture({

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
@@ -534,8 +534,8 @@ describe("<HostSettingsPanel /> Overview OS service externally-managed outcome",
         "managed by an external supervisor",
       );
     });
-    expect(screen.queryByTestId("host-overview-service-register")).toBeNull();
-    expect(screen.queryByTestId("host-overview-service-deregister")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Re-register" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Deregister" })).toBeNull();
     expect(screen.queryByTestId("host-overview-service-manifest")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/host-overview-os-service.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-os-service.ts
@@ -171,9 +171,12 @@ export function useOverviewOsService(input: {
  *   answer could hide the repair verbs indefinitely, since this query has no
  *   poll. `undefined` routes the description to "couldn't read" while the
  *   verbs keep their repair posture.
- * - `externallyManaged`: a registration someone ELSE owns - Desktop's
- *   SMAppService, or the env-var supervisor. Both verbs are withheld: the CLI
- *   either refuses the write or installs a second unit beside the owner's.
+ * - `externallyManaged`: a registration someone ELSE owns, reported on either
+ *   axis - the CLI's own `state` answer (Desktop's SMAppService owns a label
+ *   the CLI can see) or the host's `externally-managed` OUTCOME (the env-var
+ *   supervisor; the host refused to consult the CLI at all). Both verbs are
+ *   withheld: the CLI either refuses the write or installs a second unit
+ *   beside the owner's.
  * - `cliUnavailable`: the read affirmatively said there is NO CLI. Only the
  *   affirmative answer hides the verbs - ambiguity keeps Re-register exactly
  *   when someone is debugging a flaky host.
@@ -198,7 +201,9 @@ function deriveServiceStatusView(input: {
   return {
     status,
     ok,
-    externallyManaged: ok?.state === "externally-managed",
+    externallyManaged:
+      ok?.state === "externally-managed" ||
+      status?.outcome === "externally-managed",
     cliUnavailable: status?.outcome === "cli-unavailable",
     statusUnresolved: status === undefined && input.loading,
   };
@@ -331,6 +336,12 @@ function describeServiceState(input: {
       return input.status.state === "running"
         ? "Registered and running. The OS service manifest starts the host at user login."
         : "Registered but not running. The OS service manifest starts the host at user login.";
+    case "externally-managed":
+      // The host did not consult the CLI: an external supervisor owns its
+      // service lifecycle, and the canonical label the CLI would inspect is
+      // not the unit actually running this host. No label or manifest line to
+      // show — the supervising unit is outside the CLI's sight.
+      return `${input.hostName}'s service is managed by an external supervisor, which owns its registration.`;
     case "cli-unavailable":
       return `${input.hostName} has no Traycer CLI, so its service registration can't be read from here.`;
     default:

--- a/protocol/src/host/maintenance/schemas.ts
+++ b/protocol/src/host/maintenance/schemas.ts
@@ -290,6 +290,17 @@ export const hostServiceStatusResponseSchema = z.discriminatedUnion("outcome", [
     /** The plist / unit / scheduled-task path the registration lives at. */
     manifestPath: z.string().min(1),
   }),
+  /**
+   * The host refused to consult the CLI at all: an external supervisor owns
+   * its service lifecycle (`TRAYCER_HOST_UPDATES=external`), and the CANONICAL
+   * label the CLI would inspect is not the unit actually running this host —
+   * the read would answer about the wrong service. Distinct from `ok` with
+   * `state: "externally-managed"`, which is the CLI's own answer about a label
+   * it CAN see (Desktop's SMAppService): here there is no label or manifest
+   * path to report, because the supervising unit is outside the CLI's sight.
+   * Same gate `host.service.register` / `.deregister` already answer with.
+   */
+  z.object({ outcome: z.literal("externally-managed") }),
   z.object({ outcome: z.literal("cli-unavailable") }),
   z.object({ outcome: z.literal("cli-failed") }),
   z.object({ outcome: z.literal("invalid-output") }),


### PR DESCRIPTION
An externally supervised host (`TRAYCER_HOST_UPDATES=external`) refuses `host.service.register` and `.deregister` because the CLI's canonical service label is not the unit actually running it — but the status READ had no arm to say so, and answered about the wrong service instead: `not-installed`, with a manifest path for a unit nothing is running.

## What

- **protocol**: `hostServiceStatusResponseSchema` grows an `externally-managed` outcome arm — inside the still-unreleased v1.0 of the three `host.service.*` methods, exactly like the arm `register` and `deregister` already carry. No new minor and no projection gating, because no peer that has these methods lacks the arm. Distinct from `ok` + `state: "externally-managed"` (the CLI's own answer about a label it CAN see, e.g. Desktop's SMAppService): here there is no label or manifest path to report, because the supervising unit is outside the CLI's sight.
- **gui-app**: the new outcome folds into the existing `externallyManaged` derivation — both verbs withheld, no manifest line — and the section description names the external supervisor instead of describing a registration the host never read.

## Why now

Follow-through on the deferred codex finding on traycerai/traycer-internal#4950 (`host.service.status` unguarded on externally supervised hosts). The deferral reason — not slipping a second schema change into #1156 mid-flight — expired when #1156 merged; the host-side gate lands in the internal PR once this is pinned.

## Validation

- protocol suite: 156 files / 2440 tests green
- gui-app: `host-overview-mutations` (new pin: outcome withholds both verbs + names the supervisor; negotiation-gated section made non-vacuous), `host-overview-updates`, `host-overview-fixups`, `host-settings-panel-capability`, `host-overview-identity-card` green
- `bun run compile --skip-nx-cache` green (5 projects), gui-app eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)