### PR TITLE
fix(gui-app): preserve delayed scrollbar departures

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline-follow-latch.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline-follow-latch.test.ts
@@ -682,6 +682,41 @@ describe("useChatTimelineFollowLatch", () => {
     expect(listRef.scrollToEnd).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves a scrollbar drag through pointerup until its delayed scroll report", () => {
+    const node = shim.makeNode({
+      scrollTop: 1000,
+      scrollHeight: 1500,
+      clientHeight: 500,
+    });
+    const listRef = makeFakeListRef(node);
+    const onFollowIntentChange = vi.fn();
+    const { result } = renderHook(() =>
+      useChatTimelineFollowLatch(listRef, true, true, {
+        onFollowIntentChange,
+        onReaderGesture: undefined,
+        isCorrectionSuppressed: undefined,
+        resolveSuppressedEndLanding: undefined,
+      }),
+    );
+
+    result.current.noteReaderGesture({
+      direction: "indeterminate",
+      freezeInFlightScroll: true,
+      publishesReaderPosition: true,
+    });
+    // The compositor has moved the thumb, but under long-list main-thread
+    // pressure pointer completion and layout maintenance can run before the
+    // coalesced native scroll event is delivered.
+    shim.setGeometry(node, { scrollTop: 200 });
+    node.dispatchEvent(new PointerEvent("pointerup"));
+    shim.setGeometry(node, { scrollHeight: 1700 });
+    result.current.followEndIfPermitted();
+    fireNativeScroll(node);
+
+    expect(listRef.scrollToEnd).not.toHaveBeenCalled();
+    expect(onFollowIntentChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("converges a toward-end reader landing when content grows before scroll delivery", () => {
     const node = shim.makeNode({
       scrollTop: 700,

--- a/clients/gui-app/src/components/chat/chat-timeline-follow-latch.ts
+++ b/clients/gui-app/src/components/chat/chat-timeline-follow-latch.ts
@@ -572,16 +572,30 @@ export function useChatTimelineFollowLatch(
     const clearTouch = (): void => {
       lastTouchClientYRef.current = null;
     };
-    const clearPointerPreflight = (): void => {
+    const completePointerPreflight = (): void => {
       const armedDeparture = armedReaderDepartureRef.current;
       if (
         armedDeparture?.source === "gesture" &&
         armedDeparture.direction === "indeterminate"
       ) {
-        // A scrollbar pointer-down is publishing, but a click/release with no
-        // drag emits no scroll event. Pointer completion deterministically
-        // releases only that indeterminate arm; wheel/touch/keyboard arms do
-        // not share this completion signal.
+        const liveNode = listRef.current?.getScrollableNode();
+        const liveGeometry = liveNode ? readScrollGeometry(liveNode) : null;
+        if (
+          liveGeometry !== null &&
+          isChatTimelineGeometryMeasurable(liveGeometry) &&
+          !isChatTimelineAtStrictBottom(liveGeometry)
+        ) {
+          // A scrollbar drag can update live scrollTop before main-thread
+          // pressure allows its coalesced native scroll event through. Publish
+          // the already-visible departure now, while its arm is intact, so an
+          // intervening ResizeObserver cannot classify it as layout-owned and
+          // yank the viewport back to the tail.
+          observeLiveGeometry();
+          return;
+        }
+        // A click/release whose live geometry stayed at the strict edge was a
+        // no-op and may emit no scroll event. Release only that preflight so a
+        // later stream mutation can continue following normally.
         armedReaderDepartureRef.current = null;
       }
     };
@@ -590,10 +604,10 @@ export function useChatTimelineFollowLatch(
     node.addEventListener("touchmove", handleTouchMove, { passive: true });
     node.addEventListener("touchend", clearTouch, { passive: true });
     node.addEventListener("touchcancel", clearTouch, { passive: true });
-    node.addEventListener("pointerup", clearPointerPreflight, {
+    node.addEventListener("pointerup", completePointerPreflight, {
       passive: true,
     });
-    node.addEventListener("pointercancel", clearPointerPreflight, {
+    node.addEventListener("pointercancel", completePointerPreflight, {
       passive: true,
     });
     // Viewport-layout trigger (divider drag / pane resize): fires with no
@@ -613,8 +627,8 @@ export function useChatTimelineFollowLatch(
       node.removeEventListener("touchmove", handleTouchMove);
       node.removeEventListener("touchend", clearTouch);
       node.removeEventListener("touchcancel", clearTouch);
-      node.removeEventListener("pointerup", clearPointerPreflight);
-      node.removeEventListener("pointercancel", clearPointerPreflight);
+      node.removeEventListener("pointerup", completePointerPreflight);
+      node.removeEventListener("pointercancel", completePointerPreflight);
       resizeObserver.disconnect();
       cancelActiveCorrection();
     };
@@ -622,6 +636,7 @@ export function useChatTimelineFollowLatch(
     scrollNode,
     cancelActiveCorrection,
     followEndIfPermitted,
+    listRef,
     noteReaderGesture,
     observeLiveGeometry,
   ]);


### PR DESCRIPTION
## Summary\n\n- preserve an armed scrollbar departure when pointer completion arrives before the delayed native scroll event\n- publish already-visible non-bottom geometry at pointerup or pointercancel so ResizeObserver maintenance cannot reclaim the viewport\n- keep no-op scrollbar clicks at the strict edge clearing their preflight normally\n- add a deterministic regression for compositor movement followed by pointerup, content growth, and delayed scroll delivery\n\n## Related issue\n\nFollow-up to #1140 and #1159.\n\n## Validation\n\n- Red proof on current main: the new regression issued one unwanted scrollToEnd correction\n- Focused follow-latch suite: 36/36 passed\n- React Compiler variant: 10/10 passed\n- React Doctor changed-file scan: no issues\n- Authenticated desktop renderer: with the chat at strict bottom, simulated compositor geometry moved 5,000 px before scroll delivery; pointerup immediately activated free-scroll intent and Jump to Latest instead of allowing end correction\n\n## Checklist\n\n- [x] Pre-commit static checks pass\n- [ ] Separate CI test checks pass\n- [x] Tests added/updated where it makes sense\n- [x] Commits are signed off per the DCO