### PR TITLE
fix(gui-app,desktop): prevent renderer memory leaks

### DIFF
--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -49,6 +49,8 @@ interface FakeBridgeHandle {
     readonly bytes: ArrayBuffer;
   }>;
   emit(snapshot: LocalHostSnapshot | null): void;
+  emitSystemResumed(): void;
+  systemResumedBridgeSubscriptionCount(): number;
 }
 
 function buildFakeBridge(
@@ -57,6 +59,7 @@ function buildFakeBridge(
   let lastEmitted: LocalHostSnapshot | null = initialSnapshot;
   let firstSubscriberServed = false;
   const handlers = new Set<(snapshot: LocalHostSnapshot | null) => void>();
+  const systemResumedHandlers = new Set<() => void>();
 
   const tokenSlot = { value: null as string | null };
   const respawnCounter = { count: 0 };
@@ -142,9 +145,14 @@ function buildFakeBridge(
         },
       };
     },
-    onSystemResumed: (_handler: () => void) => ({
-      dispose: () => undefined,
-    }),
+    onSystemResumed: (handler: () => void) => {
+      systemResumedHandlers.add(handler);
+      return {
+        dispose: () => {
+          systemResumedHandlers.delete(handler);
+        },
+      };
+    },
     requestHostRespawn: async () => {
       respawnCounter.count += 1;
       return { kind: "restarted" as const };
@@ -561,6 +569,14 @@ function buildFakeBridge(
       for (const handler of handlers) {
         handler(snapshot);
       }
+    },
+    emitSystemResumed(): void {
+      for (const handler of systemResumedHandlers) {
+        handler();
+      }
+    },
+    systemResumedBridgeSubscriptionCount(): number {
+      return systemResumedHandlers.size;
     },
   };
 }
@@ -997,5 +1013,35 @@ describe("DesktopRunnerHost.onLocalHostChange", () => {
       late.push(snapshot);
     });
     expect(late).toEqual([validSnapshot]);
+  });
+});
+
+describe("DesktopRunnerHost.onSystemResumed", () => {
+  it("fans out through one bridge subscription and releases it on dispose", () => {
+    const fake = buildFakeBridge(null);
+    const host = new DesktopRunnerHost({
+      bridge: fake.bridge,
+      signInUrl: "https://auth.example.invalid/sign-in",
+    });
+    const calls = Array.from({ length: 12 }, () => vi.fn());
+    const subscriptions = calls.map((handler) => host.onSystemResumed(handler));
+
+    expect(fake.systemResumedBridgeSubscriptionCount()).toBe(1);
+    fake.emitSystemResumed();
+    for (const handler of calls) expect(handler).toHaveBeenCalledTimes(1);
+
+    subscriptions[0]?.dispose();
+    fake.emitSystemResumed();
+    expect(calls[0]).toHaveBeenCalledTimes(1);
+    for (const handler of calls.slice(1)) {
+      expect(handler).toHaveBeenCalledTimes(2);
+    }
+
+    host.dispose();
+    expect(fake.systemResumedBridgeSubscriptionCount()).toBe(0);
+    fake.emitSystemResumed();
+    for (const handler of calls.slice(1)) {
+      expect(handler).toHaveBeenCalledTimes(2);
+    }
   });
 });

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -602,6 +602,7 @@ export class DesktopRunnerHost implements IRunnerHost {
   private readonly localHostHandlers = new Set<
     (snapshot: LocalHostSnapshot | null) => void
   >();
+  private readonly systemResumedHandlers = new Set<() => void>();
   private readonly bridgeSubscriptions: Disposable[] = [];
 
   constructor(options: DesktopRunnerHostOptions) {
@@ -632,6 +633,11 @@ export class DesktopRunnerHost implements IRunnerHost {
         this.cachedLocalHost = snapshot;
         for (const handler of this.localHostHandlers) {
           handler(snapshot);
+        }
+      }),
+      this.bridge.onSystemResumed(() => {
+        for (const handler of this.systemResumedHandlers) {
+          handler();
         }
       }),
     );
