### PR TITLE
feat(protocol): durable turn tail on Claude session anchors

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/profile-durability-f4-tombstone-display.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/profile-durability-f4-tombstone-display.test.tsx
@@ -103,6 +103,7 @@ function anchorWithLabelSnapshot(labelSnapshot: string): ChatSessionAnchor {
       secondaryWorkspaces: [],
     },
     claudeMessageUuid: "uuid-1",
+    turnTailUuid: null,
     createdAt: 100,
     coveredUntilMessageId: null,
     profileId: "removed-uuid",

--- a/clients/gui-app/src/components/chat/__tests__/tombstone-footer-accent-continuity.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/tombstone-footer-accent-continuity.test.tsx
@@ -94,6 +94,7 @@ function anchor(accentColor: string | null): ChatSessionAnchor {
       secondaryWorkspaces: [],
     },
     claudeMessageUuid: "uuid-1",
+    turnTailUuid: null,
     createdAt: 100,
     coveredUntilMessageId: null,
     profileId: "removed-uuid",

--- a/clients/gui-app/src/components/chat/__tests__/use-tombstoned-profile-label.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/use-tombstoned-profile-label.test.tsx
@@ -19,6 +19,7 @@ function claudeAnchor(
       secondaryWorkspaces: [],
     },
     claudeMessageUuid: "uuid-1",
+    turnTailUuid: null,
     createdAt: 100,
     coveredUntilMessageId: null,
     profileId,

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -123,6 +123,7 @@ function claudeSessionAnchor(
       secondaryWorkspaces: [],
     },
     claudeMessageUuid: "claude-message-1",
+    turnTailUuid: null,
     createdAt: 1000,
     coveredUntilMessageId: null,
   };

