### PR TITLE
fix(gui-app): derive the global-resources verdict from the stream itself

### DIFF
--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -283,9 +283,16 @@ vi.mock(
       >();
     return {
       ...actual,
-      useGlobalResourcesUnsupported: (claimedHostId: string | null) =>
-        globalResourcesUnsupportedMock.unsupported ??
-        actual.useGlobalResourcesUnsupported(claimedHostId),
+      // Call first, THEN let the mock win — never `mock ?? real()`. `??`
+      // short-circuits, so the real hook (three inner hooks now) would go
+      // uncalled whenever an override is set; a test that flips `unsupported`
+      // on a mounted tree then changes the hook count and React throws
+      // "Rendered fewer hooks than expected". Same shape as the projection
+      // override above.
+      useGlobalResourcesUnsupported: (claimedHostId: string | null) => {
+        const real = actual.useGlobalResourcesUnsupported(claimedHostId);
+        return globalResourcesUnsupportedMock.unsupported ?? real;
+      },
     };
   },
 );

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -283,9 +283,9 @@ vi.mock(
       >();
     return {
       ...actual,
-      useGlobalResourcesUnsupported: () =>
+      useGlobalResourcesUnsupported: (claimedHostId: string | null) =>
         globalResourcesUnsupportedMock.unsupported ??
-        actual.useGlobalResourcesUnsupported(),
+        actual.useGlobalResourcesUnsupported(claimedHostId),
     };
   },
 );

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -641,18 +641,21 @@ function ResourceMonitorContent(props: {
   const scopeUnusable =
     props.hasExplicitPick && !isHostScopeUsable(scope.status);
   // A reachable host whose stream cannot serve this subscription is a THIRD
-  // outcome, and it is terminal: the mount declines to acquire, so nothing will
-  // ever attribute a projection to this machine. Only checked while watching
-  // another one — following the active host, an old host still has the
-  // per-epic fallback, which is genuinely its own data.
+  // outcome, and it is terminal: nothing will ever attribute a usable global
+  // projection to this machine, whether because the mount declined to acquire
+  // or because the stream it did open negotiated a version too old to carry
+  // one. Only checked while watching another host — following the active one,
+  // an old host still has the per-epic fallback, which is genuinely its data.
   //
-  // Gated on the stream actually being BOUND to the pick, because this verdict
-  // is read from whichever client the context is serving. While a pick's own
-  // binding is unresolved (still dialling, or backing off after a close) that
-  // is the AMBIENT one, and an old ambient host would have us report the picked
-  // machine as outdated on evidence collected from a different computer
-  // entirely. Unbound, we have not asked this host anything yet.
-  const resourcesUnsupported = useGlobalResourcesUnsupported();
+  // Gated on the stream actually being BOUND to the pick, because the pre-check
+  // half of this verdict is read from whichever client the context is serving.
+  // While a pick's own binding is unresolved (still dialling, or backing off
+  // after a close) that is the AMBIENT one, and an old ambient host would have
+  // us report the picked machine as outdated on evidence collected from a
+  // different computer entirely. Unbound, we have not asked this host anything
+  // yet. The stream half carries its own, stricter attribution check, since the
+  // registry entry it reads is a singleton that can outlive a swap.
+  const resourcesUnsupported = useGlobalResourcesUnsupported(scope.hostId);
   const streamIncompatible =
     props.streamBoundToScope &&
     watchesNamedHost(scope, props.hasExplicitPick) &&

--- a/clients/gui-app/src/hooks/resources/__tests__/use-global-resources-unsupported.test.tsx
+++ b/clients/gui-app/src/hooks/resources/__tests__/use-global-resources-unsupported.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
+import type { StreamMethodSupport } from "@traycer-clients/shared/host-transport/ws-stream-client";
+import type { ResourcesStreamCallbacks } from "@traycer-clients/shared/host-transport/resources-stream-client";
+import { createResourcesStore } from "@/stores/resources/resources-store";
+import { resourcesRegistry } from "@/stores/resources/resources-registry";
+import { useGlobalResourcesUnsupported } from "@/hooks/resources/use-global-resources-unsupported";
+
+// The pre-check's two inputs, and nothing else. Everything downstream of them -
+// the registry, the store, the verdict plumbing - runs for real, because the
+// composition of the two sources is the entire subject here.
+const streamMock = vi.hoisted(() => ({
+  support: null as StreamMethodSupport | null,
+  version: null as SchemaVersion | null,
+}));
+
+vi.mock("@/lib/host/stream-runtime-context", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/host/stream-runtime-context")>();
+  return {
+    ...actual,
+    useStreamMethodSupport: () => streamMock.support,
+    useStreamMethodSchemaVersion: () => streamMock.version,
+  };
+});
+
+/**
+ * Exactly what `RemoteStreamClient` reports for every method, by design:
+ * `"unknown"` support and no client-wide schema version. This is the shape that
+ * makes the pre-check unable to answer.
+ */
+function pretendRemoteHost(): void {
+  streamMock.support = "unknown";
+  streamMock.version = null;
+}
+
+/** Opens a real global entry for `hostId` and publishes `verdict` through it. */
+function openGlobalStream(
+  hostId: string,
+  verdict: "supported" | "unsupported",
+): void {
+  let captured: ResourcesStreamCallbacks | null = null;
+  const emit = (): ResourcesStreamCallbacks => {
+    if (captured === null) throw new Error("stream callbacks not wired");
+    return captured;
+  };
+  resourcesRegistry.acquireGlobal("token", hostId, () =>
+    createResourcesStore({
+      scope: { kind: "global" },
+      streamClientFactory: (_scope, callbacks) => {
+        captured = callbacks;
+        return { close: () => undefined };
+      },
+    }),
+  );
+  emit().onScopeSupport(verdict);
+}
+
+describe("useGlobalResourcesUnsupported", () => {
+  afterEach(() => {
+    resourcesRegistry.disposeAll();
+    streamMock.support = null;
+    streamMock.version = null;
+  });
+
+  // The gap this hook's second source exists to close, stated as a fact about
+  // the first one: on a remote host the pre-check has nothing to convict with,
+  // so on its own it clears every host it can never actually see.
+  it("is not convicted by the pre-check alone on a remote host", () => {
+    pretendRemoteHost();
+
+    const { result } = renderHook(() =>
+      useGlobalResourcesUnsupported("host-a"),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("convicts a remote host from the verdict its own stream produced", () => {
+    pretendRemoteHost();
+    openGlobalStream("host-a", "unsupported");
+
+    const { result } = renderHook(() =>
+      useGlobalResourcesUnsupported("host-a"),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  // The verdict is about one machine. Reading it for another is how a swap
+  // still in flight would print the notice under the wrong host's name.
+  it("does not carry one host's verdict onto another", () => {
+    pretendRemoteHost();
+    openGlobalStream("host-a", "unsupported");
+
+    const { result } = renderHook(() =>
+      useGlobalResourcesUnsupported("host-b"),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("leaves a remote host cleared when its stream negotiated a global-capable version", () => {
+    pretendRemoteHost();
+    openGlobalStream("host-a", "supported");
+
+    const { result } = renderHook(() =>
+      useGlobalResourcesUnsupported("host-a"),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  // The local path is unchanged and must stay that way: it convicts BEFORE any
+  // stream exists, which is what lets the mount decline to acquire at all.
+  it("still convicts a local host from the pre-check with no stream open", () => {
+    streamMock.support = "supported";
+    streamMock.version = { major: 1, minor: 0 };
+
+    const { result } = renderHook(() =>
+      useGlobalResourcesUnsupported("host-a"),
+    );
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/gui-app/src/hooks/resources/use-global-resources-unsupported.ts
+++ b/clients/gui-app/src/hooks/resources/use-global-resources-unsupported.ts
@@ -1,50 +1,78 @@
+import { supportsGlobalResourcesScope } from "@traycer-clients/shared/host-transport/resources-stream-client";
 import {
   useStreamMethodSchemaVersion,
   useStreamMethodSupport,
 } from "@/lib/host/stream-runtime-context";
-
-function resourcesGlobalSupported(
-  version: { readonly major: number; readonly minor: number } | null,
-): boolean {
-  return version === null || (version.major === 1 && version.minor >= 1);
-}
+import { useGlobalResourcesScopeSupport } from "@/stores/resources/resources-registry";
 
 /**
- * Whether the stream this subtree is bound to can serve a GLOBAL resources
- * subscription at all — `false` while the handshake is still unresolved, since
- * "we have not negotiated yet" is not a verdict.
+ * The verdict available BEFORE any global stream is opened, read from the
+ * ambient `StreamRuntimeContext` — so under a host-scoped provider (the
+ * resource monitor's picker) this answers for the PICKED host, not the active
+ * one.
  *
- * Read through the ambient `StreamRuntimeContext`, so under a host-scoped
- * provider (the resource monitor's picker) this answers for the PICKED host,
- * not the active one.
+ * This is what `GlobalResourcesStreamMount` gates on, and it is deliberately
+ * NOT the whole answer (see `useGlobalResourcesUnsupported`). It reports only
+ * what a client-wide capability cache can know without dialling, which is why
+ * it can decline to acquire at all: convicting a host here costs nothing,
+ * because no stream had to be opened to learn it.
  *
- * It lives in one place because two surfaces have to agree on it and must not
- * drift: `GlobalResourcesStreamMount`, which declines to acquire, and the
- * monitor's panel, which has to say so. Without the second, a host too old for
- * a global stream sits on "Waiting for <host>…" forever — there is no acquire,
- * so no attribution, so no event that could ever end the wait.
- *
- * KNOWN GAP — this answers for LOCAL hosts only. `RemoteStreamClient` reports
- * `"unknown"` support and a `null` schema version for every method BY DESIGN:
- * the mux session resolves an incompatible method as a fatal error on the
- * subscribe attempt, not as a queryable pre-check, so there is no learned
- * capability cache to read. Both terms below therefore stay false for a remote
- * host and this returns `false` — the mount acquires and an old remote host
- * waits rather than being told why.
- *
- * That is the pre-picker behaviour preserved, not a regression: the ambient
- * host this used to gate is normally the local one. But the picker's whole
- * purpose is watching another machine, so the population that most needs the
- * notice is exactly the one that cannot get it. Closing it means deriving the
- * verdict from what the remote session really produces — the terminal failure
- * of the subscribe — rather than from a pre-check that cannot answer. Tracked
- * separately rather than widened into this change.
+ * It answers for LOCAL hosts only. `RemoteStreamClient` reports `"unknown"`
+ * support and a `null` schema version for every method BY DESIGN — the mux
+ * session resolves an incompatible method as a fatal on the subscribe attempt,
+ * not as a queryable pre-check, so there is no learned capability cache to
+ * read. Both terms below therefore stay false for a remote host and this
+ * returns `false`: the mount acquires, which is exactly right, because opening
+ * the stream is how a remote host's capability becomes knowable at all.
  */
-export function useGlobalResourcesUnsupported(): boolean {
+export function useGlobalResourcesPreCheckUnsupported(): boolean {
   const resourcesSupport = useStreamMethodSupport("resources.subscribe");
   const resourcesVersion = useStreamMethodSchemaVersion("resources.subscribe");
   return (
     resourcesSupport === "unsupported" ||
-    (resourcesVersion !== null && !resourcesGlobalSupported(resourcesVersion))
+    (resourcesVersion !== null &&
+      !supportsGlobalResourcesScope(resourcesVersion))
   );
+}
+
+/**
+ * Whether the host this subtree is bound to can serve a GLOBAL resources
+ * subscription at all — `false` while the evidence is still unresolved, since
+ * "we have not negotiated yet" is not a verdict.
+ *
+ * Two independent sources, because neither covers both transports:
+ *
+ *  1. the pre-check above, which answers for a local host before a stream
+ *     exists, and
+ *  2. the live stream's own negotiation, republished by the registry, which is
+ *     the ONLY thing that can answer for a remote one.
+ *
+ * (2) is not merely a fallback for (1)'s blind spot on remote hosts — it is the
+ * only signal that catches an `@1.0` host of EITHER kind that got past the
+ * mount, because such a host does not fail a global subscribe. The `@1.1`
+ * request keeps `epicId` on the wire so the probe downgrades cleanly, so the
+ * old host accepts it and answers with one empty projection for an epic named
+ * `__global__` that does not exist — indistinguishable, from the outside, from
+ * a healthy stream on an idle machine. Its negotiated VERSION is what gives it
+ * away.
+ *
+ * Read by the monitor's panel, which has to SAY so. Without it a host too old
+ * for a global stream sits on "Waiting for <host>…" forever: nothing will ever
+ * attribute a projection to that machine, so no event could ever end the wait.
+ *
+ * `claimedHostId` is the machine the CALLER is naming on screen. (2) is only
+ * repeated for the host its stream was actually opened against — see
+ * `getGlobalScopeSupport`. (1) needs no such check: it is read through this
+ * subtree's own stream context, which under a scoped provider is already the
+ * picked host's.
+ *
+ * Both hooks run unconditionally — `||` would short-circuit the second one out
+ * of the render on exactly the frames where the first is true.
+ */
+export function useGlobalResourcesUnsupported(
+  claimedHostId: string | null,
+): boolean {
+  const preCheckUnsupported = useGlobalResourcesPreCheckUnsupported();
+  const streamScopeSupport = useGlobalResourcesScopeSupport(claimedHostId);
+  return preCheckUnsupported || streamScopeSupport === "unsupported";
 }

--- a/clients/gui-app/src/providers/__tests__/global-resources-stream-mount.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/global-resources-stream-mount.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render } from "@testing-library/react";
 import type { ResourcesStreamCallbacks } from "@traycer-clients/shared/host-transport/resources-stream-client";
 import type { StreamMethodSupport } from "@traycer-clients/shared/host-transport/ws-stream-client";
+import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import { GlobalResourcesStreamMount } from "@/providers/resources-stream-mount";
 import { __setResourcesStreamClientFactoryForTests } from "@/providers/resources-stream-factory-override";
 import { resourcesRegistry } from "@/stores/resources/resources-registry";
@@ -28,12 +30,47 @@ vi.mock("@/lib/host/stream-runtime-context", async (importOriginal) => {
     await importOriginal<typeof import("@/lib/host/stream-runtime-context")>();
   return {
     ...actual,
-    useWsStreamClient: () => null,
+    useWsStreamClient: () => fakeStreamClient,
     useStreamHostId: () => "host-a",
     useStreamMethodSupport: () => streamMock.support,
     useStreamMethodSchemaVersion: () => streamMock.version,
   };
 });
+
+// The transport, present only so the mount can subscribe to its recovery
+// signal. Nothing below ever calls through it — the resources stream itself is
+// driven by `__setResourcesStreamClientFactoryForTests`.
+const recoveryListeners = new Set<() => void>();
+
+const fakeStreamClient: IHostStreamClient<HostStreamRpcRegistry> = {
+  subscribe: () => {
+    throw new Error("not exercised by this test");
+  },
+  subscribeWithParamsProvider: () => {
+    throw new Error("not exercised by this test");
+  },
+  close: () => undefined,
+  isClosed: () => false,
+  notifyBearerRotated: () => undefined,
+  reconnectAll: () => undefined,
+  getMethodSupport: () => "unknown",
+  subscribeMethodSupport: () => () => undefined,
+  getMethodSchemaVersion: () => null,
+  subscribeAvailabilityRecovered: (listener) => {
+    recoveryListeners.add(listener);
+    return () => {
+      recoveryListeners.delete(listener);
+    };
+  },
+  getClosedReason: () => null,
+  onClosed: () => () => undefined,
+  instanceId: "fake-global-resources-stream-client",
+};
+
+/** The host came back — a resume, a restart, or an in-place upgrade. */
+function fireAvailabilityRecovered(): void {
+  for (const listener of Array.from(recoveryListeners)) listener();
+}
 
 describe("GlobalResourcesStreamMount", () => {
   afterEach(() => {
@@ -103,5 +140,74 @@ describe("GlobalResourcesStreamMount", () => {
     expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe(
       "unsupported",
     );
+  });
+
+  /**
+   * The escape hatch for the one verdict that cannot clear itself.
+   *
+   * A version verdict self-heals — its stream stays open, so a drop takes the
+   * negotiated version with it and the resume re-negotiates. A TERMINAL
+   * incompatible close does not: it fails only the stream while the shared
+   * session stays healthy, so the transport identity never changes and nothing
+   * above would rebuild. Without this, a host upgraded in place goes on being
+   * called incapable for as long as the surface stays mounted.
+   */
+  it("re-probes a terminal verdict when the transport reports the host came back", () => {
+    let captured: ResourcesStreamCallbacks | null = null;
+    let builds = 0;
+    const emit = (): ResourcesStreamCallbacks => {
+      if (captured === null) throw new Error("stream callbacks not wired");
+      return captured;
+    };
+    __setResourcesStreamClientFactoryForTests((_scope, callbacks) => {
+      builds += 1;
+      captured = callbacks;
+      return { close: () => undefined };
+    });
+
+    render(<GlobalResourcesStreamMount />);
+    act(() => {
+      emit().onScopeSupport("unsupported");
+    });
+    expect(builds).toBe(1);
+
+    act(() => {
+      fireAvailabilityRecovered();
+    });
+
+    // A fresh stream against the host that just came back, and the stale
+    // verdict gone with the store that held it.
+    expect(builds).toBe(2);
+    expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe("unknown");
+  });
+
+  // The re-probe is gated on `unsupported` for this reason. Recovery fires on
+  // every ordinary resume — and on `RemoteStreamClient` even on the clean first
+  // open — so an ungated version would tear down and rebuild a perfectly good
+  // stream on every blip, dropping its projection each time.
+  it("leaves a working stream alone when the transport merely reconnects", () => {
+    let captured: ResourcesStreamCallbacks | null = null;
+    let builds = 0;
+    const emit = (): ResourcesStreamCallbacks => {
+      if (captured === null) throw new Error("stream callbacks not wired");
+      return captured;
+    };
+    __setResourcesStreamClientFactoryForTests((_scope, callbacks) => {
+      builds += 1;
+      captured = callbacks;
+      return { close: () => undefined };
+    });
+
+    render(<GlobalResourcesStreamMount />);
+    act(() => {
+      emit().onScopeSupport("supported");
+    });
+
+    act(() => {
+      fireAvailabilityRecovered();
+    });
+
+    expect(builds).toBe(1);
+    expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe("supported");
   });
 });

--- a/clients/gui-app/src/providers/__tests__/global-resources-stream-mount.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/global-resources-stream-mount.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import type { ResourcesStreamCallbacks } from "@traycer-clients/shared/host-transport/resources-stream-client";
+import { GlobalResourcesStreamMount } from "@/providers/resources-stream-mount";
+import { __setResourcesStreamClientFactoryForTests } from "@/providers/resources-stream-factory-override";
+import { resourcesRegistry } from "@/stores/resources/resources-registry";
+
+// A remote host, as the transport actually reports one: `"unknown"` support and
+// no client-wide schema version for any method. This is what makes the
+// pre-check unable to convict, which is the state this mount has to survive.
+vi.mock("@/lib/host/stream-runtime-context", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/host/stream-runtime-context")>();
+  return {
+    ...actual,
+    useWsStreamClient: () => null,
+    useStreamHostId: () => "host-a",
+    useStreamMethodSupport: () => "unknown",
+    useStreamMethodSchemaVersion: () => null,
+  };
+});
+
+describe("GlobalResourcesStreamMount", () => {
+  afterEach(() => {
+    __setResourcesStreamClientFactoryForTests(null);
+    resourcesRegistry.disposeAll();
+  });
+
+  /**
+   * The mount gates on the PRE-STREAM verdict, never the full one the panel
+   * reads — and this is what that buys.
+   *
+   * Gating on the full verdict is a loop with no exit: acquire → the stream
+   * negotiates `@1.0` and reports `unsupported` → the effect re-runs and
+   * releases → the store holding the verdict is disposed with it → the verdict
+   * reverts to `unknown` → acquire again. It would re-dial a host forever, on
+   * the strength of having successfully learned something about it.
+   *
+   * Asserted as "built once and still held", because a single rebuild is the
+   * first lap of that loop, not a lesser symptom of it.
+   */
+  it("keeps the stream it opened after that stream convicts its own host", () => {
+    let captured: ResourcesStreamCallbacks | null = null;
+    let builds = 0;
+    const emit = (): ResourcesStreamCallbacks => {
+      if (captured === null) throw new Error("stream callbacks not wired");
+      return captured;
+    };
+    __setResourcesStreamClientFactoryForTests((_scope, callbacks) => {
+      builds += 1;
+      captured = callbacks;
+      return { close: () => undefined };
+    });
+
+    render(<GlobalResourcesStreamMount />);
+    expect(builds).toBe(1);
+
+    act(() => {
+      emit().onScopeSupport("unsupported");
+    });
+
+    expect(builds).toBe(1);
+    expect(resourcesRegistry.getGlobal()).not.toBeNull();
+    expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe(
+      "unsupported",
+    );
+  });
+});

--- a/clients/gui-app/src/providers/__tests__/global-resources-stream-mount.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/global-resources-stream-mount.test.tsx
@@ -1,13 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import type { ResourcesStreamCallbacks } from "@traycer-clients/shared/host-transport/resources-stream-client";
+import type { StreamMethodSupport } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { GlobalResourcesStreamMount } from "@/providers/resources-stream-mount";
 import { __setResourcesStreamClientFactoryForTests } from "@/providers/resources-stream-factory-override";
 import { resourcesRegistry } from "@/stores/resources/resources-registry";
 
-// A remote host, as the transport actually reports one: `"unknown"` support and
-// no client-wide schema version for any method. This is what makes the
-// pre-check unable to convict, which is the state this mount has to survive.
+// The two inputs the pre-check reads. Defaults are a REMOTE host as the
+// transport actually reports one — `"unknown"` support and no client-wide
+// schema version for any method — which is the state that leaves the pre-check
+// unable to convict, and the state this mount has to survive.
+// Typed through the factory's RETURN annotation, not an `as` on the value:
+// `eslint --fix` strips a redundant-looking assertion here, and `support` then
+// widens to `string`, which quietly accepts a typo'd verdict.
+const streamMock = vi.hoisted(
+  (): {
+    support: StreamMethodSupport;
+    version: { readonly major: number; readonly minor: number } | null;
+  } => ({
+    support: "unknown",
+    version: null,
+  }),
+);
+
 vi.mock("@/lib/host/stream-runtime-context", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/lib/host/stream-runtime-context")>();
@@ -15,8 +30,8 @@ vi.mock("@/lib/host/stream-runtime-context", async (importOriginal) => {
     ...actual,
     useWsStreamClient: () => null,
     useStreamHostId: () => "host-a",
-    useStreamMethodSupport: () => "unknown",
-    useStreamMethodSchemaVersion: () => null,
+    useStreamMethodSupport: () => streamMock.support,
+    useStreamMethodSchemaVersion: () => streamMock.version,
   };
 });
 
@@ -24,6 +39,30 @@ describe("GlobalResourcesStreamMount", () => {
   afterEach(() => {
     __setResourcesStreamClientFactoryForTests(null);
     resourcesRegistry.disposeAll();
+    cleanup();
+    streamMock.support = "unknown";
+    streamMock.version = null;
+  });
+
+  /**
+   * The other side of the gate, and the reason it is still the PRE-STREAM
+   * verdict: when the pre-check CAN convict — a local host, where the
+   * client-wide capability cache is real — nothing is dialled at all. That is
+   * what the pre-check buys, and it is only visible as an absence.
+   */
+  it("never opens a stream when the pre-check already convicted the host", () => {
+    streamMock.support = "supported";
+    streamMock.version = { major: 1, minor: 0 };
+    let builds = 0;
+    __setResourcesStreamClientFactoryForTests((_scope, _callbacks) => {
+      builds += 1;
+      return { close: () => undefined };
+    });
+
+    render(<GlobalResourcesStreamMount />);
+
+    expect(builds).toBe(0);
+    expect(resourcesRegistry.getGlobal()).toBeNull();
   });
 
   /**

--- a/clients/gui-app/src/providers/resources-stream-mount.tsx
+++ b/clients/gui-app/src/providers/resources-stream-mount.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { ResourcesStreamClient } from "@traycer-clients/shared/host-transport/resources-stream-client";
 import {
   useStreamHostId,
@@ -107,12 +107,55 @@ export function GlobalResourcesStreamMount(): ReactNode {
   // empty projection and then, having nothing to say about an epic that does
   // not exist, stays silent.
   const resourcesUnsupported = useGlobalResourcesPreCheckUnsupported();
+  // Bumped ONLY by the recovery listener below — never during a render.
+  const [reprobeGeneration, setReprobeGeneration] = useState(0);
+  // "Which stream should be open": the transport, plus the re-probe generation.
+  // The generation belongs in the identity rather than in the effect alone, so
+  // a bump rebuilds the entry even when a second lease holder would otherwise
+  // keep the existing one alive.
+  const reacquireToken = useMemo(
+    () => ({ transport: wsStreamClient, reprobeGeneration }),
+    [wsStreamClient, reprobeGeneration],
+  );
+
+  /**
+   * Re-probes a verdict that cannot clear itself.
+   *
+   * A version verdict self-heals: that stream stays open, a drop takes its
+   * negotiated version with it, and the resume re-negotiates. A TERMINAL
+   * incompatible close has no such path — it fails only the stream, while the
+   * shared session stays healthy, so the transport identity never changes and
+   * nothing above would ever rebuild. A host that advertises no bridgeable
+   * `resources.subscribe` and is then upgraded in place would keep being called
+   * incapable for as long as this surface stayed mounted.
+   *
+   * Driven off transport recovery, which is the only positive evidence that the
+   * host on the other end may not be the one we judged.
+   */
+  useEffect(() => {
+    if (wsStreamClient === null) return;
+    return wsStreamClient.subscribeAvailabilityRecovered(() => {
+      // Read IMPERATIVELY. As an effect dependency this verdict is a loop:
+      // it changes → the effect re-runs → release/acquire → the fresh store
+      // reports `unknown` → it changes again. Edge-triggered off recovery it
+      // cannot self-perpetuate, because a re-probe that lands on the same
+      // terminal verdict emits no further recovery event.
+      //
+      // Gated on `unsupported` so an ordinary reconnect — including the clean
+      // first open, which `RemoteStreamClient` also reports — does not tear
+      // down and rebuild a working stream, losing its projection each time.
+      if (resourcesRegistry.getGlobalScopeSupport(hostId) !== "unsupported") {
+        return;
+      }
+      setReprobeGeneration((generation) => generation + 1);
+    });
+  }, [hostId, wsStreamClient]);
 
   useEffect(() => {
     if (resourcesUnsupported) return;
     const override = getResourcesStreamClientFactoryOverride();
     if (override === null && wsStreamClient === null) return;
-    const clientToken: unknown = override !== null ? override : wsStreamClient;
+    const clientToken: unknown = reacquireToken;
     const streamClientFactory: ResourcesStreamClientFactory =
       override !== null
         ? override
@@ -142,7 +185,7 @@ export function GlobalResourcesStreamMount(): ReactNode {
     // rebuild the entry rather than leave the projection speaking for the wrong
     // machine. In practice it now moves WITH `wsStreamClient` (one binding, one
     // change), so this rarely fires on its own.
-  }, [hostId, resourcesUnsupported, wsStreamClient]);
+  }, [hostId, reacquireToken, resourcesUnsupported, wsStreamClient]);
 
   return null;
 }

--- a/clients/gui-app/src/providers/resources-stream-mount.tsx
+++ b/clients/gui-app/src/providers/resources-stream-mount.tsx
@@ -5,7 +5,7 @@ import {
   useStreamMethodSupport,
   useWsStreamClient,
 } from "@/lib/host/stream-runtime-context";
-import { useGlobalResourcesUnsupported } from "@/hooks/resources/use-global-resources-unsupported";
+import { useGlobalResourcesPreCheckUnsupported } from "@/hooks/resources/use-global-resources-unsupported";
 import { resourcesRegistry } from "@/stores/resources/resources-registry";
 import {
   createResourcesStore,
@@ -96,7 +96,17 @@ export function GlobalResourcesStreamMount(): ReactNode {
   // reader checks its data against, so it has to be the host this transport is
   // actually dialing rather than the one the caller believes it asked for.
   const hostId = useStreamHostId();
-  const resourcesUnsupported = useGlobalResourcesUnsupported();
+  // The PRE-STREAM verdict only, never the full one the panel reads. The full
+  // one includes this stream's own negotiation, so gating the acquire on it
+  // would be a loop: acquire → learn `unsupported` → release → the verdict dies
+  // with the store → acquire again. The pre-check cannot move as a result of
+  // anything this effect does, which is what makes it safe to gate on.
+  //
+  // So a host convicted only by its own stream keeps that stream open. It costs
+  // one idle subscription: an `@1.0` host answers a global probe with a single
+  // empty projection and then, having nothing to say about an epic that does
+  // not exist, stays silent.
+  const resourcesUnsupported = useGlobalResourcesPreCheckUnsupported();
 
   useEffect(() => {
     if (resourcesUnsupported) return;

--- a/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
+++ b/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
@@ -498,6 +498,36 @@ describe("global scope support", () => {
     handle.dispose();
   });
 
+  // A remote session that is already ready but does not advertise the method
+  // rejects the subscribe synchronously, and `LogicalStream.onStatusChange`
+  // REPLAYS that terminal close the moment a handler is installed — which the
+  // typed wrapper does in its constructor. So the verdict lands while
+  // `streamClientFactory` is still running. Nothing follows a terminal close to
+  // republish it, so losing it here strands the surface forever.
+  it("keeps a verdict published while the stream was still being constructed", () => {
+    const handle = createResourcesStore({
+      scope: { kind: "global" },
+      streamClientFactory: (_scope, callbacks) => {
+        callbacks.onScopeSupport("unsupported");
+        callbacks.onConnectionStatus("closed", {
+          kind: "fatalError",
+          details: {
+            code: "INCOMPATIBLE",
+            reason: "host does not advertise resources.subscribe",
+            incompatibleMethods: null,
+            upgradeGuidance: null,
+          },
+        });
+        return { close: () => undefined };
+      },
+    });
+
+    expect(handle.store.getState().scopeSupport).toBe("unsupported");
+    expect(handle.store.getState().connectionStatus).toBe("closed");
+
+    handle.dispose();
+  });
+
   it("reads unknown with no global entry to ask", () => {
     expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe("unknown");
   });

--- a/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
+++ b/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
@@ -537,6 +537,47 @@ describe("global scope support", () => {
   // Two unnamed things are not the same thing. An entry whose mount could not
   // name its host, asked about a scope that has not resolved one either, would
   // match on `null === null` and convict a machine neither side identified.
+  // Following the ACTIVE host nothing on screen names a machine, so no
+  // incompatible notice is shown — the surface just renders the projection. An
+  // `@1.0` host's global entry outranks the per-epic fallback purely by
+  // existing, so leaving it in place publishes emptiness from a stream that
+  // will never carry anything, while the per-epic streams on the very same
+  // transport hold that host's real numbers. That read as "Waiting for resource
+  // data." forever.
+  it("falls back to the per-epic entries when the global stream cannot serve the scope", () => {
+    const globalFake = makeFakeClient();
+    const epicFake = makeFakeClient();
+    resourcesRegistry.acquireGlobal("token-global", "host-a", () =>
+      createResourcesStore({
+        scope: { kind: "global" },
+        streamClientFactory: globalFake.factory,
+      }),
+    );
+    resourcesRegistry.acquire("epic-1", "token-epic", "host-a", () =>
+      createResourcesStore({
+        scope: { kind: "epic", epicId: "epic-1" },
+        streamClientFactory: epicFake.factory,
+      }),
+    );
+    epicFake.callbacks().onSnapshot(
+      projection({
+        sampledAt: 1_000,
+        owners: [makeOwner("terminal", "term-1", { cpuPercent: 11 })],
+      }),
+    );
+
+    // While the global stream has not judged itself, it still owns the answer -
+    // and it is empty, because an `@1.0` host answered about `__global__`.
+    expect(resourcesRegistry.getGlobalProjection().owners).toHaveLength(0);
+
+    globalFake.callbacks().onScopeSupport("unsupported");
+
+    const projected = resourcesRegistry.getGlobalProjection();
+    expect(projected.owners).toHaveLength(1);
+    expect(projected.owners[0].cpuPercent).toBe(11);
+    expect(projected.hostId).toBe("host-a");
+  });
+
   it("does not match an unnamed entry to an unnamed claim", () => {
     const fake = makeFakeClient();
     resourcesRegistry.acquireGlobal("token-a", null, () =>

--- a/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
+++ b/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
@@ -477,3 +477,76 @@ describe("resourcesRegistry", () => {
     expect(global.owners).toHaveLength(2);
   });
 });
+
+describe("global scope support", () => {
+  afterEach(() => {
+    resourcesRegistry.disposeAll();
+  });
+
+  it("starts unknown and records the verdict the stream publishes", () => {
+    const fake = makeFakeClient();
+    const handle = createResourcesStore({
+      scope: { kind: "global" },
+      streamClientFactory: fake.factory,
+    });
+
+    expect(handle.store.getState().scopeSupport).toBe("unknown");
+
+    fake.callbacks().onScopeSupport("unsupported");
+    expect(handle.store.getState().scopeSupport).toBe("unsupported");
+
+    handle.dispose();
+  });
+
+  it("reads unknown with no global entry to ask", () => {
+    expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe("unknown");
+  });
+
+  it("repeats the verdict for the host the stream was opened against", () => {
+    const fake = makeFakeClient();
+    resourcesRegistry.acquireGlobal("token-a", "host-a", () =>
+      createResourcesStore({
+        scope: { kind: "global" },
+        streamClientFactory: fake.factory,
+      }),
+    );
+    fake.callbacks().onScopeSupport("unsupported");
+
+    expect(resourcesRegistry.getGlobalScopeSupport("host-a")).toBe(
+      "unsupported",
+    );
+  });
+
+  // The entry is a module singleton that outlives a swap, so the verdict it
+  // holds routinely belongs to the machine we just STOPPED watching. Repeating
+  // it for whoever asks would print "cannot report its processes" under the
+  // name of a host that never said any such thing.
+  it("refuses to repeat one host's verdict for another", () => {
+    const fake = makeFakeClient();
+    resourcesRegistry.acquireGlobal("token-a", "host-a", () =>
+      createResourcesStore({
+        scope: { kind: "global" },
+        streamClientFactory: fake.factory,
+      }),
+    );
+    fake.callbacks().onScopeSupport("unsupported");
+
+    expect(resourcesRegistry.getGlobalScopeSupport("host-b")).toBe("unknown");
+  });
+
+  // Two unnamed things are not the same thing. An entry whose mount could not
+  // name its host, asked about a scope that has not resolved one either, would
+  // match on `null === null` and convict a machine neither side identified.
+  it("does not match an unnamed entry to an unnamed claim", () => {
+    const fake = makeFakeClient();
+    resourcesRegistry.acquireGlobal("token-a", null, () =>
+      createResourcesStore({
+        scope: { kind: "global" },
+        streamClientFactory: fake.factory,
+      }),
+    );
+    fake.callbacks().onScopeSupport("unsupported");
+
+    expect(resourcesRegistry.getGlobalScopeSupport(null)).toBe("unknown");
+  });
+});

--- a/clients/gui-app/src/stores/resources/resources-registry.ts
+++ b/clients/gui-app/src/stores/resources/resources-registry.ts
@@ -1,6 +1,7 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { create, useStore } from "zustand";
 import type { ResourceOwnerKindWireV14 } from "@traycer/protocol/host/resources/subscribe";
+import type { ResourcesScopeSupport } from "@traycer-clients/shared/host-transport/resources-stream-client";
 import {
   resourceOwnerKey,
   type AppResourceUsage,
@@ -246,6 +247,37 @@ class ResourcesRegistry {
     return this.globalEntry?.handle ?? null;
   }
 
+  /**
+   * The live global stream's verdict on whether it can serve a global subscribe
+   * — but only when that stream was opened against `claimedHostId`, the machine
+   * the asking surface is NAMING.
+   *
+   * The attribution is not optional, and it is the strict, positive-proof kind
+   * (`hostId` must be non-null and must match), for the same reason
+   * `attributedProjection` demands it of the data: this entry is a module
+   * singleton that outlives any one transport, so it routinely describes a
+   * machine the current reading was not opened against — a host swap in flight,
+   * where the entry is named at acquire time, one commit before the replacement
+   * binding reaches context. Unchecked, picking an up-to-date host while the
+   * previous (old) one's entry is still live would print "cannot report its
+   * processes" under the NEW host's name. A verdict is an accusation about a
+   * specific machine; it may only be repeated for the machine it was made about.
+   *
+   * No entry — and any mismatch — reads as `"unknown"`, never `"unsupported"`.
+   * The mount declines to acquire for a host the client-wide pre-check already
+   * convicted, so that absence is the pre-check's answer being acted on, not a
+   * second independent one; reporting it as a verdict here would make every
+   * pre-mount frame, the whole hydration gap, claim the host is too old.
+   */
+  getGlobalScopeSupport(claimedHostId: string | null): ResourcesScopeSupport {
+    const entry = this.globalEntry;
+    if (entry === null) return "unknown";
+    if (entry.hostId === null || entry.hostId !== claimedHostId) {
+      return "unknown";
+    }
+    return entry.handle.store.getState().scopeSupport;
+  }
+
   acquire(
     epicId: string,
     clientToken: unknown,
@@ -445,6 +477,7 @@ export const resourcesRegistry = new ResourcesRegistry();
 const emptyResourcesStore = create<ResourcesState>()(() => ({
   key: "",
   connectionStatus: "closed",
+  scopeSupport: "unknown",
   sampledAt: null,
   owners: new Map(),
   app: null,
@@ -494,6 +527,30 @@ export function useEpicResourceUsage(epicId: string): EpicResourceUsage | null {
   const handle = useResourcesHandle(epicId);
   const store = handle === null ? emptyResourcesStore : handle.store;
   return useStore(store, (state) => state.epic);
+}
+
+/**
+ * Reactive `ResourcesRegistry.getGlobalScopeSupport` for the host the caller is
+ * naming. Rides the same global listener set as the projection, which every
+ * entry's store change already notifies, so a verdict published mid-stream
+ * reaches the panel on the frame it lands rather than on whatever unrelated
+ * render happens next.
+ *
+ * Returns a primitive rather than the projection, so a caller can watch the
+ * verdict without re-rendering on every resource tick.
+ */
+export function useGlobalResourcesScopeSupport(
+  claimedHostId: string | null,
+): ResourcesScopeSupport {
+  const subscribe = useCallback(
+    (onChange: () => void) => resourcesRegistry.subscribeGlobal(onChange),
+    [],
+  );
+  const getSnapshot = useCallback(
+    () => resourcesRegistry.getGlobalScopeSupport(claimedHostId),
+    [claimedHostId],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useGlobalResourceProjection(): GlobalResourceProjection {

--- a/clients/gui-app/src/stores/resources/resources-registry.ts
+++ b/clients/gui-app/src/stores/resources/resources-registry.ts
@@ -128,10 +128,9 @@ class ResourcesRegistry {
     if (this.globalProjectionCache?.version === this.globalVersion) {
       return this.globalProjectionCache.projection;
     }
-    if (this.globalEntry !== null) {
-      const projection = this.getGlobalProjectionFromGlobalEntry(
-        this.globalEntry,
-      );
+    const globalEntry = this.usableGlobalEntry();
+    if (globalEntry !== null) {
+      const projection = this.getGlobalProjectionFromGlobalEntry(globalEntry);
       this.globalProjectionCache = {
         version: this.globalVersion,
         projection,
@@ -188,6 +187,31 @@ class ResourcesRegistry {
       projection,
     };
     return projection;
+  }
+
+  /**
+   * The global entry, or `null` when its own stream has reported that this host
+   * cannot serve a global subscribe.
+   *
+   * An `@1.0` host accepts the downgraded global probe and answers with one
+   * empty projection for an epic named `__global__` that does not exist. That
+   * entry outranks the per-epic fallback below purely by existing, so without
+   * this the surface publishes emptiness from a stream that will never carry
+   * anything, while the per-epic streams on the very same transport are holding
+   * that host's real numbers. Following the active host — where nothing on
+   * screen names a machine and so no incompatible notice is shown — that read
+   * as "Waiting for resource data." forever.
+   *
+   * Only `"unsupported"` disqualifies it. `"unknown"` is the ordinary state
+   * before a negotiation settles, and treating it as a verdict would drop every
+   * global projection for the whole handshake window.
+   */
+  private usableGlobalEntry(): RegistryEntry | null {
+    const entry = this.globalEntry;
+    if (entry === null) return null;
+    return entry.handle.store.getState().scopeSupport === "unsupported"
+      ? null
+      : entry;
   }
 
   private getGlobalProjectionFromGlobalEntry(

--- a/clients/gui-app/src/stores/resources/resources-store.ts
+++ b/clients/gui-app/src/stores/resources/resources-store.ts
@@ -319,59 +319,66 @@ export function createResourcesStore(
   const key =
     options.scope.kind === "global" ? "__global__" : options.scope.epicId;
 
-  const store = create<ResourcesState>()((set) => {
-    const applyProjection = (payload: ResourcesProjectionPayload): void => {
+  const store = create<ResourcesState>()(() => ({
+    key,
+    connectionStatus: "connecting",
+    scopeSupport: "unknown",
+    sampledAt: null,
+    owners: EMPTY_OWNERS,
+    app: null,
+    hostTree: null,
+    other: null,
+    epic: null,
+    epics: EMPTY_EPICS,
+    dispose: () => {
       if (disposed) return;
-      set((state) => ({
-        sampledAt: payload.sampledAt,
-        owners: mergeOwners(state.owners, payload, options.scope),
-        app: mergeApp(state.app, payload.app),
-        hostTree: mergeHostTree(state.hostTree, payload.hostTree),
-        other: mergeOther(state.other, payload.other),
-        epic: mergeEpic(state.epic, payload.epic),
-        epics: mergeEpics(state.epics, payload),
-      }));
-    };
+      disposed = true;
+      if (streamClient === null) return;
+      const client = streamClient;
+      streamClient = null;
+      client.close();
+    },
+  }));
 
-    const callbacks: ResourcesStreamCallbacks = {
-      onSnapshot: applyProjection,
-      onUpdate: applyProjection,
-      onConnectionStatus: (
-        status: StreamConnectionStatus,
-        _reason: StreamCloseReason | null,
-      ) => {
-        if (disposed) return;
-        set({ connectionStatus: status });
-      },
-      onScopeSupport: (support: ResourcesScopeSupport) => {
-        if (disposed) return;
-        set({ scopeSupport: support });
-      },
-    };
+  const applyProjection = (payload: ResourcesProjectionPayload): void => {
+    if (disposed) return;
+    store.setState((state) => ({
+      sampledAt: payload.sampledAt,
+      owners: mergeOwners(state.owners, payload, options.scope),
+      app: mergeApp(state.app, payload.app),
+      hostTree: mergeHostTree(state.hostTree, payload.hostTree),
+      other: mergeOther(state.other, payload.other),
+      epic: mergeEpic(state.epic, payload.epic),
+      epics: mergeEpics(state.epics, payload),
+    }));
+  };
 
-    streamClient = options.streamClientFactory(options.scope, callbacks);
+  const callbacks: ResourcesStreamCallbacks = {
+    onSnapshot: applyProjection,
+    onUpdate: applyProjection,
+    onConnectionStatus: (
+      status: StreamConnectionStatus,
+      _reason: StreamCloseReason | null,
+    ) => {
+      if (disposed) return;
+      store.setState({ connectionStatus: status });
+    },
+    onScopeSupport: (support: ResourcesScopeSupport) => {
+      if (disposed) return;
+      store.setState({ scopeSupport: support });
+    },
+  };
 
-    return {
-      key,
-      connectionStatus: "connecting",
-      scopeSupport: "unknown",
-      sampledAt: null,
-      owners: EMPTY_OWNERS,
-      app: null,
-      hostTree: null,
-      other: null,
-      epic: null,
-      epics: EMPTY_EPICS,
-      dispose: () => {
-        if (disposed) return;
-        disposed = true;
-        if (streamClient === null) return;
-        const client = streamClient;
-        streamClient = null;
-        client.close();
-      },
-    };
-  });
+  // Opened only AFTER the initial state is installed, never from inside the
+  // zustand initializer. A stream can publish before its factory returns: a
+  // remote session that is already ready but does not advertise the method
+  // rejects the subscribe synchronously, and `LogicalStream.onStatusChange`
+  // replays that terminal close the instant the typed wrapper's constructor
+  // installs a handler. Built inside the initializer, those writes land on a
+  // state object the initializer's own `return` then overwrites - and a
+  // terminal close has nothing following it to republish the verdict, so the
+  // surface waits forever on a host that already answered.
+  streamClient = options.streamClientFactory(options.scope, callbacks);
 
   return {
     key,

--- a/clients/gui-app/src/stores/resources/resources-store.ts
+++ b/clients/gui-app/src/stores/resources/resources-store.ts
@@ -5,6 +5,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type {
   ResourcesProjectionPayload,
+  ResourcesScopeSupport,
   ResourcesStreamScope,
   ResourcesStreamCallbacks,
   ResourcesStreamClient,
@@ -70,6 +71,17 @@ export function globalResourceOwnerKey(
 export interface ResourcesState {
   readonly key: string;
   readonly connectionStatus: StreamConnectionStatus;
+  /**
+   * Whether the host this stream negotiated with can serve THIS store's scope -
+   * the transport-agnostic half of that question, learned from the session
+   * itself rather than from a capability pre-check only a local client can
+   * answer. See `ResourcesScopeSupport`.
+   *
+   * A global-scope store answering `"unsupported"` is the whole reason this
+   * exists: it is the only way a REMOTE host too old for a global stream is
+   * ever distinguishable from one that is merely quiet.
+   */
+  readonly scopeSupport: ResourcesScopeSupport;
   /** `null` until the first projection lands. */
   readonly sampledAt: number | null;
   /**
@@ -331,6 +343,10 @@ export function createResourcesStore(
         if (disposed) return;
         set({ connectionStatus: status });
       },
+      onScopeSupport: (support: ResourcesScopeSupport) => {
+        if (disposed) return;
+        set({ scopeSupport: support });
+      },
     };
 
     streamClient = options.streamClientFactory(options.scope, callbacks);
@@ -338,6 +354,7 @@ export function createResourcesStore(
     return {
       key,
       connectionStatus: "connecting",
+      scopeSupport: "unknown",
       sampledAt: null,
       owners: EMPTY_OWNERS,
       app: null,

--- a/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
@@ -138,19 +138,33 @@ function completeHandshakeAt(
   respondToOpen(socket, resourcesVersion);
 }
 
-/** Records every scope verdict the client publishes, newest last. */
+/**
+ * Records every scope verdict the client publishes, newest last — plus one
+ * ORDERED log interleaving verdicts with connection statuses, because the
+ * client documents that it publishes the verdict first and a consumer reacting
+ * to `closed` depends on it. Recording only the verdicts would let a swap of
+ * those two calls pass every test here.
+ */
 function trackScopeSupport(): {
   readonly callbacks: ResourcesStreamCallbacks;
   readonly verdicts: ResourcesScopeSupport[];
+  readonly events: string[];
 } {
   const verdicts: ResourcesScopeSupport[] = [];
+  const events: string[] = [];
   return {
     verdicts,
+    events,
     callbacks: {
       onSnapshot: () => undefined,
       onUpdate: () => undefined,
-      onConnectionStatus: () => undefined,
-      onScopeSupport: (support) => verdicts.push(support),
+      onConnectionStatus: (status) => {
+        events.push(`status:${status}`);
+      },
+      onScopeSupport: (support) => {
+        events.push(`support:${support}`);
+        verdicts.push(support);
+      },
     },
   };
 }
@@ -587,6 +601,27 @@ describe("ResourcesStreamClient scope support", () => {
     });
 
     expect(verdicts).toEqual(["supported"]);
+
+    client.close();
+  });
+
+  // The client documents this ordering as load-bearing: a consumer reacting to
+  // the `closed` transition has to already see WHY, rather than reading the
+  // verdict from the previous round. Nothing but this asserts it.
+  it("publishes the verdict before the status it was derived from", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, events } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "global" },
+      callbacks,
+    });
+    // Terminal INCOMPATIBLE: the transition that carries both a status and the
+    // verdict explaining it, which is exactly where the order can be observed.
+    completeHandshakeAt(sockets[0], { major: 2, minor: 0 });
+
+    expect(events).toEqual(["support:unsupported", "status:closed"]);
 
     client.close();
   });

--- a/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
@@ -21,6 +21,7 @@ import { WsStreamClient } from "../ws-stream-client";
 import {
   ResourcesStreamClient,
   type ResourcesProjectionPayload,
+  type ResourcesScopeSupport,
   type ResourcesStreamCallbacks,
 } from "../resources-stream-client";
 
@@ -49,6 +50,10 @@ class StubStreamWebSocket implements StreamWebSocketLike {
 
   fireText(data: unknown): void {
     this.onmessage?.({ type: "text", data: JSON.stringify(data) });
+  }
+
+  fireClose(code: number, reason: string, wasClean: boolean): void {
+    this.onclose?.({ code, reason, wasClean });
   }
 }
 
@@ -99,15 +104,55 @@ function makeWsStreamClient(
   });
 }
 
-function completeHandshake(socket: StubStreamWebSocket): void {
+/**
+ * Acks the open with the client's own manifest echoed back, except that
+ * `resources.subscribe` is pinned to `resourcesVersion` when one is given -
+ * which is how a host too old to carry a global projection is expressed, since
+ * the negotiated version IS the whole signal.
+ */
+function respondToOpen(
+  socket: StubStreamWebSocket,
+  resourcesVersion: { readonly major: number; readonly minor: number } | null,
+): void {
   socket.fireOpen();
   const openParsed = JSON.parse(socket.textSent[0]) as {
     readonly manifest: Record<string, { major: number; minor: number }>;
   };
   socket.fireText({
     kind: "openAck",
-    manifest: openParsed.manifest,
+    manifest:
+      resourcesVersion === null
+        ? openParsed.manifest
+        : { ...openParsed.manifest, "resources.subscribe": resourcesVersion },
   });
+}
+
+function completeHandshake(socket: StubStreamWebSocket): void {
+  respondToOpen(socket, null);
+}
+
+function completeHandshakeAt(
+  socket: StubStreamWebSocket,
+  resourcesVersion: { readonly major: number; readonly minor: number },
+): void {
+  respondToOpen(socket, resourcesVersion);
+}
+
+/** Records every scope verdict the client publishes, newest last. */
+function trackScopeSupport(): {
+  readonly callbacks: ResourcesStreamCallbacks;
+  readonly verdicts: ResourcesScopeSupport[];
+} {
+  const verdicts: ResourcesScopeSupport[] = [];
+  return {
+    verdicts,
+    callbacks: {
+      onSnapshot: () => undefined,
+      onUpdate: () => undefined,
+      onConnectionStatus: () => undefined,
+      onScopeSupport: (support) => verdicts.push(support),
+    },
+  };
 }
 
 function parseText(raw: string): Record<string, unknown> {
@@ -207,6 +252,7 @@ describe("ResourcesStreamClient", () => {
       onSnapshot: (p) => snapshots.push(p),
       onUpdate: (p) => updates.push(p),
       onConnectionStatus: () => undefined,
+      onScopeSupport: () => undefined,
     };
 
     const client = new ResourcesStreamClient({
@@ -276,6 +322,7 @@ describe("ResourcesStreamClient", () => {
         onSnapshot: (p) => snapshots.push(p),
         onUpdate: () => {},
         onConnectionStatus: () => {},
+        onScopeSupport: () => {},
       },
     });
     completeHandshake(sockets[0]);
@@ -311,6 +358,7 @@ describe("ResourcesStreamClient", () => {
         onSnapshot: (p) => snapshots.push(p),
         onUpdate: () => {},
         onConnectionStatus: () => {},
+        onScopeSupport: () => {},
       },
     });
     completeHandshake(sockets[0]);
@@ -359,6 +407,7 @@ describe("ResourcesStreamClient", () => {
         onSnapshot: (p) => snapshots.push(p),
         onUpdate: () => {},
         onConnectionStatus: () => {},
+        onScopeSupport: () => {},
       },
     });
     completeHandshake(sockets[0]);
@@ -394,6 +443,7 @@ describe("ResourcesStreamClient", () => {
         onSnapshot: (p) => snapshots.push(p),
         onUpdate: (p) => updates.push(p),
         onConnectionStatus: () => undefined,
+        onScopeSupport: () => undefined,
       },
     });
     completeHandshake(sockets[0]);
@@ -408,6 +458,157 @@ describe("ResourcesStreamClient", () => {
 
     expect(snapshots).toHaveLength(0);
     expect(updates).toHaveLength(0);
+
+    client.close();
+  });
+});
+
+/**
+ * The scope verdict is what lets a surface say "this host cannot report its
+ * processes" instead of waiting forever on a stream that will never carry one.
+ * These cover it on the LOCAL transport because that is what this suite can
+ * drive end to end - but every signal it reads (the session's own negotiated
+ * version, and a terminal incompatible close) is `IStreamSession` surface that
+ * `LogicalStream` implements identically, which is the entire point: the
+ * client-wide capability cache the old pre-check read is the one thing a remote
+ * session does NOT have.
+ */
+describe("ResourcesStreamClient scope support", () => {
+  it("clears a global scope on a host that negotiates a global-capable version", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, verdicts } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "global" },
+      callbacks,
+    });
+    completeHandshake(sockets[0]);
+
+    expect(verdicts).toEqual(["supported"]);
+
+    client.close();
+  });
+
+  // The case that has no other tell. An `@1.0` host does not reject a global
+  // probe - the `@1.1` request keeps `epicId` on the wire so the downgrade
+  // succeeds - so it accepts, reads only `epicId`, and answers about an epic
+  // called `__global__` that does not exist. No error, no close, one empty
+  // projection, silence. Asserting the subscribe actually WENT OUT at `@1.0`
+  // with the scope field stripped is what proves the verdict came from the
+  // negotiation rather than from a failure that never happened.
+  it("convicts a host whose global probe silently downgraded to @1.0", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, verdicts } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "global" },
+      callbacks,
+    });
+    completeHandshakeAt(sockets[0], { major: 1, minor: 0 });
+
+    expect(parseText(sockets[0].textSent[1])).toEqual({
+      kind: "subscribe",
+      method: "resources.subscribe",
+      schemaVersion: { major: 1, minor: 0 },
+      params: { epicId: "__global__" },
+    });
+    expect(sockets[0].closed).toBeNull();
+    expect(verdicts).toEqual(["unsupported"]);
+
+    client.close();
+  });
+
+  // Same host, same negotiation, opposite verdict: `@1.0` serves a per-epic
+  // subscription perfectly well, and that fallback is genuinely this machine's
+  // own data. A verdict that keyed on the version alone would blank it.
+  it("clears an epic scope on that same @1.0 host", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, verdicts } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "epic", epicId: "epic-1" },
+      callbacks,
+    });
+    completeHandshakeAt(sockets[0], { major: 1, minor: 0 });
+
+    expect(verdicts).toEqual(["supported"]);
+
+    client.close();
+  });
+
+  // The other half: a host that does not advertise a bridgeable method at all
+  // never negotiates a version to judge, and fails the mirror check instead.
+  // This is the close a REMOTE session produces for the same host.
+  it("convicts a host whose method cannot be bridged at all", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, verdicts } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "global" },
+      callbacks,
+    });
+    // No cross-major stream bridge exists, so the mirror check fails and the
+    // client goes terminal with INCOMPATIBLE before any subscribe is sent.
+    completeHandshakeAt(sockets[0], { major: 2, minor: 0 });
+
+    expect(verdicts).toEqual(["unsupported"]);
+
+    client.close();
+  });
+
+  // Every fatal arrives through the one channel, and most of them say nothing
+  // about capability. Reading this one as incompatibility would accuse a host
+  // that is merely unauthorized of being too old - permanently, since nothing
+  // reconnects after a terminal close to correct it.
+  it("does not read a non-capability fatal as incompatibility", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, verdicts } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "global" },
+      callbacks,
+    });
+    completeHandshake(sockets[0]);
+    expect(verdicts).toEqual(["supported"]);
+
+    sockets[0].fireText({
+      kind: "fatalError",
+      details: {
+        code: "UNAUTHORIZED",
+        reason: "bearer rejected",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      },
+    });
+
+    expect(verdicts).toEqual(["supported"]);
+
+    client.close();
+  });
+
+  // A verdict belongs to the connection that produced it. A reconnect may reach
+  // a NEW host incarnation - an upgrade is exactly how one stops being too old -
+  // so capability has to be re-probed, never remembered across the gap.
+  it("drops the verdict when the connection that negotiated it goes away", () => {
+    const { factory, sockets } = makeFactory();
+    const { callbacks, verdicts } = trackScopeSupport();
+
+    const client = new ResourcesStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      scope: { kind: "global" },
+      callbacks,
+    });
+    completeHandshakeAt(sockets[0], { major: 1, minor: 0 });
+    expect(verdicts).toEqual(["unsupported"]);
+
+    sockets[0].fireClose(1006, "connection lost", false);
+
+    expect(verdicts).toEqual(["unsupported", "unknown"]);
 
     client.close();
   });

--- a/clients/shared/host-transport/i-stream-session.ts
+++ b/clients/shared/host-transport/i-stream-session.ts
@@ -60,6 +60,17 @@ export type StreamCloseReason =
  * channel and say nothing about what the host can serve. Reading any of them as
  * incompatibility would pin a permanent "this host is too old" verdict on a
  * failure the next dial clears - and worse, on hosts that are perfectly capable.
+ *
+ * `INCOMPATIBLE` is the whole list, because it is the whole set that is
+ * actually emitted here: `checkStreamMethodCompatibility` (both the local
+ * mirror check and `RemoteSession.openSubscription`) is the only producer of a
+ * capability fatal on a stream. `DOWNGRADE_UNSUPPORTED` reads like a member and
+ * is NOT one - it is a `DowngradeResult` error on a unary RPC result, never a
+ * `FatalErrorDetails.code` - so adding it would widen this to a code that
+ * cannot arrive, which no test could ever hold honest. `FatalErrorDetails.code`
+ * is an open `string` by design (older hosts must be able to send codes we do
+ * not know), so this cannot be a total switch; it is a membership test, and it
+ * must only name codes with a real emitter.
  */
 export function isMethodIncompatibleClose(
   reason: StreamCloseReason | null,
@@ -67,8 +78,7 @@ export function isMethodIncompatibleClose(
   if (reason === null || reason.kind !== "fatalError") {
     return false;
   }
-  const code = reason.details.code;
-  return code === "INCOMPATIBLE" || code === "DOWNGRADE_UNSUPPORTED";
+  return reason.details.code === "INCOMPATIBLE";
 }
 
 /**

--- a/clients/shared/host-transport/i-stream-session.ts
+++ b/clients/shared/host-transport/i-stream-session.ts
@@ -42,6 +42,36 @@ export type StreamCloseReason =
     };
 
 /**
+ * Whether a close reason PROVES the connected host cannot serve this session's
+ * method at all - the fatal class that is a statement about the host's
+ * CAPABILITY rather than about this attempt.
+ *
+ * It is the only capability evidence a remote session ever produces: the mux
+ * resolves an incompatible method as a fatal on the subscribe attempt rather
+ * than as a queryable pre-check, so `RemoteStreamClient.getMethodSupport`
+ * answers `"unknown"` forever and a consumer that waits for it waits for
+ * nothing (see `getMethodSupport`'s own note). The local `StreamSession`
+ * reaches the same close through its mirror check, so a caller reading this
+ * gets one answer on both transports.
+ *
+ * Deliberately a WHITELIST rather than "any fatal". `CLIENT_CLOSED` (a late
+ * subscribe on a torn-down client), `UNAUTHORIZED`, `STREAM_MESSAGE_TOO_LARGE`,
+ * `PLAN_RESTRICTED` and the transport timeouts all arrive through this same
+ * channel and say nothing about what the host can serve. Reading any of them as
+ * incompatibility would pin a permanent "this host is too old" verdict on a
+ * failure the next dial clears - and worse, on hosts that are perfectly capable.
+ */
+export function isMethodIncompatibleClose(
+  reason: StreamCloseReason | null,
+): boolean {
+  if (reason === null || reason.kind !== "fatalError") {
+    return false;
+  }
+  const code = reason.details.code;
+  return code === "INCOMPATIBLE" || code === "DOWNGRADE_UNSUPPORTED";
+}
+
+/**
  * Frame envelope shape exposed to session consumers. The `kind` discriminant
  * plus `hasBinaryPayload` is the minimum the transport needs to route each
  * frame; every other field is contract-specific and is preserved verbatim

--- a/clients/shared/host-transport/resources-stream-client.ts
+++ b/clients/shared/host-transport/resources-stream-client.ts
@@ -15,11 +15,13 @@ import {
   resourcesSubscribeServerFrameSchemaV14,
 } from "@traycer/protocol/host/resources/subscribe";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
-import type {
-  IStreamSession,
-  StreamCloseReason,
-  StreamConnectionStatus,
-  StreamFrameEnvelope,
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
+import {
+  isMethodIncompatibleClose,
+  type IStreamSession,
+  type StreamCloseReason,
+  type StreamConnectionStatus,
+  type StreamFrameEnvelope,
 } from "./i-stream-session";
 import type { IStreamClient } from "./i-stream-client";
 
@@ -54,6 +56,30 @@ export type ResourcesStreamScope =
   | {
       readonly kind: "global";
     };
+
+/**
+ * Whether a NEGOTIATED `resources.subscribe` version can serve a global-scope
+ * subscribe. The global scope arrived in `@1.1`; `@1.0` predates the `scope`
+ * field entirely.
+ *
+ * Exported because two places have to agree on the threshold and must not
+ * drift: this client, which reads the version its own session negotiated, and
+ * the renderer's pre-check, which reads the client-wide one before any session
+ * exists. Takes a non-null version on purpose - "not negotiated yet" is not a
+ * verdict, and each caller has its own reason for that state.
+ */
+export function supportsGlobalResourcesScope(version: SchemaVersion): boolean {
+  return version.major === 1 && version.minor >= 1;
+}
+
+/**
+ * Whether the host on the other end of THIS session can serve the scope it was
+ * opened for. `"unknown"` until a negotiation settles, and again from the
+ * moment one is dropped by a reconnect - a reconnect may reach a new host
+ * incarnation, so capability has to be re-probed rather than remembered (the
+ * same discipline `WsStreamClient.resetMethodSupport` follows).
+ */
+export type ResourcesScopeSupport = "unknown" | "supported" | "unsupported";
 
 const GLOBAL_RESOURCES_EPIC_ID = "__global__";
 
@@ -91,6 +117,12 @@ export interface ResourcesStreamCallbacks {
     status: StreamConnectionStatus,
     reason: StreamCloseReason | null,
   ) => void;
+  /**
+   * Fires when the verdict on this session's scope changes - see
+   * {@link ResourcesScopeSupport}. Never fires with the value the consumer
+   * already holds, so it is safe to drive a store write directly.
+   */
+  readonly onScopeSupport: (support: ResourcesScopeSupport) => void;
 }
 
 export interface ResourcesStreamClientOptions {
@@ -110,11 +142,14 @@ export interface ResourcesStreamClientOptions {
  */
 export class ResourcesStreamClient {
   private readonly session: IStreamSession;
+  private readonly scope: ResourcesStreamScope;
   private readonly callbacks: ResourcesStreamCallbacks;
   private closed: boolean;
+  private scopeSupport: ResourcesScopeSupport = "unknown";
 
   constructor(options: ResourcesStreamClientOptions) {
     this.callbacks = options.callbacks;
+    this.scope = options.scope;
     this.closed = false;
 
     this.session = options.wsStreamClient.subscribe(
@@ -125,8 +160,75 @@ export class ResourcesStreamClient {
       this.handleServerFrame(envelope, binaryPayload);
     });
     this.session.onStatusChange((status, reason) => {
+      // Before the status itself, so a consumer reacting to the `closed`
+      // transition already sees why rather than reading last round's verdict.
+      this.updateScopeSupport(status, reason);
       this.callbacks.onConnectionStatus(status, reason);
     });
+  }
+
+  /**
+   * Publishes the scope verdict when - and only when - this transition carried
+   * evidence that changes it.
+   *
+   * This exists because the pre-check it backs up cannot answer on a remote
+   * host: `RemoteStreamClient` reports `"unknown"` support and a `null`
+   * client-wide schema version for every method by design. What a remote
+   * session DOES produce is this session's own negotiated version and, for a
+   * method the host never advertises, a terminal incompatible close - and both
+   * are equally available on the local transport, so one rule covers both.
+   *
+   * Not folded into the version test: an `@1.0` host does NOT fail a global
+   * subscribe. The `@1.1` request keeps `epicId` on the wire precisely so the
+   * probe downgrades cleanly, so an old host accepts it, reads only `epicId`,
+   * and answers with one empty projection for an epic named `__global__` that
+   * does not exist. It looks exactly like a healthy stream on a quiet machine,
+   * which is why the negotiated VERSION - not the close - is what catches it.
+   */
+  private updateScopeSupport(
+    status: StreamConnectionStatus,
+    reason: StreamCloseReason | null,
+  ): void {
+    const next = this.deriveScopeSupport(status, reason);
+    if (next === null || next === this.scopeSupport) {
+      return;
+    }
+    this.scopeSupport = next;
+    this.callbacks.onScopeSupport(next);
+  }
+
+  /** `null` = this transition carried no evidence; hold the current verdict. */
+  private deriveScopeSupport(
+    status: StreamConnectionStatus,
+    reason: StreamCloseReason | null,
+  ): ResourcesScopeSupport | null {
+    if (status === "closed") {
+      // Every other close - caller teardown, an auth rejection, a plan gate -
+      // is about this attempt, not about what the host can serve. Holding the
+      // previous verdict is what keeps a terminal incompatible close STANDING:
+      // it is disposed, so nothing follows it that could clear the notice.
+      return isMethodIncompatibleClose(reason) ? "unsupported" : null;
+    }
+    // Otherwise the verdict is worth exactly what this session's negotiated
+    // version is worth - and `connecting` / `reconnecting` have none, BY
+    // CONTRACT: `getNegotiatedSchemaVersion` is null before a handshake settles
+    // and null again the moment a drop takes it. That is what re-probes a
+    // reconnect instead of carrying a verdict across it, which matters because
+    // a reconnect may reach a NEW host incarnation - an upgrade is exactly how
+    // a host stops being too old. One rule rather than a separate reset, so
+    // there is no second place for the two to disagree.
+    const negotiated = this.session.getNegotiatedSchemaVersion();
+    if (negotiated === null) {
+      return "unknown";
+    }
+    if (this.scope.kind === "epic") {
+      // Every version of this method serves an epic scope; opening at all is
+      // the proof.
+      return "supported";
+    }
+    return supportsGlobalResourcesScope(negotiated)
+      ? "supported"
+      : "unsupported";
   }
 
   /**

--- a/clients/shared/host-transport/resources-stream-client.ts
+++ b/clients/shared/host-transport/resources-stream-client.ts
@@ -208,17 +208,20 @@ export class ResourcesStreamClient {
       // previous verdict is what keeps a terminal incompatible close STANDING:
       // it is disposed, so nothing follows it that could clear the notice.
       //
-      // KNOWN LIMIT, and it is only this branch. A version verdict SELF-HEALS:
-      // that stream stays open, so a drop takes its negotiated version with it
-      // (see below), the verdict falls back to "unknown", and the resume
-      // re-negotiates - an upgraded host clears itself. A terminal close has no
-      // such path: an incompatible METHOD fails only the stream
-      // (`RemoteSession.openSubscription` calls `goFatal` and deletes the
-      // subscription) while the shared session stays healthy, so the transport
-      // identity never changes and nothing re-probes. A host that advertises no
-      // bridgeable `resources.subscribe` at all and is then upgraded in place
-      // keeps this verdict until the surface remounts. Narrow, and strictly
-      // better than the wait-forever it replaces, but not self-correcting.
+      // This verdict cannot expire on its own, and that asymmetry is the point.
+      // A version verdict SELF-HEALS: that stream stays open, so a drop takes
+      // its negotiated version with it (see below), the verdict falls back to
+      // "unknown", and the resume re-negotiates - an upgraded host clears
+      // itself. A terminal close has no such path: an incompatible METHOD fails
+      // only the stream (`RemoteSession.openSubscription` calls `goFatal` and
+      // deletes the subscription) while the shared session stays healthy, so
+      // the transport identity never changes and nothing here re-probes.
+      //
+      // Clearing it is therefore an OWNER's job, not this rule's: the verdict
+      // is what this session observed, and this session will observe nothing
+      // further. `GlobalResourcesStreamMount` re-probes by rebuilding the
+      // stream when the transport reports the endpoint recovered - the only
+      // evidence that the host on the other end may not be the one we judged.
       return isMethodIncompatibleClose(reason) ? "unsupported" : null;
     }
     // Otherwise the verdict is worth exactly what this session's negotiated

--- a/clients/shared/host-transport/resources-stream-client.ts
+++ b/clients/shared/host-transport/resources-stream-client.ts
@@ -207,6 +207,18 @@ export class ResourcesStreamClient {
       // is about this attempt, not about what the host can serve. Holding the
       // previous verdict is what keeps a terminal incompatible close STANDING:
       // it is disposed, so nothing follows it that could clear the notice.
+      //
+      // KNOWN LIMIT, and it is only this branch. A version verdict SELF-HEALS:
+      // that stream stays open, so a drop takes its negotiated version with it
+      // (see below), the verdict falls back to "unknown", and the resume
+      // re-negotiates - an upgraded host clears itself. A terminal close has no
+      // such path: an incompatible METHOD fails only the stream
+      // (`RemoteSession.openSubscription` calls `goFatal` and deletes the
+      // subscription) while the shared session stays healthy, so the transport
+      // identity never changes and nothing re-probes. A host that advertises no
+      // bridgeable `resources.subscribe` at all and is then upgraded in place
+      // keeps this verdict until the surface remounts. Narrow, and strictly
+      // better than the wait-forever it replaces, but not self-correcting.
       return isMethodIncompatibleClose(reason) ? "unsupported" : null;
     }
     // Otherwise the verdict is worth exactly what this session's negotiated


### PR DESCRIPTION
## Summary

`useGlobalResourcesUnsupported` decides whether a host can serve a global
`resources.subscribe`, and it answered for **local** hosts only.
`RemoteStreamClient` reports `"unknown"` support and a `null` schema version for
every method by design, so both its terms stayed false for a remote host: the
mount acquired, and an old remote host sat on "Waiting for &lt;host&gt;…"
indefinitely instead of being told why.

The picker added in #1194 exists to watch *another* machine, so the population
that most needs the incompatible-host notice was exactly the one that could not
receive it.

The fix is a second source, read from the live session rather than from a
pre-check that cannot answer. Both signals it uses are `IStreamSession` surface
that `LogicalStream` implements identically — so one rule now covers both
transports.

## The `@1.0` case has no terminal failure to derive from

Worth stating plainly, because the issue proposed deriving the verdict from the
terminal failure of the subscribe: **an `@1.0` host does not fail a global
subscribe.**

The `@1.1` open request keeps `epicId` on the wire precisely so a newer client
can downgrade a global probe cleanly (`subscribe.ts`, and its own comment says
so). So the old host accepts the request, reads only `epicId`, and answers with
one empty projection for an epic named `__global__` that does not exist — no
error, no close, then silence. From the outside that is indistinguishable from a
healthy stream on an idle machine, which is why a close-based rule cannot see it.

So the primary signal is **this session's own negotiated version**
(`IStreamSession.getNegotiatedSchemaVersion`), which is per-session and therefore
real on both transports — unlike the client-wide cache the pre-check reads, which
only a local client populates. The terminal close covers the other half, a host
that never advertises the method at all.

## What counts as a capability close

`isMethodIncompatibleClose` is a whitelist — `INCOMPATIBLE` /
`DOWNGRADE_UNSUPPORTED` — not "any fatal". Every fatal arrives through the one
channel, and `CLIENT_CLOSED` (a late subscribe on a torn-down client),
`UNAUTHORIZED`, `PLAN_RESTRICTED` and the transport timeouts say nothing about
what the host can serve. Reading any of them as incompatibility would pin a
permanent "this host is too old" notice on a perfectly capable machine, with
nothing following a terminal close to correct it.

## Two things the shape had to avoid

**The mount still gates on the pre-stream verdict alone.** Gating it on the full
verdict is a loop with no exit: acquire → the stream negotiates `@1.0` and
reports `unsupported` → the effect re-runs and releases → the store holding the
verdict is disposed with it → the verdict reverts to `unknown` → acquire again.
It would re-dial a host forever on the strength of having successfully learned
something about it. A host convicted only by its own stream therefore keeps that
stream; it costs one idle subscription and nothing else.

**The verdict is attributed.** The registry entry is a module singleton that
outlives any one transport, so it routinely describes the machine we just
stopped watching — the entry is named at acquire time, one commit before a
replacement binding reaches context. It is repeated only for the host its stream
was actually opened against, with the same strict positive proof
`attributedProjection` already demands of the data. Unchecked, picking an
up-to-date host while the previous (old) one's entry was still live would print
"cannot report its processes" under the **new** host's name. A verdict is an
accusation about a specific machine; it may only be repeated for the machine it
was made about. Two unnamed things are not the same thing either, so a `null`
entry never matches a `null` claim.

## Related issue

Fixes #1197. Follow-up to #1194, which added the picker and documented this gap.

## Validation

- `bun run compile --skip-nx-cache` clean across all 5 projects — uncached
  deliberately; a cached green is not evidence when the tree has been edited
- `bun run lint` clean (gui-app + shared)
- 31 gui-app test files / 353 tests across `components/resources`,
  `stores/resources`, `providers`, `hooks/resources` and the managed-command
  resources acceptance test, plus the full 17-file / 214-test shared
  `host-transport` suite
- Red proof — each new predicate reverted in turn, confirming the matching test
  fails and then passes again on restore:
  - the negotiated-version branch → "convicts a host whose global probe silently
    downgraded to @1.0" (and the reconnect case with it)
  - the fatal-code whitelist → "does not read a non-capability fatal as
    incompatibility"
  - the null-version guard → "drops the verdict when the connection that
    negotiated it goes away"
  - the epic-scope branch → "clears an epic scope on that same @1.0 host"
  - the registry attribution check → all three cross-host cases
  - the hook's stream-derived term → "convicts a remote host from the verdict its
    own stream produced"
  - the mount's pre-check gate swapped for the full verdict → "keeps the stream
    it opened after that stream convicts its own host" fails with `expected 2 to
    be 1`, catching the first lap of the rebuild loop
- **One dead branch was found and removed this way**: an explicit `connecting` /
  `reconnecting` reset that no mutation could make fail, because
  `getNegotiatedSchemaVersion` is null across a drop *by contract* and the
  null-version guard already covered it. Collapsed to a single rule so there is
  no second place for the two to disagree.
- `react-doctor`: no new rule classes. The two
  `react-compiler-no-manual-memoization` warnings on the new hook are the
  `useSyncExternalStore` pattern this same file already uses at lines 496/500
  (2100 instances repo-wide), and the `useCallback`s are load-bearing there —
  an unstable `subscribe`/`getSnapshot` resubscribes every render.

## Not in this PR

The internal-repo gitlink bump is a separate, deliberate change after this
merges — never pin the internal repo to an unmerged OSS branch.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