@@ -889,10 +895,12 @@ export class DesktopRunnerHost implements IRunnerHost {
   }
 
   onSystemResumed(handler: () => void): Disposable {
-    // Pure pass-through to the preload bridge's per-event subscription; the
-    // caller owns the returned Disposable (unlike `onLocalHostChange`, there
-    // is no cached snapshot to replay on subscribe).
-    return toDisposable(this.bridge.onSystemResumed(handler));
+    this.systemResumedHandlers.add(handler);
+    return {
+      dispose: () => {
+        this.systemResumedHandlers.delete(handler);
+      },
+    };
   }
 
   requestHostRespawn(): Promise<HostRestartRequestResult> {
@@ -905,6 +913,7 @@ export class DesktopRunnerHost implements IRunnerHost {
       subscription?.dispose();
     }
     this.localHostHandlers.clear();
+    this.systemResumedHandlers.clear();
   }
 
   private buildHostPicker(): IHostPicker {

--- a/clients/gui-app/src/components/chat/__tests__/chat-message-stopped-boundary-integration.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-stopped-boundary-integration.test.tsx
@@ -109,7 +109,7 @@ const displayContext: RenderedMessagesDisplayContext = {
   }),
   resolveAgentReasoningLabel: (_sender, reasoningEffort) =>
     reasoningEffort === null ? null : `Resolved ${reasoningEffort}`,
-  contentBlocksText: () => "",
+  contentBlocksPreview: () => "",
 };
 
 function userMessage(messageId: string): Extract<Message, { role: "user" }> {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -136,7 +136,7 @@ import { useSetupTerminalListRefreshDriver } from "@/hooks/chats/use-setup-termi
 import { useSetupTerminalTabRegisterDriver } from "@/hooks/chats/use-setup-terminal-tab-register-driver";
 import { useCloneSourceOwnerUserId } from "@/hooks/chats/use-clone-source-owner";
 import { type InitialChatHandoffScope } from "@/stores/epics/initial-chat-handoff-store";
-import { contentBlocksText } from "@/lib/chat/content-block-text";
+import { contentBlocksPreview } from "@/lib/chat/content-block-text";
 import {
   buildSubmittedChatJSONContent,
   type SlashCommandCatalog,
@@ -1410,7 +1410,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         resolveAgentSenderDisplay(sender, displayContext),
       resolveAgentReasoningLabel: (sender, reasoningEffort) =>
         resolveAgentReasoningLabel(sender, reasoningEffort, displayContext),
-      contentBlocksText,
+      contentBlocksPreview,
     }),
     [displayContext],
   );

--- a/clients/gui-app/src/lib/chat/__tests__/content-block-text.test.ts
+++ b/clients/gui-app/src/lib/chat/__tests__/content-block-text.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { ContentBlock } from "@traycer/protocol/persistence/epic/schemas";
-import { contentBlocksText } from "@/lib/chat/content-block-text";
+import { contentBlocksPreview } from "@/lib/chat/content-block-text";
 
