### PR TITLE
feat(gui-app): let the epic usage chart group by harness or model

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -37,6 +37,24 @@ function chartDayCount(): number {
   return data.length;
 }
 
+/**
+ * The mounted trend chart's series names, in the last captured ECharts
+ * option's series order - reads the same "last mocked instance, last
+ * captured option" seam as {@link chartDayCount}, so a `chartGroupBy` switch
+ * (which remounts the chart via its `key` prop) is picked up by re-reading
+ * the newest mock instance rather than the original one.
+ */
+function chartSeriesNames(): readonly string[] {
+  const option = getEChartsMockInstances().at(-1)?.options.at(-1);
+  if (option === undefined) throw new Error("no ECharts option captured");
+  const { series } = option as UsageChartOption;
+  if (series === undefined) return [];
+  const list = Array.isArray(series) ? series : [series];
+  return list.map((entry) =>
+    typeof entry.name === "string" ? entry.name : "",
+  );
+}
+
 type UsageSummaryRequest = RequestOfMethod<
   HostRpcRegistry,
   "host.usage.summary"
@@ -156,6 +174,45 @@ function usageSummaryResponse(): UsageSummaryResponse {
   };
 }
 
+/**
+ * `usageSummaryResponse()` plus a second same-day bucket from a different
+ * harness/model, so the chart has something to actually regroup: switching
+ * `chartGroupBy` folds the same two buckets by a different key and the
+ * series names must change with it. `totals.factCount` tracks the bucket
+ * count rather than staying pinned at the base fixture's `1`.
+ */
+function usageSummaryResponseWithTwoBuckets(): UsageSummaryResponse {
+  const base = usageSummaryResponse();
+  const secondBucket = {
+    day: "2026-08-09",
+    harnessId: "codex",
+    model: "gpt-5.6-sol",
+    factCount: 1,
+    tokens: {
+      uncachedInputTokens: 100,
+      cacheReadInputTokens: 0,
+      cacheCreationTokens: 0,
+      outputTokens: 50,
+    },
+    knownCostUsd: 2.5,
+    knownCacheSavingsUsd: 0,
+    knownReasoningTokens: 0,
+    costProvenance: "providerReported",
+  } satisfies UsageSummaryResponse["summary"]["buckets"][number];
+  return {
+    ...base,
+    summary: {
+      ...base.summary,
+      totals: {
+        ...base.summary.totals,
+        factCount: 2,
+        knownCostUsd: 5,
+      },
+      buckets: [...base.summary.buckets, secondBucket],
+    },
+  };
+}
+
 function renderDialog(
   handler: (request: UsageSummaryRequest) => UsageSummaryResponse,
 ): {
@@ -245,6 +302,41 @@ describe("<EpicUsageDialog />", () => {
       expect(screen.getByTestId("usage-daily-chart")).toBeTruthy();
     });
     expect(chartDayCount()).toBe(30);
+  });
+
+  it("groups the chart by harness by default, and by model after switching the toggle", async () => {
+    const user = userEvent.setup();
+    renderDialog(usageSummaryResponseWithTwoBuckets);
+    await screen.findByTestId("usage-cost-figure");
+    await waitFor(() => {
+      expect(screen.getByTestId("usage-daily-chart")).toBeTruthy();
+    });
+    expect(chartSeriesNames()).toEqual(["claude", "codex"]);
+
+    await user.click(screen.getByTestId("usage-chart-groupby-model"));
+
+    await waitFor(() => {
+      expect(chartSeriesNames()).toEqual(["claude-sonnet-5", "gpt-5.6-sol"]);
+    });
+  });
+
+  it("does not render the group-by toggle when the window has no facts", async () => {
+    renderDialog(() => {
+      const base = usageSummaryResponse();
+      return {
+        ...base,
+        summary: {
+          ...base.summary,
+          totals: { ...base.summary.totals, factCount: 0, knownCostUsd: 0 },
+          buckets: [],
+        },
+      };
+    });
+
+    const costFigure = await screen.findByTestId("usage-cost-figure");
+    expect(costFigure).toBeTruthy();
+    expect(screen.queryByTestId("usage-chart-groupby-harness")).toBeNull();
+    expect(screen.queryByTestId("usage-chart-groupby-model")).toBeNull();
   });
 
   it("renders a retryable error card, never a silent fallback, when the RPC fails", async () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
@@ -24,8 +24,10 @@ import { lastNCalendarDays } from "@/lib/usage-analytics/day-window";
 import {
   buildUsageChartColumns,
   buildUsageSeriesScaleForBuckets,
+  type UsageChartGroupBy,
 } from "@/lib/usage-analytics/usage-chart-data";
 import { UsageCostFigure } from "@/components/usage-analytics/usage-cost-figure";
+import { UsageChartGroupByToggle } from "@/components/usage-analytics/usage-chart-groupby-toggle";
 import { UsageDailyChart } from "@/components/usage-analytics/usage-daily-chart";
 import { UsageErrorCard } from "@/components/usage-analytics/usage-error-card";
 import { UsageChatBreakdown } from "@/components/usage-analytics/usage-chat-breakdown";
@@ -58,6 +60,13 @@ export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
   const { epicId, client, open, onOpenChange } = props;
   const [windowDays, setWindowDays] =
     useState<UsageSummaryWindowDays>(DEFAULT_WINDOW_DAYS);
+  // Held here rather than in the body: Radix unmounts `DialogContent` - and
+  // with it the body - while the dialog is closed, so a grouping picked
+  // there would silently reset on every reopen. This component outlives
+  // that (it lives as long as its `EpicShell`), which is the same reason
+  // the window selection above it is held here.
+  const [chartGroupBy, setChartGroupBy] =
+    useState<UsageChartGroupBy>("harness");
   const request = useMemo(
     () =>
       buildUsageSummaryRequest({
@@ -90,7 +99,11 @@ export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
         </div>
         <UsageWindowPicker windowDays={windowDays} onChange={setWindowDays} />
         <div className="min-h-0 flex-1 overflow-y-auto">
-          <EpicUsageDialogBody query={query} />
+          <EpicUsageDialogBody
+            query={query}
+            chartGroupBy={chartGroupBy}
+            onChartGroupByChange={setChartGroupBy}
+          />
         </div>
         <DialogFooter className="-mx-4 -mb-4 mt-0 border-t bg-muted/50 px-4 py-3">
           <Button
@@ -113,8 +126,10 @@ export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
 
 function EpicUsageDialogBody(props: {
   readonly query: UsageSummaryQueryResult;
+  readonly chartGroupBy: UsageChartGroupBy;
+  readonly onChartGroupByChange: (groupBy: UsageChartGroupBy) => void;
 }): ReactNode {
-  const { query } = props;
+  const { query, chartGroupBy, onChartGroupByChange } = props;
 
   if (query.isLoading) {
     return (
@@ -148,13 +163,18 @@ function EpicUsageDialogBody(props: {
 
   const { summary, coverage, servedBy } = query.data;
   const days = daysForSummaryWindow(summary);
-  const scale = buildUsageSeriesScaleForBuckets(summary.buckets, "harness");
+  // One scale, keyed by the reader's grouping. Unlike the Settings
+  // dashboard - where the harness split beside the headline needs a
+  // harness-keyed scale of its own regardless of what the chart shows - the
+  // chart is this dialog's only consumer of the scale, so there is no second
+  // one to keep pinned to harnesses.
+  const scale = buildUsageSeriesScaleForBuckets(summary.buckets, chartGroupBy);
   const columns = buildUsageChartColumns({
     days,
     buckets: summary.buckets,
     scale,
     metric: "cost",
-    groupBy: "harness",
+    groupBy: chartGroupBy,
   });
 
   return (
@@ -168,13 +188,29 @@ function EpicUsageDialogBody(props: {
         hostScopeName={null}
         size="default"
       />
+      {/* The toggle lives inside this guard, not beside the window picker
+          above: with no facts there is no chart for it to regroup, and a
+          control that changes nothing visible reads as broken. */}
       {summary.totals.factCount === 0 ? null : (
-        <UsageDailyChart
-          columns={columns}
-          scale={scale}
-          metric="cost"
-          groupBy="harness"
-        />
+        <div className="flex flex-col gap-2">
+          <div className="flex justify-end">
+            <UsageChartGroupByToggle
+              groupBy={chartGroupBy}
+              onChange={onChartGroupByChange}
+            />
+          </div>
+          {/* `key` per the prop's contract: the legend's hidden-series set is
+              keyed by the current grouping's series keys, so a switch
+              remounts rather than letting stale harness keys filter model
+              bands. */}
+          <UsageDailyChart
+            key={chartGroupBy}
+            columns={columns}
+            scale={scale}
+            metric="cost"
+            groupBy={chartGroupBy}
+          />
+        </div>
       )}
       <div>
         <h3 className="mb-2 text-ui-sm font-medium text-foreground">


### PR DESCRIPTION
## Summary

The Settings usage dashboard gained a Harness/Model toggle over its daily chart in #1168; the epic usage dialog kept the same chart pinned to `"harness"` with no way to ask the other question. Same reader, same chart, two different answers depending on where it was opened. This wires the existing `UsageChartGroupByToggle` into the epic dialog.

- grouping is held in `EpicUsageDialog`, not its body: Radix unmounts `DialogContent` while closed, so a selection held in the body would silently reset on every reopen — the same reason the window picker's state lives there
- the series scale is keyed by the reader's grouping. Unlike the Settings panel, where the harness split beside the headline needs a harness-keyed scale of its own regardless of the chart, the chart is this dialog's only consumer of the scale
- the toggle stays inside the `factCount === 0` guard — with no chart to regroup, a control that changes nothing visible reads as broken
- the chart remounts on switch (`key={chartGroupBy}`) per the prop's contract, so the legend's hidden-series set cannot filter model bands with stale harness keys

## Related issue

Follow-up to #1168.

## Validation

- `epic-usage-dialog` suite: 7/7 green; React Compiler variant 10/10
- new coverage: the default harness series regroup to model series after clicking the toggle, and a no-facts window renders no toggle at all
- pre-commit affected build, compile, lint, and format checks

## Checklist

- [x] Pre-commit static checks pass
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off per the DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)
