### PR TITLE
feat(gui-app): wire the PR diff tile into bundle-find

### DIFF
--- a/clients/gui-app/src/components/diff/bundle-diff-find-registration-hooks.ts
+++ b/clients/gui-app/src/components/diff/bundle-diff-find-registration-hooks.ts
@@ -49,6 +49,16 @@ export interface BundleDiffFindRegistrationContextValue {
     state: BundleDiffFindCoverageState,
   ) => void;
   readonly registerLoadedPatch: (entry: BundleDiffFindLoadedPatchInput) => void;
+  /**
+   * Drop a retained patch. A loaded patch outlives its section on purpose
+   * (see `registerLoadedPatch`), and takes precedence over any coverage
+   * state in the coverage counts - so a section whose LATER request for the
+   * same content fails ("Load Full" past a truncation, a refetch) must
+   * unregister the bytes it no longer renders, or find keeps matching text
+   * that is not in the DOM and reports the file as truncated instead of
+   * failed. Idempotent: an unknown file id is a no-op.
+   */
+  readonly unregisterLoadedPatch: (fileId: string) => void;
 }
 
 interface BundleDiffFindSessionState {
@@ -61,6 +71,7 @@ const NOOP_CONTEXT: BundleDiffFindRegistrationContextValue = {
   notifySectionMounted: () => undefined,
   registerCoverageState: () => undefined,
   registerLoadedPatch: () => undefined,
+  unregisterLoadedPatch: () => undefined,
 };
 
 export const BundleDiffFindRegistrationContext =
@@ -175,13 +186,38 @@ export function useRegisterBundleDiffTileFindAdapter(args: {
     [args.contentIdentity],
   );
 
+  const unregisterLoadedPatch = useCallback(
+    (fileId: string): void => {
+      setSession((current) =>
+        ensureSession(current, args.contentIdentity, (next) => {
+          // Same identity discipline as registration: only a real removal
+          // may churn `loadedPatches` (the source memo keys on it).
+          if (!next.loadedPatches.has(fileId)) return next;
+          const loadedPatches = new Map(next.loadedPatches);
+          loadedPatches.delete(fileId);
+          return {
+            ...next,
+            loadedPatches,
+          };
+        }),
+      );
+    },
+    [args.contentIdentity],
+  );
+
   return useMemo(
     () => ({
       notifySectionMounted,
       registerCoverageState,
       registerLoadedPatch,
+      unregisterLoadedPatch,
     }),
-    [notifySectionMounted, registerCoverageState, registerLoadedPatch],
+    [
+      notifySectionMounted,
+      registerCoverageState,
+      registerLoadedPatch,
+      unregisterLoadedPatch,
+    ],
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-bundle-file-section-image-routing.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-bundle-file-section-image-routing.test.tsx
@@ -92,6 +92,7 @@ vi.mock("@/components/diff/bundle-diff-find-registration-hooks", () => ({
     registerCoverageState: state.coverage,
     notifySectionMounted: state.mounted,
     registerLoadedPatch: vi.fn(),
+    unregisterLoadedPatch: vi.fn(),
   }),
 }));
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
@@ -260,12 +260,18 @@ function BundleInlineDiff(props: BundleInlineDiffProps): ReactNode {
     queryEnabled: true,
     resumeDetachedDraft: true,
   });