--- a/protocol/scripts/compat/compat-exceptions.json
+++ b/protocol/scripts/compat/compat-exceptions.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Static policy encoding which host→client payload paths are catalog-gated (id-agnostic — future harnesses never touch this file). Not a per-change review mechanism. Method/path support globs (* one segment, ** any depth; method * is non-dot). Catalog methods agent.gui.listHarnesses / agent.list / providers.list must never appear here for host→client payloads — growth on those requires freezing the shipped line and opening a new major with downgrade bridges (amp 003d7586 / devin 407d110 template).",
+  "$comment": "Static policy encoding which host\u2192client payload paths are catalog-gated (id-agnostic \u2014 future harnesses never touch this file). Not a per-change review mechanism. Method/path support globs (* one segment, ** any depth; method * is non-dot). Catalog methods agent.gui.listHarnesses / agent.list / providers.list must never appear here for host\u2192client payloads \u2014 growth on those requires freezing the shipped line and opening a new major with downgrade bridges (amp 003d7586 / devin 407d110 template).",
   "exceptions": [
     {
       "family": "unary",
@@ -208,6 +208,14 @@
       "payload": "serverFrame",
       "path": "**.coveredUntilMessageId",
       "reason": "Session-anchor/chain seed-coverage field on a parsed stream (frames are live-schema-parsed, so the tolerance executes): nullable/.default(null), and null is the documented 'no seed context ever existed' semantic - literally true for a host that predates fake-context seeding (#187). No shipped client reads the field; only the host's own seeding consumes it."
+    },
+    {
+      "family": "stream",
+      "method": "chat.subscribe",
+      "version": "*",
+      "payload": "serverFrame",
+      "path": "**.turnTailUuid",
+      "reason": "Session-anchor turn-tail field on a parsed stream (frames are live-schema-parsed, so the tolerance executes): nullable/.default(null), and null is the documented 'no tail recorded' semantic - literally true for every anchor written before tail recording existed. No shipped client reads the field; only the host's own rewind-fork resolution consumes it."
     },
     {
       "family": "stream",

--- a/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
+++ b/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
@@ -599,6 +599,7 @@ export function accumulateEvent(
     case "session.resumed":
     case "turn.started":
     case "user_message.anchor_resolved":
+    case "user_message.anchor_tail_updated":
     case "usage.updated":
       return blocks;
 

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -1039,6 +1039,29 @@ export type UserMessageAnchorResolvedEvent = z.infer<
   typeof userMessageAnchorResolvedEventSchema
 >;
 
+/**
+ * Advances the durable turn-tail on a user message's session anchor while the
+ * turn is still streaming (see `turnTailUuid` on the persisted Claude anchor).
+ * Emitted per provider transcript row, so a crash mid-turn leaves the tail at
+ * the last row the host actually observed. Host-internal: the chat session
+ * consumes it before the blockDelta broadcast, so it never reaches the wire
+ * and needs no subscribe-version freeze entry.
+ */
+export const userMessageAnchorTailUpdatedEventSchema = z.object({
+  ...baseRuntimeEventFields,
+  type: z.literal("user_message.anchor_tail_updated"),
+  messageId: z.string(),
+  harnessId: z.literal("claude"),
+  // Session the tail row belongs to. A tail is only meaningful on the anchor
+  // that names the same session; the consumer drops a mismatch instead of
+  // stitching a row from one transcript onto an anchor for another.
+  sessionId: z.string(),
+  tailUuid: z.string(),
+});
+export type UserMessageAnchorTailUpdatedEvent = z.infer<
+  typeof userMessageAnchorTailUpdatedEventSchema
+>;
+
 export const turnCompletedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("turn.completed"),
@@ -1200,6 +1223,7 @@ export const runtimeEventSchema = z.discriminatedUnion("type", [
   workflowCompletedEventSchema,
   providerNoticeUpsertEventSchema,
   imageResolutionUpdatedEventSchema,
+  userMessageAnchorTailUpdatedEventSchema,
 ]);
 export type RuntimeEvent = z.infer<typeof runtimeEventSchema>;
 

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -1056,7 +1056,14 @@ export const userMessageAnchorTailUpdatedEventSchema = z.object({
   // that names the same session; the consumer drops a mismatch instead of
   // stitching a row from one transcript onto an anchor for another.
   sessionId: z.string(),
-  tailUuid: z.string(),
+  // Null CLEARS the recorded tail. Emitted when tail ownership moves to a
+  // just-accepted steer: acceptance is stdin-enqueue, but the CLI only
+  // consumes the queued message at its next boundary, so rows emitted in
+  // that window still belong to the PREVIOUS message. Freezing the previous
+  // tail at hand-off would cut its slice early; clearing it hands the slice
+  // back to the boundary scan, which stops exactly at the steer's
+  // queued_command attachment row.
+  tailUuid: z.string().nullable(),
 });
 export type UserMessageAnchorTailUpdatedEvent = z.infer<
   typeof userMessageAnchorTailUpdatedEventSchema

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -27,6 +27,7 @@ import {
   userMessagePayloadSchema,
   userMessageSchema,
   userMessageSchemaPreInReplyTo,
+  userMessageSchemaPreTurnTail,
   userMessageSenderSchema,
   userMessageSenderSchemaPreInReplyTo,
   type ChatEvent,
@@ -893,6 +894,18 @@ const chatSubscribeCommonServerFrameSchemasPreInReplyTo =
     message: userMessageSchemaPreInReplyTo,
     queue: chatQueueStateSchemaPreInReplyTo,
     event: chatEventSchemaPreInReplyTo,
+  });
+
+// Frozen common frames bound to `chat.subscribe@1.6`: live queue/event trees,
+// but the message swapped for its pre-`turnTailUuid` freeze - 1.6 shipped
+// before the Claude anchor gained `turnTailUuid`, and its surface is frozen
+// EXACTLY (`chat-subscribe-v16-surface-compat.test.ts`), so a `messageAccepted`
+// frame on that line must never declare the field.
+const chatSubscribeCommonServerFrameSchemasPreTurnTail =
+  buildChatSubscribeCommonServerFrameSchemas({
+    message: userMessageSchemaPreTurnTail,
+    queue: chatQueueStateSchema,
+    event: chatEventSchema,
   });
 
 // Frozen common frames bound to `chat.subscribe@1.4–1.5`: live message/event
@@ -1892,11 +1905,13 @@ export const chatSubscribeV15 = defineStreamRpcContract({
 // directly (a bug: it let every later change to `chatSchema`/`messageSchema`/
 // `contentBlockSchema` mutate this released line) - pinned here to its
 // pre-image shape so this line can never observe `imageResults`/the image
-// resolution record added on `1.7`. Only `chat` (→ `chatSchemaPreImage`) and
-// `blockDelta`'s event (→ `runtimeEventSchemaPreImage`) actually differ from
-// the live shapes; queue/message/managedCommands/turnStateChanged are
-// untouched by images, so this bundle reuses those live sub-schemas exactly
-// like `chatSubscribeServerFrameSchemaV14`/`V15` do.
+// resolution record added on `1.7`. `chat` (→ `chatSchemaPreImage`),
+// `blockDelta`'s event (→ `runtimeEventSchemaPreImage`), and the common
+// frames' message (→ `userMessageSchemaPreTurnTail`, via the pre-turn-tail
+// bundle: the Claude anchor gained `turnTailUuid` after 1.6 shipped) differ
+// from the live shapes; queue/managedCommands/turnStateChanged are untouched
+// by either freeze point, so those reuse the live sub-schemas exactly like
+// `chatSubscribeServerFrameSchemaV14`/`V15` do.
 const chatSnapshotSchemaV16 = z.object({
   chat: chatSchemaPreImage,
   access: chatAccessSchema,
@@ -1925,7 +1940,7 @@ const chatSubscribeServerFrameSchemaV16 = z.discriminatedUnion("kind", [
   chatSubscribeSnapshotServerFrameSchemaV16,
   chatSubscribeTurnStateChangedServerFrameSchema,
   chatSubscribeManagedCommandsChangedServerFrameSchema,
-  ...chatSubscribeCommonServerFrameSchemas,
+  ...chatSubscribeCommonServerFrameSchemasPreTurnTail,
   blockDeltaServerFrameSchema(runtimeEventSchemaPreImage),
 ]);
 

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
@@ -647,6 +647,17 @@ export const epicSchemaSurfaceBaseline = {
                                   "claudeMessageUuid": {
                                     "type": "string"
                                   },
+                                  "turnTailUuid": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
                                   "createdAt": {
                                     "type": "number"
                                   },
@@ -7888,6 +7899,17 @@ export const epicSchemaSurfaceBaseline = {
                                   "claudeMessageUuid": {
                                     "type": "string"
                                   },
+                                  "turnTailUuid": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
                                   "createdAt": {
                                     "type": "number"
                                   },
@@ -7953,6 +7975,7 @@ export const epicSchemaSurfaceBaseline = {
                                   "sessionId",
                                   "sessionWorkspaceSnapshot",
                                   "claudeMessageUuid",
+                                  "turnTailUuid",
                                   "createdAt",
                                   "coveredUntilMessageId",
                                   "profileId",

--- a/protocol/src/persistence/epic/messages.ts
+++ b/protocol/src/persistence/epic/messages.ts
@@ -14,6 +14,7 @@ import {
   agentSenderSchema,
   agentSenderSchemaPreInReplyTo,
   chatSessionAnchorSchema,
+  chatSessionAnchorSchemaPreTurnTail,
   userMessageSenderSchema,
   userMessageSenderSchemaPreInReplyTo,
 } from "@traycer/protocol/persistence/epic/senders";
@@ -261,10 +262,37 @@ export const assistantMessageSchemaPreImage = z.object({
   serviceTier: z.string().nullable().default(null),
 });
 
-// `userMessageSchema` is reused live (unswapped): user-authored messages
-// never carry image results or a resolution record, so nothing about them
-// changes at the image-freeze point.
+// Wire-freeze copy of `userMessageSchema` with `sessionAnchor` swapped for
+// its pre-`turnTailUuid` freeze (see `claudeChatSessionAnchorSchemaPreTurnTail`).
+// Bound to the released `chat.subscribe@1.6` line - snapshot frames via
+// `messageSchemaPreImage` below, `messageAccepted` frames via the
+// pre-turn-tail common frame bundle in `subscribe.ts` - whose surface is
+// frozen EXACTLY, so it can never observe the Claude anchor's `turnTailUuid`.
+// Field-for-field hand copy, NOT `.omit()`/`.extend()` off the live shape.
+export const userMessageSchemaPreTurnTail = z
+  .object({
+    role: z.literal("user"),
+    messageId: z.string(),
+    sender: userMessageSenderSchema,
+    message: userMessagePayloadSchema,
+    timestamp: z.number(),
+    sessionAnchor: chatSessionAnchorSchemaPreTurnTail.nullable(),
+  })
+  .superRefine((message, ctx) => {
+    if (message.sender.type === message.message.kind) return;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["message", "kind"],
+      message: "User message sender.type must match message.kind.",
+    });
+  });
+
+// The user branch is the pre-turn-tail freeze, not the live `userMessageSchema`:
+// user messages carry no image fields (nothing changed for them at the
+// image-freeze point), but their `sessionAnchor` gained `turnTailUuid` after
+// `chat.subscribe@1.6` shipped, and this union is bound to that exactly-frozen
+// line via the frozen chat trees.
 export const messageSchemaPreImage = z.discriminatedUnion("role", [
-  userMessageSchema,
+  userMessageSchemaPreTurnTail,
   assistantMessageSchemaPreImage,
 ]);

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -160,6 +160,24 @@ export const claudeChatSessionAnchorSchema = z.object({
   sessionId: z.string(),
   sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
   claudeMessageUuid: z.string(),
+  // Last transcript row uuid of this message's turn slice, recorded live from
+  // the stream (monotone last-write-wins) rather than re-derived later from
+  // the transcript. `claudeMessageUuid` marks where the turn STARTS; this
+  // marks where it ENDS, which is what a rewind fork must slice at. It is a
+  // recorded fact where the fallback boundary scan is a best-effort
+  // classification of raw rows - the host prefers the FURTHEST endpoint the
+  // two can prove, so a tail that went stale (e.g. a crash after later rows
+  // were written) extends rather than truncates. The scan itself is
+  // compact-proof: it runs over raw transcript rows, which a `/compact`
+  // re-root orphans from the parent chain but never removes from the file
+  // (only the pre-fix chain-walk view lost them). For a message closed out
+  // by a mid-turn steer this is CLEARED, not frozen - steer acceptance is
+  // stdin-enqueue, so rows in the enqueue window still belong to the
+  // previous message and only the scan (which stops at the steer's
+  // queued_command attachment row) knows the true boundary. `null`: cleared
+  // by hand-off, anchors persisted before this field existed, or a turn that
+  // died before any row streamed - all resolve via the scan alone.
+  turnTailUuid: z.string().nullable().default(null),
   createdAt: z.number(),
   coveredUntilMessageId: z.string().nullable().default(null),
   ...profileSnapshotFields,
@@ -451,3 +469,49 @@ export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   huggingFaceChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;
+
+// ── Wire-freeze variant (pre-turnTailUuid) ──────────────────────────────────
+// Hand-frozen copy of the claude anchor from before `turnTailUuid` existed.
+// Bound (via `userMessageSchemaPreTurnTail`) to the released
+// `chat.subscribe@1.6` serverFrames, whose surface is frozen EXACTLY by
+// `chat-subscribe-v16-surface-compat.test.ts` - the tolerance-based
+// compat-exception that covers 1.0-1.5 does not apply to that exact freeze.
+// Field-for-field hand copy, NOT `.omit()`, so a future anchor field cannot
+// silently leak onto the frozen line.
+export const claudeChatSessionAnchorSchemaPreTurnTail = z.object({
+  harnessId: z.literal("claude"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  claudeMessageUuid: z.string(),
+  createdAt: z.number(),
+  coveredUntilMessageId: z.string().nullable().default(null),
+  ...profileSnapshotFields,
+});
+
+// Non-claude variants reuse their live shapes: the pre-turn-tail freeze point
+// only concerns the claude anchor.
+export const chatSessionAnchorSchemaPreTurnTail = z.discriminatedUnion(
+  "harnessId",
+  [
+    claudeChatSessionAnchorSchemaPreTurnTail,
+    codexChatSessionAnchorSchema,
+    openCodeChatSessionAnchorSchema,
+    cursorChatSessionAnchorSchema,
+    traycerChatSessionAnchorSchema,
+    openRouterChatSessionAnchorSchema,
+    grokChatSessionAnchorSchema,
+    qwenChatSessionAnchorSchema,
+    kiroChatSessionAnchorSchema,
+    droidChatSessionAnchorSchema,
+    kimiChatSessionAnchorSchema,
+    copilotChatSessionAnchorSchema,
+    kilocodeChatSessionAnchorSchema,
+    ampChatSessionAnchorSchema,
+    devinChatSessionAnchorSchema,
+    piChatSessionAnchorSchema,
+    hermesChatSessionAnchorSchema,
+    ompChatSessionAnchorSchema,
+    huggingFaceChatSessionAnchorSchema,
+  ],
+);


### PR DESCRIPTION
## What

Claude chat session anchors gain `turnTailUuid` — the uuid of the last transcript row of the anchored message's turn, recorded live from the stream instead of re-derived from the transcript at rewind time.

- `claudeChatSessionAnchorSchema.turnTailUuid`: `nullable().default(null)` — every anchor written before tail recording parses unchanged; `null` = "no tail recorded" routes resolution to the transcript-scan fallback.
- New `user_message.anchor_tail_updated` runtime event (live union only, not the frozen pre-`inReplyTo` lines). Host-internal carrier: the chat session consumes it before the blockDelta broadcast, so it never reaches the wire or the accumulator. `tailUuid: null` clears a recorded tail (used when tail ownership hands off to a mid-turn steer — rows between stdin-enqueue and CLI consumption still belong to the previous message, so its slice resolves via the boundary scan that stops at the steer's `queued_command` attachment row).
- `compat-exceptions.json` entry for `**.turnTailUuid` on `chat.subscribe` serverFrames, following the `profileId`/`coveredUntilMessageId` precedent: nullable-defaulted anchor field, live-schema-parsed frames, no shipped client reads it.
- `epic-schema-surface` fixture regenerated (additive).

## Why

Deriving the turn boundary lazily at rewind time is what silently broke edits after `/compact` (the boundary scan ran on the chain-walk transcript view, which a compact re-roots) and after steers (a steered message persists as an attachment row invisible to that view). Recording the tail as a durable fact removes the derivation. Host-side consumer lands in the internal repo (traycer-internal `traycer/tidy-newt`).

## Compatibility

Old anchors parse via the null default and use the fallback path; old hosts reading new anchors strip the unknown key (zod object default). No migration, no `chat.subscribe` version bump, no client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
