### PR TITLE
fix(gui-app): resolve composer host RPCs through the composer's target host

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -74,3 +74,15 @@ paths = [
 regexes = [
   '''^eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9[.]eyJzdWIiOiIxMjM0NTY3ODkwIn0[.]dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U$''',
 ]
+
+[[allowlists]]
+description = "Base64 non-UTF-8 path fixtures in the split PR-diff find/body suites. Both values decode to literal filename BYTES - `YmFkLf8udHh0` is `bad-\\xff.txt` and `YmFkLf4udHh0` is `bad-\\xfe.txt` - fed to the `pathBytes` wire field to prove byte-exact round-tripping of paths that are not valid UTF-8. The generic-api-key rule matches them only on base64 shape and entropy; neither is a credential. Same situation as the chat-messages scrollStateKey entry above: `fetch-depth: 0` makes the PR scan see these on the in-flight branch that introduces them (`traycer/non-utf8-path-bytes`), so every unrelated PR fails until this lands - it cannot wait for that branch to merge. Scoped to both exact values and both source paths so unrelated findings stay reportable."
+condition = "AND"
+regexTarget = "secret"
+paths = [
+  '''^clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find\.test\.tsx$''',
+  '''^clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-local-diff-body\.test\.tsx$''',
+]
+regexes = [
+  '''^YmFkLf(?:8|4)udHh0$''',
+]

--- a/clients/gui-app/AGENTS.md
+++ b/clients/gui-app/AGENTS.md
@@ -79,8 +79,10 @@ Host scope: tab tiles use `useTabHostId()` / `useTabHostClient()`; app-wide
 surfaces use `useReactiveActiveHostId()` / `useHostClient()`. Don't mix.
 
 Composers have a **target host** (tab host, fork dialog's fixed host, the
-new-conversation modal's pinned host; `null` = app-wide default only on the
-landing page, whose picker rebinds that default). Every host RPC around a
+new-conversation modal's host). `null` means "follow the app-wide default":
+that is the landing page, whose picker rebinds that default, and the
+new-conversation modal opened from the app-wide sidebar trigger, which sits
+outside every `TabHostProvider`. Every host RPC around a
 composer — mentions, slash commands, harness/model catalog, providers/profiles,
 pack retry, catalog refresh — and every surface that dispatches into the
 focused composer (the palette's Pick provider/model, via

--- a/clients/gui-app/AGENTS.md
+++ b/clients/gui-app/AGENTS.md
@@ -78,6 +78,18 @@ Every host RPC / AuthService / RunnerHost request goes through Query. No
 Host scope: tab tiles use `useTabHostId()` / `useTabHostClient()`; app-wide
 surfaces use `useReactiveActiveHostId()` / `useHostClient()`. Don't mix.
 
+Composers have a **target host** (tab host, fork dialog's fixed host, the
+new-conversation modal's pinned host; `null` = app-wide default only on the
+landing page, whose picker rebinds that default). Every host RPC around a
+composer — mentions, slash commands, harness/model catalog, providers/profiles,
+pack retry, catalog refresh — and every surface that dispatches into the
+focused composer (the palette's Pick provider/model, via
+`FocusedComposerEntry.hostClient`) resolves through that host's client
+(`…ForClient` hooks / `runTargetHostId` → `useHostClientForHostId`). The
+default-host wrappers (`useDefaultHostClient()`, `useProvidersList()`,
+`useGuiHarness*Query()`) are for app-wide surfaces only (prefetcher, Settings,
+a palette with no focused composer) — never inside a composer surface.
+
 ## Routing
 
 - Auth/redirects → route `beforeLoad`; search → `validateSearch`; critical

--- a/clients/gui-app/AGENTS.md
+++ b/clients/gui-app/AGENTS.md
@@ -92,6 +92,16 @@ default-host wrappers (`useDefaultHostClient()`, `useProvidersList()`,
 `useGuiHarness*Query()`) are for app-wide surfaces only (prefetcher, Settings,
 a palette with no focused composer) — never inside a composer surface.
 
+**Deliberate exception — dictation.** `useDictationAvailability` /
+`useVoiceDictation` stay on the app-wide host (`useHostClient()`) even inside a
+host-pinned composer. They describe the person at the keyboard, not the run:
+`speech.dictate` streams live microphone audio and `speech.ensureModel`
+downloads an on-device model, so following a remote run target would ship a
+user's audio to a machine they only picked to execute a turn on, and drop a
+model download there. The cost is real and accepted — a composer pinned to
+host B gates its mic on the app-wide host's model, not B's. Scope a NEW
+composer RPC to the target host unless it is about the human's input devices.
+
 ## Routing
 
 - Auth/redirects → route `beforeLoad`; search → `validateSearch`; critical

--- a/clients/gui-app/src/components/chat/__tests__/profile-durability-d4-chat-fork-tombstoned.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/profile-durability-d4-chat-fork-tombstoned.test.tsx
@@ -94,7 +94,7 @@ vi.mock(
 );
 
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessesQuery: () => ({
+  useGuiHarnessesQueryForClient: () => ({
     data: {
       harnesses: [
         {
@@ -110,7 +110,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     },
     isPending: false,
   }),
-  useGuiHarnessModelsQuery: () => ({
+  useGuiHarnessModelsQueryForClient: () => ({
     data: {
       models: [
         {

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -168,12 +168,13 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
   // resolution is needed at this call site. Never authoritative (`fallback`/
   // `none`): this dialog has no reauth gate of its own, so a genuinely-
   // tombstoned source profile must be corrected to ambient here rather than
-  // silently submitted to `createChat`.
+  // silently submitted to `createChat`. The catalog reads through the same
+  // tab client, so the fork offers the tab host's harnesses/models.
   const toolbarStore = useComposerToolbarStore(
     null,
     fallbackSeedSource(target?.settingsSeed ?? null, tabHostClient),
     null,
-    false,
+    { hostClient: tabHostClient, tuiOnly: false },
   );
   const modelResolved = useStore(
     toolbarStore,

--- a/clients/gui-app/src/components/chat/composer/__tests__/profile-durability-banner-flash-fix.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/profile-durability-banner-flash-fix.test.tsx
@@ -73,7 +73,7 @@ vi.mock("@/hooks/host/use-host-query", () => ({
   },
 }));
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessesQuery: () => ({
+  useGuiHarnessesQueryForClient: () => ({
     data: {
       harnesses: [
         {
@@ -89,7 +89,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     },
     isPending: false,
   }),
-  useGuiHarnessModelsQuery: () => ({
+  useGuiHarnessModelsQueryForClient: () => ({
     data: {
       models: [
         {
@@ -250,7 +250,10 @@ function ChatComposerLikeHarness(props: {
     props.fallbackSettingsSeed,
     TAB_HOST_CLIENT,
   );
-  const toolbarStore = useComposerToolbarStore(null, seedSource, null, false);
+  const toolbarStore = useComposerToolbarStore(null, seedSource, null, {
+    hostClient: TAB_HOST_CLIENT,
+    tuiOnly: false,
+  });
   const harnessId = useStore(toolbarStore, (s) => s.selection.harnessId);
   const profileId = useStore(toolbarStore, (s) => s.selection.profileId);
   const reauthGate = useProviderReauthGate(

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -304,11 +304,14 @@ function ChatComposerImpl(props: ChatComposerProps) {
   // catalog churn - stays inside the toolbar leaves and the submit path.
   // Only the focused top-level surface owns composer controls, automatic focus,
   // and their catalog subscriptions. Visible split partners retain their body.
+  // The catalog is the TAB host's (`hostClient`), like every other read in
+  // this composer - a tab bound to another host offers that host's harnesses
+  // and models, never the app-wide default's.
   const toolbarStore = useComposerToolbarStore(
     focused ? "chat-tile" : null,
     seedSource,
     onSettingsChange,
-    false,
+    { hostClient, tuiOnly: false },
   );
   const harnessId = useStore(toolbarStore, (s) => s.selection.harnessId);
   const profileId = useStore(toolbarStore, (s) => s.selection.profileId);

--- a/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
@@ -331,6 +331,7 @@ export function useMentionItems(params: UseMentionItemsParams): void {
     refetch: refetchEpicMentions,
   } = useEpicMentionEntries({
     requests: epicRequests,
+    client: hostClient,
   });
   const epicTitleByIdFromCache = useMemo(() => {
     if (cachedEpicTasks.length === 0) return EMPTY_TITLE_MAP;

--- a/clients/gui-app/src/components/epic-canvas/__tests__/add-node-dropdown-terminal-agent.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/add-node-dropdown-terminal-agent.test.tsx
@@ -11,6 +11,33 @@ const mocks = vi.hoisted(() => ({
   onAddTerminalAgent: vi.fn(),
 }));
 
+// Records the `hostId` each call was made with, so tests can assert the
+// terminal-agent launcher resolves its picker's target host through THIS
+// primitive - keyed on the launch host scope - rather than the app-wide
+// default. The returned "client" is just the hostId echoed back: neither the
+// mocked `useComposerToolbarStore` nor `useProvidersListForClient` below read
+// it for content, only `add-node-dropdown.tsx` itself threads it through.
+const hostClientForHostIdMock = vi.hoisted(() => ({
+  calls: [] as Array<string | null>,
+}));
+
+// Records the host-scoped props each render passed to the picker, so tests
+// can assert `createProfileHostId` / `runTargetHostId` follow the launch host
+// scope without needing the real (heavy) picker to mount.
+const harnessModelPickerMock = vi.hoisted(() => ({
+  calls: [] as Array<{
+    readonly createProfileHostId: string | null;
+    readonly runTargetHostId: string | null;
+  }>,
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: (hostId: string | null) => {
+    hostClientForHostIdMock.calls.push(hostId);
+    return hostId;
+  },
+}));
+
 vi.mock("@/components/home/hooks/use-composer-toolbar-store", async () => {
   const { createStore } = await import("zustand/vanilla");
   const store = createStore(() => ({
@@ -30,7 +57,16 @@ vi.mock("@/components/home/hooks/use-composer-toolbar-store", async () => {
 });
 
 vi.mock("@/components/home/pickers/harness-model-picker", () => ({
-  HarnessModelPicker: () => <div>Claude Opus</div>,
+  HarnessModelPicker: (props: {
+    readonly createProfileHostId: string | null;
+    readonly runTargetHostId: string | null;
+  }) => {
+    harnessModelPickerMock.calls.push({
+      createProfileHostId: props.createProfileHostId,
+      runTargetHostId: props.runTargetHostId,
+    });
+    return <div>Claude Opus</div>;
+  },
 }));
 
 vi.mock("@/components/home/pickers/agent-mode-toggle", () => ({
@@ -39,6 +75,19 @@ vi.mock("@/components/home/pickers/agent-mode-toggle", () => ({
 
 vi.mock("@/hooks/providers/use-providers-list-query", () => ({
   useProvidersList: () => ({
+    data: {
+      providers: [
+        {
+          providerId: "claude-code",
+          terminalAgentArgs: "",
+        },
+      ],
+    },
+  }),
+  // `TerminalAgentSubMenuContent` now reads through this (its fixed-scope
+  // launch host client) rather than the app-wide `useProvidersList` - same
+  // canned data, since this suite doesn't vary it by host.
+  useProvidersListForClient: () => ({
     data: {
       providers: [
         {
@@ -68,6 +117,8 @@ import { useSeededWorkspaceSnapshotStore } from "@/stores/worktree/seeded-worksp
 describe("<AddNodeDropdown /> terminal-agent launch", () => {
   afterEach(() => {
     mocks.onAddTerminalAgent.mockReset();
+    hostClientForHostIdMock.calls.length = 0;
+    harnessModelPickerMock.calls.length = 0;
     useWorkspaceFoldersStore.setState({
       folders: [],
       folderInfoByPath: {},
@@ -175,6 +226,88 @@ describe("<AddNodeDropdown /> terminal-agent launch", () => {
           workspaceMode: "inherit",
         }),
       );
+    });
+  });
+
+  it("resolves the picker's target host through useHostClientForHostId, keyed on the launch host scope", async () => {
+    render(
+      <AddNodeDropdown
+        open
+        onOpenChange={() => undefined}
+        menuPlacement="row"
+        menuTestId="add-node-menu"
+        itemTestId={(type) => `add-${type}`}
+        onAdd={() => undefined}
+        epicId="epic-test"
+        onAddTerminalAgent={mocks.onAddTerminalAgent}
+        terminalAgentWorkspaceSeed={null}
+        terminalAgentHostScope={{
+          kind: "fixed",
+          hostId: "host-b",
+          hostClient: null,
+        }}
+        terminalAgentStagingKey={undefined}
+        tuiAgentPending={false}
+        disabled={false}
+        disabledTooltip={null}
+        disabledTypes={undefined}
+        excludeTypes={undefined}
+      >
+        <button type="button">Add node</button>
+      </AddNodeDropdown>,
+    );
+
+    const terminalAgentTrigger = await screen.findByTestId(
+      "add-node-menu-terminal-agent",
+    );
+    terminalAgentTrigger.focus();
+    fireEvent.keyDown(terminalAgentTrigger, { key: "ArrowRight" });
+    await screen.findByRole("button", { name: "Start" });
+
+    expect(hostClientForHostIdMock.calls.at(-1)).toBe("host-b");
+    expect(harnessModelPickerMock.calls.at(-1)).toEqual({
+      createProfileHostId: "host-b",
+      runTargetHostId: "host-b",
+    });
+
+    cleanup();
+    hostClientForHostIdMock.calls.length = 0;
+    harnessModelPickerMock.calls.length = 0;
+
+    render(
+      <AddNodeDropdown
+        open
+        onOpenChange={() => undefined}
+        menuPlacement="row"
+        menuTestId="add-node-menu"
+        itemTestId={(type) => `add-${type}`}
+        onAdd={() => undefined}
+        epicId="epic-test"
+        onAddTerminalAgent={mocks.onAddTerminalAgent}
+        terminalAgentWorkspaceSeed={null}
+        terminalAgentHostScope={undefined}
+        terminalAgentStagingKey={undefined}
+        tuiAgentPending={false}
+        disabled={false}
+        disabledTooltip={null}
+        disabledTypes={undefined}
+        excludeTypes={undefined}
+      >
+        <button type="button">Add node</button>
+      </AddNodeDropdown>,
+    );
+
+    const undefinedScopeTrigger = await screen.findByTestId(
+      "add-node-menu-terminal-agent",
+    );
+    undefinedScopeTrigger.focus();
+    fireEvent.keyDown(undefinedScopeTrigger, { key: "ArrowRight" });
+    await screen.findByRole("button", { name: "Start" });
+
+    expect(hostClientForHostIdMock.calls.at(-1)).toBeNull();
+    expect(harnessModelPickerMock.calls.at(-1)).toEqual({
+      createProfileHostId: null,
+      runTargetHostId: null,
     });
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/add-node-dropdown.tsx
+++ b/clients/gui-app/src/components/epic-canvas/add-node-dropdown.tsx
@@ -44,7 +44,8 @@ import {
   type HostWorkspaceControlsHostScope,
 } from "@/components/home/host-workspace-selector/host-workspace-controls-scope";
 import { preserveWhenNestedOverlay } from "@/components/home/host-workspace-selector/preserve-when-nested-overlay";
-import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useProvidersListForClient } from "@/hooks/providers/use-providers-list-query";
 import type { ForkWorkspaceSeed } from "@/lib/worktree/fork-workspace-seed";
 import type { TerminalAgentWorktreeCreateInput } from "@/components/epic-canvas/hooks/use-terminal-agent-worktree-gate";
 import { readSeededLaunchWorkspace } from "@/lib/worktree/seeded-launch-worktree-intent";
@@ -286,13 +287,20 @@ function TerminalAgentSubMenuContent(props: TerminalAgentSubMenuContentProps) {
     tuiAgentPending,
     workspaceSeed,
   } = props;
+  // The host the agent launches on - `hostScope`'s fixed host when a row
+  // pins one, else `null` = the app-wide default the active-scope host list
+  // rebinds. Resolved through the SAME primitive the picker below applies to
+  // its `runTargetHostId`, so the toolbar store's catalog, the picker and the
+  // saved-args `providers.list` read below can never disagree on the host,
+  // and none of them can drift onto another host than the workspace controls
+  // create on.
+  const launchHostId = hostScope.kind === "fixed" ? hostScope.hostId : null;
+  const launchHostClient = useHostClientForHostId(launchHostId);
   // No seed here - nothing to validate.
-  const toolbarStore = useComposerToolbarStore(
-    null,
-    { kind: "none" },
-    null,
-    true,
-  );
+  const toolbarStore = useComposerToolbarStore(null, { kind: "none" }, null, {
+    hostClient: launchHostClient,
+    tuiOnly: true,
+  });
   const selection = useStore(toolbarStore, (state) => state.selection);
   const selectedHarnessId = selection.harnessId;
   const reasoning = useStore(toolbarStore, (state) => state.reasoning);
@@ -303,7 +311,7 @@ function TerminalAgentSubMenuContent(props: TerminalAgentSubMenuContentProps) {
         ?.find((harness) => harness.id === state.selection.harnessId)
         ?.modes.includes("tui") ?? false,
   );
-  const providersQuery = useProvidersList({
+  const providersQuery = useProvidersListForClient(launchHostClient, {
     enabled: true,
     subscribed: true,
   });
@@ -398,11 +406,12 @@ function TerminalAgentSubMenuContent(props: TerminalAgentSubMenuContentProps) {
             lockedHarnessId={null}
             disabled={tuiAgentPending}
             registerActivation={false}
-            // Adding a brand-new node has no existing tab to bind to yet -
-            // the app-wide default host is the correct scope, same as this
-            // dropdown's own `useProvidersList()` read below.
-            createProfileHostId={null}
-            runTargetHostId={null}
+            // The launch host (see `launchHostId` above): a row-pinned fixed
+            // host, or `null` = the app-wide default for a brand-new node
+            // with no tab to bind to yet - the same scope as this submenu's
+            // own `providers.list` read.
+            createProfileHostId={launchHostId}
+            runTargetHostId={launchHostId}
             profileAdmission={null}
           />
         </div>

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/profile-durability-d4-terminal-fork-tombstoned.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/profile-durability-d4-terminal-fork-tombstoned.test.tsx
@@ -98,7 +98,7 @@ vi.mock(
 );
 
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessesQuery: () => ({
+  useGuiHarnessesQueryForClient: () => ({
     data: {
       harnesses: [
         {
@@ -114,7 +114,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     },
     isPending: false,
   }),
-  useGuiHarnessModelsQuery: () => ({
+  useGuiHarnessModelsQueryForClient: () => ({
     data: {
       models: [
         {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-fork-dialog-real-picker.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-fork-dialog-real-picker.test.tsx
@@ -246,7 +246,7 @@ vi.mock("react-virtuoso", async () => {
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
   useDefaultHostClient: () => null,
   harnessCatalogEntryNeedsRefresh: () => true,
-  useGuiHarnessesQuery: () => ({
+  useGuiHarnessesQueryForClient: () => ({
     data: {
       harnesses: [
         {
@@ -265,7 +265,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     isPending: false,
     error: null,
   }),
-  useGuiHarnessModelsQuery: () => ({
+  useGuiHarnessModelsQueryForClient: () => ({
     data: {
       harnessId: "claude",
       models: [
@@ -295,7 +295,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     error: null,
     refetch: () => Promise.resolve({ data: undefined }),
   }),
-  useGuiHarnessCatalog: () => ({
+  useGuiHarnessCatalogForClient: () => ({
     harnesses: [
       {
         id: "claude",
@@ -331,7 +331,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     harnessesError: null,
     modelsLoading: false,
   }),
-  useRefreshHarnessCatalog: () => async () => {},
+  useRefreshHarnessCatalogForClient: () => async () => {},
 }));
 
 vi.mock("@/components/home/pickers/agent-mode-toggle", () => ({

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-fork-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-fork-dialog.test.tsx
@@ -161,7 +161,7 @@ vi.mock(
 );
 
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessesQuery: () => ({
+  useGuiHarnessesQueryForClient: () => ({
     data: {
       harnesses: [
         {
@@ -177,7 +177,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     },
     isPending: false,
   }),
-  useGuiHarnessModelsQuery: () => ({
+  useGuiHarnessModelsQueryForClient: () => ({
     data: {
       models: [
         {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-binding-chip.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-binding-chip.test.tsx
@@ -30,6 +30,12 @@ vi.mock("@/lib/host", () => {
     useHostClient: () => ({
       request: () => new Promise(() => {}),
       getActiveHostId: () => "host-test",
+      // `useTabHostClient` resolves through `useHostClientForHostId`, which
+      // asks the default client for the tab's entry (live directory first,
+      // then the active entry) before handing it to `useHostClientFor` -
+      // mocked below to return the same stub client for any entry.
+      resolveHostById: () => entry,
+      getActiveHost: () => entry,
       getRequestContextUserId: () => "user-test",
       onChange: () => () => undefined,
     }),

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -126,7 +126,6 @@ import { useCloudChatList } from "@/hooks/chats/use-cloud-chat-queries";
 import { cloudRowIsViewersOwn } from "@/lib/chats/unified-chat-list";
 import { flattenCollaborators } from "@/hooks/epics/use-epic-collaborators-query";
 import {
-  useGuiHarnessCatalog,
   useGuiHarnessCatalogForClient,
   type GuiHarnessCatalogEntry,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
@@ -1214,36 +1213,27 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   );
   const collaborators = useCachedCollaborators(currentEpicId);
   // Label-only, cache-only projection: this tile's own composer (which fetches
-  // the TAB host's catalog) and the app-wide `HarnessCatalogPrefetcher` (which
-  // fills the default host's, for every harness) own the fetch; this reads
-  // those host-keyed caches (never fetches) so ANY visible transcript —
-  // including a restored terminal-focused split with an inactive chat and no
-  // live catalog publisher — renders friendly model/reasoning labels
-  // immediately, and a host/user switch re-keys the queries and swaps labels.
-  // Detaches when hidden.
+  // the TAB host's catalog) owns the fetch; this reads that host-keyed cache
+  // (never fetches) so ANY visible transcript — including a restored
+  // terminal-focused split with an inactive chat and no live catalog publisher
+  // — renders friendly model/reasoning labels immediately, and a host/user
+  // switch re-keys the queries and swaps labels. Detaches when hidden.
   //
-  // Two slots, tab host layered OVER the default host: the tab slot is the
-  // catalog the composer below actually offers, so a model only that host has
-  // gets its friendly label; the default slot covers a harness whose models
-  // the tab slot has not fetched yet (an older turn's harness) with the same
-  // slug's label from the host every user has. On a default-host tab both
-  // reads are the same slot.
+  // ONE slot, the tab host's - never layered over the default host's. This
+  // transcript describes turns that ran on the TAB host, so a slug that host
+  // does not advertise must degrade to the raw slug rather than borrow a label
+  // (or a reasoning-effort label, which is version-specific) from a host that
+  // never served the turn. On a default-host tab this is the slot the
+  // app-load prefetcher already filled, so nothing changes there; on a
+  // remote-host tab the labels appear once anything warms that host's catalog
+  // — opening this tile's own composer picker does exactly that.
   const tabHostCatalogClient = useTabHostClient();
   const tabModelCatalog = useGuiHarnessCatalogForClient(
     tabHostCatalogClient,
     null,
     { enabled: false, subscribed: surfaceVisible },
   );
-  const defaultModelCatalog = useGuiHarnessCatalog(null, {
-    enabled: false,
-    subscribed: surfaceVisible,
-  });
-  // Later entries win in the `new Map(...)` builders below, so the tab host's
-  // labels take precedence wherever both slots know the same model.
-  const displayCatalog = useMemo(
-    () => [...defaultModelCatalog.harnesses, ...tabModelCatalog.harnesses],
-    [defaultModelCatalog.harnesses, tabModelCatalog.harnesses],
-  );
+  const displayCatalog = tabModelCatalog.harnesses;
   const modelLabels = useMemo<ReadonlyMap<string, string>>(
     () =>
       new Map(

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -127,6 +127,7 @@ import { cloudRowIsViewersOwn } from "@/lib/chats/unified-chat-list";
 import { flattenCollaborators } from "@/hooks/epics/use-epic-collaborators-query";
 import {
   useGuiHarnessCatalog,
+  useGuiHarnessCatalogForClient,
   type GuiHarnessCatalogEntry,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useInitialChatHandoffDriver } from "@/hooks/chats/use-initial-chat-handoff-driver";
@@ -1212,17 +1213,37 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     ),
   );
   const collaborators = useCachedCollaborators(currentEpicId);
-  // Label-only, cache-only projection: the focused composer's toolbar and the
-  // app-wide `HarnessCatalogPrefetcher` own the fetch; this reads the same
-  // host-keyed cache (never fetches) so ANY visible transcript — including a
-  // restored terminal-focused split with an inactive chat and no live catalog
-  // publisher — renders friendly model/reasoning labels immediately, and a
-  // host/user switch re-keys the query and swaps labels. Detaches when hidden.
-  const modelCatalog = useGuiHarnessCatalog(null, {
+  // Label-only, cache-only projection: this tile's own composer (which fetches
+  // the TAB host's catalog) and the app-wide `HarnessCatalogPrefetcher` (which
+  // fills the default host's, for every harness) own the fetch; this reads
+  // those host-keyed caches (never fetches) so ANY visible transcript —
+  // including a restored terminal-focused split with an inactive chat and no
+  // live catalog publisher — renders friendly model/reasoning labels
+  // immediately, and a host/user switch re-keys the queries and swaps labels.
+  // Detaches when hidden.
+  //
+  // Two slots, tab host layered OVER the default host: the tab slot is the
+  // catalog the composer below actually offers, so a model only that host has
+  // gets its friendly label; the default slot covers a harness whose models
+  // the tab slot has not fetched yet (an older turn's harness) with the same
+  // slug's label from the host every user has. On a default-host tab both
+  // reads are the same slot.
+  const tabHostCatalogClient = useTabHostClient();
+  const tabModelCatalog = useGuiHarnessCatalogForClient(
+    tabHostCatalogClient,
+    null,
+    { enabled: false, subscribed: surfaceVisible },
+  );
+  const defaultModelCatalog = useGuiHarnessCatalog(null, {
     enabled: false,
     subscribed: surfaceVisible,
   });
-  const displayCatalog = modelCatalog.harnesses;
+  // Later entries win in the `new Map(...)` builders below, so the tab host's
+  // labels take precedence wherever both slots know the same model.
+  const displayCatalog = useMemo(
+    () => [...defaultModelCatalog.harnesses, ...tabModelCatalog.harnesses],
+    [defaultModelCatalog.harnesses, tabModelCatalog.harnesses],
+  );
   const modelLabels = useMemo<ReadonlyMap<string, string>>(
     () =>
       new Map(

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-agent-fork-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-agent-fork-dialog.tsx
@@ -232,12 +232,14 @@ function TerminalAgentForkDialogBody(props: TerminalAgentForkDialogProps) {
   // host), so no separate resolution is needed at this call site. Never
   // authoritative: this dialog has no reauth gate of its own, so a
   // genuinely-tombstoned source profile must be corrected to ambient here
-  // rather than silently submitted to `createAgent.create`.
+  // rather than silently submitted to `createAgent.create`. The catalog reads
+  // through the same fixed client, so the fork offers this host's harnesses
+  // and models.
   const toolbarStore = useComposerToolbarStore(
     null,
     fallbackSeedSource(settingsSeed, hostClient),
     null,
-    true,
+    { hostClient, tuiOnly: true },
   );
   const createAgent = useCreateTuiAgentForClient(hostClient, hostId);
   const validateForkProfile = useValidateTuiForkProfile(hostClient);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -558,17 +558,19 @@ export function NewConversationModalBody(props: {
   );
   // `draftSettings` can fall back to `runSettingsSeed`/`latestSettingsSeed`
   // (see `useNewConversationModalSeed`), neither of which is host-scoped or
-  // kept in sync with live profile removals - validated against the active
-  // host (this modal always creates there, per its workspace controls below)
-  // via the same machinery `useComposerToolbarStore` runs for every composer
+  // kept in sync with live profile removals - validated against the host this
+  // modal creates on (`hostClient`: the pinned host, else the active one) via
+  // the same machinery `useComposerToolbarStore` runs for every composer
   // surface. Never authoritative: this modal has no reauth gate of its own,
   // so a genuinely-removed profile must be corrected to ambient here rather
-  // than silently submitted as the new chat/agent's initial settings.
+  // than silently submitted as the new chat/agent's initial settings. The
+  // catalog reads through that same client, so a pinned modal offers the
+  // pinned host's harnesses/models, not the active host's.
   const toolbarStore = useComposerToolbarStore(
     null,
     fallbackSeedSource(draftSettings, hostClient),
     handleToolbarSettingsChange,
-    draftComposerMode === "terminal",
+    { hostClient, tuiOnly: draftComposerMode === "terminal" },
   );
   const harnessId = useStore(
     toolbarStore,
@@ -989,6 +991,10 @@ export function NewConversationModalBody(props: {
       hasPastedImageBytes={hasPastedImageBytes}
       ingestPastedComposerImages={null}
       onEditorReady={null}
+      // The pinned host (or `null` = active), the same id `hostClient` above
+      // resolves - so the toolbar's and terminal launcher's pickers offer this
+      // host's harnesses/models/profiles and create profiles on it.
+      hostId={hostId}
       onSubmit={handleSubmit}
       onStartTerminal={handleStartTerminal}
       onDocumentChange={handleDocumentChange}

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker-intent-rpc.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker-intent-rpc.test.tsx
@@ -87,8 +87,19 @@ vi.mock("@/hooks/providers/use-providers-list-query", () => ({
   }),
 }));
 
+// `runTargetHostId` is always `null` in this suite's fixtures (see
+// `renderPickerWithFixture`), so this mirrors the real hook's `null` branch
+// exactly: fall back to the app-wide default host's client
+// (`hostBindingMock.current?.hostClient`, the same real `HostClient` over a
+// `MockHostMessenger` the suite's RPC-count assertions depend on) rather than
+// a bare sentinel string. The picker now threads this client straight into
+// `useHostQuery` (via the REAL, unmocked `…ForClient` catalog hooks - see the
+// file header), which calls `client?.getActiveHostId()` - a plain string
+// lacks that method and throws, which is exactly what regressed every test
+// in this file before this fix.
 vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
-  useHostClientForHostId: (hostId: string | null) => hostId ?? "default",
+  useHostClientForHostId: (hostId: string | null) =>
+    hostId === null ? (hostBindingMock.current?.hostClient ?? null) : hostId,
 }));
 
 vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -142,6 +142,15 @@ const queryMock = vi.hoisted(() => ({
   // `providerStates` for every target host, matching the pre-fix behavior
   // where the gate always read the default host's list.
   providerStatesByClient: new Map<string, ProviderCliState[]>(),
+  // Per-target-host overrides for the harness-catalog `…ForClient` hooks,
+  // keyed by the same `useHostClientForHostId` sentinel as
+  // `providerStatesByClient` above. Unpopulated (the common case): every
+  // `…ForClient` call falls back to the single `harnesses` /
+  // `selectedModelsByHarness` / `catalogHarnesses` fixture below, matching
+  // pre-fix behavior where every call read the same data regardless of host.
+  harnessesByClient: new Map<string, HarnessOption[]>(),
+  modelsByClient: new Map<string, Map<string, ReadonlyArray<ModelOption>>>(),
+  catalogHarnessesByClient: new Map<string, CatalogHarness[]>(),
   unresolvedHostIds: new Set<string>(),
   cloneCatalogOnRead: false,
   calls: {
@@ -149,17 +158,24 @@ const queryMock = vi.hoisted(() => ({
       readonly enabled: boolean;
       readonly subscribed: boolean;
     }>,
+    // The `client` each `…ForClient` call was invoked with (recorded
+    // separately from `calls.harnesses` / `calls.models` / `calls.catalog`
+    // above so their pre-existing `toEqual({ enabled, subscribed })`
+    // assertions keep matching exactly, with no extra field to account for).
+    harnessClients: [] as Array<string | null>,
     catalog: [] as Array<{
       readonly workingDirectory: string | null;
       readonly enabled: boolean;
       readonly subscribed: boolean;
     }>,
+    catalogClients: [] as Array<string | null>,
     models: [] as Array<{
       readonly harnessId: string;
       readonly workingDirectory: string | null;
       readonly enabled: boolean;
       readonly subscribed: boolean;
     }>,
+    modelClients: [] as Array<string | null>,
     providers: [] as Array<{
       readonly enabled: boolean;
       readonly subscribed: boolean;
@@ -171,6 +187,10 @@ const queryMock = vi.hoisted(() => ({
       readonly subscribed: boolean;
     }>,
     ensurePack: [] as string[],
+    // `useRefreshHarnessCatalogForClient`'s own `client` argument (not the
+    // client the returned refresh function later resolves internally - this
+    // suite mocks the hook itself, so this is the one signal available).
+    refresh: [] as Array<string | null>,
   },
 }));
 
@@ -210,15 +230,40 @@ vi.mock("@/hooks/providers/use-providers-list-query", () => ({
     client: string | null,
     activity: QueryActivity,
   ) => {
+    // The picker now issues TWO `useProvidersListForClient` calls (the rail,
+    // and the create-profile capability gate) where it used to issue ONE
+    // `useProvidersList` call for the rail - recording both here keeps
+    // `calls.providers` a faithful "every providers-list observer this
+    // render created" log. Both calls share the same `activityEnabled` in
+    // every fixture in this file, so existing `.at(-1)` assertions on
+    // enabled/subscribed are unaffected by which call lands last.
+    queryMock.calls.providers.push({
+      enabled: activity.enabled,
+      subscribed: activity.subscribed,
+    });
+    // A `null` client models an UNRESOLVED run-target host - `useHostQuery`
+    // disables the query outright (`enabled: (query) => client === null ? ...
+    // false`), so a real disabled query with no cached data reports
+    // `isPending: true`/`data: undefined` forever, never the DEFAULT host's
+    // cached providers. Falling back to `providerStates` here (the pre-fix
+    // behavior) would leak the default host's profiles into a picker bound to
+    // a host that never resolved.
+    if (client === null) {
+      return {
+        data: undefined,
+        isPending: true,
+        isError: false,
+        error: null,
+        isFetching: false,
+      };
+    }
     const providers =
-      client === null
-        ? queryMock.providerStates
-        : (queryMock.providerStatesByClient.get(client) ??
-          queryMock.providerStates);
+      queryMock.providerStatesByClient.get(client) ?? queryMock.providerStates;
     return {
       data: activity.enabled ? { providers } : undefined,
       isPending: false,
       isError: false,
+      error: null,
       isFetching: false,
     };
   },
@@ -389,18 +434,41 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
   // freshness policy, and the RPCs it gates, are covered against a mocked host
   // transport in `harness-model-picker-intent-rpc.test.tsx`.
   harnessCatalogEntryNeedsRefresh: () => true,
-  useGuiHarnessesQuery: (activity: QueryActivity) => {
+  // The picker resolves its own client (`useHostClientForHostId`, mocked
+  // above to a sentinel keyed by `runTargetHostId`) and threads it into every
+  // `…ForClient` call below. This suite's fixtures are not per-host (see
+  // `queryMock`), so every `…ForClient` variant delegates to the SAME data -
+  // the `client` argument is only ever recorded, never used to branch, unless
+  // a test specifically layers `queryMock.harnessesByClient` (see below).
+  useGuiHarnessesQueryForClient: (
+    client: string | null,
+    activity: QueryActivity,
+  ) => {
     queryMock.calls.harnesses.push({
       enabled: activity.enabled,
       subscribed: activity.subscribed,
     });
+    queryMock.calls.harnessClients.push(client);
+    // A `null` client models an unresolved run-target host: `useHostQuery`
+    // disables the underlying query, so a real disabled query with no cached
+    // data reports `isPending: true`/`data: undefined` forever - never the
+    // default host's cached harness list. See the matching comment on
+    // `useProvidersListForClient` above for why this must not fall back.
+    if (client === null) {
+      return { data: undefined, isPending: true, isError: false, error: null };
+    }
+    const harnesses = queryMock.harnessesByClient.has(client)
+      ? (queryMock.harnessesByClient.get(client) ?? [])
+      : queryMock.harnesses;
     return {
-      data: activity.enabled ? { harnesses: queryMock.harnesses } : undefined,
+      data: activity.enabled ? { harnesses } : undefined,
       isPending: activity.enabled && queryMock.harnessesLoading,
+      isError: queryMock.harnessesError !== null,
       error: queryMock.harnessesError,
     };
   },
-  useGuiHarnessModelsQuery: (
+  useGuiHarnessModelsQueryForClient: (
+    client: string | null,
     harnessId: string,
     workingDirectory: string | null,
     activity: QueryActivity,
@@ -411,14 +479,31 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
       enabled: activity.enabled,
       subscribed: activity.subscribed,
     });
+    queryMock.calls.modelClients.push(client);
+    // See `useGuiHarnessesQueryForClient` above: a `null` client is a
+    // permanently-disabled query, never a default-host fallback.
+    if (client === null) {
+      return {
+        data: undefined,
+        isPending: true,
+        isError: false,
+        error: null,
+        refetch: () => Promise.resolve({ data: undefined }),
+      };
+    }
+    const modelsByHarness = queryMock.modelsByClient.has(client)
+      ? (queryMock.modelsByClient.get(client) ??
+        queryMock.selectedModelsByHarness)
+      : queryMock.selectedModelsByHarness;
     return {
       data: activity.enabled
         ? {
             harnessId,
-            models: queryMock.selectedModelsByHarness.get(harnessId) ?? [],
+            models: modelsByHarness.get(harnessId) ?? [],
           }
         : undefined,
       isPending: false,
+      isError: false,
       error: null,
       // The picker's intent-edge effects call `.refetch()` on both queries
       // whenever the popover opens or the selection changes (real RPC
@@ -448,7 +533,8 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
       refetch: () => Promise.resolve({ data: undefined }),
     };
   },
-  useGuiHarnessCatalog: (
+  useGuiHarnessCatalogForClient: (
+    client: string | null,
     workingDirectory: string | null,
     activity: QueryActivity,
   ) => {
@@ -457,14 +543,36 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
       enabled: activity.enabled,
       subscribed: activity.subscribed,
     });
+    queryMock.calls.catalogClients.push(client);
+    // See `useGuiHarnessesQueryForClient` above: with a `null` client the
+    // underlying harnesses query is permanently disabled, so the REAL
+    // composed hook reports an empty catalog (never the default host's cached
+    // one) that is NOT loading - it gates `harnessesLoading` on the client,
+    // since a disabled query's `isPending` would otherwise read as loading
+    // forever - and no model queries ever fire since there are no available
+    // harness ids to fan out over.
+    if (client === null) {
+      return {
+        harnesses: [],
+        harnessesLoading: false,
+        harnessesError: null,
+        modelsLoading: false,
+      };
+    }
+    const harnesses = queryMock.catalogHarnessesByClient.has(client)
+      ? (queryMock.catalogHarnessesByClient.get(client) ?? [])
+      : catalogHarnessesForRender();
     return {
-      harnesses: activity.enabled ? catalogHarnessesForRender() : [],
+      harnesses: activity.enabled ? harnesses : [],
       harnessesLoading: activity.enabled && queryMock.catalogHarnessesLoading,
       harnessesError: null,
       modelsLoading: activity.enabled && queryMock.modelsLoading,
     };
   },
-  useRefreshHarnessCatalog: () => async () => {},
+  useRefreshHarnessCatalogForClient: (client: string | null) => () => {
+    queryMock.calls.refresh.push(client);
+    return Promise.resolve();
+  },
 }));
 
 import { HarnessModelPicker } from "@/components/home/pickers/harness-model-picker";
@@ -919,14 +1027,21 @@ describe("<HarnessModelPicker />", () => {
     queryMock.modelsLoading = false;
     queryMock.providerStates = [];
     queryMock.providerStatesByClient = new Map();
+    queryMock.harnessesByClient = new Map();
+    queryMock.modelsByClient = new Map();
+    queryMock.catalogHarnessesByClient = new Map();
     queryMock.unresolvedHostIds = new Set();
     queryMock.cloneCatalogOnRead = false;
     queryMock.calls.harnesses = [];
+    queryMock.calls.harnessClients = [];
     queryMock.calls.catalog = [];
+    queryMock.calls.catalogClients = [];
     queryMock.calls.models = [];
+    queryMock.calls.modelClients = [];
     queryMock.calls.providers = [];
     queryMock.calls.commands = [];
     queryMock.calls.ensurePack = [];
+    queryMock.calls.refresh = [];
     profileUsageHookMock.runTargetHostIds = [];
     profileUsageHookMock.calls = [];
     openSettingsMock.mockClear();
@@ -1466,6 +1581,61 @@ describe("<HarnessModelPicker />", () => {
       enabled: true,
       subscribed: true,
     });
+  });
+
+  // S11 coverage: the picker's harness rail, model rows, and refresh button
+  // all resolve through the composer's run-target host, never the app-wide
+  // default - a regression back to the old default-host resolution would
+  // render THIS test's `installCatalog()` fixture (GPT-5.5 etc.) instead of
+  // host-b's, and would invalidate "default" instead of "host-b" on refresh.
+  it("resolves the rail, model rows, and refresh target from the run-target host (host-b), not the app-wide default", async () => {
+    const hostBModels = [
+      model({ slug: "host-b-model", label: "Host B Model" }),
+    ];
+    queryMock.harnessesByClient.set("host-b", [CODEX_HARNESS]);
+    queryMock.catalogHarnessesByClient.set("host-b", [
+      catalogHarness(CODEX_HARNESS, hostBModels),
+    ]);
+    queryMock.modelsByClient.set("host-b", new Map([["codex", hostBModels]]));
+    queryMock.providerStatesByClient.set("host-b", [
+      providerCliStateWithProfiles({ providerId: "codex", profiles: [] }),
+    ]);
+
+    renderPicker({
+      createProfileHostId: "host-b",
+      selection: {
+        harnessId: "codex",
+        modelSlug: "host-b-model",
+        profileId: null,
+      },
+    });
+
+    // The trigger and the rows reflect host-b's catalog - never the default
+    // host's `installCatalog()` fixture, which has no "Host B Model" and no
+    // "host-b-model" slug.
+    await openPickerByTriggerName(/^Host B Model/);
+    expect(screen.getByRole("option", { name: /Host B Model/ })).not.toBeNull();
+    expect(screen.queryByRole("option", { name: /GPT-5\.5/ })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh providers & models" }),
+    );
+
+    await waitFor(() => expect(queryMock.calls.refresh.at(-1)).toBe("host-b"));
+    expect(queryMock.calls.refresh).not.toContain("default");
+  });
+
+  it("resolves the rail, model rows, and refresh target from the app-wide default host when runTargetHostId is null (unchanged behavior)", async () => {
+    renderPicker(undefined);
+
+    await openPicker();
+    expect(screen.getByRole("option", { name: /GPT-5\.5/ })).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh providers & models" }),
+    );
+
+    await waitFor(() => expect(queryMock.calls.refresh.at(-1)).toBe("default"));
   });
 
   it("hides unavailable providers that are not recoverable from the rail", async () => {
@@ -2412,22 +2582,31 @@ describe("<HarnessModelPicker />", () => {
     expect(useProviderProfileAddFlowStore.getState().hostId).toBe("tab-host-1");
   });
 
-  it("keeps usage identity-only when the run target's profile identities differ from the visible default-host rows", async () => {
-    const visibleProfiles = claudeProfilesForDropdown();
+  // Before the rail was host-scoped this asserted `profiles: []`: the rail's
+  // visible rows came from the default host ("Work") while the dropdown's
+  // comparison query read the tab host ("Remote Work"), and
+  // `resolveHostConsistentUsageProfiles` collapsed the disagreement to
+  // identity-only. Both now read `tab-host-1`, so the default host's
+  // divergent snapshot is simply never consulted - and with the identities
+  // still unresolved (`identity: null`, the fixture default) the join no
+  // longer demands a resolved account to recognize the same host's rows.
+  it("feeds usage comparison the run target's own unresolved-identity rows and ignores a divergent default-host snapshot", async () => {
+    const defaultHostProfiles = claudeProfilesForDropdown();
+    const targetProfiles = defaultHostProfiles.map((profile) =>
+      profile.kind === "managed"
+        ? { ...profile, label: "Remote Work" }
+        : { ...profile },
+    );
     queryMock.providerStates = [
       providerCliStateWithProfiles({
         providerId: "claude-code",
-        profiles: visibleProfiles,
+        profiles: defaultHostProfiles,
       }),
     ];
     queryMock.providerStatesByClient.set("tab-host-1", [
       providerCliStateWithProfiles({
         providerId: "claude-code",
-        profiles: visibleProfiles.map((profile) =>
-          profile.kind === "managed"
-            ? { ...profile, label: "Remote Work" }
-            : profile,
-        ),
+        profiles: targetProfiles,
       }),
     ]);
 
@@ -2439,39 +2618,59 @@ describe("<HarnessModelPicker />", () => {
       (call) => call.providerId === "claude-code",
     );
     expect(comparisonCall?.runTargetHostId).toBe("tab-host-1");
-    expect(comparisonCall?.profiles).toEqual([]);
+    expect(targetProfiles.every((profile) => profile.identity === null)).toBe(
+      true,
+    );
+    // The target host's rows verbatim - "Remote Work", not the default
+    // host's "Work", and not `[]`.
+    expect(comparisonCall?.profiles).toEqual(targetProfiles);
+    expect(comparisonCall?.profiles).not.toEqual(defaultHostProfiles);
   });
 
-  it("keeps usage identity-only for matching labels backed by different target accounts", async () => {
-    const visibleProfiles = claudeProfilesForDropdown().map((profile) => ({
+  // Historically this modeled "same label, different underlying account":
+  // the rail's OWN visible profiles came from the app-wide DEFAULT host
+  // while `PickerProfileDropdown`'s usage-comparison query already scoped to
+  // an explicit `runTargetHostId`, so the two could genuinely disagree and
+  // `resolveHostConsistentUsageProfiles` existed to collapse that to
+  // identity-only. This migration makes the rail ALSO resolve through
+  // `runTargetHostId` (`useProvidersListForClient(runTargetClient, …)`
+  // replacing the old unscoped `useProvidersList()`), and every current
+  // caller passes the identical id for `createProfileHostId` /
+  // `runTargetHostId` - so the rail and the dropdown's own comparison query
+  // now always read the SAME host-scoped `providers.list` response. The
+  // divergence this test modeled is therefore no longer reachable through
+  // this component; rewritten to guard the new invariant it implies instead
+  // - a DIFFERENT default-host snapshot must never leak into the comparison
+  // once a run target is set, and the dropdown must resolve real usage data
+  // (not identity-only) once the two consistently-scoped reads agree.
+  it("shows real usage data, not identity-only, once the rail and the profile dropdown both resolve through the same run-target host", async () => {
+    const targetProfiles = claudeProfilesForDropdown().map((profile) => ({
       ...profile,
       identity: {
-        email: `${profile.profileId}@example.com`,
+        email: `${profile.profileId}@target.example.com`,
         tier: "pro",
-        accountUuid: `${profile.profileId}-local-account`,
+        accountUuid: `${profile.profileId}-target-account`,
       },
     }));
+    // A DIFFERENT default-host identity, proof it is never consulted once
+    // `createProfileHostId`/`runTargetHostId` name an explicit target.
     queryMock.providerStates = [
       providerCliStateWithProfiles({
         providerId: "claude-code",
-        profiles: visibleProfiles,
+        profiles: claudeProfilesForDropdown().map((profile) => ({
+          ...profile,
+          identity: {
+            email: `${profile.profileId}@default.example.com`,
+            tier: "pro",
+            accountUuid: `${profile.profileId}-default-account`,
+          },
+        })),
       }),
     ];
     queryMock.providerStatesByClient.set("tab-host-1", [
       providerCliStateWithProfiles({
         providerId: "claude-code",
-        profiles: visibleProfiles.map((profile) =>
-          profile.kind === "managed"
-            ? {
-                ...profile,
-                identity: {
-                  email: "remote@example.com",
-                  tier: "pro",
-                  accountUuid: "remote-account",
-                },
-              }
-            : profile,
-        ),
+        profiles: targetProfiles,
       }),
     ]);
 
@@ -2483,21 +2682,37 @@ describe("<HarnessModelPicker />", () => {
       (call) => call.providerId === "claude-code",
     );
     expect(comparisonCall?.runTargetHostId).toBe("tab-host-1");
-    expect(comparisonCall?.profiles).toEqual([]);
+    // The real target-host identities, not the default host's (proving no
+    // cross-host leakage) and not emptied to identity-only (proving the
+    // rail/dropdown agreement is recognized as consistent).
+    expect(comparisonCall?.profiles).toEqual(targetProfiles);
   });
 
-  it("keeps cross-host usage identity-only while both account identities are unresolved", async () => {
-    const visibleProfiles = claudeProfilesForDropdown();
+  // The second arm of the retired resolved-identity requirement: a RESOLVED
+  // identity object that carries no account key (`accountUuid` and `email`
+  // both null) used to be "unproven" on an explicit run target and emptied
+  // the whole dropdown to identity-only. Same host on both sides now, so the
+  // structural compare accepts it and the target's summaries flow through.
+  it("feeds usage comparison the run target's summaries for profiles whose resolved identity carries no account key", async () => {
+    const targetProfiles = claudeProfilesForDropdown().map((profile) => ({
+      ...profile,
+      identity: { email: null, tier: "max", accountUuid: null },
+      rateLimitStatus:
+        profile.kind === "managed" ? ("near_limit" as const) : ("ok" as const),
+      usageUpdatedAt: 42,
+    }));
+    // Default host: same profiles, unresolved and never-checked - proof the
+    // summaries below are the target's, not this snapshot's.
     queryMock.providerStates = [
       providerCliStateWithProfiles({
         providerId: "claude-code",
-        profiles: visibleProfiles,
+        profiles: claudeProfilesForDropdown(),
       }),
     ];
     queryMock.providerStatesByClient.set("tab-host-1", [
       providerCliStateWithProfiles({
         providerId: "claude-code",
-        profiles: visibleProfiles.map((profile) => ({ ...profile })),
+        profiles: targetProfiles,
       }),
     ]);
 
@@ -2509,7 +2724,46 @@ describe("<HarnessModelPicker />", () => {
       (call) => call.providerId === "claude-code",
     );
     expect(comparisonCall?.runTargetHostId).toBe("tab-host-1");
-    expect(comparisonCall?.profiles).toEqual([]);
+    expect(comparisonCall?.profiles).toEqual(targetProfiles);
+  });
+
+  // The default (`null`) target never required a resolved identity; an
+  // explicit target now behaves the same. Both arms of the old asymmetry,
+  // side by side, so a future "tighten it back for tabs only" shows up here.
+  it("gives an explicit run target and the default target the same unresolved-identity usage rows", async () => {
+    const unresolvedProfiles = claudeProfilesForDropdown();
+    queryMock.providerStates = [
+      providerCliStateWithProfiles({
+        providerId: "claude-code",
+        profiles: unresolvedProfiles,
+      }),
+    ];
+    queryMock.providerStatesByClient.set("tab-host-1", [
+      providerCliStateWithProfiles({
+        providerId: "claude-code",
+        profiles: unresolvedProfiles.map((profile) => ({ ...profile })),
+      }),
+    ]);
+
+    renderPicker({ createProfileHostId: "tab-host-1" });
+    await openPicker();
+    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+    const tabCall = profileUsageHookMock.calls.find(
+      (call) => call.providerId === "claude-code",
+    );
+    expect(tabCall?.runTargetHostId).toBe("tab-host-1");
+    expect(tabCall?.profiles).toEqual(unresolvedProfiles);
+    cleanup();
+    profileUsageHookMock.calls = [];
+
+    renderPicker(undefined);
+    await openPicker();
+    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+    const defaultCall = profileUsageHookMock.calls.find(
+      (call) => call.providerId === "claude-code",
+    );
+    expect(defaultCall?.runTargetHostId).toBeNull();
+    expect(defaultCall?.profiles).toEqual(unresolvedProfiles);
   });
 
   it("keeps unresolved usage available when the picker and run target share the default host", async () => {
@@ -2550,14 +2804,59 @@ describe("<HarnessModelPicker />", () => {
     queryMock.unresolvedHostIds.add("unreachable-host");
 
     renderPicker({ createProfileHostId: "unreachable-host" });
-    await openPicker();
-    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+    // The run-target client never resolves, so every `…ForClient` read
+    // (harnesses, catalog, providers) is disabled - there is no cached
+    // catalog to browse at all, not even the default host's, so the trigger
+    // itself reflects "nothing resolved" rather than a real model label.
+    await openPickerByTriggerName("Select model");
 
-    const comparisonCall = profileUsageHookMock.calls.find(
-      (call) => call.providerId === "claude-code",
-    );
-    expect(comparisonCall?.runTargetHostId).toBe("unreachable-host");
-    expect(comparisonCall?.profiles).toEqual([]);
+    // The rail's provider list comes through the SAME unresolved run-target
+    // client, so `profilesByHarnessId` is empty for every provider - never
+    // the default host's cached list. Under the 2-profile progressive-
+    // disclosure gate the profile dropdown never mounts at all, so the
+    // usage-comparison hook it owns is never invoked for "claude-code" - not
+    // invoked with an empty profile list, simply never invoked.
+    expect(screen.queryByTestId("profile-dropdown-content")).toBeNull();
+    expect(
+      profileUsageHookMock.calls.find(
+        (call) => call.providerId === "claude-code",
+      ),
+    ).toBeUndefined();
+  });
+
+  // The trigger's `isLoading` swaps `HarnessIcon` for `MutedAgentSpinner`
+  // (`harness-model-trigger.tsx`), which carries neither a `data-testid`
+  // (`MutedAgentSpinner` always passes `testId: undefined`) nor a
+  // distinguishing `aria-*` attribute (both the icon and the spinner render
+  // `aria-hidden="true"`). Its dots-preset span is the only element in the
+  // trigger with `tabular-nums` in its class list, so that is the marker used
+  // below rather than relying on `HarnessIcon`'s SVG (present precisely when
+  // the spinner is NOT).
+  function triggerShowsLoadingSpinner(trigger: HTMLElement): boolean {
+    return trigger.querySelector(".tabular-nums") !== null;
+  }
+
+  it("never shows the trigger's loading spinner when the run-target client is unresolved (finding #2), but does when it's resolved and genuinely pending", () => {
+    // Unresolved run-target client: `harnessesQueryPending`'s `runTargetClient
+    // !== null` guard must suppress the spinner even though the mocked
+    // harnesses query is flagged loading - a null client can never actually
+    // be "pending" a fetch that will never start.
+    queryMock.harnessesLoading = true;
+    queryMock.unresolvedHostIds.add("unreachable-host");
+    renderPicker({ createProfileHostId: "unreachable-host" });
+    const unresolvedTrigger = screen.getByRole("button", {
+      name: "Select model",
+    });
+    expect(triggerShowsLoadingSpinner(unresolvedTrigger)).toBe(false);
+    cleanup();
+
+    // Guard against over-correcting the fix into "never show the spinner":
+    // a RESOLVED run-target client with genuinely pending harnesses must
+    // still show it.
+    queryMock.harnessesLoading = true;
+    renderPicker(undefined);
+    const resolvedTrigger = screen.getByRole("button", { name: /^GPT-5\.5/ });
+    expect(triggerShowsLoadingSpinner(resolvedTrigger)).toBe(true);
   });
 
   it("feeds usage comparison the run target's summaries when profile identities match", async () => {
@@ -2784,7 +3083,13 @@ describe("<HarnessModelPicker />", () => {
         profiles: claudeProfilesForDropdown(),
       }),
     ];
-    // Target host: DOES advertise OAuth login capability.
+    // Target host: DOES advertise OAuth login capability. The rail's own
+    // visible profiles now ALSO resolve through `runTargetHostId` (this
+    // migration; it used to read the app-wide default's `providers.list`
+    // unconditionally), so this fixture needs 2+ profiles of its own for the
+    // dropdown - and thus the "Create new profile" row - to render at all;
+    // otherwise the picker falls back to the single-profile ambient-auth
+    // line and the row this test targets never exists to click.
     queryMock.providerStatesByClient.set("tab-host-1", [
       providerCliStateWithProfiles({
         providerId: "claude-code",
@@ -2794,7 +3099,7 @@ describe("<HarnessModelPicker />", () => {
           codePaste: null,
           terminalLogin: null,
         },
-        profiles: [],
+        profiles: claudeProfilesForDropdown(),
       }),
     ]);
     renderPicker({ createProfileHostId: "tab-host-1" });
@@ -2824,12 +3129,14 @@ describe("<HarnessModelPicker />", () => {
         profiles: claudeProfilesForDropdown(),
       }),
     ];
-    // Target host: no OAuth login capability.
+    // Target host: no OAuth login capability. See the sibling "enables…"
+    // test above for why this needs 2+ profiles of its own now that the
+    // rail's visible profiles also resolve through `runTargetHostId`.
     queryMock.providerStatesByClient.set("tab-host-1", [
       providerCliStateWithProfiles({
         providerId: "claude-code",
         loginCapability: null,
-        profiles: [],
+        profiles: claudeProfilesForDropdown(),
       }),
     ]);
     renderPicker({ createProfileHostId: "tab-host-1" });

--- a/clients/gui-app/src/components/home/composer/__tests__/composer-body.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-body.test.tsx
@@ -60,15 +60,44 @@ vi.mock("@/components/home/composer/composer-workspace-mode-row", () => ({
   ComposerWorkspaceRow: () => null,
 }));
 
+const bodyMocks = vi.hoisted(() => ({
+  // S11 coverage (see "forwards a non-null hostId..." below): `ComposerBody`
+  // forwards its `hostId` prop to the terminal panel's `hostId` and the
+  // toolbar's `createProfileHostId`/`runTargetHostId` - both children are
+  // mocked wholesale here, so a test can only see that forwarding by
+  // recording the props these mocks actually receive.
+  terminalPanelHostIds: [] as (string | null)[],
+  toolbarHostIds: [] as {
+    readonly createProfileHostId: string | null;
+    readonly runTargetHostId: string | null;
+  }[],
+}));
+
 vi.mock("@/components/home/composer/terminal-launch-panel", () => ({
-  TerminalLaunchPanel: () => null,
+  TerminalLaunchPanel: (props: { readonly hostId: string | null }) => {
+    bodyMocks.terminalPanelHostIds.push(props.hostId);
+    return null;
+  },
 }));
 
 vi.mock("@/components/home/toolbar/composer-toolbar", () => ({
-  ComposerToolbar: () => null,
+  ComposerToolbar: (props: {
+    readonly createProfileHostId: string | null;
+    readonly runTargetHostId: string | null;
+  }) => {
+    bodyMocks.toolbarHostIds.push({
+      createProfileHostId: props.createProfileHostId,
+      runTargetHostId: props.runTargetHostId,
+    });
+    return null;
+  },
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  bodyMocks.terminalPanelHostIds.length = 0;
+  bodyMocks.toolbarHostIds.length = 0;
+});
 
 function makePaste(): UseComposerPasteResult {
   return {
@@ -92,10 +121,12 @@ interface RenderComposerBodyOptions {
   readonly header?: ReactNode;
   readonly topBanner?: ReactNode;
   readonly stashControl?: ReactNode;
+  readonly hostId: string | null;
 }
 
 function renderComposerBody(options: RenderComposerBodyOptions) {
-  const { composerMode, paste, header, topBanner, stashControl } = options;
+  const { composerMode, paste, header, topBanner, stashControl, hostId } =
+    options;
   const toolbarStore = createComposerToolbarStore({
     seedKey: "test",
     values: {
@@ -113,6 +144,7 @@ function renderComposerBody(options: RenderComposerBodyOptions) {
       pickerStore={createComposerPickerStore()}
       editorRef={{ current: null }}
       toolbarStore={toolbarStore}
+      hostId={hostId}
       composerMode={composerMode}
       chatEditorIsActive={composerMode === "chat"}
       editorClassName=""
@@ -145,7 +177,7 @@ function renderComposerBody(options: RenderComposerBodyOptions) {
 describe("ComposerBody file-transfer routing", () => {
   it("does not dispatch file transfers to the hidden chat editor in terminal mode", () => {
     const paste = makePaste();
-    renderComposerBody({ composerMode: "terminal", paste });
+    renderComposerBody({ composerMode: "terminal", paste, hostId: null });
 
     const shell = screen.getByRole("region", { name: "Composer shell" });
     fireEvent.dragEnter(shell);
@@ -166,7 +198,7 @@ describe("ComposerBody file-transfer routing", () => {
 
   it("keeps file-transfer handling active in chat mode", () => {
     const paste = makePaste();
-    renderComposerBody({ composerMode: "chat", paste });
+    renderComposerBody({ composerMode: "chat", paste, hostId: null });
 
     const shell = screen.getByRole("region", { name: "Composer shell" });
     fireEvent.dragEnter(shell);
@@ -186,7 +218,11 @@ describe("ComposerBody file-transfer routing", () => {
 
 describe("ComposerBody image-attachment caret stabilization", () => {
   it("enables caret stabilization on the underlying prompt editor", () => {
-    renderComposerBody({ composerMode: "chat", paste: makePaste() });
+    renderComposerBody({
+      composerMode: "chat",
+      paste: makePaste(),
+      hostId: null,
+    });
 
     const editor = screen.getByRole("textbox", { name: "Prompt editor" });
     expect(editor.getAttribute("data-stabilize-caret")).toBe("true");
@@ -199,6 +235,7 @@ describe("ComposerBody topBanner placement", () => {
       composerMode: "chat",
       paste: makePaste(),
       header: <div data-testid="mode-switch-header">header</div>,
+      hostId: null,
     });
 
     expect(screen.queryByTestId("rate-limit-banner")).toBeNull();
@@ -212,6 +249,7 @@ describe("ComposerBody topBanner placement", () => {
       paste: makePaste(),
       header: <div data-testid="mode-switch-header">header</div>,
       topBanner: <div data-testid="rate-limit-banner">banner</div>,
+      hostId: null,
     });
     const header = screen.getByTestId("mode-switch-header");
     const banner = screen.getByTestId("rate-limit-banner");
@@ -247,6 +285,7 @@ describe("ComposerBody overlay utility visibility", () => {
           Stash 2
         </div>
       ),
+      hostId: null,
     });
     const stash = screen.getByRole("status", { name: "Stashed prompts" });
     expect(
@@ -266,9 +305,42 @@ describe("ComposerBody overlay utility visibility", () => {
           Stash 2
         </div>
       ),
+      hostId: null,
     });
     expect(
       screen.queryByRole("status", { name: "Stashed prompts" }),
     ).toBeNull();
+  });
+});
+
+// S11 coverage: `ComposerBody` forwards its single `hostId` prop to the
+// terminal panel and the toolbar - a regression back to reading the app-wide
+// default anywhere along that path would leave one (or both) of these
+// children pinned to `null` regardless of what the composer is bound to.
+describe("ComposerBody host scoping", () => {
+  it("forwards a non-null hostId to the terminal panel's hostId and the toolbar's createProfileHostId/runTargetHostId", () => {
+    renderComposerBody({
+      composerMode: "chat",
+      paste: makePaste(),
+      hostId: "host-b",
+    });
+
+    expect(bodyMocks.terminalPanelHostIds).toEqual(["host-b"]);
+    expect(bodyMocks.toolbarHostIds).toEqual([
+      { createProfileHostId: "host-b", runTargetHostId: "host-b" },
+    ]);
+  });
+
+  it("forwards a null hostId (app-wide default) unchanged", () => {
+    renderComposerBody({
+      composerMode: "chat",
+      paste: makePaste(),
+      hostId: null,
+    });
+
+    expect(bodyMocks.terminalPanelHostIds).toEqual([null]);
+    expect(bodyMocks.toolbarHostIds).toEqual([
+      { createProfileHostId: null, runTargetHostId: null },
+    ]);
   });
 });

--- a/clients/gui-app/src/components/home/composer/__tests__/terminal-launch-panel.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/terminal-launch-panel.test.tsx
@@ -10,14 +10,34 @@ const panelMocks = vi.hoisted(() => ({
   providers: [
     { providerId: "claude-code", terminalAgentArgs: "--from-settings" },
   ],
+  // S11 coverage (see the new "forwards a non-null hostId..." test below):
+  // records every argument these mocks receive so a test can assert the
+  // panel's `hostId` prop actually reaches the launch host's client, the
+  // `providers.list` read, and the picker - not just that SOME client/host
+  // was used.
+  hostClientCalls: [] as (string | null)[],
+  providersListClients: [] as (string | null)[],
+  pickerProps: [] as {
+    readonly createProfileHostId: string | null;
+    readonly runTargetHostId: string | null;
+  }[],
 }));
 
 vi.mock("@/components/home/pickers/harness-model-picker", () => ({
-  HarnessModelPicker: () => (
-    <button type="button" aria-label="Harness picker">
-      Claude
-    </button>
-  ),
+  HarnessModelPicker: (props: {
+    readonly createProfileHostId: string | null;
+    readonly runTargetHostId: string | null;
+  }) => {
+    panelMocks.pickerProps.push({
+      createProfileHostId: props.createProfileHostId,
+      runTargetHostId: props.runTargetHostId,
+    });
+    return (
+      <button type="button" aria-label="Harness picker">
+        Claude
+      </button>
+    );
+  },
 }));
 
 vi.mock("@/components/home/pickers/agent-mode-toggle", () => ({
@@ -32,6 +52,24 @@ vi.mock("@/hooks/providers/use-providers-list-query", () => ({
   useProvidersList: () => ({
     data: { providers: panelMocks.providers },
   }),
+  useProvidersListForClient: (client: string | null) => {
+    panelMocks.providersListClients.push(client);
+    return { data: { providers: panelMocks.providers } };
+  },
+}));
+
+// The panel now resolves its launch host's client via
+// `useHostClientForHostId(hostId)` (previously `useProvidersList()` read the
+// app-wide default unconditionally) - that hook needs a
+// `<HostRuntimeProvider>` this bare-render suite doesn't set up. Returning
+// `hostId` itself as the sentinel "client" (mirroring the picker's own
+// intent-RPC suite) lets a test assert WHICH host's client reached
+// `useProvidersListForClient` without needing a real `HostClient`.
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: (hostId: string | null) => {
+    panelMocks.hostClientCalls.push(hostId);
+    return hostId;
+  },
 }));
 
 function makeToolbarStore() {
@@ -117,6 +155,7 @@ function renderPanel(onStart: (launch: TerminalAgentLaunch) => void) {
       store={makeToolbarStore()}
       pending={false}
       disabledHint={null}
+      hostId={null}
       onStart={onStart}
     />,
   );
@@ -127,6 +166,9 @@ describe("<TerminalLaunchPanel /> terminal-agent args handoff", () => {
     panelMocks.providers = [
       { providerId: "claude-code", terminalAgentArgs: "--from-settings" },
     ];
+    panelMocks.hostClientCalls.length = 0;
+    panelMocks.providersListClients.length = 0;
+    panelMocks.pickerProps.length = 0;
   });
 
   afterEach(() => {
@@ -224,6 +266,7 @@ describe("<TerminalLaunchPanel /> terminal-agent args handoff", () => {
           store={makeGuiOnlyToolbarStore()}
           pending={false}
           disabledHint={null}
+          hostId={null}
           onStart={onStart}
         />
       </TooltipProvider>,
@@ -233,5 +276,30 @@ describe("<TerminalLaunchPanel /> terminal-agent args handoff", () => {
     expect(start.getAttribute("aria-disabled")).toBe("true");
     fireEvent.click(start);
     expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // S11 coverage: a regression back to the app-wide default host would leave
+  // `useHostClientForHostId`, `providers.list`, and the picker all pinned to
+  // `null` regardless of the `hostId` prop - this asserts the non-null host
+  // actually threads through every one of them, not just that the panel
+  // renders without crashing.
+  it("forwards a non-null hostId to the launch host's client, the providers.list read, and the picker's createProfileHostId/runTargetHostId", () => {
+    render(
+      <TerminalLaunchPanel
+        store={makeToolbarStore()}
+        pending={false}
+        disabledHint={null}
+        hostId="host-b"
+        onStart={vi.fn()}
+      />,
+    );
+
+    expect(panelMocks.hostClientCalls).toContain("host-b");
+    expect(panelMocks.hostClientCalls).not.toContain(null);
+    expect(panelMocks.providersListClients.at(-1)).toBe("host-b");
+    expect(panelMocks.pickerProps.at(-1)).toEqual({
+      createProfileHostId: "host-b",
+      runTargetHostId: "host-b",
+    });
   });
 });

--- a/clients/gui-app/src/components/home/composer/composer-body.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-body.tsx
@@ -70,6 +70,15 @@ export interface ComposerBodyProps {
    * has nothing to resume (chat / new-conversation).
    */
   readonly onEditorReady: (() => void) | null;
+  /**
+   * The host this composer creates on - threaded to the toolbar's and the
+   * terminal launcher's model pickers as their `createProfileHostId` /
+   * `runTargetHostId`, so the harnesses/models/providers they offer are that
+   * host's. `null` follows the app-wide default (the landing composer, whose
+   * own host picker rebinds that default); the new-conversation modal passes
+   * the host it was pinned to.
+   */
+  readonly hostId: string | null;
   readonly onSubmit: () => void;
   readonly onStartTerminal: (launch: TerminalAgentLaunch) => void;
   readonly onDocumentChange: (
@@ -103,6 +112,7 @@ export function ComposerBody({
   hasPastedImageBytes,
   ingestPastedComposerImages,
   onEditorReady,
+  hostId,
   onSubmit,
   onStartTerminal,
   onDocumentChange,
@@ -160,6 +170,7 @@ export function ComposerBody({
                   store={toolbarStore}
                   pending={isSubmitting}
                   disabledHint={workspaceDisabledHint}
+                  hostId={hostId}
                   onStart={onStartTerminal}
                 />
               </SurfaceActivityProvider>
@@ -183,10 +194,8 @@ export function ComposerBody({
                 dictation={dictationControl}
                 dictationPreparing={dictationPreparing}
                 settingsLocked={isSubmitting}
-                // The landing composer has no tab yet - the app-wide default
-                // host applies.
-                createProfileHostId={null}
-                runTargetHostId={null}
+                createProfileHostId={hostId}
+                runTargetHostId={hostId}
               />
             </SurfaceActivityProvider>
           </div>

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -220,12 +220,14 @@ export function LandingComposer(props: LandingComposerProps) {
   // Never authoritative: the landing composer has no reauth gate of its own
   // to defend a dead pin with a banner, so a genuinely-removed profile must
   // be corrected to ambient here rather than silently submitted as the new
-  // chat's initial settings.
+  // chat's initial settings. The catalog reads through the same `hostClient`:
+  // the landing host picker rebinds the app-wide default, so the active
+  // client IS this composer's target host.
   const toolbarStore = useComposerToolbarStore(
     "landing",
     fallbackSeedSource(settingsSeed, hostClient),
     handleToolbarSettingsChange,
-    composerMode === "terminal",
+    { hostClient, tuiOnly: composerMode === "terminal" },
   );
   const harnessId = useStore(toolbarStore, (s) => s.selection.harnessId);
   const profileId = useStore(toolbarStore, (s) => s.selection.profileId);
@@ -716,8 +718,7 @@ export function LandingComposer(props: LandingComposerProps) {
             probeTarget={rateLimitPrompt.probeTarget}
             // Landing has no tab of its own; `null` resolves the usage
             // sidecar/R-key refresh to the app-wide default host, matching
-            // `ComposerToolbar`'s own `runTargetHostId={null}` for this
-            // surface (composer-body.tsx).
+            // the `hostId={null}` this surface hands `ComposerBody` below.
             runTargetHostId={null}
             onSwitchProfile={onSwitchRateLimitedProfile}
             affectedChatCount={0}
@@ -745,6 +746,10 @@ export function LandingComposer(props: LandingComposerProps) {
       hasPastedImageBytes={hasLandingImageBytes}
       ingestPastedComposerImages={ingestPastedComposerImages}
       onEditorReady={reingestPendingImages}
+      // No tab yet: the landing composer creates on the app-wide default host,
+      // which its own host picker rebinds - so `null` (follow the default) IS
+      // the picked host here.
+      hostId={null}
       onSubmit={handleSubmit}
       onStartTerminal={handleStartTerminal}
       onDocumentChange={handleDocumentChange}

--- a/clients/gui-app/src/components/home/composer/terminal-launch-panel.tsx
+++ b/clients/gui-app/src/components/home/composer/terminal-launch-panel.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useSurfaceActivity } from "@/components/home/composer/surface-activity-hooks";
-import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useProvidersListForClient } from "@/hooks/providers/use-providers-list-query";
 import type { TerminalAgentLaunch } from "@/components/home/hooks/use-landing-composer-actions";
 import type { ComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
 import { TUI_HARNESS_ID_TO_PROVIDER_ID } from "@traycer/protocol/host/provider-schemas";
@@ -35,6 +36,13 @@ interface TerminalLaunchPanelProps {
    */
   readonly disabledHint: string | null;
   /**
+   * The host the terminal agent launches on: the picker's harnesses / models
+   * / profiles and this panel's own saved-args read (`providers.list`) all
+   * resolve against it. `null` follows the app-wide default (the landing
+   * composer); the new-conversation modal passes its pinned host.
+   */
+  readonly hostId: string | null;
+  /**
    * Fires on Start with the fully-assembled launch (harness/model/effort/agent
    * mode + CLI args). The panel owns assembly so the caller only gates the
    * workspace and dispatches.
@@ -51,7 +59,7 @@ interface TerminalLaunchPanelProps {
 // the input box keeps a stable height when switching modes. The text editor is
 // intentionally absent - terminal agents launch empty.
 function TerminalLaunchPanelImpl(props: TerminalLaunchPanelProps) {
-  const { store, pending, disabledHint, onStart } = props;
+  const { store, pending, disabledHint, hostId, onStart } = props;
   const activityEnabled = useSurfaceActivity();
   const selection = useStore(store, (s) => s.selection);
   const reasoning = useStore(store, (s) => s.reasoning);
@@ -72,7 +80,11 @@ function TerminalLaunchPanelImpl(props: TerminalLaunchPanelProps) {
   // marks the field `touched` (a per-launch override); leaving it untouched
   // forwards `null` so the host resolves the current saved default itself -
   // which also avoids sending a stale "" before `providers.list` has loaded.
-  const providersQuery = useProvidersList({
+  // Read from the launch host - the same host the picker below offers
+  // harnesses/profiles from - so the pre-filled args are the ones that host's
+  // provider settings actually hold.
+  const launchHostClient = useHostClientForHostId(hostId);
+  const providersQuery = useProvidersListForClient(launchHostClient, {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
@@ -164,11 +176,11 @@ function TerminalLaunchPanelImpl(props: TerminalLaunchPanelProps) {
           lockedHarnessId={null}
           disabled={pending}
           registerActivation
-          // Launching from the landing composer has no existing tab to bind
-          // to yet - the app-wide default host is correct, same as this
-          // panel's own `useProvidersList()` read above.
-          createProfileHostId={null}
-          runTargetHostId={null}
+          // The launch host - same scope as this panel's own `providers.list`
+          // read above (`null` = the app-wide default, for the landing
+          // composer, which has no tab to bind to yet).
+          createProfileHostId={hostId}
+          runTargetHostId={hostId}
           profileAdmission={null}
         />
         <Input

--- a/clients/gui-app/src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx
+++ b/clients/gui-app/src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { ReactNode } from "react";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { HostRpcRegistry } from "@/lib/host";
+import type { ComposerToolbarCatalogScope } from "@/components/home/hooks/use-composer-toolbar-store";
+import type { ComposerControls } from "@/lib/commands/composer-controls-registry";
 
 const harnessesData: {
   value:
@@ -56,42 +59,65 @@ const modelQueryCalls: Array<{
   readonly enabled: boolean;
   readonly subscribed: boolean;
 }> = [];
+// Records the `client` argument each `…ForClient` call was invoked with, so
+// tests can assert the store forwards the EXACT catalog scope it was given -
+// never a fallback to the app-wide default host - and forwards `null`
+// verbatim rather than substituting a default when the composer's host isn't
+// resolved yet.
+const harnessClientCalls: Array<HostClient<HostRpcRegistry> | null> = [];
+const modelClientCalls: Array<HostClient<HostRpcRegistry> | null> = [];
 const registeredComposerKinds: Array<FocusedComposerKind | null> = [];
+// Records the `hostClient` each registration was made with, so a test can
+// assert the store registers the palette's composer subpages against the
+// SAME client its own catalog reads through (`catalog.hostClient`), and
+// re-registers (a new call, not a mutation of the old one) when it changes.
+const registeredComposerHostClients: Array<HostClient<HostRpcRegistry> | null> =
+  [];
 
 // `data` is returned regardless of `enabled`, because that is what TanStack
 // does: `enabled:false` stops FETCHING, it does not evict the cache, and a
 // focused split partner observing the same key keeps it warm. Modelling it as
 // "inactive means no data" would let a consumer that blanks its own catalog on
-// blur look correct here.
+// blur look correct here. A `null` client, however, DOES model "no data" -
+// that is what disables the underlying query for real, so a composer whose
+// host hasn't resolved yet must never render another host's cached catalog.
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessesQuery: (activity: {
-    enabled: boolean;
-    subscribed: boolean;
-  }) => {
+  useGuiHarnessesQueryForClient: (
+    client: HostClient<HostRpcRegistry> | null,
+    activity: { enabled: boolean; subscribed: boolean },
+  ) => {
+    harnessClientCalls.push(client);
     harnessQueryCalls.push({
       enabled: activity.enabled,
       subscribed: activity.subscribed,
     });
-    return { data: harnessesData.value };
+    return { data: client === null ? undefined : harnessesData.value };
   },
-  useGuiHarnessModelsQuery: (
+  useGuiHarnessModelsQueryForClient: (
+    client: HostClient<HostRpcRegistry> | null,
     harnessId: string,
     workingDirectory: string | null,
     activity: { enabled: boolean; subscribed: boolean },
   ) => {
+    modelClientCalls.push(client);
     modelQueryCalls.push({
       harnessId,
       workingDirectory,
       enabled: activity.enabled,
       subscribed: activity.subscribed,
     });
-    return { data: modelsData.value };
+    return { data: client === null ? undefined : modelsData.value };
   },
 }));
 
 vi.mock("@/hooks/command-palette/use-register-composer-controls", () => ({
-  useRegisterFocusedComposerControls: (kind: FocusedComposerKind | null) => {
+  useRegisterFocusedComposerControls: (
+    kind: FocusedComposerKind | null,
+    _controls: ComposerControls,
+    hostClient: HostClient<HostRpcRegistry> | null,
+  ) => {
     registeredComposerKinds.push(kind);
+    registeredComposerHostClients.push(hostClient);
   },
 }));
 
@@ -105,6 +131,9 @@ vi.mock("@/hooks/providers/use-resolved-seeded-profile-id", () => ({
 }));
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import { SurfaceActivityProvider } from "@/components/home/composer/surface-activity-context";
 import { useComposerToolbarStore } from "@/components/home/hooks/use-composer-toolbar-store";
 import { fallbackSeedSource } from "@/lib/composer/composer-seed-source";
@@ -112,6 +141,46 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 import { useComposerHarnessMemoryStore } from "@/stores/composer/composer-harness-memory-store";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import type { FocusedComposerKind } from "@/lib/commands/types";
+
+/**
+ * A real, distinct `HostClient` instance (never a cast) so `hostClient` args
+ * threaded through `ComposerToolbarCatalogScope` compare by identity - the
+ * mocked catalog hooks above record exactly which client they were called
+ * with, so a test can assert the store forwards THIS object, not some other
+ * host's client or a fallback default.
+ */
+function buildTestHostClient(hostId: string): HostClient<HostRpcRegistry> {
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => {} },
+    // Never actually dispatched - the catalog hooks are mocked wholesale
+    // above, so this messenger exists only to satisfy `HostClient`'s
+    // constructor.
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => `req-${hostId}`,
+      handlers: {},
+    }),
+  });
+  client.bind({
+    hostId,
+    label: hostId,
+    kind: "local",
+    websocketUrl: `ws://127.0.0.1:0/${hostId}`,
+    version: "0.0.0-mock",
+    transportDialability: "dialable",
+  });
+  return client;
+}
+
+// The catalog scope every test in this file used before `hostClient` became
+// part of it - a fixed, non-null client so the mocked catalog hooks keep
+// returning `harnessesData.value` / `modelsData.value` exactly as before.
+const DEFAULT_TEST_HOST_CLIENT = buildTestHostClient("default-host");
+
+function catalogScope(tuiOnly: boolean): ComposerToolbarCatalogScope {
+  return { hostClient: DEFAULT_TEST_HOST_CLIENT, tuiOnly };
+}
 
 function seedDefault(
   harnessId: "claude" | "codex" | "opencode" | "traycer" | "cursor",
@@ -137,7 +206,10 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     modelsData.value = undefined;
     harnessQueryCalls.length = 0;
     modelQueryCalls.length = 0;
+    harnessClientCalls.length = 0;
+    modelClientCalls.length = 0;
     registeredComposerKinds.length = 0;
+    registeredComposerHostClients.length = 0;
     // Reset the sticky tier default so a tier-normalization test can't leak its
     // preference into a later test's seeded values.
     useSettingsStore.setState({ defaultServiceTier: "" });
@@ -163,7 +235,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
 
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
 
     await waitFor(() =>
@@ -186,7 +263,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
 
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
 
     // Give the catalog-sync effect a chance to (not) reroute.
@@ -203,7 +285,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     harnessesData.value = undefined;
 
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
 
     await Promise.resolve();
@@ -225,7 +312,7 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
 
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, true),
+      useComposerToolbarStore(null, { kind: "none" }, null, catalogScope(true)),
     );
 
     await waitFor(() =>
@@ -247,7 +334,7 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
 
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, true),
+      useComposerToolbarStore(null, { kind: "none" }, null, catalogScope(true)),
     );
 
     await Promise.resolve();
@@ -292,7 +379,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, true),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(true),
+      ),
     );
 
     // Reroute settles on a TUI-capable harness with a concrete model slug, so a
@@ -318,7 +410,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     seedDefault("claude");
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     act(() => {
@@ -338,7 +435,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     });
     const onSettingsChange = vi.fn();
     const { result, rerender } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     act(() => {
@@ -406,7 +508,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
 
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
 
     await waitFor(() =>
@@ -441,7 +548,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     act(() => {
@@ -488,7 +600,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     act(() => {
@@ -533,7 +650,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     act(() => {
@@ -591,7 +713,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     // Let the catalog load so the commit resolves a concrete slug and emits
@@ -619,7 +746,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     seedDefault("codex");
     const trackSpy = vi.spyOn(Analytics.getInstance(), "track");
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
     // The mount path (catalog sync / seed) never tracks; start from a clean count.
     trackSpy.mockClear();
@@ -702,7 +834,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     // The model supports both sticky values, so they carry before the commit.
@@ -773,7 +910,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     const onSettingsChange = vi.fn();
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     // The dead slug resolves to the first live model for display, with that
@@ -825,7 +967,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     modelsData.value = undefined;
     const onSettingsChange = vi.fn();
     const { result, rerender } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     // Loading window: the remembered slug is held for display but unconfirmed.
@@ -896,7 +1043,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     modelsData.value = undefined;
     const onSettingsChange = vi.fn();
     const { result, rerender } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     await waitFor(() =>
@@ -966,7 +1118,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     modelsData.value = undefined;
     const onSettingsChange = vi.fn();
     const { result, rerender } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, onSettingsChange, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        onSettingsChange,
+        catalogScope(false),
+      ),
     );
 
     // Load WITHOUT the remembered slug -> self-heals to the first model, emits it.
@@ -1027,7 +1184,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
     modelsData.value = undefined;
     const { result, rerender } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
 
     await waitFor(() =>
@@ -1072,7 +1234,7 @@ describe("useComposerToolbarStore selection reconciliation", () => {
         null,
         fallbackSeedSource(seeds.current, null),
         null,
-        false,
+        catalogScope(false),
       ),
     );
     expect(result.current.getState().selection.harnessId).toBe("codex");
@@ -1130,7 +1292,7 @@ describe("useComposerToolbarStore selection reconciliation", () => {
         null,
         fallbackSeedSource(seeds.current, null),
         null,
-        false,
+        catalogScope(false),
       ),
     );
     expect(result.current.getState().selection.profileId).toBe("work-uuid");
@@ -1169,7 +1331,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
       ],
     };
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, false),
+      useComposerToolbarStore(
+        null,
+        { kind: "none" },
+        null,
+        catalogScope(false),
+      ),
     );
 
     await waitFor(() =>
@@ -1219,7 +1386,7 @@ describe("useComposerToolbarStore selection reconciliation", () => {
       ],
     };
     const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, true),
+      useComposerToolbarStore(null, { kind: "none" }, null, catalogScope(true)),
     );
 
     await waitFor(() => {
@@ -1240,7 +1407,13 @@ describe("useComposerToolbarStore selection reconciliation", () => {
   it("detaches harness queries and command registration when inactive", () => {
     seedDefault("codex");
     renderHook(
-      () => useComposerToolbarStore("landing", { kind: "none" }, null, false),
+      () =>
+        useComposerToolbarStore(
+          "landing",
+          { kind: "none" },
+          null,
+          catalogScope(false),
+        ),
       {
         wrapper: inactiveWrapper,
       },
@@ -1297,7 +1470,13 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     };
 
     const { result } = renderHook(
-      () => useComposerToolbarStore("landing", { kind: "none" }, null, false),
+      () =>
+        useComposerToolbarStore(
+          "landing",
+          { kind: "none" },
+          null,
+          catalogScope(false),
+        ),
       { wrapper: inactiveWrapper },
     );
 
@@ -1315,5 +1494,78 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     ]);
     expect(state.reasoning).toBe("high");
     expect(state.supportedPermissionModes).toEqual(["full"]);
+  });
+
+  it("issues the catalog queries against the EXACT hostClient passed in, never a fallback to the default host's client", async () => {
+    seedDefault("codex");
+    const hostBClient = buildTestHostClient("host-b");
+    harnessesData.value = {
+      harnesses: [{ id: "codex", available: true }],
+    };
+
+    renderHook(() =>
+      useComposerToolbarStore(null, { kind: "none" }, null, {
+        hostClient: hostBClient,
+        tuiOnly: false,
+      }),
+    );
+
+    await waitFor(() => expect(harnessClientCalls.length).toBeGreaterThan(0));
+    // The exact object identity of the passed client, not merely "some
+    // client" - a regression that quietly substituted the app-wide default
+    // host's client would still pass an identity-blind assertion here.
+    expect(harnessClientCalls.at(-1)).toBe(hostBClient);
+    expect(harnessClientCalls.at(-1)).not.toBe(DEFAULT_TEST_HOST_CLIENT);
+    expect(modelClientCalls.at(-1)).toBe(hostBClient);
+    expect(modelClientCalls.at(-1)).not.toBe(DEFAULT_TEST_HOST_CLIENT);
+  });
+
+  it("forwards a null hostClient verbatim - the catalog stays empty rather than borrowing the default host's cache", async () => {
+    seedDefault("codex");
+    const { result } = renderHook(() =>
+      useComposerToolbarStore(null, { kind: "none" }, null, {
+        hostClient: null,
+        tuiOnly: false,
+      }),
+    );
+
+    await Promise.resolve();
+    // `null` reaches the query hooks unchanged - never silently swapped for
+    // the default-host client the OTHER tests in this file use.
+    expect(harnessClientCalls.at(-1)).toBeNull();
+    expect(modelClientCalls.at(-1)).toBeNull();
+    // The mocked hooks model a `null` client as a disabled query (`data:
+    // undefined`), exactly like the real `…ForClient` hooks do - so nothing
+    // renders for this composer, even though `harnessesData.value` /
+    // `modelsData.value` are the SAME module-level fixtures every other test
+    // in this file populates and reads through the default client.
+    expect(result.current.getState().catalog.harnesses).toBeUndefined();
+    expect(result.current.getState().selectedModel).toBeNull();
+  });
+
+  it("registers the focused-composer controls with the SAME hostClient as catalog.hostClient, and re-registers when it changes", () => {
+    seedDefault("codex");
+    const hostAClient = buildTestHostClient("host-a");
+    const hostBClient = buildTestHostClient("host-b");
+
+    const { rerender } = renderHook(
+      (props: { hostClient: HostClient<HostRpcRegistry> }) =>
+        useComposerToolbarStore("landing", { kind: "none" }, null, {
+          hostClient: props.hostClient,
+          tuiOnly: false,
+        }),
+      { initialProps: { hostClient: hostAClient } },
+    );
+
+    expect(registeredComposerKinds.at(-1)).toBe("landing");
+    expect(registeredComposerHostClients.at(-1)).toBe(hostAClient);
+
+    rerender({ hostClient: hostBClient });
+
+    expect(registeredComposerKinds.at(-1)).toBe("landing");
+    expect(registeredComposerHostClients.at(-1)).toBe(hostBClient);
+    // A genuine re-registration - a SECOND recorded call, not the first call's
+    // argument silently mutating in place.
+    expect(registeredComposerHostClients).toEqual([hostAClient, hostBClient]);
   });
 });

--- a/clients/gui-app/src/components/home/hooks/use-composer-toolbar-store.ts
+++ b/clients/gui-app/src/components/home/hooks/use-composer-toolbar-store.ts
@@ -6,7 +6,9 @@ import {
   useState,
 } from "react";
 import { useStore } from "zustand";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { HostRpcRegistry } from "@/lib/host";
 
 import type {
   PermissionMode,
@@ -26,8 +28,8 @@ import {
 import { commitSelection } from "@/stores/composer/commit-selection";
 import { useComposerHarnessMemoryStore } from "@/stores/composer/composer-harness-memory-store";
 import {
-  useGuiHarnessesQuery,
-  useGuiHarnessModelsQuery,
+  useGuiHarnessesQueryForClient,
+  useGuiHarnessModelsQueryForClient,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useRegisterFocusedComposerControls } from "@/hooks/command-palette/use-register-composer-controls";
 import { useResolvedSeededProfileId } from "@/hooks/providers/use-resolved-seeded-profile-id";
@@ -43,6 +45,26 @@ import {
 const EMPTY_MODELS: ReadonlyArray<ModelOption> = [];
 
 /**
+ * The catalog a composer's toolbar store resolves selections against: WHICH
+ * host's harnesses/models, and whether only TUI-capable harnesses count.
+ */
+export interface ComposerToolbarCatalogScope {
+  /**
+   * The host this composer runs turns on - a chat tab's bound host, a fork
+   * dialog's fixed host, the new-conversation modal's pinned host, the
+   * landing page's active host. The harness + model catalog is fetched
+   * through this client, so the harnesses/models the store resolves and
+   * validates a selection against are that host's, never the app-wide
+   * default's while the composer is bound elsewhere. `null` while that host's
+   * client is still resolving: the catalog stays empty rather than borrowing
+   * another host's.
+   */
+  readonly hostClient: HostClient<HostRpcRegistry> | null;
+  /** Restrict the catalog to TUI-capable harnesses (terminal launchers). */
+  readonly tuiOnly: boolean;
+}
+
+/**
  * Creates this composer's private toolbar store (see
  * `createComposerToolbarStore` for the state model) and keeps it synchronized
  * with its external inputs:
@@ -50,7 +72,8 @@ const EMPTY_MODELS: ReadonlyArray<ModelOption> = [];
  * - settings-store defaults / the seeded settings (re-seeds when the seed
  *   identity changes);
  * - the harness + model catalog queries, gated on the surrounding
- *   `SurfaceActivityContext`;
+ *   `SurfaceActivityContext` and issued against `catalog.hostClient` (see
+ *   `ComposerToolbarCatalogScope`);
  * - the latest `onSettingsChange` callback.
  *
  * When `registerAs !== null` (and the surface is active), the store's setters
@@ -85,8 +108,9 @@ export function useComposerToolbarStore(
   registerAs: FocusedComposerKind | null,
   seedSource: ComposerSeedSource,
   onSettingsChange: ((settings: ChatRunSettings) => void) | null,
-  tuiOnly: boolean,
+  catalog: ComposerToolbarCatalogScope,
 ): ComposerToolbarStore {
+  const { hostClient, tuiOnly } = catalog;
   const activityEnabled = useSurfaceActivity();
   const defaultPermission = useSettingsStore((s) => s.defaultPermission);
   const defaultSelection = useSettingsStore((s) => s.defaultSelection);
@@ -178,14 +202,19 @@ export function useComposerToolbarStore(
   // (availability rerouting included); `modelsHarnessId` rides along so a
   // stale response can never resolve a slug for the wrong harness.
   const harnessId = useStore(store, (s) => s.selection.harnessId);
-  const harnessesQuery = useGuiHarnessesQuery({
+  const harnessesQuery = useGuiHarnessesQueryForClient(hostClient, {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
-  const modelsQuery = useGuiHarnessModelsQuery(harnessId, null, {
-    enabled: activityEnabled,
-    subscribed: activityEnabled,
-  });
+  const modelsQuery = useGuiHarnessModelsQueryForClient(
+    hostClient,
+    harnessId,
+    null,
+    {
+      enabled: activityEnabled,
+      subscribed: activityEnabled,
+    },
+  );
   // Read the cache regardless of `activityEnabled`. The gate above already does
   // the whole job it exists for - an inactive surface fetches nothing and holds
   // no observer - and `enabled:false` does not evict what is already cached.
@@ -227,9 +256,13 @@ export function useComposerToolbarStore(
         commitSelection(store, harnessId, modelSlug, null),
     };
   }, [store]);
+  // The palette's composer subpages list the catalog of the SAME host this
+  // store reads it through, so what they offer is what `switchHarness` /
+  // `selectModel` can commit against.
   useRegisterFocusedComposerControls(
     activityEnabled ? registerAs : null,
     registeredControls,
+    hostClient,
   );
 
   return store;

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -19,12 +19,11 @@ import {
 } from "@/stores/composer/commit-selection";
 import {
   harnessCatalogEntryNeedsRefresh,
-  useDefaultHostClient,
-  useGuiHarnessCatalog,
+  useGuiHarnessCatalogForClient,
   useGuiHarnessCommandsQuery,
-  useGuiHarnessModelsQuery,
-  useGuiHarnessesQuery,
-  useRefreshHarnessCatalog,
+  useGuiHarnessModelsQueryForClient,
+  useGuiHarnessesQueryForClient,
+  useRefreshHarnessCatalogForClient,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
 import {
   buildAllHarnessModelRows,
@@ -75,11 +74,10 @@ import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
 import { useRegisterActiveModelPicker } from "@/hooks/command-palette/use-register-active-model-picker";
 import { useBindingForAction } from "@/stores/settings/keybinding-store";
 import { formatChordForDisplay } from "@/lib/keybindings/chord";
-import {
-  useProvidersList,
-  useProvidersListForClient,
-} from "@/hooks/providers/use-providers-list-query";
+import { useProvidersListForClient } from "@/hooks/providers/use-providers-list-query";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostRpcRegistry } from "@/lib/host";
 import {
   EMPTY_LOGIN_CAPABILITY_BY_HARNESS_ID,
   loginCapabilityByHarnessIdFromProviderStates,
@@ -153,8 +151,17 @@ interface HarnessModelPickerProps {
    * runs turns on a different one (the tab-host-binding rule).
    */
   createProfileHostId: string | null;
-  /** The exact host where the next run executes. This is explicit so usage
-   *  comparison can never silently fall back to the renderer-default host. */
+  /**
+   * The exact host where the next run executes - the composer's target host
+   * (a tab's bound host, a fork dialog's fixed host, the new-conversation
+   * modal's pinned host), or `null` for a surface that follows the app-wide
+   * default (the landing composer). EVERYTHING this picker offers resolves
+   * against it: the harness rail, provider/profile state, the model rows, the
+   * commands prewarm, the pack retry, the catalog refresh and the usage
+   * comparison - so what the user picks is what the run will actually see. It
+   * is explicit so none of those can silently fall back to the
+   * renderer-default host while the composer is bound elsewhere.
+   */
   runTargetHostId: string | null;
   /**
    * Per-row admission override for the active provider's profile strip,
@@ -258,11 +265,18 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     );
   }, [activityEnabled, closeOnly, paneActivationFocusIntent, visibleOpen]);
 
-  const harnessesQuery = useGuiHarnessesQuery({
+  // The composer's target host, resolved ONCE here and threaded into every
+  // catalog/provider read below. `useHostClientForHostId` pins a non-null id
+  // to a requester for that exact host (even when it currently matches the
+  // app-wide default, so a later default-host switch can't move this picker
+  // out from under its composer); `null` follows the mutable app-wide default,
+  // which is the landing composer's own host by construction.
+  const runTargetClient = useHostClientForHostId(runTargetHostId);
+  const harnessesQuery = useGuiHarnessesQueryForClient(runTargetClient, {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
-  const providersQuery = useProvidersList({
+  const providersQuery = useProvidersListForClient(runTargetClient, {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
@@ -282,12 +296,12 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         : providerPackPreparingByHarnessId(providersQuery.data.providers),
     [providersQuery.data],
   );
-  // Client-scoped on purpose: the rail renders the app-wide default host's
-  // providers, and this picker already resolves that client for every other
-  // query it runs. Going through `useHostClient()` instead would bind the
-  // retry to whatever host the surrounding tree happens to provide - a
-  // different host than the row the user clicked.
-  const ensurePack = useProvidersEnsurePackForClient(useDefaultHostClient());
+  // Client-scoped on purpose: the rail renders the RUN-TARGET host's providers
+  // (`providersQuery` above), so the retry must reach that same host. Going
+  // through `useHostClient()` instead would bind the retry to whatever host
+  // the surrounding tree happens to provide - a different host than the row
+  // the user clicked.
+  const ensurePack = useProvidersEnsurePackForClient(runTargetClient);
   const ensurePackMutate = ensurePack.mutate;
   // A real user gesture on a failed provider tab. This is the ONLY caller, and
   // it must stay that way: reaching the host through `providers.ensurePack` is
@@ -316,11 +330,11 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   );
   // The create-profile gate's capability data must come from the SAME host
   // the add-profile flow will target - `ProviderProfileAddFlowHost` resolves
-  // its client from this exact prop via `useHostClientForHostId`, not the
-  // app-wide default host `providersQuery` above serves the rail/dropdown/
-  // degraded state from. A tab bound to a different host would otherwise let
-  // the pre-click gate disagree with the host that receives
-  // `providers.startLogin`.
+  // its client from this exact prop via `useHostClientForHostId`. Every caller
+  // today passes the same id for `createProfileHostId` and `runTargetHostId`
+  // (so this shares `providersQuery`'s cache slot), but the two remain
+  // separately resolved: the gate must agree with the host that receives
+  // `providers.startLogin`, whatever host the rail happens to render.
   const createProfileClient = useHostClientForHostId(createProfileHostId);
   const createProfileProvidersQuery = useProvidersListForClient(
     createProfileClient,
@@ -366,7 +380,8 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // `prewarmCatalog` re-checks provider enablement for the same reason.
   const selectedHarnessRefetchGate =
     activityEnabled && selectedHarnessAvailable;
-  const selectedModelsQuery = useGuiHarnessModelsQuery(
+  const selectedModelsQuery = useGuiHarnessModelsQueryForClient(
+    runTargetClient,
     selection.harnessId,
     null,
     {
@@ -392,10 +407,11 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // TanStack fetch it on mount and on other automatic triggers - i.e. spawn a
   // provider's server outside an intent edge and outside that guard.
   // `.refetch()` ignores `enabled` (the same quirk the guard exists to
-  // contain), so the intent edges still drive it.
-  const defaultHostClient = useDefaultHostClient();
+  // contain), so the intent edges still drive it. Issued against the
+  // run-target host: that is the host whose server the run will use, so it is
+  // the one worth prewarming.
   const selectedCommandsQuery = useGuiHarnessCommandsQuery(
-    defaultHostClient,
+    runTargetClient,
     selection.harnessId,
     EMPTY_COMMANDS_WORKING_DIRECTORIES,
     {
@@ -463,7 +479,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     runSelectedHarnessIntentRefetch();
   }, [runSelectedHarnessIntentRefetch, selection.harnessId]);
   const catalogActive = activityEnabled && visibleOpen;
-  const catalog = useGuiHarnessCatalog(null, {
+  const catalog = useGuiHarnessCatalogForClient(runTargetClient, null, {
     enabled: catalogActive,
     subscribed: catalogActive,
   });
@@ -478,7 +494,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
       ),
     [catalog.harnesses, degradedHarnessIds, tuiOnly],
   );
-  const refreshCatalog = useRefreshHarnessCatalog();
+  const refreshCatalog = useRefreshHarnessCatalogForClient(runTargetClient);
   const selectedModels = selectedModelsQuery.data?.models ?? EMPTY_MODELS;
   // "Pending" has to mean a fetch is actually coming. A disabled query with no
   // cached data reports `isPending` forever, so reading it raw would leave an
@@ -486,6 +502,11 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // deliberately not making.
   const modelsPending =
     selectedHarnessRefetchGate && selectedModelsQuery.isPending;
+  const harnessesPending = harnessesQueryPending(
+    activityEnabled,
+    runTargetClient,
+    harnessesQuery.isPending,
+  );
   const presentation = useMemo(
     () =>
       deriveHarnessModelPickerPresentation({
@@ -493,15 +514,14 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         models: selectedModels,
         reasoningFooter,
         serviceTierFooter,
-        harnessesPending: activityEnabled && harnessesQuery.isPending,
+        harnessesPending,
         modelsPending,
         selectedHarnessAvailable,
         selectedHarnessProfiles:
           profilesByHarnessId.get(selection.harnessId) ?? [],
       }),
     [
-      activityEnabled,
-      harnessesQuery.isPending,
+      harnessesPending,
       modelsPending,
       profilesByHarnessId,
       reasoningFooter,
@@ -1032,6 +1052,21 @@ function isTuiCapable(harness: HarnessOption): boolean {
 // Narrow a harness list to the TUI-capable subset when `tuiOnly`, else pass it
 // through. Shared by the rail/fallback and catalog derivations so the filter
 // rule lives in one place. Generic so it preserves catalog-entry subtypes.
+/**
+ * Same rule as `modelsPending` inside the picker, for the harness list: with
+ * no run-target client (a tab host the directory hasn't resolved, or one this
+ * client cannot dial) the query is disabled, not loading - and a disabled
+ * query with no cached data reports `isPending` forever, so the trigger would
+ * spin for a fetch that will never start.
+ */
+function harnessesQueryPending(
+  activityEnabled: boolean,
+  runTargetClient: HostClient<HostRpcRegistry> | null,
+  isPending: boolean,
+): boolean {
+  return activityEnabled && runTargetClient !== null && isPending;
+}
+
 function restrictToTui<T extends HarnessOption>(
   harnesses: ReadonlyArray<T>,
   tuiOnly: boolean,

--- a/clients/gui-app/src/components/home/pickers/picker-profile-dropdown.tsx
+++ b/clients/gui-app/src/components/home/pickers/picker-profile-dropdown.tsx
@@ -73,11 +73,9 @@ function ProfileUsagePickerProfileDropdown({
     return resolveHostConsistentUsageProfiles(
       props.profiles,
       provider.profiles,
-      props.runTargetHostId !== null,
     );
   }, [
     props.profiles,
-    props.runTargetHostId,
     providerId,
     runTargetClient,
     runTargetProvidersQuery.data,
@@ -98,21 +96,34 @@ function ProfileUsagePickerProfileDropdown({
 
 /**
  * Usage rows must never combine one host's visible identity with another
- * host's rate-limit summary. Only enable comparison when the explicit run
- * target reports the same complete set of profile identities the dropdown is
+ * host's rate-limit summary. Only enable comparison when the run target
+ * reports the same complete set of profile identities the dropdown is
  * rendering; return the target host's objects so every summary field consumed
  * by `useProfileUsageComparison` comes from that same host. A missing, partial,
  * renamed, recolored, or differently-authenticated target set stays
- * identity-only until the picker receives a coherent snapshot. An explicit
- * target host also requires a concrete account identity: two unresolved null
- * identities are not evidence that independently queried hosts use the same
- * account. The null/default target is already the visible profiles' host, so
- * it may use that host's unresolved snapshot without a cross-host join.
+ * identity-only until the picker receives a coherent snapshot.
+ *
+ * `visibleProfiles` is caller-supplied, so this stays as the structural guard
+ * for a caller whose rail is scoped to some other host. Today no such caller
+ * exists: `HarnessModelPicker` resolves its rail's `providers.list` through
+ * the SAME `runTargetHostId` this dropdown queries, so both arrays come from
+ * one host's cached response and the join is a self-comparison that passes.
+ *
+ * Account identity is compared structurally, unresolved included: two
+ * `identity === null` rows (or two resolved rows with no `accountUuid` /
+ * `email` key) are the SAME row seen twice, not two independently queried
+ * hosts that happen to both be unresolved. The guard used to demand a resolved
+ * identity whenever the run target was explicit - back when the rail's
+ * visible rows came from the app-wide default host and the dropdown's from
+ * the tab host, so a null on each side proved nothing. That cross-host join no
+ * longer exists, and keeping the requirement made every tab-bound picker drop
+ * usage for the whole dropdown as soon as ONE profile's identity had not
+ * resolved yet - a state the same picker on the landing page (`null` target)
+ * always rendered through.
  */
 function resolveHostConsistentUsageProfiles(
   visibleProfiles: ReadonlyArray<ProviderProfile>,
   runTargetProfiles: ReadonlyArray<ProviderProfile>,
-  requireResolvedAccountIdentity: boolean,
 ): ReadonlyArray<ProviderProfile> {
   if (visibleProfiles.length !== runTargetProfiles.length) {
     return EMPTY_PROFILES;
@@ -126,11 +137,7 @@ function resolveHostConsistentUsageProfiles(
     );
     if (
       runTargetProfile === undefined ||
-      !hasSameVisibleProfileIdentity(
-        visibleProfile,
-        runTargetProfile,
-        requireResolvedAccountIdentity,
-      )
+      !hasSameVisibleProfileIdentity(visibleProfile, runTargetProfile)
     ) {
       return null;
     }
@@ -146,7 +153,6 @@ function resolveHostConsistentUsageProfiles(
 function hasSameVisibleProfileIdentity(
   left: ProviderProfile,
   right: ProviderProfile,
-  requireResolvedAccountIdentity: boolean,
 ): boolean {
   return (
     left.kind === right.kind &&
@@ -155,7 +161,7 @@ function hasSameVisibleProfileIdentity(
     left.auth.badgeText === right.auth.badgeText &&
     left.auth.label === right.auth.label &&
     left.auth.detail === right.auth.detail &&
-    hasSameAccountIdentity(left, right, requireResolvedAccountIdentity) &&
+    hasSameAccountIdentity(left, right) &&
     left.accentColor === right.accentColor
   );
 }
@@ -163,18 +169,9 @@ function hasSameVisibleProfileIdentity(
 function hasSameAccountIdentity(
   left: ProviderProfile,
   right: ProviderProfile,
-  requireResolvedAccountIdentity: boolean,
 ): boolean {
   if (left.identity === null || right.identity === null) {
-    return !requireResolvedAccountIdentity && left.identity === right.identity;
-  }
-  const leftKey = left.identity.accountUuid ?? left.identity.email;
-  const rightKey = right.identity.accountUuid ?? right.identity.email;
-  if (
-    requireResolvedAccountIdentity &&
-    (leftKey === null || rightKey === null)
-  ) {
-    return false;
+    return left.identity === right.identity;
   }
   return (
     left.identity.email === right.identity.email &&

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -41,6 +41,19 @@ const fetchedSettings = vi.hoisted(() => ({
   answered: false,
   lastEnabled: null as boolean | null,
 }));
+/** Per-host-id sentinel clients, plus a switch for "the owner's host cannot
+ *  be resolved" (missing from the directory / signed out). */
+const hostResolution = vi.hoisted(() => ({
+  resolveToNull: false,
+  byHostId: new Map<string, { readonly getActiveHostId: () => string }>(),
+}));
+/** The clients each host-scoped read actually received, so tests assert WHICH
+ *  host served the catalog and the provider list - not just what data came
+ *  back (data the mocks themselves supplied). */
+const scopedReads = vi.hoisted(() => ({
+  catalogClients: [] as unknown[],
+  providersClients: [] as unknown[],
+}));
 
 vi.mock("@/lib/epic-selectors", () => ({
   useChatById: () =>
@@ -57,50 +70,78 @@ vi.mock("@/hooks/use-epic-store", () => ({
     }),
 }));
 vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
-  useHostClientForHostId: () => ({ getActiveHostId: () => "host-1" }),
+  useHostClientForHostId: (hostId: string | null) => {
+    if (hostId === null || hostResolution.resolveToNull) return null;
+    const existing = hostResolution.byHostId.get(hostId);
+    if (existing !== undefined) return existing;
+    // One stable sentinel per host id, like the real hook's memoized
+    // requester - the identity assertions below compare what the catalog and
+    // provider-list reads received, which only means "same host" if the same
+    // id yields the same object.
+    const sentinel = { getActiveHostId: () => hostId };
+    hostResolution.byHostId.set(hostId, sentinel);
+    return sentinel;
+  },
 }));
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessCatalog: () => ({
-    harnesses: [
+  // Client-scoped like the real hook: a `null` client is a disabled read and
+  // yields an EMPTY catalog (never another host's entries), which is what
+  // drives the raw-slug fallback the unresolvable-host test asserts.
+  useGuiHarnessCatalogForClient: (client: unknown) => {
+    scopedReads.catalogClients.push(client);
+    return {
+      harnesses: client === null ? [] : catalogHarnesses(),
+      harnessesLoading: false,
+      harnessesError: null,
+      modelsLoading: false,
+    };
+  },
+}));
+const catalogHarnesses = vi.hoisted(() => () => [
+  {
+    id: "claude",
+    label: "Claude Code",
+    models: [
       {
-        id: "claude",
-        label: "Claude Code",
-        models: [
-          {
-            harnessId: "claude",
-            slug: "sonnet-4.5",
-            label: "Claude Sonnet 4.5",
-            supportedReasoningEfforts: [
-              { id: "high", label: "High", description: null },
-            ],
-            metadata: {},
-          },
-          // A SECOND model, so a host tuple and a local tuple can disagree
-          // visibly - which is the only way to test which one the header trusts.
-          {
-            harnessId: "claude",
-            slug: "opus-4.1",
-            label: "Claude Opus 4.1",
-            supportedReasoningEfforts: [
-              { id: "high", label: "High", description: null },
-            ],
-            metadata: {},
-          },
+        harnessId: "claude",
+        slug: "sonnet-4.5",
+        label: "Claude Sonnet 4.5",
+        supportedReasoningEfforts: [
+          { id: "high", label: "High", description: null },
         ],
+        metadata: {},
+      },
+      // A SECOND model, so a host tuple and a local tuple can disagree
+      // visibly - which is the only way to test which one the header trusts.
+      {
+        harnessId: "claude",
+        slug: "opus-4.1",
+        label: "Claude Opus 4.1",
+        supportedReasoningEfforts: [
+          { id: "high", label: "High", description: null },
+        ],
+        metadata: {},
       },
     ],
-  }),
-}));
+  },
+]);
 vi.mock("@/hooks/providers/use-providers-list-query", () => ({
-  useProvidersListForClient: () => ({
+  useProvidersListForClient: (client: unknown) => {
+    scopedReads.providersClients.push(client);
     // `claude-code` is the WIRE id for the `claude` harness; the header has to
-    // map across that boundary to find these at all.
-    data: {
-      providers: [
-        { providerId: "claude-code", profiles: wireProfiles.current },
-      ],
-    },
-  }),
+    // map across that boundary to find these at all. A `null` client is a
+    // disabled read (real hook contract): no data.
+    return {
+      data:
+        client === null
+          ? undefined
+          : {
+              providers: [
+                { providerId: "claude-code", profiles: wireProfiles.current },
+              ],
+            },
+    };
+  },
 }));
 // Records `enabled` rather than ignoring it: a mock that always answers would
 // let the header read a fetched tuple it never actually requested, and the
@@ -226,6 +267,63 @@ describe("WorktreeOwnerSettingsHeader", () => {
     fetchedSettings.current = null;
     fetchedSettings.answered = false;
     fetchedSettings.lastEnabled = null;
+    hostResolution.resolveToNull = false;
+    hostResolution.byHostId.clear();
+    scopedReads.catalogClients = [];
+    scopedReads.providersClients = [];
+  });
+
+  it("reads the harness catalog through the OWNER's host client - the same one the provider list uses", () => {
+    // The regression this guards: the catalog read went through the app-wide
+    // default host (`useGuiHarnessCatalog(null, …)`) while the provider list
+    // beside it was scoped to `props.hostId` - so a chat on another of the
+    // viewer's hosts labeled its model from the WRONG host's catalog (a model
+    // only the owner's host offers rendered as a raw slug even with that
+    // host's catalog warm).
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
+    const ownerClient = hostResolution.byHostId.get("host-1");
+    expect(ownerClient).toBeDefined();
+    expect(scopedReads.catalogClients.length).toBeGreaterThan(0);
+    // Every catalog read AND every provider-list read received the owner's
+    // pinned client - one shared host resolution, no default-host leak.
+    for (const client of scopedReads.catalogClients) {
+      expect(client).toBe(ownerClient);
+    }
+    for (const client of scopedReads.providersClients) {
+      expect(client).toBe(ownerClient);
+    }
+    // And that catalog actually carried the labels: proof the header's label
+    // source is the client-scoped read, not some other path.
+    expect(screen.getByTestId("owner-settings-model").textContent).toContain(
+      "Claude Sonnet 4.5",
+    );
+  });
+
+  it("falls back to raw slugs when the owner's host cannot be resolved, instead of borrowing another host's catalog", () => {
+    hostResolution.resolveToNull = true;
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
+    // The read still happened - with a null client (disabled), never a
+    // fallback to a different host's client.
+    expect(scopedReads.catalogClients.length).toBeGreaterThan(0);
+    for (const client of scopedReads.catalogClients) {
+      expect(client).toBeNull();
+    }
+    // Raw persisted slug, not the default host's friendly label.
+    const model = screen.getByTestId("owner-settings-model").textContent;
+    expect(model).toContain("sonnet-4.5");
+    expect(model).not.toContain("Claude Sonnet 4.5");
   });
 
   it("renders a distinct icon for each permission mode", () => {
@@ -422,6 +520,10 @@ describe("chat settings sourced from the host", () => {
     fetchedSettings.current = null;
     fetchedSettings.answered = false;
     fetchedSettings.lastEnabled = null;
+    hostResolution.resolveToNull = false;
+    hostResolution.byHostId.clear();
+    scopedReads.catalogClients = [];
+    scopedReads.providersClients = [];
   });
 
   function renderRegistryOnlyChat(): void {

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-tui-hover-card.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-tui-hover-card.test.tsx
@@ -51,7 +51,10 @@ vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
   useHostClientForHostId: () => ({ getActiveHostId: () => "host-1" }),
 }));
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
-  useGuiHarnessCatalog: () => ({
+  // The header resolves the catalog through the owner's host client; this
+  // suite is about hover-card identity, not host scoping (covered by
+  // `worktree-owner-settings-header.test.tsx`), so it answers for any client.
+  useGuiHarnessCatalogForClient: () => ({
     harnesses: [
       {
         id: "claude",

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -15,7 +15,7 @@ import {
 import { harnessProfiles } from "@/components/worktree/worktree-owner-settings-profiles";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
 import { useChatRunSettings } from "@/hooks/chats/use-chat-run-settings-query";
-import { useGuiHarnessCatalog } from "@/hooks/harnesses/use-gui-harness-catalog";
+import { useGuiHarnessCatalogForClient } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useProvidersListForClient } from "@/hooks/providers/use-providers-list-query";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import { useChatById } from "@/lib/epic-selectors";
@@ -38,8 +38,9 @@ interface TuiHeaderFields {
  * self-sources the owner's settings from the already-local per-Epic store
  * (`useChatById` / the `tuiAgents` slice) keyed by the `ownerId` the tooltip
  * already carries - it takes no settings prop, so the sidebar row that renders
- * the tooltip owns none of this. Labels resolve against the live GUI harness
- * catalog, with a raw-slug fallback whenever the catalog lacks the entry.
+ * the tooltip owns none of this. Labels resolve against the OWNER's host's
+ * live GUI harness catalog, with a raw-slug fallback whenever the catalog
+ * lacks the entry (or the owner's host cannot be resolved at all).
  *
  * It renders only while the hover card is open (mounted by `HoverCardContent`,
  * which has no `forceMount`), so nothing here can fire before open: the catalog
@@ -48,13 +49,16 @@ interface TuiHeaderFields {
  * The settings themselves cost nothing - they are a store read. Chat profile
  * labels remain pure cache reads; managed terminal profiles can fetch the same
  * live provider list their launch/fork surfaces use. The catalog is NOT free,
- * though: `useGuiHarnessesQuery` carries a finite 15-min staleTime, so opening
+ * though: the harnesses query carries a finite 15-min staleTime, so opening
  * the card on a stale availability query can refetch it, and if that surfaces a
  * newly-available harness with no cached model list the `listModels` fan-out
  * follows (which, per that module's header, can spawn the OpenCode server and
- * reset the host's idle-reap clock). In the steady state - the app-load
- * prefetcher has filled the cache and models are `staleTime: Infinity` - an
- * open renders straight from cache.
+ * reset the host's idle-reap clock) - and both now land on the OWNER's host.
+ * For an owner on the default host that is the steady state as before: the
+ * app-load prefetcher filled the same host-id-keyed cache slot and models are
+ * `staleTime: Infinity`, so an open renders straight from cache. For an owner
+ * on another host the first open fetches that host's catalog cold - the same
+ * self-sufficiency trade the provider-list read below already makes.
  */
 export function WorktreeOwnerSettingsHeader(props: {
   readonly ownerId: string;
@@ -107,7 +111,16 @@ export function WorktreeOwnerSettingsHeader(props: {
   // The dynamic label source, gated on `hasSubject` so a legacy row with no
   // settings never mounts the catalog fan-out at all. Warm entries render from
   // cache; see the component doc above for when an open can still refetch.
-  const catalog = useGuiHarnessCatalog(null, {
+  //
+  // Scoped to the OWNER's host like the provider-list read below: the tuple
+  // being labeled is what THAT host runs, so a model only that host offers
+  // must not fall back to a raw slug just because the default host's catalog
+  // lacks it. On the common path (owner on the default host) this is the same
+  // cache slot the app-load prefetcher warmed - host-id-keyed, so nothing
+  // refetches. A `null` client (owner's host missing from the directory,
+  // signed out) disables the read and labels fall back to raw slugs - honest,
+  // rather than borrowing another host's catalog under this host's name.
+  const catalog = useGuiHarnessCatalogForClient(hostClient, null, {
     enabled: hasSubject,
     subscribed: hasSubject,
   });

--- a/clients/gui-app/src/hooks/command-palette/use-focused-composer-entry.ts
+++ b/clients/gui-app/src/hooks/command-palette/use-focused-composer-entry.ts
@@ -1,0 +1,27 @@
+/**
+ * Reactive read of the focused composer's registry entry (see
+ * `FocusedComposerEntry`), for consumers that need its target-host client.
+ * Subscribes via `useSyncExternalStore`, the same way `useFocusedComposerKind`
+ * does, so the palette's composer subpages re-render when focus moves to a
+ * composer on another host. The entry object is stable per registration, so
+ * it is its own snapshot.
+ *
+ * Callers must distinguish "no focused composer" (`null` entry) from
+ * "focused, host still resolving" (`entry.hostClient === null`): the palette
+ * lists the app-wide default host's catalog for the former (nothing to
+ * dispatch into anyway) and nothing for the latter, never another host's.
+ */
+import { useSyncExternalStore } from "react";
+import {
+  getFocusedComposerControls,
+  subscribeFocusedComposerControls,
+  type FocusedComposerEntry,
+} from "@/lib/commands/composer-controls-registry";
+
+export function useFocusedComposerEntry(): FocusedComposerEntry | null {
+  return useSyncExternalStore(
+    subscribeFocusedComposerControls,
+    getFocusedComposerControls,
+    getFocusedComposerControls,
+  );
+}

--- a/clients/gui-app/src/hooks/command-palette/use-register-composer-controls.ts
+++ b/clients/gui-app/src/hooks/command-palette/use-register-composer-controls.ts
@@ -10,15 +10,26 @@
  * always reads the latest setter through the ref.
  */
 import { useEffect, useRef } from "react";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostRpcRegistry } from "@/lib/host";
 import {
   registerFocusedComposerControls,
   type ComposerControls,
 } from "@/lib/commands/composer-controls-registry";
 import type { FocusedComposerKind } from "@/lib/commands/types";
 
+/**
+ * `hostClient` is the composer's target host (see
+ * `FocusedComposerEntry.hostClient`). Unlike the setters it is NOT parked in
+ * the ref: the palette reads it to decide WHICH host's catalog to list, so a
+ * change must re-register (and notify subscribers), not just be picked up on
+ * the next dispatch. Client identity only changes on real host events
+ * (directory resolution, auth), so the re-registration churn is negligible.
+ */
 export function useRegisterFocusedComposerControls(
   kind: FocusedComposerKind | null,
   controls: ComposerControls,
+  hostClient: HostClient<HostRpcRegistry> | null,
 ): void {
   const controlsRef = useRef<ComposerControls>(controls);
 
@@ -28,23 +39,27 @@ export function useRegisterFocusedComposerControls(
 
   useEffect(() => {
     if (kind === null) return;
-    const dispose = registerFocusedComposerControls(kind, {
-      setReasoning: (level) => {
-        controlsRef.current.setReasoning(level);
+    const dispose = registerFocusedComposerControls(
+      kind,
+      {
+        setReasoning: (level) => {
+          controlsRef.current.setReasoning(level);
+        },
+        setServiceTier: (tier) => {
+          controlsRef.current.setServiceTier(tier);
+        },
+        setPermission: (mode) => {
+          controlsRef.current.setPermission(mode);
+        },
+        switchHarness: (harnessId) => {
+          controlsRef.current.switchHarness(harnessId);
+        },
+        selectModel: (harnessId, modelSlug) => {
+          controlsRef.current.selectModel(harnessId, modelSlug);
+        },
       },
-      setServiceTier: (tier) => {
-        controlsRef.current.setServiceTier(tier);
-      },
-      setPermission: (mode) => {
-        controlsRef.current.setPermission(mode);
-      },
-      switchHarness: (harnessId) => {
-        controlsRef.current.switchHarness(harnessId);
-      },
-      selectModel: (harnessId, modelSlug) => {
-        controlsRef.current.selectModel(harnessId, modelSlug);
-      },
-    });
+      hostClient,
+    );
     return dispose;
-  }, [kind]);
+  }, [hostClient, kind]);
 }

--- a/clients/gui-app/src/hooks/composer/__tests__/use-epic-mention-entries-refresh-error.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-epic-mention-entries-refresh-error.test.tsx
@@ -109,7 +109,14 @@ function pendingRefetch(): {
 }
 
 function renderEntries() {
-  return renderHook(() => useEpicMentionEntries({ requests: [] }));
+  // `@/hooks/host/use-reactive-host-readiness` and `@/hooks/host/use-host-queries`
+  // are mocked wholesale above and ignore their arguments entirely, so `client`
+  // is never actually read by anything this suite exercises - `null` is enough
+  // (this file's whole point is the refetch/host-swap toast logic downstream
+  // of those two hooks, not client resolution itself).
+  return renderHook(() =>
+    useEpicMentionEntries({ requests: [], client: null }),
+  );
 }
 
 afterEach(() => {

--- a/clients/gui-app/src/hooks/composer/__tests__/use-epic-mention-entries.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-epic-mention-entries.test.tsx
@@ -1,56 +1,126 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import type {
+  EpicMentionEpicSuggestion,
+  EpicMentionEpicsResponse,
+  EpicMentionSpecsResponse,
+} from "@traycer/protocol/host/index";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
 import { useEpicMentionEntries } from "../use-epic-mention-entries";
 
-const request = vi.fn();
-const getActiveHostId = vi.fn(() => "host-test");
+/**
+ * `useEpicMentionEntries` now takes its host `client` explicitly (S11: it no
+ * longer resolves `useHostBinding()` internally) - a composer bound to a
+ * non-default host must list THAT host's epics/specs, never the app-wide
+ * default's. `HostClient` has private fields, so it can't be duck-typed; each
+ * fixture builds a real instance over a `MockHostMessenger`, mirroring the
+ * pattern in `use-gui-harness-catalog.test.tsx` / the picker's intent-RPC
+ * suite. Method handlers delegate to per-fixture `vi.fn()`s so tests keep the
+ * familiar `mockResolvedValueOnce` shape while assertions can tell exactly
+ * WHICH fixture's transport a request reached (not just what came back).
+ */
 
-vi.mock("@/lib/host", () => ({
-  useHostBinding: () => ({
-    hostClient: {
-      getActiveHostId,
-      getRequestContextUserId: () => "user-test",
-      onChange: () => () => undefined,
-      request,
-      requestWithSignal: request,
-    },
-  }),
-}));
+function epicSuggestion(id: string): EpicMentionEpicSuggestion {
+  return {
+    kind: "epic",
+    id: `epic:${id}`,
+    token: `epic:${id}`,
+    epicId: id,
+    label: "Login flow",
+    description: "1 spec",
+    status: "active",
+    updatedAt: 123,
+  };
+}
 
-function wrapper(props: { children: ReactNode }) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+function specSuggestion(
+  id: string,
+): EpicMentionSpecsResponse["entries"][number] {
+  return {
+    kind: "epic-artifact",
+    id: `spec:${id}`,
+    token: `spec:${id}`,
+    epicId: id,
+    epicTitle: "Login flow",
+    artifactId: `artifact-${id}`,
+    artifactType: "spec",
+    label: "Login spec",
+    description: "1 spec",
+    status: null,
+    updatedAt: 123,
+  };
+}
+
+interface MentionFixture {
+  readonly client: HostClient<HostRpcRegistry>;
+  readonly mentionEpics: Mock<
+    (params: unknown) => Promise<EpicMentionEpicsResponse>
+  >;
+  readonly mentionSpecs: Mock<
+    (params: unknown) => Promise<EpicMentionSpecsResponse>
+  >;
+  readonly Wrapper: (props: { readonly children: ReactNode }) => ReactNode;
+}
+
+function buildMentionFixture(hostId: string): MentionFixture {
+  const queryClient = createAppQueryClient();
+  const mentionEpics = vi.fn<
+    (params: unknown) => Promise<EpicMentionEpicsResponse>
+  >(() => Promise.resolve({ entries: [] }));
+  const mentionSpecs = vi.fn<
+    (params: unknown) => Promise<EpicMentionSpecsResponse>
+  >(() => Promise.resolve({ entries: [] }));
+  let requestCounter = 0;
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: createHostQueryInvalidator(queryClient),
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => {
+        requestCounter += 1;
+        return `req-${hostId}-${String(requestCounter)}`;
+      },
+      handlers: {
+        "epic.mentionEpics": (params) => mentionEpics(params),
+        "epic.mentionSpecs": (params) => mentionSpecs(params),
+      },
+    }),
   });
-  return (
+  client.bind({
+    hostId,
+    label: hostId,
+    kind: "local",
+    websocketUrl: `ws://127.0.0.1:0/${hostId}`,
+    version: "0.0.0-mock",
+    transportDialability: "dialable",
+  });
+  client.setRequestContext(
+    createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+  );
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
     <QueryClientProvider client={queryClient}>
       {props.children}
     </QueryClientProvider>
   );
+  return { client, mentionEpics, mentionSpecs, Wrapper };
 }
 
 describe("useEpicMentionEntries", () => {
   afterEach(() => {
     cleanup();
-    request.mockReset();
-    getActiveHostId.mockReturnValue("host-test");
   });
 
-  it("requests host-backed epic mention suggestions", async () => {
-    request.mockResolvedValueOnce({
-      entries: [
-        {
-          kind: "epic",
-          id: "epic:epic-1",
-          token: "epic:epic-1",
-          epicId: "epic-1",
-          label: "Login flow",
-          description: "1 spec",
-          status: "active",
-          updatedAt: 123,
-        },
-      ],
+  it("requests host-backed epic mention suggestions through the passed client", async () => {
+    const fixture = buildMentionFixture("host-1");
+    fixture.mentionEpics.mockResolvedValueOnce({
+      entries: [epicSuggestion("epic-1")],
     });
 
     const { result } = renderHook(
@@ -62,47 +132,44 @@ describe("useEpicMentionEntries", () => {
               params: { query: "login", limit: 8 },
             },
           ],
+          client: fixture.client,
         }),
-      { wrapper },
+      { wrapper: fixture.Wrapper },
     );
 
     await waitFor(() => expect(result.current.data).toHaveLength(1));
-    expect(request).toHaveBeenCalledWith(
-      "epic.mentionEpics",
-      { query: "login", limit: 8 },
-      expect.any(AbortSignal),
-    );
+    expect(fixture.mentionEpics).toHaveBeenCalledWith({
+      query: "login",
+      limit: 8,
+    });
   });
 
   it("does not request suggestions without request descriptors", () => {
+    const fixture = buildMentionFixture("host-1");
+
     renderHook(
       () =>
         useEpicMentionEntries({
           requests: [],
+          client: fixture.client,
         }),
-      { wrapper },
+      { wrapper: fixture.Wrapper },
     );
 
-    expect(request).not.toHaveBeenCalled();
+    expect(fixture.mentionEpics).not.toHaveBeenCalled();
+    expect(fixture.mentionSpecs).not.toHaveBeenCalled();
   });
 
   it("exposes a refetch that re-issues every epic.mention* query and returns a Promise", async () => {
     // Regression for the Artifacts refresh no-op: the top-bar button used to
     // call setStep(current), which the picker store early-returns from. The
     // button now awaits this refetch, so it must actually hit the host again.
-    request.mockResolvedValue({
-      entries: [
-        {
-          kind: "epic",
-          id: "epic:epic-1",
-          token: "epic:epic-1",
-          epicId: "epic-1",
-          label: "Login flow",
-          description: "1 spec",
-          status: "active",
-          updatedAt: 123,
-        },
-      ],
+    const fixture = buildMentionFixture("host-1");
+    fixture.mentionEpics.mockResolvedValue({
+      entries: [epicSuggestion("epic-1")],
+    });
+    fixture.mentionSpecs.mockResolvedValue({
+      entries: [specSuggestion("epic-1")],
     });
 
     const { result } = renderHook(
@@ -118,30 +185,83 @@ describe("useEpicMentionEntries", () => {
               params: { query: "login", limit: 8 },
             },
           ],
+          client: fixture.client,
         }),
-      { wrapper },
+      { wrapper: fixture.Wrapper },
     );
 
     await waitFor(() => expect(result.current.data.length).toBeGreaterThan(0));
-    const callsAfterMount = request.mock.calls.length;
-    expect(callsAfterMount).toBeGreaterThanOrEqual(2);
+    expect(fixture.mentionEpics).toHaveBeenCalledTimes(1);
+    expect(fixture.mentionSpecs).toHaveBeenCalledTimes(1);
 
     const pending = result.current.refetch();
     expect(pending).toBeInstanceOf(Promise);
     await pending;
 
-    await waitFor(() =>
-      expect(request.mock.calls.length).toBeGreaterThan(callsAfterMount),
-    );
     // Both underlying queries must be re-issued.
-    const methodsAfterRefetch = request.mock.calls.map(
-      (call: ReadonlyArray<unknown>) => call[0],
+    await waitFor(() => {
+      expect(fixture.mentionEpics).toHaveBeenCalledTimes(2);
+      expect(fixture.mentionSpecs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // Coverage for the new required `client` param (S11): the composer's host
+  // is the ONE the request actually reaches - not a sibling host, and not the
+  // app-wide default - and a `null` client (the composer's host not resolved
+  // yet) issues nothing at all rather than silently falling back.
+  it("issues requests through the passed client, never a different host's transport", async () => {
+    const fixtureA = buildMentionFixture("host-a");
+    const fixtureB = buildMentionFixture("host-b");
+    fixtureA.mentionEpics.mockResolvedValue({
+      entries: [epicSuggestion("epic-a")],
+    });
+    fixtureB.mentionEpics.mockResolvedValue({
+      entries: [epicSuggestion("epic-b")],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useEpicMentionEntries({
+          requests: [
+            {
+              method: "epic.mentionEpics",
+              params: { query: "login", limit: 8 },
+            },
+          ],
+          client: fixtureB.client,
+        }),
+      { wrapper: fixtureB.Wrapper },
     );
-    expect(
-      methodsAfterRefetch.filter((m) => m === "epic.mentionEpics").length,
-    ).toBeGreaterThanOrEqual(2);
-    expect(
-      methodsAfterRefetch.filter((m) => m === "epic.mentionSpecs").length,
-    ).toBeGreaterThanOrEqual(2);
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(result.current.data).toEqual([epicSuggestion("epic-b")]);
+    expect(fixtureB.mentionEpics).toHaveBeenCalledTimes(1);
+    // Host A's transport was never even reached - not a data-shape
+    // coincidence, the request never left for it.
+    expect(fixtureA.mentionEpics).not.toHaveBeenCalled();
+  });
+
+  it("client: null issues no request and returns empty data", async () => {
+    const fixture = buildMentionFixture("host-a");
+
+    const { result } = renderHook(
+      () =>
+        useEpicMentionEntries({
+          requests: [
+            {
+              method: "epic.mentionEpics",
+              params: { query: "login", limit: 8 },
+            },
+          ],
+          client: null,
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    // Give any (incorrect) fallback fetch a chance to have fired.
+    await Promise.resolve();
+    expect(fixture.mentionEpics).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/clients/gui-app/src/hooks/composer/use-dictation-availability.ts
+++ b/clients/gui-app/src/hooks/composer/use-dictation-availability.ts
@@ -39,6 +39,17 @@ export interface DictationAvailability {
  * status. Composers gate the mic button + shortcut on `ready` (so dictation is
  * never offered, and the OS mic prompt never fires, before the on-device model
  * exists) and surface `preparing` as a status indicator while it downloads.
+ *
+ * DELIBERATELY the app-wide host (`useHostClient()`), not the composer's target
+ * host - the documented exception to the composer host-scope rule in
+ * `AGENTS.md`. Dictation describes the person at the keyboard, not the run:
+ * `speech.dictate` streams live microphone audio and `speech.ensureModel`
+ * downloads an on-device model, so following a remote run target would ship a
+ * user's audio to a machine they only picked to execute a turn on, and drop a
+ * model download there. The accepted cost is that a composer pinned to another
+ * host gates its mic on the app-wide host's model rather than that host's. Do
+ * not "fix" this by threading a target client through - it is a change to where
+ * a user's voice goes, and wants that conversation first.
  */
 export function useDictationAvailability(
   enabled: boolean,

--- a/clients/gui-app/src/hooks/composer/use-epic-mention-entries.ts
+++ b/clients/gui-app/src/hooks/composer/use-epic-mention-entries.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { EpicMentionSuggestion } from "@traycer/protocol/host/index";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
-import { useHostBinding } from "@/lib/host";
 import { useHostQueries } from "@/hooks/host/use-host-queries";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import { toastFromHostError } from "@/lib/host-error-toast";
@@ -14,6 +14,12 @@ import type {
 
 export interface UseEpicMentionEntriesParams {
   readonly requests: ReadonlyArray<MentionEpicRequest>;
+  /**
+   * The composer's host - the SAME client its workspace/terminal/GitHub
+   * mention lanes use, so a tab bound to a non-default host lists that host's
+   * artifacts and never the app-wide default's. `null` disables the queries.
+   */
+  readonly client: HostClient<HostRpcRegistry> | null;
 }
 
 export interface UseEpicMentionEntriesResult {
@@ -38,14 +44,14 @@ export interface UseEpicMentionEntriesResult {
 export function useEpicMentionEntries(
   params: UseEpicMentionEntriesParams,
 ): UseEpicMentionEntriesResult {
-  const binding = useHostBinding();
-  const client = binding?.hostClient ?? null;
+  const { client } = params;
   const readiness = useReactiveHostReadiness(client);
 
   // The CURRENTLY bound host, readable when the refetch below settles. That
-  // continuation is a plain promise chain closed over one render; an app-wide
-  // composer can rebind while the round-trip is in flight, and the closure has
-  // no way to see it. The ref is the live end of the comparison.
+  // continuation is a plain promise chain closed over one render; a composer
+  // following the app-wide host can rebind while the round-trip is in flight,
+  // and the closure has no way to see it. The ref is the live end of the
+  // comparison.
   const boundHostIdRef = useRef(readiness.hostId);
   useEffect(() => {
     boundHostIdRef.current = readiness.hostId;

--- a/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
+++ b/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
@@ -5,7 +5,7 @@ import {
   type Query,
   type QueryClient,
 } from "@tanstack/react-query";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
@@ -14,6 +14,7 @@ import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtur
 import type {
   GuiHarnessId,
   ListGuiHarnessesResponse,
+  ListGuiAgentCommandsResponse,
   ListGuiAgentModelsResponse,
 } from "@traycer/protocol/host/index";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
@@ -26,9 +27,14 @@ import { createAppQueryClient } from "@/lib/query-client";
 import { getConditionPollEpisodeCoordinator } from "@/lib/query/condition-poll-episode-coordinator";
 import {
   useGuiHarnessCatalog,
+  useGuiHarnessCatalogForClient,
+  useGuiHarnessCommandsQuery,
   useGuiHarnessesQuery,
+  useGuiHarnessesQueryForClient,
   useGuiHarnessModelsQuery,
+  useGuiHarnessModelsQueryForClient,
   useRefreshHarnessCatalog,
+  useRefreshHarnessCatalogForClient,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
 
 const hostBindingMock = vi.hoisted(() => ({
@@ -688,5 +694,233 @@ describe("useGuiHarnessCatalog cache-only label reader (MED5)", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(hidden.result.current.harnesses).toHaveLength(0);
+  });
+});
+
+// Coverage for the composer host-scoping migration: every `…ForClient`
+// catalog hook takes its client explicitly rather than resolving the
+// app-wide default via `useHostBinding()`. These guard the two invariants a
+// regression to the old default-host resolution would break: a refresh must
+// hit ONLY the client's own host (never bleed into a sibling host's cache),
+// and a `null` client (a composer whose host hasn't resolved yet) must
+// disable the query outright rather than quietly falling back to whatever
+// `useHostBinding()` currently reports.
+describe("…ForClient catalog hooks are scoped to the client argument, not the app-wide default", () => {
+  afterEach(() => {
+    hostBindingMock.current = null;
+    cleanup();
+  });
+
+  interface HostCallCounts {
+    harnesses: number;
+    models: number;
+    commands: number;
+  }
+
+  function buildHostClient(
+    queryClient: QueryClient,
+    hostId: string,
+    calls: HostCallCounts,
+  ): HostClient<HostRpcRegistry> {
+    let requestCounter = 0;
+    const client = new HostClient<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      invalidator: createHostQueryInvalidator(queryClient),
+      messenger: new MockHostMessenger<HostRpcRegistry>({
+        registry: hostRpcRegistry,
+        requestId: () => {
+          requestCounter += 1;
+          return `req-${hostId}-${String(requestCounter)}`;
+        },
+        handlers: {
+          "agent.gui.listHarnesses": () => {
+            calls.harnesses += 1;
+            return { harnesses: harnesses(["opencode"]) };
+          },
+          "agent.gui.listModels": () => {
+            calls.models += 1;
+            return modelsResponse(1);
+          },
+          "agent.gui.listCommands": (): ListGuiAgentCommandsResponse => {
+            calls.commands += 1;
+            return { harnessId: "opencode", commands: [] };
+          },
+        },
+      }),
+    });
+    client.bind({
+      hostId,
+      label: hostId,
+      kind: "local",
+      websocketUrl: `ws://127.0.0.1:0/${hostId}`,
+      version: "0.0.0-mock",
+      transportDialability: "dialable",
+    });
+    client.setRequestContext(
+      createRequestContextFixture({
+        origin: "renderer",
+        bearerToken: `tok-${hostId}`,
+      }),
+    );
+    return client;
+  }
+
+  it("useRefreshHarnessCatalogForClient invalidates only the target host's three catalog methods, leaving another host's cache untouched", async () => {
+    const queryClient = createAppQueryClient();
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+    const hostACalls: HostCallCounts = { harnesses: 0, models: 0, commands: 0 };
+    const hostBCalls: HostCallCounts = { harnesses: 0, models: 0, commands: 0 };
+    const clientA = buildHostClient(queryClient, "host-a", hostACalls);
+    const clientB = buildHostClient(queryClient, "host-b", hostBCalls);
+
+    renderHook(
+      () => {
+        useGuiHarnessesQueryForClient(clientA, {
+          enabled: true,
+          subscribed: true,
+        });
+        useGuiHarnessModelsQueryForClient(clientA, "opencode", null, {
+          enabled: true,
+          subscribed: true,
+        });
+        useGuiHarnessCommandsQuery(clientA, "opencode", [], {
+          enabled: true,
+          subscribed: true,
+        });
+      },
+      { wrapper: Wrapper },
+    );
+    renderHook(
+      () => {
+        useGuiHarnessesQueryForClient(clientB, {
+          enabled: true,
+          subscribed: true,
+        });
+        useGuiHarnessModelsQueryForClient(clientB, "opencode", null, {
+          enabled: true,
+          subscribed: true,
+        });
+        useGuiHarnessCommandsQuery(clientB, "opencode", [], {
+          enabled: true,
+          subscribed: true,
+        });
+      },
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(hostACalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
+      expect(hostBCalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
+    });
+
+    const { result } = renderHook(
+      () => useRefreshHarnessCatalogForClient(clientB),
+      { wrapper: Wrapper },
+    );
+    await act(async () => {
+      await result.current();
+    });
+
+    // Host B's three catalog methods were re-fetched by the refresh...
+    await waitFor(() => {
+      expect(hostBCalls).toEqual({ harnesses: 2, models: 2, commands: 2 });
+    });
+    // ...and host A's cache - a DIFFERENT client, never passed to the
+    // refresh - was never touched. A regression that resolved the refresh
+    // target through the app-wide default (rather than the `client`
+    // argument) would either refresh the wrong host or refresh both.
+    expect(hostACalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
+  });
+
+  it("useGuiHarnessesQueryForClient(null, …) disables the query outright - never falls back to the app-wide default host", async () => {
+    const queryClient = createAppQueryClient();
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+    // A live default-host binding IS present (mirrors a real app where some
+    // OTHER host is the app-wide default) - if `client: null` ever fell back
+    // to it, this fixture would make that fallback observable as fetched
+    // data. `useGuiHarnessesQueryForClient` never reads `useHostBinding()`,
+    // so the fixture is a negative control: it must never be consulted.
+    const defaultHostCalls: HostCallCounts = {
+      harnesses: 0,
+      models: 0,
+      commands: 0,
+    };
+    hostBindingMock.current = {
+      hostClient: buildHostClient(
+        queryClient,
+        "default-host",
+        defaultHostCalls,
+      ),
+    };
+
+    const { result } = renderHook(
+      () =>
+        useGuiHarnessesQueryForClient(null, {
+          enabled: true,
+          subscribed: true,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBe(true);
+    expect(defaultHostCalls).toEqual({ harnesses: 0, models: 0, commands: 0 });
+  });
+
+  it("useGuiHarnessCatalogForClient(null, …) reports an empty catalog that is NOT loading - a disabled query is not a fetch in flight", async () => {
+    const queryClient = createAppQueryClient();
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+    const defaultHostCalls: HostCallCounts = {
+      harnesses: 0,
+      models: 0,
+      commands: 0,
+    };
+    hostBindingMock.current = {
+      hostClient: buildHostClient(
+        queryClient,
+        "default-host",
+        defaultHostCalls,
+      ),
+    };
+
+    const { result } = renderHook(
+      () =>
+        useGuiHarnessCatalogForClient(null, null, {
+          enabled: true,
+          subscribed: true,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The underlying query is disabled (`isPending: true` forever, see the
+    // sibling test) - the composed catalog must not surface that as
+    // "loading", or every consumer (the picker rail, the palette) would spin
+    // for a fetch that never starts.
+    expect(result.current.harnesses).toEqual([]);
+    expect(result.current.harnessesLoading).toBe(false);
+    expect(result.current.modelsLoading).toBe(false);
+    expect(result.current.harnessesError).toBeNull();
+    expect(defaultHostCalls).toEqual({ harnesses: 0, models: 0, commands: 0 });
   });
 });

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -136,9 +136,16 @@ const EMPTY_GUI_MODEL_REQUESTS: ReadonlyArray<{
 /**
  * The app-wide default host's client (`null` while unbound), factored out so
  * the `?.`/`??` fallback lives in one place instead of being repeated at
- * every call site below - and so callers outside this module (e.g. the model
- * picker's commands-prewarm query) can resolve the same default-host scope
- * without duplicating it inline.
+ * every call site below - and so callers outside this module can resolve the
+ * same default-host scope without duplicating it inline.
+ *
+ * App-wide surfaces (the app-load prefetcher, Settings, the command palette)
+ * read the catalog through the default-host wrappers below. A COMPOSER never
+ * does: every composer surface has a target host - the tab's bound host, a
+ * fork dialog's fixed host, the new-conversation modal's pinned host, or the
+ * landing page's active host - and reads its catalog through the
+ * `...ForClient` variants with that host's client, so the harnesses, models
+ * and commands it offers are the ones the run will actually see.
  */
 export function useDefaultHostClient(): HostClient<HostRpcRegistry> | null {
   return useHostBinding()?.hostClient ?? null;
@@ -147,7 +154,19 @@ export function useDefaultHostClient(): HostClient<HostRpcRegistry> | null {
 export function useGuiHarnessesQuery(
   activity: QueryActivityOptions,
 ): UseQueryResult<ListGuiHarnessesResponse, HostRpcError> {
-  const client = useDefaultHostClient();
+  return useGuiHarnessesQueryForClient(useDefaultHostClient(), activity);
+}
+
+/**
+ * Client-scoped `agent.gui.listHarnesses`. `client === null` (a tab host the
+ * directory has not resolved yet, or an unbound runtime) disables the query
+ * rather than falling back to the default host - a composer must never offer
+ * another host's harnesses under its own host's name.
+ */
+export function useGuiHarnessesQueryForClient(
+  client: HostClient<HostRpcRegistry> | null,
+  activity: QueryActivityOptions,
+): UseQueryResult<ListGuiHarnessesResponse, HostRpcError> {
   return useHostQuery<HostRpcRegistry, "agent.gui.listHarnesses">({
     cacheKeyIdentity: undefined,
     client,
@@ -166,7 +185,21 @@ export function useGuiHarnessModelsQuery(
   workingDirectory: string | null,
   activity: QueryActivityOptions,
 ): UseQueryResult<ListGuiAgentModelsResponse, HostRpcError> {
-  const client = useDefaultHostClient();
+  return useGuiHarnessModelsQueryForClient(
+    useDefaultHostClient(),
+    harnessId,
+    workingDirectory,
+    activity,
+  );
+}
+
+/** Client-scoped `agent.gui.listModels`; see `useGuiHarnessesQueryForClient`. */
+export function useGuiHarnessModelsQueryForClient(
+  client: HostClient<HostRpcRegistry> | null,
+  harnessId: GuiHarnessId,
+  workingDirectory: string | null,
+  activity: QueryActivityOptions,
+): UseQueryResult<ListGuiAgentModelsResponse, HostRpcError> {
   const params = useMemo(
     () => ({ harnessId, workingDirectory }),
     [harnessId, workingDirectory],
@@ -225,8 +258,24 @@ export function useGuiHarnessCatalog(
   workingDirectory: string | null,
   activity: QueryActivityOptions,
 ): GuiHarnessCatalog {
-  const harnessesQuery = useGuiHarnessesQuery(activity);
-  const client = useDefaultHostClient();
+  return useGuiHarnessCatalogForClient(
+    useDefaultHostClient(),
+    workingDirectory,
+    activity,
+  );
+}
+
+/**
+ * Client-scoped harness + model catalog; see `useGuiHarnessesQueryForClient`.
+ * The model picker reads its rail/rows through this with the composer's
+ * run-target client.
+ */
+export function useGuiHarnessCatalogForClient(
+  client: HostClient<HostRpcRegistry> | null,
+  workingDirectory: string | null,
+  activity: QueryActivityOptions,
+): GuiHarnessCatalog {
+  const harnessesQuery = useGuiHarnessesQueryForClient(client, activity);
   // Fetching is gated by `enabled` (inside the sub-query hooks); the projection
   // is gated by `subscribed` alone, so a cache-only reader
   // (`{ enabled: false, subscribed: true }`) still surfaces the cached catalog
@@ -302,15 +351,22 @@ export function useGuiHarnessCatalog(
     () => modelQueries.some((query) => query.isPending),
     [modelQueries],
   );
+  // "Loading" means a fetch is actually coming. With no client the harness
+  // query is disabled, and a disabled query with no cached data reports
+  // `isPending` forever - reading it raw would leave the picker's rail (and
+  // any other consumer) spinning for a fetch that will never start. The model
+  // fan-out needs no such gate: it only exists once harnesses loaded, which
+  // needs a client.
+  const harnessesLoading = client !== null && harnessesQuery.isPending;
 
   return useMemo(
     () => ({
       harnesses,
-      harnessesLoading: harnessesQuery.isPending,
+      harnessesLoading,
       harnessesError: harnessesQuery.error,
       modelsLoading,
     }),
-    [harnesses, harnessesQuery.error, harnessesQuery.isPending, modelsLoading],
+    [harnesses, harnessesQuery.error, harnessesLoading, modelsLoading],
   );
 }
 
@@ -331,10 +387,22 @@ const REFRESHABLE_CATALOG_METHODS = [
  * at spawn.)
  */
 export function useRefreshHarnessCatalog(): () => Promise<void> {
+  return useRefreshHarnessCatalogForClient(useHostClient());
+}
+
+/**
+ * Client-scoped catalog refresh: invalidates the catalog keys of the host
+ * `client` targets, so the picker's refresh button re-fetches the catalog of
+ * the host the composer runs on - never the app-wide active host's while a tab
+ * or dialog is bound elsewhere. A `null` client (host not resolved yet) is a
+ * no-op, matching the disabled queries it would otherwise refetch.
+ */
+export function useRefreshHarnessCatalogForClient(
+  client: HostClient<HostRpcRegistry> | null,
+): () => Promise<void> {
   const queryClient = useQueryClient();
-  const client = useHostClient();
   return useCallback(async () => {
-    const hostId = client.getActiveHostId();
+    const hostId = client?.getActiveHostId() ?? null;
     if (hostId === null) return;
     getConditionPollEpisodeCoordinator(queryClient).resetQueryByKey(
       hostQueryKeys.method<HostRpcRegistry, "agent.gui.listHarnesses">(

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -139,13 +139,19 @@ const EMPTY_GUI_MODEL_REQUESTS: ReadonlyArray<{
  * every call site below - and so callers outside this module can resolve the
  * same default-host scope without duplicating it inline.
  *
- * App-wide surfaces (the app-load prefetcher, Settings, the command palette)
- * read the catalog through the default-host wrappers below. A COMPOSER never
- * does: every composer surface has a target host - the tab's bound host, a
- * fork dialog's fixed host, the new-conversation modal's pinned host, or the
- * landing page's active host - and reads its catalog through the
+ * App-wide surfaces (the app-load prefetcher, Settings, and the command
+ * palette WHEN NO COMPOSER IS FOCUSED) read the catalog through the
+ * default-host wrappers below. A COMPOSER never does: every composer surface
+ * has a target host - the tab's bound host, a fork dialog's fixed host, or
+ * the app-wide default followed through `null` (the landing page, whose
+ * picker rebinds that default, and the new-conversation modal opened from the
+ * sidebar's app-wide trigger) - and reads its catalog through the
  * `...ForClient` variants with that host's client, so the harnesses, models
- * and commands it offers are the ones the run will actually see.
+ * and commands it offers are the ones the run will actually see. With a
+ * composer focused the palette follows it, reading through
+ * `FocusedComposerEntry.hostClient` - otherwise its Pick provider / Pick
+ * model subpages would list one host's catalog and dispatch into another
+ * host's composer store.
  */
 export function useDefaultHostClient(): HostClient<HostRpcRegistry> | null {
   return useHostBinding()?.hostClient ?? null;

--- a/clients/gui-app/src/hooks/host/__tests__/use-tab-host-client.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-tab-host-client.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import {
+  hostRpcRegistry,
+  type HostRpcRegistry,
+} from "@traycer/protocol/host/index";
+import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
+
+// Same harness as `use-host-client-for-host-id.test.ts`: the runtime's default
+// client is a real `HostClient` whose `findHostById` is the LIVE directory,
+// while the directory Query snapshot (`useHostDirectoryList().data`) is
+// controlled separately - so a test can hold the snapshot at `undefined`
+// (first render, before the query resolves) while the live directory already
+// knows the host.
+const globalClientRef = vi.hoisted<{
+  value: HostClient<HostRpcRegistry> | null;
+}>(() => ({ value: null }));
+const directoryState = vi.hoisted<{
+  data: readonly HostDirectoryEntry[] | undefined;
+}>(() => ({ data: undefined }));
+
+function getGlobalClient(): HostClient<HostRpcRegistry> {
+  if (globalClientRef.value === null) {
+    throw new Error("test global client not configured");
+  }
+  return globalClientRef.value;
+}
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: getGlobalClient,
+}));
+
+vi.mock("@/lib/host/runtime", () => ({
+  useHostClient: getGlobalClient,
+}));
+
+vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
+  useHostDirectoryList: () => ({ data: directoryState.data }),
+}));
+
+import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
+
+const TAB_HOST: HostDirectoryEntry = {
+  ...mockLocalHostEntry,
+  hostId: "tab-host-b",
+  websocketUrl: "ws://127.0.0.1:59999/stream",
+};
+
+function buildGlobalClient(
+  listDirectory: () => readonly HostDirectoryEntry[],
+): HostClient<HostRpcRegistry> {
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => {} },
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => "req-1",
+      handlers: {},
+    }),
+    findHostById: (hostId) =>
+      listDirectory().find((entry) => entry.hostId === hostId) ?? null,
+  });
+  client.bind(mockLocalHostEntry);
+  client.setRequestContext(
+    createRequestContextFixture({
+      origin: "renderer",
+      bearerToken: "tok-1",
+    }),
+  );
+  return client;
+}
+
+function tabWrapper(hostId: string) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <TabHostProvider hostId={hostId}>{children}</TabHostProvider>;
+  };
+}
+
+interface BothClients {
+  readonly tab: HostClient<HostRpcRegistry> | null;
+  readonly byId: HostClient<HostRpcRegistry> | null;
+}
+
+/**
+ * The exact pairing a chat tab produces: its toolbar store reads
+ * `useTabHostClient()` while the picker beside it is handed the same id as a
+ * plain `runTargetHostId` and resolves `useHostClientForHostId(id)`. Both in
+ * ONE render, so the assertions below compare what a single paint sees.
+ */
+function useBothClients(hostId: string): BothClients {
+  const tab = useTabHostClient();
+  const byId = useHostClientForHostId(hostId);
+  return { tab, byId };
+}
+
+describe("useTabHostClient", () => {
+  afterEach(() => {
+    cleanup();
+    globalClientRef.value = null;
+    directoryState.data = undefined;
+  });
+
+  it("resolves on the FIRST render from the live directory, in the same paint as useHostClientForHostId, before the directory Query snapshot has data", () => {
+    globalClientRef.value = buildGlobalClient(() => [
+      mockLocalHostEntry,
+      TAB_HOST,
+    ]);
+    // First render: the Query snapshot is still `undefined`.
+    directoryState.data = undefined;
+    let renders = 0;
+
+    const { result } = renderHook(
+      () => {
+        renders += 1;
+        return useBothClients(TAB_HOST.hostId);
+      },
+      { wrapper: tabWrapper(TAB_HOST.hostId) },
+    );
+
+    // Neither hook has effects, so this IS the first (and only) render.
+    expect(renders).toBe(1);
+    expect(result.current.tab).not.toBeNull();
+    expect(result.current.byId).not.toBeNull();
+    expect(result.current.tab?.getActiveHostId()).toBe(TAB_HOST.hostId);
+    expect(result.current.byId?.getActiveHostId()).toBe(TAB_HOST.hostId);
+  });
+
+  it("agrees with useHostClientForHostId on `null` when the tab's host is nowhere in the directory", () => {
+    globalClientRef.value = buildGlobalClient(() => [mockLocalHostEntry]);
+    directoryState.data = [mockLocalHostEntry];
+    const { result } = renderHook(() => useBothClients("host-nobody-knows"), {
+      wrapper: tabWrapper("host-nobody-knows"),
+    });
+
+    expect(result.current.tab).toBeNull();
+    expect(result.current.byId).toBeNull();
+  });
+
+  it("stays a pinned requester - never the mutable default client - even when the tab's host IS the app-wide default", () => {
+    const globalClient = buildGlobalClient(() => [mockLocalHostEntry]);
+    globalClientRef.value = globalClient;
+    directoryState.data = undefined;
+    const { result } = renderHook(
+      () => useBothClients(mockLocalHostEntry.hostId),
+      {
+        wrapper: tabWrapper(mockLocalHostEntry.hostId),
+      },
+    );
+
+    expect(result.current.tab).not.toBeNull();
+    expect(result.current.tab).not.toBe(globalClient);
+    expect(result.current.tab?.getActiveHostId()).toBe(
+      mockLocalHostEntry.hostId,
+    );
+  });
+
+  it("returns null with no authenticated request context (signed out), like its sibling", () => {
+    const globalClient = buildGlobalClient(() => [
+      mockLocalHostEntry,
+      TAB_HOST,
+    ]);
+    globalClient.setRequestContext(null);
+    globalClientRef.value = globalClient;
+    directoryState.data = [mockLocalHostEntry, TAB_HOST];
+    const { result } = renderHook(() => useBothClients(TAB_HOST.hostId), {
+      wrapper: tabWrapper(TAB_HOST.hostId),
+    });
+
+    expect(result.current.tab).toBeNull();
+    expect(result.current.byId).toBeNull();
+  });
+});

--- a/clients/gui-app/src/hooks/host/use-host-client-for-host-id.ts
+++ b/clients/gui-app/src/hooks/host/use-host-client-for-host-id.ts
@@ -5,16 +5,18 @@ import { useHostClientFor } from "@/hooks/host/use-host-client-for";
 import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query";
 
 /**
- * Resolves the `HostClient` a caller mounted OUTSIDE `<TabHostProvider>`
- * should target for an explicit host id captured elsewhere (e.g. a tab's
- * bound host, threaded through as a plain id). `null` follows the mutable
- * app-wide default; every explicit id receives a pinned requester, including
- * when it currently matches that default. This prevents a fixed-host caller
- * from silently moving when the user changes the app-wide host before its next
- * render. Every globally-mounted surface that must agree on "which host does
- * this id resolve to" (the picker's create-profile capability gate,
- * `ProviderProfileAddFlowHost` itself) shares this one resolution so they can
- * never disagree about the target host.
+ * Resolves the `HostClient` for an explicit host id captured elsewhere (a
+ * tab's bound host threaded through as a plain id, a fork dialog's fixed
+ * host). `null` follows the mutable app-wide default; every explicit id
+ * receives a pinned requester, including when it currently matches that
+ * default. This prevents a fixed-host caller from silently moving when the
+ * user changes the app-wide host before its next render. Every surface that
+ * must agree on "which host does this id resolve to" (a tab's own consumers
+ * via `useTabHostClient`, the picker's `runTargetHostId` / create-profile
+ * capability gate, `ProviderProfileAddFlowHost` itself) shares this one
+ * resolution - same entry lookup order, same `null` conditions - so they can
+ * never disagree about the target host, or about whether it has resolved yet
+ * in a given paint.
  */
 export function useHostClientForHostId(
   hostId: string | null,

--- a/clients/gui-app/src/hooks/host/use-tab-host-client.ts
+++ b/clients/gui-app/src/hooks/host/use-tab-host-client.ts
@@ -1,9 +1,7 @@
-import { useMemo } from "react";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
-import { useHostClientFor } from "@/hooks/host/use-host-client-for";
-import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query";
+import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
 
 /**
  * Builds a routed `HostRequester` bound to the CURRENT tab's host
@@ -16,19 +14,26 @@ import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query
  * (`terminal.kill`) - resolve their client here so they never silently switch
  * host scope by render context.
  *
- * The entry is resolved from the referentially stable directory list so the
- * underlying `useHostClientFor` memoizes per host. Returns `null` until the
- * directory resolves the entry (or when signed out); callers treat `null` as
- * "not ready" - `useHostQuery` disables itself and the kill mutation no-ops.
+ * This is the in-tab form of `useHostClientForHostId`: the tab id is
+ * non-null, so it always takes that hook's pinned-requester path, resolving
+ * the entry from the runtime's live directory first and the directory Query
+ * snapshot only as a fallback. Sharing that one resolution matters because a
+ * tab composer hands the SAME id to surfaces mounted beside it as a plain
+ * `runTargetHostId` (the model picker, `ProviderProfileAddFlowHost`), which
+ * resolve through `useHostClientForHostId` directly - so the toolbar store's
+ * client and the picker's client are non-null in the same paint. The previous
+ * snapshot-only lookup here returned `null` for the first render while the
+ * picker beside it was already resolved, and every consumer treating `null`
+ * as "not ready" (queries disabled, catalog empty) lagged the picker by a
+ * paint.
+ *
+ * Still `null` when the directory does not hold the tab's host, the entry has
+ * no websocket URL, or there is no authenticated request context (signed
+ * out); callers keep treating `null` as "not ready" - `useHostQuery` disables
+ * itself and the kill mutation no-ops.
  *
  * Must be called inside `<TabHostProvider>` (every tile renderer is wrapped).
  */
 export function useTabHostClient(): HostClient<HostRpcRegistry> | null {
-  const tabHostId = useTabHostId();
-  const directory = useHostDirectoryList();
-  const entry = useMemo(
-    () => (directory.data ?? []).find((e) => e.hostId === tabHostId) ?? null,
-    [directory.data, tabHostId],
-  );
-  return useHostClientFor(entry);
+  return useHostClientForHostId(useTabHostId());
 }

--- a/clients/gui-app/src/lib/commands/__tests__/composer-controls-registry.test.ts
+++ b/clients/gui-app/src/lib/commands/__tests__/composer-controls-registry.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
   getFocusedComposerControls,
   registerFocusedComposerControls,
   resetFocusedComposerControlsForTests,
   subscribeFocusedComposerControls,
 } from "@/lib/commands/composer-controls-registry";
+import type { HostRpcRegistry } from "@/lib/host";
 
 function noopControls() {
   return {
@@ -15,6 +19,33 @@ function noopControls() {
     switchHarness: () => undefined,
     selectModel: () => undefined,
   };
+}
+
+/**
+ * A real, distinct `HostClient` instance (never a cast) so identity
+ * assertions on `FocusedComposerEntry.hostClient` compare the exact object a
+ * test registered. Never actually dispatched - nothing in this file issues a
+ * real RPC through it.
+ */
+function buildTestHostClient(hostId: string): HostClient<HostRpcRegistry> {
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => {} },
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => `req-${hostId}`,
+      handlers: {},
+    }),
+  });
+  client.bind({
+    hostId,
+    label: hostId,
+    kind: "local",
+    websocketUrl: `ws://127.0.0.1:0/${hostId}`,
+    version: "0.0.0-mock",
+    transportDialability: "dialable",
+  });
+  return client;
 }
 
 describe("focused composer controls registry", () => {
@@ -28,7 +59,7 @@ describe("focused composer controls registry", () => {
 
   it("registers an entry and exposes it via getter", () => {
     const controls = noopControls();
-    const dispose = registerFocusedComposerControls("landing", controls);
+    const dispose = registerFocusedComposerControls("landing", controls, null);
     const entry = getFocusedComposerControls();
     expect(entry?.kind).toBe("landing");
     expect(entry?.controls).toBe(controls);
@@ -39,8 +70,12 @@ describe("focused composer controls registry", () => {
   it("the latest registration wins; disposing the winner clears the slot", () => {
     const first = noopControls();
     const second = noopControls();
-    registerFocusedComposerControls("landing", first);
-    const disposeSecond = registerFocusedComposerControls("chat-tile", second);
+    registerFocusedComposerControls("landing", first, null);
+    const disposeSecond = registerFocusedComposerControls(
+      "chat-tile",
+      second,
+      null,
+    );
     expect(getFocusedComposerControls()?.controls).toBe(second);
     disposeSecond();
     expect(getFocusedComposerControls()).toBeNull();
@@ -49,8 +84,12 @@ describe("focused composer controls registry", () => {
   it("disposing a non-winner is a no-op (slot keeps the winner)", () => {
     const first = noopControls();
     const second = noopControls();
-    const disposeFirst = registerFocusedComposerControls("landing", first);
-    registerFocusedComposerControls("chat-tile", second);
+    const disposeFirst = registerFocusedComposerControls(
+      "landing",
+      first,
+      null,
+    );
+    registerFocusedComposerControls("chat-tile", second, null);
     disposeFirst();
     expect(getFocusedComposerControls()?.controls).toBe(second);
   });
@@ -63,10 +102,22 @@ describe("focused composer controls registry", () => {
     const disposeRegister = registerFocusedComposerControls(
       "landing",
       noopControls(),
+      null,
     );
     expect(calls).toBe(1);
     disposeRegister();
     expect(calls).toBe(2);
     dispose();
+  });
+
+  it("exposes the hostClient passed in; re-registering the same kind with a different client replaces it (last wins)", () => {
+    const clientA = buildTestHostClient("host-a");
+    const clientB = buildTestHostClient("host-b");
+
+    registerFocusedComposerControls("landing", noopControls(), clientA);
+    expect(getFocusedComposerControls()?.hostClient).toBe(clientA);
+
+    registerFocusedComposerControls("landing", noopControls(), clientB);
+    expect(getFocusedComposerControls()?.hostClient).toBe(clientB);
   });
 });

--- a/clients/gui-app/src/lib/commands/__tests__/composer.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/composer.source.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render } from "@testing-library/react";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
   registerFocusedComposerControls,
   resetFocusedComposerControlsForTests,
@@ -17,8 +20,10 @@ import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversatio
 import type {
   CommandContext,
   CommandItem,
+  CommandSubpage,
   FocusedComposerKind,
 } from "@/lib/commands/types";
+import type { HostRpcRegistry } from "@/lib/host";
 import type { WorktreeIntent } from "@traycer/protocol/host/worktree-schemas";
 
 const catalogMock = vi.hoisted(() => ({
@@ -52,6 +57,20 @@ const catalogMock = vi.hoisted(() => ({
   ],
 }));
 
+/**
+ * Minimal shape the mocked `useDefaultHostClient` / `useGuiHarnessCatalogForClient`
+ * need: only object identity matters to the assertions below (which host's
+ * catalog the subpages asked for), never any real RPC behavior.
+ */
+interface FakeCatalogHostClient {
+  readonly getActiveHostId: () => string | null;
+}
+
+const focusedComposerCatalogMock = vi.hoisted(() => ({
+  defaultClient: { getActiveHostId: () => "default-host" },
+  clientCalls: [] as Array<{ getActiveHostId: () => string | null } | null>,
+}));
+
 interface CreateChatPayload {
   readonly epicId: string;
   readonly parentId: string | null;
@@ -79,6 +98,22 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     harnessesError: null,
     modelsLoading: false,
   }),
+  useDefaultHostClient: (): FakeCatalogHostClient =>
+    focusedComposerCatalogMock.defaultClient,
+  // Records the `client` each call was invoked with, so tests can assert the
+  // composer subpages resolve the FOCUSED composer's host client (not the
+  // default host's) - regardless of which client was passed, this returns
+  // the same fixture catalog `useGuiHarnessCatalog` above does, since none of
+  // this file's cases need per-host catalog content, only per-host routing.
+  useGuiHarnessCatalogForClient: (client: FakeCatalogHostClient | null) => {
+    focusedComposerCatalogMock.clientCalls.push(client);
+    return {
+      harnesses: catalogMock.harnesses,
+      harnessesLoading: false,
+      harnessesError: null,
+      modelsLoading: false,
+    };
+  },
 }));
 
 vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
@@ -133,6 +168,17 @@ function captureItems(
   return captured;
 }
 
+function renderSubpageItems(
+  subpage: CommandSubpage,
+  focusedComposerKind: FocusedComposerKind,
+): void {
+  function SubProbe() {
+    subpage.useItems(ctx(null, focusedComposerKind));
+    return null;
+  }
+  render(<SubProbe />);
+}
+
 function stubControls(overrides: Partial<ComposerControls>): ComposerControls {
   return {
     setReasoning: () => undefined,
@@ -143,6 +189,41 @@ function stubControls(overrides: Partial<ComposerControls>): ComposerControls {
     ...overrides,
   };
 }
+
+/**
+ * A real, distinct `HostClient` instance (never a cast) so identity
+ * assertions on `FocusedComposerEntry.hostClient` compare the exact object a
+ * test registered, not some other host's client. Never actually dispatched -
+ * `registerFocusedComposerControls`'s consumers here only read it back
+ * (nothing in this file issues a real RPC through it).
+ */
+function buildTestHostClient(hostId: string): HostClient<HostRpcRegistry> {
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => {} },
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => `req-${hostId}`,
+      handlers: {},
+    }),
+  });
+  client.bind({
+    hostId,
+    label: hostId,
+    kind: "local",
+    websocketUrl: `ws://127.0.0.1:0/${hostId}`,
+    version: "0.0.0-mock",
+    transportDialability: "dialable",
+  });
+  return client;
+}
+
+// The host client every pre-existing test in this file registers a focused
+// composer with - non-null, so the composer subpages list a resolved host's
+// catalog exactly as they did before `hostClient` became part of the entry.
+// Its identity is irrelevant to those tests; only the tests that assert
+// per-host routing below construct their own distinct clients.
+const TEST_HOST_CLIENT = buildTestHostClient("test-host");
 
 function resetCanvasStore(): void {
   useEpicCanvasStore.setState({
@@ -161,6 +242,7 @@ describe("composerSource", () => {
   beforeEach(() => {
     createChatMock.mutate.mockReset();
     latestConversationWorkspaceSeedMock.seed = null;
+    focusedComposerCatalogMock.clientCalls.length = 0;
     resetCanvasStore();
     resetFocusedComposerControlsForTests();
     resetActiveModelPickerForTests();
@@ -172,6 +254,7 @@ describe("composerSource", () => {
     cleanup();
     createChatMock.mutate.mockReset();
     latestConversationWorkspaceSeedMock.seed = null;
+    focusedComposerCatalogMock.clientCalls.length = 0;
     resetCanvasStore();
     resetFocusedComposerControlsForTests();
     resetActiveModelPickerForTests();
@@ -185,7 +268,11 @@ describe("composerSource", () => {
   });
 
   it("landing composer shows provider / model; no new-chat items", () => {
-    registerFocusedComposerControls("landing", stubControls({}));
+    registerFocusedComposerControls(
+      "landing",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const ids = captureItems(null, "landing").map((i) => i.id);
     expect(ids).toContain("composer:switch-provider");
     expect(ids).toContain("composer:switch-model");
@@ -196,7 +283,11 @@ describe("composerSource", () => {
   });
 
   it("emits a context-gated Stash prompt row bound to composer.stash", () => {
-    registerFocusedComposerControls("landing", stubControls({}));
+    registerFocusedComposerControls(
+      "landing",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const item = captureItems(null, "landing").find(
       (row) => row.id === "composer:stash-prompt",
     );
@@ -209,13 +300,21 @@ describe("composerSource", () => {
   it("hides Change model… when no picker is registered", () => {
     // A focused composer with no active picker (e.g. locked/pending) registers
     // its controls but not a picker, so the toggle would no-op.
-    registerFocusedComposerControls("landing", stubControls({}));
+    registerFocusedComposerControls(
+      "landing",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const ids = captureItems(null, "landing").map((i) => i.id);
     expect(ids).not.toContain("composer:open-model-picker");
   });
 
   it("shows Change model… with the active selection when a picker is registered", () => {
-    registerFocusedComposerControls("landing", stubControls({}));
+    registerFocusedComposerControls(
+      "landing",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     registerActiveModelPicker({
       toggle: () => undefined,
       getSelectionSummary: () => "Claude Opus 4.8",
@@ -228,7 +327,11 @@ describe("composerSource", () => {
   });
 
   it("refreshes the Change model… summary when the top picker is swapped", () => {
-    registerFocusedComposerControls("landing", stubControls({}));
+    registerFocusedComposerControls(
+      "landing",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     registerActiveModelPicker({
       toggle: () => undefined,
       getSelectionSummary: () => "base",
@@ -256,7 +359,11 @@ describe("composerSource", () => {
   });
 
   it("chat-tile composer with an active epic shows the new-chat + terminal items; no Select PC", () => {
-    registerFocusedComposerControls("chat-tile", stubControls({}));
+    registerFocusedComposerControls(
+      "chat-tile",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const ids = captureItems("epic-1", "chat-tile").map((i) => i.id);
     expect(ids).toContain("composer:switch-provider");
     expect(ids).toContain("composer:switch-model");
@@ -268,7 +375,11 @@ describe("composerSource", () => {
   });
 
   it("new-chat active tile command opens the modal in chat mode (active-tile)", () => {
-    registerFocusedComposerControls("chat-tile", stubControls({}));
+    registerFocusedComposerControls(
+      "chat-tile",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const items = captureItems("epic-1", "chat-tile");
     const item = items.find((candidate) => {
       return candidate.id === "composer:new-chat:replace";
@@ -295,7 +406,11 @@ describe("composerSource", () => {
   });
 
   it("new-chat split command opens the modal in chat mode with the active group's split placement", () => {
-    registerFocusedComposerControls("chat-tile", stubControls({}));
+    registerFocusedComposerControls(
+      "chat-tile",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     useEpicCanvasStore
       .getState()
       .seedEpic("epic-1", { tabId: "epic-1", name: "Epic 1" }, []);
@@ -339,13 +454,21 @@ describe("composerSource", () => {
   });
 
   it("chat-tile without an active epic hides new-chat items", () => {
-    registerFocusedComposerControls("chat-tile", stubControls({}));
+    registerFocusedComposerControls(
+      "chat-tile",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const ids = captureItems(null, "chat-tile").map((i) => i.id);
     expect(ids).not.toContain("composer:new-chat:replace");
   });
 
   it("provider / model entry items carry a subpage", () => {
-    registerFocusedComposerControls("landing", stubControls({}));
+    registerFocusedComposerControls(
+      "landing",
+      stubControls({}),
+      TEST_HOST_CLIENT,
+    );
     const items = captureItems(null, "landing");
     const provider = items.find((i) => i.id === "composer:switch-provider");
     const model = items.find((i) => i.id === "composer:switch-model");
@@ -361,6 +484,7 @@ describe("composerSource", () => {
         selectModel: (harnessId, modelSlug) =>
           picks.push({ harnessId, modelSlug }),
       }),
+      TEST_HOST_CLIENT,
     );
 
     const items = captureItems(null, "landing");
@@ -393,6 +517,7 @@ describe("composerSource", () => {
       stubControls({
         switchHarness: (harnessId) => switches.push(harnessId),
       }),
+      TEST_HOST_CLIENT,
     );
 
     const items = captureItems(null, "landing");
@@ -420,5 +545,66 @@ describe("composerSource", () => {
     // remembered model/effort/tier), never the old `setSelection(firstModel…)`.
     // (`setSelection` is no longer part of `ComposerControls` at all.)
     expect(switches).toEqual(["codex"]);
+  });
+
+  it("the provider and model subpages resolve the FOCUSED composer's host client, not the default host's", () => {
+    const hostClientB = buildTestHostClient("host-b");
+    registerFocusedComposerControls("landing", stubControls({}), hostClientB);
+
+    const items = captureItems(null, "landing");
+    const providerSubpage = items.find(
+      (i) => i.id === "composer:switch-provider",
+    )?.subpage;
+    const modelSubpage = items.find(
+      (i) => i.id === "composer:switch-model",
+    )?.subpage;
+    if (providerSubpage === null || providerSubpage === undefined) {
+      throw new Error("expected a provider subpage");
+    }
+    if (modelSubpage === null || modelSubpage === undefined) {
+      throw new Error("expected a model subpage");
+    }
+
+    renderSubpageItems(providerSubpage, "landing");
+    expect(focusedComposerCatalogMock.clientCalls.at(-1)).toBe(hostClientB);
+
+    renderSubpageItems(modelSubpage, "landing");
+    expect(focusedComposerCatalogMock.clientCalls.at(-1)).toBe(hostClientB);
+  });
+
+  it("with no focused composer registered, the provider subpage resolves the default host's client", () => {
+    // `ctx.focusedComposerKind` (below) only decides which top-level items
+    // render; `useFocusedComposerCatalog` reads the REGISTRY instead - never
+    // populated in this test - to decide "focused or not". This models a
+    // palette rendered while no composer has registered itself as focused.
+    const items = captureItems(null, "landing");
+    const providerSubpage = items.find(
+      (i) => i.id === "composer:switch-provider",
+    )?.subpage;
+    if (providerSubpage === null || providerSubpage === undefined) {
+      throw new Error("expected a provider subpage");
+    }
+
+    renderSubpageItems(providerSubpage, "landing");
+
+    expect(focusedComposerCatalogMock.clientCalls.at(-1)).toBe(
+      focusedComposerCatalogMock.defaultClient,
+    );
+  });
+
+  it("a focused composer whose host client hasn't resolved yet is passed through as null, never the default host's", () => {
+    registerFocusedComposerControls("landing", stubControls({}), null);
+
+    const items = captureItems(null, "landing");
+    const modelSubpage = items.find(
+      (i) => i.id === "composer:switch-model",
+    )?.subpage;
+    if (modelSubpage === null || modelSubpage === undefined) {
+      throw new Error("expected a model subpage");
+    }
+
+    renderSubpageItems(modelSubpage, "landing");
+
+    expect(focusedComposerCatalogMock.clientCalls.at(-1)).toBeNull();
   });
 });

--- a/clients/gui-app/src/lib/commands/composer-controls-registry.ts
+++ b/clients/gui-app/src/lib/commands/composer-controls-registry.ts
@@ -13,12 +13,14 @@
  * for the React entry point that enforces these semantics correctly
  * under mount / unmount / focus-change sequences.
  */
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type {
   PermissionMode,
   ProviderId,
   ReasoningLevel,
   ServiceTier,
 } from "@/components/home/data/landing-options";
+import type { HostRpcRegistry } from "@/lib/host";
 import type { FocusedComposerKind } from "@/lib/commands/types";
 
 export interface ComposerControls {
@@ -42,6 +44,16 @@ export interface ComposerControls {
 export interface FocusedComposerEntry {
   readonly kind: FocusedComposerKind;
   readonly controls: ComposerControls;
+  /**
+   * The focused composer's target host - the client its own toolbar store
+   * reads the harness/model catalog through. The palette's "Pick provider" /
+   * "Pick model" subpages list THIS host's catalog, so what they offer is
+   * what `switchHarness` / `selectModel` can actually commit against; listing
+   * the app-wide default host's would offer a chat tab bound to another host
+   * providers it does not have. `null` while that host's client is still
+   * resolving (the subpages then list nothing rather than another host's).
+   */
+  readonly hostClient: HostClient<HostRpcRegistry> | null;
 }
 
 let registered: FocusedComposerEntry | null = null;
@@ -50,8 +62,9 @@ const listeners = new Set<() => void>();
 export function registerFocusedComposerControls(
   kind: FocusedComposerKind,
   controls: ComposerControls,
+  hostClient: HostClient<HostRpcRegistry> | null,
 ): () => void {
-  const entry: FocusedComposerEntry = { kind, controls };
+  const entry: FocusedComposerEntry = { kind, controls, hostClient };
   registered = entry;
   notify();
   return () => {

--- a/clients/gui-app/src/lib/commands/sources/composer.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/composer.source.ts
@@ -23,7 +23,12 @@ import {
   type HarnessOption,
   type ModelOption,
 } from "@/components/home/data/landing-options";
-import { useGuiHarnessCatalog } from "@/hooks/harnesses/use-gui-harness-catalog";
+import {
+  useDefaultHostClient,
+  useGuiHarnessCatalogForClient,
+  type GuiHarnessCatalog,
+} from "@/hooks/harnesses/use-gui-harness-catalog";
+import { useFocusedComposerEntry } from "@/hooks/command-palette/use-focused-composer-entry";
 import { getFocusedComposerControls } from "@/lib/commands/composer-controls-registry";
 import {
   getActiveModelPicker,
@@ -300,11 +305,28 @@ const MODEL_SUBPAGE: CommandSubpage = {
   useItems: () => useModelSubpageItems(),
 };
 
+/**
+ * The catalog the composer subpages list: the FOCUSED composer's target
+ * host's, because that is the store `switchHarness` / `selectModel` dispatch
+ * into (`getFocusedComposerControls()` in the items' `run`) - a chat tab bound
+ * to another host must be offered that host's providers/models, not the
+ * app-wide default's. With no focused composer there is nothing to dispatch
+ * into, so the default host's catalog is listed (harmless); with a focused
+ * composer whose host client has not resolved, nothing is listed rather than
+ * another host's.
+ */
+function useFocusedComposerCatalog(): GuiHarnessCatalog {
+  const entry = useFocusedComposerEntry();
+  const defaultClient = useDefaultHostClient();
+  return useGuiHarnessCatalogForClient(
+    entry === null ? defaultClient : entry.hostClient,
+    null,
+    { enabled: true, subscribed: true },
+  );
+}
+
 function useProviderSubpageItems(): ReadonlyArray<CommandItem> {
-  const catalog = useGuiHarnessCatalog(null, {
-    enabled: true,
-    subscribed: true,
-  });
+  const catalog = useFocusedComposerCatalog();
   return useMemo(
     () =>
       catalog.harnesses.flatMap((provider) =>
@@ -315,10 +337,7 @@ function useProviderSubpageItems(): ReadonlyArray<CommandItem> {
 }
 
 function useModelSubpageItems(): ReadonlyArray<CommandItem> {
-  const catalog = useGuiHarnessCatalog(null, {
-    enabled: true,
-    subscribed: true,
-  });
+  const catalog = useFocusedComposerCatalog();
   return useMemo(
     () =>
       catalog.harnesses.flatMap((provider) =>


### PR DESCRIPTION
## Summary

Every composer surface has a **target host** — the host shown in the picker below it (a tab's bound host, a fork dialog's fixed host, the new-conversation modal's pinned host; on the landing page the picker rebinds the app-wide default, so `null` *is* that host by construction). Several composer-adjacent reads ignored it and went through the app-wide default instead, so a chat tab bound to remote host B listed host A's harnesses, models, providers and profiles.

Scoped to the composer's target host:

- the model picker's harness rail, model rows, profiles, degraded state, managed-pack retry, commands prewarm and catalog refresh
- the toolbar store's own harness/model catalog — the choke point every composer goes through. `useComposerToolbarStore` now takes `{ hostClient, tuiOnly }` and each caller passes its own client
- `ComposerBody` / `TerminalLaunchPanel`, which hard-coded `runTargetHostId={null}` (so the pinned new-agent modal used the default host); both gained a `hostId` prop
- artifact @-mentions — `useEpicMentionEntries` ignored its caller's client
- the command palette's **Pick provider / Pick model** subpages, which dispatch into the focused composer: `FocusedComposerEntry` now carries that composer's `hostClient`
- the chat-tile transcript label projection, so a model only the tab host offers gets its friendly label instead of a raw slug
- the worktree owner hover card's catalog, which sat beside a per-owner client already scoped to that owner's host

`use-gui-harness-catalog` gained `…ForClient` variants; the old names remain as default-host wrappers for genuinely app-wide surfaces (prefetcher, Settings, a palette with no focused composer).

Two supporting cleanups fall out of the above:

- **`useTabHostClient()` is now `useHostClientForHostId(useTabHostId())`.** It resolved entries from the directory Query snapshot only, so it was `null` for the first render while a picker beside it — handed the same id — had already resolved from the runtime's live directory. One shared resolution means they can never disagree on nullness within a paint.
- **`picker-profile-dropdown`'s usage join drops its resolved-account-identity requirement.** It existed because the rail's rows came from the default host while the dropdown's came from the tab host, so a `null` identity on each side proved nothing. With one host on both sides it only served to drop usage for the whole dropdown whenever a single profile's identity had not resolved yet — something the landing picker never did.

A `null` client stays "not ready" everywhere: queries disable, catalogs are empty and labels fall back to raw slugs, rather than borrowing another host's data under this host's name. The picker's trigger spinner is gated on a resolved client, since a disabled query reports `isPending` forever.

### Why threading, not a nested `HostRuntimeProvider`

Re-providing the runtime context under each composer would silently retarget *every* `useHostClient()` in that subtree — clone-on-host-switch, the workspace selector, `useReactiveActiveHostId()` — an unauditable blast radius. Explicit threading matches how `createProfileHostId` / `useProvidersListForClient` were already done here.

## Validation

- `bun run compile` (gui-app, `tsc -b`) — clean
- `eslint --max-warnings 0` + `prettier --check` on every changed file — clean
- **Full gui-app suite: 1293 files / 13734 tests passing**
- New coverage asserts *which* client each read received — not values the test itself supplied — across the toolbar store, picker rail/models/refresh, mentions, palette subpages, catalog-refresh invalidation, and the owner hover card. The host-scoping tests were mutation-probed (revert the scoping → they fail).
- An independent cold review of the change produced 8 findings; 7 are folded in (palette host divergence, a permanent trigger spinner on a null client, chat-tile labels from the wrong host, a stale comment and JSDoc, a `useDefaultHostClient()` leak in the add-node submenu, and gating `harnessesLoading` at the source), and the 8th — the `useTabHostClient` nullness asymmetry — is fixed here too.

## Notes

Not covered by automation: the chat-tile transcript label merge only surfaces in the completed-turn elapsed-footer tooltip, for which no fixture exists. Verify manually on a remote-host tab by hovering the elapsed footer of a completed turn whose model only that host offers.

`clients/gui-app/AGENTS.md` records the rule so the next composer surface starts scoped.