-describe("contentBlocksText", () => {
+describe("contentBlocksPreview", () => {
   it("falls back to the plain text for an ordinary text block", () => {
     const blocks: ReadonlyArray<ContentBlock> = [
       {
@@ -15,7 +15,7 @@ describe("contentBlocksText", () => {
       },
     ];
 
-    expect(contentBlocksText(blocks)).toBe("Hello there.");
+    expect(contentBlocksPreview(blocks)).toBe("Hello there.");
   });
 
   it("includes provider notice title, message, and detail label/value text", () => {
@@ -43,9 +43,45 @@ describe("contentBlocksText", () => {
       },
     ];
 
-    const text = contentBlocksText(blocks);
+    const text = contentBlocksPreview(blocks);
     expect(text).toContain("Model changed");
     expect(text).toContain("Codex switched from gpt-5 to gpt-5-safe.");
     expect(text).toContain("Reason: highRiskCyberActivity");
+  });
+
+  it("retains only a bounded preview of a very large text block", () => {
+    const blocks: ReadonlyArray<ContentBlock> = [
+      {
+        type: "text",
+        blockId: "large-text",
+        status: "completed",
+        timestamp: 1,
+        text: `Reply ${"x".repeat(500_000)}`,
+        providerNotice: null,
+      },
+    ];
+
+    const preview = contentBlocksPreview(blocks);
+    expect(preview.length).toBeLessThanOrEqual(201);
+    expect(preview.startsWith("Reply xxx")).toBe(true);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("does not retain a full copy of a large reasoning block", () => {
+    const blocks: ReadonlyArray<ContentBlock> = [
+      {
+        type: "reasoning",
+        blockId: "large-reasoning",
+        status: "completed",
+        timestamp: 1,
+        startedAt: null,
+        content: "r".repeat(500_000),
+      },
+    ];
+
+    const preview = contentBlocksPreview(blocks);
+    expect(preview.length).toBeLessThanOrEqual(201);
+    expect(preview.startsWith("Reasoning rrr")).toBe(true);
+    expect(preview.endsWith("…")).toBe(true);
   });
 });

--- a/clients/gui-app/src/lib/chat/content-block-text.ts
+++ b/clients/gui-app/src/lib/chat/content-block-text.ts
@@ -1,138 +1,269 @@
-import type {
-  ApprovalBlock,
-  CompactionBlock,
-  ContentBlock,
-  InterviewBlock,
-  PlanBlock,
-  SteerBlock,
-  SubAgentBlock,
-  TodoBlock,
-} from "@traycer/protocol/persistence/epic/schemas";
-import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
+import type { ContentBlock } from "@traycer/protocol/persistence/epic/schemas";
+import type { JsonContent } from "@traycer/protocol/common/registry";
 import { isRenderableSubAgentBlock } from "./subagent-blocks";
 
-export function contentBlocksText(blocks: ReadonlyArray<ContentBlock>): string {
+const CONTENT_BLOCKS_PREVIEW_MAX_CHARS = 200;
+const CONTENT_BLOCKS_PREVIEW_SOURCE_SCAN_LIMIT = 16_384;
+const WHITESPACE_RE = /\s/;
+
+/**
+ * Builds the small assistant-row text projection used by the turn minimap.
+ * The message body itself renders from structured segments, so retaining a
+ * second, fully joined copy of every block only makes the transcript larger.
+ */
+export function contentBlocksPreview(
+  blocks: ReadonlyArray<ContentBlock>,
+): string {
   if (blocks.length === 0) return "Working...";
-  return blocks
-    .flatMap((block) => {
-      const text = contentBlockText(block);
-      return text.length > 0 ? [text] : [];
-    })
-    .join("\n\n");
+  const preview = new ContentBlocksPreviewBuilder();
+  for (const block of blocks) {
+    if (preview.stopped) break;
+    preview.append("\n\n");
+    appendContentBlockPreview(preview, block);
+  }
+  return preview.finish();
 }
 
-function contentBlockText(block: ContentBlock): string {
+class ContentBlocksPreviewBuilder {
+  private output = "";
+  private pendingSpace = false;
+  private sourceUnitsRead = 0;
+  private truncated = false;
+
+  get stopped(): boolean {
+    return this.truncated;
+  }
+
+  get visibleLength(): number {
+    return this.output.length;
+  }
+
+  append(text: string): void {
+    if (text.length === 0 || this.truncated) return;
+    const remainingSourceUnits =
+      CONTENT_BLOCKS_PREVIEW_SOURCE_SCAN_LIMIT - this.sourceUnitsRead;
+    if (remainingSourceUnits <= 0) {
+      this.truncated = true;
+      return;
+    }
+
+    const scanLength = Math.min(text.length, remainingSourceUnits);
+    for (let index = 0; index < scanLength; index += 1) {
+      this.sourceUnitsRead += 1;
+      const character = text[index];
+      if (WHITESPACE_RE.test(character)) {
+        if (this.output.length > 0) this.pendingSpace = true;
+        continue;
+      }
+      if (this.pendingSpace) {
+        this.output += " ";
+        this.pendingSpace = false;
+      }
+      this.output += character;
+      if (this.output.length > CONTENT_BLOCKS_PREVIEW_MAX_CHARS + 1) {
+        this.truncated = true;
+        return;
+      }
+    }
+    if (scanLength < text.length) this.truncated = true;
+  }
+
+  finish(): string {
+    if (this.output.length === 0) return "";
+    if (
+      !this.truncated &&
+      this.output.length <= CONTENT_BLOCKS_PREVIEW_MAX_CHARS
+    ) {
+      return this.output;
+    }
+    return `${sliceWholeCodePoints(
+      this.output,
+      CONTENT_BLOCKS_PREVIEW_MAX_CHARS,
+    ).trimEnd()}…`;
+  }
+}
+
+function sliceWholeCodePoints(text: string, maxUnits: number): string {
+  const cut = text.slice(0, maxUnits);
+  const last = cut.charCodeAt(cut.length - 1);
+  const endsOnLeadingSurrogate = last >= 0xd800 && last <= 0xdbff;
+  return endsOnLeadingSurrogate ? cut.slice(0, -1) : cut;
+}
+
+function appendContentBlockPreview(
+  preview: ContentBlocksPreviewBuilder,
+  block: ContentBlock,
+): void {
   switch (block.type) {
-    case "text":
-      return textBlockText(block);
+    case "text": {
+      const notice = block.providerNotice;
+      if (notice === null) {
+        preview.append(block.text);
+        return;
+      }
+      appendSeparated(preview, [notice.title, notice.message ?? ""], " · ");
+      for (const detail of notice.details) {
+        if (detail.label.length === 0 && detail.value.length === 0) continue;
+        preview.append(" · ");
+        appendSeparated(preview, [detail.label, detail.value], ": ");
+      }
+      return;
+    }
     case "reasoning":
-      return `Reasoning\n${block.content}`;
+      preview.append("Reasoning\n");
+      preview.append(block.content);
+      return;
     case "tool_call":
-      return `Tool: ${block.toolName}`;
+      preview.append("Tool: ");
+      preview.append(block.toolName);
+      return;
     case "file_change":
-      return `File change: ${block.filePath}`;
+      preview.append("File change: ");
+      preview.append(block.filePath);
+      return;
     case "command":
-      return `$ ${block.command}`;
-    case "subagent":
-      return subAgentBlockText(block);
+      preview.append("$ ");
+      preview.append(block.command);
+      return;
+    default:
+      appendStructuredContentBlockPreview(preview, block);
+  }
+}
+
+type StructuredContentBlock = Exclude<
+  ContentBlock,
+  { type: "text" | "reasoning" | "tool_call" | "file_change" | "command" }
+>;
+
+function appendStructuredContentBlockPreview(
+  preview: ContentBlocksPreviewBuilder,
+  block: StructuredContentBlock,
+): void {
+  switch (block.type) {
+    case "subagent": {
+      if (!isRenderableSubAgentBlock(block)) return;
+      preview.append(block.result ?? block.task ?? "Subagent");
+      return;
+    }
     case "approval":
-      return approvalBlockText(block);
+      preview.append(block.description ?? "Approval requested");
+      return;
     case "todo":
-      return todoBlockText(block);
+      for (const item of block.items) {
+        preview.append(item.status);
+        preview.append(": ");
+        preview.append(item.text);
+        preview.append("\n");
+      }
+      return;
     case "plan":
-      return planBlockText(block);
+      preview.append(block.markdownPreview);
+      return;
     case "error":
-      return block.message;
+      preview.append(block.message);
+      return;
+    default:
+      appendLifecycleContentBlockPreview(preview, block);
+  }
+}
+
+type LifecycleContentBlock = Exclude<
+  StructuredContentBlock,
+  { type: "subagent" | "approval" | "todo" | "plan" | "error" }
+>;
+
+function appendLifecycleContentBlockPreview(
+  preview: ContentBlocksPreviewBuilder,
+  block: LifecycleContentBlock,
+): void {
+  switch (block.type) {
     case "compaction":
-      return compactionBlockText(block);
-    case "autonomous_resume":
-      return autonomousResumeBlockText(block);
+      preview.append(
+        block.status === "errored"
+          ? (block.error ?? "Context compaction failed")
+          : (block.summary ?? "Context compacted"),
+      );
+      return;
+    case "autonomous_resume": {
+      if (block.triggers.length === 0) {
+        preview.append("Resumed");
+        return;
+      }
+      preview.append("Resumed: ");
+      for (const trigger of block.triggers) {
+        preview.append(trigger.title);
+        preview.append(" ");
+        preview.append(trigger.status);
+        preview.append("; ");
+      }
+      return;
+    }
     case "interview":
-      return interviewBlockText(block);
+      preview.append(block.title ?? block.description ?? "Interview requested");
+      return;
     case "steer":
-      return steerBlockText(block);
-    case "artifact_operation":
-      return artifactOperationBlockText(block);
+      appendComposerContentPreview(preview, block.content);
+      return;
+    case "artifact_operation": {
+      switch (block.operation) {
+        case "create":
+          preview.append("Created ");
+          break;
+        case "update":
+          preview.append("Updated ");
+          break;
+        case "delete":
+          preview.append("Deleted ");
+          break;
+      }
+      preview.append(block.kind);
+      return;
+    }
   }
 }
 
-function textBlockText(block: Extract<ContentBlock, { type: "text" }>): string {
-  const notice = block.providerNotice;
-  return notice === null ? block.text : providerNoticeText(notice);
-}
-
-function providerNoticeText(
-  notice: NonNullable<
-    Extract<ContentBlock, { type: "text" }>["providerNotice"]
-  >,
-): string {
-  const detailParts = (detail: (typeof notice.details)[number]) => {
-    const parts = [detail.label, detail.value].filter(
-      (part) => part.length > 0,
-    );
-    return parts.length === 0 ? [] : [parts.join(": ")];
-  };
-
-  return [
-    notice.title,
-    notice.message ?? "",
-    ...notice.details.flatMap(detailParts),
-  ]
-    .filter((part) => part.length > 0)
-    .join(" · ");
-}
-
-function autonomousResumeBlockText(
-  block: Extract<ContentBlock, { type: "autonomous_resume" }>,
-): string {
-  if (block.triggers.length === 0) return "Resumed";
-  return `Resumed: ${block.triggers
-    .map((trigger) => `${trigger.title} ${trigger.status}`)
-    .join("; ")}`;
-}
-
-function artifactOperationBlockText(
-  block: Extract<ContentBlock, { type: "artifact_operation" }>,
-): string {
-  switch (block.operation) {
-    case "create":
-      return `Created ${block.kind}`;
-    case "update":
-      return `Updated ${block.kind}`;
-    case "delete":
-      return `Deleted ${block.kind}`;
+function appendSeparated(
+  preview: ContentBlocksPreviewBuilder,
+  values: ReadonlyArray<string>,
+  separator: string,
+): void {
+  let appended = false;
+  for (const value of values) {
+    if (value.length === 0) continue;
+    if (appended) preview.append(separator);
+    preview.append(value);
+    appended = true;
   }
 }
 
-function subAgentBlockText(block: SubAgentBlock): string {
-  if (!isRenderableSubAgentBlock(block)) return "";
-  return block.result ?? block.task ?? "Subagent";
-}
-
-function approvalBlockText(block: ApprovalBlock): string {
-  return block.description ?? "Approval requested";
-}
-
-function todoBlockText(block: TodoBlock): string {
-  return block.items.map((item) => `${item.status}: ${item.text}`).join("\n");
-}
-
-function planBlockText(block: PlanBlock): string {
-  return block.markdownPreview;
-}
-
-function compactionBlockText(block: CompactionBlock): string {
-  if (block.status === "errored") {
-    return block.error ?? "Context compaction failed";
+function appendComposerContentPreview(
+  preview: ContentBlocksPreviewBuilder,
+  content: JsonContent,
+): void {
+  const visibleLengthBefore = preview.visibleLength;
+  appendComposerNodesPreview(preview, content.content ?? []);
+  if (preview.visibleLength === visibleLengthBefore) {
+    preview.append("Follow-up queued");
   }
-  return block.summary ?? "Context compacted";
 }
 
-function interviewBlockText(block: InterviewBlock): string {
-  return block.title ?? block.description ?? "Interview requested";
-}
-
-function steerBlockText(block: SteerBlock): string {
-  const text = extractPlainTextFromComposerJSONContent(block.content).trim();
-  return text.length === 0 ? "Follow-up queued" : text;
+function appendComposerNodesPreview(
+  preview: ContentBlocksPreviewBuilder,
+  nodes: ReadonlyArray<JsonContent>,
+): void {
+  for (const node of nodes) {
+    if (preview.stopped) return;
+    if (node.type === "text") {
+      preview.append(node.text ?? "");
+    } else if (node.type === "hardBreak") {
+      preview.append("\n");
+    } else if (node.type === "mention" || node.type === "slashCommand") {
+      const label = node.attrs?.label;
+      const name = node.attrs?.name;
+      if (typeof label === "string") preview.append(label);
+      else if (typeof name === "string") preview.append(name);
+    } else {
+      appendComposerNodesPreview(preview, node.content ?? []);
+    }
+  }
 }

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages-assistant-images.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages-assistant-images.test.tsx
@@ -54,7 +54,7 @@ const displayContext: RenderedMessagesDisplayContext = {
     modelLabel: null,
   }),
   resolveAgentReasoningLabel: () => null,
-  contentBlocksText: () => "",
+  contentBlocksPreview: () => "",
 };
 
 function toolCallInputFields(toolName: string, input: unknown) {

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -383,7 +383,7 @@ const displayContext: RenderedMessagesDisplayContext = {
   }),
   resolveAgentReasoningLabel: (_sender, reasoningEffort) =>
     reasoningEffort === null ? null : `Resolved ${reasoningEffort}`,
-  contentBlocksText: () => "",
+  contentBlocksPreview: () => "",
 };
 
 /**

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -94,7 +94,9 @@ export interface RenderedMessagesDisplayContext {
     sender: AgentSender,
     reasoningEffort: string | null,
   ) => string | null;
-  readonly contentBlocksText: (blocks: ReadonlyArray<ContentBlock>) => string;
+  readonly contentBlocksPreview: (
+    blocks: ReadonlyArray<ContentBlock>,
+  ) => string;
 }
 
 export interface RenderedMessagesInput {
@@ -2257,7 +2259,7 @@ function renderAssistantTurnSlice(
   return {
     id: assistantSliceRowId(input.turnKey, input.chunkIndex, input.split),
     role: "assistant",
-    content: input.ctx.contentBlocksText(input.blocks),
+    content: input.ctx.contentBlocksPreview(input.blocks),
     segments: buildAssistantSegments(
       input.blocks,
       input.checkpointView,


### PR DESCRIPTION
## Summary

- replace the unbounded assistant-row `contentBlocksText(...).join()` projection with a directly-built, 200-character bounded preview while preserving complete structured segments for transcript rendering and search
- multiplex all renderer `systemResumed` consumers through one `DesktopRunnerHost` preload subscription and release both individual callbacks and the bridge listener at their lifecycle boundaries
- add regressions for 500,000-character text/reasoning blocks and 12 simultaneous resume consumers

The staging symptom was an Electron renderer OOM and automatic renderer reload, not a full app or host restart. Crashpad reported a full 4 GB V8 cage and captured the fatal allocation in the old content-block `join` path. Reloads also emitted `MaxListenersExceededWarning` for `runnerHost:event:systemResumed`.

The full transcript remains available: persisted blocks and assistant `segments` are unchanged. The bounded string is only the secondary assistant-row projection consumed by the already 200-character turn minimap preview.

## Related issue

No linked issue.

## Validation

- desktop runner-host focused suite: 20 tests passed
- content-block preview focused suite: 4 tests passed, including 500,000-character inputs
- rendered-message and stopped-boundary suites: 115 tests passed
- React Compiler validation suite: 10 tests passed
- affected pre-commit Nx lint/format/build/compile gate passed
- focused GUI ESLint and canonical GUI compile passed

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
