### PR TITLE
feat(gui-app): rebuild the usage dialogs as fixed-frame mini-dashboards

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-usage-dialog.test.tsx
@@ -181,10 +181,48 @@ describe("<ChatUsageDialog />", () => {
 
     // Synchronously after opening the query has not resolved yet.
     expect(screen.getByTestId("usage-dialog-skeleton")).toBeTruthy();
-    expect(screen.queryByText("Loading usage…")).toBeNull();
+    // Skeleton visually, sr-only status audibly - the blocks themselves are
+    // `aria-hidden`, so without this the state has no accessible name.
+    expect(screen.getByRole("status").getAttribute("data-testid")).toBe(
+      "usage-dialog-skeleton",
+    );
+    expect(screen.getByText("Loading usage…").className).toContain("sr-only");
 
     await screen.findByTestId("usage-cost-figure");
     expect(screen.queryByTestId("usage-dialog-skeleton")).toBeNull();
+  });
+
+  it("qualifies an empty local-plane read rather than claiming no usage anywhere", async () => {
+    handlerHolder.current = () => {
+      const base = usageSummaryResponse();
+      return {
+        ...base,
+        servedBy: "local",
+        summary: {
+          ...base.summary,
+          totals: { ...base.summary.totals, factCount: 0, knownCostUsd: 0 },
+          buckets: [],
+          chatBuckets: [],
+          turnRows: [],
+        },
+      };
+    };
+    renderWithClient();
+    act(() => {
+      useChatUsageDialogStore.getState().open({
+        hostId: mockLocalHostEntry.hostId,
+        chatId: "chat-1",
+        chatTitle: "Fix the flaky test",
+      });
+    });
+
+    await screen.findByTestId("usage-dialog-empty");
+    // Without this the dialog makes an account-wide claim out of a
+    // machine-local result - the qualification the cost figure carries on
+    // the loaded branch has to survive the route into empty.
+    expect(
+      screen.getByTestId("usage-served-by-local-note").textContent,
+    ).toContain("This machine's usage only");
   });
 
   it("opens on a store target and renders the chat's headline + title", async () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-usage-dialog.test.tsx
@@ -225,6 +225,28 @@ describe("<ChatUsageDialog />", () => {
     ).toContain("This machine's usage only");
   });
 
