### PR TITLE
feat(protocol,gui-app): byte-exact non-UTF-8 paths across the split PR diff

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -54,17 +54,6 @@ regexes = [
 ]
 
 [[allowlists]]
-description = "PR-diff byte-path token fixtures (protocol 1.1 pathBytes sidecars). Each value is base64 of a NON-UTF-8 test FILENAME ('bad-\\xff.txt' / 'bad-\\xfe.txt'), which the generic-api-key rule matches only because the test constants are literally named *_TOKEN. A path token is a public wire identity, never a credential. Value-pinned and path-scoped to the two suites; fetch-depth: 0 means the PR scan sees the introducing commit on the in-flight branch, so this cannot wait for a rename."
-condition = "AND"
-regexTarget = "secret"
-paths = [
-  '''^clients/gui-app/src/components/epic-canvas/(?:pr/__tests__/pr-local-diff-body|renderers/__tests__/pr-diff-tile-find)\.test\.tsx$''',
-]
-regexes = [
-  '''^YmFkLf[84]udHh0$''',
-]
-
-[[allowlists]]
 description = "RFC 6455's public sample client nonce in the historic loopback handshake probe. Require both the exact nonce and its source path so unrelated findings remain reportable."
 condition = "AND"
 regexTarget = "secret"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -54,6 +54,17 @@ regexes = [
 ]
 
 [[allowlists]]
+description = "PR-diff byte-path token fixtures (protocol 1.1 pathBytes sidecars). Each value is base64 of a NON-UTF-8 test FILENAME ('bad-\\xff.txt' / 'bad-\\xfe.txt'), which the generic-api-key rule matches only because the test constants are literally named *_TOKEN. A path token is a public wire identity, never a credential. Value-pinned and path-scoped to the two suites; fetch-depth: 0 means the PR scan sees the introducing commit on the in-flight branch, so this cannot wait for a rename."
+condition = "AND"
+regexTarget = "secret"
+paths = [
+  '''^clients/gui-app/src/components/epic-canvas/(?:pr/__tests__/pr-local-diff-body|renderers/__tests__/pr-diff-tile-find)\.test\.tsx$''',
+]
+regexes = [
+  '''^YmFkLf[84]udHh0$''',
+]
+
+[[allowlists]]
 description = "RFC 6455's public sample client nonce in the historic loopback handshake probe. Require both the exact nonce and its source path so unrelated findings remain reportable."
 condition = "AND"
 regexTarget = "secret"