+  // A mounted section showing NO content - pending for a key with no data
+  // yet (a "Load Full" re-ask), or an error - drops the patch it registered
+  // before: past "Load Full" the truncated bytes will never render again, so
+  // leaving them indexed would have find match text that is not in the DOM
+  // and park navigation on a skeleton or the error block. Retention is for
+  // UNMOUNTED rows only (see `unregisterLoadedPatch`).
+  useEffect(() => {
+    if (!displayedDiffPending) return;
+    bundleFindRegistration.unregisterLoadedPatch(props.bundleFindFileId);
+  }, [bundleFindRegistration, displayedDiffPending, props.bundleFindFileId]);
   useEffect(() => {
     if (displayedDiffError === null) return;
-    // The error block is the only thing on screen now: drop the retained
-    // patch too, or a "Load Full" that fails after a truncated diff was shown
-    // leaves find matching text that is no longer in the DOM (see
-    // `unregisterLoadedPatch`).
     bundleFindRegistration.unregisterLoadedPatch(props.bundleFindFileId);
     bundleFindRegistration.registerCoverageState(
       props.bundleFindFileId,

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
@@ -262,6 +262,11 @@ function BundleInlineDiff(props: BundleInlineDiffProps): ReactNode {
   });
   useEffect(() => {
     if (displayedDiffError === null) return;
+    // The error block is the only thing on screen now: drop the retained
+    // patch too, or a "Load Full" that fails after a truncated diff was shown
+    // leaves find matching text that is no longer in the DOM (see
+    // `unregisterLoadedPatch`).
+    bundleFindRegistration.unregisterLoadedPatch(props.bundleFindFileId);
     bundleFindRegistration.registerCoverageState(
       props.bundleFindFileId,
       "failed",

--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-bundle-diff-find.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-bundle-diff-find.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { PrLocalDiffSummaryFile } from "@traycer/protocol/host/pr-schemas";
+import { isPrLocalDiffLargeFile } from "@/lib/pr/pr-local-diff-large-file";
+import {
+  prBundleDiffFindFileId,
+  prBundleLoadedPatchCacheKey,
+} from "@/components/epic-canvas/pr/pr-bundle-diff-find";
+
+function file(
+  overrides: Partial<PrLocalDiffSummaryFile>,
+): PrLocalDiffSummaryFile {
+  return {
+    path: "src/a.ts",
+    previousPath: null,
+    status: "modified",
+    insertions: 3,
+    deletions: 1,
+    isBinary: false,
+    ...overrides,
+  };
+}
+
+describe("isPrLocalDiffLargeFile", () => {
+  it("is large when insertions is null", () => {
+    expect(isPrLocalDiffLargeFile(file({ insertions: null }))).toBe(true);
+  });
+
+  it("is large when deletions is null", () => {
+    expect(isPrLocalDiffLargeFile(file({ deletions: null }))).toBe(true);
+  });
+
+  it("is large when insertions + deletions exceeds the threshold", () => {
+    expect(
+      isPrLocalDiffLargeFile(file({ insertions: 900, deletions: 101 })),
+    ).toBe(true);
+  });
+
+  it("is not large when insertions + deletions is at or under the threshold", () => {
+    expect(
+      isPrLocalDiffLargeFile(file({ insertions: 900, deletions: 100 })),
+    ).toBe(false);
+  });
+});
+
+describe("prBundleDiffFindFileId", () => {
+  it("prefixes the path with pr:", () => {
+    expect(prBundleDiffFindFileId(file({ path: "src/a.ts" }))).toBe(
+      "pr:src/a.ts",
+    );
+  });
+});
+
+describe("prBundleLoadedPatchCacheKey", () => {
+  function key(overrides: {
+    readonly comparisonKey?: string;
+    readonly file?: PrLocalDiffSummaryFile;
+    readonly ignoreWhitespace?: boolean;
+    readonly isTruncated?: boolean;
+  }): string {
+    return prBundleLoadedPatchCacheKey({
+      comparisonKey: "base..head",
+      file: file({}),
+      ignoreWhitespace: false,
+      isTruncated: false,
+      ...overrides,
+    });
+  }
+
+  it("is equal for equal inputs", () => {
+    expect(key({})).toBe(key({}));
+  });
+
+  it("differs when comparisonKey differs", () => {
+    expect(key({ comparisonKey: "base..head" })).not.toBe(
+      key({ comparisonKey: "other..head" }),
+    );
+  });
+
+  it("differs when ignoreWhitespace differs", () => {
+    expect(key({ ignoreWhitespace: false })).not.toBe(
+      key({ ignoreWhitespace: true }),
+    );
+  });
+
+  it("differs when isTruncated differs", () => {
+    expect(key({ isTruncated: false })).not.toBe(key({ isTruncated: true }));
+  });
+
+  it("differs when the file's path differs", () => {
+    expect(key({ file: file({ path: "src/a.ts" }) })).not.toBe(
+      key({ file: file({ path: "src/b.ts" }) }),
+    );
+  });
+
+  it("differs when the file's previousPath differs", () => {
+    expect(key({ file: file({ previousPath: null }) })).not.toBe(
+      key({ file: file({ previousPath: "src/old.ts" }) }),
+    );
+  });
+
+  it("cannot collide across fields for a path containing the JSON-unsafe marker string", () => {
+    const weirdPath = 'pr-local-diff","truncated';
+    const a = prBundleLoadedPatchCacheKey({
+      comparisonKey: "base..head",
+      file: file({ path: weirdPath, previousPath: null }),
+      ignoreWhitespace: false,
+      isTruncated: false,
+    });
+    const b = prBundleLoadedPatchCacheKey({
+      comparisonKey: "base..head",
+      file: file({ path: "src/a.ts", previousPath: null }),
+      ignoreWhitespace: false,
+      isTruncated: true,
+    });
+    expect(a).not.toBe(b);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-bundle-diff-find.ts
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-bundle-diff-find.ts
@@ -1,0 +1,277 @@
+import { useCallback, useMemo, type RefObject } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
+import type { PrLocalDiffSummaryFile } from "@traycer/protocol/host/pr-schemas";
+import { getBasename, getDirname } from "@/lib/path/cross-platform-path";
+import { isPrLocalDiffLargeFile } from "@/lib/pr/pr-local-diff-large-file";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { TILE_KIND_PR_DIFF } from "@/stores/epics/canvas/tile-kinds";
+import type { PrDiffTileRef } from "@/stores/epics/canvas/types";
+import type {
+  BundleDiffFindCoverageState,
+  BundleDiffFindFileInput,
+} from "@/stores/tile-find";
+import {
+  useBundleDiffFindNavigation,
+  useRegisterBundleDiffTileFindAdapter,
+  type BundleDiffFindFileNavigationInput,
+  type BundleDiffFindRegistrationContextValue,
+} from "@/components/diff/bundle-diff-find-registration-hooks";
+
+/**
+ * How a PR diff tile's file sections get their patch bytes, as far as the
+ * find session cares: `split` sections fetch on mount, `monolith` sections
+ * read from a whole-PR response that was fetched once (old-host fallback).
+ */
+export type PrBundleDiffFindPatchMode = "split" | "monolith";
+
+// Stable identity for a PR range-diff file within the find index. Shared by
+// the session (coverage / loaded-patch registration) and the section renderer
+// (`data-bundle-diff-file-id`, `notifySectionMounted`) so reveal targets the
+// same file id the index was built with. Keyed on `path` alone because that is
+// the list's row identity too (`computeItemKey`): a range diff names each
+// destination path once, and a rename's `previousPath` is a property of the
+// row, not a second row.
+export function prBundleDiffFindFileId(file: PrLocalDiffSummaryFile): string {
+  return `pr:${file.path}`;
+}
+
+/**
+ * Cache key for a loaded patch registered against the PR find session:
+ * OID-addressed through `comparisonKey` (the summary's `mergeBase..head`, or
+ * the monolith's), plus everything else that changes the bytes - the
+ * whitespace mode, the path pair, and whether the per-file byte budget cut
+ * the patch. Two different patches must never share a key, since the index
+ * treats an unchanged key as an unchanged patch. JSON-encoded so a path can
+ * never collide with a neighbouring field.
+ */
+export function prBundleLoadedPatchCacheKey(args: {
+  readonly comparisonKey: string;
+  readonly file: PrLocalDiffSummaryFile;
+  readonly ignoreWhitespace: boolean;
+  readonly isTruncated: boolean;
+}): string {
+  return JSON.stringify([
+    "pr-local-diff",
+    args.comparisonKey,
+    args.ignoreWhitespace,
+    args.file.previousPath,
+    args.file.path,
+    args.isTruncated ? "truncated" : "full",
+  ]);
+}
+
+/**
+ * The coverage a file starts at before its section ever mounts. Terminal
+ * states first - a binary file, or a monolith file the whole-PR byte budget
+ * never reached, cannot become searchable by expanding or scrolling - then the
+ * two states a reveal CAN clear (expand, then mount-and-fetch), then the
+ * guarded one: a large file's content stays unsearched until its "Load diff"
+ * is pressed, exactly as the Git bundle keeps its large rows out of the index
+ * (see `gitBundleDiffFindCoverageState`).
+ */
+function prBundleDiffFindCoverageState(args: {
+  readonly file: PrLocalDiffSummaryFile;
+  readonly collapsed: boolean;
+  /** Monolith mode: the patch the response carried, `null` past the budget. */
+  readonly monolithPatch: string | null | undefined;
+}): BundleDiffFindCoverageState {
+  if (args.file.isBinary) return "binary";
+  if (args.monolithPatch === null) return "truncated";
+  if (args.collapsed) return "collapsed";
+  if (isPrLocalDiffLargeFile(args.file)) return "large";
+  return "unloaded";
+}
+
+function prBundleDiffFindFileInput(args: {
+  readonly file: PrLocalDiffSummaryFile;
+  readonly collapsed: boolean;
+  readonly monolithPatch: string | null | undefined;
+}): BundleDiffFindFileInput {
+  const fileId = prBundleDiffFindFileId(args.file);
+  const directory = getDirname(args.file.path);
+  const previousPath = args.file.previousPath ?? "";
+  return {
+    id: fileId,
+    filePath: args.file.path,
+    coverageState: prBundleDiffFindCoverageState(args),
+    metadataUnits: [
+      {
+        id: `pr-diff-file:${fileId}`,
+        filePath: args.file.path,
+        scopeId: fileId,
+        text: [
+          getBasename(args.file.path),
+          directory.length > 0 ? directory : "Repository root",
+          args.file.path,
+          previousPath,
+          args.file.status,
+          args.file.insertions === null
+            ? ""
+            : `${args.file.insertions} additions`,
+          args.file.deletions === null
+            ? ""
+            : `${args.file.deletions} deletions`,
+          args.file.isBinary ? "binary" : "",
+        ]
+          .filter((part) => part.length > 0)
+          .join(" "),
+      },
+    ],
+  };
+}
+
+/**
+ * The find session's content identity: a new comparison (the checkout moved,
+ * a whitespace flip), a different data plumbing (split ↔ monolith after a
+ * mid-session capability change) or a different file list opens a fresh
+ * session, dropping the loaded patches and coverage of the old one - they
+ * described bytes the tile no longer shows.
+ */
+function prBundleDiffFindContentIdentity(args: {
+  readonly comparisonKey: string;
+  readonly patchMode: PrBundleDiffFindPatchMode;
+  readonly ignoreWhitespace: boolean;
+  readonly files: ReadonlyArray<PrLocalDiffSummaryFile>;
+}): string {
+  return JSON.stringify([
+    "pr-diff",
+    args.patchMode,
+    args.comparisonKey,
+    args.ignoreWhitespace,
+    args.files.map((file) => [
+      file.path,
+      file.previousPath,
+      file.status,
+      file.isBinary,
+      file.insertions,
+      file.deletions,
+    ]),
+  ]);
+}
+
+/**
+ * Owns the PR diff tile's bundle find session: file-input construction,
+ * content identity, collapsed-file expansion, navigation, and adapter
+ * registration - `useGitBundleDiffFind` for the PR range diff. The renderer
+ * stays responsible only for the file list, scroll restoration, and composing
+ * the result into the virtualized tree; sections register their coverage and
+ * loaded patches through the returned context value.
+ *
+ * Both patch modes share this one session, so what "searchable" means is the
+ * same in split and fallback mode: file metadata for every file up front,
+ * plus every patch a mounted section has rendered - retained after the row
+ * virtualizes away. Reveal scrolls the list to the target row (mounting it,
+ * which in split mode issues its fetch) and expands a collapsed one; the
+ * coverage message names the files that were not searched.
+ */
+export function usePrBundleDiffFind(args: {
+  readonly node: PrDiffTileRef;
+  readonly viewTabId: string;
+  readonly files: ReadonlyArray<PrLocalDiffSummaryFile>;
+  readonly comparisonKey: string;
+  readonly patchMode: PrBundleDiffFindPatchMode;
+  /** Monolith mode's per-path patches (`null` = past the budget), else null. */
+  readonly monolithPatches: ReadonlyMap<string, string | null> | null;
+  readonly ignoreWhitespace: boolean;
+  readonly virtuosoRef: RefObject<VirtuosoHandle | null>;
+}): {
+  readonly registration: BundleDiffFindRegistrationContextValue;
+  readonly setRootElement: (element: HTMLDivElement | null) => void;
+} {
+  const updateView = useEpicCanvasStore((s) => s.updatePrDiffTileViewInTab);
+  const {
+    comparisonKey,
+    files,
+    ignoreWhitespace,
+    monolithPatches,
+    node,
+    patchMode,
+    viewTabId,
+    virtuosoRef,
+  } = args;
+  const nodeId = node.id;
+  const nodeView = node.view;
+  const collapsedFilePaths = nodeView.collapsedFilePaths;
+
+  const bundleFindFiles = useMemo(
+    () =>
+      files.map((file) =>
+        prBundleDiffFindFileInput({
+          file,
+          collapsed: collapsedFilePaths.includes(file.path),
+          monolithPatch: monolithPatches?.get(file.path),
+        }),
+      ),
+    [collapsedFilePaths, files, monolithPatches],
+  );
+  const bundleFindNavigationFiles = useMemo(
+    () =>
+      bundleFindFiles.map((file): BundleDiffFindFileNavigationInput => ({
+        id: file.id,
+        filePath: file.filePath,
+      })),
+    [bundleFindFiles],
+  );
+  const collapsedBundleFindFileIds = useMemo(
+    () =>
+      new Set(
+        bundleFindFiles.flatMap((file) =>
+          collapsedFilePaths.includes(file.filePath) ? [file.id] : [],
+        ),
+      ),
+    [bundleFindFiles, collapsedFilePaths],
+  );
+  const expandBundleFindFile = useCallback(
+    (fileId: string): void => {
+      const file = bundleFindFiles.find((candidate) => candidate.id === fileId);
+      if (file === undefined) return;
+      if (!collapsedFilePaths.includes(file.filePath)) return;
+      updateView(viewTabId, nodeId, {
+        ...nodeView,
+        collapsedFilePaths: collapsedFilePaths.filter(
+          (filePath) => filePath !== file.filePath,
+        ),
+      });
+    },
+    [
+      bundleFindFiles,
+      collapsedFilePaths,
+      nodeId,
+      nodeView,
+      updateView,
+      viewTabId,
+    ],
+  );
+  const bundleFindNavigation = useBundleDiffFindNavigation({
+    files: bundleFindNavigationFiles,
+    collapsedFileIds: collapsedBundleFindFileIds,
+    expandFile: expandBundleFindFile,
+    virtuosoRef,
+  });
+  const bundleFindContentIdentity = useMemo(
+    () =>
+      prBundleDiffFindContentIdentity({
+        comparisonKey,
+        patchMode,
+        ignoreWhitespace,
+        files,
+      }),
+    [comparisonKey, files, ignoreWhitespace, patchMode],
+  );
+  const registration = useRegisterBundleDiffTileFindAdapter({
+    tileInstanceId: node.instanceId,
+    tileKind: TILE_KIND_PR_DIFF,
+    files: bundleFindFiles,
+    contentIdentity: bundleFindContentIdentity,
+    renderer: bundleFindNavigation,
+    sourceOverride: null,
+  });
+  const setRootElement = useCallback(
+    (element: HTMLDivElement | null): void => {
+      bundleFindNavigation.setRootElement(element);
+    },
+    [bundleFindNavigation],
+  );
+
+  return { registration, setRootElement };
+}

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
@@ -16,6 +16,8 @@ import type {
 } from "@traycer/protocol/host/pr-schemas";
 import { DEFAULT_PR_LOCAL_FILE_DIFF_BYTE_BUDGET } from "@traycer/protocol/host/pr-schemas";
 import { Button } from "@/components/ui/button";
+import { BundleDiffFindRegistrationProvider } from "@/components/diff/bundle-diff-find-registration";
+import { useBundleDiffFindRegistrationContext } from "@/components/diff/bundle-diff-find-registration-hooks";
 import { DiffContentPrimitive } from "@/components/epic-canvas/git-diff/diff-content-primitive";
 import { DiffBundleCollapseChevron } from "@/components/epic-canvas/git-diff/diff-bundle-file-section";
 import { DiffContentLoadingSkeleton } from "@/components/epic-canvas/git-diff/diff-content-loading-skeleton";
@@ -24,8 +26,13 @@ import { TruncatedBanner } from "@/components/epic-canvas/git-diff/truncated-ban
 import { GitSectionStatsSummary } from "@/components/epic-canvas/git-diff/diff-tab-shell";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { PrExternalGitHubLink } from "@/components/epic-canvas/pr/pr-external-github-link";
-import { BUNDLE_INLINE_LINE_THRESHOLD } from "@/lib/git/bundle-thresholds";
+import {
+  prBundleDiffFindFileId,
+  prBundleLoadedPatchCacheKey,
+  usePrBundleDiffFind,
+} from "@/components/epic-canvas/pr/pr-bundle-diff-find";
 import type { DiffViewerPreferences } from "@/lib/diff/diff-viewer-preferences";
+import { isPrLocalDiffLargeFile } from "@/lib/pr/pr-local-diff-large-file";
 import {
   isHostUnsupportedError,
   usePrLocalFileDiffQuery,
@@ -283,6 +290,23 @@ function PrLocalDiffFilesView(props: {
       props.node.instanceId,
       props.files.length > 0,
     );
+  // One find session for BOTH patch modes - the sections below register their
+  // coverage and loaded patches through its context regardless of where the
+  // bytes came from, so what "searchable" means cannot diverge between a new
+  // host and the old-host fallback. Registered before the empty-range return
+  // so the hook order is stable across a range that empties and refills.
+  const { registration: bundleFindRegistration, setRootElement } =
+    usePrBundleDiffFind({
+      node: props.node,
+      viewTabId: props.viewTabId,
+      files: props.files,
+      comparisonKey: props.mode.comparisonKey,
+      patchMode: props.mode.kind,
+      monolithPatches:
+        props.mode.kind === "monolith" ? props.mode.patches : null,
+      ignoreWhitespace: props.preferences.ignoreWhitespace,
+      virtuosoRef,
+    });
 
   if (props.files.length === 0) {
     return (
@@ -296,63 +320,68 @@ function PrLocalDiffFilesView(props: {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      {props.isStale ? (
-        <p
-          className="flex min-w-0 shrink-0 items-start gap-2 border-b border-warning/40 bg-warning/10 px-3 py-2 text-ui-xs text-foreground"
-          data-testid="pr-diff-stale"
-        >
-          <FileWarning
-            className="mt-px size-3.5 shrink-0 text-warning"
-            aria-hidden
-          />
-          <span className="min-w-0">
-            This is your local checkout at{" "}
-            <span className="font-mono">{props.localHeadOid.slice(0, 7)}</span>.
-            GitHub is showing a different commit, so pushed changes you haven’t
-            pulled — or local commits you haven’t pushed — will not match.
-          </span>
-        </p>
-      ) : null}
-      <Virtuoso
-        ref={virtuosoRef}
-        restoreStateFrom={restoreStateFrom}
-        isScrolling={isScrolling}
-        data={props.files}
-        className="min-h-0 flex-1"
-        overscan={6}
-        computeItemKey={(_index, file) => file.path}
-        // eslint-disable-next-line react/no-unstable-nested-components -- Virtuoso row renderer, not a component definition.
-        itemContent={(_index, file) => (
-          <PrLocalDiffFileSection
-            node={props.node}
-            viewTabId={props.viewTabId}
-            file={file}
-            mode={props.mode}
-            prUrl={props.prUrl}
-            preferences={props.preferences}
-          />
-        )}
-      />
-      {props.monolithTruncation !== null ? (
-        <p
-          className="shrink-0 border-t border-border/60 px-3 py-2 text-ui-xs text-muted-foreground/70"
-          data-testid="pr-diff-truncated"
-        >
-          The patch was cut off after {props.monolithTruncation.shownPatches} of{" "}
-          {props.files.length} files.{" "}
-          {props.prUrl !== null ? (
-            <PrExternalGitHubLink
-              href={`${props.prUrl}/files`}
-              className="text-primary hover:underline"
-              testId="pr-diff-truncated-github-link"
-            >
-              View the full diff on GitHub
-            </PrExternalGitHubLink>
-          ) : null}
-        </p>
-      ) : null}
-    </div>
+    <BundleDiffFindRegistrationProvider value={bundleFindRegistration}>
+      <div ref={setRootElement} className="flex h-full min-h-0 flex-col">
+        {props.isStale ? (
+          <p
+            className="flex min-w-0 shrink-0 items-start gap-2 border-b border-warning/40 bg-warning/10 px-3 py-2 text-ui-xs text-foreground"
+            data-testid="pr-diff-stale"
+          >
+            <FileWarning
+              className="mt-px size-3.5 shrink-0 text-warning"
+              aria-hidden
+            />
+            <span className="min-w-0">
+              This is your local checkout at{" "}
+              <span className="font-mono">
+                {props.localHeadOid.slice(0, 7)}
+              </span>
+              . GitHub is showing a different commit, so pushed changes you
+              haven’t pulled — or local commits you haven’t pushed — will not
+              match.
+            </span>
+          </p>
+        ) : null}
+        <Virtuoso
+          ref={virtuosoRef}
+          restoreStateFrom={restoreStateFrom}
+          isScrolling={isScrolling}
+          data={props.files}
+          className="min-h-0 flex-1"
+          overscan={6}
+          computeItemKey={(_index, file) => file.path}
+          // eslint-disable-next-line react/no-unstable-nested-components -- Virtuoso row renderer, not a component definition.
+          itemContent={(_index, file) => (
+            <PrLocalDiffFileSection
+              node={props.node}
+              viewTabId={props.viewTabId}
+              file={file}
+              mode={props.mode}
+              prUrl={props.prUrl}
+              preferences={props.preferences}
+            />
+          )}
+        />
+        {props.monolithTruncation !== null ? (
+          <p
+            className="shrink-0 border-t border-border/60 px-3 py-2 text-ui-xs text-muted-foreground/70"
+            data-testid="pr-diff-truncated"
+          >
+            The patch was cut off after {props.monolithTruncation.shownPatches}{" "}
+            of {props.files.length} files.{" "}
+            {props.prUrl !== null ? (
+              <PrExternalGitHubLink
+                href={`${props.prUrl}/files`}
+                className="text-primary hover:underline"
+                testId="pr-diff-truncated-github-link"
+              >
+                View the full diff on GitHub
+              </PrExternalGitHubLink>
+            ) : null}
+          </p>
+        ) : null}
+      </div>
+    </BundleDiffFindRegistrationProvider>
   );
 }
 
@@ -371,6 +400,8 @@ function PrLocalDiffFileSection(props: {
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
   const { file, node } = props;
+  const bundleFindRegistration = useBundleDiffFindRegistrationContext();
+  const bundleFindFileId = prBundleDiffFindFileId(file);
   const toggleCollapsed = useEpicCanvasStore(
     (state) => state.togglePrDiffFileCollapsedInTab,
   );
@@ -379,6 +410,14 @@ function PrLocalDiffFileSection(props: {
   const toggle = useCallback((): void => {
     toggleCollapsed(viewTabId, node.id, file.path);
   }, [file.path, node.id, toggleCollapsed, viewTabId]);
+  // Re-notify when a collapsed section expands (find-driven or manual): the
+  // diff body only mounts while expanded, so a mount-only notification would
+  // leave a freshly-revealed match painted nowhere. The find session repaints
+  // in place from this - no scroll, no search replay.
+  useEffect(() => {
+    if (collapsed) return;
+    bundleFindRegistration.notifySectionMounted(bundleFindFileId);
+  }, [bundleFindFileId, bundleFindRegistration, collapsed]);
 
   const label =
     file.previousPath === null
@@ -389,11 +428,14 @@ function PrLocalDiffFileSection(props: {
   // "open in editor" button, and a range diff has no file on disk to open -
   // both endpoints are commits, and the working-tree copy of a path may hold
   // neither side of the change. The rest of the frame (sticky header, border
-  // rhythm, chevron) is reproduced so the two diff surfaces still read alike.
+  // rhythm, chevron) is reproduced so the two diff surfaces still read alike -
+  // including the two find identity attributes the frame stamps, which are
+  // how a revealed match is scoped to this section's DOM.
   return (
     <div
       className="border-b border-border/70 bg-background"
       data-diff-find-file={file.path}
+      data-bundle-diff-file-id={bundleFindFileId}
     >
       <button
         type="button"
@@ -414,6 +456,7 @@ function PrLocalDiffFileSection(props: {
       {collapsed ? null : (
         <PrLocalDiffFileBody
           file={file}
+          bundleFindFileId={bundleFindFileId}
           mode={props.mode}
           prUrl={props.prUrl}
           preferences={props.preferences}
@@ -423,24 +466,16 @@ function PrLocalDiffFileSection(props: {
   );
 }
 
-/**
- * `null` line counts count as LARGE, not small: they mean the numstat sweep
- * had nothing to say about a (non-binary) file, so its size is unknown - and
- * the placeholder's failure mode ("one extra click") is far cheaper than the
- * inline mode's (parsing an unbounded patch on mount).
- */
-function isLargeFile(file: PrLocalDiffSummaryFile): boolean {
-  if (file.insertions === null || file.deletions === null) return true;
-  return file.insertions + file.deletions > BUNDLE_INLINE_LINE_THRESHOLD;
-}
-
 function PrLocalDiffFileBody(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly bundleFindFileId: string;
   readonly mode: PrDiffPatchMode;
   readonly prUrl: string | null;
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
   const { file, mode } = props;
+  // A summary-declared binary needs no section-level find registration: the
+  // session already files it under "binary" coverage from the file list.
   if (file.isBinary) {
     return (
       <PrLocalDiffNote>Binary file — no text diff to show.</PrLocalDiffNote>
@@ -456,6 +491,8 @@ function PrLocalDiffFileBody(props: {
       <PrMonolithFileBody
         key={stateKey}
         file={file}
+        bundleFindFileId={props.bundleFindFileId}
+        comparisonKey={mode.comparisonKey}
         patch={mode.patches.get(file.path) ?? null}
         prUrl={props.prUrl}
         preferences={props.preferences}
@@ -466,6 +503,7 @@ function PrLocalDiffFileBody(props: {
     <PrSplitFileBody
       key={stateKey}
       file={file}
+      bundleFindFileId={props.bundleFindFileId}
       mode={mode}
       preferences={props.preferences}
     />
@@ -479,6 +517,7 @@ function PrLocalDiffFileBody(props: {
  */
 function PrSplitFileBody(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly bundleFindFileId: string;
   readonly mode: Extract<PrDiffPatchMode, { kind: "split" }>;
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
@@ -486,7 +525,11 @@ function PrSplitFileBody(props: {
   const handleLoad = useCallback((): void => {
     setLoadRequested(true);
   }, []);
-  if (isLargeFile(props.file) && !loadRequested) {
+  // The placeholder registers nothing with find: the session already files a
+  // large file under "large" coverage from the file list, and a find reveal
+  // deliberately does NOT press this button for the reader - the guard exists
+  // to keep an unbounded patch off the main thread until asked for.
+  if (isPrLocalDiffLargeFile(props.file) && !loadRequested) {
     return (
       <PrLargeDiffPlaceholder path={props.file.path} onLoad={handleLoad} />
     );
@@ -494,6 +537,7 @@ function PrSplitFileBody(props: {
   return (
     <PrLocalFileDiffContent
       file={props.file}
+      bundleFindFileId={props.bundleFindFileId}
       mode={props.mode}
       preferences={props.preferences}
     />
@@ -508,6 +552,8 @@ function PrSplitFileBody(props: {
  */
 function PrMonolithFileBody(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly bundleFindFileId: string;
+  readonly comparisonKey: string;
   readonly patch: string | null;
   readonly prUrl: string | null;
   readonly preferences: DiffViewerPreferences;
@@ -518,7 +564,9 @@ function PrMonolithFileBody(props: {
   }, []);
   // `null` and empty are different facts and get different sentences: the byte
   // budget never reached this file, versus the range genuinely changed nothing
-  // in it (a pure mode change, say).
+  // in it (a pure mode change, say). Neither state registers with find here:
+  // the session files a `null` patch under "truncated" coverage from the
+  // monolith itself, and an empty patch registers as loaded below.
   if (props.patch === null) {
     return (
       <PrLocalDiffNote>
@@ -535,7 +583,7 @@ function PrMonolithFileBody(props: {
       </PrLocalDiffNote>
     );
   }
-  if (isLargeFile(props.file) && !loadRequested) {
+  if (isPrLocalDiffLargeFile(props.file) && !loadRequested) {
     return (
       <PrLargeDiffPlaceholder path={props.file.path} onLoad={handleLoad} />
     );
@@ -544,6 +592,16 @@ function PrMonolithFileBody(props: {
     <PrPatchContent
       patch={props.patch}
       cacheScope={`pr-local-diff:${props.file.path}`}
+      find={{
+        fileId: props.bundleFindFileId,
+        cacheKey: prBundleLoadedPatchCacheKey({
+          comparisonKey: props.comparisonKey,
+          file: props.file,
+          ignoreWhitespace: props.preferences.ignoreWhitespace,
+          isTruncated: false,
+        }),
+        isTruncated: false,
+      }}
       preferences={props.preferences}
     />
   );
@@ -557,10 +615,12 @@ function PrMonolithFileBody(props: {
  */
 function PrLocalFileDiffContent(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly bundleFindFileId: string;
   readonly mode: Extract<PrDiffPatchMode, { kind: "split" }>;
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
-  const { file, mode } = props;
+  const { bundleFindFileId, file, mode } = props;
+  const bundleFindRegistration = useBundleDiffFindRegistrationContext();
   const [loadFull, setLoadFull] = useState(false);
   const handleLoadFull = useCallback((): void => {
     setLoadFull(true);
@@ -608,6 +668,29 @@ function PrLocalFileDiffContent(props: {
     onRangeDrift();
   }, [unavailableReason, methodUnsupported, onRangeDrift]);
 
+  // Find coverage for the answers that carry NO searchable patch: an errored
+  // query and an `unavailable` file both mean the reader is looking at an
+  // error block, not content ("failed"); a response the summary called text
+  // but git calls binary joins the summary-declared binaries. A loaded patch
+  // registers itself from `PrPatchContent`, and a later success supersedes a
+  // registered failure in the session's coverage counts.
+  const responseBinary = response?.kind === "diff" && response.isBinary;
+  const responseFailed = query.error !== null || unavailableReason !== null;
+  useEffect(() => {
+    if (responseFailed) {
+      bundleFindRegistration.registerCoverageState(bundleFindFileId, "failed");
+      return;
+    }
+    if (responseBinary) {
+      bundleFindRegistration.registerCoverageState(bundleFindFileId, "binary");
+    }
+  }, [
+    bundleFindFileId,
+    bundleFindRegistration,
+    responseBinary,
+    responseFailed,
+  ]);
+
   if (query.isPending) {
     return (
       <DiffContentLoadingSkeleton
@@ -651,17 +734,52 @@ function PrLocalFileDiffContent(props: {
       <PrPatchContent
         patch={response.patch}
         cacheScope={`pr-local-diff:${mode.mergeBaseOid}:${mode.headOid}:${file.path}`}
+        find={{
+          fileId: bundleFindFileId,
+          cacheKey: prBundleLoadedPatchCacheKey({
+            comparisonKey: mode.comparisonKey,
+            file,
+            ignoreWhitespace: props.preferences.ignoreWhitespace,
+            isTruncated: response.isTruncated,
+          }),
+          isTruncated: response.isTruncated,
+        }}
         preferences={props.preferences}
       />
     </>
   );
 }
 
+/**
+ * The one place a PR file's patch bytes reach the screen, in either patch
+ * mode - so it is also the one place they reach the find index. Registering
+ * here (rather than in each mode's fetch/lookup body) is what keeps "what
+ * find can search" identical between a new host and the fallback: a rendered
+ * patch is a searchable patch, and stays one after the row virtualizes away.
+ */
 function PrPatchContent(props: {
   readonly patch: string;
   readonly cacheScope: string;
+  readonly find: {
+    readonly fileId: string;
+    readonly cacheKey: string;
+    readonly isTruncated: boolean;
+  };
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
+  const bundleFindRegistration = useBundleDiffFindRegistrationContext();
+  const { cacheKey, fileId, isTruncated } = props.find;
+  // Registered BEFORE the hunk check on purpose: a header-only change has no
+  // rows to search, but leaving it unregistered would count it as "unloaded"
+  // in the coverage message forever, and it is fully loaded.
+  useEffect(() => {
+    bundleFindRegistration.registerLoadedPatch({
+      fileId,
+      patch: props.patch,
+      cacheKey,
+      isTruncated,
+    });
+  }, [bundleFindRegistration, cacheKey, fileId, isTruncated, props.patch]);
   // A patch with no `@@` hunk is a change git states entirely in headers — a
   // pure rename, or a mode change. Real, but there are no lines to render, and
   // the diff viewer would draw an empty frame for it. The wire contract does

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
@@ -1,4 +1,6 @@
 import {
+  createContext,
+  use,
   useCallback,
   useEffect,
   useMemo,
@@ -88,14 +90,15 @@ type PrDiffPatchMode =
     };
 
 /**
- * React `key` for a section's STATEFUL body, so its per-section overrides -
- * "Load diff" on a large file, "Load Full" past a truncation - reset by
- * remount whenever the comparison they were approved FOR changes. Without
- * this, sections key only by path: a summary refresh that resolves new OIDs
- * (the local branch advanced), or a whitespace-mode flip, would carry a
- * previously-approved `byteBudget: null` straight onto the NEW comparison
- * and defeat the 256KiB guard - the same identity discipline
- * `useEditableGitDiffSurface` applies via `fullDiffIdentity`.
+ * The identity of a section's body FOR ONE COMPARISON: its React `key`, and
+ * the key its per-section "load" approvals ({@link PrSectionLoadApprovals})
+ * are granted under - "Load diff" on a large file, "Load Full" past a
+ * truncation. Both expire whenever the comparison they were approved FOR
+ * changes. Without this, sections would key only by path: a summary refresh
+ * that resolves new OIDs (the local branch advanced), or a whitespace-mode
+ * flip, would carry a previously-approved `byteBudget: null` straight onto
+ * the NEW comparison and defeat the 256KiB guard - the same identity
+ * discipline `useEditableGitDiffSurface` applies via `fullDiffIdentity`.
  */
 function sectionStateKey(
   mode: PrDiffPatchMode,
@@ -110,6 +113,76 @@ function sectionStateKey(
     // NUL-joined: it is the one byte a git path can never contain, so two
     // fields can never collide into another identity’s key.
   ].join("\0");
+}
+
+/**
+ * The per-section "load" approvals - "Load diff" on a large file, "Load
+ * Full" past a truncation - keyed by {@link sectionStateKey}.
+ *
+ * Held at the FILES-VIEW level rather than as row state for one reason: the
+ * find session retains a loaded patch after its row unmounts (a collapse, or
+ * Virtuoso evicting it), and a retained patch must remount the SAME
+ * renderable bytes when a match in it is revealed. Row-local approvals die
+ * with the row, so the reveal would land on the large-file placeholder (no
+ * DOM to paint the match in) or on the bounded re-fetch of a fully-loaded
+ * truncated file (its cached truncated answer registers over the retained
+ * full patch, and the tail's matches vanish). Approvals and retention share
+ * one lifetime - the files view - and one identity discipline: an approval
+ * is granted for a comparison and expires with it, which is what keying by
+ * `sectionStateKey` gives (the key embeds the comparison and the whitespace
+ * mode), so a summary refresh that resolves new OIDs still cannot carry a
+ * `byteBudget: null` onto a comparison it was never approved for.
+ */
+interface PrSectionLoadApprovals {
+  readonly isLoadRequested: (stateKey: string) => boolean;
+  readonly isLoadFull: (stateKey: string) => boolean;
+  readonly approveLoad: (stateKey: string) => void;
+  readonly approveLoadFull: (stateKey: string) => void;
+}
+
+const PrSectionLoadApprovalsContext =
+  createContext<PrSectionLoadApprovals | null>(null);
+
+function usePrSectionLoadApprovals(): PrSectionLoadApprovals {
+  const approvals = use(PrSectionLoadApprovalsContext);
+  if (approvals === null) {
+    throw new Error(
+      "PR diff sections must render inside PrLocalDiffFilesView (no load-approval scope).",
+    );
+  }
+  return approvals;
+}
+
+/** Files-view state behind {@link PrSectionLoadApprovals}. */
+function usePrSectionLoadApprovalsState(): PrSectionLoadApprovals {
+  const [loadRequested, setLoadRequested] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [loadFull, setLoadFull] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const isLoadRequested = useCallback(
+    (stateKey: string): boolean => loadRequested.has(stateKey),
+    [loadRequested],
+  );
+  const isLoadFull = useCallback(
+    (stateKey: string): boolean => loadFull.has(stateKey),
+    [loadFull],
+  );
+  const approveLoad = useCallback((stateKey: string): void => {
+    setLoadRequested((current) =>
+      current.has(stateKey) ? current : new Set(current).add(stateKey),
+    );
+  }, []);
+  const approveLoadFull = useCallback((stateKey: string): void => {
+    setLoadFull((current) =>
+      current.has(stateKey) ? current : new Set(current).add(stateKey),
+    );
+  }, []);
+  return useMemo(
+    () => ({ isLoadRequested, isLoadFull, approveLoad, approveLoadFull }),
+    [approveLoad, approveLoadFull, isLoadFull, isLoadRequested],
+  );
 }
 
 /**
@@ -307,6 +380,8 @@ function PrLocalDiffFilesView(props: {
       ignoreWhitespace: props.preferences.ignoreWhitespace,
       virtuosoRef,
     });
+  // Same lifetime as the find session above, on purpose - see the type's doc.
+  const loadApprovals = usePrSectionLoadApprovalsState();
 
   if (props.files.length === 0) {
     return (
@@ -321,66 +396,69 @@ function PrLocalDiffFilesView(props: {
 
   return (
     <BundleDiffFindRegistrationProvider value={bundleFindRegistration}>
-      <div ref={setRootElement} className="flex h-full min-h-0 flex-col">
-        {props.isStale ? (
-          <p
-            className="flex min-w-0 shrink-0 items-start gap-2 border-b border-warning/40 bg-warning/10 px-3 py-2 text-ui-xs text-foreground"
-            data-testid="pr-diff-stale"
-          >
-            <FileWarning
-              className="mt-px size-3.5 shrink-0 text-warning"
-              aria-hidden
-            />
-            <span className="min-w-0">
-              This is your local checkout at{" "}
-              <span className="font-mono">
-                {props.localHeadOid.slice(0, 7)}
+      <PrSectionLoadApprovalsContext.Provider value={loadApprovals}>
+        <div ref={setRootElement} className="flex h-full min-h-0 flex-col">
+          {props.isStale ? (
+            <p
+              className="flex min-w-0 shrink-0 items-start gap-2 border-b border-warning/40 bg-warning/10 px-3 py-2 text-ui-xs text-foreground"
+              data-testid="pr-diff-stale"
+            >
+              <FileWarning
+                className="mt-px size-3.5 shrink-0 text-warning"
+                aria-hidden
+              />
+              <span className="min-w-0">
+                This is your local checkout at{" "}
+                <span className="font-mono">
+                  {props.localHeadOid.slice(0, 7)}
+                </span>
+                . GitHub is showing a different commit, so pushed changes you
+                haven’t pulled — or local commits you haven’t pushed — will not
+                match.
               </span>
-              . GitHub is showing a different commit, so pushed changes you
-              haven’t pulled — or local commits you haven’t pushed — will not
-              match.
-            </span>
-          </p>
-        ) : null}
-        <Virtuoso
-          ref={virtuosoRef}
-          restoreStateFrom={restoreStateFrom}
-          isScrolling={isScrolling}
-          data={props.files}
-          className="min-h-0 flex-1"
-          overscan={6}
-          computeItemKey={(_index, file) => file.path}
-          // eslint-disable-next-line react/no-unstable-nested-components -- Virtuoso row renderer, not a component definition.
-          itemContent={(_index, file) => (
-            <PrLocalDiffFileSection
-              node={props.node}
-              viewTabId={props.viewTabId}
-              file={file}
-              mode={props.mode}
-              prUrl={props.prUrl}
-              preferences={props.preferences}
-            />
-          )}
-        />
-        {props.monolithTruncation !== null ? (
-          <p
-            className="shrink-0 border-t border-border/60 px-3 py-2 text-ui-xs text-muted-foreground/70"
-            data-testid="pr-diff-truncated"
-          >
-            The patch was cut off after {props.monolithTruncation.shownPatches}{" "}
-            of {props.files.length} files.{" "}
-            {props.prUrl !== null ? (
-              <PrExternalGitHubLink
-                href={`${props.prUrl}/files`}
-                className="text-primary hover:underline"
-                testId="pr-diff-truncated-github-link"
-              >
-                View the full diff on GitHub
-              </PrExternalGitHubLink>
-            ) : null}
-          </p>
-        ) : null}
-      </div>
+            </p>
+          ) : null}
+          <Virtuoso
+            ref={virtuosoRef}
+            restoreStateFrom={restoreStateFrom}
+            isScrolling={isScrolling}
+            data={props.files}
+            className="min-h-0 flex-1"
+            overscan={6}
+            computeItemKey={(_index, file) => file.path}
+            // eslint-disable-next-line react/no-unstable-nested-components -- Virtuoso row renderer, not a component definition.
+            itemContent={(_index, file) => (
+              <PrLocalDiffFileSection
+                node={props.node}
+                viewTabId={props.viewTabId}
+                file={file}
+                mode={props.mode}
+                prUrl={props.prUrl}
+                preferences={props.preferences}
+              />
+            )}
+          />
+          {props.monolithTruncation !== null ? (
+            <p
+              className="shrink-0 border-t border-border/60 px-3 py-2 text-ui-xs text-muted-foreground/70"
+              data-testid="pr-diff-truncated"
+            >
+              The patch was cut off after{" "}
+              {props.monolithTruncation.shownPatches} of {props.files.length}{" "}
+              files.{" "}
+              {props.prUrl !== null ? (
+                <PrExternalGitHubLink
+                  href={`${props.prUrl}/files`}
+                  className="text-primary hover:underline"
+                  testId="pr-diff-truncated-github-link"
+                >
+                  View the full diff on GitHub
+                </PrExternalGitHubLink>
+              ) : null}
+            </p>
+          ) : null}
+        </div>
+      </PrSectionLoadApprovalsContext.Provider>
     </BundleDiffFindRegistrationProvider>
   );
 }
@@ -490,6 +568,7 @@ function PrLocalDiffFileBody(props: {
     return (
       <PrMonolithFileBody
         key={stateKey}
+        stateKey={stateKey}
         file={file}
         bundleFindFileId={props.bundleFindFileId}
         comparisonKey={mode.comparisonKey}
@@ -502,6 +581,7 @@ function PrLocalDiffFileBody(props: {
   return (
     <PrSplitFileBody
       key={stateKey}
+      stateKey={stateKey}
       file={file}
       bundleFindFileId={props.bundleFindFileId}
       mode={mode}
@@ -517,19 +597,24 @@ function PrLocalDiffFileBody(props: {
  */
 function PrSplitFileBody(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly stateKey: string;
   readonly bundleFindFileId: string;
   readonly mode: Extract<PrDiffPatchMode, { kind: "split" }>;
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
-  const [loadRequested, setLoadRequested] = useState(false);
+  const { stateKey } = props;
+  const loadApprovals = usePrSectionLoadApprovals();
   const handleLoad = useCallback((): void => {
-    setLoadRequested(true);
-  }, []);
+    loadApprovals.approveLoad(stateKey);
+  }, [loadApprovals, stateKey]);
   // The placeholder registers nothing with find: the session already files a
   // large file under "large" coverage from the file list, and a find reveal
   // deliberately does NOT press this button for the reader - the guard exists
   // to keep an unbounded patch off the main thread until asked for.
-  if (isPrLocalDiffLargeFile(props.file) && !loadRequested) {
+  if (
+    isPrLocalDiffLargeFile(props.file) &&
+    !loadApprovals.isLoadRequested(stateKey)
+  ) {
     return (
       <PrLargeDiffPlaceholder path={props.file.path} onLoad={handleLoad} />
     );
@@ -537,6 +622,7 @@ function PrSplitFileBody(props: {
   return (
     <PrLocalFileDiffContent
       file={props.file}
+      stateKey={stateKey}
       bundleFindFileId={props.bundleFindFileId}
       mode={props.mode}
       preferences={props.preferences}
@@ -552,16 +638,18 @@ function PrSplitFileBody(props: {
  */
 function PrMonolithFileBody(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly stateKey: string;
   readonly bundleFindFileId: string;
   readonly comparisonKey: string;
   readonly patch: string | null;
   readonly prUrl: string | null;
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
-  const [loadRequested, setLoadRequested] = useState(false);
+  const { stateKey } = props;
+  const loadApprovals = usePrSectionLoadApprovals();
   const handleLoad = useCallback((): void => {
-    setLoadRequested(true);
-  }, []);
+    loadApprovals.approveLoad(stateKey);
+  }, [loadApprovals, stateKey]);
   // `null` and empty are different facts and get different sentences: the byte
   // budget never reached this file, versus the range genuinely changed nothing
   // in it (a pure mode change, say). Neither state registers with find here:
@@ -583,7 +671,10 @@ function PrMonolithFileBody(props: {
       </PrLocalDiffNote>
     );
   }
-  if (isPrLocalDiffLargeFile(props.file) && !loadRequested) {
+  if (
+    isPrLocalDiffLargeFile(props.file) &&
+    !loadApprovals.isLoadRequested(stateKey)
+  ) {
     return (
       <PrLargeDiffPlaceholder path={props.file.path} onLoad={handleLoad} />
     );
@@ -615,16 +706,18 @@ function PrMonolithFileBody(props: {
  */
 function PrLocalFileDiffContent(props: {
   readonly file: PrLocalDiffSummaryFile;
+  readonly stateKey: string;
   readonly bundleFindFileId: string;
   readonly mode: Extract<PrDiffPatchMode, { kind: "split" }>;
   readonly preferences: DiffViewerPreferences;
 }): ReactNode {
-  const { bundleFindFileId, file, mode } = props;
+  const { bundleFindFileId, file, mode, stateKey } = props;
   const bundleFindRegistration = useBundleDiffFindRegistrationContext();
-  const [loadFull, setLoadFull] = useState(false);
+  const loadApprovals = usePrSectionLoadApprovals();
+  const loadFull = loadApprovals.isLoadFull(stateKey);
   const handleLoadFull = useCallback((): void => {
-    setLoadFull(true);
-  }, []);
+    loadApprovals.approveLoadFull(stateKey);
+  }, [loadApprovals, stateKey]);
   const query = usePrLocalFileDiffQuery({
     target: mode.target,
     mergeBaseOid: mode.mergeBaseOid,

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
@@ -767,10 +767,18 @@ function PrLocalFileDiffContent(props: {
   // but git calls binary joins the summary-declared binaries. A loaded patch
   // registers itself from `PrPatchContent`, and a later success supersedes a
   // registered failure in the session's coverage counts.
+  //
+  // A failure also UNREGISTERS whatever this section registered before: the
+  // session retains a loaded patch past its unmount on purpose, and a
+  // retained patch outranks any coverage state - so a "Load Full" that fails
+  // after a truncated patch was shown (a new query key, no data of its own)
+  // would otherwise leave find matching text that is not in the DOM and
+  // calling the file truncated rather than failed.
   const responseBinary = response?.kind === "diff" && response.isBinary;
   const responseFailed = query.error !== null || unavailableReason !== null;
   useEffect(() => {
     if (responseFailed) {
+      bundleFindRegistration.unregisterLoadedPatch(bundleFindFileId);
       bundleFindRegistration.registerCoverageState(bundleFindFileId, "failed");
       return;
     }

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
@@ -768,17 +768,26 @@ function PrLocalFileDiffContent(props: {
   // registers itself from `PrPatchContent`, and a later success supersedes a
   // registered failure in the session's coverage counts.
   //
-  // A failure also UNREGISTERS whatever this section registered before: the
-  // session retains a loaded patch past its unmount on purpose, and a
-  // retained patch outranks any coverage state - so a "Load Full" that fails
-  // after a truncated patch was shown (a new query key, no data of its own)
-  // would otherwise leave find matching text that is not in the DOM and
-  // calling the file truncated rather than failed.
+  // A section that is mounted but shows NO content - a query pending for a
+  // key that has no data yet, an error, an `unavailable` answer - also
+  // UNREGISTERS whatever it registered before. The session retains a loaded
+  // patch past its section's UNMOUNT on purpose (the row can remount and
+  // show those bytes again), and a retained patch outranks any coverage
+  // state; but a mounted section past "Load Full" will never render the
+  // truncated bytes again - the approval only moves forward - so from the
+  // moment the new key is pending they are dead for this comparison, and
+  // leaving them indexed would have find match text that is not in the DOM,
+  // report the file as truncated rather than loading/failed, and park
+  // navigation on a skeleton. Registered ⇔ renderable by this section, or
+  // retained after its unmount.
   const responseBinary = response?.kind === "diff" && response.isBinary;
   const responseFailed = query.error !== null || unavailableReason !== null;
+  const contentAbsent = query.isPending || responseFailed;
   useEffect(() => {
-    if (responseFailed) {
+    if (contentAbsent) {
       bundleFindRegistration.unregisterLoadedPatch(bundleFindFileId);
+    }
+    if (responseFailed) {
       bundleFindRegistration.registerCoverageState(bundleFindFileId, "failed");
       return;
     }
@@ -788,6 +797,7 @@ function PrLocalFileDiffContent(props: {
   }, [
     bundleFindFileId,
     bundleFindRegistration,
+    contentAbsent,
     responseBinary,
     responseFailed,
   ]);

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
@@ -705,7 +705,91 @@ describe("<PrDiffTile /> bundle find", () => {
     expect(message).toMatch(/failed/u);
     expect(message).not.toMatch(/truncated/u);
   });
+
+  it("drops a retained truncated patch from find while 'Load Full' is still pending", async () => {
+    // Past "Load Full" the section will never render the truncated bytes
+    // again (the approval only moves forward), so they are dead for find
+    // from the moment the new query key is pending - not only once it fails.
+    // The tail token appears ONLY in the full patch, so the counts tell the
+    // three phases apart: 1 (truncated shown) → 0 (skeleton) → 2 (full).
+    const TRUNCATED_TOKEN = "SharedToken";
+    const TAIL_TOKEN = "TailOnlyToken";
+    const files = [summaryFile({ path: "src/slow.ts" })];
+    const fullFetch = deferred<PrGetLocalFileDiffResponse>();
+    tabHostClient.request.mockImplementation(
+      (method: string, params: unknown) => {
+        if (method === "pr.getLocalDiffSummary")
+          return Promise.resolve(summaryOkWithFiles(files));
+        if (method === "pr.getLocalFileDiff") {
+          if (requestByteBudget(params) === null) return fullFetch.promise;
+          return Promise.resolve({
+            ...fileDiffOk(patchWithNeedle("src/slow.ts", TRUNCATED_TOKEN)),
+            isTruncated: true,
+            truncatedAfterBytes: 64,
+          });
+        }
+        return Promise.reject(new Error(`unexpected method ${method}`));
+      },
+    );
+    const { node } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: null,
+    });
+    await screen.findByTestId("diff-content");
+
+    search(node.instanceId, TRUNCATED_TOKEN);
+    expect(tileSnapshot(node.instanceId).total).toBe(1);
+    act(() => {
+      useTileFindStore.getState().close(node.instanceId);
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Load Full" }));
+    await screen.findByTestId("diff-content-loading-skeleton");
+
+    search(node.instanceId, TRUNCATED_TOKEN);
+    expect(tileSnapshot(node.instanceId).total).toBe(0);
+    expect(tileSnapshot(node.instanceId).coverageMessage ?? "").not.toMatch(
+      /truncated/u,
+    );
+    act(() => {
+      useTileFindStore.getState().close(node.instanceId);
+    });
+
+    const fullPatch = [
+      `diff --git a/src/slow.ts b/src/slow.ts`,
+      `--- a/src/slow.ts`,
+      `+++ b/src/slow.ts`,
+      "@@ -1,2 +1,2 @@",
+      "-const label = 'Old';",
+      `+const label = '${TRUNCATED_TOKEN}';`,
+      "-const tail = 'OldTail';",
+      `+const tail = '${TAIL_TOKEN} ${TRUNCATED_TOKEN}';`,
+      "",
+    ].join("\n");
+    await act(async () => {
+      fullFetch.resolve(fileDiffOk(fullPatch));
+      await fullFetch.promise;
+    });
+    await screen.findByTestId("diff-content");
+
+    search(node.instanceId, TRUNCATED_TOKEN);
+    expect(tileSnapshot(node.instanceId).total).toBe(2);
+    expect(tileSnapshot(node.instanceId).coverageMessage).toBeNull();
+  });
 });
+
+// A promise the test settles by hand, so a request can be held in its
+// pending state while the tile is inspected.
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve: (value: T) => resolve(value) };
+}
 
 function requestByteBudget(params: unknown): number | null | undefined {
   if (typeof params !== "object" || params === null) return undefined;

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
@@ -655,4 +655,62 @@ describe("<PrDiffTile /> bundle find", () => {
       total: 1,
     });
   });
+
+  it("drops a retained truncated patch from find when 'Load Full' fails", async () => {
+    // A retained loaded patch outranks any coverage state in the coverage
+    // counts, and the session keeps it past the section's unmount on purpose.
+    // So when the "Load Full" re-ask (a NEW query key: byteBudget null) fails,
+    // the section must unregister the truncated bytes it no longer renders -
+    // otherwise find keeps matching text that is not in the DOM and reports
+    // the file as truncated instead of failed.
+    const TRUNCATED_TOKEN = "TruncatedToken";
+    const files = [summaryFile({ path: "src/cut.ts" })];
+    tabHostClient.request.mockImplementation(
+      (method: string, params: unknown) => {
+        if (method === "pr.getLocalDiffSummary")
+          return Promise.resolve(summaryOkWithFiles(files));
+        if (method === "pr.getLocalFileDiff") {
+          if (requestByteBudget(params) === null)
+            return Promise.reject(new Error("full fetch boom"));
+          return Promise.resolve({
+            ...fileDiffOk(patchWithNeedle("src/cut.ts", TRUNCATED_TOKEN)),
+            isTruncated: true,
+            truncatedAfterBytes: 64,
+          });
+        }
+        return Promise.reject(new Error(`unexpected method ${method}`));
+      },
+    );
+    const { node } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: null,
+    });
+    await screen.findByTestId("diff-content");
+
+    // A truncated patch is searchable but flagged: the coverage message names
+    // it, so the snapshot is "partial" rather than "ready".
+    search(node.instanceId, TRUNCATED_TOKEN);
+    expect(tileSnapshot(node.instanceId).total).toBe(1);
+    expect(tileSnapshot(node.instanceId).coverageMessage).toMatch(/truncated/u);
+    act(() => {
+      useTileFindStore.getState().close(node.instanceId);
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Load Full" }));
+    await screen.findByText("Diff Loading Error");
+
+    search(node.instanceId, TRUNCATED_TOKEN);
+    expect(tileSnapshot(node.instanceId).total).toBe(0);
+    const message = tileSnapshot(node.instanceId).coverageMessage ?? "";
+    expect(message).toMatch(/failed/u);
+    expect(message).not.toMatch(/truncated/u);
+  });
 });
+
+function requestByteBudget(params: unknown): number | null | undefined {
+  if (typeof params !== "object" || params === null) return undefined;
+  if (!("byteBudget" in params)) return undefined;
+  const budget = params.byteBudget;
+  if (budget === null) return null;
+  return typeof budget === "number" ? budget : undefined;
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
@@ -1,0 +1,658 @@
+import type { ReactNode } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  type RenderResult,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import type {
+  PrDetailCore,
+  PrGetLocalDiffResponse,
+  PrGetLocalDiffSummaryResponse,
+  PrGetLocalFileDiffResponse,
+  PrLocalDiffSummaryFile,
+} from "@traycer/protocol/host/pr-schemas";
+import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
+import { TileFindScope } from "@/components/epic-canvas/tile-find/tile-find-scope";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
+import { makePrDiffTile } from "@/lib/pr/pr-diff-tile";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import {
+  useTileFindStore,
+  type TileFindStateSnapshot,
+} from "@/stores/tile-find";
+import type { PrDetailSubscriptionResult } from "@/hooks/pr/use-pr-detail-subscription";
+import type { PrDiffTileRef } from "@/stores/epics/canvas/types";
+import { PrDiffTile } from "@/components/epic-canvas/renderers/pr-diff-tile";
+
+interface VirtuosoMockProps {
+  readonly data: ReadonlyArray<unknown>;
+  readonly itemContent: (index: number, item: unknown) => ReactNode;
+  readonly computeItemKey: (index: number, item: unknown) => string;
+}
+
+const virtuosoState = vi.hoisted(() => ({
+  renderRows: true,
+  scrollIntoView: vi.fn(),
+}));
+
+vi.mock("react-virtuoso", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    Virtuoso: React.forwardRef<unknown, VirtuosoMockProps>((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        scrollIntoView: virtuosoState.scrollIntoView,
+        getState: (
+          callback: (snapshot: { readonly scrollTop: number }) => void,
+        ) => {
+          callback({ scrollTop: 0 });
+        },
+      }));
+      return (
+        <div data-testid="virtuoso">
+          {virtuosoState.renderRows
+            ? props.data.map((item, index) => (
+                <div key={props.computeItemKey(index, item)}>
+                  {props.itemContent(index, item)}
+                </div>
+              ))
+            : null}
+        </div>
+      );
+    }),
+  };
+});
+
+const tabHostClient = vi.hoisted(() => ({
+  request: vi.fn(),
+  onChange: (_listener: () => void) => () => undefined,
+  getActiveHostId: vi.fn((): string | null => "host-1"),
+  getRequestContextUserId: vi.fn((): string | null => "user-1"),
+}));
+
+const detailSubscription: { current: PrDetailSubscriptionResult } = vi.hoisted(
+  () => ({
+    current: {
+      data: null,
+      error: null,
+      isPending: false,
+      sendRefresh: () => undefined,
+      methodSupported: true,
+    },
+  }),
+);
+
+vi.mock("@/hooks/host/use-tab-host-client", () => ({
+  useTabHostClient: () => tabHostClient,
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => ({
+    status: "reachable",
+    hostLabel: "Host 1",
+    unavailability: null,
+  }),
+}));
+
+vi.mock("@/hooks/pr/use-pr-detail-subscription", () => ({
+  usePrDetailSubscription: () => detailSubscription.current,
+}));
+
+vi.mock("@/components/epic-canvas/git-diff/diff-content-primitive", () => ({
+  DiffContentPrimitive: (props: { readonly patch: string }) => (
+    <pre data-testid="diff-content">{props.patch}</pre>
+  ),
+  DiffContentFrame: null,
+}));
+
+function detailCore(): PrDetailCore {
+  return {
+    observedAt: 1_000,
+    githubHost: "github.com",
+    base: { owner: "acme", repo: "widgets", prNumber: 7 },
+    prUrl: "https://github.com/acme/widgets/pull/7",
+    state: "open",
+    isDraft: false,
+    title: "Add feature X",
+    body: "Some description",
+    author: { login: "octocat", avatarUrl: null },
+    baseRefName: "main",
+    headRefName: "feature/x",
+    headRefOid: "a".repeat(40),
+    additions: 10,
+    deletions: 2,
+    checksRollup: { success: 1, failure: 0, pending: 0, total: 1 },
+    reviewDecision: null,
+    reviewRequests: [],
+    commentCount: 0,
+    updatedAt: 1_000,
+    mergedAt: null,
+    repoIdentifier: { owner: "acme", repo: "widgets" },
+    repoRole: "superproject",
+    linkGroupKey: "/tmp/worktrees/widgets",
+    owners: [],
+  };
+}
+
+function populatedSubscription(): PrDetailSubscriptionResult {
+  return {
+    data: {
+      sourceStatus: "ok",
+      notice: null,
+      liveness: "live",
+      core: detailCore(),
+      checks: { observedAt: 1_000, contexts: [], isTruncated: false },
+      activity: { observedAt: 1_000, items: [], isTruncated: false },
+      reviewThreads: { observedAt: 1_000, threads: [], isTruncated: false },
+      files: {
+        observedAt: 1_000,
+        files: [],
+        totalCount: null,
+        isTruncated: false,
+      },
+      commits: {
+        observedAt: 1_000,
+        commits: [],
+        totalCount: null,
+        isTruncated: false,
+      },
+    },
+    error: null,
+    isPending: false,
+    sendRefresh: () => undefined,
+    methodSupported: true,
+  };
+}
+
+function summaryFile(
+  overrides: Partial<PrLocalDiffSummaryFile> & { readonly path: string },
+): PrLocalDiffSummaryFile {
+  return {
+    previousPath: null,
+    status: "modified",
+    insertions: 3,
+    deletions: 1,
+    isBinary: false,
+    ...overrides,
+  };
+}
+
+function summaryOkWithFiles(
+  files: readonly PrLocalDiffSummaryFile[],
+): PrGetLocalDiffSummaryResponse {
+  return {
+    kind: "summary",
+    runningDir: "/tmp/worktrees/widgets",
+    resolvedBaseRef: "origin/main",
+    baseOid: "b".repeat(40),
+    mergeBaseOid: "c".repeat(40),
+    localHeadOid: "a".repeat(40),
+    isStale: false,
+    files: [...files],
+  };
+}
+
+function patchWithNeedle(path: string, needle: string): string {
+  return [
+    `diff --git a/${path} b/${path}`,
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    "@@ -1 +1 @@",
+    "-const label = 'Old';",
+    `+const label = '${needle}';`,
+    "",
+  ].join("\n");
+}
+
+function fileDiffOk(patch: string): PrGetLocalFileDiffResponse {
+  return {
+    kind: "diff",
+    patch,
+    isBinary: false,
+    isTruncated: false,
+    truncatedAfterBytes: null,
+  };
+}
+
+function unsupportedError(): HostRpcError {
+  return new HostRpcError({
+    code: "E_HOST_UNSUPPORTED",
+    message: "host does not support this method",
+    requestId: "req-unsupported",
+    method: "pr.getLocalDiffSummary",
+    fatalDetails: null,
+  });
+}
+
+function requestPath(params: unknown): string {
+  if (typeof params !== "object" || params === null) return "";
+  if (!("path" in params)) return "";
+  const path = params.path;
+  return typeof path === "string" ? path : "";
+}
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function tileOnTab(tabId: string, instanceId: string): PrDiffTileRef {
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+  const ref = canvas?.tilesByInstanceId[instanceId];
+  if (ref === undefined || ref.type !== "pr-diff") {
+    throw new Error("expected a PR diff tile on the tab");
+  }
+  return ref;
+}
+
+function tileTree(args: {
+  readonly queryClient: QueryClient;
+  readonly node: PrDiffTileRef;
+  readonly tabId: string;
+}): ReactNode {
+  return (
+    <QueryClientProvider client={args.queryClient}>
+      <TabHostProvider hostId="host-1">
+        <TooltipProvider>
+          <TileFindScope
+            node={args.node}
+            viewTabId={args.tabId}
+            tileId={args.node.id}
+            epicId="epic-1"
+            isActive
+          >
+            <PrDiffTile
+              node={args.node}
+              epicId="epic-1"
+              viewTabId={args.tabId}
+              isActive
+            />
+          </TileFindScope>
+        </TooltipProvider>
+      </TabHostProvider>
+    </QueryClientProvider>
+  );
+}
+
+// Awaits the mocked Virtuoso mounting before returning: the summary fetch
+// resolves asynchronously, and `PrLocalDiffFilesView` (and with it, the real
+// bundle-find adapter registration) does not exist in the tree until that
+// resolves. Touching the tile-find store beforehand only ever reaches the
+// scope's default "unavailable" adapter — see `TileFindScope`'s registration
+// effect — and a `waitFor` retry loop built on that never converges: each
+// retry mutates the DOM, which re-wakes the loop before the pending summary
+// promise's microtask ever gets a turn, so it spins until the surrounding
+// test's own timeout kills it rather than `waitFor`'s much shorter one.
+async function renderTile(args: {
+  readonly queryClient: QueryClient;
+  readonly collapsedFilePaths: readonly string[] | null;
+}): Promise<{
+  readonly view: RenderResult;
+  readonly node: PrDiffTileRef;
+  readonly tabId: string;
+}> {
+  const base = makePrDiffTile({
+    hostId: "host-1",
+    githubHost: "github.com",
+    owner: "acme",
+    repo: "widgets",
+    prNumber: 7,
+  });
+  const node: PrDiffTileRef =
+    args.collapsedFilePaths === null
+      ? base
+      : {
+          ...base,
+          view: { collapsedFilePaths: [...args.collapsedFilePaths] },
+        };
+  const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic");
+  useEpicCanvasStore.getState().openTileInTab(tabId, node);
+  const view = render(tileTree({ queryClient: args.queryClient, node, tabId }));
+  await screen.findByTestId("virtuoso");
+  return { view, node, tabId };
+}
+
+// A single, non-retrying search. Deliberately NOT a `waitFor(() => { search();
+// expect(...) })` retry loop: every `search()` call publishes a new snapshot
+// to the tile-find store's subscribers, which re-renders `TileFindBar` and
+// mutates the DOM. Wrapping that in `waitFor` lets its own MutationObserver
+// re-invoke the callback before the real async work this test is waiting on
+// (a summary or per-file fetch settling) ever gets a turn on the microtask
+// queue - the retries never stop timing out, they just spin as fast as the
+// JS engine allows, hard enough that even the surrounding test's own timeout
+// can starve. Callers instead await a concrete DOM signal that the async
+// work is done (`screen.findBy*`, which never touches the store) and then
+// call `search` exactly once.
+function search(instanceId: string, query: string): void {
+  act(() => {
+    const store = useTileFindStore.getState();
+    store.openForTile(instanceId);
+    store.setQuery(instanceId, query);
+    store.search(instanceId);
+  });
+}
+
+function tileSnapshot(instanceId: string): TileFindStateSnapshot {
+  const snapshot =
+    useTileFindStore.getState().uiByTileInstanceId[instanceId]?.lastSnapshot;
+  if (snapshot === undefined) {
+    throw new Error("Missing PR bundle find snapshot");
+  }
+  return snapshot;
+}
+
+describe("<PrDiffTile /> bundle find", () => {
+  let originalElementScrollTo: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    virtuosoState.renderRows = true;
+    virtuosoState.scrollIntoView.mockClear();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useSettingsStore.setState({
+      diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
+    });
+    tabHostClient.request.mockReset();
+    tabHostClient.getActiveHostId.mockReturnValue("host-1");
+    tabHostClient.getRequestContextUserId.mockReturnValue("user-1");
+    detailSubscription.current = populatedSubscription();
+    // jsdom has no `Element.prototype.scrollTo` - a revealed FILE-level (metadata)
+    // match with no paintable line element falls back to it (see
+    // `revealDiffFindMatches`), which is exactly what a collapsed file's
+    // metadata-only match hits.
+    originalElementScrollTo = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "scrollTo",
+    );
+    Element.prototype.scrollTo = (): void => undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useTileFindStore.getState().resetForTests();
+    if (originalElementScrollTo === undefined) {
+      Reflect.deleteProperty(Element.prototype, "scrollTo");
+    } else {
+      Object.defineProperty(
+        Element.prototype,
+        "scrollTo",
+        originalElementScrollTo,
+      );
+    }
+  });
+
+  it("indexes every file's metadata up front, even with rows unrendered", async () => {
+    const files = [
+      summaryFile({ path: "src/alpha.ts" }),
+      summaryFile({ path: "src/beta.ts" }),
+    ];
+    tabHostClient.request.mockImplementation((method: string) => {
+      if (method === "pr.getLocalDiffSummary")
+        return Promise.resolve(summaryOkWithFiles(files));
+      return Promise.reject(new Error(`unexpected method ${method}`));
+    });
+    virtuosoState.renderRows = false;
+    const { node } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: null,
+    });
+
+    search(node.instanceId, "beta");
+    expect(tileSnapshot(node.instanceId).total).toBeGreaterThanOrEqual(1);
+    expect(
+      tabHostClient.request.mock.calls.some(
+        (call) => call[0] === "pr.getLocalFileDiff",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a loaded split patch searchable after its virtualized row unmounts", async () => {
+    const NEEDLE = "MountedNeedle";
+    const files = [summaryFile({ path: "src/mounted.ts" })];
+    tabHostClient.request.mockImplementation((method: string) => {
+      if (method === "pr.getLocalDiffSummary")
+        return Promise.resolve(summaryOkWithFiles(files));
+      if (method === "pr.getLocalFileDiff")
+        return Promise.resolve(
+          fileDiffOk(patchWithNeedle("src/mounted.ts", NEEDLE)),
+        );
+      return Promise.reject(new Error(`unexpected method ${method}`));
+    });
+    const queryClient = makeQueryClient();
+    const rendered = await renderTile({
+      queryClient,
+      collapsedFilePaths: null,
+    });
+    const { node, tabId } = rendered;
+    await screen.findByTestId("diff-content");
+
+    search(node.instanceId, NEEDLE);
+    expect(tileSnapshot(node.instanceId)).toMatchObject({
+      status: "ready",
+      total: 1,
+    });
+
+    virtuosoState.renderRows = false;
+    rendered.view.rerender(tileTree({ queryClient, node, tabId }));
+
+    search(node.instanceId, NEEDLE);
+    expect(tileSnapshot(node.instanceId)).toMatchObject({
+      status: "ready",
+      total: 1,
+    });
+  });
+
+  it("names unsearched files in the coverage message: unloaded, collapsed, large, binary", async () => {
+    const files = [
+      summaryFile({ path: "src/unloaded.ts" }),
+      summaryFile({ path: "src/binary.bin", isBinary: true }),
+      summaryFile({ path: "src/large.ts", insertions: 2000, deletions: 0 }),
+      summaryFile({ path: "src/collapsed.ts" }),
+    ];
+    tabHostClient.request.mockImplementation((method: string) => {
+      if (method === "pr.getLocalDiffSummary")
+        return Promise.resolve(summaryOkWithFiles(files));
+      return Promise.reject(new Error(`unexpected method ${method}`));
+    });
+    virtuosoState.renderRows = false;
+    const { node } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: ["src/collapsed.ts"],
+    });
+
+    search(node.instanceId, "src");
+    const message = tileSnapshot(node.instanceId).coverageMessage ?? "";
+    expect(message).toMatch(/unloaded/u);
+    expect(message).toMatch(/collapsed/u);
+    expect(message).toMatch(/large/u);
+    expect(message).toMatch(/binary/u);
+  });
+
+  it("reveals a match in a collapsed file: scrolls to its row and expands it", async () => {
+    const files = [
+      summaryFile({ path: "src/normal.ts" }),
+      summaryFile({ path: "src/collapse-target.ts" }),
+    ];
+    tabHostClient.request.mockImplementation(
+      (method: string, params: unknown) => {
+        if (method === "pr.getLocalDiffSummary")
+          return Promise.resolve(summaryOkWithFiles(files));
+        if (method === "pr.getLocalFileDiff")
+          return Promise.resolve(
+            fileDiffOk(patchWithNeedle(requestPath(params), "Needle")),
+          );
+        return Promise.reject(new Error(`unexpected method ${method}`));
+      },
+    );
+    const { node, tabId } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: ["src/collapse-target.ts"],
+    });
+    await screen.findByTestId("diff-content");
+
+    search(node.instanceId, "collapse-target");
+    expect(tileSnapshot(node.instanceId).total).toBeGreaterThanOrEqual(1);
+
+    expect(virtuosoState.scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 1 }),
+    );
+    expect(
+      tileOnTab(tabId, node.instanceId).view.collapsedFilePaths,
+    ).not.toContain("src/collapse-target.ts");
+  });
+
+  it("registers 'failed' coverage when the split per-file fetch rejects", async () => {
+    const files = [summaryFile({ path: "src/failing.ts" })];
+    tabHostClient.request.mockImplementation((method: string) => {
+      if (method === "pr.getLocalDiffSummary")
+        return Promise.resolve(summaryOkWithFiles(files));
+      if (method === "pr.getLocalFileDiff")
+        return Promise.reject(new Error("boom"));
+      return Promise.reject(new Error(`unexpected method ${method}`));
+    });
+    const { node } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: null,
+    });
+    await screen.findByText("Diff Loading Error");
+
+    search(node.instanceId, "failing");
+    expect(tileSnapshot(node.instanceId).coverageMessage).toMatch(/failed/u);
+  });
+
+  it("monolith fallback: a mounted patch is searchable and a null patch counts as truncated", async () => {
+    const MONOLITH_NEEDLE = "MonolithNeedle";
+    const monolithResponse: PrGetLocalDiffResponse = {
+      kind: "diff",
+      runningDir: "/tmp/worktrees/widgets",
+      resolvedBaseRef: "origin/main",
+      baseOid: "b".repeat(40),
+      mergeBaseOid: "c".repeat(40),
+      localHeadOid: "a".repeat(40),
+      isStale: false,
+      isTruncated: true,
+      files: [
+        {
+          path: "src/mono-a.ts",
+          previousPath: null,
+          status: "modified",
+          insertions: 3,
+          deletions: 1,
+          isBinary: false,
+          patch: patchWithNeedle("src/mono-a.ts", MONOLITH_NEEDLE),
+        },
+        {
+          path: "src/mono-b.ts",
+          previousPath: null,
+          status: "modified",
+          insertions: 3,
+          deletions: 1,
+          isBinary: false,
+          patch: null,
+        },
+      ],
+    };
+    tabHostClient.request.mockImplementation((method: string) => {
+      if (method === "pr.getLocalDiffSummary")
+        return Promise.reject(unsupportedError());
+      if (method === "pr.getLocalDiff")
+        return Promise.resolve(monolithResponse);
+      return Promise.reject(new Error(`unexpected method ${method}`));
+    });
+    const { node } = await renderTile({
+      queryClient: makeQueryClient(),
+      collapsedFilePaths: null,
+    });
+    await screen.findByTestId("diff-content");
+
+    search(node.instanceId, MONOLITH_NEEDLE);
+    expect(tileSnapshot(node.instanceId).total).toBe(1);
+    expect(tileSnapshot(node.instanceId).coverageMessage).toMatch(/truncated/u);
+  });
+
+  it("keeps a large file's loaded patch renderable after collapse and re-expand", async () => {
+    const HUGE_TOKEN = "HugeToken";
+    const files = [
+      summaryFile({ path: "src/huge.ts", insertions: 2000, deletions: 0 }),
+    ];
+    tabHostClient.request.mockImplementation((method: string) => {
+      if (method === "pr.getLocalDiffSummary")
+        return Promise.resolve(summaryOkWithFiles(files));
+      if (method === "pr.getLocalFileDiff")
+        return Promise.resolve(
+          fileDiffOk(patchWithNeedle("src/huge.ts", HUGE_TOKEN)),
+        );
+      return Promise.reject(new Error(`unexpected method ${method}`));
+    });
+    const queryClient = makeQueryClient();
+    const rendered = await renderTile({
+      queryClient,
+      collapsedFilePaths: null,
+    });
+    const { node, tabId } = rendered;
+
+    const loadButton = await screen.findByRole("button", {
+      name: "Load diff",
+    });
+    fireEvent.click(loadButton);
+    await screen.findByTestId("diff-content");
+
+    search(node.instanceId, HUGE_TOKEN);
+    expect(tileSnapshot(node.instanceId)).toMatchObject({
+      status: "ready",
+      total: 1,
+    });
+    // Close the find session before collapsing: the adapter's `reveal` keeps
+    // the active match's file expanded (see `useBundleDiffFindNavigation`'s
+    // `reveal` - `if (collapsedFileIds.has(fileId)) expandFile(fileId)`), and
+    // that reveal replays whenever the renderer identity changes, which a
+    // `collapsedFilePaths` toggle causes. Leaving the session open would have
+    // the tile silently re-expand the file out from under the toggle below.
+    act(() => {
+      useTileFindStore.getState().close(node.instanceId);
+    });
+
+    // Collapse: the load approval is held at the files-view level (keyed by
+    // comparison + path), not on the row, so it must survive the row
+    // unmounting - collapse then expand exercises exactly that. `PrDiffTile`
+    // reads `node.view` from its prop, not reactively from the store, so
+    // each toggle is followed by a rerender with the store's current node
+    // (mirroring `pr-diff-tile.test.tsx`'s `tileOnTab` + rerender pattern).
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .togglePrDiffFileCollapsedInTab(tabId, node.id, "src/huge.ts");
+    });
+    const collapsedNode = tileOnTab(tabId, node.instanceId);
+    expect(collapsedNode.view.collapsedFilePaths).toContain("src/huge.ts");
+    rendered.view.rerender(
+      tileTree({ queryClient, node: collapsedNode, tabId }),
+    );
+
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .togglePrDiffFileCollapsedInTab(tabId, node.id, "src/huge.ts");
+    });
+    const expandedNode = tileOnTab(tabId, node.instanceId);
+    expect(expandedNode.view.collapsedFilePaths).not.toContain("src/huge.ts");
+    rendered.view.rerender(
+      tileTree({ queryClient, node: expandedNode, tabId }),
+    );
+
+    await screen.findByTestId("diff-content");
+    expect(screen.queryByRole("button", { name: "Load diff" })).toBeNull();
+
+    search(node.instanceId, HUGE_TOKEN);
+    expect(tileSnapshot(node.instanceId)).toMatchObject({
+      status: "ready",
+      total: 1,
+    });
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/snapshot-bundle-diff-file-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/snapshot-bundle-diff-file-navigation.test.tsx
@@ -94,6 +94,7 @@ vi.mock(
         notifySectionMounted: testState.notifySectionMounted,
         registerCoverageState: vi.fn(),
         registerLoadedPatch: testState.registerLoadedPatch,
+        unregisterLoadedPatch: vi.fn(),
       }),
     };
   },

--- a/clients/gui-app/src/lib/pr/pr-local-diff-large-file.ts
+++ b/clients/gui-app/src/lib/pr/pr-local-diff-large-file.ts
@@ -1,0 +1,21 @@
+import type { PrLocalDiffSummaryFile } from "@traycer/protocol/host/pr-schemas";
+import { BUNDLE_INLINE_LINE_THRESHOLD } from "@/lib/git/bundle-thresholds";
+
+/**
+ * Whether a PR range-diff file is too large to render (or fetch) inline
+ * without an explicit "Load diff" - the same `BUNDLE_INLINE_LINE_THRESHOLD`
+ * the Git Diff bundle applies to its rows.
+ *
+ * `null` line counts count as LARGE, not small: they mean the numstat sweep
+ * had nothing to say about a (non-binary) file, so its size is unknown - and
+ * the placeholder's failure mode ("one extra click") is far cheaper than the
+ * inline mode's (parsing an unbounded patch on mount).
+ *
+ * Shared by the section renderer (placeholder vs. inline) and the find
+ * session (a large file's content is not searchable until it is loaded), so
+ * the two can never disagree about which files are guarded.
+ */
+export function isPrLocalDiffLargeFile(file: PrLocalDiffSummaryFile): boolean {
+  if (file.insertions === null || file.deletions === null) return true;
+  return file.insertions + file.deletions > BUNDLE_INLINE_LINE_THRESHOLD;
+}


### PR DESCRIPTION
Closes #1195.

## What

The virtualized PR diff tile now registers with the app's bundle-find machinery, mirroring the Git bundle tile (`useGitBundleDiffFind`). Before this the tile registered **no** tile-find adapter at all — before *or* after the summary/per-file split (#1183) — so the in-app find bar reported *"Search is not available for this tile yet."* on PR tiles, and after the split native find-in-page only saw the rows Virtuoso had mounted.

## How

- **`usePrBundleDiffFind`** (`components/epic-canvas/pr/pr-bundle-diff-find.ts`) — per-file metadata units for every file up front (basename, dir, path, previousPath, status, ±counts, "binary" — searchable without a mount), input-level coverage states (`binary` → monolith `patch: null` = `truncated` → `collapsed` → `large` → `unloaded`), a content identity keyed on the comparison OIDs + whitespace mode + patch mode + file list, and reveal navigation via `useBundleDiffFindNavigation` (scrolls Virtuoso to the row — mounting it, which in split mode issues its fetch — and expands a collapsed one via `updatePrDiffTileViewInTab`).
- **One session for both patch modes.** `PrLocalDiffFilesView` owns it; the shared `PrLocalDiffFileSection` stamps `data-bundle-diff-file-id` and notifies on expand; the split fetch body registers `failed` (query error / `unavailable`) and `binary` (`response.isBinary`); **`PrPatchContent`** — the one place a patch reaches the screen in either mode — registers the loaded patch under an OID-addressed cache key, *before* its hunk check (a header-only change is loaded, not "unloaded"). So what "searchable" means is identical for a new host and the old-host monolith fallback by construction, and a patch stays searchable after its row virtualizes away.
- **Large files** stay out of the index until "Load diff" is pressed; a find reveal does **not** press it — same guard as the bundle tile's `large` rows (the placeholder exists to keep an unbounded patch off the main thread until asked for). The coverage message says "N large files were not fully searched".
- **"Load diff" / "Load Full" approvals** are held at the files-view level (`PrSectionLoadApprovals` context, keyed by `sectionStateKey`) rather than as row `useState` — the find session retains a loaded patch after its row unmounts, so a reveal that remounts the row must render the same bytes, not the placeholder or a bounded re-fetch. Keying by `sectionStateKey` keeps the existing guarantee that an approval expires with the comparison it was granted for.
- `isPrLocalDiffLargeFile` hoisted to `lib/pr/` so the renderer and the find session cannot disagree about which files are guarded.

Not in scope, called out for honesty: no loading/error `sourceOverride` (the tile's skeleton and unavailable body leave no adapter registered — the pre-range states are brief and honestly "unavailable"); the Git bundle tile's own row-local `fullDiffIdentity` has the same remount-after-retention characteristic for its truncated rows — same class, separate change if wanted.

## Review

Cold-reviewed (2 rounds, converged): round 1 raised one should-fix — the load-approval lifetime mismatch above — fixed in `aa13f99a`; round 2 verified the repair on both failure scenarios, approval expiry, context-churn/effect hygiene, and the throw-on-missing-provider choice, with no new defects.

## Tests

`52/52` across the four PR suites; 19 new:
- pure (`pr-bundle-diff-find.test.ts`): large-file predicate (null counts are large), file id, cache key differs on every byte-changing input and is JSON-safe against path/field collisions.
- integrated (`pr-diff-tile-find.test.tsx`, `<PrDiffTile>` under `TileFindScope` with the real tile-find + canvas stores, mocked Virtuoso with a `renderRows` toggle): metadata indexed without a mount; loaded split patch survives row unmount (mutation-probed against `PrPatchContent`'s registration); coverage message names unloaded/collapsed/large/binary; reveal into a collapsed file scrolls to its index and expands it; rejected per-file fetch ⇒ `failed`; monolith fallback searches a mounted patch and counts `patch: null` as `truncated`; a large file's "Load diff" approval survives collapse + re-expand.

Two test-authoring notes are documented in the suite for the next person: don't wrap `search()` in `waitFor` when the host client is Promise-mocked (the store publish re-wakes `waitFor`'s MutationObserver before the pending fetch's microtask ever runs — it spins at 100% CPU); and close the find session before toggling collapse, since reveal keeps the active match's file expanded on every renderer identity change (shared bundle-find behavior).