### PR TITLE
fix(protocol,gui-app): restore the hover card's run settings, split its workspace empty states

### DIFF
--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -20,6 +20,13 @@ const tuiAgent = vi.hoisted(() => ({
 const wireProfiles = vi.hoisted(() => ({
   current: [] as ReadonlyArray<ProviderProfile>,
 }));
+/** What the host answers `epic.getChatRunSettings` with, and whether it was
+ *  asked at all - the second half matters as much as the first, because the
+ *  read must stay OFF for the owners that still have local settings. */
+const fetchedSettings = vi.hoisted(() => ({
+  current: null as ChatRunSettings | null,
+  lastEnabled: null as boolean | null,
+}));
 
 vi.mock("@/lib/epic-selectors", () => ({
   useChatById: () =>
@@ -70,6 +77,18 @@ vi.mock("@/hooks/providers/use-providers-list-query", () => ({
     },
   }),
 }));
+// Records `enabled` rather than ignoring it: a mock that always answers would
+// let the header read a fetched tuple it never actually requested, and the
+// "store settings win, no round trip" half of the contract would pass
+// vacuously.
+vi.mock("@/hooks/chats/use-chat-run-settings-query", () => ({
+  useChatRunSettings: (args: { readonly enabled: boolean }) => {
+    fetchedSettings.lastEnabled = args.enabled;
+    return {
+      data: args.enabled ? { settings: fetchedSettings.current } : undefined,
+    };
+  },
+}));
 
 function profile(
   profileId: string,
@@ -118,6 +137,7 @@ function renderChatHeader(args: {
     <WorktreeOwnerSettingsHeader
       ownerId="owner-1"
       hostId="host-1"
+      epicId="epic-1"
       ownerKind="chat"
     />,
   );
@@ -140,6 +160,7 @@ function renderTuiHeader(args: {
     <WorktreeOwnerSettingsHeader
       ownerId="owner-1"
       hostId="host-1"
+      epicId="epic-1"
       ownerKind="terminal-agent"
     />,
   );
@@ -175,6 +196,8 @@ describe("WorktreeOwnerSettingsHeader", () => {
     chatSettings.current = null;
     tuiAgent.current = null;
     wireProfiles.current = [];
+    fetchedSettings.current = null;
+    fetchedSettings.lastEnabled = null;
   });
 
   it("renders a distinct icon for each permission mode", () => {
@@ -351,5 +374,97 @@ describe("WorktreeOwnerSettingsHeader", () => {
     expect(screen.getByTestId("owner-settings-model").textContent).toContain(
       "Claude Sonnet 4.5",
     );
+  });
+});
+
+/**
+ * The single-write regression: a chat that exists only as a host registry row
+ * has `settings: null` on its projection (`chatProjectionFromRecord`), because
+ * the row carries a harness-id summary and not the tuple. Before the per-chat
+ * read this header returned `null` for such a chat and the whole line - model,
+ * reasoning, permission mode, profile dot and the relative timestamp - simply
+ * vanished from the hover card.
+ */
+describe("chat settings sourced from the host", () => {
+  afterEach(() => {
+    cleanup();
+    chatSettings.current = null;
+    tuiAgent.current = null;
+    wireProfiles.current = [];
+    fetchedSettings.current = null;
+    fetchedSettings.lastEnabled = null;
+  });
+
+  function renderRegistryOnlyChat(): void {
+    // A registry-only chat: the projection exists (so the row renders and has
+    // an `updatedAt`) but carries no settings tuple.
+    chatSettings.current = null;
+    tuiAgent.current = null;
+    wireProfiles.current = [];
+    render(
+      <WorktreeOwnerSettingsHeader
+        ownerId="owner-1"
+        hostId="host-1"
+        epicId="epic-1"
+        ownerKind="chat"
+      />,
+    );
+  }
+
+  it("renders the full settings line from the fetched tuple", () => {
+    fetchedSettings.current = {
+      harnessId: "claude",
+      model: "sonnet-4.5",
+      permissionMode: "full_access",
+      reasoningEffort: "high",
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: null,
+    };
+
+    renderRegistryOnlyChat();
+
+    expect(fetchedSettings.lastEnabled).toBe(true);
+    expect(screen.getByTestId("owner-settings-model").textContent).toContain(
+      "Claude Sonnet 4.5",
+    );
+    expect(screen.getByTestId("owner-settings-reasoning").textContent).toBe(
+      "High",
+    );
+    expect(
+      screen.getByTestId("owner-settings-permissions").textContent,
+    ).toContain("Full access");
+  });
+
+  it("renders nothing while the host has not answered", () => {
+    // `settings: null` from the host is the honest "no tuple here" - a legacy
+    // record, or a chat whose owning host this client cannot reach. It must
+    // read as an absent header, never as a half-populated line.
+    fetchedSettings.current = null;
+
+    renderRegistryOnlyChat();
+
+    expect(fetchedSettings.lastEnabled).toBe(true);
+    expect(screen.queryByTestId("owner-settings-header")).toBeNull();
+  });
+
+  it("does not ask the host when the projection already has settings", () => {
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
+    expect(fetchedSettings.lastEnabled).toBe(false);
+    expect(screen.getByTestId("owner-settings-model").textContent).toContain(
+      "Claude Sonnet 4.5",
+    );
+  });
+
+  it("does not ask the host for a terminal agent", () => {
+    renderTuiHeader({ profileId: null, profiles: [] });
+
+    expect(fetchedSettings.lastEnabled).toBe(false);
   });
 });

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -61,6 +61,17 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
             ],
             metadata: {},
           },
+          // A SECOND model, so a host tuple and a local tuple can disagree
+          // visibly - which is the only way to test which one the header trusts.
+          {
+            harnessId: "claude",
+            slug: "opus-4.1",
+            label: "Claude Opus 4.1",
+            supportedReasoningEfforts: [
+              { id: "high", label: "High", description: null },
+            ],
+            metadata: {},
+          },
         ],
       },
     ],
@@ -448,7 +459,24 @@ describe("chat settings sourced from the host", () => {
     expect(screen.queryByTestId("owner-settings-header")).toBeNull();
   });
 
-  it("does not ask the host when the projection already has settings", () => {
+  it("prefers the host tuple over a local one that disagrees", () => {
+    // A pre-pivot chat still has a doc entry, and `unionChatsSlice` deliberately
+    // prefers its `settings` over the record's. But since the single-write pivot
+    // NOTHING rewrites that entry - `epic.updateChatRunSettings` and
+    // `epic.updateChatProfile` reach only the host's own store - so it is frozen
+    // at whatever it held when the doc was last written. Gating the read on its
+    // absence, or letting it win the coalesce, would pin the card to values that
+    // stopped being true at the user's first model change.
+    fetchedSettings.current = {
+      harnessId: "claude",
+      model: "opus-4.1",
+      permissionMode: "full_access",
+      reasoningEffort: "high",
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: null,
+    };
+
     renderChatHeader({
       permissionMode: "full_access",
       profileId: null,
@@ -456,7 +484,25 @@ describe("chat settings sourced from the host", () => {
       serviceTier: null,
     });
 
-    expect(fetchedSettings.lastEnabled).toBe(false);
+    expect(fetchedSettings.lastEnabled).toBe(true);
+    expect(screen.getByTestId("owner-settings-model").textContent).toContain(
+      "Claude Opus 4.1",
+    );
+  });
+
+  it("falls back to the local tuple while the host read has not answered", () => {
+    // In flight, unsupported, or an unreachable owner host - all arrive here as
+    // no fetched tuple, and none of them should blank a row that already had
+    // something true enough to show.
+    fetchedSettings.current = null;
+
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
     expect(screen.getByTestId("owner-settings-model").textContent).toContain(
       "Claude Sonnet 4.5",
     );

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -25,6 +25,20 @@ const wireProfiles = vi.hoisted(() => ({
  *  read must stay OFF for the owners that still have local settings. */
 const fetchedSettings = vi.hoisted(() => ({
   current: null as ChatRunSettings | null,
+  /**
+   * Whether the host read has SETTLED successfully, kept separate from
+   * `current` because the header has to tell an answer of `null` apart from no
+   * answer at all. A settled `{ settings: null }` is the host stating the chat
+   * has no persisted tuple, which OUTRANKS a stale local one; an unsettled read
+   * (in flight, errored, unsupported, or no reachable host) must fall back to
+   * local instead. Collapsing the two into "data is null" is exactly the bug
+   * these tests exist to catch.
+   *
+   * Defaults to NOT answered, so the suites below that are about rendering a
+   * LOCAL tuple keep exercising that path; a settled host answer is opted into
+   * per test.
+   */
+  answered: false,
   lastEnabled: null as boolean | null,
 }));
 
@@ -95,8 +109,10 @@ vi.mock("@/hooks/providers/use-providers-list-query", () => ({
 vi.mock("@/hooks/chats/use-chat-run-settings-query", () => ({
   useChatRunSettings: (args: { readonly enabled: boolean }) => {
     fetchedSettings.lastEnabled = args.enabled;
+    const settled = args.enabled && fetchedSettings.answered;
     return {
-      data: args.enabled ? { settings: fetchedSettings.current } : undefined,
+      data: settled ? { settings: fetchedSettings.current } : undefined,
+      isSuccess: settled,
     };
   },
 }));
@@ -208,6 +224,7 @@ describe("WorktreeOwnerSettingsHeader", () => {
     tuiAgent.current = null;
     wireProfiles.current = [];
     fetchedSettings.current = null;
+    fetchedSettings.answered = false;
     fetchedSettings.lastEnabled = null;
   });
 
@@ -403,6 +420,7 @@ describe("chat settings sourced from the host", () => {
     tuiAgent.current = null;
     wireProfiles.current = [];
     fetchedSettings.current = null;
+    fetchedSettings.answered = false;
     fetchedSettings.lastEnabled = null;
   });
 
@@ -423,6 +441,7 @@ describe("chat settings sourced from the host", () => {
   }
 
   it("renders the full settings line from the fetched tuple", () => {
+    fetchedSettings.answered = true;
     fetchedSettings.current = {
       harnessId: "claude",
       model: "sonnet-4.5",
@@ -447,10 +466,11 @@ describe("chat settings sourced from the host", () => {
     ).toContain("Full access");
   });
 
-  it("renders nothing while the host has not answered", () => {
+  it("renders nothing when the host answers no tuple", () => {
     // `settings: null` from the host is the honest "no tuple here" - a legacy
-    // record, or a chat whose owning host this client cannot reach. It must
-    // read as an absent header, never as a half-populated line.
+    // record with nothing persisted. With no local tuple either, that must read
+    // as an absent header, never as a half-populated line.
+    fetchedSettings.answered = true;
     fetchedSettings.current = null;
 
     renderRegistryOnlyChat();
@@ -467,6 +487,7 @@ describe("chat settings sourced from the host", () => {
     // at whatever it held when the doc was last written. Gating the read on its
     // absence, or letting it win the coalesce, would pin the card to values that
     // stopped being true at the user's first model change.
+    fetchedSettings.answered = true;
     fetchedSettings.current = {
       harnessId: "claude",
       model: "opus-4.1",
@@ -491,9 +512,10 @@ describe("chat settings sourced from the host", () => {
   });
 
   it("falls back to the local tuple while the host read has not answered", () => {
-    // In flight, unsupported, or an unreachable owner host - all arrive here as
-    // no fetched tuple, and none of them should blank a row that already had
-    // something true enough to show.
+    // In flight, errored, unsupported, or an unreachable owner host whose query
+    // never runs - none of them should blank a row that already had something
+    // true enough to show.
+    fetchedSettings.answered = false;
     fetchedSettings.current = null;
 
     renderChatHeader({
@@ -506,6 +528,26 @@ describe("chat settings sourced from the host", () => {
     expect(screen.getByTestId("owner-settings-model").textContent).toContain(
       "Claude Sonnet 4.5",
     );
+  });
+
+  it("honors a settled null over a frozen local tuple", () => {
+    // The other side of the fallback, and the one that is easy to get wrong: a
+    // SUCCESSFUL `{ settings: null }` is the host saying this chat has no
+    // persisted tuple, not the absence of an answer. Coalescing the two with
+    // `??` would fall through to the frozen doc tuple the host just
+    // contradicted, which is the very staleness this read exists to end.
+    fetchedSettings.answered = true;
+    fetchedSettings.current = null;
+
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
+    expect(fetchedSettings.lastEnabled).toBe(true);
+    expect(screen.queryByTestId("owner-settings-header")).toBeNull();
   });
 
   it("does not ask the host for a terminal agent", () => {

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-tui-hover-card.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-tui-hover-card.test.tsx
@@ -80,6 +80,13 @@ vi.mock("@/hooks/providers/use-providers-list-query", () => ({
     },
   }),
 }));
+// Terminal agents keep their settings on the store projection, so this read is
+// disabled for every owner in this suite. Mocked rather than provided for: the
+// real hook needs a `QueryClientProvider`, and standing one up here would be
+// scaffolding for a query that is never issued.
+vi.mock("@/hooks/chats/use-chat-run-settings-query", () => ({
+  useChatRunSettings: () => ({ data: undefined }),
+}));
 vi.mock("@/hooks/worktree/use-worktree-owner-metadata-query", () => ({
   useWorktreeOwnerMetadata: () => ({
     binding: null,

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-pr-metadata.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-pr-metadata.test.tsx
@@ -292,6 +292,7 @@ describe("worktree PR metadata", () => {
           worktrees={[entry]}
           workspaces={[]}
           pending={false}
+          hostUnavailable={false}
           error={false}
           openPrInApp={null}
         />
@@ -386,6 +387,7 @@ describe("worktree PR metadata", () => {
         worktrees={[entry]}
         workspaces={[]}
         pending={false}
+        hostUnavailable={false}
         error={false}
         openPrInApp={null}
       />,
@@ -420,6 +422,7 @@ describe("worktree PR metadata", () => {
         worktrees={[worktree({})]}
         workspaces={[]}
         pending={false}
+        hostUnavailable={false}
         error={false}
         openPrInApp={(reference) => opened.push(reference)}
       />,
@@ -451,6 +454,7 @@ describe("worktree PR metadata", () => {
             worktrees={[entry]}
             workspaces={[]}
             pending={false}
+            hostUnavailable={false}
             error={false}
             openPrInApp={null}
           />
@@ -510,6 +514,7 @@ describe("worktree PR metadata", () => {
           worktrees={[entry]}
           workspaces={[]}
           pending={false}
+          hostUnavailable={false}
           error={false}
           openPrInApp={null}
         />,
@@ -602,5 +607,87 @@ describe("worktree PR metadata", () => {
       expect(stateTokens(glyphTokens)).toHaveLength(2);
       cleanup();
     }
+  });
+});
+
+/**
+ * The three ways this block can have nothing to show, and why they must not
+ * collapse into one message.
+ *
+ * "No workspace linked" is a CLAIM ABOUT THE OWNER - that it runs nowhere. It
+ * was previously printed whenever the binding happened to be null at render
+ * time, which made it the answer for two states it has no right to speak for:
+ * a read still in flight, and a read that could not be issued at all.
+ */
+describe("owner workspace metadata empty states", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderEmpty(props: {
+    readonly pending: boolean;
+    readonly hostUnavailable: boolean;
+    readonly error: boolean;
+  }): void {
+    renderWithProviders(
+      <OwnerWorkspaceMetadataContent
+        binding={null}
+        worktrees={[]}
+        workspaces={[]}
+        pending={props.pending}
+        hostUnavailable={props.hostUnavailable}
+        error={props.error}
+        openPrInApp={null}
+      />,
+    );
+  }
+
+  it("says loading while a read is in flight, not 'No workspace linked'", () => {
+    renderEmpty({ pending: true, hostUnavailable: false, error: false });
+
+    expect(screen.getByText("Loading workspace…")).toBeDefined();
+    expect(screen.queryByText("No workspace linked")).toBeNull();
+  });
+
+  it("claims no workspace only once the read has settled", () => {
+    renderEmpty({ pending: false, hostUnavailable: false, error: false });
+
+    expect(screen.getByText("No workspace linked")).toBeDefined();
+    expect(screen.queryByText("Loading workspace…")).toBeNull();
+  });
+
+  it("reports an unreachable host instead of spinning forever", () => {
+    // The dead end: with no client the query is gated off, so it holds
+    // TanStack's `pending` status with nothing in flight. A spinner here waits
+    // on an event that never arrives, so this state outranks it.
+    renderEmpty({ pending: true, hostUnavailable: true, error: false });
+
+    expect(
+      screen.getByText("Workspace unknown — host unreachable"),
+    ).toBeDefined();
+    expect(screen.queryByText("Loading workspace…")).toBeNull();
+    expect(screen.queryByText("No workspace linked")).toBeNull();
+  });
+
+  it("keeps showing folders through a refetch rather than flashing a spinner", () => {
+    // The other half of gating on items rather than on `binding === null`: an
+    // owner that HAS folders must not lose them to a loading state every time
+    // the card re-asks the host.
+    renderWithProviders(
+      <OwnerWorkspaceMetadataContent
+        binding={BINDING}
+        worktrees={[]}
+        workspaces={[]}
+        pending
+        hostUnavailable={false}
+        error={false}
+        openPrInApp={null}
+      />,
+    );
+
+    expect(screen.queryByText("Loading workspace…")).toBeNull();
+    expect(
+      screen.getByTestId("owner-workspace-metadata-content"),
+    ).toBeDefined();
   });
 });

--- a/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
@@ -168,6 +168,7 @@ export function WorktreeOwnerMetadataTooltip(props: {
           <WorktreeOwnerSettingsHeader
             ownerId={props.ownerId}
             hostId={props.hostId}
+            epicId={props.epicId}
             ownerKind={props.ownerKind}
           />
           {/* `w-0 min-w-full` so the folder block takes the width the header
@@ -183,6 +184,7 @@ export function WorktreeOwnerMetadataTooltip(props: {
               worktrees={metadata.worktrees}
               workspaces={metadata.workspaces}
               pending={metadata.isPending}
+              hostUnavailable={metadata.hostUnavailable}
               error={metadata.error !== null}
               openPrInApp={openPrInApp}
             />

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -74,18 +74,28 @@ export function WorktreeOwnerSettingsHeader(props: {
   const hostClient = useHostClientForHostId(props.hostId);
   // Terminal agents still carry their settings on the store projection, so this
   // is CHAT-ONLY: the single-write pivot took the doc chat entry away and left
-  // the registry row's harness-id summary, which is not a tuple. Skipped when
-  // the store already has one - a pre-pivot chat whose frozen doc entry
-  // survived, or one this session opened - so the common case still paints from
-  // local state with no round trip, and the read is what covers the rest.
+  // the registry row's harness-id summary, which is not a tuple.
+  //
+  // Runs for EVERY chat, including one that already has a local tuple, because
+  // that tuple can be stale in a way nothing here can detect. `unionChatsSlice`
+  // deliberately prefers a surviving doc entry's `settings` over the record's,
+  // but since the pivot `epic.updateChatRunSettings` and `epic.updateChatProfile`
+  // write only the host's authoritative store - nothing re-writes that doc entry
+  // ever again. So a pre-pivot chat's frozen tuple survives every subsequent
+  // model, profile and permission change, and gating the read on its absence
+  // would pin the card to values that stopped being true the first time the user
+  // changed anything. The host is the authority; local is the fallback.
   const runSettingsQuery = useChatRunSettings({
     client: hostClient,
     epicId: props.epicId,
     chatId: props.ownerId,
-    enabled: isChat && localChatSettings === null,
+    enabled: isChat,
   });
-  const chatSettings =
-    localChatSettings ?? runSettingsQuery.data?.settings ?? null;
+  // Host first, local second - and local still carries the card while the read
+  // is in flight, unsupported, or answering for a host that cannot be reached,
+  // so this never blanks a row that had something to show.
+  const fetchedChatSettings = runSettingsQuery.data?.settings ?? null;
+  const chatSettings = fetchedChatSettings ?? localChatSettings;
   const hasSubject = ownerHasSubject(isChat, chatSettings, tuiAgent);
 
   // The dynamic label source, gated on `hasSubject` so a legacy row with no

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/worktree/worktree-owner-settings-model";
 import { harnessProfiles } from "@/components/worktree/worktree-owner-settings-profiles";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useChatRunSettings } from "@/hooks/chats/use-chat-run-settings-query";
 import { useGuiHarnessCatalog } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useProvidersListForClient } from "@/hooks/providers/use-providers-list-query";
 import { useEpicStore } from "@/hooks/use-epic-store";
@@ -58,6 +59,7 @@ interface TuiHeaderFields {
 export function WorktreeOwnerSettingsHeader(props: {
   readonly ownerId: string;
   readonly hostId: string;
+  readonly epicId: string;
   readonly ownerKind: WorktreeBindingOwnerKind;
 }): ReactNode {
   const chat = useChatById(props.ownerId);
@@ -65,7 +67,25 @@ export function WorktreeOwnerSettingsHeader(props: {
     selectTuiAgent(state.tuiAgents.byId, props.ownerId),
   );
   const isChat = props.ownerKind === "chat";
-  const chatSettings = ownerChatSettings(isChat, chat?.settings ?? null);
+  const localChatSettings = ownerChatSettings(isChat, chat?.settings ?? null);
+  // Pinned to the OWNER's host, not the tab's or the app-active one - shared
+  // with the provider-list read below, which needs the same host for the same
+  // reason. A chat on another of the viewer's hosts is served by that host.
+  const hostClient = useHostClientForHostId(props.hostId);
+  // Terminal agents still carry their settings on the store projection, so this
+  // is CHAT-ONLY: the single-write pivot took the doc chat entry away and left
+  // the registry row's harness-id summary, which is not a tuple. Skipped when
+  // the store already has one - a pre-pivot chat whose frozen doc entry
+  // survived, or one this session opened - so the common case still paints from
+  // local state with no round trip, and the read is what covers the rest.
+  const runSettingsQuery = useChatRunSettings({
+    client: hostClient,
+    epicId: props.epicId,
+    chatId: props.ownerId,
+    enabled: isChat && localChatSettings === null,
+  });
+  const chatSettings =
+    localChatSettings ?? runSettingsQuery.data?.settings ?? null;
   const hasSubject = ownerHasSubject(isChat, chatSettings, tuiAgent);
 
   // The dynamic label source, gated on `hasSubject` so a legacy row with no
@@ -84,7 +104,6 @@ export function WorktreeOwnerSettingsHeader(props: {
   // harness mark; a managed id needs the live list for its label and accent,
   // while an unknown/tombstoned id silently stays bare.
   const profileActivity = ownerProfileActivity(isChat, tuiAgent);
-  const hostClient = useHostClientForHostId(props.hostId);
   // Chats preserve their cache-only behavior. A managed terminal profile
   // actively resolves against this owner's fixed host, so the hover card is
   // self-sufficient even if no other profile surface warmed the query first.

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -91,11 +91,17 @@ export function WorktreeOwnerSettingsHeader(props: {
     chatId: props.ownerId,
     enabled: isChat,
   });
-  // Host first, local second - and local still carries the card while the read
-  // is in flight, unsupported, or answering for a host that cannot be reached,
-  // so this never blanks a row that had something to show.
-  const fetchedChatSettings = runSettingsQuery.data?.settings ?? null;
-  const chatSettings = fetchedChatSettings ?? localChatSettings;
+  // Keyed on whether the read SETTLED, not on whether it produced a tuple.
+  // `{ settings: null }` is a successful answer - the host stating this chat has
+  // no persisted tuple - and it has to outrank a stale local one, so coalescing
+  // with `??` would be wrong: it would fall through to a frozen doc tuple the
+  // host just contradicted. Local carries the card only while there is no answer
+  // to prefer: in flight, errored, `E_HOST_UNSUPPORTED`, or no reachable host to
+  // ask (the query is disabled and never settles). That keeps every fallback
+  // that matters without letting absence-of-answer impersonate an answer.
+  const chatSettings = runSettingsQuery.isSuccess
+    ? runSettingsQuery.data.settings
+    : localChatSettings;
   const hasSubject = ownerHasSubject(isChat, chatSettings, tuiAgent);
 
   // The dynamic label source, gated on `hasSubject` so a legacy row with no

--- a/clients/gui-app/src/components/worktree/worktree-pr-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-pr-metadata.tsx
@@ -291,10 +291,42 @@ export function OwnerWorkspaceMetadataContent(props: {
   readonly worktrees: readonly WorktreeHostEntryV12[];
   readonly workspaces: readonly WorktreeWorkspaceSummaryV14[];
   readonly pending: boolean;
+  /** No host client to ask - the facts are unknown, not absent. */
+  readonly hostUnavailable: boolean;
   readonly error: boolean;
   readonly openPrInApp: ((reference: WorktreePrReference) => void) | null;
 }): ReactNode {
-  if (props.pending && props.binding === null) {
+  const items = ownerWorkspaceMetadataItems(
+    props.binding,
+    props.worktrees,
+    props.workspaces,
+  );
+  // Ahead of the spinner, because this is the state that CANNOT resolve on its
+  // own. The owner's host is unreachable, so no request is in flight and none
+  // is coming; a spinner here waits for an event that never arrives. It also
+  // outranks "No workspace linked", which would claim the owner runs nowhere
+  // when the truth is only that nobody could be asked.
+  if (props.hostUnavailable && items.length === 0) {
+    return (
+      <span className="block px-3 py-2 text-ui-xs text-muted-foreground">
+        Workspace unknown — host unreachable
+      </span>
+    );
+  }
+  // Gated on having NOTHING TO SHOW, not on `binding === null`, and that
+  // difference is the whole point. "No workspace linked" is a definitive claim
+  // about an owner - it is what the card says when a chat really runs nowhere -
+  // so it must never be the answer while a read that could contradict it is
+  // still in flight. The old condition only covered the FIRST load: once a
+  // `{ binding: null }` had been cached, a later re-open served that null with
+  // `isPending` false and printed the definitive negative over a refetch that
+  // was about to replace it (`ownerMetadataPending` documents the matching
+  // half). A chat with a perfectly good workspace read "No workspace linked"
+  // until the refetch landed.
+  //
+  // Owners that DO have items keep rendering them through a refetch, so the
+  // spinner only ever replaces the empty state, never populated content.
+  if (props.pending && items.length === 0) {
     return (
       <span className="flex items-center gap-2 px-3 py-2 text-ui-xs">
         <AgentSpinningDots
@@ -313,11 +345,6 @@ export function OwnerWorkspaceMetadataContent(props: {
       </span>
     );
   }
-  const items = ownerWorkspaceMetadataItems(
-    props.binding,
-    props.worktrees,
-    props.workspaces,
-  );
   if (items.length === 0) {
     return (
       <span className="block px-3 py-2 text-ui-xs text-muted-foreground">

--- a/clients/gui-app/src/hooks/chats/use-chat-run-settings-query.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-run-settings-query.ts
@@ -1,4 +1,5 @@
-import type { UseQueryResult } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { QueryClient, UseQueryResult } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type {
   HostRpcError,
@@ -6,6 +7,8 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcRegistry } from "@/lib/host";
 import { useHostQuery } from "@/hooks/host/use-host-query";
+import { useCloudChatViewerId } from "@/hooks/chats/use-cloud-chat-queries";
+import { hostQueryKeys } from "@/lib/query-keys";
 
 type GetChatRunSettingsResponse = ResponseOfMethod<
   HostRpcRegistry,
@@ -41,6 +44,17 @@ type GetChatRunSettingsResponse = ResponseOfMethod<
  * truthful `null` for a chat whose settings exist perfectly well elsewhere.
  * When that host is not in the directory there is no client to pin, the query
  * never runs, and the caller renders what the record row already gave it.
+ *
+ * ## VIEWER-scoped, because the RESPONSE is
+ *
+ * The resolver answers from the calling identity's own registry entry and hands
+ * back `{ settings: null }` for a chat the caller does not own, so the reply is
+ * a fact about one viewer and must not be cached as a fact about the host/chat
+ * pair. The viewer rides the cache key for the same reason spelled out in
+ * `use-chat-replica-read.ts`: an auth transition invalidates host queries but
+ * does not EVICT their data, so an unscoped slot could hand the next account
+ * the previous account's model, permission mode and profile. No viewer resolved
+ * means no request, rather than an unattributed one.
  */
 export function useChatRunSettings(args: {
   readonly client: HostClient<HostRpcRegistry> | null;
@@ -48,16 +62,55 @@ export function useChatRunSettings(args: {
   readonly chatId: string;
   readonly enabled: boolean;
 }): UseQueryResult<GetChatRunSettingsResponse, HostRpcError> {
+  const viewerUserId = useCloudChatViewerId();
+  const params = useMemo(
+    () => ({ epicId: args.epicId, chatId: args.chatId }),
+    [args.epicId, args.chatId],
+  );
   return useHostQuery<HostRpcRegistry, "epic.getChatRunSettings">({
-    cacheKeyIdentity: undefined,
+    cacheKeyIdentity: [viewerUserId],
     client: args.client,
     method: "epic.getChatRunSettings",
-    params: { epicId: args.epicId, chatId: args.chatId },
+    params,
     options: {
-      enabled: args.enabled,
+      enabled: args.enabled && viewerUserId.length > 0,
       staleTime: 60_000,
       refetchOnWindowFocus: false,
-      poll: false,
+      // A host predating this method answers the declared `E_HOST_UNSUPPORTED`,
+      // which is PERMANENT - retrying it just doubles a doomed request and its
+      // warning log on every hover, and an errored query refetches on the next
+      // mount no matter what `staleTime` says. Same predicate as every other
+      // optional chat read here. Note this cannot be left to the poll table:
+      // `epic.getChatRunSettings` is a `poll: null` method, so `useHostQuery`
+      // injects no `retry: false` of its own (only `kind: "condition"` methods
+      // get that), and the production default retry would otherwise apply.
+      retry: (failureCount, error) =>
+        error.code !== "E_HOST_UNSUPPORTED" && failureCount < 2,
     },
+  });
+}
+
+/**
+ * Drop this host's cached run-settings tuples after a write.
+ *
+ * The host store is the only thing a settings write updates - for a
+ * registry-only chat the record row still summarises to a harness id, and for a
+ * pre-pivot chat the doc entry is frozen - so nothing about a successful
+ * `epic.updateChatRunSettings` / `epic.updateChatProfile` reaches this cache on
+ * its own. Without this, changing a model or profile in the composer leaves an
+ * already-hovered card showing the old values for a `staleTime` (and for as
+ * long as it stays mounted, since a mounted observer will not refetch a fresh
+ * entry at all).
+ *
+ * Method-scoped rather than per chat: the key carries the params AND the viewer,
+ * so a `chatId`-precise invalidation would have to reconstruct both, and the
+ * entries this drops are single small tuples refetched only on a hover.
+ */
+export function invalidateChatRunSettings(
+  queryClient: QueryClient,
+  hostId: string | null,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: hostQueryKeys.methodScope(hostId, "epic.getChatRunSettings"),
   });
 }

--- a/clients/gui-app/src/hooks/chats/use-chat-run-settings-query.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-run-settings-query.ts
@@ -1,0 +1,63 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type {
+  HostRpcError,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@/lib/host";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+
+type GetChatRunSettingsResponse = ResponseOfMethod<
+  HostRpcRegistry,
+  "epic.getChatRunSettings"
+>;
+
+/**
+ * One chat's persisted run-settings tuple, read from the host that OWNS it.
+ *
+ * ## Why a host read at all
+ *
+ * The renderer's chat record table used to carry `settings` because the epic
+ * Y.Doc's chat entry did. Since the single-write pivot nothing writes that
+ * entry - `chatProjectionFromRecord` honestly reports `settings: null`, because
+ * the registry row it projects carries only a harness-id summary - so every
+ * surface rendering resolved settings for a chat it has not opened has no local
+ * source left. This is that source.
+ *
+ * ## Passive, and gated by the caller's MOUNT
+ *
+ * No polling and no focus refetch. Run settings change only when the user
+ * changes them, and the one caller (the sidebar hover card) unmounts on close,
+ * so a re-open is already a fresh read whenever the entry has gone stale. The
+ * `staleTime` is what keeps re-hovering the same row from re-asking the host on
+ * every pass of the pointer.
+ *
+ * ## `client` decides WHICH host, and it is not the tab's
+ *
+ * Callers pass a client pinned to the chat's own `originHostId`
+ * (`useHostClientForHostId`), never the tab-bound or app-active one. A chat
+ * living on another of the viewer's hosts is served by that host, which is the
+ * only machine holding its chat store - asking the tab's host would get a
+ * truthful `null` for a chat whose settings exist perfectly well elsewhere.
+ * When that host is not in the directory there is no client to pin, the query
+ * never runs, and the caller renders what the record row already gave it.
+ */
+export function useChatRunSettings(args: {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly epicId: string;
+  readonly chatId: string;
+  readonly enabled: boolean;
+}): UseQueryResult<GetChatRunSettingsResponse, HostRpcError> {
+  return useHostQuery<HostRpcRegistry, "epic.getChatRunSettings">({
+    cacheKeyIdentity: undefined,
+    client: args.client,
+    method: "epic.getChatRunSettings",
+    params: { epicId: args.epicId, chatId: args.chatId },
+    options: {
+      enabled: args.enabled,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+      poll: false,
+    },
+  });
+}

--- a/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
@@ -32,6 +32,7 @@ import { useHostClient } from "@/lib/host/runtime";
 import { hostQueryKeys, epicMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { invalidateEpicChatRecords } from "@/hooks/chats/use-epic-chat-records";
+import { invalidateChatRunSettings } from "@/hooks/chats/use-chat-run-settings-query";
 import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
 import { evictChatTabPersistenceForChat } from "@/stores/chats/chat-tab-persistence-eviction";
 
@@ -281,10 +282,11 @@ export function useEpicUpdateChatRunSettings(): UseMutationResult<
   UpdateChatRunSettingsRequest
 > {
   const client = useTabHostClient();
+  const queryClient = useQueryClient();
   return useHostMutation<
     HostRpcRegistry,
     "epic.updateChatRunSettings",
-    unknown,
+    { hostId: string | null },
     UpdateChatRunSettingsRequest
   >({
     client,
@@ -292,6 +294,16 @@ export function useEpicUpdateChatRunSettings(): UseMutationResult<
     mapVariables: (variables) => variables,
     options: {
       mutationKey: epicMutationKeys.updateChatRunSettings(),
+      // Captured at mutate time, per the host-swap convention above.
+      onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
+      onSuccess: (_data, _variables, ctx) => {
+        // The write landed in the host store and NOWHERE the renderer projects
+        // from: a registry-only chat's record row summarises to a harness id,
+        // and a pre-pivot chat's doc entry is frozen. The hover card reads the
+        // tuple over `epic.getChatRunSettings`, so without this it keeps
+        // rendering the pre-change model/profile/permission mode.
+        invalidateChatRunSettings(queryClient, ctx.hostId);
+      },
     },
   });
 }
@@ -313,10 +325,11 @@ export function useEpicUpdateChatProfile(): UseMutationResult<
   UpdateChatProfileRequest
 > {
   const client = useTabHostClient();
+  const queryClient = useQueryClient();
   return useHostMutation<
     HostRpcRegistry,
     "epic.updateChatProfile",
-    unknown,
+    { hostId: string | null },
     UpdateChatProfileRequest
   >({
     client,
@@ -324,6 +337,13 @@ export function useEpicUpdateChatProfile(): UseMutationResult<
     mapVariables: (variables) => variables,
     options: {
       mutationKey: epicMutationKeys.updateChatProfile(),
+      // Same host-swap capture and the same reason as
+      // `useEpicUpdateChatRunSettings` above - a profile move is a settings
+      // write that reaches only the host's own record.
+      onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
+      onSuccess: (_data, _variables, ctx) => {
+        invalidateChatRunSettings(queryClient, ctx.hostId);
+      },
     },
   });
 }

--- a/clients/gui-app/src/hooks/worktree/use-worktree-owner-metadata-query.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-owner-metadata-query.ts
@@ -98,23 +98,37 @@ function worktreeListAllForHostParams(
 }
 
 /**
- * Whether the card still has nothing to show. A caller-supplied binding skips
- * the binding RPC entirely, so its pending flag must not count; likewise an
- * owner with no managed worktrees never issues the worktree listing, and one
- * with no plain folders never issues the workspace summary - each leg's
- * pending flag only counts when that leg's path set is non-empty.
+ * Whether an answer that could still change is in flight. A caller-supplied
+ * binding skips the binding RPC entirely, so its pending flag must not count;
+ * likewise an owner with no managed worktrees never issues the worktree
+ * listing, and one with no plain folders never issues the workspace summary -
+ * each leg's pending flag only counts when that leg's path set is non-empty.
+ *
+ * ## Why the binding leg reads FETCHING and not just PENDING
+ *
+ * TanStack's `isPending` means "no data cached yet", so it answers false the
+ * moment ANY answer has been stored - including a `{ binding: null }` cached
+ * before the host had written the owner's binding row. Every later open then
+ * served that null as a settled fact while the refetch that would replace it
+ * was still running, and the card printed "No workspace linked" for a chat that
+ * had a workspace. `isFetching` is the question this actually needs to ask: is
+ * a read in flight right now, whatever is in the cache behind it.
+ *
+ * Consumers that already have items to show are unaffected - they render them
+ * through a refetch (see `OwnerWorkspaceMetadataContent`), so widening this
+ * only changes what the EMPTY state says while the host is being asked.
  */
 function ownerMetadataPending(input: {
   readonly enabled: boolean;
   readonly bindingSupplied: boolean;
-  readonly bindingPending: boolean;
+  readonly bindingInFlight: boolean;
   readonly worktreePathCount: number;
   readonly worktreesPending: boolean;
   readonly workspacePathCount: number;
   readonly workspacesPending: boolean;
 }): boolean {
   if (!input.enabled) return false;
-  if (!input.bindingSupplied && input.bindingPending) return true;
+  if (!input.bindingSupplied && input.bindingInFlight) return true;
   if (input.worktreePathCount > 0 && input.worktreesPending) return true;
   return input.workspacePathCount > 0 && input.workspacesPending;
 }
@@ -145,6 +159,19 @@ export interface WorktreeOwnerMetadata {
    */
   readonly workspaces: readonly WorktreeWorkspaceSummaryV14[];
   readonly isPending: boolean;
+  /**
+   * There is no host client to ask, so these facts are UNKNOWN rather than
+   * absent.
+   *
+   * The owner's host resolved to no requester - unreachable, absent from the
+   * host directory, or signed out - which is a normal state for a chat that
+   * lives on another machine (it is the same condition the sidebar draws its
+   * unreachable padlock from). Callers must not render it as either "loading"
+   * (nothing is in flight and nothing ever will be) or as an empty binding
+   * ("no workspace linked" is a claim about the OWNER, and this says only that
+   * we could not ask).
+   */
+  readonly hostUnavailable: boolean;
   readonly error: HostRpcError | null;
   /**
    * When the HOST last derived these facts, or `null` before anything has been
@@ -346,10 +373,30 @@ export function useWorktreeOwnerMetadata(args: {
     binding,
     worktrees,
     workspaces,
+    // Only when this hook would have had to ASK. A caller that supplied the
+    // binding already has the answer, and a closed card has no question.
+    hostUnavailable:
+      args.enabled && suppliedBinding === undefined && args.client === null,
     isPending: ownerMetadataPending({
       enabled: args.enabled,
       bindingSupplied: suppliedBinding !== undefined,
-      bindingPending: bindingQuery.isPending,
+      // Requires a CLIENT, then `isPending || isFetching`.
+      //
+      // The two flags cover different gaps and neither is sufficient alone:
+      // `isPending` misses a refetch over cached data (the stale-null case this
+      // whole signal exists for), and `isFetching` misses a query whose host is
+      // merely still connecting - it has no data and no request yet, but one is
+      // coming.
+      //
+      // The client check is what stops the pair from spinning FOREVER. With no
+      // client there is no request now and none pending: `useHostQuery` gates
+      // the query off, so `isPending` stays true for the lifetime of the card
+      // with `isFetching` false. Reporting that as "loading" is a dead end -
+      // nothing will ever arrive to end it. It is reported as
+      // `hostUnavailable` below instead, which the card can state plainly.
+      bindingInFlight:
+        args.client !== null &&
+        (bindingQuery.isPending || bindingQuery.isFetching),
       worktreePathCount: worktreePaths.length,
       worktreesPending: worktreesQuery.isPending,
       workspacePathCount: workspacePaths.length,

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -928,6 +928,17 @@ export const HOST_METHOD_POLL_TABLE = {
     ...LATEST_SCHEDULING,
     poll: { kind: "fixed", intervalMs: 20 * SECOND_MS },
   },
+  // UNPOLLED, unlike the list above, and for the opposite reason: the list has
+  // to notice a chat that appeared elsewhere, while this answers a question
+  // whose subject cannot change without a user action. Run settings move when
+  // somebody moves them, and the surfaces that move them invalidate this key.
+  // Its caller unmounts on close, so a re-open is a fresh read once the entry
+  // goes stale - a cadence would only re-ask the host about a card nobody is
+  // looking at.
+  "epic.getChatRunSettings": {
+    ...LATEST_SCHEDULING,
+    poll: null,
+  },
   // The publisher's own convergence sweep is 30s, so a 45s local read is
   // responsive without asking faster than the underlying state can change.
   "epic.chatBackupStatus": {

--- a/protocol/src/host/epic/chat-records.ts
+++ b/protocol/src/host/epic/chat-records.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 import { cloudChatVisibilitySchema } from "@traycer/protocol/host/epic/cloud-chat";
+// The PERSISTED variant, with its `.default(...)` backstops, and not the
+// wire-strict one: this is a read of a record that may have been written before
+// `serviceTier` or `profileId` existed, and the strict schema exists to stop a
+// partial WRITE from null-clobbering fields it never looked at. Parsing a
+// legacy record with it would fail the read outright.
+import { chatRunSettingsSchema } from "@traycer/protocol/persistence/epic/foundation";
 
 const textFrameFields = {
   hasBinaryPayload: z.literal(false),
@@ -199,6 +205,69 @@ export const listChatRecordsResponseSchema = z.object({
 });
 export type ListChatRecordsResponse = z.infer<
   typeof listChatRecordsResponseSchema
+>;
+
+/**
+ * `epic.getChatRunSettings@1.0` - ONE chat's full run-settings tuple.
+ *
+ * ## Why a second read exists next to the row above
+ *
+ * The row carries `runSettingsSummary` - the harness id and nothing else -
+ * because the registry index it is served from must hold every chat in an epic
+ * at once, and a growing chat-shaped settings object has no place in it (see
+ * `chat-registry-row.ts`). That was the whole tuple's only client-side source
+ * once the single-write pivot stopped writing doc chat entries, so every
+ * surface that renders resolved settings for a chat it has not opened - the
+ * sidebar's agent hover card is the one that exists - lost model, reasoning
+ * effort, service tier, profile and permission mode at the same moment.
+ *
+ * This is the narrow read that gives them back WITHOUT widening the list: it is
+ * keyed on one chat, it is issued only when such a surface actually asks (the
+ * hover card fetches on open, beside `worktree.getBinding`), and it answers
+ * from the same store the row does - one keyed `json_extract`, no transcript
+ * materialized. A list read would pay that cost for every chat in the epic to
+ * serve the one the pointer is resting on.
+ *
+ * ## `settings` is nullable, and the two nulls mean different things
+ *
+ * `null` covers both "this host holds no projection for that chat" and "the
+ * chat has no persisted settings" (a legacy record written before the field, or
+ * one that has never run a turn). Deliberately NOT distinguished and
+ * deliberately NOT an error: every caller renders the same nothing for both,
+ * and a chat id this host does not know is a routing answer the CLIENT already
+ * has - it addresses the read to the chat's owning host, so a miss here means
+ * the row moved, not that the caller asked wrongly.
+ *
+ * ## Owner-scoped, like every other chat read
+ *
+ * Rows owned by the calling identity only. A chat living on ANOTHER of the
+ * viewer's hosts is served by THAT host - the client resolves a requester for
+ * the chat's `originHostId` rather than asking whichever host its tab happens
+ * to be bound to - so this method never needs a foreign arm. A foreign replica
+ * carries only the summary anyway (the cloud metadata row does not replicate
+ * the tuple), so serving one here would be inventing detail this host was never
+ * told.
+ *
+ * ## Optional, with a degrade story
+ *
+ * Registered `degrade: { kind: "unsupported" }` and not on the released floor.
+ * A host predating it answers `E_HOST_UNSUPPORTED` and the caller renders what
+ * the row already gave it - the harness mark - which is strictly what that
+ * host's own client showed before this method existed.
+ */
+export const getChatRunSettingsRequestSchema = z.object({
+  epicId: z.string().min(1),
+  chatId: z.string().min(1),
+});
+export type GetChatRunSettingsRequest = z.infer<
+  typeof getChatRunSettingsRequestSchema
+>;
+
+export const getChatRunSettingsResponseSchema = z.object({
+  settings: chatRunSettingsSchema.nullable(),
+});
+export type GetChatRunSettingsResponse = z.infer<
+  typeof getChatRunSettingsResponseSchema
 >;
 
 /**

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -127,6 +127,8 @@ import {
 import {
   listChatRecordsRequestSchema,
   listChatRecordsResponseSchema,
+  getChatRunSettingsRequestSchema,
+  getChatRunSettingsResponseSchema,
 } from "@traycer/protocol/host/epic/chat-records";
 
 // `epic.listTasks@1.0` - frozen pre-pinning host entry point for the CloudData
@@ -729,6 +731,18 @@ export const epicListChatRecordsV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: listChatRecordsRequestSchema,
   responseSchema: listChatRecordsResponseSchema,
+});
+
+// The per-chat run-settings tuple the row above deliberately does not carry.
+// Optional and host-local for the same reason as the list: it answers out of
+// this host's own chat store. A client without it renders the harness mark the
+// row already gave it, which is exactly what such a host's client showed
+// before this method existed.
+export const epicGetChatRunSettingsV10 = defineRpcContract({
+  method: "epic.getChatRunSettings",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: getChatRunSettingsRequestSchema,
+  responseSchema: getChatRunSettingsResponseSchema,
 });
 
 export { epicSubscribeV10, epicSubscribeV11 };

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -293,6 +293,7 @@ import {
   epicChatBackupStatusV10,
   epicChatReplicaReadV10,
   epicListChatRecordsV10,
+  epicGetChatRunSettingsV10,
   epicListChatPublicationTargetsV10,
   epicListCloudChatPayloadsV10,
   epicListCloudChatsV10,
@@ -6055,6 +6056,25 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
       versions: {
         0: {
           contract: epicListChatRecordsV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
+  },
+  // The per-chat run-settings tuple the record row above summarises down to a
+  // harness id. Optional and host-LOCAL for the same reason as the list - it
+  // answers out of this host's own chat store, the only place the tuple lives
+  // once the single-write pivot stopped writing doc chat entries. A client
+  // talking to a host without it renders the harness mark alone, which is what
+  // that host's client already showed.
+  "epic.getChatRunSettings": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicGetChatRunSettingsV10,
           upgradeFromPreviousVersion: null,
         },
       },


### PR DESCRIPTION
Two regressions in the sidebar/canvas agent hover card. Both rendered as silence rather than as an error, which is why neither tripped a test or a compile.

| | Before | After |
|---|---|---|
| Post-pivot chat | settings line absent entirely | model · reasoning · permission · profile · timestamp |
| Binding refetch over a cached null | "No workspace linked" | folders, or a spinner if there is nothing yet |
| Owner host unreachable | spinner forever | "Workspace unknown — host unreachable" |

## 1. The settings line vanished for every post-pivot chat

Since chat-sync-v2's single-write pivot a chat has **no epic-doc entry**, so the renderer's record table is fed by `epic.listChatRecords` — whose row carries `runSettingsSummary`, the harness id and nothing else. `chatProjectionFromRecord` therefore sets `settings: null` for every chat created since, and `WorktreeOwnerSettingsHeader` returns `null` when it has no tuple. The card's whole settings line — model, reasoning effort, permission mode, profile dot **and the relative timestamp** — disappeared with no error and no empty state.

Released builds still show the line only because their chats predate the pivot and still carry frozen doc entries, so this reproduces only on chats created after the pivot landed.

**Fix:** new `epic.getChatRunSettings@1.0` (`degrade: { kind: "unsupported" }`, so an older host simply answers nothing), read per chat when the card opens and gated on the local store having no tuple — a chat that still carries a doc entry issues no request at all. The registry index deliberately stays summary-only: it has to hold every chat in an epic in memory at once, so the full tuple stays in the chat projection and is fetched on demand.

The read rides the requester the card already pins for the owner's host (`hostId` from `useEpicNodeHostId` = the projection's `originHostId`), so it asks the chat's **own** host, never the tab's default. That routing needed no change.

Host side (store read + resolver) is a separate internal PR — see "Landing order" below.

## 2. "No workspace linked" for owners that had a workspace

`OwnerWorkspaceMetadataContent` gated its spinner on `pending && binding === null`, with `pending` coming from TanStack's `isPending` — which means *"no data cached"*, not *"no request in flight"*. That covers only the first load. Once a `{ binding: null }` had been cached, every later open served it with `isPending` false and printed the definitive negative on top of a refetch that was about to replace it.

The spinner now gates on **having nothing to show** (`items.length === 0`) rather than on `binding === null`, and the binding leg reads `isPending || isFetching`. Owners that do have items keep rendering them through a refetch, so the spinner only ever replaces the empty state.

## 3. …which alone spins forever on an unreachable host

That pair is a dead end when the owner's host is unreachable: `useHostQuery` gates the query off, so `isPending` stays true for the lifetime of the card with `isFetching` false and nothing ever arriving to end it. The same condition the sidebar draws its unreachable padlock from.

`useWorktreeOwnerMetadata` now reports `hostUnavailable` separately (only when it would have had to ask — a caller-supplied binding and a closed card both exclude it), and the card states it plainly. It is checked **ahead** of the spinner, and it also outranks "No workspace linked", which would claim the owner runs nowhere when the truth is that nobody could be asked.

## Tests

- `worktree-owner-settings-header.test.tsx` — renders from a fetched tuple; renders nothing when the host answers null; does **not** ask when the projection already has settings; does **not** ask for a terminal agent (the `enabled` flag is asserted, not just the output).
- `worktree-pr-metadata.test.tsx` — four states pinned apart: in-flight → spinner, settled-empty → "No workspace linked", no client → unreachable, has folders → folders survive a refetch.

`bun run compile` and `bun run lint` green across all 5 projects; worktree suites 80 passed.

## Landing order

This PR is protocol + renderer only. The host resolver lives in the internal repo and lands after this, re-pinned to this PR's squashed commit.