### PR TITLE
fix(shared): bound cloud chat part downloads

### DIFF
--- a/clients/shared/cloud-chat/__tests__/cloud-chat-reader.test.ts
+++ b/clients/shared/cloud-chat/__tests__/cloud-chat-reader.test.ts
@@ -196,6 +196,68 @@ describe("cold read", () => {
 
     await expect(result).rejects.toThrow("synchronous queued failure");
   });
+
+  it("stops dialling queued parts once the read has already failed", async () => {
+    const published = await publishCloudChat({
+      ...DEFAULT_PUBLISH,
+      cohorts: Array.from(
+        { length: CLOUD_CHAT_PART_FETCH_CONCURRENCY + 8 },
+        (_, index) => [userMessage(`m-${index}`)],
+      ),
+    });
+    const serving = servingBehaviour(published);
+    const failingDigest = published.parts[0]?.address.sha256 ?? "";
+    let releaseSaturated: () => void = () => undefined;
+    const saturated = new Promise<void>((resolve) => {
+      releaseSaturated = resolve;
+    });
+    const releases: Array<() => void> = [];
+    let failFirstPart: (reason: Error) => void = () => undefined;
+    let dialled = 0;
+
+    const port: CloudChatReadPort = {
+      resolveHead: () => Promise.resolve(serving.resolve()),
+      readPart: (request) => {
+        dialled += 1;
+        if (request.sha256 === failingDigest) {
+          return new Promise((_resolve, reject) => {
+            failFirstPart = reject;
+          });
+        }
+        return new Promise((resolve) => {
+          releases.push(() => resolve(serving.part(request.sha256)));
+          if (releases.length === CLOUD_CHAT_PART_FETCH_CONCURRENCY - 1) {
+            releaseSaturated();
+          }
+        });
+      },
+    };
+
+    const result = readCloudChat({
+      identity: IDENTITY,
+      port,
+      cache: new InMemoryChatPartCache(),
+      sha256Hex: webCryptoSha256Hex,
+    });
+
+    // Saturate the gate, so the remaining parts are genuinely QUEUED behind it
+    // rather than already dialled, then fail the read.
+    await saturated;
+    failFirstPart(new Error("part transport failure"));
+    await expect(result).rejects.toThrow("part transport failure");
+
+    // Draining the in-flight wave is what would otherwise pull each queued part
+    // in behind it - one `startNext` per completion.
+    for (const release of releases) release();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // A rejected fetch abandons the queue directly, so the failing wave is all
+    // that is ever dialled. The tolerance covers the other failure shape - a
+    // part that RESOLVES and is then rejected by verification - where the read
+    // dies a few microtask hops later and one queued part can slip in first.
+    expect(dialled).toBeLessThanOrEqual(CLOUD_CHAT_PART_FETCH_CONCURRENCY + 1);
+    expect(dialled).toBeLessThan(published.parts.length);
+  });
 });
 
 describe("the incremental read", () => {

--- a/clients/shared/cloud-chat/__tests__/cloud-chat-reader.test.ts
+++ b/clients/shared/cloud-chat/__tests__/cloud-chat-reader.test.ts
@@ -5,8 +5,10 @@ import {
   webCryptoSha256Hex,
 } from "@traycer-clients/shared/cloud-chat/bytes";
 import {
+  CLOUD_CHAT_PART_FETCH_CONCURRENCY,
   readCloudChat,
   type CloudChatRead,
+  type CloudChatReadPort,
 } from "@traycer-clients/shared/cloud-chat/cloud-chat-reader";
 import {
   InMemoryChatPartCache,
@@ -119,6 +121,81 @@ describe("cold read", () => {
       result.outcome.chat.messages.map((message) => message.raw.messageId),
     ).toEqual(["m-user", "m-assistant", "m-user-2", "m-assistant-2"]);
   });
+
+  it("never exceeds the part request concurrency ceiling", async () => {
+    const published = await publishCloudChat({
+      ...DEFAULT_PUBLISH,
+      cohorts: Array.from(
+        { length: CLOUD_CHAT_PART_FETCH_CONCURRENCY + 5 },
+        (_, index) => [userMessage(`m-${index}`)],
+      ),
+    });
+    const serving = servingBehaviour(published);
+    let active = 0;
+    let maximum = 0;
+    const port = recordingPort({
+      resolve: serving.resolve,
+      part: async (sha256) => {
+        active += 1;
+        maximum = Math.max(maximum, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        try {
+          return serving.part(sha256);
+        } finally {
+          active -= 1;
+        }
+      },
+    });
+
+    expect((await read(port, new InMemoryChatPartCache())).outcome.kind).toBe(
+      "ok",
+    );
+    expect(maximum).toBe(CLOUD_CHAT_PART_FETCH_CONCURRENCY);
+    expect(port.partCalls).toHaveLength(published.parts.length);
+  });
+
+  it("settles when queued port work throws synchronously", async () => {
+    const published = await publishCloudChat({
+      ...DEFAULT_PUBLISH,
+      cohorts: Array.from(
+        { length: CLOUD_CHAT_PART_FETCH_CONCURRENCY + 1 },
+        (_, index) => [userMessage(`m-${index}`)],
+      ),
+    });
+    const serving = servingBehaviour(published);
+    const queuedDigest =
+      published.parts[CLOUD_CHAT_PART_FETCH_CONCURRENCY]?.address.sha256 ?? "";
+    let releaseSaturated: () => void = () => undefined;
+    const saturated = new Promise<void>((resolve) => {
+      releaseSaturated = resolve;
+    });
+    const releases: Array<() => void> = [];
+    const port: CloudChatReadPort = {
+      resolveHead: () => Promise.resolve(serving.resolve()),
+      readPart: (request) => {
+        if (request.sha256 === queuedDigest) {
+          throw new Error("synchronous queued failure");
+        }
+        return new Promise((resolve) => {
+          releases.push(() => resolve(serving.part(request.sha256)));
+          if (releases.length === CLOUD_CHAT_PART_FETCH_CONCURRENCY) {
+            releaseSaturated();
+          }
+        });
+      },
+    };
+
+    const result = readCloudChat({
+      identity: IDENTITY,
+      port,
+      cache: new InMemoryChatPartCache(),
+      sha256Hex: webCryptoSha256Hex,
+    });
+    await saturated;
+    releases[0]?.();
+
+    await expect(result).rejects.toThrow("synchronous queued failure");
+  });
 });
 
 describe("the incremental read", () => {
@@ -204,6 +281,33 @@ describe("the incremental read", () => {
     expect(await cache.get(published.parts[0].address.sha256)).toEqual(
       published.parts[0].bytes,
     );
+  });
+
+  it("resumes after a failed part without refetching verified siblings", async () => {
+    const published = await publishCloudChat(DEFAULT_PUBLISH);
+    const serving = servingBehaviour(published);
+    const cache = new InMemoryChatPartCache();
+    const failedDigest = published.parts[1].address.sha256;
+    let shouldFail = true;
+    const firstPort = recordingPort({
+      resolve: serving.resolve,
+      part: async (sha256) => {
+        if (sha256 === failedDigest && shouldFail) {
+          shouldFail = false;
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          throw new Error("transient part failure");
+        }
+        return serving.part(sha256);
+      },
+    });
+
+    await expect(read(firstPort, cache)).rejects.toThrow(
+      "transient part failure",
+    );
+
+    const retryPort = recordingPort(serving);
+    expect((await read(retryPort, cache)).outcome.kind).toBe("ok");
+    expect(retryPort.partCalls).toEqual([failedDigest]);
   });
 
   it("does not cache bytes that fail their own content address", async () => {

--- a/clients/shared/cloud-chat/cloud-chat-reader.ts
+++ b/clients/shared/cloud-chat/cloud-chat-reader.ts
@@ -101,6 +101,9 @@ export interface ReadCloudChatOptions {
   readonly sha256Hex: Sha256Hex;
 }
 
+/** Maximum simultaneous part downloads for one cloud-chat materialization. */
+export const CLOUD_CHAT_PART_FETCH_CONCURRENCY = 12;
+
 // ---- Outcomes ----------------------------------------------------------- //
 
 export type CloudChatReadOutcome =
@@ -274,10 +277,11 @@ export async function readCloudChat(
   // port, so a refusal here reaches `fetchPart` zero times. That is structural
   // rather than a discipline this module keeps, which is what makes "no part
   // egress for a chat we cannot read" assertable as a call count.
+  const partFetchGate = new ConcurrencyGate(CLOUD_CHAT_PART_FETCH_CONCURRENCY);
   const assembly = await assembleChat({
     head: decoded.record,
     readerSupports: CHAT_SYNC_READER_VERSION,
-    fetch: (request) => stagePart(request, options),
+    fetch: (request) => stagePart(request, options, partFetchGate),
   }).catch((error: unknown) => {
     if (error instanceof PartUnavailableError) return error;
     if (error instanceof PartOversizedError) return error;
@@ -382,6 +386,7 @@ class PartOversizedError extends Error {
 async function stagePart(
   request: ChatPartRequest,
   options: ReadCloudChatOptions,
+  partFetchGate: ConcurrencyGate,
 ): Promise<StagedChatPart> {
   const cached = await options.cache.get(request.part.sha256);
   if (cached !== null) {
@@ -396,12 +401,14 @@ async function stagePart(
     if (matchesRequestedPart(staged, request)) return staged;
   }
 
-  const response = await options.port.readPart({
-    identity: options.identity,
-    sha256: request.part.sha256,
-    // From the HEAD, so the host can bound the transfer without parsing it.
-    declaredByteLength: request.part.byteLength,
-  });
+  const response = await partFetchGate.run(() =>
+    options.port.readPart({
+      identity: options.identity,
+      sha256: request.part.sha256,
+      // From the HEAD, so the host can bound the transfer without parsing it.
+      declaredByteLength: request.part.byteLength,
+    }),
+  );
 
   if (response.outcome.status === "not-found") {
     throw new PartUnavailableError(
@@ -506,4 +513,31 @@ function corruptRead(
       diagnostic,
     },
   };
+}
+
+type QueuedWork = () => void;
+
+/** Small per-read semaphore; completion order remains assembly's concern. */
+class ConcurrencyGate {
+  private active = 0;
+  private readonly queued: QueuedWork[] = [];
+
+  constructor(private readonly ceiling: number) {}
+
+  run<T>(work: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const start = (): void => {
+        this.active += 1;
+        Promise.resolve()
+          .then(work)
+          .then(resolve, reject)
+          .finally(() => {
+            this.active -= 1;
+            this.queued.shift()?.();
+          });
+      };
+      if (this.active < this.ceiling) start();
+      else this.queued.push(start);
+    });
+  }
 }

--- a/clients/shared/cloud-chat/cloud-chat-reader.ts
+++ b/clients/shared/cloud-chat/cloud-chat-reader.ts
@@ -282,11 +282,17 @@ export async function readCloudChat(
     head: decoded.record,
     readerSupports: CHAT_SYNC_READER_VERSION,
     fetch: (request) => stagePart(request, options, partFetchGate),
-  }).catch((error: unknown) => {
-    if (error instanceof PartUnavailableError) return error;
-    if (error instanceof PartOversizedError) return error;
-    throw error;
-  });
+  })
+    .catch((error: unknown) => {
+      if (error instanceof PartUnavailableError) return error;
+      if (error instanceof PartOversizedError) return error;
+      throw error;
+    })
+    // The read is over either way, so nothing queued behind the ceiling is
+    // still wanted. On the failure path this is what stops a dead read from
+    // spending the rest of the chat's egress; on the success path every part
+    // has already run, so it is a no-op.
+    .finally(() => partFetchGate.abandonQueued());
 
   if (assembly instanceof PartOversizedError) {
     return {
@@ -515,29 +521,83 @@ function corruptRead(
   };
 }
 
-type QueuedWork = () => void;
+type QueuedWork = {
+  readonly start: () => void;
+  readonly drop: (reason: Error) => void;
+};
+
+/** Raised for queued parts a settled read no longer needs. */
+class PartFetchAbandonedError extends Error {
+  constructor() {
+    super("cloud-chat-reader: part fetch abandoned after the read settled");
+    this.name = "PartFetchAbandonedError";
+  }
+}
 
 /** Small per-read semaphore; completion order remains assembly's concern. */
 class ConcurrencyGate {
   private active = 0;
   private readonly queued: QueuedWork[] = [];
+  private abandoned: Error | null = null;
 
   constructor(private readonly ceiling: number) {}
 
   run<T>(work: () => Promise<T>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
+      if (this.abandoned !== null) {
+        reject(this.abandoned);
+        return;
+      }
       const start = (): void => {
         this.active += 1;
         Promise.resolve()
           .then(work)
-          .then(resolve, reject)
+          .then(resolve, (error: unknown) => {
+            // This gate serves exactly one `assembleChat`, and that fails the
+            // whole read on the first bad part - so a rejected fetch means
+            // nothing still queued can be wanted. Abandoning here rather than
+            // waiting for the outer `finally` matters because this callback
+            // runs several microtask hops earlier: otherwise the completing
+            // request's own dequeue admits one more part on the way out.
+            // Reject BEFORE abandoning: `assembleChat` reports whichever part
+            // promise settles first, and the caller must see the real transport
+            // failure rather than this gate's synthetic abandonment reason.
+            reject(error);
+            this.abandonQueued();
+          })
           .finally(() => {
             this.active -= 1;
-            this.queued.shift()?.();
+            this.startNext();
           });
       };
       if (this.active < this.ceiling) start();
-      else this.queued.push(start);
+      else this.queued.push({ start, drop: reject });
     });
+  }
+
+  /**
+   * Stop admitting queued parts, because the read they belong to has already
+   * settled.
+   *
+   * `assembleChat` fails the whole read on the FIRST bad part, so without this
+   * every queued part would still be dialled afterwards: a 400-part chat that
+   * fails on part 3 would go on to fetch the other ~388 for a transcript no
+   * caller can still receive. Worse, the GUI retries a failed read twice
+   * (`use-cloud-chat-queries.ts`), and each attempt builds its own gate - so
+   * abandoned gates draining alongside live ones put far more than `ceiling`
+   * requests in flight, defeating the bound this class exists to impose.
+   *
+   * Requests already started are left alone: cancelling them buys nothing (the
+   * bytes are in flight) and their results still populate any caller cache.
+   */
+  abandonQueued(): void {
+    if (this.abandoned !== null) return;
+    this.abandoned = new PartFetchAbandonedError();
+    for (const entry of this.queued.splice(0)) entry.drop(this.abandoned);
+  }
+
+  private startNext(): void {
+    if (this.abandoned !== null) return;
+    this.queued.shift()?.start();
   }
 }


### PR DESCRIPTION
Bounds the fan-out when a cloud chat is materialized from its head.

## Problem

`assembleChat` builds its request list from the head and fires **every**
part through one `Promise.all`. The protocol module reserves the ceiling
for its callers by contract — *"a caller that needs a concurrency ceiling
imposes it inside its own port"* — but this reader never imposed one.

Measured against real published heads, converged chats run ~250 KiB/part
(a 20.5 MiB chat is 82 parts). A 100 MB chat is ~400 parts, so reading one
opened ~400 simultaneous HTTP requests.

## Change

A small per-materialization semaphore in the reader's own fetch port,
capped at 12 in flight. `assembleChat` is untouched: the gate wraps only
the network leg inside `stagePart`, so cache hits never consume a slot,
and the existing gate → verify → head-order assembly pipeline is
unchanged.

Queued work is invoked via `Promise.resolve().then(work)` so a synchronous
throw rejects and releases its slot rather than stranding the caller's
promise and leaking a permit.

## Notes

- No protocol change. The head already names every part by digest.
- No integrity property is weakened: per-part digest/length verification,
  head-order assembly, and fail-closed-on-mismatch all behave as before.
  The existing property test — the same head assembles identically under
  any completion order — covers reordering under a ceiling and stays green.
- The host side of this work (a content-addressed resume store, retention,
  and fetch deadlines) lives in the internal repo and depends on this
  branch only through the submodule pin.

## Verification

`bun run test cloud-chat/__tests__/cloud-chat-reader.test.ts` — 24/24,
including a new max-concurrency counter asserting saturation at exactly
12 and never above it. Ablated: bypassing the gate drives the observed
maximum to 18, turning the test red.