--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-bundle-diff-find.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-bundle-diff-find.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PrLocalDiffSummaryFile } from "@traycer/protocol/host/pr-schemas";
+import type { PrLocalDiffSummaryFileV11 } from "@traycer/protocol/host/pr-schemas";
 import { isPrLocalDiffLargeFile } from "@/lib/pr/pr-local-diff-large-file";
 import {
   prBundleDiffFindFileId,
@@ -7,8 +7,8 @@ import {
 } from "@/components/epic-canvas/pr/pr-bundle-diff-find";
 
 function file(
-  overrides: Partial<PrLocalDiffSummaryFile>,
-): PrLocalDiffSummaryFile {
+  overrides: Partial<PrLocalDiffSummaryFileV11>,
+): PrLocalDiffSummaryFileV11 {
   return {
     path: "src/a.ts",
     previousPath: null,
@@ -16,6 +16,8 @@ function file(
     insertions: 3,
     deletions: 1,
     isBinary: false,
+    pathBytes: null,
+    previousPathBytes: null,
     ...overrides,
   };
 }
@@ -43,9 +45,11 @@ describe("isPrLocalDiffLargeFile", () => {
 });
 
 describe("prBundleDiffFindFileId", () => {
-  it("prefixes the path with pr:", () => {
+  it("prefixes the tagged canonical file key with pr:", () => {
+    // A clean (non-byte-addressed) path tags as `p:` before the `pr:` prefix
+    // is added - see `prLocalDiffFileKey`.
     expect(prBundleDiffFindFileId(file({ path: "src/a.ts" }))).toBe(
-      "pr:src/a.ts",
+      "pr:p:src/a.ts",
     );
   });
 });
@@ -53,7 +57,7 @@ describe("prBundleDiffFindFileId", () => {
 describe("prBundleLoadedPatchCacheKey", () => {
   function key(overrides: {
     readonly comparisonKey?: string;
-    readonly file?: PrLocalDiffSummaryFile;
+    readonly file?: PrLocalDiffSummaryFileV11;
     readonly ignoreWhitespace?: boolean;
     readonly isTruncated?: boolean;
   }): string {

--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-local-diff-body.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-local-diff-body.test.tsx
@@ -14,9 +14,9 @@ import { VirtuosoMockContext } from "react-virtuoso";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type {
   PrGetLocalDiffResponse,
-  PrGetLocalDiffSummaryResponse,
+  PrGetLocalDiffSummaryResponseV11,
   PrGetLocalFileDiffResponse,
-  PrLocalDiffSummaryFile,
+  PrLocalDiffSummaryFileV11,
 } from "@traycer/protocol/host/pr-schemas";
 import { DEFAULT_PR_LOCAL_FILE_DIFF_BYTE_BUDGET } from "@traycer/protocol/host/pr-schemas";
 import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
@@ -136,8 +136,8 @@ function diffResponse(
 }
 
 function summaryFile(
-  overrides: Partial<PrLocalDiffSummaryFile>,
-): PrLocalDiffSummaryFile {
+  overrides: Partial<PrLocalDiffSummaryFileV11>,
+): PrLocalDiffSummaryFileV11 {
   return {
     path: "src/a.ts",
     previousPath: null,
@@ -145,15 +145,17 @@ function summaryFile(
     insertions: 3,
     deletions: 1,
     isBinary: false,
+    pathBytes: null,
+    previousPathBytes: null,
     ...overrides,
   };
 }
 
 function summaryResponse(
   overrides: Partial<
-    Extract<PrGetLocalDiffSummaryResponse, { kind: "summary" }>
+    Extract<PrGetLocalDiffSummaryResponseV11, { kind: "summary" }>
   >,
-): PrGetLocalDiffSummaryResponse {
+): PrGetLocalDiffSummaryResponseV11 {
   return {
     kind: "summary",
     runningDir: "/tmp/worktrees/widgets",
@@ -180,11 +182,19 @@ function fileDiffOk(
   };
 }
 
+/** The `pathBytes` a `pr.getLocalFileDiff` request carried, or `null`. */
+function requestPathBytes(params: unknown): string | null {
+  if (typeof params !== "object" || params === null) return null;
+  if (!("pathBytes" in params)) return null;
+  const pathBytes = params.pathBytes;
+  return typeof pathBytes === "string" ? pathBytes : null;
+}
+
 function bodyTree(args: {
   readonly node: PrDiffTileRef;
   readonly viewTabId: string;
   readonly target: PrLocalDiffTarget | null;
-  readonly summary: PrGetLocalDiffSummaryResponse | null;
+  readonly summary: PrGetLocalDiffSummaryResponseV11 | null;
   readonly monolith: PrGetLocalDiffResponse | null;
   readonly onRangeDrift: (() => void) | undefined;
   readonly preferences: DiffViewerPreferences | undefined;
@@ -224,7 +234,7 @@ function renderBody(args: {
   readonly node: PrDiffTileRef;
   readonly viewTabId: string;
   readonly target: PrLocalDiffTarget | null;
-  readonly summary: PrGetLocalDiffSummaryResponse | null;
+  readonly summary: PrGetLocalDiffSummaryResponseV11 | null;
   readonly monolith: PrGetLocalDiffResponse | null;
   readonly onRangeDrift: (() => void) | undefined;
   readonly preferences: DiffViewerPreferences | undefined;
@@ -321,7 +331,7 @@ describe("PrLocalDiffBody (monolith fallback)", () => {
     // patch the moment the tile opens.
     const node: PrDiffTileRef = {
       ...tile(),
-      view: { collapsedFilePaths: ["src/a.ts"] },
+      view: { collapsedFileKeys: ["p:src/a.ts"] },
     };
     const tabId = openRealTabWithTile(node);
     renderMonolith({
@@ -352,8 +362,8 @@ describe("PrLocalDiffBody (monolith fallback)", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     fireEvent.click(toggle);
 
-    expect(tileOnTab(tabId, node.instanceId).view.collapsedFilePaths).toEqual([
-      "src/a.ts",
+    expect(tileOnTab(tabId, node.instanceId).view.collapsedFileKeys).toEqual([
+      "p:src/a.ts",
     ]);
   });
 
@@ -514,6 +524,64 @@ describe("PrLocalDiffBody (split)", () => {
     expect(files).toHaveLength(2);
     expect(files[0]?.textContent).toContain("src/a.ts");
     expect(files[1]?.textContent).toContain("src/b.ts");
+  });
+
+  it("keeps two lossy-name-colliding files as distinct rows, each fetching with its own pathBytes token", async () => {
+    // Both files decode to the SAME lossy display path ("bad-�.txt") but
+    // carry different raw-byte tokens (bytes of "bad-\xff.txt" and
+    // "bad-\xfe.txt" respectively) - the exact collision the tagged key space
+    // exists to keep apart.
+    const TOKEN_A = "YmFkLf8udHh0";
+    const TOKEN_B = "YmFkLf4udHh0";
+    const node = tile();
+    const tabId = openRealTabWithTile(node);
+    tabHostClient.request.mockImplementation(
+      (method: string, params: unknown) => {
+        if (method !== "pr.getLocalFileDiff") {
+          return Promise.reject(new Error(`unexpected method ${method}`));
+        }
+        const token = requestPathBytes(params) ?? "MISSING";
+        return Promise.resolve(
+          fileDiffOk({
+            patch: `diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+${token}`,
+          }),
+        );
+      },
+    );
+    renderBody({
+      node,
+      viewTabId: tabId,
+      target: localDiffTarget(),
+      summary: summaryResponse({
+        files: [
+          summaryFile({ path: "bad-�.txt", pathBytes: TOKEN_A }),
+          summaryFile({ path: "bad-�.txt", pathBytes: TOKEN_B }),
+        ],
+      }),
+      monolith: null,
+      onRangeDrift: undefined,
+      preferences: undefined,
+    });
+
+    const rows = await screen.findAllByTestId("pr-diff-file");
+    expect(rows).toHaveLength(2);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("diff-content")).toHaveLength(2);
+    });
+    const contents = screen.getAllByTestId("diff-content");
+    const texts = contents.map((el) => el.textContent);
+    expect(texts.filter((text) => text.includes(TOKEN_A))).toHaveLength(1);
+    expect(texts.filter((text) => text.includes(TOKEN_B))).toHaveLength(1);
+
+    const fileDiffCalls = tabHostClient.request.mock.calls.filter(
+      (call) => call[0] === "pr.getLocalFileDiff",
+    );
+    expect(fileDiffCalls).toHaveLength(2);
+    const tokensSent = fileDiffCalls
+      .map((call) => requestPathBytes(call[1]))
+      .sort();
+    expect(tokensSent).toEqual([TOKEN_A, TOKEN_B].sort());
   });
 
   it("fetches a mounted expanded section and renders the patch", async () => {
@@ -782,7 +850,7 @@ describe("PrLocalDiffBody (split)", () => {
   it("does not fetch a collapsed split-mode file, and collapse still writes the store", () => {
     const node: PrDiffTileRef = {
       ...tile(),
-      view: { collapsedFilePaths: ["src/a.ts"] },
+      view: { collapsedFileKeys: ["p:src/a.ts"] },
     };
     const tabId = openRealTabWithTile(node);
     tabHostClient.request.mockResolvedValue(fileDiffOk({}));
@@ -804,7 +872,7 @@ describe("PrLocalDiffBody (split)", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     fireEvent.click(toggle);
 
-    expect(tileOnTab(tabId, node.instanceId).view.collapsedFilePaths).toEqual(
+    expect(tileOnTab(tabId, node.instanceId).view.collapsedFileKeys).toEqual(
       [],
     );
   });

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-bundle-diff-find.ts
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-bundle-diff-find.ts
@@ -1,8 +1,12 @@
 import { useCallback, useMemo, type RefObject } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
-import type { PrLocalDiffSummaryFile } from "@traycer/protocol/host/pr-schemas";
 import { getBasename, getDirname } from "@/lib/path/cross-platform-path";
 import { isPrLocalDiffLargeFile } from "@/lib/pr/pr-local-diff-large-file";
+import {
+  isPrLocalDiffFileCollapsed,
+  prLocalDiffFileKey,
+  type PrLocalDiffViewFile,
+} from "@/lib/pr/pr-local-diff-file-key";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { TILE_KIND_PR_DIFF } from "@/stores/epics/canvas/tile-kinds";
 import type { PrDiffTileRef } from "@/stores/epics/canvas/types";
@@ -27,12 +31,13 @@ export type PrBundleDiffFindPatchMode = "split" | "monolith";
 // Stable identity for a PR range-diff file within the find index. Shared by
 // the session (coverage / loaded-patch registration) and the section renderer
 // (`data-bundle-diff-file-id`, `notifySectionMounted`) so reveal targets the
-// same file id the index was built with. Keyed on `path` alone because that is
-// the list's row identity too (`computeItemKey`): a range diff names each
-// destination path once, and a rename's `previousPath` is a property of the
-// row, not a second row.
-export function prBundleDiffFindFileId(file: PrLocalDiffSummaryFile): string {
-  return `pr:${file.path}`;
+// same file id the index was built with. Keyed on the CANONICAL file key
+// because that is the list's row identity too (`computeItemKey`): a range
+// diff names each destination once, and a rename's previous side is a
+// property of the row, not a second row - but the lossy `path` alone is NOT
+// unique when two byte paths replace to the same string.
+export function prBundleDiffFindFileId(file: PrLocalDiffViewFile): string {
+  return `pr:${prLocalDiffFileKey(file)}`;
 }
 
 /**
@@ -46,7 +51,7 @@ export function prBundleDiffFindFileId(file: PrLocalDiffSummaryFile): string {
  */
 export function prBundleLoadedPatchCacheKey(args: {
   readonly comparisonKey: string;
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly ignoreWhitespace: boolean;
   readonly isTruncated: boolean;
 }): string {
@@ -56,6 +61,10 @@ export function prBundleLoadedPatchCacheKey(args: {
     args.ignoreWhitespace,
     args.file.previousPath,
     args.file.path,
+    // The byte-path sidecars are patch identity too: two lossy-name
+    // colliding files carry different patches under the same `path` string.
+    args.file.previousPathBytes,
+    args.file.pathBytes,
     args.isTruncated ? "truncated" : "full",
   ]);
 }
@@ -70,7 +79,7 @@ export function prBundleLoadedPatchCacheKey(args: {
  * (see `gitBundleDiffFindCoverageState`).
  */
 function prBundleDiffFindCoverageState(args: {
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly collapsed: boolean;
   /** Monolith mode: the patch the response carried, `null` past the budget. */
   readonly monolithPatch: string | null | undefined;
@@ -83,7 +92,7 @@ function prBundleDiffFindCoverageState(args: {
 }
 
 function prBundleDiffFindFileInput(args: {
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly collapsed: boolean;
   readonly monolithPatch: string | null | undefined;
 }): BundleDiffFindFileInput {
@@ -131,7 +140,7 @@ function prBundleDiffFindContentIdentity(args: {
   readonly comparisonKey: string;
   readonly patchMode: PrBundleDiffFindPatchMode;
   readonly ignoreWhitespace: boolean;
-  readonly files: ReadonlyArray<PrLocalDiffSummaryFile>;
+  readonly files: ReadonlyArray<PrLocalDiffViewFile>;
 }): string {
   return JSON.stringify([
     "pr-diff",
@@ -141,6 +150,8 @@ function prBundleDiffFindContentIdentity(args: {
     args.files.map((file) => [
       file.path,
       file.previousPath,
+      file.pathBytes,
+      file.previousPathBytes,
       file.status,
       file.isBinary,
       file.insertions,
@@ -167,7 +178,7 @@ function prBundleDiffFindContentIdentity(args: {
 export function usePrBundleDiffFind(args: {
   readonly node: PrDiffTileRef;
   readonly viewTabId: string;
-  readonly files: ReadonlyArray<PrLocalDiffSummaryFile>;
+  readonly files: ReadonlyArray<PrLocalDiffViewFile>;
   readonly comparisonKey: string;
   readonly patchMode: PrBundleDiffFindPatchMode;
   /** Monolith mode's per-path patches (`null` = past the budget), else null. */
@@ -191,18 +202,23 @@ export function usePrBundleDiffFind(args: {
   } = args;
   const nodeId = node.id;
   const nodeView = node.view;
-  const collapsedFilePaths = nodeView.collapsedFilePaths;
+  // Collapse membership goes through the SAME predicate the row chevron and
+  // the toolbar's collapse-all use (`isPrLocalDiffFileCollapsed`), so find
+  // coverage, reveal-expand and the visible chevrons can never disagree
+  // about what "collapsed" means. Monolith patch lookups stay on the lossy
+  // `path` - that map came from a source whose identity IS the lossy string.
+  const collapsedFileKeys = nodeView.collapsedFileKeys;
 
   const bundleFindFiles = useMemo(
     () =>
       files.map((file) =>
         prBundleDiffFindFileInput({
           file,
-          collapsed: collapsedFilePaths.includes(file.path),
+          collapsed: isPrLocalDiffFileCollapsed(collapsedFileKeys, file),
           monolithPatch: monolithPatches?.get(file.path),
         }),
       ),
-    [collapsedFilePaths, files, monolithPatches],
+    [collapsedFileKeys, files, monolithPatches],
   );
   const bundleFindNavigationFiles = useMemo(
     () =>
@@ -215,32 +231,28 @@ export function usePrBundleDiffFind(args: {
   const collapsedBundleFindFileIds = useMemo(
     () =>
       new Set(
-        bundleFindFiles.flatMap((file) =>
-          collapsedFilePaths.includes(file.filePath) ? [file.id] : [],
+        files.flatMap((file) =>
+          isPrLocalDiffFileCollapsed(collapsedFileKeys, file)
+            ? [prBundleDiffFindFileId(file)]
+            : [],
         ),
       ),
-    [bundleFindFiles, collapsedFilePaths],
+    [collapsedFileKeys, files],
   );
   const expandBundleFindFile = useCallback(
     (fileId: string): void => {
-      const file = bundleFindFiles.find((candidate) => candidate.id === fileId);
+      const file = files.find(
+        (candidate) => prBundleDiffFindFileId(candidate) === fileId,
+      );
       if (file === undefined) return;
-      if (!collapsedFilePaths.includes(file.filePath)) return;
+      if (!isPrLocalDiffFileCollapsed(collapsedFileKeys, file)) return;
+      const fileKey = prLocalDiffFileKey(file);
       updateView(viewTabId, nodeId, {
         ...nodeView,
-        collapsedFilePaths: collapsedFilePaths.filter(
-          (filePath) => filePath !== file.filePath,
-        ),
+        collapsedFileKeys: collapsedFileKeys.filter((key) => key !== fileKey),
       });
     },
-    [
-      bundleFindFiles,
-      collapsedFilePaths,
-      nodeId,
-      nodeView,
-      updateView,
-      viewTabId,
-    ],
+    [collapsedFileKeys, files, nodeId, nodeView, updateView, viewTabId],
   );
   const bundleFindNavigation = useBundleDiffFindNavigation({
     files: bundleFindNavigationFiles,

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-local-diff-body.tsx
@@ -12,8 +12,7 @@ import { FileWarning } from "lucide-react";
 import { Virtuoso } from "react-virtuoso";
 import type {
   PrGetLocalDiffResponse,
-  PrGetLocalDiffSummaryResponse,
-  PrLocalDiffSummaryFile,
+  PrGetLocalDiffSummaryResponseV11,
   PrLocalDiffUnavailableReason,
 } from "@traycer/protocol/host/pr-schemas";
 import { DEFAULT_PR_LOCAL_FILE_DIFF_BYTE_BUDGET } from "@traycer/protocol/host/pr-schemas";
@@ -36,6 +35,12 @@ import {
 import type { DiffViewerPreferences } from "@/lib/diff/diff-viewer-preferences";
 import { isPrLocalDiffLargeFile } from "@/lib/pr/pr-local-diff-large-file";
 import {
+  isPrLocalDiffFileCollapsed,
+  prLocalDiffFileKey,
+  prLocalDiffPreviousSideKey,
+  type PrLocalDiffViewFile,
+} from "@/lib/pr/pr-local-diff-file-key";
+import {
   isHostUnsupportedError,
   usePrLocalFileDiffQuery,
   type PrLocalDiffTarget,
@@ -45,7 +50,7 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { PrDiffTileRef } from "@/stores/epics/canvas/types";
 
 type PrLocalDiffSummarySuccess = Extract<
-  PrGetLocalDiffSummaryResponse,
+  PrGetLocalDiffSummaryResponseV11,
   { kind: "summary" }
 >;
 
@@ -102,16 +107,20 @@ type PrDiffPatchMode =
  */
 function sectionStateKey(
   mode: PrDiffPatchMode,
-  file: PrLocalDiffSummaryFile,
+  file: PrLocalDiffViewFile,
   ignoreWhitespace: boolean,
 ): string {
   return [
     mode.comparisonKey,
     String(ignoreWhitespace),
-    file.previousPath ?? "",
-    file.path,
-    // NUL-joined: it is the one byte a git path can never contain, so two
-    // fields can never collide into another identity’s key.
+    // Tagged per-side identities, not the lossy display strings: two files
+    // whose replaced names collide must not share an approval, and a rename
+    // side is byte-addressed independently of its partner.
+    prLocalDiffPreviousSideKey(file),
+    prLocalDiffFileKey(file),
+    // NUL-joined: it is the one byte neither a git path nor a base64 token
+    // can contain, so two fields can never collide into another identity's
+    // key.
   ].join("\0");
 }
 
@@ -209,7 +218,7 @@ export function PrLocalDiffBody(props: {
   readonly viewTabId: string;
   readonly target: PrLocalDiffTarget | null;
   /** The summary response, when the host supports the split methods. */
-  readonly summary: PrGetLocalDiffSummaryResponse | null;
+  readonly summary: PrGetLocalDiffSummaryResponseV11 | null;
   /** The monolith response, only in `E_HOST_UNSUPPORTED` fallback mode. */
   readonly monolith: PrGetLocalDiffResponse | null;
   /** Bounded range-drift recovery - see the tile's `handleRangeDrift`. */
@@ -223,6 +232,26 @@ export function PrLocalDiffBody(props: {
       monolithDiff === null
         ? null
         : new Map(monolithDiff.files.map((file) => [file.path, file.patch])),
+    [monolithDiff],
+  );
+  // The mode seam's normalization: monolith files become view files with
+  // `null` sidecars (legacy-unknown - a 1.0 host never reported byte paths),
+  // so every consumer below the seam keys files one way and the tagged keys
+  // all degrade to `p:` in fallback mode, by construction.
+  const monolithViewFiles = useMemo(
+    () =>
+      monolithDiff === null
+        ? null
+        : monolithDiff.files.map((file): PrLocalDiffViewFile => ({
+            path: file.path,
+            previousPath: file.previousPath,
+            status: file.status,
+            insertions: file.insertions,
+            deletions: file.deletions,
+            isBinary: file.isBinary,
+            pathBytes: null,
+            previousPathBytes: null,
+          })),
     [monolithDiff],
   );
 
@@ -250,14 +279,18 @@ export function PrLocalDiffBody(props: {
     );
   }
 
-  if (monolithDiff !== null && monolithPatches !== null) {
+  if (
+    monolithDiff !== null &&
+    monolithPatches !== null &&
+    monolithViewFiles !== null
+  ) {
     return (
       <PrLocalDiffFilesView
         node={props.node}
         viewTabId={props.viewTabId}
         isStale={monolithDiff.isStale}
         localHeadOid={monolithDiff.localHeadOid}
-        files={monolithDiff.files}
+        files={monolithViewFiles}
         monolithTruncation={
           monolithDiff.isTruncated
             ? {
@@ -295,7 +328,7 @@ export function PrLocalDiffBody(props: {
  * "no checkout" line rather than a guess.
  */
 function unavailableReason(
-  summary: PrGetLocalDiffSummaryResponse | null,
+  summary: PrGetLocalDiffSummaryResponseV11 | null,
   monolith: PrGetLocalDiffResponse | null,
 ): PrLocalDiffUnavailableReason | null {
   if (summary?.kind === "unavailable") return summary.reason;
@@ -309,7 +342,7 @@ function unavailableReason(
 // misses have never been told apart on this surface, and the per-file error
 // blocks (split mode) are where a transient failure actually surfaces now.
 function PrLocalDiffUnavailable(props: {
-  readonly summary: PrGetLocalDiffSummaryResponse | null;
+  readonly summary: PrGetLocalDiffSummaryResponseV11 | null;
   readonly monolith: PrGetLocalDiffResponse | null;
   readonly hasTarget: boolean;
   readonly prUrl: string | null;
@@ -348,7 +381,7 @@ function PrLocalDiffFilesView(props: {
   readonly viewTabId: string;
   readonly isStale: boolean;
   readonly localHeadOid: string;
-  readonly files: readonly PrLocalDiffSummaryFile[];
+  readonly files: readonly PrLocalDiffViewFile[];
   /** Monolith mode only: the whole-PR byte budget cut the patch sweep off. */
   readonly monolithTruncation: { readonly shownPatches: number } | null;
   readonly mode: PrDiffPatchMode;
@@ -425,7 +458,7 @@ function PrLocalDiffFilesView(props: {
             data={props.files}
             className="min-h-0 flex-1"
             overscan={6}
-            computeItemKey={(_index, file) => file.path}
+            computeItemKey={(_index, file) => prLocalDiffFileKey(file)}
             // eslint-disable-next-line react/no-unstable-nested-components -- Virtuoso row renderer, not a component definition.
             itemContent={(_index, file) => (
               <PrLocalDiffFileSection
@@ -472,7 +505,7 @@ function PrLocalDiffFilesView(props: {
 function PrLocalDiffFileSection(props: {
   readonly node: PrDiffTileRef;
   readonly viewTabId: string;
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly mode: PrDiffPatchMode;
   readonly prUrl: string | null;
   readonly preferences: DiffViewerPreferences;
@@ -483,11 +516,15 @@ function PrLocalDiffFileSection(props: {
   const toggleCollapsed = useEpicCanvasStore(
     (state) => state.togglePrDiffFileCollapsedInTab,
   );
-  const collapsed = node.view.collapsedFilePaths.includes(file.path);
+  const fileKey = prLocalDiffFileKey(file);
+  const collapsed = isPrLocalDiffFileCollapsed(
+    node.view.collapsedFileKeys,
+    file,
+  );
   const { viewTabId } = props;
   const toggle = useCallback((): void => {
-    toggleCollapsed(viewTabId, node.id, file.path);
-  }, [file.path, node.id, toggleCollapsed, viewTabId]);
+    toggleCollapsed(viewTabId, node.id, fileKey);
+  }, [fileKey, node.id, toggleCollapsed, viewTabId]);
   // Re-notify when a collapsed section expands (find-driven or manual): the
   // diff body only mounts while expanded, so a mount-only notification would
   // leave a freshly-revealed match painted nowhere. The find session repaints
@@ -545,7 +582,7 @@ function PrLocalDiffFileSection(props: {
 }
 
 function PrLocalDiffFileBody(props: {
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly bundleFindFileId: string;
   readonly mode: PrDiffPatchMode;
   readonly prUrl: string | null;
@@ -596,7 +633,7 @@ function PrLocalDiffFileBody(props: {
  * diff" button swaps in the fetching body on demand.
  */
 function PrSplitFileBody(props: {
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly stateKey: string;
   readonly bundleFindFileId: string;
   readonly mode: Extract<PrDiffPatchMode, { kind: "split" }>;
@@ -637,7 +674,7 @@ function PrSplitFileBody(props: {
  * GitHub, because a host in this mode has no per-file method to ask.
  */
 function PrMonolithFileBody(props: {
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly stateKey: string;
   readonly bundleFindFileId: string;
   readonly comparisonKey: string;
@@ -682,7 +719,7 @@ function PrMonolithFileBody(props: {
   return (
     <PrPatchContent
       patch={props.patch}
-      cacheScope={`pr-local-diff:${props.file.path}`}
+      cacheScope={`pr-local-diff:${prLocalDiffFileKey(props.file)}`}
       find={{
         fileId: props.bundleFindFileId,
         cacheKey: prBundleLoadedPatchCacheKey({
@@ -705,7 +742,7 @@ function PrMonolithFileBody(props: {
  * the tile's.
  */
 function PrLocalFileDiffContent(props: {
-  readonly file: PrLocalDiffSummaryFile;
+  readonly file: PrLocalDiffViewFile;
   readonly stateKey: string;
   readonly bundleFindFileId: string;
   readonly mode: Extract<PrDiffPatchMode, { kind: "split" }>;
@@ -724,6 +761,8 @@ function PrLocalFileDiffContent(props: {
     headOid: mode.headOid,
     path: file.path,
     previousPath: file.previousPath,
+    pathBytes: file.pathBytes,
+    previousPathBytes: file.previousPathBytes,
     ignoreWhitespace: props.preferences.ignoreWhitespace,
     byteBudget: loadFull ? null : DEFAULT_PR_LOCAL_FILE_DIFF_BYTE_BUDGET,
     enabled: true,
@@ -844,7 +883,7 @@ function PrLocalFileDiffContent(props: {
       ) : null}
       <PrPatchContent
         patch={response.patch}
-        cacheScope={`pr-local-diff:${mode.mergeBaseOid}:${mode.headOid}:${file.path}`}
+        cacheScope={`pr-local-diff:${mode.mergeBaseOid}:${mode.headOid}:${prLocalDiffFileKey(file)}`}
         find={{
           fileId: bundleFindFileId,
           cacheKey: prBundleLoadedPatchCacheKey({

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/pr-diff-tile-find.test.tsx
@@ -13,9 +13,9 @@ import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messen
 import type {
   PrDetailCore,
   PrGetLocalDiffResponse,
-  PrGetLocalDiffSummaryResponse,
+  PrGetLocalDiffSummaryResponseV11,
   PrGetLocalFileDiffResponse,
-  PrLocalDiffSummaryFile,
+  PrLocalDiffSummaryFileV11,
 } from "@traycer/protocol/host/pr-schemas";
 import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
 import { TileFindScope } from "@/components/epic-canvas/tile-find/tile-find-scope";
@@ -172,21 +172,23 @@ function populatedSubscription(): PrDetailSubscriptionResult {
 }
 
 function summaryFile(
-  overrides: Partial<PrLocalDiffSummaryFile> & { readonly path: string },
-): PrLocalDiffSummaryFile {
+  overrides: Partial<PrLocalDiffSummaryFileV11> & { readonly path: string },
+): PrLocalDiffSummaryFileV11 {
   return {
     previousPath: null,
     status: "modified",
     insertions: 3,
     deletions: 1,
     isBinary: false,
+    pathBytes: null,
+    previousPathBytes: null,
     ...overrides,
   };
 }
 
 function summaryOkWithFiles(
-  files: readonly PrLocalDiffSummaryFile[],
-): PrGetLocalDiffSummaryResponse {
+  files: readonly PrLocalDiffSummaryFileV11[],
+): PrGetLocalDiffSummaryResponseV11 {
   return {
     kind: "summary",
     runningDir: "/tmp/worktrees/widgets",
@@ -291,7 +293,7 @@ function tileTree(args: {
 // test's own timeout kills it rather than `waitFor`'s much shorter one.
 async function renderTile(args: {
   readonly queryClient: QueryClient;
-  readonly collapsedFilePaths: readonly string[] | null;
+  readonly collapsedFileKeys: readonly string[] | null;
 }): Promise<{
   readonly view: RenderResult;
   readonly node: PrDiffTileRef;
@@ -305,11 +307,11 @@ async function renderTile(args: {
     prNumber: 7,
   });
   const node: PrDiffTileRef =
-    args.collapsedFilePaths === null
+    args.collapsedFileKeys === null
       ? base
       : {
           ...base,
-          view: { collapsedFilePaths: [...args.collapsedFilePaths] },
+          view: { collapsedFileKeys: [...args.collapsedFileKeys] },
         };
   const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic");
   useEpicCanvasStore.getState().openTileInTab(tabId, node);
@@ -400,7 +402,7 @@ describe("<PrDiffTile /> bundle find", () => {
     virtuosoState.renderRows = false;
     const { node } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
 
     search(node.instanceId, "beta");
@@ -427,7 +429,7 @@ describe("<PrDiffTile /> bundle find", () => {
     const queryClient = makeQueryClient();
     const rendered = await renderTile({
       queryClient,
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
     const { node, tabId } = rendered;
     await screen.findByTestId("diff-content");
@@ -463,7 +465,7 @@ describe("<PrDiffTile /> bundle find", () => {
     virtuosoState.renderRows = false;
     const { node } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: ["src/collapsed.ts"],
+      collapsedFileKeys: ["p:src/collapsed.ts"],
     });
 
     search(node.instanceId, "src");
@@ -492,7 +494,7 @@ describe("<PrDiffTile /> bundle find", () => {
     );
     const { node, tabId } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: ["src/collapse-target.ts"],
+      collapsedFileKeys: ["p:src/collapse-target.ts"],
     });
     await screen.findByTestId("diff-content");
 
@@ -503,8 +505,53 @@ describe("<PrDiffTile /> bundle find", () => {
       expect.objectContaining({ index: 1 }),
     );
     expect(
-      tileOnTab(tabId, node.instanceId).view.collapsedFilePaths,
-    ).not.toContain("src/collapse-target.ts");
+      tileOnTab(tabId, node.instanceId).view.collapsedFileKeys,
+    ).not.toContain("p:src/collapse-target.ts");
+  });
+
+  it("counts a byte-keyed collapsed file in coverage, and reveals it by removing exactly its tagged key", async () => {
+    const BYTE_TOKEN = "YmFkLf8udHh0";
+    const files = [
+      summaryFile({ path: "src/normal.ts" }),
+      summaryFile({ path: "src/byte-target.ts", pathBytes: BYTE_TOKEN }),
+    ];
+    tabHostClient.request.mockImplementation(
+      (method: string, params: unknown) => {
+        if (method === "pr.getLocalDiffSummary")
+          return Promise.resolve(summaryOkWithFiles(files));
+        if (method === "pr.getLocalFileDiff")
+          return Promise.resolve(
+            fileDiffOk(patchWithNeedle(requestPath(params), "Needle")),
+          );
+        return Promise.reject(new Error(`unexpected method ${method}`));
+      },
+    );
+    const { node, tabId } = await renderTile({
+      queryClient: makeQueryClient(),
+      // Collapsed via its TAGGED `b:` key, not the lossy `p:<path>` form -
+      // the byte file has no bare-path entry at all.
+      collapsedFileKeys: [`b:${BYTE_TOKEN}`],
+    });
+    await screen.findByTestId("diff-content");
+
+    // A query that matches both files' metadata (both live under `src/`)
+    // still counts the byte-keyed file as "collapsed" - the reveal below,
+    // which targets it specifically, is what expands it.
+    search(node.instanceId, "src");
+    expect(tileSnapshot(node.instanceId).coverageMessage ?? "").toMatch(
+      /1 collapsed file/u,
+    );
+
+    // A match on its own path reveals it: scrolls to its row and expands it
+    // by removing EXACTLY the tagged `b:` key.
+    search(node.instanceId, "byte-target");
+    expect(tileSnapshot(node.instanceId).total).toBeGreaterThanOrEqual(1);
+    expect(virtuosoState.scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 1 }),
+    );
+    expect(tileOnTab(tabId, node.instanceId).view.collapsedFileKeys).toEqual(
+      [],
+    );
   });
 
   it("registers 'failed' coverage when the split per-file fetch rejects", async () => {
@@ -518,7 +565,7 @@ describe("<PrDiffTile /> bundle find", () => {
     });
     const { node } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
     await screen.findByText("Diff Loading Error");
 
@@ -567,7 +614,7 @@ describe("<PrDiffTile /> bundle find", () => {
     });
     const { node } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
     await screen.findByTestId("diff-content");
 
@@ -593,7 +640,7 @@ describe("<PrDiffTile /> bundle find", () => {
     const queryClient = makeQueryClient();
     const rendered = await renderTile({
       queryClient,
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
     const { node, tabId } = rendered;
 
@@ -612,7 +659,7 @@ describe("<PrDiffTile /> bundle find", () => {
     // the active match's file expanded (see `useBundleDiffFindNavigation`'s
     // `reveal` - `if (collapsedFileIds.has(fileId)) expandFile(fileId)`), and
     // that reveal replays whenever the renderer identity changes, which a
-    // `collapsedFilePaths` toggle causes. Leaving the session open would have
+    // `collapsedFileKeys` toggle causes. Leaving the session open would have
     // the tile silently re-expand the file out from under the toggle below.
     act(() => {
       useTileFindStore.getState().close(node.instanceId);
@@ -627,10 +674,10 @@ describe("<PrDiffTile /> bundle find", () => {
     act(() => {
       useEpicCanvasStore
         .getState()
-        .togglePrDiffFileCollapsedInTab(tabId, node.id, "src/huge.ts");
+        .togglePrDiffFileCollapsedInTab(tabId, node.id, "p:src/huge.ts");
     });
     const collapsedNode = tileOnTab(tabId, node.instanceId);
-    expect(collapsedNode.view.collapsedFilePaths).toContain("src/huge.ts");
+    expect(collapsedNode.view.collapsedFileKeys).toContain("p:src/huge.ts");
     rendered.view.rerender(
       tileTree({ queryClient, node: collapsedNode, tabId }),
     );
@@ -638,10 +685,10 @@ describe("<PrDiffTile /> bundle find", () => {
     act(() => {
       useEpicCanvasStore
         .getState()
-        .togglePrDiffFileCollapsedInTab(tabId, node.id, "src/huge.ts");
+        .togglePrDiffFileCollapsedInTab(tabId, node.id, "p:src/huge.ts");
     });
     const expandedNode = tileOnTab(tabId, node.instanceId);
-    expect(expandedNode.view.collapsedFilePaths).not.toContain("src/huge.ts");
+    expect(expandedNode.view.collapsedFileKeys).not.toContain("p:src/huge.ts");
     rendered.view.rerender(
       tileTree({ queryClient, node: expandedNode, tabId }),
     );
@@ -683,7 +730,7 @@ describe("<PrDiffTile /> bundle find", () => {
     );
     const { node } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
     await screen.findByTestId("diff-content");
 
@@ -733,7 +780,7 @@ describe("<PrDiffTile /> bundle find", () => {
     );
     const { node } = await renderTile({
       queryClient: makeQueryClient(),
-      collapsedFilePaths: null,
+      collapsedFileKeys: null,
     });
     await screen.findByTestId("diff-content");
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/pr-diff-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/pr-diff-tile.tsx
@@ -8,8 +8,9 @@ import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-m
 import type {
   PrDetailCore,
   PrGetLocalDiffResponse,
-  PrGetLocalDiffSummaryResponse,
+  PrGetLocalDiffSummaryResponseV11,
 } from "@traycer/protocol/host/pr-schemas";
+import { prLocalDiffPathKey } from "@/lib/pr/pr-local-diff-file-key";
 import type { PrDiffTileRef } from "@/stores/epics/canvas/types";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
@@ -81,15 +82,21 @@ export function PrDiffTile(props: PrDiffTileProps): ReactNode {
   );
 }
 
-/** What the toolbar/header need to know about whichever range resolved. */
+/**
+ * What the toolbar/header need to know about whichever range resolved.
+ * `fileKeys` are canonical file keys (`prLocalDiffFileKey`), NOT display
+ * paths: the toolbar's collapse-all writes them into the tile's
+ * `collapsedFileKeys`, so they must be the same identity the rows and the
+ * find session key by. The header only ever counts them.
+ */
 interface PrDiffRangeMeta {
   readonly resolvedBaseRef: string;
-  readonly filePaths: readonly string[];
+  readonly fileKeys: readonly string[];
 }
 
 interface PrLocalDiffTileData {
   readonly summaryQuery: UseQueryResult<
-    PrGetLocalDiffSummaryResponse,
+    PrGetLocalDiffSummaryResponseV11,
     HostRpcError
   >;
   readonly monolithQuery: UseQueryResult<PrGetLocalDiffResponse, HostRpcError>;
@@ -103,7 +110,7 @@ interface PrLocalDiffTileData {
    * keeps calling the now-missing per-file method, and the monolith fallback
    * is fetched but never read.
    */
-  readonly summaryData: PrGetLocalDiffSummaryResponse | null;
+  readonly summaryData: PrGetLocalDiffSummaryResponseV11 | null;
   /**
    * The monolith response the tile may ACT on - `null` outside fallback
    * mode. Gated HERE beside `summaryData`'s suppression so the two halves
@@ -174,41 +181,53 @@ function isMutableFileDiffEntry(query: Query): boolean {
 
 /** The OID pair naming a resolved summary range, for drift-recovery gating. */
 function summaryRangeKey(
-  summary: PrGetLocalDiffSummaryResponse | null,
+  summary: PrGetLocalDiffSummaryResponseV11 | null,
 ): string | null {
   if (summary?.kind !== "summary") return null;
   return `${summary.mergeBaseOid}..${summary.localHeadOid}`;
 }
 
-/** The toolbar's collapse-all model, or `null` before any range resolved. */
+/**
+ * The toolbar's collapse-all model, or `null` before any range resolved.
+ * The membership check is the same canonical-key comparison the row chevron
+ * and the find session make - the third of the three collapse gates. The
+ * toolbar's `filePaths` slot carries the keys OPAQUELY (it never reads
+ * them, only writes the list back wholesale).
+ */
 function collapseAllFor(
   range: PrDiffRangeMeta | null,
-  collapsedFilePaths: ReadonlyArray<string>,
+  collapsedFileKeys: ReadonlyArray<string>,
 ): { allCollapsed: boolean; filePaths: readonly string[] } | null {
-  if (range === null || range.filePaths.length === 0) return null;
+  if (range === null || range.fileKeys.length === 0) return null;
+  const collapsed = new Set(collapsedFileKeys);
   return {
-    allCollapsed: range.filePaths.every((path) =>
-      collapsedFilePaths.includes(path),
-    ),
-    filePaths: range.filePaths,
+    allCollapsed: range.fileKeys.every((key) => collapsed.has(key)),
+    filePaths: range.fileKeys,
   };
 }
 
 function resolvedRangeMeta(
-  summary: PrGetLocalDiffSummaryResponse | null,
+  summary: PrGetLocalDiffSummaryResponseV11 | null,
   monolith: PrGetLocalDiffResponse | null,
   summaryUnsupported: boolean,
 ): PrDiffRangeMeta | null {
   if (summary?.kind === "summary") {
     return {
       resolvedBaseRef: summary.resolvedBaseRef,
-      filePaths: summary.files.map((file) => file.path),
+      fileKeys: summary.files.map((file) =>
+        prLocalDiffPathKey(file.path, file.pathBytes),
+      ),
     };
   }
   if (summaryUnsupported && monolith?.kind === "diff") {
     return {
       resolvedBaseRef: monolith.resolvedBaseRef,
-      filePaths: monolith.files.map((file) => file.path),
+      // Monolith files carry no sidecars (a 1.0-only host), so every key is
+      // the clean-path form - the same normalization the body's mode seam
+      // applies.
+      fileKeys: monolith.files.map((file) =>
+        prLocalDiffPathKey(file.path, null),
+      ),
     };
   }
   return null;
@@ -281,12 +300,16 @@ function PrDiffTileLive(props: PrDiffTileProps): ReactNode {
     });
   }, [queryClient, tabHostId, target]);
 
+  // The shared toolbar's `collapsedFilePaths` slot is OPAQUE strings it only
+  // round-trips; for the PR tile those strings are canonical file keys, and
+  // the patch handler maps them back into the tile's own `collapsedFileKeys`
+  // field (never the legacy bare-path field - see `PrDiffTileViewState`).
   const toolbarView = useMemo<DiffTabToolbarView>(
     () => ({
       ...preferences,
-      collapsedFilePaths: node.view.collapsedFilePaths,
+      collapsedFilePaths: node.view.collapsedFileKeys,
     }),
-    [preferences, node.view.collapsedFilePaths],
+    [preferences, node.view.collapsedFileKeys],
   );
 
   const handleViewPatch = useCallback(
@@ -294,7 +317,7 @@ function PrDiffTileLive(props: PrDiffTileProps): ReactNode {
       if ("collapsedFilePaths" in patch) {
         updateView(props.viewTabId, node.id, {
           ...node.view,
-          collapsedFilePaths: patch.collapsedFilePaths,
+          collapsedFileKeys: patch.collapsedFilePaths,
         });
         return;
       }
@@ -372,7 +395,7 @@ function PrDiffTileLive(props: PrDiffTileProps): ReactNode {
     recoveredRangeRef.current = null;
   }, [rangeKey]);
 
-  const collapseAll = collapseAllFor(range, node.view.collapsedFilePaths);
+  const collapseAll = collapseAllFor(range, node.view.collapsedFileKeys);
   const header = prDiffTileHeader(node, core, range);
 
   return (
@@ -432,7 +455,7 @@ function prDiffTileHeader(
       secondaryLine: coordinates,
     };
   }
-  const count = range.filePaths.length;
+  const count = range.fileKeys.length;
   const fileCount = `${count} file${count === 1 ? "" : "s"}`;
   const head = core?.headRefName ?? "head";
   return {

--- a/clients/gui-app/src/hooks/pr/use-pr-local-diff.ts
+++ b/clients/gui-app/src/hooks/pr/use-pr-local-diff.ts
@@ -9,8 +9,8 @@ import type {
   PrGetLocalDiffRequest,
   PrGetLocalDiffResponse,
   PrGetLocalDiffSummaryRequest,
-  PrGetLocalDiffSummaryResponse,
-  PrGetLocalFileDiffRequest,
+  PrGetLocalDiffSummaryResponseV11,
+  PrGetLocalFileDiffRequestV11,
   PrGetLocalFileDiffResponse,
 } from "@traycer/protocol/host/pr-schemas";
 import { DEFAULT_PR_LOCAL_DIFF_BYTE_BUDGET } from "@traycer/protocol/host/pr-schemas";
@@ -224,7 +224,7 @@ export function usePrLocalDiffSummaryQuery(args: {
   readonly target: PrLocalDiffTarget | null;
   readonly ignoreWhitespace: boolean;
   readonly enabled: boolean;
-}): UseQueryResult<PrGetLocalDiffSummaryResponse, HostRpcError> {
+}): UseQueryResult<PrGetLocalDiffSummaryResponseV11, HostRpcError> {
   const hostId = useTabHostId();
   const client = useTabHostClient();
   // A non-null tab client is NOT yet a usable one: during startup, sign-in
@@ -242,7 +242,7 @@ export function usePrLocalDiffSummaryQuery(args: {
     // through `hostQueryKeys.scope`; adding it would refetch on client
     // identity drift alone.
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
-    ...queryOptions<PrGetLocalDiffSummaryResponse, HostRpcError>({
+    ...queryOptions<PrGetLocalDiffSummaryResponseV11, HostRpcError>({
       queryKey: [
         ...prQueryKeys.localDiffSummary({
           hostId,
@@ -310,6 +310,14 @@ export function usePrLocalFileDiffQuery(args: {
   readonly headOid: string;
   readonly path: string;
   readonly previousPath: string | null;
+  /**
+   * The summary row's byte-path sidecars, forwarded VERBATIM per side (never
+   * derived client-side). They are request identity: part of the query key
+   * and the wire request both, so two lossy-name-colliding files can never
+   * share a cache slot or an answer.
+   */
+  readonly pathBytes: string | null;
+  readonly previousPathBytes: string | null;
   readonly ignoreWhitespace: boolean;
   readonly byteBudget: number | null;
   readonly enabled: boolean;
@@ -337,6 +345,8 @@ export function usePrLocalFileDiffQuery(args: {
           headOid: args.headOid,
           path: args.path,
           previousPath: args.previousPath,
+          pathBytes: args.pathBytes,
+          previousPathBytes: args.previousPathBytes,
           ignoreWhitespace: args.ignoreWhitespace,
           byteBudget: args.byteBudget,
         }),
@@ -346,7 +356,7 @@ export function usePrLocalFileDiffQuery(args: {
           if (client === null) {
             throw hostClientUnavailableError("pr.getLocalFileDiff");
           }
-          const request: PrGetLocalFileDiffRequest = {
+          const request: PrGetLocalFileDiffRequestV11 = {
             epicId: target.epicId,
             linkGroupKey: target.linkGroupKey,
             repoIdentifier: target.repoIdentifier,
@@ -355,6 +365,8 @@ export function usePrLocalFileDiffQuery(args: {
             headOid: args.headOid,
             path: args.path,
             previousPath: args.previousPath,
+            pathBytes: args.pathBytes,
+            previousPathBytes: args.previousPathBytes,
             ignoreWhitespace: args.ignoreWhitespace,
             byteBudget: args.byteBudget,
           };

--- a/clients/gui-app/src/lib/diff/diff-tile-view-state.ts
+++ b/clients/gui-app/src/lib/diff/diff-tile-view-state.ts
@@ -1,7 +1,16 @@
-import type { GitDiffTileViewState } from "@/stores/epics/canvas/types";
+import type {
+  GitDiffTileViewState,
+  PrDiffTileViewState,
+} from "@/stores/epics/canvas/types";
 
 export function createDiffTileViewState(): GitDiffTileViewState {
   return {
     collapsedFilePaths: [],
+  };
+}
+
+export function createPrDiffTileViewState(): PrDiffTileViewState {
+  return {
+    collapsedFileKeys: [],
   };
 }

--- a/clients/gui-app/src/lib/pr/__tests__/pr-local-diff-file-key.test.ts
+++ b/clients/gui-app/src/lib/pr/__tests__/pr-local-diff-file-key.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import type { PrLocalDiffSummaryFileV11 } from "@traycer/protocol/host/pr-schemas";
+import {
+  isPrLocalDiffFileCollapsed,
+  prLocalDiffFileKey,
+  prLocalDiffPathKey,
+  prLocalDiffPreviousSideKey,
+} from "../pr-local-diff-file-key";
+
+function viewFile(
+  overrides: Partial<PrLocalDiffSummaryFileV11>,
+): PrLocalDiffSummaryFileV11 {
+  return {
+    path: "src/a.ts",
+    previousPath: null,
+    status: "modified",
+    insertions: 1,
+    deletions: 1,
+    isBinary: false,
+    pathBytes: null,
+    previousPathBytes: null,
+    ...overrides,
+  };
+}
+
+describe("prLocalDiffFileKey / prLocalDiffPathKey", () => {
+  it("tags a clean path with p: and a byte token with b:", () => {
+    expect(prLocalDiffPathKey("src/a.ts", null)).toBe("p:src/a.ts");
+    expect(prLocalDiffPathKey("src/a.ts", "dG9rZW4=")).toBe("b:dG9rZW4=");
+  });
+
+  // The whole point of the tag: without it, a clean file literally NAMED
+  // like some other file's token would collide with that file's key in the
+  // same string space. `YmFkLf8udHh0` is real base64 (the byte token of
+  // `bad-\xff.txt`) and also a syntactically valid file name.
+  it("keeps a clean file named like a token distinct from the byte file that token belongs to", () => {
+    const cleanFileNamedLikeAToken = viewFile({
+      path: "YmFkLf8udHh0",
+      pathBytes: null,
+    });
+    const byteFile = viewFile({
+      path: "bad-�.txt",
+      pathBytes: "YmFkLf8udHh0",
+    });
+
+    const cleanKey = prLocalDiffFileKey(cleanFileNamedLikeAToken);
+    const byteKey = prLocalDiffFileKey(byteFile);
+
+    expect(cleanKey).toBe("p:YmFkLf8udHh0");
+    expect(byteKey).toBe("b:YmFkLf8udHh0");
+    expect(cleanKey).not.toBe(byteKey);
+  });
+
+  it("keys a byte-addressed file on its token, not its lossy display path", () => {
+    const fileA = viewFile({ path: "bad-�.txt", pathBytes: "AAAA" });
+    const fileB = viewFile({ path: "bad-�.txt", pathBytes: "BBBB" });
+    expect(prLocalDiffFileKey(fileA)).not.toBe(prLocalDiffFileKey(fileB));
+  });
+});
+
+describe("prLocalDiffPreviousSideKey", () => {
+  it("is empty for a non-rename (previousPath null)", () => {
+    expect(prLocalDiffPreviousSideKey(viewFile({ previousPath: null }))).toBe(
+      "",
+    );
+  });
+
+  it("tags a clean rename source with p:", () => {
+    const file = viewFile({
+      previousPath: "old/path.ts",
+      previousPathBytes: null,
+    });
+    expect(prLocalDiffPreviousSideKey(file)).toBe("p:old/path.ts");
+  });
+
+  it("tags a byte-addressed rename source with b:", () => {
+    const file = viewFile({
+      previousPath: "old-�.ts",
+      previousPathBytes: "dG9rZW4=",
+    });
+    expect(prLocalDiffPreviousSideKey(file)).toBe("b:dG9rZW4=");
+  });
+
+  // Each side is derived independently of the other - a byte destination can
+  // legitimately sit beside a clean source, and vice versa (the common
+  // rename-away-from-a-bad-name case).
+  it("derives the source side independently of the destination side: byte destination, clean source", () => {
+    const file = viewFile({
+      path: "renamed-�.ts",
+      pathBytes: "ZGVzdA==",
+      previousPath: "old/clean.ts",
+      previousPathBytes: null,
+    });
+    expect(prLocalDiffFileKey(file)).toBe("b:ZGVzdA==");
+    expect(prLocalDiffPreviousSideKey(file)).toBe("p:old/clean.ts");
+  });
+
+  it("derives the source side independently of the destination side: clean destination, byte source", () => {
+    const file = viewFile({
+      path: "new/clean.ts",
+      pathBytes: null,
+      previousPath: "old-�.ts",
+      previousPathBytes: "c3JjLXRva2Vu",
+    });
+    expect(prLocalDiffFileKey(file)).toBe("p:new/clean.ts");
+    expect(prLocalDiffPreviousSideKey(file)).toBe("b:c3JjLXRva2Vu");
+  });
+});
+
+describe("isPrLocalDiffFileCollapsed", () => {
+  it("does not match a bare-path entry equal to file.path", () => {
+    // `collapsedFileKeys` holds TAGGED keys and nothing else; a legacy or
+    // hand-built bare-path entry must not alias the tagged form.
+    const file = viewFile({ path: "src/a.ts", pathBytes: null });
+    expect(isPrLocalDiffFileCollapsed(["src/a.ts"], file)).toBe(false);
+  });
+
+  it("matches the tagged p: entry for a clean file", () => {
+    const file = viewFile({ path: "src/a.ts", pathBytes: null });
+    expect(isPrLocalDiffFileCollapsed(["p:src/a.ts"], file)).toBe(true);
+  });
+
+  it("matches the tagged b: entry for a byte-addressed file, and only that", () => {
+    const file = viewFile({
+      path: "bad-�.txt",
+      pathBytes: "YmFkLf8udHh0",
+    });
+    expect(isPrLocalDiffFileCollapsed(["b:YmFkLf8udHh0"], file)).toBe(true);
+    expect(isPrLocalDiffFileCollapsed(["p:bad-�.txt"], file)).toBe(false);
+    expect(isPrLocalDiffFileCollapsed(["bad-�.txt"], file)).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/pr/pr-diff-tile.ts
+++ b/clients/gui-app/src/lib/pr/pr-diff-tile.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { createDiffTileViewState } from "@/lib/diff/diff-tile-view-state";
+import { createPrDiffTileViewState } from "@/lib/diff/diff-tile-view-state";
 import { TILE_KIND_PR_DIFF } from "@/stores/epics/canvas/tile-kinds";
 import type { PrDiffTileRef } from "@/stores/epics/canvas/types";
 
@@ -53,6 +53,6 @@ export function makePrDiffTile(args: {
     owner: args.owner,
     repo: args.repo,
     prNumber: args.prNumber,
-    view: createDiffTileViewState(),
+    view: createPrDiffTileViewState(),
   };
 }

--- a/clients/gui-app/src/lib/pr/pr-local-diff-file-key.ts
+++ b/clients/gui-app/src/lib/pr/pr-local-diff-file-key.ts
@@ -1,0 +1,64 @@
+import type { PrLocalDiffSummaryFileV11 } from "@traycer/protocol/host/pr-schemas";
+
+/**
+ * One file of the PR diff view, in either patch mode: the 1.1 summary row
+ * shape. Monolith-fallback files normalize into it at the mode seam with
+ * `null` sidecars (legacy-unknown), so every consumer downstream of the seam
+ * keys files exactly one way. `path`/`previousPath` are DISPLAY strings
+ * (possibly lossy); `pathBytes`/`previousPathBytes` are opaque canonical
+ * tokens the host minted - never decoded client-side, only echoed and keyed.
+ */
+export type PrLocalDiffViewFile = PrLocalDiffSummaryFileV11;
+
+/**
+ * One path side's identity in the tagged key space: `b:<token>` when the
+ * side is byte-addressed, `p:<path>` when it is clean.
+ *
+ * The tag is what makes the key injective: a bare `pathBytes ?? path` would
+ * put tokens and paths in one string space, where a clean file literally
+ * NAMED like some token collides with the token's file. With the tag, the
+ * two domains cannot meet.
+ */
+export function prLocalDiffPathKey(
+  path: string,
+  pathBytes: string | null,
+): string {
+  return pathBytes !== null ? `b:${pathBytes}` : `p:${path}`;
+}
+
+/**
+ * THE identity of a PR-diff view file - its destination side, tagged.
+ * Row keys, collapse entries, find file ids, section state keys and patch
+ * cache scopes all derive from this one function; keying any of them on the
+ * lossy `path` instead is how two distinct byte paths merge into one row.
+ * Against a 1.0 host every sidecar is `null`, so every key degrades to `p:`
+ * and behavior is exactly the pre-1.1 view's.
+ */
+export function prLocalDiffFileKey(file: PrLocalDiffViewFile): string {
+  return prLocalDiffPathKey(file.path, file.pathBytes);
+}
+
+/**
+ * The rename-source side's identity, `""` for a non-rename. Derived per side
+ * and independently of the destination: a clean source beside a byte
+ * destination is legal (and the common rename-away-from-bad-name case).
+ */
+export function prLocalDiffPreviousSideKey(file: PrLocalDiffViewFile): string {
+  if (file.previousPath === null) return "";
+  return prLocalDiffPathKey(file.previousPath, file.previousPathBytes);
+}
+
+/**
+ * Collapse membership for one file - the ONE predicate behind all three
+ * collapse gates (the row chevron, the toolbar's collapse-all, and the find
+ * session's coverage/reveal), so what "collapsed" means cannot diverge
+ * between them. Entries in `collapsedFileKeys` are {@link prLocalDiffFileKey}
+ * values and nothing else; the legacy bare-path `collapsedFilePaths` field is
+ * never read for PR tiles (see `PrDiffTileViewState`).
+ */
+export function isPrLocalDiffFileCollapsed(
+  collapsedFileKeys: ReadonlyArray<string>,
+  file: PrLocalDiffViewFile,
+): boolean {
+  return collapsedFileKeys.includes(prLocalDiffFileKey(file));
+}

--- a/clients/gui-app/src/lib/query-keys/__tests__/pr-query-keys.test.ts
+++ b/clients/gui-app/src/lib/query-keys/__tests__/pr-query-keys.test.ts
@@ -61,6 +61,8 @@ const FILE_BASE = {
   headOid: "a".repeat(40),
   path: "src/a.ts",
   previousPath: null as string | null,
+  pathBytes: null as string | null,
+  previousPathBytes: null as string | null,
   ignoreWhitespace: false,
   byteBudget: 262144 as number | null,
 };
@@ -121,6 +123,8 @@ describe("prQueryKeys.localFileDiff", () => {
       { headOid: "e".repeat(40) },
       { path: "src/b.ts" },
       { previousPath: "src/old.ts" },
+      { pathBytes: "cGF0aA==" },
+      { previousPathBytes: "b2xkcGF0aA==" },
       { ignoreWhitespace: true },
       { byteBudget: null },
     ]) {

--- a/clients/gui-app/src/lib/query-keys/pr-query-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/pr-query-keys.ts
@@ -188,6 +188,12 @@ export const prQueryKeys = {
       readonly headOid: string;
       readonly path: string;
       readonly previousPath: string | null;
+      // The byte-path sidecars are part of the key because they are part of
+      // the request identity: two files whose lossy `path` strings collide
+      // differ ONLY in their tokens, and sharing a slot would hand one
+      // file's patch to the other.
+      readonly pathBytes: string | null;
+      readonly previousPathBytes: string | null;
       readonly ignoreWhitespace: boolean;
       readonly byteBudget: number | null;
     },
@@ -198,6 +204,8 @@ export const prQueryKeys = {
       args.headOid,
       args.path,
       args.previousPath,
+      args.pathBytes,
+      args.previousPathBytes,
       args.ignoreWhitespace,
       args.byteBudget,
     ] as const,

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-schema.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-schema.test.ts
@@ -11,6 +11,11 @@ import {
 } from "@/lib/git/git-diff-tile";
 import { makePrDetailTile } from "@/lib/pr/pr-detail-tile";
 import { makePrDiffTile } from "@/lib/pr/pr-diff-tile";
+import {
+  parsePrDiffTileViewState,
+  serializePrDiffTileViewState,
+} from "@/stores/epics/canvas/tile-schema/diff-tile-view";
+import { prDiffTileSchema } from "@/stores/epics/canvas/tile-schema/pr-diff-tile";
 import type {
   EpicArtifactRef,
   EpicTerminalRef,
@@ -418,5 +423,61 @@ describe("isTileRefRecordBacked", () => {
   it("treats stale unknown persisted tile kinds as not record-backed", () => {
     expect(isTileRefRecordBacked({ type: "workspaces" })).toBe(false);
     expect(isTileRefRecordBacked({ type: null })).toBe(false);
+  });
+});
+
+describe("parsePrDiffTileViewState / serializePrDiffTileViewState", () => {
+  it("ignores a legacy collapsedFilePaths field entirely - even an entry literally spelled like a tagged key", () => {
+    // `p:foo` here is a legacy BARE path (a file named "p:foo"), not a tagged
+    // key - the codec must not treat it as one just because it looks like it.
+    expect(
+      parsePrDiffTileViewState({
+        collapsedFilePaths: ["p:foo", "src/a.ts"],
+      }),
+    ).toEqual({ collapsedFileKeys: [] });
+  });
+
+  it("round-trips collapsedFileKeys through serialize -> parse", () => {
+    const view = { collapsedFileKeys: ["p:src/a.ts", "b:AAA="] };
+    expect(
+      parsePrDiffTileViewState(serializePrDiffTileViewState(view)),
+    ).toEqual(view);
+  });
+});
+
+describe("prDiffTileSchema persisted state", () => {
+  const base = makePrDiffTile({
+    hostId: HOST,
+    githubHost: "github.com",
+    owner: "acme",
+    repo: "widgets",
+    prNumber: 42,
+  });
+
+  it("hydrates a persisted tile whose view carries only legacy collapsedFilePaths with an empty collapsedFileKeys", () => {
+    const legacyPersisted = {
+      id: base.id,
+      instanceId: base.instanceId,
+      type: "pr-diff",
+      name: base.name,
+      hostId: base.hostId,
+      githubHost: base.githubHost,
+      owner: base.owner,
+      repo: base.repo,
+      prNumber: base.prNumber,
+      view: { collapsedFilePaths: ["src/a.ts"] },
+    };
+    const parsed = prDiffTileSchema.parse(legacyPersisted);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.view).toEqual({ collapsedFileKeys: [] });
+  });
+
+  it("round-trips a tile carrying tagged collapse keys through serialize -> parse", () => {
+    const ref = {
+      ...base,
+      view: { collapsedFileKeys: ["p:src/a.ts", "b:AAA="] },
+    };
+    const parsed = prDiffTileSchema.parse(prDiffTileSchema.serialize(ref));
+    expect(parsed).toEqual(ref);
   });
 });

--- a/clients/gui-app/src/stores/epics/canvas/actions.ts
+++ b/clients/gui-app/src/stores/epics/canvas/actions.ts
@@ -25,6 +25,7 @@ import type {
   EpicCanvasState,
   GitDiffTileRef,
   GitDiffTileViewState,
+  PrDiffTileViewState,
   TilesByInstanceId,
 } from "./types";
 import {
@@ -1491,7 +1492,7 @@ export function toggleSnapshotDiffBundleFileCollapsed(
 export function updatePrDiffTileView(
   state: EpicCanvasState,
   tileId: string,
-  view: GitDiffTileViewState,
+  view: PrDiffTileViewState,
 ): EpicCanvasState {
   return updateTilesWhere(
     state,
@@ -1507,16 +1508,33 @@ export function updatePrDiffTileView(
  * No `ref.diff.kind` gate, unlike the git and snapshot pairs: a PR diff tile
  * is ALWAYS the multi-file view (there is no single-file PR diff tile), so
  * there is no non-bundle variant to exclude.
+ *
+ * `fileKey` is a tagged canonical key (`prLocalDiffFileKey`), toggled in the
+ * PR tile's own `collapsedFileKeys` - deliberately NOT the shared
+ * `toggleCollapsedFilePath`, whose bare-path field the PR tile no longer
+ * reads or writes.
  */
 export function togglePrDiffFileCollapsed(
   state: EpicCanvasState,
   tileId: string,
-  filePath: string,
+  fileKey: string,
 ): EpicCanvasState {
   return updateTilesWhere(
     state,
     (ref) => ref.id === tileId && isPrDiffTileRef(ref),
-    (ref) => toggleCollapsedFilePath(ref, filePath),
+    (ref) => {
+      if (!isPrDiffTileRef(ref)) return ref;
+      const collapsed = new Set(ref.view.collapsedFileKeys);
+      if (collapsed.has(fileKey)) {
+        collapsed.delete(fileKey);
+      } else {
+        collapsed.add(fileKey);
+      }
+      return {
+        ...ref,
+        view: { ...ref.view, collapsedFileKeys: [...collapsed] },
+      };
+    },
   );
 }
 
@@ -1524,11 +1542,7 @@ function toggleCollapsedFilePath(
   ref: EpicCanvasTileRef,
   filePath: string,
 ): EpicCanvasTileRef {
-  if (
-    !isGitDiffTileRef(ref) &&
-    !isSnapshotDiffTileRef(ref) &&
-    !isPrDiffTileRef(ref)
-  ) {
+  if (!isGitDiffTileRef(ref) && !isSnapshotDiffTileRef(ref)) {
     return ref;
   }
   const collapsed = new Set(ref.view.collapsedFilePaths);

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -109,6 +109,7 @@ import {
   type CommGraphTileViewState,
   type EpicViewTab,
   type GitDiffTileViewState,
+  type PrDiffTileViewState,
   type SplitDirection,
   type TilesByInstanceId,
 } from "@/stores/epics/canvas/types";
@@ -492,7 +493,7 @@ export interface EpicCanvasStore {
   updatePrDiffTileViewInTab: (
     tabId: string,
     tileId: string,
-    view: GitDiffTileViewState,
+    view: PrDiffTileViewState,
   ) => void;
   toggleGitDiffBundleFileCollapsedInTab: (
     tabId: string,
@@ -504,10 +505,12 @@ export interface EpicCanvasStore {
     tileId: string,
     filePath: string,
   ) => void;
+  // `fileKey` is a tagged canonical key (`prLocalDiffFileKey`), never a bare
+  // path - PR collapse entries live in their own key space (`PrDiffTileViewState`).
   togglePrDiffFileCollapsedInTab: (
     tabId: string,
     tileId: string,
-    filePath: string,
+    fileKey: string,
   ) => void;
   promotePreviewInTab: (tabId: string, paneId: string) => void;
   applyNestedRouteFocus: (tabId: string, target: NestedFocusTarget) => void;
@@ -1923,10 +1926,10 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           );
         },
 
-        togglePrDiffFileCollapsedInTab: (tabId, tileId, filePath) => {
+        togglePrDiffFileCollapsedInTab: (tabId, tileId, fileKey) => {
           set((state) =>
             updateTabCanvas(state, tabId, (canvas) =>
-              togglePrDiffFileCollapsed(canvas, tileId, filePath),
+              togglePrDiffFileCollapsed(canvas, tileId, fileKey),
             ),
           );
         },

--- a/clients/gui-app/src/stores/epics/canvas/tile-schema/diff-tile-view.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-schema/diff-tile-view.ts
@@ -1,5 +1,5 @@
 import type { DesktopJsonValue } from "@/lib/windows/types";
-import type { GitDiffTileViewState } from "../types";
+import type { GitDiffTileViewState, PrDiffTileViewState } from "../types";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -24,5 +24,31 @@ export function serializeDiffTileViewState(
 ): DesktopJsonValue {
   return {
     collapsedFilePaths: [...view.collapsedFilePaths],
+  };
+}
+
+/**
+ * PR-tile codec: reads ONLY `collapsedFileKeys` (tagged canonical keys) and
+ * deliberately ignores a legacy `collapsedFilePaths` in the stored record.
+ * The two fields hold different value domains that can spell identical
+ * strings (a bare path `p:foo` vs the tagged key of `foo`), so migrating or
+ * dual-reading the old field would let a legacy entry alias a tagged key;
+ * field-level separation is the one construction where it cannot. Old PR
+ * tiles hydrate with nothing collapsed, once.
+ */
+export function parsePrDiffTileViewState(
+  value: unknown,
+): PrDiffTileViewState | null {
+  if (!isRecord(value)) return null;
+  return {
+    collapsedFileKeys: readStringArray(value.collapsedFileKeys),
+  };
+}
+
+export function serializePrDiffTileViewState(
+  view: PrDiffTileViewState,
+): DesktopJsonValue {
+  return {
+    collapsedFileKeys: [...view.collapsedFileKeys],
   };
 }

--- a/clients/gui-app/src/stores/epics/canvas/tile-schema/pr-diff-tile.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-schema/pr-diff-tile.ts
@@ -12,8 +12,8 @@ import type { TileSchema } from "./index";
 import { readTileInstanceId } from "./instance-id";
 import { isPersistedPrNumber } from "./pr-number";
 import {
-  parseDiffTileViewState,
-  serializeDiffTileViewState,
+  parsePrDiffTileViewState,
+  serializePrDiffTileViewState,
 } from "./diff-tile-view";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -33,7 +33,7 @@ function parsePrDiffTileRef(value: unknown): PrDiffTileRef | null {
   ) {
     return null;
   }
-  const view = parseDiffTileViewState(value.view);
+  const view = parsePrDiffTileViewState(value.view);
   if (view === null) return null;
   const githubHost = value.githubHost;
   const owner = value.owner;
@@ -70,7 +70,7 @@ function serializePrDiffTileRef(ref: PrDiffTileRef): DesktopJsonValue {
     owner: ref.owner,
     repo: ref.repo,
     prNumber: ref.prNumber,
-    view: serializeDiffTileViewState(ref.view),
+    view: serializePrDiffTileViewState(ref.view),
   };
 }
 

--- a/clients/gui-app/src/stores/epics/canvas/types.ts
+++ b/clients/gui-app/src/stores/epics/canvas/types.ts
@@ -184,6 +184,21 @@ export interface GitDiffTileViewState {
   readonly collapsedFilePaths: ReadonlyArray<string>;
 }
 
+/**
+ * The PR diff tile's OWN persisted view state, structurally separate from
+ * {@link GitDiffTileViewState} on purpose. Entries are tagged canonical file
+ * keys (`prLocalDiffFileKey`: `b:<token>` / `p:<path>`), not bare paths - and
+ * the field is a DIFFERENT field, not a reinterpretation of
+ * `collapsedFilePaths`, because no value-level rule can tell a legacy bare
+ * entry for a file literally named `p:foo` apart from the tagged key of
+ * `foo`. The PR tile's codec reads only this field and ignores any legacy
+ * `collapsedFilePaths` in a stored record: a one-time collapse-state reset
+ * for PR diff tiles, in exchange for keys that cannot alias.
+ */
+export interface PrDiffTileViewState {
+  readonly collapsedFileKeys: ReadonlyArray<string>;
+}
+
 export interface GitDiffFileTilePayload {
   readonly kind: "file";
   readonly runningDir: string;
@@ -432,7 +447,7 @@ export interface PrDiffTileRef {
   readonly owner: string;
   readonly repo: string;
   readonly prNumber: number;
-  readonly view: GitDiffTileViewState;
+  readonly view: PrDiffTileViewState;
 }
 
 export type EpicCanvasTileRef =

--- a/protocol/src/host/__tests__/pr-schemas.test.ts
+++ b/protocol/src/host/__tests__/pr-schemas.test.ts
@@ -1780,6 +1780,37 @@ describe("prLocalDiffSummaryFileV11Schema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("rejects every noncanonical alias of a token at the schema, so an alias can never become a distinct identity", () => {
+    // Each decodes (forgivingly) to bytes whose canonical encoding differs:
+    // missing padding, url-safe alphabet, embedded whitespace, trailing
+    // junk, nonzero padding bits, and a plainly non-base64 string.
+    const aliases = ["/w", "_w==", " dG9rZW4=", "dG9rZW4=junk", "Yf==", "not-base64"];
+    for (const alias of aliases) {
+      expect(
+        prLocalDiffSummaryFileV11Schema.safeParse({
+          ...SUMMARY_FILE_V11_BASE_FIXTURE,
+          pathBytes: alias,
+          previousPathBytes: null,
+        }).success,
+      ).toBe(false);
+      expect(
+        prGetLocalFileDiffRequestV11Schema.safeParse({
+          ...LOCAL_FILE_DIFF_REQUEST_FIXTURE,
+          pathBytes: null,
+          previousPathBytes: alias,
+        }).success,
+      ).toBe(false);
+    }
+    // The canonical spelling of the first alias's bytes IS accepted.
+    expect(
+      prLocalDiffSummaryFileV11Schema.safeParse({
+        ...SUMMARY_FILE_V11_BASE_FIXTURE,
+        pathBytes: "/w==",
+        previousPathBytes: null,
+      }).success,
+    ).toBe(true);
+  });
 });
 
 describe("prGetLocalFileDiffRequestV11Schema", () => {

--- a/protocol/src/host/__tests__/pr-schemas.test.ts
+++ b/protocol/src/host/__tests__/pr-schemas.test.ts
@@ -31,10 +31,13 @@ import {
   prGetLocalDiffResponseSchema,
   prGetLocalDiffSummaryRequestSchema,
   prGetLocalDiffSummaryResponseSchema,
+  prGetLocalDiffSummaryResponseV11Schema,
   prGetLocalFileDiffRequestSchema,
+  prGetLocalFileDiffRequestV11Schema,
   prGetLocalFileDiffResponseSchema,
   prLocalDiffFileSchema,
   prLocalDiffSummaryFileSchema,
+  prLocalDiffSummaryFileV11Schema,
   prLocalDiffOidSchema,
   prLinkGroupKeySchema,
   prRepoIdentifierSchema,
@@ -46,7 +49,11 @@ import {
   prSubscribeDetailV10,
   prGetLocalDiffV10,
   prGetLocalDiffSummaryV10,
+  prGetLocalDiffSummaryV11,
+  prGetLocalDiffSummaryUpgradeV10ToV11,
   prGetLocalFileDiffV10,
+  prGetLocalFileDiffV11,
+  prGetLocalFileDiffUpgradeV10ToV11,
 } from "@traycer/protocol/host/pr-contracts";
 import { splitConnectionManifest } from "@traycer/protocol/framework/index";
 import { hostRpcRegistry } from "@traycer/protocol/host/registry";
@@ -1597,11 +1604,217 @@ describe("pr split RPC contracts", () => {
     expect(split.manifest["pr.getLocalFileDiff"]).toBeUndefined();
     expect(split.optionalManifest["pr.getLocalDiffSummary"]).toEqual({
       major: 1,
-      minor: 0,
+      minor: 1,
     });
     expect(split.optionalManifest["pr.getLocalFileDiff"]).toEqual({
       major: 1,
-      minor: 0,
+      minor: 1,
     });
+  });
+});
+
+describe("pr split RPC v1.1 byte-path registry entries", () => {
+  it("registers the v1.1 contracts as latestMinor with the exact exported instances", () => {
+    const summary = hostRpcRegistry["pr.getLocalDiffSummary"];
+    const fileDiff = hostRpcRegistry["pr.getLocalFileDiff"];
+
+    expect(summary[1].latestMinor).toBe(1);
+    expect(fileDiff[1].latestMinor).toBe(1);
+
+    const summaryV11 = summary[1].versions[1];
+    const fileDiffV11 = fileDiff[1].versions[1];
+
+    expect(summaryV11.contract).toBe(prGetLocalDiffSummaryV11);
+    expect(fileDiffV11.contract).toBe(prGetLocalFileDiffV11);
+    expect(summaryV11.upgradeFromPreviousVersion).toBe(
+      prGetLocalDiffSummaryUpgradeV10ToV11,
+    );
+    expect(fileDiffV11.upgradeFromPreviousVersion).toBe(
+      prGetLocalFileDiffUpgradeV10ToV11,
+    );
+    expect(summaryV11.contract.schemaVersion).toEqual({ major: 1, minor: 1 });
+    expect(fileDiffV11.contract.schemaVersion).toEqual({
+      major: 1,
+      minor: 1,
+    });
+  });
+});
+
+describe("prGetLocalDiffSummaryUpgradeV10ToV11", () => {
+  it("upgradeRequest is identity - the request shape is unchanged at 1.1", () => {
+    const request = prGetLocalDiffSummaryRequestSchema.parse(
+      LOCAL_DIFF_SUMMARY_REQUEST_FIXTURE,
+    );
+    expect(prGetLocalDiffSummaryUpgradeV10ToV11.upgradeRequest(request)).toBe(
+      request,
+    );
+  });
+
+  it("fills null byte-path sidecars on every file of a v1.0 summary response, leaving everything else identical", () => {
+    const v10 = prGetLocalDiffSummaryResponseSchema.parse({
+      kind: "summary",
+      runningDir: "/tmp/worktrees/widgets",
+      resolvedBaseRef: "origin/development",
+      baseOid: "b".repeat(40),
+      mergeBaseOid: "c".repeat(40),
+      localHeadOid: "a".repeat(40),
+      isStale: false,
+      files: [
+        {
+          path: LOCAL_DIFF_FILE_FIXTURE.path,
+          previousPath: LOCAL_DIFF_FILE_FIXTURE.previousPath,
+          status: LOCAL_DIFF_FILE_FIXTURE.status,
+          insertions: LOCAL_DIFF_FILE_FIXTURE.insertions,
+          deletions: LOCAL_DIFF_FILE_FIXTURE.deletions,
+          isBinary: LOCAL_DIFF_FILE_FIXTURE.isBinary,
+        },
+      ],
+    });
+    if (v10.kind !== "summary") throw new Error("expected a summary fixture");
+
+    const upgraded = prGetLocalDiffSummaryUpgradeV10ToV11.upgradeResponse(v10);
+
+    expect(upgraded.kind).toBe("summary");
+    if (upgraded.kind !== "summary") return;
+    expect(upgraded.files).toEqual([
+      { ...v10.files[0], pathBytes: null, previousPathBytes: null },
+    ]);
+    expect(() =>
+      prGetLocalDiffSummaryResponseV11Schema.parse(upgraded),
+    ).not.toThrow();
+  });
+
+  it("passes an unavailable v1.0 response through unchanged", () => {
+    for (const reason of [
+      "no-local-checkout",
+      "repo-mismatch",
+      "ref-unavailable",
+      "no-merge-base",
+      "git-unavailable",
+    ] as const) {
+      const unavailable = prGetLocalDiffSummaryResponseSchema.parse({
+        kind: "unavailable",
+        reason,
+      });
+      const upgraded =
+        prGetLocalDiffSummaryUpgradeV10ToV11.upgradeResponse(unavailable);
+      expect(upgraded).toEqual(unavailable);
+    }
+  });
+});
+
+describe("prGetLocalFileDiffUpgradeV10ToV11", () => {
+  it("fills null byte-path sidecars on a v1.0 request", () => {
+    const request = prGetLocalFileDiffRequestSchema.parse(
+      LOCAL_FILE_DIFF_REQUEST_FIXTURE,
+    );
+    const upgraded =
+      prGetLocalFileDiffUpgradeV10ToV11.upgradeRequest(request);
+    expect(upgraded).toEqual({
+      ...request,
+      pathBytes: null,
+      previousPathBytes: null,
+    });
+    expect(() =>
+      prGetLocalFileDiffRequestV11Schema.parse(upgraded),
+    ).not.toThrow();
+  });
+
+  it("upgradeResponse is identity - the response shape is unchanged at 1.1", () => {
+    const response = prGetLocalFileDiffResponseSchema.parse({
+      kind: "diff",
+      patch: "",
+      isBinary: false,
+      isTruncated: false,
+      truncatedAfterBytes: null,
+    });
+    expect(prGetLocalFileDiffUpgradeV10ToV11.upgradeResponse(response)).toBe(
+      response,
+    );
+  });
+});
+
+const SUMMARY_FILE_V11_BASE_FIXTURE = {
+  path: LOCAL_DIFF_FILE_FIXTURE.path,
+  previousPath: null,
+  status: LOCAL_DIFF_FILE_FIXTURE.status,
+  insertions: LOCAL_DIFF_FILE_FIXTURE.insertions,
+  deletions: LOCAL_DIFF_FILE_FIXTURE.deletions,
+  isBinary: LOCAL_DIFF_FILE_FIXTURE.isBinary,
+};
+
+describe("prLocalDiffSummaryFileV11Schema", () => {
+  it("accepts a non-null token string, independently per side", () => {
+    const parsed = prLocalDiffSummaryFileV11Schema.parse({
+      ...SUMMARY_FILE_V11_BASE_FIXTURE,
+      pathBytes: "dG9rZW4=",
+      previousPathBytes: null,
+    });
+    expect(parsed.pathBytes).toBe("dG9rZW4=");
+    expect(parsed.previousPathBytes).toBeNull();
+  });
+
+  it("accepts null, independently per side", () => {
+    const parsed = prLocalDiffSummaryFileV11Schema.parse({
+      ...SUMMARY_FILE_V11_BASE_FIXTURE,
+      pathBytes: null,
+      previousPathBytes: "dG9rZW4=",
+    });
+    expect(parsed.pathBytes).toBeNull();
+    expect(parsed.previousPathBytes).toBe("dG9rZW4=");
+  });
+
+  it("rejects an empty string for either sidecar rather than treating it as a real (empty) token", () => {
+    expect(
+      prLocalDiffSummaryFileV11Schema.safeParse({
+        ...SUMMARY_FILE_V11_BASE_FIXTURE,
+        pathBytes: "",
+        previousPathBytes: null,
+      }).success,
+    ).toBe(false);
+    expect(
+      prLocalDiffSummaryFileV11Schema.safeParse({
+        ...SUMMARY_FILE_V11_BASE_FIXTURE,
+        pathBytes: null,
+        previousPathBytes: "",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("prGetLocalFileDiffRequestV11Schema", () => {
+  it("accepts a non-null token string and null, independently per side", () => {
+    const withToken = prGetLocalFileDiffRequestV11Schema.parse({
+      ...LOCAL_FILE_DIFF_REQUEST_FIXTURE,
+      pathBytes: "dG9rZW4=",
+      previousPathBytes: null,
+    });
+    expect(withToken.pathBytes).toBe("dG9rZW4=");
+    expect(withToken.previousPathBytes).toBeNull();
+
+    const withPreviousToken = prGetLocalFileDiffRequestV11Schema.parse({
+      ...LOCAL_FILE_DIFF_REQUEST_FIXTURE,
+      pathBytes: null,
+      previousPathBytes: "dG9rZW4=",
+    });
+    expect(withPreviousToken.pathBytes).toBeNull();
+    expect(withPreviousToken.previousPathBytes).toBe("dG9rZW4=");
+  });
+
+  it("rejects an empty string for either sidecar", () => {
+    expect(
+      prGetLocalFileDiffRequestV11Schema.safeParse({
+        ...LOCAL_FILE_DIFF_REQUEST_FIXTURE,
+        pathBytes: "",
+        previousPathBytes: null,
+      }).success,
+    ).toBe(false);
+    expect(
+      prGetLocalFileDiffRequestV11Schema.safeParse({
+        ...LOCAL_FILE_DIFF_REQUEST_FIXTURE,
+        pathBytes: null,
+        previousPathBytes: "",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/protocol/src/host/pr-contracts.ts
+++ b/protocol/src/host/pr-contracts.ts
@@ -9,7 +9,10 @@
  * these methods simply doesn't advertise them). The unaries must each
  * declare `degrade` and stay out of the floor - see their notes.
  */
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 import {
   prSubscribeListForEpicOpenRequestSchema,
@@ -21,7 +24,9 @@ import {
   prGetLocalDiffResponseSchema,
   prGetLocalDiffSummaryRequestSchema,
   prGetLocalDiffSummaryResponseSchema,
+  prGetLocalDiffSummaryResponseV11Schema,
   prGetLocalFileDiffRequestSchema,
+  prGetLocalFileDiffRequestV11Schema,
   prGetLocalFileDiffResponseSchema,
 } from "./pr-schemas";
 
@@ -105,6 +110,51 @@ export const prGetLocalDiffSummaryV10 = defineRpcContract({
 });
 
 /**
+ * `pr.getLocalDiffSummary@1.1` - additive byte-path sidecars
+ * (`pathBytes`/`previousPathBytes`) on every file row, so a non-UTF-8 path
+ * survives the summary -> per-file round trip byte-exactly instead of
+ * degrading to a U+FFFD-replaced string that matches nothing. Request is
+ * unchanged. A minor (not a new name) because stripping the sidecars against
+ * a 1.0 peer only loses this rare-path improvement - semantics of every
+ * existing field are unchanged - unlike the request-side "no patches" flag
+ * hazard that justified splitting the method names in the first place.
+ */
+export const prGetLocalDiffSummaryV11 = defineRpcContract({
+  method: "pr.getLocalDiffSummary",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: prGetLocalDiffSummaryRequestSchema,
+  responseSchema: prGetLocalDiffSummaryResponseV11Schema,
+});
+
+// A v1.0 host never reported byte paths; `null` here means exactly that -
+// "no byte report", which deliberately coincides with the clean-path
+// encoding. That is safe because a v1.0 host's `path` is the only identity
+// it ever served, so the client's behavior degrades to today's, on purpose.
+// Note the response fold in the OTHER direction (1.1 host serving a 1.0
+// caller) is NOT this bridge's inverse: dropping sidecars can leave two
+// identical-name rows, so the host folds rows before emission (a Zod strip
+// removes fields, not rows).
+export const prGetLocalDiffSummaryUpgradeV10ToV11 = defineUpgradePath<
+  typeof prGetLocalDiffSummaryV10,
+  typeof prGetLocalDiffSummaryV11
+>({
+  from: prGetLocalDiffSummaryV10.schemaVersion,
+  to: prGetLocalDiffSummaryV11.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) =>
+    response.kind === "summary"
+      ? {
+          ...response,
+          files: response.files.map((file) => ({
+            ...file,
+            pathBytes: null,
+            previousPathBytes: null,
+          })),
+        }
+      : response,
+});
+
+/**
  * `pr.getLocalFileDiff@1.0` - one file's patch from a range
  * `pr.getLocalDiffSummary` resolved, addressed by the summary's OID pair.
  * Mirrors `git.getFileDiff`'s per-file contract (256KiB default budget,
@@ -123,4 +173,36 @@ export const prGetLocalFileDiffV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: prGetLocalFileDiffRequestSchema,
   responseSchema: prGetLocalFileDiffResponseSchema,
+});
+
+/**
+ * `pr.getLocalFileDiff@1.1` - the request echoes the summary row's
+ * byte-path sidecars per side, so the host can address the file by its raw
+ * bytes instead of a lossy string that matches no index entry. Response is
+ * unchanged (`patch` stays lossy UTF-8 for display - renderer parity with
+ * the monolith). Shipped together with `pr.getLocalDiffSummary@1.1`: the
+ * sidecars a client echoes can only have come from a 1.1 summary.
+ */
+export const prGetLocalFileDiffV11 = defineRpcContract({
+  method: "pr.getLocalFileDiff",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: prGetLocalFileDiffRequestV11Schema,
+  responseSchema: prGetLocalFileDiffResponseSchema,
+});
+
+// Bridge-filled `null` means "legacy peer - token unavailable", NOT "path
+// verified clean UTF-8". The host treats both identically (plain string
+// pathspec, today's behavior) and never infers byte-validity from a null.
+export const prGetLocalFileDiffUpgradeV10ToV11 = defineUpgradePath<
+  typeof prGetLocalFileDiffV10,
+  typeof prGetLocalFileDiffV11
+>({
+  from: prGetLocalFileDiffV10.schemaVersion,
+  to: prGetLocalFileDiffV11.schemaVersion,
+  upgradeRequest: (request) => ({
+    ...request,
+    pathBytes: null,
+    previousPathBytes: null,
+  }),
+  upgradeResponse: (response) => response,
 });

--- a/protocol/src/host/pr-schemas.ts
+++ b/protocol/src/host/pr-schemas.ts
@@ -800,21 +800,52 @@ export type PrLocalDiffSummaryFile = z.infer<
 >;
 
 /**
+ * A byte-path sidecar token: CANONICAL standard base64 of raw path bytes.
+ *
+ * Canonicality is enforced at the schema, not just documented: clients use
+ * the token STRING as file/cache/collapse identity, so a noncanonical alias
+ * of the same bytes (`/w` for `/w==`, the url-safe alphabet, embedded
+ * whitespace, nonzero padding bits) would otherwise become a distinct
+ * identity for the same file on any peer that trusts wire validation.
+ * `btoa(atob(x)) === x` is exactly that predicate, in browser and Node
+ * alike: forgiving-base64 tolerates every alias class, so round-tripping
+ * detects each one. The host still re-validates independently - plus the
+ * checks that need the decoded bytes and the sibling field (non-UTF-8-ness,
+ * companion-path equality) - because it cannot know its caller parsed a
+ * request at all.
+ */
+export const prPathBytesTokenSchema = z
+  .string()
+  .min(1)
+  .refine(isCanonicalBase64, {
+    message: "byte-path token must be canonical base64",
+  });
+
+function isCanonicalBase64(value: string): boolean {
+  try {
+    return btoa(atob(value)) === value;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * v1.1 of one summary file: the byte-path sidecars.
  *
- * `pathBytes` / `previousPathBytes` are CANONICAL base64 of the raw path
- * bytes exactly as git reported them, non-null IFF those bytes are not valid
- * UTF-8. `path` stays what it always was - the (possibly lossy,
- * U+FFFD-bearing) UTF-8 decode, display-only - so a v1.0 reader sees exactly
- * the strings it saw before. Each rename side is derived independently: a
- * clean source beside a byte destination legitimately carries
- * `previousPathBytes: null`. Clients treat tokens as opaque: never decoded,
- * only echoed into `pr.getLocalFileDiff` and used as identity keys.
+ * `pathBytes` / `previousPathBytes` are canonical base64
+ * ({@link prPathBytesTokenSchema}) of the raw path bytes exactly as git
+ * reported them, non-null IFF those bytes are not valid UTF-8. `path` stays
+ * what it always was - the (possibly lossy, U+FFFD-bearing) UTF-8 decode,
+ * display-only - so a v1.0 reader sees exactly the strings it saw before.
+ * Each rename side is derived independently: a clean source beside a byte
+ * destination legitimately carries `previousPathBytes: null`. Clients treat
+ * tokens as opaque: never decoded, only echoed into `pr.getLocalFileDiff`
+ * and used as identity keys.
  */
 export const prLocalDiffSummaryFileV11Schema =
   prLocalDiffSummaryFileSchema.extend({
-    pathBytes: z.string().min(1).nullable(),
-    previousPathBytes: z.string().min(1).nullable(),
+    pathBytes: prPathBytesTokenSchema.nullable(),
+    previousPathBytes: prPathBytesTokenSchema.nullable(),
   });
 export type PrLocalDiffSummaryFileV11 = z.infer<
   typeof prLocalDiffSummaryFileV11Schema
@@ -939,8 +970,8 @@ export type PrGetLocalFileDiffRequest = z.infer<
  */
 export const prGetLocalFileDiffRequestV11Schema =
   prGetLocalFileDiffRequestSchema.extend({
-    pathBytes: z.string().min(1).nullable(),
-    previousPathBytes: z.string().min(1).nullable(),
+    pathBytes: prPathBytesTokenSchema.nullable(),
+    previousPathBytes: prPathBytesTokenSchema.nullable(),
   });
 export type PrGetLocalFileDiffRequestV11 = z.infer<
   typeof prGetLocalFileDiffRequestV11Schema

--- a/protocol/src/host/pr-schemas.ts
+++ b/protocol/src/host/pr-schemas.ts
@@ -800,6 +800,27 @@ export type PrLocalDiffSummaryFile = z.infer<
 >;
 
 /**
+ * v1.1 of one summary file: the byte-path sidecars.
+ *
+ * `pathBytes` / `previousPathBytes` are CANONICAL base64 of the raw path
+ * bytes exactly as git reported them, non-null IFF those bytes are not valid
+ * UTF-8. `path` stays what it always was - the (possibly lossy,
+ * U+FFFD-bearing) UTF-8 decode, display-only - so a v1.0 reader sees exactly
+ * the strings it saw before. Each rename side is derived independently: a
+ * clean source beside a byte destination legitimately carries
+ * `previousPathBytes: null`. Clients treat tokens as opaque: never decoded,
+ * only echoed into `pr.getLocalFileDiff` and used as identity keys.
+ */
+export const prLocalDiffSummaryFileV11Schema =
+  prLocalDiffSummaryFileSchema.extend({
+    pathBytes: z.string().min(1).nullable(),
+    previousPathBytes: z.string().min(1).nullable(),
+  });
+export type PrLocalDiffSummaryFileV11 = z.infer<
+  typeof prLocalDiffSummaryFileV11Schema
+>;
+
+/**
  * `pr.getLocalDiffSummary` response - the `diff` variant of
  * `pr.getLocalDiff`'s response minus per-file `patch` and minus
  * `isTruncated` (nothing here is byte-capped, so nothing can truncate).
@@ -831,6 +852,37 @@ export const prGetLocalDiffSummaryResponseSchema = z.discriminatedUnion(
 );
 export type PrGetLocalDiffSummaryResponse = z.infer<
   typeof prGetLocalDiffSummaryResponseSchema
+>;
+
+/**
+ * v1.1 `pr.getLocalDiffSummary` response: the v1.0 shape with
+ * {@link prLocalDiffSummaryFileV11Schema} rows (field docs on the v1.0
+ * schema). Only a 1.1-negotiated peer may receive two rows whose lossy
+ * `path` strings collide (distinct `pathBytes`); the host folds such rows
+ * back into the legacy lossy merge for a 1.0 caller, which keys rows and its
+ * client-side patch map by `path` alone.
+ */
+export const prGetLocalDiffSummaryResponseV11Schema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("unavailable"),
+      reason: prLocalDiffUnavailableReasonSchema,
+    }),
+    z.object({
+      kind: z.literal("summary"),
+      runningDir: z.string(),
+      resolvedBaseRef: z.string(),
+      baseOid: prLocalDiffOidSchema,
+      mergeBaseOid: prLocalDiffOidSchema,
+      localHeadOid: prLocalDiffOidSchema,
+      isStale: z.boolean(),
+      files: z.array(prLocalDiffSummaryFileV11Schema),
+    }),
+  ],
+);
+export type PrGetLocalDiffSummaryResponseV11 = z.infer<
+  typeof prGetLocalDiffSummaryResponseV11Schema
 >;
 
 /**
@@ -873,6 +925,25 @@ export const prGetLocalFileDiffRequestSchema = z.object({
 });
 export type PrGetLocalFileDiffRequest = z.infer<
   typeof prGetLocalFileDiffRequestSchema
+>;
+
+/**
+ * v1.1 `pr.getLocalFileDiff` request: the summary row's byte-path sidecars,
+ * echoed verbatim per side (never derived client-side).
+ *
+ * `null` from a 1.1 peer means "this side's `path` IS the byte-exact UTF-8
+ * path". A request that arrived through the 1.0->1.1 bridge carries
+ * bridge-filled `null`s that mean only "legacy peer - token unavailable";
+ * the host treats both identically as the plain string pathspec (today's
+ * behavior) and must never infer byte-validity from them.
+ */
+export const prGetLocalFileDiffRequestV11Schema =
+  prGetLocalFileDiffRequestSchema.extend({
+    pathBytes: z.string().min(1).nullable(),
+    previousPathBytes: z.string().min(1).nullable(),
+  });
+export type PrGetLocalFileDiffRequestV11 = z.infer<
+  typeof prGetLocalFileDiffRequestV11Schema
 >;
 
 /**

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -471,7 +471,11 @@ import {
   prSubscribeDetailV10,
   prGetLocalDiffV10,
   prGetLocalDiffSummaryV10,
+  prGetLocalDiffSummaryV11,
+  prGetLocalDiffSummaryUpgradeV10ToV11,
   prGetLocalFileDiffV10,
+  prGetLocalFileDiffV11,
+  prGetLocalFileDiffUpgradeV10ToV11,
 } from "@traycer/protocol/host/pr-contracts";
 import {
   mentionGithubCatalogV10,
@@ -6814,11 +6818,19 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
   "pr.getLocalDiffSummary": {
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: prGetLocalDiffSummaryV10,
           upgradeFromPreviousVersion: null,
+        },
+        // 1.1: byte-path sidecars (`pathBytes`/`previousPathBytes`) on every
+        // file row, so non-UTF-8 paths survive the summary -> per-file round
+        // trip. The 1.0-caller response fold (rows, not fields) lives host-
+        // side at emission; the bridge here only fills request-side nulls.
+        1: {
+          contract: prGetLocalDiffSummaryV11,
+          upgradeFromPreviousVersion: prGetLocalDiffSummaryUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},
@@ -6827,11 +6839,17 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
   "pr.getLocalFileDiff": {
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: prGetLocalFileDiffV10,
           upgradeFromPreviousVersion: null,
+        },
+        // 1.1: the request echoes the summary row's byte-path sidecars per
+        // side; bridge-filled `null` = "legacy peer", identical to clean.
+        1: {
+          contract: prGetLocalFileDiffV11,
+          upgradeFromPreviousVersion: prGetLocalFileDiffUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## What

A path with non-UTF-8 bytes breaks the split PR diff twice over: the lossy UTF-8 decode replaces invalid bytes with U+FFFD, so **(1)** the path the client echoes into `pr.getLocalFileDiff` matches no index entry and the row renders an empty patch, and **(2)** the replacement is many-to-one, so two real files whose replaced names collide merge into one summary row with the wrong patch attached. (Follow-up filed as traycerai/traycer-internal#4980 on the split that landed in #1183.)

## Protocol

- `pr.getLocalDiffSummary` and `pr.getLocalFileDiff` go **1.0 → 1.1** with additive required-nullable sidecars `pathBytes` / `previousPathBytes`: **canonical base64 of the raw path bytes, non-null iff the bytes are not valid UTF-8**, derived independently per rename side.
- Upgrade bridges fill `null` for legacy peers (the `hostStatus` 1.0→1.1 pattern). A bridge-filled `null` means "token unavailable", which the host treats identically to a clean path — today's behavior, on purpose.
- The 1.1-host-serving-a-1.0-caller response fold (rows, not fields — a Zod strip cannot merge rows) lives host-side at emission; nothing here changes the 1.0 wire.

## GUI

- File identity becomes the tagged injective key `b:<token>` / `p:<path>` (`pr-local-diff-file-key.ts`). A bare token-or-path union would let a clean file literally named like a token collide with the token's file.
- Every identity consumer keys on it: row keys, section state keys, per-file query keys and cache scopes, bundle-find file ids / cache keys / content identity, and **all three collapse gates** (row chevron, toolbar collapse-all, find session) through one shared membership predicate.
- Persisted collapse state moves to a PR-tile-only `PrDiffTileViewState.collapsedFileKeys` whose parser **ignores** the legacy `collapsedFilePaths` field entirely: no value-level rule can tell a legacy bare entry spelling `p:foo` from the tagged key of `foo`, so the separation is structural — a one-time collapse reset for PR diff tiles.
- The per-file request forwards both sidecars verbatim per side; the query key carries them (request identity).

## Compatibility

Against a 1.0 host every sidecar is `null`, every key degrades to `p:`, and behavior is exactly today's — including monolith fallback. The host-side byte-space parsing, per-side pathspec adapter, and version-gated summary emission land in the internal repo (gitlink bump after this merges).

## Tests

- Protocol: 1.1 contract/bridge/registry pins (118 tests in `pr-schemas.test.ts`).
- GUI: key-derivation units incl. the token/path collision pair; persisted-state units (legacy record → empty collapse set; tagged round-trip retained); integrated colliding-pair rendering with per-row token forwarding; find-session collapse/reveal on tagged keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)