+  it("absorbs the sheet's bottom safe-area inset in the body, having no footer", async () => {
+    renderWithClient();
+    act(() => {
+      useChatUsageDialogStore.getState().open({
+        hostId: mockLocalHostEntry.hostId,
+        chatId: "chat-1",
+        chatTitle: "Fix the flaky test",
+      });
+    });
+    await screen.findByTestId("usage-cost-figure");
+
+    // The epic dialog's footer takes this inset for it; this dialog has no
+    // footer, so the body is what reaches the sheet's `bottom-0` and an
+    // expanded drilldown would otherwise scroll under the home indicator.
+    expect(screen.getByTestId("chat-usage-dialog").className).toContain(
+      "max-[28rem]:bottom-0",
+    );
+    expect(screen.getByTestId("usage-dialog-body").className).toContain(
+      "max-[28rem]:pb-[env(safe-area-inset-bottom)]",
+    );
+  });
+
   it("opens on a store target and renders the chat's headline + title", async () => {
     renderWithClient();
     act(() => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-usage-dialog.test.tsx
@@ -169,6 +169,24 @@ describe("<ChatUsageDialog />", () => {
     expect(usageSummaryCallCount.current).toBeGreaterThan(0);
   });
 
+  it("shows the layout skeleton, not a spinner, while the summary loads", async () => {
+    renderWithClient();
+    act(() => {
+      useChatUsageDialogStore.getState().open({
+        hostId: mockLocalHostEntry.hostId,
+        chatId: "chat-1",
+        chatTitle: "Fix the flaky test",
+      });
+    });
+
+    // Synchronously after opening the query has not resolved yet.
+    expect(screen.getByTestId("usage-dialog-skeleton")).toBeTruthy();
+    expect(screen.queryByText("Loading usage…")).toBeNull();
+
+    await screen.findByTestId("usage-cost-figure");
+    expect(screen.queryByTestId("usage-dialog-skeleton")).toBeNull();
+  });
+
   it("opens on a store target and renders the chat's headline + title", async () => {
     renderWithClient();
     act(() => {

--- a/clients/gui-app/src/components/chat/chat-usage-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-usage-dialog.tsx
@@ -1,15 +1,9 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { ChevronDown, LineChart } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import {
   Collapsible,
   CollapsibleContent,
@@ -22,8 +16,17 @@ import {
   type UsageSummaryResponse,
 } from "@/hooks/usage-analytics/use-usage-summary-query";
 import { UsageCostFigure } from "@/components/usage-analytics/usage-cost-figure";
-import { UsageErrorCard } from "@/components/usage-analytics/usage-error-card";
 import { UsageTurnDrilldown } from "@/components/usage-analytics/usage-turn-drilldown";
+import {
+  UsageDialogFrame,
+  USAGE_DIALOG_SHEET_CLASSES,
+} from "@/components/usage-analytics/usage-dialog-frame";
+import {
+  UsageDialogEmpty,
+  UsageDialogErrorState,
+  UsageDialogSkeleton,
+  UsageDialogUnavailable,
+} from "@/components/usage-analytics/usage-dialog-states";
 import {
   useChatUsageDialogStore,
   type ChatUsageDialogTarget,
@@ -45,6 +48,11 @@ const FILLER_WINDOW_DAYS = 30;
  * (`window: "epic"` bounded by `chatId`, per the wire's own naming for "the
  * epic/chat's own fact span") - a chat's cost line is "how much has this
  * chat cost", not a rolling window, so there is no window picker here.
+ *
+ * Same fixed-frame system as `EpicUsageDialog` (decision 5a: same width,
+ * shorter height - the turn drilldown table is the one consumer that
+ * benefits from the width). No footer: the chat scope has no Settings
+ * destination.
  */
 export function ChatUsageDialog(): ReactNode {
   const target = useChatUsageDialogStore((s) => s.target);
@@ -80,7 +88,10 @@ export function ChatUsageDialog(): ReactNode {
       }}
     >
       <DialogContent
-        className="flex max-h-[min(90dvh,38rem)] w-[min(92vw,32rem)] min-w-0 flex-col gap-4 overflow-hidden sm:max-w-lg"
+        className={cn(
+          "flex h-[min(80dvh,34rem)] w-[min(92vw,48rem)] min-w-0 flex-col gap-4 overflow-hidden sm:max-w-3xl",
+          USAGE_DIALOG_SHEET_CLASSES,
+        )}
         data-testid="chat-usage-dialog"
       >
         {target === null ? null : (
@@ -99,28 +110,18 @@ function ChatUsageDialogBody(props: {
   const [drilldownOpen, setDrilldownOpen] = useState(false);
 
   return (
-    <>
-      <div className="flex min-w-0 items-start gap-3">
-        <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/15">
-          <LineChart className="size-4" aria-hidden />
-        </div>
-        <div className="min-h-0 min-w-0 flex-1 space-y-1">
-          <DialogTitle className="truncate text-ui font-semibold leading-snug wrap-anywhere">
-            Usage — {target.chatTitle}
-          </DialogTitle>
-          <DialogDescription>
-            Cost and token usage for this chat's full history.
-          </DialogDescription>
-        </div>
-      </div>
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <ChatUsageDialogContent
-          query={query}
-          drilldownOpen={drilldownOpen}
-          onDrilldownOpenChange={setDrilldownOpen}
-        />
-      </div>
-    </>
+    <UsageDialogFrame
+      title={`Usage — ${target.chatTitle}`}
+      description="Cost and token usage for this chat's full history."
+      headerControls={null}
+      footer={null}
+    >
+      <ChatUsageDialogContent
+        query={query}
+        drilldownOpen={drilldownOpen}
+        onDrilldownOpenChange={setDrilldownOpen}
+      />
+    </UsageDialogFrame>
   );
 }
 
@@ -131,21 +132,10 @@ function ChatUsageDialogContent(props: {
 }): ReactNode {
   const { query, drilldownOpen, onDrilldownOpenChange } = props;
 
-  if (query.isLoading) {
-    return (
-      <div className="flex items-center gap-2 py-6 text-ui-sm text-muted-foreground">
-        <AgentSpinningDots
-          className={undefined}
-          testId={undefined}
-          variant={undefined}
-        />
-        Loading usage…
-      </div>
-    );
-  }
+  if (query.isLoading) return <UsageDialogSkeleton variant="chat" />;
   if (query.error !== null) {
     return (
-      <UsageErrorCard
+      <UsageDialogErrorState
         error={query.error}
         onRetry={() => {
           void query.refetch();
@@ -153,15 +143,21 @@ function ChatUsageDialogContent(props: {
       />
     );
   }
-  if (query.data === undefined) {
-    return (
-      <p className="py-6 text-ui-sm text-muted-foreground">
-        Usage data unavailable.
-      </p>
-    );
-  }
+  if (query.data === undefined) return <UsageDialogUnavailable />;
 
   const { summary, coverage, servedBy } = query.data;
+  // Full-lifetime read: unlike the epic dialog's empty state there is no
+  // wider window to offer, so no chips.
+  if (summary.totals.factCount === 0) {
+    return (
+      <UsageDialogEmpty
+        headline="No usage recorded"
+        hint="Turns in this chat haven't reported any usage yet."
+      >
+        {null}
+      </UsageDialogEmpty>
+    );
+  }
   // Gate on the array the drilldown actually renders, not on `factCount`:
   // `turnRows` is nullable on the wire, so a host that answers with facts
   // but no per-turn rows would otherwise offer a "Show 0 turns" toggle onto

--- a/clients/gui-app/src/components/chat/chat-usage-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-usage-dialog.tsx
@@ -15,6 +15,7 @@ import {
   useUsageSummaryForClient,
   type UsageSummaryResponse,
 } from "@/hooks/usage-analytics/use-usage-summary-query";
+import { servedByScopeNote } from "@/lib/usage-analytics/cost-format";
 import { UsageCostFigure } from "@/components/usage-analytics/usage-cost-figure";
 import { UsageTurnDrilldown } from "@/components/usage-analytics/usage-turn-drilldown";
 import {
@@ -153,6 +154,9 @@ function ChatUsageDialogContent(props: {
       <UsageDialogEmpty
         headline="No usage recorded"
         hint="Turns in this chat haven't reported any usage yet."
+        // Same qualification the loaded branch's figure carries: on the local
+        // plane "no usage" is a claim about this machine only.
+        note={servedByScopeNote(servedBy, null)}
       >
         {null}
       </UsageDialogEmpty>

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -318,25 +318,94 @@ describe("<EpicUsageDialog />", () => {
     await waitFor(() => {
       expect(chartSeriesNames()).toEqual(["claude-sonnet-5", "gpt-5.6-sol"]);
     });
+    // The harness split keeps its own harness-keyed scale: with the chart's
+    // key space now models, a single shared scale would drop every split
+    // row to the "Other" fallback token.
+    const dot = screen
+      .getByTestId("usage-harness-split-row-claude")
+      .querySelector("span");
+    expect(dot?.style.backgroundColor).toBe("var(--usage-series-1)");
   });
 
-  it("does not render the group-by toggle when the window has no facts", async () => {
-    renderDialog(() => {
-      const base = usageSummaryResponse();
-      return {
-        ...base,
-        summary: {
-          ...base.summary,
-          totals: { ...base.summary.totals, factCount: 0, knownCostUsd: 0 },
-          buckets: [],
-        },
-      };
-    });
+  it("routes an empty window to the empty state, offering only wider windows", async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn(
+      (_request: UsageSummaryRequest): UsageSummaryResponse => {
+        const base = usageSummaryResponse();
+        return {
+          ...base,
+          summary: {
+            ...base.summary,
+            totals: { ...base.summary.totals, factCount: 0, knownCostUsd: 0 },
+            buckets: [],
+            chatBuckets: [],
+          },
+        };
+      },
+    );
+    renderDialog(handler);
 
-    const costFigure = await screen.findByTestId("usage-cost-figure");
-    expect(costFigure).toBeTruthy();
+    await screen.findByTestId("usage-dialog-empty");
+    // The empty routing owns the state entirely: no hero, no breakdown, no
+    // toggle - not a loaded layout full of zero-crumbs.
+    expect(screen.queryByTestId("usage-cost-figure")).toBeNull();
+    expect(screen.queryByTestId("usage-chat-breakdown")).toBeNull();
     expect(screen.queryByTestId("usage-chart-groupby-harness")).toBeNull();
     expect(screen.queryByTestId("usage-chart-groupby-model")).toBeNull();
+
+    // The default 7-day empty offers the two WIDER windows, and a chip
+    // re-issues the request at its window.
+    expect(screen.getByTestId("usage-empty-window-30")).toBeTruthy();
+    await user.click(screen.getByTestId("usage-empty-window-90"));
+    await waitFor(() => {
+      expect(handler.mock.calls.at(-1)?.at(0)).toMatchObject({
+        windowDays: 90,
+      });
+    });
+    expect(
+      screen.getByTestId("usage-window-90").getAttribute("data-state"),
+    ).toBe("active");
+
+    // A 90-day empty offers none - a chip that re-requests the current
+    // window would be a broken control.
+    await screen.findByTestId("usage-dialog-empty");
+    expect(screen.queryByTestId("usage-empty-window-30")).toBeNull();
+    expect(screen.queryByTestId("usage-empty-window-90")).toBeNull();
+  });
+
+  it("renders the layout skeleton inside the constant frame while loading", async () => {
+    renderDialog(usageSummaryResponse);
+
+    // Synchronously after mount the query has not resolved: the body shows
+    // the layout-mirroring skeleton, never a spinner line, while the frame
+    // (window picker, footer) is already in place around it.
+    expect(screen.getByTestId("usage-dialog-skeleton")).toBeTruthy();
+    expect(screen.queryByText("Loading usage…")).toBeNull();
+    expect(screen.getByTestId("usage-window-7")).toBeTruthy();
+    expect(screen.getByTestId("epic-usage-view-full-dashboard")).toBeTruthy();
+
+    await screen.findByTestId("usage-cost-figure");
+    expect(screen.queryByTestId("usage-dialog-skeleton")).toBeNull();
+  });
+
+  it("keeps the fixed-frame and responsive structure classes on the shell", async () => {
+    renderDialog(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+
+    // jsdom can't exercise container queries or viewport variants - the
+    // structure and classes ARE the testable contract here; rendering-level
+    // verification is the manual pass.
+    const content = screen.getByTestId("epic-usage-dialog");
+    expect(content.className).toContain("h-[min(88dvh,46rem)]");
+    expect(content.className).toContain("sm:max-w-3xl");
+    expect(content.className).toContain("max-[28rem]:bottom-0");
+    expect(content.className).toContain("max-[28rem]:h-[94dvh]");
+    expect(screen.getByTestId("usage-dialog-body").className).toContain(
+      "@container",
+    );
+    expect(screen.getByTestId("epic-usage-hero").className).toContain(
+      "@min-[40rem]:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]",
+    );
   });
 
   it("renders a retryable error card, never a silent fallback, when the RPC fails", async () => {
@@ -345,5 +414,8 @@ describe("<EpicUsageDialog />", () => {
     });
     expect(await screen.findByTestId("usage-error-card")).toBeTruthy();
     expect(screen.queryByTestId("usage-cost-figure")).toBeNull();
+    // The frame stays constant around the error fill.
+    expect(screen.getByTestId("usage-window-7")).toBeTruthy();
+    expect(screen.getByTestId("epic-usage-view-full-dashboard")).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -459,6 +459,11 @@ describe("<EpicUsageDialog />", () => {
     expect(screen.getByTestId("epic-usage-hero").className).toContain(
       "@min-[40rem]:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]",
     );
+    // This dialog HAS a footer, and the footer is what absorbs the sheet's
+    // home-indicator inset - the body must not double it.
+    expect(screen.getByTestId("usage-dialog-body").className).not.toContain(
+      "safe-area-inset-bottom",
+    );
   });
 
   it("renders a retryable error card, never a silent fallback, when the RPC fails", async () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -373,6 +373,54 @@ describe("<EpicUsageDialog />", () => {
     expect(screen.queryByTestId("usage-empty-window-90")).toBeNull();
   });
 
+  it("qualifies an empty local-plane read instead of claiming an account-wide zero", async () => {
+    renderDialog((_request: UsageSummaryRequest): UsageSummaryResponse => {
+      const base = usageSummaryResponse();
+      return {
+        ...base,
+        // A local read speaks for THIS machine only, so its zero is not the
+        // account's zero. The loaded branch carries that qualification on
+        // the cost figure; routing to the empty state must not drop it.
+        servedBy: "local",
+        summary: {
+          ...base.summary,
+          totals: { ...base.summary.totals, factCount: 0, knownCostUsd: 0 },
+          buckets: [],
+          chatBuckets: [],
+        },
+      };
+    });
+
+    await screen.findByTestId("usage-dialog-empty");
+    expect(
+      screen.getByTestId("usage-served-by-local-note").textContent,
+    ).toContain("This machine's usage only");
+  });
+
+  it("keeps the absent-usage disclaimer with the stat tiles", async () => {
+    renderDialog((_request: UsageSummaryRequest): UsageSummaryResponse => {
+      const base = usageSummaryResponse();
+      return {
+        ...base,
+        summary: {
+          ...base.summary,
+          // Turns that reported nothing add a silent zero to every token sum
+          // in the tiles, so the tiles cannot stand unqualified.
+          usageCompletenessBreakdown: { measured: 1, partial: 0, absent: 2 },
+        },
+      };
+    });
+
+    const note = await screen.findByTestId("usage-stat-tiles-absent-note");
+    expect(note.textContent).toContain("2 turns");
+    // Paired with the tiles themselves, the way Settings pairs them.
+    expect(
+      within(screen.getByTestId("epic-usage-hero")).getByTestId(
+        "usage-stat-tiles-absent-note",
+      ),
+    ).toBeTruthy();
+  });
+
   it("renders the layout skeleton inside the constant frame while loading", async () => {
     renderDialog(usageSummaryResponse);
 
@@ -380,7 +428,12 @@ describe("<EpicUsageDialog />", () => {
     // the layout-mirroring skeleton, never a spinner line, while the frame
     // (window picker, footer) is already in place around it.
     expect(screen.getByTestId("usage-dialog-skeleton")).toBeTruthy();
-    expect(screen.queryByText("Loading usage…")).toBeNull();
+    // The skeleton blocks are `aria-hidden`, so the state carries its name
+    // in an sr-only status instead - visually a skeleton, audibly still
+    // "Loading usage…", which the spinner line it replaced used to say.
+    const status = screen.getByRole("status");
+    expect(status.getAttribute("data-testid")).toBe("usage-dialog-skeleton");
+    expect(screen.getByText("Loading usage…").className).toContain("sr-only");
     expect(screen.getByTestId("usage-window-7")).toBeTruthy();
     expect(screen.getByTestId("epic-usage-view-full-dashboard")).toBeTruthy();
 

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
@@ -19,7 +19,14 @@ import {
   type UsageChartGroupBy,
 } from "@/lib/usage-analytics/usage-chart-data";
 import { buildUsageHarnessSplitRows } from "@/lib/usage-analytics/usage-harness-split";
-import { buildUsageStatTiles } from "@/lib/usage-analytics/usage-stat-tiles";
+import {
+  buildUsageStatTiles,
+  usageCompletenessAbsentNote,
+} from "@/lib/usage-analytics/usage-stat-tiles";
+import {
+  servedByScopeNote,
+  type UsageServedBy,
+} from "@/lib/usage-analytics/cost-format";
 import { formatDateRangeLabel } from "@/lib/usage-analytics/format-metric-value";
 import { cn } from "@/lib/utils";
 import { UsageCostFigure } from "@/components/usage-analytics/usage-cost-figure";
@@ -182,6 +189,7 @@ function EpicUsageDialogBody(props: {
       <EpicUsageEmptyState
         windowDays={props.windowDays}
         onWindowDaysChange={props.onWindowDaysChange}
+        servedBy={query.data.servedBy}
       />
     );
   }
@@ -210,12 +218,17 @@ function widerWindows(
 function EpicUsageEmptyState(props: {
   readonly windowDays: UsageSummaryWindowDays;
   readonly onWindowDaysChange: (windowDays: UsageSummaryWindowDays) => void;
+  readonly servedBy: UsageServedBy;
 }): ReactNode {
   const wider = widerWindows(props.windowDays);
   return (
     <UsageDialogEmpty
       headline={`No usage in the last ${String(props.windowDays)} days`}
       hint="Chats and agents in this epic haven't recorded usage in this window."
+      // A local-plane read only speaks for THIS machine, so an unqualified
+      // "no usage" would overclaim - the same note `UsageCostFigure` carries
+      // on the loaded branch (`hostScopeName` null for the reason below).
+      note={servedByScopeNote(props.servedBy, null)}
     >
       {wider.length === 0 ? null : (
         <div className="flex flex-wrap justify-center gap-2">
@@ -268,6 +281,14 @@ function EpicUsageLoadedBody(props: {
   });
   const harnessRows = buildUsageHarnessSplitRows(summary.buckets);
   const statTiles = buildUsageStatTiles(summary.totals, summary.buckets);
+  // Travels with the tiles wherever they render, per the note's own
+  // contract: turns that reported no usage at all still add a silent zero to
+  // every token sum in them, so unqualified tiles read as "this work used no
+  // cache" rather than "this work reported nothing". Settings pairs the two
+  // the same way - this dialog only needs it because it now shows tiles.
+  const absentNote = usageCompletenessAbsentNote(
+    summary.usageCompletenessBreakdown,
+  );
   const dateRangeLabel = formatDateRangeLabel(days);
 
   return (
@@ -303,7 +324,17 @@ function EpicUsageLoadedBody(props: {
             showTokens={false}
           />
         </div>
-        <UsageStatTiles tiles={statTiles} variant="curated" />
+        <div className="flex flex-col gap-1.5">
+          <UsageStatTiles tiles={statTiles} variant="curated" />
+          {absentNote === null ? null : (
+            <p
+              className="text-ui-xs text-muted-foreground/80"
+              data-testid="usage-stat-tiles-absent-note"
+            >
+              {absentNote}
+            </p>
+          )}
+        </div>
       </div>
       <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-card/40 p-3">
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
@@ -1,17 +1,9 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { LineChart } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import type { HostRpcRegistry } from "@/lib/host";
 import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
 import {
@@ -26,12 +18,27 @@ import {
   buildUsageSeriesScaleForBuckets,
   type UsageChartGroupBy,
 } from "@/lib/usage-analytics/usage-chart-data";
+import { buildUsageHarnessSplitRows } from "@/lib/usage-analytics/usage-harness-split";
+import { buildUsageStatTiles } from "@/lib/usage-analytics/usage-stat-tiles";
+import { formatDateRangeLabel } from "@/lib/usage-analytics/format-metric-value";
+import { cn } from "@/lib/utils";
 import { UsageCostFigure } from "@/components/usage-analytics/usage-cost-figure";
 import { UsageChartGroupByToggle } from "@/components/usage-analytics/usage-chart-groupby-toggle";
 import { UsageDailyChart } from "@/components/usage-analytics/usage-daily-chart";
-import { UsageErrorCard } from "@/components/usage-analytics/usage-error-card";
 import { UsageChatBreakdown } from "@/components/usage-analytics/usage-chat-breakdown";
+import { UsageHarnessSplit } from "@/components/usage-analytics/usage-harness-split";
+import { UsageStatTiles } from "@/components/usage-analytics/usage-stat-tiles";
 import { UsageWindowPicker } from "@/components/usage-analytics/usage-window-picker";
+import {
+  UsageDialogFrame,
+  USAGE_DIALOG_SHEET_CLASSES,
+} from "@/components/usage-analytics/usage-dialog-frame";
+import {
+  UsageDialogEmpty,
+  UsageDialogErrorState,
+  UsageDialogSkeleton,
+  UsageDialogUnavailable,
+} from "@/components/usage-analytics/usage-dialog-states";
 
 export interface EpicUsageDialogProps {
   readonly epicId: string;
@@ -47,14 +54,23 @@ type UsageSummaryQueryResult = UseQueryResult<
 
 const DEFAULT_WINDOW_DAYS: UsageSummaryWindowDays = 7;
 
+// >=44px touch targets on coarse pointers without growing the tabs list's
+// hardcoded h-8: an invisible overlay extends each trigger's vertical hit
+// area (the trigger is already `relative`; `after:` is taken by the
+// line-variant indicator, so this rides `before:`).
+const COARSE_POINTER_TRIGGER =
+  "pointer-coarse:before:absolute pointer-coarse:before:inset-x-0 pointer-coarse:before:-inset-y-2.5";
+
 /**
  * The scoped epic panel ticket 12 replaces the ambient cost badge with:
- * headline (`UsageCostFigure`, reused unmodified), a small per-day trend
- * chart, and a by-chat/agent breakdown, with window options 7/30/90. Cost is
- * on-demand by construction - the query is only
- * `enabled` while the dialog is open, so there is nothing ambient left to
- * silently revert (fixup-01's failure mode). `poll: false` matches every
- * other actively-viewed usage surface (Settings' `UsageSummaryPanel`).
+ * headline (`UsageCostFigure`), harness split, curated stat tiles, a
+ * per-day trend chart, and a by-chat/agent breakdown, with window options
+ * 7/30/90 - variant B of the usage-dialog redesign (48rem mini-dashboard
+ * in a fixed frame; states swap inside it, never resize it). Cost is
+ * on-demand by construction - the query is only `enabled` while the dialog
+ * is open, so there is nothing ambient left to silently revert (fixup-01's
+ * failure mode). `poll: false` matches every other actively-viewed usage
+ * surface (Settings' `UsageSummaryPanel`).
  */
 export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
   const { epicId, client, open, onOpenChange } = props;
@@ -81,71 +97,74 @@ export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex max-h-[min(90dvh,38rem)] w-[min(92vw,32rem)] min-w-0 flex-col gap-4 overflow-hidden sm:max-w-lg"
+        // Fixed `h` - not `max-h` - is the no-jump fix: every state renders
+        // into the same frame. `sm:max-w-3xl` overrides the primitive's
+        // `sm:max-w-sm` cap (load-bearing, same reason the earlier shape
+        // carried `sm:max-w-lg`).
+        className={cn(
+          "flex h-[min(88dvh,46rem)] w-[min(92vw,48rem)] min-w-0 flex-col gap-4 overflow-hidden sm:max-w-3xl",
+          USAGE_DIALOG_SHEET_CLASSES,
+          "max-[28rem]:h-[94dvh]",
+        )}
         data-testid="epic-usage-dialog"
       >
-        <div className="flex min-w-0 items-start gap-3">
-          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/15">
-            <LineChart className="size-4" aria-hidden />
-          </div>
-          <div className="min-h-0 min-w-0 flex-1 space-y-1">
-            <DialogTitle className="text-ui font-semibold leading-snug">
-              Usage
-            </DialogTitle>
-            <DialogDescription>
-              Cost and token usage for this epic.
-            </DialogDescription>
-          </div>
-        </div>
-        <UsageWindowPicker windowDays={windowDays} onChange={setWindowDays} />
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        <UsageDialogFrame
+          title="Usage"
+          description="Cost and token usage for this epic."
+          headerControls={
+            <UsageWindowPicker
+              windowDays={windowDays}
+              onChange={setWindowDays}
+              triggerClassName={COARSE_POINTER_TRIGGER}
+            />
+          }
+          footer={
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="max-[28rem]:w-full"
+              data-testid="epic-usage-view-full-dashboard"
+              onClick={() => {
+                onOpenChange(false);
+                openSettings({ section: "usage", resetToGeneral: false });
+              }}
+            >
+              View full usage →
+            </Button>
+          }
+        >
           <EpicUsageDialogBody
             query={query}
+            windowDays={windowDays}
+            onWindowDaysChange={setWindowDays}
             chartGroupBy={chartGroupBy}
             onChartGroupByChange={setChartGroupBy}
           />
-        </div>
-        <DialogFooter className="-mx-4 -mb-4 mt-0 border-t bg-muted/50 px-4 py-3">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            data-testid="epic-usage-view-full-dashboard"
-            onClick={() => {
-              onOpenChange(false);
-              openSettings({ section: "usage", resetToGeneral: false });
-            }}
-          >
-            View full usage →
-          </Button>
-        </DialogFooter>
+        </UsageDialogFrame>
       </DialogContent>
     </Dialog>
   );
 }
 
+/**
+ * One state switch, in routing order; every branch renders into the
+ * frame's body slot while the frame (header, picker, footer) stays
+ * constant around it.
+ */
 function EpicUsageDialogBody(props: {
   readonly query: UsageSummaryQueryResult;
+  readonly windowDays: UsageSummaryWindowDays;
+  readonly onWindowDaysChange: (windowDays: UsageSummaryWindowDays) => void;
   readonly chartGroupBy: UsageChartGroupBy;
   readonly onChartGroupByChange: (groupBy: UsageChartGroupBy) => void;
 }): ReactNode {
-  const { query, chartGroupBy, onChartGroupByChange } = props;
+  const { query } = props;
 
-  if (query.isLoading) {
-    return (
-      <div className="flex items-center gap-2 py-6 text-ui-sm text-muted-foreground">
-        <AgentSpinningDots
-          className={undefined}
-          testId={undefined}
-          variant={undefined}
-        />
-        Loading usage…
-      </div>
-    );
-  }
+  if (query.isLoading) return <UsageDialogSkeleton variant="epic" />;
   if (query.error !== null) {
     return (
-      <UsageErrorCard
+      <UsageDialogErrorState
         error={query.error}
         onRetry={() => {
           void query.refetch();
@@ -153,65 +172,160 @@ function EpicUsageDialogBody(props: {
       />
     );
   }
-  if (query.data === undefined) {
+  if (query.data === undefined) return <UsageDialogUnavailable />;
+  // The empty routing owns "nothing in this window" entirely: the loaded
+  // layout below can assume facts exist, which is also why the group-by
+  // toggle no longer needs a factCount guard of its own - a control with
+  // nothing to regroup is unreachable from the loaded branch.
+  if (query.data.summary.totals.factCount === 0) {
     return (
-      <p className="py-6 text-ui-sm text-muted-foreground">
-        Usage data unavailable.
-      </p>
+      <EpicUsageEmptyState
+        windowDays={props.windowDays}
+        onWindowDaysChange={props.onWindowDaysChange}
+      />
     );
   }
+  return (
+    <EpicUsageLoadedBody
+      data={query.data}
+      chartGroupBy={props.chartGroupBy}
+      onChartGroupByChange={props.onChartGroupByChange}
+    />
+  );
+}
 
-  const { summary, coverage, servedBy } = query.data;
+/**
+ * Wider windows only: a chip that re-requests the CURRENT window would be
+ * a broken control, so a 90-day empty offers none. (365 exists on the wire
+ * for the activity heatmap and is never a picker state here.)
+ */
+function widerWindows(
+  windowDays: UsageSummaryWindowDays,
+): readonly UsageSummaryWindowDays[] {
+  if (windowDays === 7) return [30, 90];
+  if (windowDays === 30) return [90];
+  return [];
+}
+
+function EpicUsageEmptyState(props: {
+  readonly windowDays: UsageSummaryWindowDays;
+  readonly onWindowDaysChange: (windowDays: UsageSummaryWindowDays) => void;
+}): ReactNode {
+  const wider = widerWindows(props.windowDays);
+  return (
+    <UsageDialogEmpty
+      headline={`No usage in the last ${String(props.windowDays)} days`}
+      hint="Chats and agents in this epic haven't recorded usage in this window."
+    >
+      {wider.length === 0 ? null : (
+        <div className="flex flex-wrap justify-center gap-2">
+          {wider.map((days) => (
+            <Button
+              key={days}
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid={`usage-empty-window-${String(days)}`}
+              onClick={() => {
+                props.onWindowDaysChange(days);
+              }}
+            >
+              Show {days} days
+            </Button>
+          ))}
+        </div>
+      )}
+    </UsageDialogEmpty>
+  );
+}
+
+function EpicUsageLoadedBody(props: {
+  readonly data: UsageSummaryResponse;
+  readonly chartGroupBy: UsageChartGroupBy;
+  readonly onChartGroupByChange: (groupBy: UsageChartGroupBy) => void;
+}): ReactNode {
+  const { chartGroupBy } = props;
+  const { summary, coverage, servedBy } = props.data;
   const days = daysForSummaryWindow(summary);
-  // One scale, keyed by the reader's grouping. Unlike the Settings
-  // dashboard - where the harness split beside the headline needs a
-  // harness-keyed scale of its own regardless of what the chart shows - the
-  // chart is this dialog's only consumer of the scale, so there is no second
-  // one to keep pinned to harnesses.
-  const scale = buildUsageSeriesScaleForBuckets(summary.buckets, chartGroupBy);
+  // Two scales, the Settings dashboard's shape: the harness split beside
+  // the headline always stacks by harness, so it keeps a harness-keyed
+  // scale regardless of what the chart shows, and the chart shares it only
+  // while it groups by harness. A single `chartGroupBy`-keyed scale was
+  // the earlier shape here, and it grayed every split row the moment the
+  // chart regrouped by model - `colorVar` falls back to the "Other" token
+  // for keys outside its space.
+  const scale = buildUsageSeriesScaleForBuckets(summary.buckets, "harness");
+  const chartScale =
+    chartGroupBy === "harness"
+      ? scale
+      : buildUsageSeriesScaleForBuckets(summary.buckets, "model");
   const columns = buildUsageChartColumns({
     days,
     buckets: summary.buckets,
-    scale,
+    scale: chartScale,
     metric: "cost",
     groupBy: chartGroupBy,
   });
+  const harnessRows = buildUsageHarnessSplitRows(summary.buckets);
+  const statTiles = buildUsageStatTiles(summary.totals, summary.buckets);
+  const dateRangeLabel = formatDateRangeLabel(days);
 
   return (
-    <div className="flex flex-col gap-4">
-      <UsageCostFigure
-        totals={summary.totals}
-        coverage={coverage}
-        servedBy={servedBy}
-        // The host dimension is irrelevant at this scope: an epic's (or a
-        // chat's) work is the same work wherever it ran.
-        hostScopeName={null}
-        size="default"
-      />
-      {/* The toggle lives inside this guard, not beside the window picker
-          above: with no facts there is no chart for it to regroup, and a
-          control that changes nothing visible reads as broken. */}
-      {summary.totals.factCount === 0 ? null : (
-        <div className="flex flex-col gap-2">
-          <div className="flex justify-end">
-            <UsageChartGroupByToggle
-              groupBy={chartGroupBy}
-              onChange={onChartGroupByChange}
+    // `usage-chart-root` scopes the `--usage-series-*` palette over BOTH
+    // consumers - the chart and its sibling harness split - the same
+    // reason Settings hangs it on their common ancestor.
+    <div className="usage-chart-root flex flex-col gap-5">
+      <div
+        className="grid grid-cols-1 gap-4 @min-[40rem]:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]"
+        data-testid="epic-usage-hero"
+      >
+        <div className="flex min-w-0 flex-col gap-3">
+          <div className="flex flex-col gap-0.5">
+            <UsageCostFigure
+              totals={summary.totals}
+              coverage={coverage}
+              servedBy={servedBy}
+              // The host dimension is irrelevant at this scope: an epic's
+              // (or a chat's) work is the same work wherever it ran.
+              hostScopeName={null}
+              size="display"
             />
+            <span
+              className="text-ui-xs text-muted-foreground"
+              data-testid="usage-date-range-label"
+            >
+              {dateRangeLabel}
+            </span>
           </div>
-          {/* `key` per the prop's contract: the legend's hidden-series set is
-              keyed by the current grouping's series keys, so a switch
-              remounts rather than letting stale harness keys filter model
-              bands. */}
-          <UsageDailyChart
-            key={chartGroupBy}
-            columns={columns}
+          <UsageHarnessSplit
+            rows={harnessRows}
             scale={scale}
-            metric="cost"
-            groupBy={chartGroupBy}
+            showTokens={false}
           />
         </div>
-      )}
+        <UsageStatTiles tiles={statTiles} variant="curated" />
+      </div>
+      <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-card/40 p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-ui-sm font-medium text-foreground">Daily cost</h3>
+          <UsageChartGroupByToggle
+            groupBy={chartGroupBy}
+            onChange={props.onChartGroupByChange}
+            triggerClassName={COARSE_POINTER_TRIGGER}
+          />
+        </div>
+        {/* `key` per the prop's contract: the legend's hidden-series set is
+            keyed by the current grouping's series keys, so a switch
+            remounts rather than letting stale harness keys filter model
+            bands. */}
+        <UsageDailyChart
+          key={chartGroupBy}
+          columns={columns}
+          scale={chartScale}
+          metric="cost"
+          groupBy={chartGroupBy}
+        />
+      </div>
       <div>
         <h3 className="mb-2 text-ui-sm font-medium text-foreground">
           By chat / agent
@@ -236,11 +350,13 @@ function EpicUsageDialogBody(props: {
  * while staying closed - so opening it after a local midnight built columns
  * ending on the previous day and dropped the newest buckets the query had
  * just returned.
+ *
+ * Only called from the loaded branch, where the empty routing has already
+ * guaranteed facts exist.
  */
 function daysForSummaryWindow(
   summary: UsageSummaryResponse["summary"],
 ): readonly string[] {
-  if (summary.totals.factCount === 0) return [];
   return lastNCalendarDays(
     summary.window.windowDays,
     summary.window.timezone,

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-chart-groupby-toggle.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-chart-groupby-toggle.test.tsx
@@ -7,7 +7,13 @@ afterEach(cleanup);
 
 describe("UsageChartGroupByToggle", () => {
   it("renders both triggers", () => {
-    render(<UsageChartGroupByToggle groupBy="harness" onChange={vi.fn()} />);
+    render(
+      <UsageChartGroupByToggle
+        groupBy="harness"
+        onChange={vi.fn()}
+        triggerClassName={undefined}
+      />,
+    );
     expect(screen.getByRole("tab", { name: "Harness" })).toBeDefined();
     expect(screen.getByRole("tab", { name: "Model" })).toBeDefined();
   });
@@ -17,7 +23,13 @@ describe("UsageChartGroupByToggle", () => {
     // the full pointer sequence, matching real interaction.
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<UsageChartGroupByToggle groupBy="harness" onChange={onChange} />);
+    render(
+      <UsageChartGroupByToggle
+        groupBy="harness"
+        onChange={onChange}
+        triggerClassName={undefined}
+      />,
+    );
     await user.click(screen.getByRole("tab", { name: "Model" }));
     expect(onChange).toHaveBeenCalledWith("model");
   });

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-window-picker.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-window-picker.test.tsx
@@ -12,13 +12,25 @@ describe("UsageWindowPicker", () => {
     // pointer sequence (mousedown included), matching real interaction.
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<UsageWindowPicker windowDays={7} onChange={onChange} />);
+    render(
+      <UsageWindowPicker
+        windowDays={7}
+        onChange={onChange}
+        triggerClassName={undefined}
+      />,
+    );
     await user.click(screen.getByRole("tab", { name: "30 days" }));
     expect(onChange).toHaveBeenCalledWith(30);
   });
 
   it("marks the current window as the active tab", () => {
-    render(<UsageWindowPicker windowDays={90} onChange={() => undefined} />);
+    render(
+      <UsageWindowPicker
+        windowDays={90}
+        onChange={() => undefined}
+        triggerClassName={undefined}
+      />,
+    );
     expect(
       screen.getByRole("tab", { name: "90 days" }).getAttribute("data-state"),
     ).toBe("active");
@@ -28,7 +40,13 @@ describe("UsageWindowPicker", () => {
   });
 
   it("lets the window tabs wrap within a narrow container", () => {
-    render(<UsageWindowPicker windowDays={7} onChange={() => undefined} />);
+    render(
+      <UsageWindowPicker
+        windowDays={7}
+        onChange={() => undefined}
+        triggerClassName={undefined}
+      />,
+    );
     expect(screen.getByRole("tablist").className).toContain("max-w-full");
     expect(screen.getByRole("tablist").className).toContain("flex-wrap");
   });

--- a/clients/gui-app/src/components/usage-analytics/usage-chart-groupby-toggle.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-chart-groupby-toggle.tsx
@@ -5,6 +5,13 @@ import type { UsageChartGroupBy } from "@/lib/usage-analytics/usage-chart-data";
 export interface UsageChartGroupByToggleProps {
   readonly groupBy: UsageChartGroupBy;
   readonly onChange: (groupBy: UsageChartGroupBy) => void;
+  /**
+   * Extra classes merged onto each trigger - the styling seam the Tabs
+   * primitive doesn't otherwise expose (its list hardcodes `h-8`), used by
+   * the usage dialogs for coarse-pointer touch-target bumps. `undefined`
+   * keeps the primitive's sizing (Settings).
+   */
+  readonly triggerClassName: string | undefined;
 }
 
 /**
@@ -24,10 +31,18 @@ export function UsageChartGroupByToggle(
       }}
     >
       <TabsList aria-label="Group chart by">
-        <TabsTrigger value="harness" data-testid="usage-chart-groupby-harness">
+        <TabsTrigger
+          value="harness"
+          className={props.triggerClassName}
+          data-testid="usage-chart-groupby-harness"
+        >
           Harness
         </TabsTrigger>
-        <TabsTrigger value="model" data-testid="usage-chart-groupby-model">
+        <TabsTrigger
+          value="model"
+          className={props.triggerClassName}
+          data-testid="usage-chart-groupby-model"
+        >
           Model
         </TabsTrigger>
       </TabsList>

--- a/clients/gui-app/src/components/usage-analytics/usage-cost-figure.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-cost-figure.tsx
@@ -21,7 +21,12 @@ export interface UsageCostFigureProps {
    * subject is the same work wherever it ran).
    */
   readonly hostScopeName: string | null;
-  readonly size: "compact" | "default";
+  /**
+   * `display` is the epic usage dialog's hero treatment: one step larger,
+   * proportional figures. `default` (Settings' hero, the chat dialog) and
+   * `compact` are untouched by it.
+   */
+  readonly size: "compact" | "default" | "display";
 }
 
 /**
@@ -42,10 +47,14 @@ export function UsageCostFigure(props: UsageCostFigureProps): ReactNode {
   const tooltip =
     totals.factCount === 0 ? null : usageCostTooltip(totals, coverage);
   const scopeNote = servedByScopeNote(servedBy, hostScopeName);
-  const compact = size === "compact";
   const amountClassName = cn(
-    "font-semibold tabular-nums text-foreground",
-    compact ? "text-ui-sm" : "text-title-md",
+    "font-semibold text-foreground",
+    size === "compact" && "text-ui-sm tabular-nums",
+    size === "default" && "text-title-md tabular-nums",
+    // No `tabular-nums` at display size on purpose: tabular figures give
+    // every digit a zero's width, which reads loose on a standalone hero
+    // number - they are for columns that must align, not display type.
+    size === "display" && "text-title-lg",
   );
 
   return (

--- a/clients/gui-app/src/components/usage-analytics/usage-dialog-frame.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-dialog-frame.tsx
@@ -5,6 +5,7 @@ import {
   DialogFooter,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 
 /**
  * Phone tier (viewport < 28rem): the centered dialog becomes a bottom
@@ -68,7 +69,17 @@ export function UsageDialogFrame(props: UsageDialogFrameProps): ReactNode {
         )}
       </div>
       <div
-        className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable] @container"
+        className={cn(
+          "min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable] @container",
+          // The footer normally absorbs the home-indicator inset for the
+          // whole sheet. Without one (the chat dialog) the body is what
+          // reaches `bottom-0`, so it has to absorb it instead - otherwise
+          // an expanded turn drilldown scrolls its last rows under the
+          // indicator. Additive on top of the content's own padding, and
+          // exactly `0` wherever the inset is.
+          props.footer === null &&
+            "max-[28rem]:pb-[env(safe-area-inset-bottom)]",
+        )}
         data-testid="usage-dialog-body"
       >
         {props.children}

--- a/clients/gui-app/src/components/usage-analytics/usage-dialog-frame.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-dialog-frame.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import { LineChart } from "lucide-react";
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Phone tier (viewport < 28rem): the centered dialog becomes a bottom
+ * sheet. Viewport-keyed (`max-[28rem]:`) deliberately, unlike the content
+ * folds inside the body, which key on the dialog's own container width -
+ * whether the frame is a sheet is a property of the screen, not of the
+ * dialog's width. Tailwind emits variant rules after base utilities, so
+ * these override the primitive's centered positioning without
+ * `!important`. Heights stay dialog-owned: the epic dialog adds
+ * `max-[28rem]:h-[94dvh]`; the chat dialog keeps its shorter fixed height.
+ */
+export const USAGE_DIALOG_SHEET_CLASSES =
+  "max-[28rem]:top-auto max-[28rem]:bottom-0 max-[28rem]:left-0 max-[28rem]:translate-x-0 max-[28rem]:translate-y-0 max-[28rem]:w-screen max-[28rem]:max-w-none max-[28rem]:rounded-b-none";
+
+export interface UsageDialogFrameProps {
+  readonly title: ReactNode;
+  readonly description: ReactNode;
+  /** Trailing header controls (the epic dialog's window picker) - `null` when the dialog has none. */
+  readonly headerControls: ReactNode;
+  /** Pinned footer content - `null` when the dialog has no footer (the chat scope has no Settings destination). */
+  readonly footer: ReactNode;
+  readonly children: ReactNode;
+}
+
+/**
+ * The usage dialogs' shared fixed-frame scaffold, mounted inside a
+ * fixed-`h` `DialogContent`: pinned header row (icon ring + title +
+ * trailing controls), scrollable body, optional pinned footer. The frame
+ * renders unconditionally around every body state - loading, error, empty,
+ * loaded - which is the whole "no jump" guarantee: states swap inside a
+ * constant frame instead of resizing it.
+ *
+ * The body is the `@container` the content folds key on, and it reserves a
+ * stable scrollbar gutter so a classic (non-overlay) scrollbar can't
+ * shrink the container's inline size and fire a fold early.
+ */
+export function UsageDialogFrame(props: UsageDialogFrameProps): ReactNode {
+  return (
+    <>
+      {/* Sheet affordance only - X and scrim-tap remain the dismissals. */}
+      <div
+        aria-hidden
+        className="mx-auto hidden h-1 w-9 shrink-0 rounded-full bg-muted-foreground/25 max-[28rem]:block"
+      />
+      {/* `pr-8` clears the primitive's absolutely-positioned close button
+          (`top-2 right-2`) so inline header controls never land under it. */}
+      <div className="flex min-w-0 items-start gap-3 pr-8 max-[28rem]:flex-col">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/15">
+            <LineChart className="size-4" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <DialogTitle className="truncate text-ui font-semibold leading-snug wrap-anywhere">
+              {props.title}
+            </DialogTitle>
+            <DialogDescription>{props.description}</DialogDescription>
+          </div>
+        </div>
+        {props.headerControls === null ? null : (
+          <div className="shrink-0">{props.headerControls}</div>
+        )}
+      </div>
+      <div
+        className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable] @container"
+        data-testid="usage-dialog-body"
+      >
+        {props.children}
+      </div>
+      {props.footer === null ? null : (
+        <DialogFooter className="-mx-4 -mb-4 mt-0 border-t bg-muted/50 px-4 py-3 max-[28rem]:rounded-b-none max-[28rem]:pb-[max(env(safe-area-inset-bottom),0.75rem)]">
+          {props.footer}
+        </DialogFooter>
+      )}
+    </>
+  );
+}

--- a/clients/gui-app/src/components/usage-analytics/usage-dialog-states.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-dialog-states.tsx
@@ -20,7 +20,13 @@ export function UsageDialogSkeleton(
   props: UsageDialogSkeletonProps,
 ): ReactNode {
   return (
-    <div aria-busy="true" data-testid="usage-dialog-skeleton">
+    <div role="status" aria-busy="true" data-testid="usage-dialog-skeleton">
+      {/* The blocks below are decorative (`aria-hidden`), so without this the
+          state has no accessible name at all and a screen reader gets nothing
+          between open and data - the spinner this replaced at least carried a
+          "Loading usage…" label. `role="status"` announces it politely and
+          again when the data swaps it out. */}
+      <span className="sr-only">Loading usage…</span>
       <div
         aria-hidden
         className={cn(
@@ -94,6 +100,14 @@ function ChatUsageSkeletonBlocks(): ReactNode {
 export interface UsageDialogEmptyProps {
   readonly headline: string;
   readonly hint: string;
+  /**
+   * The plane/scope qualification that `UsageCostFigure` carries on a loaded
+   * read (`servedByScopeNote`) - `null` when the read needs none. Empty is a
+   * CLAIM ("no usage"), and a local-plane zero only means this machine has
+   * none, so the qualification has to survive the route into this state
+   * rather than disappearing with the figure that used to render it.
+   */
+  readonly note: string | null;
   /** Action chips below the hint (the epic dialog's wider-window offers) - `null` when the state has no action to offer. */
   readonly children: ReactNode;
 }
@@ -113,6 +127,14 @@ export function UsageDialogEmpty(props: UsageDialogEmptyProps): ReactNode {
         <p className="mx-auto max-w-[36ch] text-ui-sm text-muted-foreground">
           {props.hint}
         </p>
+        {props.note === null ? null : (
+          <p
+            className="mx-auto max-w-[36ch] text-ui-xs text-muted-foreground/80"
+            data-testid="usage-served-by-local-note"
+          >
+            {props.note}
+          </p>
+        )}
       </div>
       {props.children}
     </div>

--- a/clients/gui-app/src/components/usage-analytics/usage-dialog-states.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-dialog-states.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from "react";
+import { LineChart } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { UsageErrorCard } from "@/components/usage-analytics/usage-error-card";
+import { cn } from "@/lib/utils";
+
+export interface UsageDialogSkeletonProps {
+  /** Which dialog's loaded layout to mirror - the epic mini-dashboard or the chat hero + turn list. */
+  readonly variant: "epic" | "chat";
+}
+
+/**
+ * Loading fill that mirrors the loaded layout - the same hero grid, chart
+ * clamp, and row rhythm as the data that replaces it, so nothing shifts
+ * when it lands. Deliberately not a spinner (and outside the
+ * `AgentSpinningDots` rule for that reason): a skeleton at the loaded
+ * layout's own shape IS the fixed frame's no-jump guarantee.
+ */
+export function UsageDialogSkeleton(
+  props: UsageDialogSkeletonProps,
+): ReactNode {
+  return (
+    <div aria-busy="true" data-testid="usage-dialog-skeleton">
+      <div
+        aria-hidden
+        className={cn(
+          "flex flex-col",
+          props.variant === "epic" ? "gap-5" : "gap-3",
+        )}
+      >
+        {props.variant === "epic" ? (
+          <EpicUsageSkeletonBlocks />
+        ) : (
+          <ChatUsageSkeletonBlocks />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mirrors `EpicUsageLoadedBody`: hero zone (headline + split left, 2x2
+ * tiles right, folding to one column with the same container query), the
+ * chart at its exact height clamp, then breakdown table lines.
+ */
+function EpicUsageSkeletonBlocks(): ReactNode {
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-4 @min-[40rem]:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]">
+        <div className="flex min-w-0 flex-col gap-3">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <div className="flex flex-col gap-2.5">
+            <Skeleton className="h-3.5 w-full" />
+            <Skeleton className="h-3.5 w-full" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+        </div>
+      </div>
+      <Skeleton className="h-[clamp(11rem,26vh,16rem)] w-full" />
+      <div className="flex flex-col gap-2.5">
+        <Skeleton className="h-3.5 w-full" />
+        <Skeleton className="h-3.5 w-full" />
+        <Skeleton className="h-3.5 w-2/3" />
+      </div>
+    </>
+  );
+}
+
+/** Mirrors the chat dialog's loaded body: hero figure + turn-row lines. */
+function ChatUsageSkeletonBlocks(): ReactNode {
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-1/3" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+      <div className="flex flex-col gap-2.5">
+        <Skeleton className="h-3.5 w-full" />
+        <Skeleton className="h-3.5 w-full" />
+        <Skeleton className="h-3.5 w-2/3" />
+      </div>
+    </>
+  );
+}
+
+export interface UsageDialogEmptyProps {
+  readonly headline: string;
+  readonly hint: string;
+  /** Action chips below the hint (the epic dialog's wider-window offers) - `null` when the state has no action to offer. */
+  readonly children: ReactNode;
+}
+
+/** Centered empty composition at the frame's constant size: icon ring, headline, hint, optional actions. */
+export function UsageDialogEmpty(props: UsageDialogEmptyProps): ReactNode {
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col items-center justify-center gap-3 px-4 py-6 text-center"
+      data-testid="usage-dialog-empty"
+    >
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <LineChart className="size-5" aria-hidden />
+      </div>
+      <div className="space-y-1">
+        <p className="text-ui font-medium text-foreground">{props.headline}</p>
+        <p className="mx-auto max-w-[36ch] text-ui-sm text-muted-foreground">
+          {props.hint}
+        </p>
+      </div>
+      {props.children}
+    </div>
+  );
+}
+
+export interface UsageDialogErrorStateProps {
+  readonly error: Error;
+  readonly onRetry: () => void;
+}
+
+/** Centers the existing retryable card in the fixed frame - the card itself is reused unmodified. */
+export function UsageDialogErrorState(
+  props: UsageDialogErrorStateProps,
+): ReactNode {
+  return (
+    <div className="flex h-full flex-col justify-center py-6">
+      <div className="mx-auto w-full max-w-md">
+        <UsageErrorCard error={props.error} onRetry={props.onRetry} />
+      </div>
+    </div>
+  );
+}
+
+/** The settled-but-dataless fill (no error, no response), centered in the same frame. */
+export function UsageDialogUnavailable(): ReactNode {
+  return (
+    <div className="flex h-full items-center justify-center py-6">
+      <p className="text-ui-sm text-muted-foreground">
+        Usage data unavailable.
+      </p>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/usage-analytics/usage-harness-split.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-harness-split.tsx
@@ -8,6 +8,13 @@ export interface UsageHarnessSplitProps {
   readonly rows: readonly UsageHarnessSplitRow[];
   /** Ties each row's dot/bar color to the daily chart's legend - same entity, same color, never re-derived. */
   readonly scale: UsageSeriesScale;
+  /**
+   * Whether each row carries its token total after the cost. Settings shows
+   * it; the epic usage dialog passes `false` - there the stat tiles beside
+   * this split already carry the token detail, so the column would repeat
+   * them at every width.
+   */
+  readonly showTokens: boolean;
 }
 
 /**
@@ -27,6 +34,7 @@ export function UsageHarnessSplit(props: UsageHarnessSplitProps): ReactNode {
           key={row.harnessId}
           row={row}
           scale={props.scale}
+          showTokens={props.showTokens}
         />
       ))}
     </ul>
@@ -36,6 +44,7 @@ export function UsageHarnessSplit(props: UsageHarnessSplitProps): ReactNode {
 function UsageHarnessSplitItem(props: {
   readonly row: UsageHarnessSplitRow;
   readonly scale: UsageSeriesScale;
+  readonly showTokens: boolean;
 }): ReactNode {
   const { row, scale } = props;
   const color = scale.colorVar(row.harnessId);
@@ -82,9 +91,11 @@ function UsageHarnessSplitItem(props: {
       <span className="min-w-16 shrink-0 text-right tabular-nums text-ui-sm font-medium text-foreground">
         {formatUsd(row.costUsd)}
       </span>
-      <span className="min-w-16 shrink-0 text-right tabular-nums text-ui-xs text-muted-foreground">
-        {row.tokens.toLocaleString()}
-      </span>
+      {props.showTokens ? (
+        <span className="min-w-16 shrink-0 text-right tabular-nums text-ui-xs text-muted-foreground">
+          {row.tokens.toLocaleString()}
+        </span>
+      ) : null}
     </li>
   );
 }

--- a/clients/gui-app/src/components/usage-analytics/usage-stat-tiles.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-stat-tiles.tsx
@@ -5,6 +5,14 @@ import { cn } from "@/lib/utils";
 
 export interface UsageStatTilesProps {
   readonly tiles: UsageStatTilesData;
+  /**
+   * `full` - the Settings dashboard's five tiles in the responsive
+   * `sm:`/`lg:` grid. `curated` - four tiles (drops Uncached input, the
+   * most inside-baseball of the five) in a fixed 2x2, sized for the epic
+   * usage dialog's hero zone where the headline and harness split carry
+   * the rest of the story.
+   */
+  readonly variant: "full" | "curated";
 }
 
 const TOKEN_FORMAT = new Intl.NumberFormat("en-US", {
@@ -18,16 +26,20 @@ function formatTokens(value: number): string {
 }
 
 /**
- * Five stat tiles: processed tokens, cached input, uncached input, output,
- * cache savings. Every secondary line is conditional on a real, non-null
- * figure from `usage-stat-tiles.ts` - never an implied zero for a signal a
- * harness simply did not report (the ticket's binding honesty rule).
+ * Stat tiles: processed tokens, cached input, uncached input (`full`
+ * only), output, cache savings. Every secondary line is conditional on a
+ * real, non-null figure from `usage-stat-tiles.ts` - never an implied zero
+ * for a signal a harness simply did not report (the ticket's binding
+ * honesty rule).
  */
 export function UsageStatTiles(props: UsageStatTilesProps): ReactNode {
-  const { tiles } = props;
+  const { tiles, variant } = props;
   return (
     <div
-      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+      className={cn(
+        "grid grid-cols-2 gap-3",
+        variant === "full" && "sm:grid-cols-3 lg:grid-cols-5",
+      )}
       data-testid="usage-stat-tiles"
     >
       <StatTile
@@ -50,16 +62,18 @@ export function UsageStatTiles(props: UsageStatTilesProps): ReactNode {
             : `${tiles.cachedInput.percentOfObservedInput.toFixed(0)}% of observed input`
         }
       />
-      <StatTile
-        testId="usage-stat-tile-uncached"
-        label="Uncached input"
-        value={formatTokens(tiles.uncachedInput.uncachedInputTokens)}
-        detail={
-          tiles.uncachedInput.cacheCreationTokens > 0
-            ? `+ ${PLAIN_TOKEN_FORMAT.format(tiles.uncachedInput.cacheCreationTokens)} cache writes`
-            : null
-        }
-      />
+      {variant === "curated" ? null : (
+        <StatTile
+          testId="usage-stat-tile-uncached"
+          label="Uncached input"
+          value={formatTokens(tiles.uncachedInput.uncachedInputTokens)}
+          detail={
+            tiles.uncachedInput.cacheCreationTokens > 0
+              ? `+ ${PLAIN_TOKEN_FORMAT.format(tiles.uncachedInput.cacheCreationTokens)} cache writes`
+              : null
+          }
+        />
+      )}
       <StatTile
         testId="usage-stat-tile-output"
         label="Output"

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -230,7 +230,11 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
     <div className="flex w-full max-w-4xl flex-col gap-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          <UsageWindowPicker windowDays={windowDays} onChange={setWindowDays} />
+          <UsageWindowPicker
+            windowDays={windowDays}
+            onChange={setWindowDays}
+            triggerClassName={undefined}
+          />
           <UsageHostFilter
             options={hostOptions}
             hostId={hostId}
@@ -436,7 +440,7 @@ function UsageSummaryPanelBody(props: {
           hostScopeName={hostScopeName}
           size="default"
         />
-        <UsageHarnessSplit rows={harnessRows} scale={scale} />
+        <UsageHarnessSplit rows={harnessRows} scale={scale} showTokens />
       </div>
       {/* Only worth a section once there is more than one host to compare:
           a single-row "By host" list under an All-hosts filter says nothing
@@ -449,7 +453,7 @@ function UsageSummaryPanelBody(props: {
         </div>
       ) : null}
       <div className="flex flex-col gap-1.5">
-        <UsageStatTiles tiles={statTiles} />
+        <UsageStatTiles tiles={statTiles} variant="full" />
         {absentNote === null ? null : (
           <p
             className="text-ui-xs text-muted-foreground/80"
@@ -464,6 +468,7 @@ function UsageSummaryPanelBody(props: {
           <UsageChartGroupByToggle
             groupBy={chartGroupBy}
             onChange={onChartGroupByChange}
+            triggerClassName={undefined}
           />
         </div>
         {/* `key` per the prop's contract: the legend's hidden-series state

--- a/clients/gui-app/src/components/usage-analytics/usage-window-picker.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-window-picker.tsx
@@ -14,6 +14,13 @@ const WINDOW_OPTIONS: ReadonlyArray<{
 export interface UsageWindowPickerProps {
   readonly windowDays: UsageSummaryWindowDays;
   readonly onChange: (windowDays: UsageSummaryWindowDays) => void;
+  /**
+   * Extra classes merged onto each trigger - the styling seam the Tabs
+   * primitive doesn't otherwise expose (its list hardcodes `h-8`), used by
+   * the usage dialogs for coarse-pointer touch-target bumps. `undefined`
+   * keeps the primitive's sizing (Settings).
+   */
+  readonly triggerClassName: string | undefined;
 }
 
 export function UsageWindowPicker(props: UsageWindowPickerProps): ReactNode {
@@ -32,6 +39,7 @@ export function UsageWindowPicker(props: UsageWindowPickerProps): ReactNode {
           <TabsTrigger
             key={option.value}
             value={String(option.value)}
+            className={props.triggerClassName}
             data-testid={`usage-window-${String(option.value)}`}
           >
             {option.label}


### PR DESCRIPTION
## What

Redesigns the epic Usage dialog into a **48rem fixed-frame mini-dashboard**, and brings the chat Usage dialog onto the same system. Fixes the long-standing size jump: the old dialog was `max-h` (content-sized), so it opened small around a spinner line and then grew when data landed.

**Epic dialog (loaded):** display-size cost headline + date-range label + harness split on the left, a curated 2×2 of stat tiles on the right (two-column hero at container ≥ 40rem, stacked below — container-keyed, not viewport-keyed), then the daily chart in a card with the group-by toggle, then the by-chat/agent breakdown.

**State system:** loading/error/empty/loaded all render into the same fixed frame (header + window picker + footer stay put):
- Loading: a skeleton mirroring the loaded layout (same hero grid, same chart height clamp) — no spinner, nothing shifts when data lands.
- Empty: one centered composition that owns the no-facts window entirely, with chips offering only **wider** windows (7 → 30/90, 30 → 90, 90 → none).
- Error: the existing retryable card, centered.

**Phone (viewport < 28rem):** both dialogs become bottom sheets via CSS-only `max-[28rem]:` variants on the same `DialogContent` (no primitive swap), `dvh` sizing, `max()`-combined safe-area padding, and `pointer-coarse:` hit-area bumps on the tab triggers (invisible overlay — the Tabs list keeps its `h-8`).

**Chat dialog:** same frame and width, shorter height; keeps its full-lifetime read, `target === null` guard, and turn drilldown. Empty state has no window chips (there is no wider window to offer).

## Correctness notes

- **Two color scales**, matching the Settings dashboard: the harness split always keeps a harness-keyed scale; the chart shares it only while grouping by harness. A single shared scale would gray every split row the moment the chart regroups by model (`colorVar` falls back to the "Other" token for unknown keys). Regression-tested.
- Shared components gain **required** props (`variant`, `showTokens`, `triggerClassName`, `size: "display"`), so the compiler enumerates every call site; Settings passes the values that keep its rendering identical, and its suites pass untouched.
- Commits are 2 (scaffold, then dialogs + prop seams together) rather than finer-grained: required props make producer and consumer atomic under the per-commit compile hook.

## Testing

- Epic suite: empty-state routing (incl. chip re-request + 90-day no-chips), skeleton-in-frame, frame-constant-around-error, structure/class assertions for the container-query fold and sheet tier (jsdom can't exercise those — classes are the testable contract), harness-split scale survival across a group-by switch.
- Chat suite: new skeleton test; all existing contracts unchanged.
- Settings ripple suites (`usage-settings-panel`, `usage-summary-panel-host-scope`, lib tests) pass untouched.
- Verified via the Tailwind compile API that every zero-precedent variant used here (`max-[28rem]:*`, `pointer-coarse:before:*`, `@min-[40rem]:grid-cols-[…]`, `[scrollbar-gutter:stable]`) actually emits CSS under the pinned Tailwind 4.3.3.

A rendered-result pass (resize through the ladder, sheet on a phone-width viewport) is worth doing in review — jsdom covers structure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
