### PR TITLE
fix(gui-app): label worktree hover metadata as a snapshot

### DIFF
--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
@@ -32,7 +32,7 @@ vi.mock("@/hooks/worktree/use-worktree-owner-metadata-query", () => ({
     workspaces: [],
     isPending: false,
     error: null,
-    checkedAt: null,
+    checkedAt: 1_700_000_000_000,
     isRefreshing: false,
     refresh: refreshSpy,
   }),
@@ -108,6 +108,17 @@ describe("WorktreeOwnerMetadataTooltip hover gate", () => {
     expect(
       screen.getByTestId("chat-navigator-hover-title-owner-1").textContent,
     ).toBe("A complete chat title that should remain visible");
+  });
+
+  it("labels the row age as a workspace snapshot, not a fresh GitHub check", () => {
+    const trigger = renderTooltip(undefined);
+
+    hoverIn(trigger);
+    settleOpenDelay();
+
+    const label = screen.getByTestId("owner-workspace-checked-at").textContent;
+    expect(label).toMatch(/^Workspace snapshot /u);
+    expect(label).not.toContain("Checked");
   });
 
   it("swallows an open that lands after the press (the reported race)", () => {

--- a/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
@@ -340,7 +340,7 @@ function OwnerMetadataCheckedAtText(props: {
       className="text-ui-xs whitespace-nowrap text-muted-foreground"
       data-testid="owner-workspace-checked-at"
     >
-      Checked {relative}
+      Workspace snapshot {relative}
     </span>
   );
 }

--- a/clients/gui-app/src/hooks/worktree/__tests__/use-worktree-owner-metadata-query.test.tsx
+++ b/clients/gui-app/src/hooks/worktree/__tests__/use-worktree-owner-metadata-query.test.tsx
@@ -118,7 +118,8 @@ describe("useWorktreeOwnerMetadata", () => {
   it("ignores LEGACY_HOST_RESOLVED_AT rather than rendering it as an age", async () => {
     // A host predating `resolvedAt` gets its rows bridged to the literal `1`.
     // That is a resolved-MARKER, not a time: taken as one it is 1 Jan 1970, so
-    // the card would read "Checked 56y ago" on facts fetched a second ago. It
+    // the card would read "Workspace snapshot 56y ago" on facts fetched a
+    // second ago. It
     // is also the smallest possible value, so a plain `Math.min` would let one
     // legacy folder swallow every real timestamp beside it.
     const fixture = createFixture({

--- a/clients/gui-app/src/hooks/worktree/use-worktree-owner-metadata-query.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-owner-metadata-query.ts
@@ -179,8 +179,9 @@ export interface WorktreeOwnerMetadata {
    *
    * Deliberately the rows' own `resolvedAt` and not the query's client-side
    * `dataUpdatedAt`: the card unmounts on close, so every re-open refetches and
-   * `dataUpdatedAt` is always ~now - it reported "Checked now" forever while
-   * the host was serving facts from its TTL cache that could be an hour old.
+   * `dataUpdatedAt` is always ~now - it made the workspace snapshot appear
+   * current forever while the host was serving facts from its TTL cache that
+   * could be an hour old.
    * Staleness is the entire point of the label, so it has to come from the
    * side that actually does the deriving.
    */


### PR DESCRIPTION
## Summary
- rename the hover-card timestamp to “Workspace snapshot” so it no longer implies an immediate GitHub check
- keep the explanatory copy aligned with the snapshot semantics
- cover the displayed label in the hover-card regression test

## Verification
- bun run --filter @traycer-clients/gui-app test src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx