### PR TITLE
refactor(gui-app): derive chat announcements from transcript baseline

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -689,6 +689,8 @@ interface RenderChatMessagesOptions {
 interface ChatMessagesRenderState {
   messages: ReadonlyArray<ChatMessageModel>;
   baselineEpoch: number;
+  /** Mutable: a chat is auto-titled after its first turn and can be renamed. */
+  taskTitle: string;
   systemOverlayActive: boolean;
   scrollRequest: ChatMessageScrollRequest | null;
   backgroundItems: ReadonlyArray<BackgroundItem> | undefined;
@@ -743,6 +745,7 @@ function renderChatMessages(options: RenderChatMessagesOptions) {
     // every non-announcement test wants. The announcement suite drives this
     // explicitly to model mount hydration and reconnect backfill.
     baselineEpoch: options.baselineEpoch ?? 0,
+    taskTitle: options.taskTitle ?? "Test chat",
     systemOverlayActive: options.systemOverlayActive ?? false,
     scrollRequest: options.scrollRequest ?? null,
     backgroundItems: options.backgroundItems,
@@ -784,7 +787,7 @@ function renderChatMessages(options: RenderChatMessagesOptions) {
         style={{ height: VIEWPORT_HEIGHT_PX, width: VIEWPORT_WIDTH_PX }}
       >
         <ChatMessages
-          taskTitle={options.taskTitle ?? "Test chat"}
+          taskTitle={state.taskTitle}
           taskId={taskId}
           epicId={epicId}
           hostId={null}
@@ -1392,6 +1395,65 @@ describe("ChatMessages scroll policy", () => {
         expect(live?.textContent).toBe(
           "Build plan received a background completion.",
         );
+      });
+    });
+
+    it("keeps an announced sentence frozen when the chat is renamed", async () => {
+      const userMsg = makeMessage(0, "user");
+      const assistantStreaming: ChatMessageModel = {
+        ...makeMessage(1, "assistant"),
+        completedAt: null,
+        stopped: null,
+        runState: "running",
+      };
+      const assistantDone: ChatMessageModel = {
+        ...assistantStreaming,
+        completedAt: 1_700_000_000_000,
+        runState: null,
+      };
+      const { rerenderWith } = renderChatMessages({
+        messages: [userMsg, assistantStreaming],
+        scrollStateKey: "aria-rename-freeze-key",
+        taskTitle: "Build plan",
+      });
+      await settleLegendList();
+
+      const live = document.querySelector('[aria-live="polite"]');
+      rerenderWith({ messages: [userMsg, assistantDone] });
+      await settleLegendList();
+      await waitFor(() => {
+        expect(live?.textContent).toBe("Build plan finished responding.");
+      });
+      const announcedNode = live?.firstElementChild;
+
+      // A chat is auto-titled right after its first turn - exactly when this
+      // announcement is still mounted. Rewriting the text inside the live
+      // region would re-announce a completion that never happened, so the
+      // sentence stays as it was announced.
+      rerenderWith({ taskTitle: "Renamed plan" });
+      await settleLegendList();
+      expect(live?.textContent).toBe("Build plan finished responding.");
+      expect(live?.firstElementChild).toBe(announcedNode);
+
+      // Freezing is per announcement, not permanent: the next one speaks the
+      // title the reader now sees.
+      rerenderWith({
+        messages: [
+          userMsg,
+          assistantDone,
+          makeMessage(2, "user"),
+          {
+            ...makeMessage(3, "assistant"),
+            completedAt: 1_700_000_005_000,
+            stopped: null,
+            runState: null,
+          },
+        ],
+      });
+      await settleLegendList();
+
+      await waitFor(() => {
+        expect(live?.textContent).toBe("Renamed plan finished responding.");
       });
     });
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -53,6 +53,7 @@ import { scopedChatOpenId } from "@/stores/chats/open-store-scope";
 import { deriveActivityGroupRenderId } from "@/components/chat/chat-collapsible-key";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
+import { NO_TRANSCRIPT_BASELINE } from "@/stores/chats/chat-announcements";
 import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
 import {
   makeAssistantMessage,
@@ -681,10 +682,13 @@ interface RenderChatMessagesOptions {
    * would already hold.
    */
   readonly freshOpen?: boolean;
+  /** `ChatSessionState.transcriptBaselineEpoch`; see `ChatMessages`. */
+  readonly baselineEpoch?: number;
 }
 
 interface ChatMessagesRenderState {
   messages: ReadonlyArray<ChatMessageModel>;
+  baselineEpoch: number;
   systemOverlayActive: boolean;
   scrollRequest: ChatMessageScrollRequest | null;
   backgroundItems: ReadonlyArray<BackgroundItem> | undefined;
@@ -735,6 +739,10 @@ function renderChatMessages(options: RenderChatMessagesOptions) {
 
   const state: ChatMessagesRenderState = {
     messages: options.messages,
+    // Default 0: these rows arrived on a hydrated connection, which is what
+    // every non-announcement test wants. The announcement suite drives this
+    // explicitly to model mount hydration and reconnect backfill.
+    baselineEpoch: options.baselineEpoch ?? 0,
     systemOverlayActive: options.systemOverlayActive ?? false,
     scrollRequest: options.scrollRequest ?? null,
     backgroundItems: options.backgroundItems,
@@ -781,6 +789,7 @@ function renderChatMessages(options: RenderChatMessagesOptions) {
           epicId={epicId}
           hostId={null}
           messages={state.messages}
+          baselineEpoch={state.baselineEpoch}
           backgroundItems={state.backgroundItems}
           getMessageActions={() => null}
           nextStepActions={null}
@@ -1218,7 +1227,7 @@ describe("ChatMessages scroll policy", () => {
       });
     });
 
-    it("does not announce a footerless row backfilled behind known messages", async () => {
+    it("does not announce rows a reconnect backfilled into the transcript", async () => {
       const knownUser = makeMessage(2, "user");
       const knownAssistant: ChatMessageModel = {
         ...makeMessage(3, "assistant"),
@@ -1226,8 +1235,9 @@ describe("ChatMessages scroll policy", () => {
         stopped: null,
         runState: null,
       };
-      const { rerenderMessages } = renderChatMessages({
+      const { rerenderWith } = renderChatMessages({
         messages: [knownUser, knownAssistant],
+        baselineEpoch: 0,
         scrollStateKey: "aria-backfill-history-key",
         taskTitle: "Build plan",
       });
@@ -1235,20 +1245,32 @@ describe("ChatMessages scroll policy", () => {
 
       const live = document.querySelector('[aria-live="polite"]');
       expect(live?.textContent ?? "").toBe("");
-      // Reconnect/backfill hydrates an OLDER footerless notification into a
-      // transcript that mounted partial. It does not extend the transcript
-      // past the known messages, so it is history, not news.
-      rerenderMessages([
-        {
-          ...makeMessage(1, "assistant"),
-          completedAt: 1_699_999_000_000,
-          stopped: null,
-          runState: null,
-          showCompletionFooter: false,
-        },
-        knownUser,
-        knownAssistant,
-      ]);
+      // A reconnect's authoritative snapshot re-establishes the transcript on
+      // a NEW connection (the epoch advances) and can carry rows written
+      // while this client was away. Everything it delivers is history by
+      // construction - it re-baselines instead of announcing, no matter how
+      // the rows sort or when they completed.
+      rerenderWith({
+        baselineEpoch: 1,
+        messages: [
+          {
+            ...makeMessage(1, "assistant"),
+            completedAt: 1_699_999_000_000,
+            stopped: null,
+            runState: null,
+            showCompletionFooter: false,
+          },
+          knownUser,
+          knownAssistant,
+          {
+            ...makeMessage(4, "assistant"),
+            completedAt: 1_700_000_009_000,
+            stopped: null,
+            runState: null,
+            showCompletionFooter: false,
+          },
+        ],
+      });
       await settleLegendList();
 
       expect(live?.textContent ?? "").toBe("");
@@ -1329,47 +1351,7 @@ describe("ChatMessages scroll policy", () => {
       });
     });
 
-    it("announces a tied-timestamp completion appended past known rows", async () => {
-      const knownUser = makeMessage(0, "user");
-      const knownAssistant: ChatMessageModel = {
-        ...makeMessage(1, "assistant"),
-        completedAt: 1_700_000_000_000,
-        stopped: null,
-        runState: null,
-      };
-      const { rerenderMessages } = renderChatMessages({
-        messages: [knownUser, knownAssistant],
-        scrollStateKey: "aria-tied-completion-key",
-        taskTitle: "Build plan",
-      });
-      await settleLegendList();
-
-      const live = document.querySelector('[aria-live="polite"]');
-      expect(live?.textContent ?? "").toBe("");
-      // Wall-clock completion stamps are not unique: a background task can
-      // settle in the same millisecond as the previously newest completion.
-      // A tie counts as live regardless of where the row sorts.
-      rerenderMessages([
-        knownUser,
-        knownAssistant,
-        {
-          ...makeMessage(2, "assistant"),
-          completedAt: 1_700_000_000_000,
-          stopped: null,
-          runState: null,
-          showCompletionFooter: false,
-        },
-      ]);
-      await settleLegendList();
-
-      await waitFor(() => {
-        expect(live?.textContent).toBe(
-          "Build plan received a background completion.",
-        );
-      });
-    });
-
-    it("announces a tied-timestamp completion inserted before known rows", async () => {
+    it("announces a live completion older and earlier than every known row", async () => {
       const knownUser = makeMessage(0, "user");
       const knownAssistant: ChatMessageModel = {
         ...makeMessage(5, "assistant"),
@@ -1380,23 +1362,23 @@ describe("ChatMessages scroll policy", () => {
       const laterUser = makeMessage(6, "user");
       const { rerenderMessages } = renderChatMessages({
         messages: [knownUser, knownAssistant, laterUser],
-        scrollStateKey: "aria-tied-mid-insert-key",
+        scrollStateKey: "aria-live-anchored-insert-key",
         taskTitle: "Build plan",
       });
       await settleLegendList();
 
       const live = document.querySelector('[aria-live="polite"]');
       expect(live?.textContent ?? "").toBe("");
-      // The intersection of the two hard cases: an earlier turn's task
-      // settles in the same millisecond as the newest observed completion,
-      // and its preserved anchor inserts the notification BEFORE known
-      // rows. Neither recency nor position can rank it - the tie itself is
-      // the live-arrival evidence.
+      // The worst case for shape-based inference, and now a non-case: the
+      // notification is anchored at its own turn's position (BEFORE rows the
+      // reader has seen) and carries an OLDER completion stamp than the
+      // newest known one. Neither position nor recency could call this live -
+      // but the connection never re-baselined, so it is news by construction.
       rerenderMessages([
         knownUser,
         {
           ...makeMessage(2, "assistant"),
-          completedAt: 1_700_000_000_000,
+          completedAt: 1_699_999_000_000,
           stopped: null,
           runState: null,
           showCompletionFooter: false,
@@ -1413,9 +1395,109 @@ describe("ChatMessages scroll policy", () => {
       });
     });
 
-    it("does not announce history hydrated after an empty first observation", async () => {
-      const { rerenderMessages } = renderChatMessages({
+    it("announces a background completion delivered by a same-connection refresh", async () => {
+      const knownUser = makeMessage(0, "user");
+      const knownAssistant: ChatMessageModel = {
+        ...makeMessage(1, "assistant"),
+        completedAt: 1_700_000_000_000,
+        stopped: null,
+        runState: null,
+      };
+      const { rerenderWith } = renderChatMessages({
+        messages: [knownUser, knownAssistant],
+        baselineEpoch: 3,
+        scrollStateKey: "aria-same-connection-refresh-key",
+        taskTitle: "Build plan",
+      });
+      await settleLegendList();
+
+      const live = document.querySelector('[aria-live="polite"]');
+      expect(live?.textContent ?? "").toBe("");
+      // An authoritative host-side refresh on the SAME connection carries
+      // live news, so it must not be mistaken for a re-hydration: only a new
+      // connection's epoch re-baselines. The rows arrive wholesale, exactly
+      // as a reconnect's would - the epoch is the entire difference.
+      rerenderWith({
+        baselineEpoch: 3,
+        messages: [
+          knownUser,
+          knownAssistant,
+          {
+            ...makeMessage(2, "assistant"),
+            completedAt: 1_700_000_004_000,
+            stopped: null,
+            runState: null,
+            showCompletionFooter: false,
+          },
+        ],
+      });
+      await settleLegendList();
+
+      await waitFor(() => {
+        expect(live?.textContent).toBe(
+          "Build plan received a background completion.",
+        );
+      });
+    });
+
+    it("keeps announcing live completions after a reconnect re-baselines", async () => {
+      const knownUser = makeMessage(0, "user");
+      const knownAssistant: ChatMessageModel = {
+        ...makeMessage(1, "assistant"),
+        completedAt: 1_700_000_000_000,
+        stopped: null,
+        runState: null,
+      };
+      const backfilled: ChatMessageModel = {
+        ...makeMessage(2, "assistant"),
+        completedAt: 1_700_000_002_000,
+        stopped: null,
+        runState: null,
+        showCompletionFooter: false,
+      };
+      const { rerenderWith } = renderChatMessages({
+        messages: [knownUser, knownAssistant],
+        baselineEpoch: 0,
+        scrollStateKey: "aria-post-reconnect-key",
+        taskTitle: "Build plan",
+      });
+      await settleLegendList();
+
+      const live = document.querySelector('[aria-live="polite"]');
+      rerenderWith({
+        baselineEpoch: 1,
+        messages: [knownUser, knownAssistant, backfilled],
+      });
+      await settleLegendList();
+      expect(live?.textContent ?? "").toBe("");
+
+      // Re-baselining is a one-frame reset, not a mute: the reconnected
+      // connection keeps reporting live completions.
+      rerenderWith({
+        baselineEpoch: 1,
+        messages: [
+          knownUser,
+          knownAssistant,
+          backfilled,
+          {
+            ...makeMessage(3, "assistant"),
+            completedAt: 1_700_000_006_000,
+            stopped: null,
+            runState: null,
+          },
+        ],
+      });
+      await settleLegendList();
+
+      await waitFor(() => {
+        expect(live?.textContent).toBe("Build plan finished responding.");
+      });
+    });
+
+    it("does not announce the transcript that first hydration delivers", async () => {
+      const { rerenderWith } = renderChatMessages({
         messages: [],
+        baselineEpoch: NO_TRANSCRIPT_BASELINE,
         scrollStateKey: "aria-empty-baseline-key",
         taskTitle: "Build plan",
       });
@@ -1423,20 +1505,23 @@ describe("ChatMessages scroll policy", () => {
 
       const live = document.querySelector('[aria-live="polite"]');
       expect(live?.textContent ?? "").toBe("");
-      // Mounting raced hydration: the first observation saw an empty
-      // transcript, so no known row anchors the positional frame and no
-      // completion anchors the recency frame. The hydrated snapshot is
-      // history, not a live tail.
-      rerenderMessages([
-        makeMessage(0, "user"),
-        {
-          ...makeMessage(1, "assistant"),
-          completedAt: 1_700_000_000_000,
-          stopped: null,
-          runState: null,
-          showCompletionFooter: true,
-        },
-      ]);
+      // Mount raced hydration: the tile renders before the first snapshot
+      // lands, so the transcript is empty and the store still reports no
+      // baseline. The snapshot that follows IS the baseline - completed
+      // history, however recent, never announces.
+      rerenderWith({
+        baselineEpoch: 0,
+        messages: [
+          makeMessage(0, "user"),
+          {
+            ...makeMessage(1, "assistant"),
+            completedAt: 1_700_000_000_000,
+            stopped: null,
+            runState: null,
+            showCompletionFooter: true,
+          },
+        ],
+      });
       await settleLegendList();
 
       expect(live?.textContent ?? "").toBe("");
@@ -4009,6 +4094,7 @@ describe("ChatMessages scroll policy", () => {
             epicId="epic-1"
             hostId={null}
             messages={messages}
+            baselineEpoch={0}
             backgroundItems={undefined}
             getMessageActions={() => null}
             nextStepActions={null}

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -89,6 +89,8 @@ import type {
   ChatMessage as ChatMessageModel,
   MessageSegment,
 } from "@/stores/composer/chat-store";
+import type { ChatAnnouncementKind } from "@/stores/chats/chat-announcements";
+import { useChatAnnouncements } from "@/stores/chats/chat-announcements";
 import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { LegendListRef } from "@legendapp/list/react";
 import {
@@ -114,6 +116,12 @@ interface ChatMessagesProps {
   hostId: string | null;
   /** The full derived, pinned-todo-stripped row history to hand to LegendList. */
   messages: ReadonlyArray<ChatMessageModel>;
+  /**
+   * `ChatSessionState.transcriptBaselineEpoch` - which connection's snapshot
+   * established these rows. The polite-announcement deriver needs it to tell
+   * a live arrival from (re)hydrated history without guessing from row shape.
+   */
+  baselineEpoch: number;
   /** Live host-owned background items; undefined means the connected host lacks support. */
   backgroundItems: ReadonlyArray<BackgroundItem> | undefined;
   getMessageActions: (message: ChatMessageModel) => ChatMessageActions | null;
@@ -802,185 +810,25 @@ function resolvePendingMeasuredFreeRestore(
   };
 }
 
-/** Per-row snapshot the completion announcer diffs between observations. */
-interface AssistantCompletionObservation {
-  readonly completedAt: number | null;
-  readonly footerless: boolean;
-  /** Notification-content version; see `notificationSignatureOf`. */
-  readonly notificationSignature: string | null;
-  /** Settled (non-`live`) trigger count; decides completion vs update copy. */
-  readonly terminalTriggerCount: number;
-}
-
-/** What the completion announcer remembers from its previous observation. */
-interface TranscriptObservation {
-  readonly assistantById: ReadonlyMap<string, AssistantCompletionObservation>;
-  /** Every message id (any role) - the positional fallback frame. */
-  readonly messageIds: ReadonlySet<string>;
-  /** Newest completion timestamp observed - the recency frame. */
-  readonly maxCompletedAt: number | null;
-}
-
-/**
- * Content version of a row's autonomous-resume notification: the protocol
- * appends additional triggers to the existing divider when more monitored
- * tasks settle while the chat stays idle, so the same row can gain a new
- * background completion without any footer or id change. Each trigger is
- * encoded by its `live` state, not just counted - a still-running producer
- * that settles flips in place (`l` → `t`) with no length change, and that
- * transition is exactly the completion the reader is waiting to hear.
- */
-function notificationSignatureOf(message: ChatMessageModel): string | null {
-  const parts: string[] = [];
-  for (const segment of message.segments) {
-    if (segment.kind !== "autonomous_resume") continue;
-    const states = segment.triggers
-      .map((trigger) => (trigger.live ? "l" : "t"))
-      .join("");
-    parts.push(`${segment.id}:${states}`);
+function announcementTextFor(
+  taskTitle: string,
+  kind: ChatAnnouncementKind,
+): string {
+  switch (kind) {
+    case "turn-completed":
+      return `${taskTitle} finished responding.`;
+    case "background-update":
+      return `${taskTitle} received a background update.`;
+    default:
+      return `${taskTitle} received a background completion.`;
   }
-  return parts.length === 0 ? null : parts.join("|");
-}
-
-function terminalTriggerCountOf(message: ChatMessageModel): number {
-  let count = 0;
-  for (const segment of message.segments) {
-    if (segment.kind !== "autonomous_resume") continue;
-    for (const trigger of segment.triggers) {
-      if (!trigger.live) count += 1;
-    }
-  }
-  return count;
-}
-
-function hasLiveTrigger(message: ChatMessageModel): boolean {
-  return message.segments.some(
-    (segment) =>
-      segment.kind === "autonomous_resume" &&
-      segment.triggers.some((trigger) => trigger.live),
-  );
-}
-
-/**
- * A footerless row's announcement mirrors what actually settled. A `live`
- * trigger is a producer that was STILL RUNNING when the digest rendered -
- * the visible card says so - and announcing it as a "completion" would
- * contradict the screen. Completion copy therefore requires a settled
- * trigger the reader has not heard yet; news that is only still-running
- * producers is an update. A footerless row with no trigger digest at all
- * keeps completion copy - its only announceable change is its own terminal
- * transition.
- */
-function turnCompletionAnnouncementText(input: {
-  readonly taskTitle: string;
-  readonly message: ChatMessageModel;
-  readonly priorTerminalTriggerCount: number;
-}): string {
-  if (input.message.showCompletionFooter !== false) {
-    return `${input.taskTitle} finished responding.`;
-  }
-  const terminalAdded =
-    terminalTriggerCountOf(input.message) > input.priorTerminalTriggerCount;
-  if (!terminalAdded && hasLiveTrigger(input.message)) {
-    return `${input.taskTitle} received a background update.`;
-  }
-  return `${input.taskTitle} received a background completion.`;
-}
-
-/**
- * Whether an unknown terminal row is a live arrival rather than
- * hydration/backfill (this component supports transcripts growing after
- * mount). Sorted position cannot decide this alone: the projector
- * deliberately anchors a notification at its turn's original transcript
- * position, so a background task from an earlier turn that settles late
- * inserts BEFORE later rows. Completion recency is therefore the primary
- * frame - a live arrival's completion is at least as new as everything
- * previously observed. An exact timestamp tie counts as live BY CHOICE:
- * wall-clock stamps are not unique, the row snapshot carries no further
- * evidence (position provably cannot rank a tie - a tied live insertion
- * lands before known rows), and the failure costs are asymmetric - a
- * spurious polite announcement on the astronomically rare tied backfill is
- * noise, while a swallowed real completion strands a screen-reader user
- * waiting on a background task. Position decides only before any completion
- * has been observed, and needs a baseline - a previously observed row still
- * present in the transcript. Without one (first non-empty frame after
- * mounting on a still-hydrating chat) every row is history, not a live
- * tail.
- */
-function unknownRowIsLiveCompletion(input: {
-  readonly previous: TranscriptObservation;
-  readonly message: ChatMessageModel;
-  readonly index: number;
-  readonly lastKnownIndex: number;
-  readonly replacedIncompleteAssistant: boolean;
-}): boolean {
-  if (input.replacedIncompleteAssistant) return true;
-  const { maxCompletedAt } = input.previous;
-  const { completedAt } = input.message;
-  if (maxCompletedAt !== null && completedAt !== null) {
-    return completedAt >= maxCompletedAt;
-  }
-  return input.lastKnownIndex >= 0 && input.index > input.lastKnownIndex;
-}
-
-/**
- * Whether a known row's change is a fresh completion: `completedAt`
- * transitioning null → timestamp; a footerless notification adopted by its
- * provider turn (footer flips on, `completedAt` moves between two non-null
- * lifecycle values); or a footerless notification's content changing - an
- * added trigger, or a still-running trigger settling in place. A bare
- * `completedAt` shift with footer and notification content unchanged - a
- * canonicalized snapshot timestamp - stays silent.
- */
-function knownRowNewlyCompleted(
-  prior: AssistantCompletionObservation,
-  message: ChatMessageModel,
-): boolean {
-  if (prior.completedAt === null) return true;
-  if (!prior.footerless) return false;
-  if (message.showCompletionFooter !== false) return true;
-  return notificationSignatureOf(message) !== prior.notificationSignature;
-}
-
-function findNewlyCompletedAssistant(
-  previous: TranscriptObservation,
-  messages: ReadonlyArray<ChatMessageModel>,
-): ChatMessageModel | null {
-  const currentIds = new Set(messages.map((message) => message.id));
-  const replacedIncompleteAssistant = [...previous.assistantById].some(
-    ([id, observation]) =>
-      observation.completedAt === null && !currentIds.has(id),
-  );
-  let lastKnownIndex = -1;
-  for (const [index, message] of messages.entries()) {
-    if (previous.messageIds.has(message.id)) lastKnownIndex = index;
-  }
-  let completedAssistant: ChatMessageModel | null = null;
-  for (const [index, message] of messages.entries()) {
-    if (message.role !== "assistant") continue;
-    if (message.completedAt === null || message.stopped !== null) continue;
-    const prior = previous.assistantById.get(message.id);
-    const isFreshCompletion =
-      prior === undefined
-        ? unknownRowIsLiveCompletion({
-            previous,
-            message,
-            index,
-            lastKnownIndex,
-            replacedIncompleteAssistant,
-          })
-        : knownRowNewlyCompleted(prior, message);
-    if (isFreshCompletion) {
-      completedAssistant = message;
-    }
-  }
-  return completedAssistant;
 }
 
 function ChatMessagesInner(props: ChatMessagesInnerProps) {
   const {
     getMessageActions,
     backgroundItems,
+    baselineEpoch,
     composerOverlayHeight,
     identity,
     instanceId,
@@ -2497,71 +2345,18 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
 
   // --- Accessibility (decision #24): polite turn-completion announcement ----
 
-  const [turnCompletionAnnouncement, setTurnCompletionAnnouncement] = useState<{
-    readonly key: string;
-    readonly text: string;
-  } | null>(null);
-  const transcriptObservationRef = useRef<TranscriptObservation | null>(null);
-  const announcementSeqRef = useRef(0);
+  // Liveness is NOT inferred here: `useChatAnnouncements` reads the store's
+  // transcript baseline (which connection hydrated these rows) and reports
+  // the semantic transition. This layer only renders it.
+  const announcement = useChatAnnouncements({ messages, baselineEpoch });
   useLayoutEffect(() => {
-    const previous = transcriptObservationRef.current;
-    const assistantById = new Map<string, AssistantCompletionObservation>();
-    const messageIds = new Set<string>();
-    let maxCompletedAt: number | null = null;
-    for (const message of messages) {
-      messageIds.add(message.id);
-      if (message.role !== "assistant") continue;
-      assistantById.set(message.id, {
-        completedAt: message.completedAt,
-        footerless: message.showCompletionFooter === false,
-        notificationSignature: notificationSignatureOf(message),
-        terminalTriggerCount: terminalTriggerCountOf(message),
-      });
-      if (
-        message.completedAt !== null &&
-        (maxCompletedAt === null || message.completedAt > maxCompletedAt)
-      ) {
-        maxCompletedAt = message.completedAt;
-      }
-    }
-    transcriptObservationRef.current = {
-      assistantById,
-      messageIds,
-      maxCompletedAt,
-    };
-    // The first observation only records the baseline: transcript history
-    // present at mount must never announce, including footerless rows that
-    // are born terminal.
-    if (previous === null) return;
-    const completedAssistant = findNewlyCompletedAssistant(previous, messages);
-    if (completedAssistant !== null) {
-      // The key is a monotonic sequence, NOT row identity: two consecutive
-      // announcements can share id, completion timestamp AND text (a second
-      // trigger settling in the same millisecond), and an unchanged key
-      // would leave the live-region DOM unmutated - silent to screen
-      // readers.
-      announcementSeqRef.current += 1;
-      const announcement = {
-        key: String(announcementSeqRef.current),
-        text: turnCompletionAnnouncementText({
-          taskTitle,
-          message: completedAssistant,
-          priorTerminalTriggerCount:
-            previous.assistantById.get(completedAssistant.id)
-              ?.terminalTriggerCount ?? 0,
-        }),
-      };
-      // Decision #10/#16: turn completion below the fold stays anchored - no
-      // auto-reveal. The pill flips to "New reply" instead, unless the
-      // reader is already at the tail (nothing to signal).
-      const hasUnseenCompletion =
-        timelineScrollModeRef.current !== "following-end";
-      queueMicrotask(() => {
-        setTurnCompletionAnnouncement(announcement);
-        if (hasUnseenCompletion) setHasUnseenTurnCompletion(true);
-      });
-    }
-  }, [messages, taskTitle]);
+    if (announcement === null) return;
+    // Decision #10/#16: turn completion below the fold stays anchored - no
+    // auto-reveal. The pill flips to "New reply" instead, unless the reader
+    // is already at the tail (nothing to signal).
+    if (timelineScrollModeRef.current === "following-end") return;
+    setHasUnseenTurnCompletion(true);
+  }, [announcement]);
 
   // --- Stateful scroll-to-end pill (decision #16) ----------------------------
 
@@ -2651,9 +2446,11 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
           ) : null}
         </div>
         <div aria-live="polite" className="sr-only">
-          {turnCompletionAnnouncement === null ? null : (
-            <span key={turnCompletionAnnouncement.key}>
-              {turnCompletionAnnouncement.text}
+          {announcement === null ? null : (
+            // Keyed by the deriver's monotonic sequence so consecutive
+            // identical announcements still mutate the live region.
+            <span key={announcement.sequence}>
+              {announcementTextFor(taskTitle, announcement.kind)}
             </span>
           )}
         </div>

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -2349,6 +2349,25 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
   // transcript baseline (which connection hydrated these rows) and reports
   // the semantic transition. This layer only renders it.
   const announcement = useChatAnnouncements({ messages, baselineEpoch });
+  // The rendered sentence is FROZEN when the announcement is made, not
+  // recomputed per render: `taskTitle` is live (a chat is auto-titled right
+  // after its first turn, and can be renamed any time). Recomputing would
+  // rewrite the text inside the already-announced live-region node, and a
+  // screen reader re-announces on content change - a phantom completion for
+  // a rename. A later announcement re-freezes with the title current then.
+  const [renderedAnnouncement, setRenderedAnnouncement] = useState<{
+    readonly sequence: number;
+    readonly text: string;
+  } | null>(null);
+  if (
+    announcement !== null &&
+    renderedAnnouncement?.sequence !== announcement.sequence
+  ) {
+    setRenderedAnnouncement({
+      sequence: announcement.sequence,
+      text: announcementTextFor(taskTitle, announcement.kind),
+    });
+  }
   useLayoutEffect(() => {
     if (announcement === null) return;
     // Decision #10/#16: turn completion below the fold stays anchored - no
@@ -2446,11 +2465,11 @@ function ChatMessagesInner(props: ChatMessagesInnerProps) {
           ) : null}
         </div>
         <div aria-live="polite" className="sr-only">
-          {announcement === null ? null : (
+          {renderedAnnouncement === null ? null : (
             // Keyed by the deriver's monotonic sequence so consecutive
             // identical announcements still mutate the live region.
-            <span key={announcement.sequence}>
-              {announcementTextFor(taskTitle, announcement.kind)}
+            <span key={renderedAnnouncement.sequence}>
+              {renderedAnnouncement.text}
             </span>
           )}
         </div>

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1047,6 +1047,7 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
                 tabHostId={view.tabHostId}
                 workspaceRoots={view.linkResolutionRoots}
                 messages={view.messages}
+                baselineEpoch={view.transcriptBaselineEpoch}
                 backgroundItems={view.lower.backgroundItems}
                 scrollRequest={backgroundScrollRequest}
                 surfaceVisible={view.surfaceVisible}
@@ -1256,6 +1257,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       connectionStatus: s.connectionStatus,
       fatalClose: s.fatalClose,
       snapshotLoaded: s.snapshotLoaded,
+      transcriptBaselineEpoch: s.transcriptBaselineEpoch,
       chat: s.chat,
       access: s.access,
       messages: s.messages,
@@ -2354,6 +2356,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     linkResolutionRoots,
     currentEpicId,
     snapshotLoaded: state.snapshotLoaded,
+    transcriptBaselineEpoch: state.transcriptBaselineEpoch,
     fatalClose: state.fatalClose,
     onChatRetry: () => handle.store.getState().retry(),
     restoreContext,
@@ -2400,6 +2403,8 @@ interface ChatSessionMessagesSurfaceProps {
   readonly tabHostId: string | null;
   readonly workspaceRoots: ReadonlyArray<string>;
   readonly messages: ReadonlyArray<ChatMessageModel>;
+  /** Which connection's snapshot established `messages`; see `ChatMessages`. */
+  readonly baselineEpoch: number;
   readonly backgroundItems: ReadonlyArray<BackgroundItem> | undefined;
   readonly scrollRequest: ChatMessageScrollRequest | null;
   readonly surfaceVisible: boolean;
@@ -2510,6 +2515,7 @@ function ChatSessionMessagesSurface(
               epicId={props.epicId}
               hostId={props.tabHostId}
               messages={props.messages}
+              baselineEpoch={props.baselineEpoch}
               backgroundItems={props.backgroundItems}
               scrollRequest={props.scrollRequest}
               getMessageActions={props.getMessageActions}

--- a/clients/gui-app/src/lib/chats/published-chat-session.ts
+++ b/clients/gui-app/src/lib/chats/published-chat-session.ts
@@ -261,6 +261,10 @@ export function publishedChatSessionState(
     // The whole point - the transcript is here, so the surface renders it
     // rather than a loading gate.
     snapshotLoaded: true,
+    // A published copy is complete and frozen: this stands in for the
+    // snapshot that established it, so the transcript is absorbed as
+    // baseline history and nothing in it is ever announced as live.
+    transcriptBaselineEpoch: 0,
     chat: {
       parentId: null,
       id: input.chatId,

--- a/clients/gui-app/src/stores/chats/chat-announcements.ts
+++ b/clients/gui-app/src/stores/chats/chat-announcements.ts
@@ -1,0 +1,202 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import type { ChatMessage } from "@/stores/composer/chat-store";
+
+/**
+ * Polite-announcement deriver for the chat transcript (decision #24).
+ *
+ * The announcement question is "what just happened for this reader", and the
+ * only hard part is separating a LIVE arrival from transcript history. This
+ * deriver never infers that from row shape - not from sorted position, not
+ * from completion recency, not from timestamp comparisons, all of which are
+ * undecidable for cases the projector legitimately produces (a background
+ * task from an earlier turn settles late and its notification is anchored at
+ * that turn's ORIGINAL transcript position, i.e. before rows the reader has
+ * already seen; wall-clock stamps are not unique, so recency cannot rank
+ * simultaneous completions either).
+ *
+ * Instead liveness comes from HOW the data reached the client, which the
+ * chat session store knows exactly:
+ *
+ * - `baselineEpoch` changes whenever an authoritative snapshot re-established
+ *   the transcript for a NEW connection (mount hydration, reconnect
+ *   backfill). Everything visible at that moment is history by construction -
+ *   it is silently absorbed as the new baseline, however it sorts and
+ *   whenever it completed.
+ * - While the epoch is unchanged the client is connected and watching, so any
+ *   row that reaches a settled state - or whose background-completion digest
+ *   changes - is news, again regardless of position or timestamp.
+ *
+ * That leaves announcement selection a pure function of per-row semantic
+ * state keyed by row id, with no cross-row comparisons and no tie-breaking.
+ */
+
+export type ChatAnnouncementKind =
+  "turn-completed" | "background-completion" | "background-update";
+
+export interface ChatAnnouncement {
+  /**
+   * Monotonic per-transcript counter. Two consecutive announcements can be
+   * identical in every other respect (same row, same wall-clock stamp, same
+   * copy) when a second background task settles in the same millisecond, so
+   * the live region must key its child on this to guarantee a DOM mutation -
+   * without one, React reuses the node and a screen reader stays silent.
+   */
+  readonly sequence: number;
+  readonly kind: ChatAnnouncementKind;
+}
+
+/** `baselineEpoch` for a transcript whose first snapshot has not landed. */
+export const NO_TRANSCRIPT_BASELINE = -1;
+
+interface RowAnnouncementState {
+  /** Terminal and not user-stopped: a Stop is the reader's own action. */
+  readonly settled: boolean;
+  /** A background-completion notification rather than a provider turn. */
+  readonly footerless: boolean;
+  /**
+   * Content version of the row's resume notification. Encodes each trigger's
+   * `live` state, not just a count: the protocol appends triggers to the
+   * existing divider while the chat stays idle, AND a still-running producer
+   * settles IN PLACE (count unchanged, `live` flips off) - both are new
+   * background news on an otherwise unchanged row.
+   */
+  readonly notificationDigest: string | null;
+  /** Settled (non-`live`) triggers; decides completion vs update copy. */
+  readonly settledTriggerCount: number;
+  readonly hasLiveTrigger: boolean;
+}
+
+function rowAnnouncementState(message: ChatMessage): RowAnnouncementState {
+  const digestParts: string[] = [];
+  let settledTriggerCount = 0;
+  let hasLiveTrigger = false;
+  for (const segment of message.segments) {
+    if (segment.kind !== "autonomous_resume") continue;
+    let states = "";
+    for (const trigger of segment.triggers) {
+      if (trigger.live) {
+        hasLiveTrigger = true;
+        states += "l";
+      } else {
+        settledTriggerCount += 1;
+        states += "t";
+      }
+    }
+    digestParts.push(`${segment.id}:${states}`);
+  }
+  return {
+    settled: message.completedAt !== null && message.stopped === null,
+    footerless: message.showCompletionFooter === false,
+    notificationDigest: digestParts.length === 0 ? null : digestParts.join("|"),
+    settledTriggerCount,
+    hasLiveTrigger,
+  };
+}
+
+/**
+ * Copy selection for a settled row. A `live: true` trigger is a producer that
+ * was STILL RUNNING when the digest rendered - the visible card says so - and
+ * calling that a "completion" would contradict the screen. Completion copy
+ * therefore requires a settled trigger the reader has not heard about yet; a
+ * row whose only news is still-running producers gets update copy. A
+ * footerless row with no trigger digest keeps completion copy: its own
+ * terminal transition is the only thing it can be announcing.
+ */
+function announcementKindForSettledRow(
+  next: RowAnnouncementState,
+  priorSettledTriggerCount: number,
+): ChatAnnouncementKind {
+  if (!next.footerless) return "turn-completed";
+  if (next.settledTriggerCount > priorSettledTriggerCount) {
+    return "background-completion";
+  }
+  return next.hasLiveTrigger ? "background-update" : "background-completion";
+}
+
+/**
+ * The announceable transitions, all on a stable row id:
+ *
+ * - a row the reader has never seen arrives settled (a batched snapshot can
+ *   deliver a notification and its adopting provider turn together, and the
+ *   live row is replaced by its persisted row under a new id);
+ * - a known row reaches a settled state;
+ * - a footerless notification is adopted by its provider turn (the footer
+ *   flips on);
+ * - a footerless notification's digest changes (a trigger is appended, or a
+ *   still-running one settles in place).
+ *
+ * A settled row whose footer and digest are both unchanged stays silent -
+ * that is a canonicalized snapshot timestamp, not news.
+ */
+function announcementKindFor(
+  prior: RowAnnouncementState | undefined,
+  next: RowAnnouncementState,
+): ChatAnnouncementKind | null {
+  if (!next.settled) return null;
+  if (prior === undefined) return announcementKindForSettledRow(next, 0);
+  if (!prior.settled) {
+    return announcementKindForSettledRow(next, prior.settledTriggerCount);
+  }
+  if (!prior.footerless) return null;
+  if (!next.footerless) return "turn-completed";
+  if (next.notificationDigest === prior.notificationDigest) return null;
+  return announcementKindForSettledRow(next, prior.settledTriggerCount);
+}
+
+export interface ChatAnnouncementsInput {
+  readonly messages: ReadonlyArray<ChatMessage>;
+  /**
+   * `ChatSessionState.transcriptBaselineEpoch` - the connection whose
+   * authoritative snapshot established the current transcript. A change means
+   * "this transcript was (re)hydrated wholesale"; an unchanged value means
+   * "we have been connected and watching since the last observation".
+   */
+  readonly baselineEpoch: number;
+}
+
+export function useChatAnnouncements(
+  input: ChatAnnouncementsInput,
+): ChatAnnouncement | null {
+  const { messages, baselineEpoch } = input;
+  const [announcement, setAnnouncement] = useState<ChatAnnouncement | null>(
+    null,
+  );
+  const observedRef = useRef<ReadonlyMap<string, RowAnnouncementState> | null>(
+    null,
+  );
+  const baselineEpochRef = useRef<number | null>(null);
+  const sequenceRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const observed = new Map<string, RowAnnouncementState>();
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+      observed.set(message.id, rowAnnouncementState(message));
+    }
+    const previous = observedRef.current;
+    const previousEpoch = baselineEpochRef.current;
+    observedRef.current = observed;
+    baselineEpochRef.current = baselineEpoch;
+    // First observation, or a snapshot that re-established the transcript:
+    // absorb it as the baseline. History never announces.
+    if (previous === null || previousEpoch !== baselineEpoch) return;
+    let kind: ChatAnnouncementKind | null = null;
+    for (const message of messages) {
+      const next = observed.get(message.id);
+      if (next === undefined) continue;
+      const candidate = announcementKindFor(previous.get(message.id), next);
+      // Last announceable row wins: a batch that settles one turn while
+      // appending the next running one announces the settled turn.
+      if (candidate !== null) kind = candidate;
+    }
+    if (kind === null) return;
+    sequenceRef.current += 1;
+    const sequence = sequenceRef.current;
+    // Deferred out of the layout pass: the announcement drives a sibling
+    // latch and a live-region child, neither of which belongs in the commit
+    // that produced the rows.
+    queueMicrotask(() => setAnnouncement({ sequence, kind }));
+  }, [messages, baselineEpoch]);
+
+  return announcement;
+}

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -15,6 +15,7 @@ import {
   removeOptimisticQueuedItemByClientActionId,
   removeOptimisticQueuedItemByMessageId,
 } from "@/stores/chats/optimistic-queue";
+import { NO_TRANSCRIPT_BASELINE } from "@/stores/chats/chat-announcements";
 import type {
   StreamFlushCoordinator,
   StreamFlushLease,
@@ -321,6 +322,22 @@ export interface ChatSessionState {
    */
   readonly fatalClose: FatalErrorDetails | null;
   readonly snapshotLoaded: boolean;
+  /**
+   * The connection whose authoritative snapshot established the CURRENT
+   * transcript, or `NO_TRANSCRIPT_BASELINE` before the first one lands.
+   *
+   * Consumers that must tell a live arrival from transcript history read
+   * this instead of inferring it from row shape (see `useChatAnnouncements`):
+   * a changed value means the transcript was (re)hydrated wholesale - mount,
+   * or a reconnect that can backfill rows written while this client was
+   * away - so whatever is visible is history. An unchanged value means the
+   * client has been connected and watching since the last observation, so
+   * anything that appears or settles is live, however it sorts and whenever
+   * its timestamps say it happened. Steady-state snapshots on the SAME
+   * connection (an authoritative host-side refresh) deliberately keep the
+   * value, since those carry live news too.
+   */
+  readonly transcriptBaselineEpoch: number;
   readonly chat: Chat | null;
   readonly access: ChatAccess | null;
   readonly messages: ReadonlyArray<Message>;
@@ -1092,6 +1109,10 @@ export function createChatSessionStoreWithNotificationDependencies(
             failedSendRestoration: settled.failedSendRestoration,
             restore: sweepStaleRestoreSlot(state.restore, connectionEpoch),
             snapshotLoaded: true,
+            // Stamped with the CONNECTION, not a per-snapshot counter: a
+            // reconnect's backfill re-baselines transcript consumers, while a
+            // steady-state refresh on this same connection does not.
+            transcriptBaselineEpoch: connectionEpoch,
             worktreeBinding: frame.snapshot.worktreeBinding,
             missingWorktreePaths: frame.snapshot.missingWorktreePaths,
             liveAssistantMessage: liveAssistantForTurnStateFrame({
@@ -1802,6 +1823,7 @@ export function createChatSessionStoreWithNotificationDependencies(
       connectionStatus: "connecting",
       fatalClose: null,
       snapshotLoaded: false,
+      transcriptBaselineEpoch: NO_TRANSCRIPT_BASELINE,
       chat: null,
       access: null,
       messages: [],


### PR DESCRIPTION
## Summary

Replaces the chat transcript's polite-announcement inference with a semantic
event derived from the session store's transcript baseline, so the live-region
layer stops guessing whether a row is a live arrival or history.

Follow-up to #1178, which fixed eight review-flagged cells in that inference.

## Why

The announcer had to answer exactly one question — is this row a LIVE arrival
or transcript history — and it answered by diffing rendered row snapshots:
sorted position, completion recency, timestamp ties, footer flips. Every one of
those frames is undecidable for output the projector legitimately produces:

- A background task from an earlier turn settles late, and the projector
  deliberately anchors its notification at that turn's ORIGINAL transcript
  position — so it lands BEFORE rows the reader has already seen, exactly where
  backfill lands. Position cannot separate them.
- Wall-clock completion stamps are not unique, so recency cannot rank
  simultaneous completions, and a tie has no shape-based tie-breaker at all.

Each fix narrowed one cell and exposed the next, because the information simply
is not in the rows.

## Approach

Liveness is not a property of a row's shape — it is a property of how the row
reached the client, which `chat-session-store` knows exactly. It now publishes
`transcriptBaselineEpoch`, the connection whose authoritative snapshot
established the current transcript:

- **Changed** → the transcript was (re)hydrated wholesale (mount, or a reconnect
  that can backfill rows written while this client was away). What is visible is
  history and is absorbed silently as the new baseline.
- **Unchanged** → the client has been connected and watching since the last
  observation, so anything that appears or settles is news, however it sorts and
  whenever its timestamps say it happened.
- A steady-state refresh on the *same* connection deliberately keeps the value,
  since those frames carry live news too.

`useChatAnnouncements` (new, `stores/chats/chat-announcements.ts`) consumes that
and reports a semantic event — `turn-completed`, `background-completion`,
`background-update` — selected per row by stable id, with no cross-row
comparison and no tie-breaking. `chat-messages.tsx` only renders the copy and
keys the live region on the deriver's monotonic sequence.

Deleted with the inference: `unknownRowIsLiveCompletion`,
`knownRowNewlyCompleted`, `findNewlyCompletedAssistant`,
`notificationSignatureOf`, `terminalTriggerCountOf`, `hasLiveTrigger`,
`turnCompletionAnnouncementText`, and the transcript observation tracking
`maxCompletedAt` and message positions (-275 lines in the component).

## Behavior

Preserved for every case the previous heuristics got right. The tests now state
the rule rather than the workaround:

- a live notification announces even when it sorts **before** known rows **and**
  carries an **older** stamp than the newest known completion — the case no
  shape-based heuristic could ever get right;
- a reconnect's backfill re-baselines instead of announcing;
- a same-connection authoritative refresh still announces;
- re-baselining is a one-frame reset, not a mute;
- first hydration after an empty mount stays silent;
- copy still distinguishes a settled background task from a still-running
  (`live: true`) one.

## Validation

- `chat-messages.test.tsx` + `rendered-messages.test.tsx` — 237 passed
- `chat-session-store.test.ts` + `lib/chats` suites — 284 passed
- ESLint (`--max-warnings 0`) and Prettier clean on all changed files

Note: `bun run compile` in my working tree reports pre-existing errors unrelated
to this change (duplicate `prosemirror-view` versions, missing
`@tanstack/react-form`) in files this PR does not touch; CI installs fresh deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)