### PR TITLE
perf(gui-app): scope the model catalog fan-out to the app-load fill

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1226,13 +1226,15 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   // (or a reasoning-effort label, which is version-specific) from a host that
   // never served the turn. On a default-host tab this is the slot the
   // app-load prefetcher already filled, so nothing changes there; on a
-  // remote-host tab the labels appear once anything warms that host's catalog
-  // — opening this tile's own composer picker does exactly that.
+  // remote-host tab the labels appear as that host's per-harness slots warm —
+  // this tile's own composer warms its selected harness on mount, and its
+  // picker warms whatever the user browses (the catalog fan-out itself is
+  // `"cached-only"` everywhere but the app-load fill).
   const tabHostCatalogClient = useTabHostClient();
   const tabModelCatalog = useGuiHarnessCatalogForClient(
     tabHostCatalogClient,
     null,
-    { enabled: false, subscribed: surfaceVisible },
+    { enabled: false, subscribed: surfaceVisible, modelsFetch: "cached-only" },
   );
   const displayCatalog = tabModelCatalog.harnesses;
   const modelLabels = useMemo<ReadonlyMap<string, string>>(

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker-intent-rpc.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker-intent-rpc.test.tsx
@@ -430,6 +430,19 @@ async function openPickerByTriggerName(
   await screen.findByRole("textbox", { name: /^Search/ });
 }
 
+/**
+ * Waits for `label` to appear among the MODEL ROWS. Scoped to the row list
+ * because the trigger shows the same text after a commit - and re-queried on
+ * every retry because a cold browse renders the "Loading models" state row
+ * (no scroller) until the browsed provider's real fetch lands, then remounts
+ * the Virtuoso list under a fresh node.
+ */
+async function findModelRow(label: string): Promise<void> {
+  await waitFor(() => {
+    within(screen.getByTestId("virtuoso-scroller")).getByText(label);
+  });
+}
+
 async function closePickerByTriggerName(
   triggerName: string | RegExp,
 ): Promise<void> {
@@ -518,7 +531,58 @@ describe("<HarnessModelPicker /> real-RPC intent edges", () => {
     expect(countFor(fixture.calls.listCommands, "codex")).toBe(1);
   });
 
-  it("refetches ONLY the selected harness when the picker opens after the refresh window, never the whole catalog", async () => {
+  it("first open on a cold host fetches ONLY the selected harness's models - never the whole rail", async () => {
+    const fixture = createPickerRpcFixture([
+      harnessEntry("codex", true),
+      harnessEntry("claude", true),
+      harnessEntry("opencode", true),
+    ]);
+    renderPickerWithFixture(fixture, defaultSelection("codex"));
+    await screen.findByText("codex Model 1");
+
+    await openPickerByTriggerName(/^codex Model 1/);
+    // The open edge prewarms the selected harness's commands - wait for that
+    // real RPC so the open has fully settled before asserting an absence.
+    await waitFor(() => {
+      expect(countFor(fixture.calls.listCommands, "codex")).toBe(1);
+    });
+
+    // The cold-host regression this suite now holds: the picker's catalog
+    // read is `"cached-only"`, so opening it on a host whose model slots are
+    // all empty (this fixture's fresh client stands in for a remote host no
+    // prefetcher ever filled) issues zero rail-wide listModels - previously
+    // one spawned provider server per available entry - and exactly one for
+    // the harness the user is actually on.
+    expect(countFor(fixture.calls.listModels, "codex")).toBe(1);
+    expect(countFor(fixture.calls.listModels, "claude")).toBe(0);
+    expect(countFor(fixture.calls.listModels, "opencode")).toBe(0);
+  });
+
+  it("browsing a rail entry fetches exactly that provider's models, exactly once - the rest of the rail stays cold", async () => {
+    const fixture = createPickerRpcFixture([
+      harnessEntry("codex", true),
+      harnessEntry("claude", true),
+      harnessEntry("opencode", true),
+    ]);
+    renderPickerWithFixture(fixture, defaultSelection("codex"));
+    await screen.findByText("codex Model 1");
+    await openPickerByTriggerName(/^codex Model 1/);
+
+    fireEvent.click(screen.getByRole("tab", { name: "claude" }));
+    await findModelRow("claude Model 1");
+
+    // Exactly once: browsing an available entry commits the selection in the
+    // same commit that enables its first fetch, so the browsed-provider and
+    // selected-harness queries land on ONE cold slot and dedupe into one
+    // fetch. (The selection intent edge also races this slot; its in-flight
+    // guard is covered as a unit in `use-gui-harness-catalog.test.tsx` - this
+    // mock transport honors the abort before its handler runs, so a canceled
+    // re-issue would not be countable here.)
+    expect(countFor(fixture.calls.listModels, "claude")).toBe(1);
+    expect(countFor(fixture.calls.listModels, "opencode")).toBe(0);
+  });
+
+  it("refetches ONLY the selected harness when the picker opens after the refresh window, never the rest of the rail", async () => {
     const fixture = createPickerRpcFixture([
       harnessEntry("codex", true),
       harnessEntry("claude", true),
@@ -527,14 +591,12 @@ describe("<HarnessModelPicker /> real-RPC intent edges", () => {
     await screen.findByText("codex Model 1");
 
     await openPickerByTriggerName(/^codex Model 1/);
-    // The batched fan-out fills every AVAILABLE harness the first time the
-    // picker opens - claude has no cached entry yet, and TanStack's no-data
-    // path ignores `staleTime`. Wait for that real RPC before snapshotting: the
-    // rows only render for whichever provider is browsed (still codex), so it
-    // isn't observable in the DOM.
-    await waitFor(() => {
-      expect(countFor(fixture.calls.listModels, "claude")).toBeGreaterThan(0);
-    });
+    // Warm claude the way anything warms on a cold host now: by browsing it.
+    // Then return the committed selection to codex before closing.
+    fireEvent.click(screen.getByRole("tab", { name: "claude" }));
+    await findModelRow("claude Model 1");
+    fireEvent.click(screen.getByRole("tab", { name: "codex" }));
+    await findModelRow("codex Model 1");
     await closePickerByTriggerName(/^codex Model 1/);
     const codexBeforeReopen = countFor(fixture.calls.listModels, "codex");
     const claudeBeforeReopen = countFor(fixture.calls.listModels, "claude");
@@ -542,23 +604,20 @@ describe("<HarnessModelPicker /> real-RPC intent edges", () => {
     ageCachePastRefreshWindow();
     await openPickerByTriggerName(/^codex Model 1/);
 
-    // The aged catalog re-pulls exactly the harness the user is on...
+    // The aged open re-pulls exactly the harness the user is on...
     await waitFor(() => {
       expect(countFor(fixture.calls.listModels, "codex")).toBe(
         codexBeforeReopen + 1,
       );
     });
-    // ...and NOT the ones they aren't. This is the regression the suite exists
-    // for: with a finite `staleTime` on the batched fan-out, re-mounting it on
-    // an aged cache re-pulled the ENTIRE rail on this edge - every provider,
-    // including OpenCode-backed ones the user never touched, each respawning a
-    // reaped server.
+    // ...and NOT the warm-but-aged one they aren't: no fan-out exists to
+    // re-pull the rail, and the open edge refreshes only the selection.
     expect(countFor(fixture.calls.listModels, "claude")).toBe(
       claudeBeforeReopen,
     );
   });
 
-  it("prewarms the newly selected harness's commands on a rail selection change, without refetching its warm models", async () => {
+  it("prewarms the newly selected harness's commands on a rail selection change, without re-pulling the models that switch just fetched", async () => {
     const fixture = createPickerRpcFixture([
       harnessEntry("codex", true),
       harnessEntry("claude", true),
@@ -567,27 +626,20 @@ describe("<HarnessModelPicker /> real-RPC intent edges", () => {
     await screen.findByText("codex Model 1");
 
     await openPickerByTriggerName(/^codex Model 1/);
-    await waitFor(() => {
-      expect(countFor(fixture.calls.listModels, "claude")).toBeGreaterThan(0);
-    });
-    const claudeModelsAfterOpen = countFor(fixture.calls.listModels, "claude");
 
     fireEvent.click(screen.getByRole("tab", { name: "claude" }));
     // "claude Model 1" now matches both the trigger's updated label AND the
     // browsed row - scope to the row list to disambiguate.
-    await within(screen.getByTestId("virtuoso-scroller")).findByText(
-      "claude Model 1",
-    );
+    await findModelRow("claude Model 1");
 
     // Commands have never loaded for claude, so selecting it warms its server.
     await waitFor(() => {
       expect(countFor(fixture.calls.listCommands, "claude")).toBe(1);
     });
-    // Its models were fetched by the fan-out moments ago, so the selection edge
-    // leaves them on cache rather than re-pulling them.
-    expect(countFor(fixture.calls.listModels, "claude")).toBe(
-      claudeModelsAfterOpen,
-    );
+    // ONE models fetch for the whole browse+commit: the browsed-provider and
+    // selected-harness queries share the cache slot, and the intent edge
+    // joins the fetch in flight rather than re-issuing it.
+    expect(countFor(fixture.calls.listModels, "claude")).toBe(1);
   });
 
   it("refetches only the newly selected harness's models on a rail selection change after the refresh window, and never the harness it left", async () => {
@@ -599,17 +651,19 @@ describe("<HarnessModelPicker /> real-RPC intent edges", () => {
     await screen.findByText("codex Model 1");
 
     await openPickerByTriggerName(/^codex Model 1/);
-    await waitFor(() => {
-      expect(countFor(fixture.calls.listModels, "claude")).toBeGreaterThan(0);
-    });
+    // Warm claude by browsing it, then return to codex, so the aged switch
+    // below is a real selection CHANGE landing on warm-but-aged data.
+    fireEvent.click(screen.getByRole("tab", { name: "claude" }));
+    await findModelRow("claude Model 1");
+    fireEvent.click(screen.getByRole("tab", { name: "codex" }));
+    await findModelRow("codex Model 1");
+
     ageCachePastRefreshWindow();
     const codexModelsAged = countFor(fixture.calls.listModels, "codex");
     const claudeModelsAged = countFor(fixture.calls.listModels, "claude");
 
     fireEvent.click(screen.getByRole("tab", { name: "claude" }));
-    await within(screen.getByTestId("virtuoso-scroller")).findByText(
-      "claude Model 1",
-    );
+    await findModelRow("claude Model 1");
 
     await waitFor(() => {
       expect(countFor(fixture.calls.listModels, "claude")).toBe(

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -24,6 +24,7 @@ import {
   useGuiHarnessModelsQueryForClient,
   useGuiHarnessesQueryForClient,
   useRefreshHarnessCatalogForClient,
+  type GuiHarnessCatalogEntry,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
 import {
   buildAllHarnessModelRows,
@@ -457,12 +458,14 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     const commands = selectedCommandsQueryRef.current;
     if (harnessCatalogEntryNeedsRefresh(commands)) void commands.refetch();
   }, []);
-  // Explicit intent edges, and the ONLY thing that refreshes a model catalog
-  // outside the app-load fill and the manual refresh button - every model query
-  // is cache-only now (see `use-gui-harness-catalog.ts`). They refresh just the
-  // selected harness, so opening the picker no longer fans out across every
-  // provider, and only once its cached entry has aged past the window, so an
-  // open on warm cache costs nothing. That also makes them the intent-driven
+  // Explicit intent edges - the only thing that RE-fetches an already-warm
+  // model catalog outside the app-load fill and the manual refresh button
+  // (first loads belong to `selectedModelsQuery` / `activeProviderModelsQuery`
+  // below via TanStack's no-data path; every model query is cache-only, see
+  // `use-gui-harness-catalog.ts`). They refresh just the selected harness, so
+  // opening the picker never fans out across every provider, and only once
+  // its cached entry has aged past the window, so an open on warm cache costs
+  // nothing. That also makes them the intent-driven
   // prewarm for a reaped OpenCode-backed server (the age threshold is the
   // host's idle timeout) and the error-recovery path, now that a failed fetch
   // no longer self-heals on a background timer.
@@ -479,9 +482,17 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     runSelectedHarnessIntentRefetch();
   }, [runSelectedHarnessIntentRefetch, selection.harnessId]);
   const catalogActive = activityEnabled && visibleOpen;
+  // `"cached-only"`: the open popover renders every rail entry's models from
+  // whatever the run-target host's cache slots hold (the prefetcher's app-load
+  // fill on the default host; nothing, at first, on a cold remote one). The
+  // fetches are the picker's own and per-harness - `selectedModelsQuery` above
+  // for the committed selection, `activeProviderModelsQuery` below for the
+  // browsed rail entry - so opening the picker on a cold host spawns at most
+  // the one provider the user is looking at, never the whole rail.
   const catalog = useGuiHarnessCatalogForClient(runTargetClient, null, {
     enabled: catalogActive,
     subscribed: catalogActive,
+    modelsFetch: "cached-only",
   });
   // In terminal mode the rail/rows only offer TUI-capable harnesses; GUI-only
   // providers (e.g. `traycer`) are filtered out of the catalog up front so every
@@ -561,10 +572,12 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     createProfileHostIsLocal,
     loginCapabilityByHarnessId.get(resolvedActiveProviderId),
   );
-  const activeProvider =
-    catalogHarnesses.find(
-      (harness) => harness.id === resolvedActiveProviderId,
-    ) ?? null;
+  const activeProvider = useBrowsedProviderCatalogEntry({
+    runTargetClient,
+    browsedProviderId: resolvedActiveProviderId,
+    catalogHarnesses,
+    catalogActive,
+  });
   // The profile browsed/selected within the active provider: prefer the
   // reducer's `activeProfileId` (a strip click or ⌘-digit rail switch) if it
   // belongs to this harness, else the committed selection's profile if it
@@ -1041,6 +1054,53 @@ function modelPickerSelectionSummary(
   if (label.length === 0) return null;
   if (reasoningLabel === null) return label;
   return `${label} · Thinking ${reasoningLabel}`;
+}
+
+/**
+ * The browsed rail provider's catalog entry, with its models fetched on the
+ * picker's own gate now that the catalog fan-out is `"cached-only"`: browsing
+ * a rail entry is the intent edge that loads - and, for an OpenCode-backed
+ * provider on a cold host, spawns - exactly that provider. Committing a
+ * selection points `selectedModelsQuery` at the same cache key, so the common
+ * browse==selection case dedupes into one fetch; a degraded-but-available
+ * entry (browsable without committing) is covered by THIS query alone.
+ * Unavailable entries stay unfetched (mirroring `selectedHarnessRefetchGate`:
+ * their panel shows a CTA instead of rows), and a warm slot is never
+ * re-pulled (`staleTime: Infinity`).
+ *
+ * `modelsLoading` is overridden from this hook's own query rather than read
+ * off the catalog entry: the catalog's flag mirrors the shared slot's fetch
+ * state, which only turns on once the query here actually dispatches - one
+ * painted frame after a cold browse. This observer knows it is ABOUT to fetch
+ * (`isPending` behind the gate covers that optimistic pre-dispatch render),
+ * so the panel's spinner shows from the first frame instead of flashing "No
+ * models available".
+ */
+function useBrowsedProviderCatalogEntry(input: {
+  readonly runTargetClient: HostClient<HostRpcRegistry> | null;
+  readonly browsedProviderId: ProviderId;
+  readonly catalogHarnesses: ReadonlyArray<GuiHarnessCatalogEntry>;
+  readonly catalogActive: boolean;
+}): GuiHarnessCatalogEntry | null {
+  const entry =
+    input.catalogHarnesses.find(
+      (harness) => harness.id === input.browsedProviderId,
+    ) ?? null;
+  const fetchGate = input.catalogActive && entry?.available === true;
+  const modelsQuery = useGuiHarnessModelsQueryForClient(
+    input.runTargetClient,
+    input.browsedProviderId,
+    null,
+    {
+      enabled: fetchGate,
+      subscribed: input.catalogActive,
+    },
+  );
+  const modelsLoading = fetchGate && modelsQuery.isPending;
+  return useMemo(
+    () => (entry === null ? null : { ...entry, modelsLoading }),
+    [entry, modelsLoading],
+  );
 }
 
 // Restrict to harnesses whose adapter advertises a TUI surface. Runtime

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -53,6 +53,11 @@ const hostResolution = vi.hoisted(() => ({
 const scopedReads = vi.hoisted(() => ({
   catalogClients: [] as unknown[],
   providersClients: [] as unknown[],
+  warmupCalls: [] as Array<{
+    readonly client: unknown;
+    readonly harnessId: string | null;
+    readonly enabled: boolean;
+  }>,
 }));
 
 vi.mock("@/lib/epic-selectors", () => ({
@@ -95,6 +100,21 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
       harnessesError: null,
       modelsLoading: false,
     };
+  },
+  // The header's targeted subject-harness warmup (its catalog read is
+  // `"cached-only"`, so this is the ONLY model fetch the card may cause).
+  // Recorded so tests can assert it targets the owner's host and the subject
+  // harness - never a fan-out and never another host's client.
+  useGuiHarnessModelsWarmup: (
+    client: unknown,
+    harnessId: string | null,
+    activity: { readonly enabled: boolean; readonly subscribed: boolean },
+  ) => {
+    scopedReads.warmupCalls.push({
+      client,
+      harnessId,
+      enabled: activity.enabled,
+    });
   },
 }));
 const catalogHarnesses = vi.hoisted(() => () => [
@@ -271,6 +291,30 @@ describe("WorktreeOwnerSettingsHeader", () => {
     hostResolution.byHostId.clear();
     scopedReads.catalogClients = [];
     scopedReads.providersClients = [];
+    scopedReads.warmupCalls = [];
+  });
+
+  it("warms exactly the subject harness's models on the owner's host - the card's only permitted model fetch", () => {
+    // The catalog read is `"cached-only"` (an all-harness `listModels`
+    // fan-out here would spawn every provider server on the owner's host to
+    // label one tuple), so the targeted warmup is what keeps a cold remote
+    // owner's model label resolving instead of falling back to a raw slug
+    // forever. It must aim at the subject harness on the OWNER's client.
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
+    const ownerClient = hostResolution.byHostId.get("host-1");
+    expect(ownerClient).toBeDefined();
+    expect(scopedReads.warmupCalls.length).toBeGreaterThan(0);
+    for (const call of scopedReads.warmupCalls) {
+      expect(call.client).toBe(ownerClient);
+      expect(call.harnessId).toBe("claude");
+      expect(call.enabled).toBe(true);
+    }
   });
 
   it("reads the harness catalog through the OWNER's host client - the same one the provider list uses", () => {
@@ -524,6 +568,7 @@ describe("chat settings sourced from the host", () => {
     hostResolution.byHostId.clear();
     scopedReads.catalogClients = [];
     scopedReads.providersClients = [];
+    scopedReads.warmupCalls = [];
   });
 
   function renderRegistryOnlyChat(): void {

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -59,6 +59,9 @@ const scopedReads = vi.hoisted(() => ({
     readonly enabled: boolean;
   }>,
 }));
+/** Availability of the fixture's one harness, so tests can drive the subject
+ *  warmup's availability gate (a tombstoned/disabled subject must not fetch). */
+const catalogAvailability = vi.hoisted(() => ({ subjectAvailable: true }));
 
 vi.mock("@/lib/epic-selectors", () => ({
   useChatById: () =>
@@ -121,6 +124,9 @@ const catalogHarnesses = vi.hoisted(() => () => [
   {
     id: "claude",
     label: "Claude Code",
+    // The subject warmup gates on this flag (an availability-blind warmup
+    // would hit a disabled provider's listModels on every card open).
+    available: catalogAvailability.subjectAvailable,
     models: [
       {
         harnessId: "claude",
@@ -292,6 +298,7 @@ describe("WorktreeOwnerSettingsHeader", () => {
     scopedReads.catalogClients = [];
     scopedReads.providersClients = [];
     scopedReads.warmupCalls = [];
+    catalogAvailability.subjectAvailable = true;
   });
 
   it("warms exactly the subject harness's models on the owner's host - the card's only permitted model fetch", () => {
@@ -314,6 +321,25 @@ describe("WorktreeOwnerSettingsHeader", () => {
       expect(call.client).toBe(ownerClient);
       expect(call.harnessId).toBe("claude");
       expect(call.enabled).toBe(true);
+    }
+  });
+
+  it("keeps the warmup disabled while the subject harness is unavailable - a tombstoned subject must not hit its provider's listModels", () => {
+    // The tuple is persisted history: it can name a harness the owner's host
+    // has since disabled or lost. `hasSubject` is still true (the card
+    // renders, with the raw-slug fallback), so availability is the ONLY thing
+    // standing between every card open and a doomed listModels attempt.
+    catalogAvailability.subjectAvailable = false;
+    renderChatHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+      serviceTier: null,
+    });
+
+    expect(scopedReads.warmupCalls.length).toBeGreaterThan(0);
+    for (const call of scopedReads.warmupCalls) {
+      expect(call.enabled).toBe(false);
     }
   });
 
@@ -569,6 +595,7 @@ describe("chat settings sourced from the host", () => {
     scopedReads.catalogClients = [];
     scopedReads.providersClients = [];
     scopedReads.warmupCalls = [];
+    catalogAvailability.subjectAvailable = true;
   });
 
   function renderRegistryOnlyChat(): void {

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-tui-hover-card.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-tui-hover-card.test.tsx
@@ -51,6 +51,9 @@ vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
   useHostClientForHostId: () => ({ getActiveHostId: () => "host-1" }),
 }));
 vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
+  // The header's subject-harness warmup; targeting is covered by
+  // `worktree-owner-settings-header.test.tsx`, so a no-op suffices here.
+  useGuiHarnessModelsWarmup: () => undefined,
   // The header resolves the catalog through the owner's host client; this
   // suite is about hover-card identity, not host scoping (covered by
   // `worktree-owner-settings-header.test.tsx`), so it answers for any client.

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -138,8 +138,18 @@ export function WorktreeOwnerSettingsHeader(props: {
     subscribed: hasSubject,
     modelsFetch: "cached-only",
   });
+  // Gated on the subject's availability, not just `hasSubject`: the tuple is
+  // persisted history, so it can name a harness the owner's host has since
+  // disabled or lost - and an availability-blind warmup would hit that
+  // provider's `listModels` on every card open (the fan-out and the picker
+  // both fetch available harnesses only). Until the harness list resolves,
+  // availability is unknown and the warmup simply waits; an unavailable
+  // subject keeps the documented raw-slug fallback.
+  const subjectAvailable =
+    catalog.harnesses.find((harness) => harness.id === subjectHarnessId)
+      ?.available === true;
   useGuiHarnessModelsWarmup(hostClient, subjectHarnessId, {
-    enabled: hasSubject,
+    enabled: hasSubject && subjectAvailable,
     subscribed: hasSubject,
   });
 

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -15,7 +15,10 @@ import {
 import { harnessProfiles } from "@/components/worktree/worktree-owner-settings-profiles";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
 import { useChatRunSettings } from "@/hooks/chats/use-chat-run-settings-query";
-import { useGuiHarnessCatalogForClient } from "@/hooks/harnesses/use-gui-harness-catalog";
+import {
+  useGuiHarnessCatalogForClient,
+  useGuiHarnessModelsWarmup,
+} from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useProvidersListForClient } from "@/hooks/providers/use-providers-list-query";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import { useChatById } from "@/lib/epic-selectors";
@@ -50,15 +53,19 @@ interface TuiHeaderFields {
  * labels remain pure cache reads; managed terminal profiles can fetch the same
  * live provider list their launch/fork surfaces use. The catalog is NOT free,
  * though: the harnesses query carries a finite 15-min staleTime, so opening
- * the card on a stale availability query can refetch it, and if that surfaces a
- * newly-available harness with no cached model list the `listModels` fan-out
- * follows (which, per that module's header, can spawn the OpenCode server and
- * reset the host's idle-reap clock) - and both now land on the OWNER's host.
- * For an owner on the default host that is the steady state as before: the
- * app-load prefetcher filled the same host-id-keyed cache slot and models are
+ * the card on a stale availability query can refetch it - on the OWNER's host.
+ * Models are narrower still: the catalog read is `"cached-only"` (the
+ * all-harness `listModels` fan-out belongs to the app-load fill alone - per
+ * that module's header, a cold fan-out is one spawned provider server per rail
+ * entry), and the ONE harness this card actually labels - the subject tuple's -
+ * is warmed by a targeted `useGuiHarnessModelsWarmup`. For an owner on the
+ * default host that is the steady state as before: the app-load prefetcher
+ * filled the same host-id-keyed cache slot and models are
  * `staleTime: Infinity`, so an open renders straight from cache. For an owner
- * on another host the first open fetches that host's catalog cold - the same
- * self-sufficiency trade the provider-list read below already makes.
+ * on another host the first open fetches that host's harness list and the
+ * subject harness's models cold - the same self-sufficiency trade the
+ * provider-list read below already makes, at the cost of one provider rather
+ * than the fleet.
  */
 export function WorktreeOwnerSettingsHeader(props: {
   readonly ownerId: string;
@@ -107,10 +114,11 @@ export function WorktreeOwnerSettingsHeader(props: {
     ? runSettingsQuery.data.settings
     : localChatSettings;
   const hasSubject = ownerHasSubject(isChat, chatSettings, tuiAgent);
+  const subjectHarnessId = ownerHarnessId(chatSettings, tuiAgent);
 
   // The dynamic label source, gated on `hasSubject` so a legacy row with no
-  // settings never mounts the catalog fan-out at all. Warm entries render from
-  // cache; see the component doc above for when an open can still refetch.
+  // settings never mounts the reads at all. Warm entries render from cache;
+  // see the component doc above for when an open can still refetch.
   //
   // Scoped to the OWNER's host like the provider-list read below: the tuple
   // being labeled is what THAT host runs, so a model only that host offers
@@ -120,7 +128,17 @@ export function WorktreeOwnerSettingsHeader(props: {
   // refetches. A `null` client (owner's host missing from the directory,
   // signed out) disables the read and labels fall back to raw slugs - honest,
   // rather than borrowing another host's catalog under this host's name.
+  //
+  // `"cached-only"` + a targeted warmup: this card labels exactly ONE model
+  // tuple, so the only model list it may pull on a cold host is the subject
+  // harness's own - an all-harness fan-out here would spawn every provider
+  // server on the owner's host to render one line of text.
   const catalog = useGuiHarnessCatalogForClient(hostClient, null, {
+    enabled: hasSubject,
+    subscribed: hasSubject,
+    modelsFetch: "cached-only",
+  });
+  useGuiHarnessModelsWarmup(hostClient, subjectHarnessId, {
     enabled: hasSubject,
     subscribed: hasSubject,
   });
@@ -148,7 +166,7 @@ export function WorktreeOwnerSettingsHeader(props: {
     harnesses: catalog.harnesses,
     profiles: harnessProfiles(
       providersList.data?.providers ?? null,
-      ownerHarnessId(chatSettings, tuiAgent),
+      subjectHarnessId,
     ),
   });
   if (view === null) return null;

--- a/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
+++ b/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
@@ -26,6 +26,8 @@ import {
 import { createAppQueryClient } from "@/lib/query-client";
 import { getConditionPollEpisodeCoordinator } from "@/lib/query/condition-poll-episode-coordinator";
 import {
+  HARNESS_CATALOG_REFRESH_AFTER_MS,
+  harnessCatalogEntryNeedsRefresh,
   useGuiHarnessCatalog,
   useGuiHarnessCatalogForClient,
   useGuiHarnessCommandsQuery,
@@ -33,6 +35,7 @@ import {
   useGuiHarnessesQueryForClient,
   useGuiHarnessModelsQuery,
   useGuiHarnessModelsQueryForClient,
+  useGuiHarnessModelsWarmup,
   useRefreshHarnessCatalog,
   useRefreshHarnessCatalogForClient,
 } from "@/hooks/harnesses/use-gui-harness-catalog";
@@ -538,7 +541,12 @@ describe("useGuiHarnessCatalog (batched interval removal regression)", () => {
     });
 
     renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: true, subscribed: true }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "all-harnesses",
+        }),
       { wrapper: fixture.Wrapper },
     );
 
@@ -561,7 +569,12 @@ describe("useGuiHarnessCatalog (batched interval removal regression)", () => {
     });
 
     const hook = renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: true, subscribed: true }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "all-harnesses",
+        }),
       { wrapper: fixture.Wrapper },
     );
     await act(async () => {
@@ -604,7 +617,12 @@ describe("useGuiHarnessCatalog (batched interval removal regression)", () => {
     });
 
     renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: true, subscribed: true }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "all-harnesses",
+        }),
       { wrapper: fixture.Wrapper },
     );
 
@@ -645,7 +663,12 @@ describe("useGuiHarnessCatalog cache-only label reader (MED5)", () => {
 
     // The prefetch/owner warms the host-keyed cache once.
     const owner = renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: true, subscribed: true }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "all-harnesses",
+        }),
       { wrapper: fixture.Wrapper },
     );
     await act(async () => {
@@ -658,7 +681,12 @@ describe("useGuiHarnessCatalog cache-only label reader (MED5)", () => {
     // A VISIBLE-but-not-owning reader (enabled:false) reads the same cache with
     // no live publisher and issues zero requests, yet gets friendly labels.
     const reader = renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: false, subscribed: true }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: false,
+          subscribed: true,
+          modelsFetch: "cached-only",
+        }),
       { wrapper: fixture.Wrapper },
     );
     await act(async () => {
@@ -678,7 +706,12 @@ describe("useGuiHarnessCatalog cache-only label reader (MED5)", () => {
       "agent.gui.listModels": () => modelsResponse(2),
     });
     const owner = renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: true, subscribed: true }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "all-harnesses",
+        }),
       { wrapper: fixture.Wrapper },
     );
     await act(async () => {
@@ -687,7 +720,12 @@ describe("useGuiHarnessCatalog cache-only label reader (MED5)", () => {
     owner.unmount();
 
     const hidden = renderHook(
-      () => useGuiHarnessCatalog(null, { enabled: false, subscribed: false }),
+      () =>
+        useGuiHarnessCatalog(null, {
+          enabled: false,
+          subscribed: false,
+          modelsFetch: "cached-only",
+        }),
       { wrapper: fixture.Wrapper },
     );
     await act(async () => {
@@ -905,6 +943,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
         useGuiHarnessCatalogForClient(null, null, {
           enabled: true,
           subscribed: true,
+          modelsFetch: "all-harnesses",
         }),
       { wrapper: Wrapper },
     );
@@ -922,5 +961,299 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     expect(result.current.modelsLoading).toBe(false);
     expect(result.current.harnessesError).toBeNull();
     expect(defaultHostCalls).toEqual({ harnesses: 0, models: 0, commands: 0 });
+  });
+});
+
+// The intent-edge freshness predicate, as a unit: the in-flight arm cannot be
+// proven through a mocked transport (it honors the abort before its handler
+// runs, so the canceled first request of a cancel-and-re-issue never shows in
+// an RPC count), but on a real host both requests arrive - the picker's
+// intent-rpc suite counts the OTHER arms and leans on this one directly.
+describe("harnessCatalogEntryNeedsRefresh", () => {
+  it("never reports an in-flight entry as due - refetch() defaults to cancelRefetch, so 'due' would cancel and re-issue the request underway", () => {
+    // The cold browse-commit race: the enabled-transition fetch has already
+    // dispatched (dataUpdatedAt still 0) when the selection intent edge asks.
+    expect(
+      harnessCatalogEntryNeedsRefresh({
+        dataUpdatedAt: 0,
+        isError: false,
+        isFetching: true,
+      }),
+    ).toBe(false);
+    // Same while an errored entry's recovery refetch is already underway.
+    expect(
+      harnessCatalogEntryNeedsRefresh({
+        dataUpdatedAt: 1,
+        isError: true,
+        isFetching: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the due arms: never-loaded, errored and aged entries refresh; a fresh one does not", () => {
+    expect(
+      harnessCatalogEntryNeedsRefresh({
+        dataUpdatedAt: 0,
+        isError: false,
+        isFetching: false,
+      }),
+    ).toBe(true);
+    expect(
+      harnessCatalogEntryNeedsRefresh({
+        dataUpdatedAt: Date.now(),
+        isError: true,
+        isFetching: false,
+      }),
+    ).toBe(true);
+    expect(
+      harnessCatalogEntryNeedsRefresh({
+        dataUpdatedAt: Date.now() - HARNESS_CATALOG_REFRESH_AFTER_MS - 1,
+        isError: false,
+        isFetching: false,
+      }),
+    ).toBe(true);
+    expect(
+      harnessCatalogEntryNeedsRefresh({
+        dataUpdatedAt: Date.now(),
+        isError: false,
+        isFetching: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+// Coverage for the cold-host narrowing: the all-harness `listModels` fan-out
+// belongs to the app-load fill alone (`modelsFetch: "all-harnesses"`); every
+// user-facing surface passes `"cached-only"` and warms specific harnesses
+// through its own targeted query on the shared cache slot. TanStack's no-data
+// path ignores `staleTime`, so before this scope existed ANY enabled catalog
+// mount on a cold (non-prefetched, usually remote) host fanned `listModels`
+// across every available harness - one spawned provider server per rail entry,
+// on first picker open.
+describe('useGuiHarnessCatalogForClient modelsFetch: "cached-only"', () => {
+  afterEach(() => {
+    hostBindingMock.current = null;
+    cleanup();
+  });
+
+  interface ScopedFixture {
+    readonly Wrapper: (props: { readonly children: ReactNode }) => ReactNode;
+    readonly client: HostClient<HostRpcRegistry>;
+    /** Harness ids of every `agent.gui.listModels` request, in arrival order. */
+    readonly modelCalls: GuiHarnessId[];
+  }
+
+  function createScopedFixture(
+    ids: ReadonlyArray<GuiHarnessId>,
+    listModelsHandler:
+      | (() => Promise<ListGuiAgentModelsResponse> | ListGuiAgentModelsResponse)
+      | null,
+  ): ScopedFixture {
+    const queryClient = createAppQueryClient();
+    const modelCalls: GuiHarnessId[] = [];
+    let requestCounter = 0;
+    const client = new HostClient<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      invalidator: createHostQueryInvalidator(queryClient),
+      messenger: new MockHostMessenger<HostRpcRegistry>({
+        registry: hostRpcRegistry,
+        requestId: () => {
+          requestCounter += 1;
+          return `req-${String(requestCounter)}`;
+        },
+        handlers: {
+          "agent.gui.listHarnesses": () => ({ harnesses: harnesses(ids) }),
+          "agent.gui.listModels": (params) => {
+            modelCalls.push(params.harnessId);
+            return listModelsHandler === null
+              ? modelsResponse(1)
+              : listModelsHandler();
+          },
+        },
+      }),
+    });
+    client.bind(mockLocalHostEntry);
+    client.setRequestContext(
+      createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+    );
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+    return { Wrapper, client, modelCalls };
+  }
+
+  it("issues ZERO listModels on a cold cache, and reports entries as not loading rather than eternally pending", async () => {
+    const fixture = createScopedFixture(["opencode", "claude"], null);
+    const { result } = renderHook(
+      () =>
+        useGuiHarnessCatalogForClient(fixture.client, null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "cached-only",
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.harnesses).toHaveLength(2);
+    });
+    // The fan-out (were it enabled) dispatches in an effect right after the
+    // harness list lands - give it that beat so this asserts absence where
+    // absence would show, not before the code under test could have run.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fixture.modelCalls).toEqual([]);
+    // The trap the `isLoading` predicate exists for: a disabled observer on a
+    // no-data slot is `isPending` forever, and surfacing that as "loading"
+    // would spin every consumer for a fetch that never starts.
+    expect(result.current.harnesses[0].modelsLoading).toBe(false);
+    expect(result.current.modelsLoading).toBe(false);
+  });
+
+  it('"all-harnesses" on the same fixture still fans out across every available harness - the positive control for the zero above', async () => {
+    const fixture = createScopedFixture(["opencode", "claude"], null);
+    renderHook(
+      () =>
+        useGuiHarnessCatalogForClient(fixture.client, null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "all-harnesses",
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+    await waitFor(() => {
+      expect([...fixture.modelCalls].sort()).toEqual(["claude", "opencode"]);
+    });
+  });
+
+  it("surfaces models a targeted per-harness query fetched into the shared slot, leaving every other harness unfetched", async () => {
+    const fixture = createScopedFixture(["opencode", "claude"], null);
+    const { result } = renderHook(
+      () => ({
+        catalog: useGuiHarnessCatalogForClient(fixture.client, null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "cached-only",
+        }),
+        // The picker's composition: its own standalone query for the harness
+        // it is actually about (selected/browsed), same cache slot.
+        selected: useGuiHarnessModelsQueryForClient(
+          fixture.client,
+          "opencode",
+          null,
+          { enabled: true, subscribed: true },
+        ),
+      }),
+      { wrapper: fixture.Wrapper },
+    );
+    await waitFor(() => {
+      const entry = result.current.catalog.harnesses.find(
+        (harness) => harness.id === "opencode",
+      );
+      expect(entry?.models).toHaveLength(1);
+    });
+    expect(fixture.modelCalls).toEqual(["opencode"]);
+    const claude = result.current.catalog.harnesses.find(
+      (harness) => harness.id === "claude",
+    );
+    expect(claude?.models).toHaveLength(0);
+    expect(claude?.modelsLoading).toBe(false);
+  });
+
+  it("reports modelsLoading for exactly the harness a targeted fetch is filling, while it is in flight", async () => {
+    // The initializer is unreachable: a Promise executor runs synchronously,
+    // so `release` is the real resolver before the fixture is even built -
+    // but TS cannot see that, and a `| null` type would narrow the later call
+    // to `null`.
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fixture = createScopedFixture(["opencode", "claude"], async () => {
+      await gate;
+      return modelsResponse(1);
+    });
+    const { result } = renderHook(
+      () => ({
+        catalog: useGuiHarnessCatalogForClient(fixture.client, null, {
+          enabled: true,
+          subscribed: true,
+          modelsFetch: "cached-only",
+        }),
+        selected: useGuiHarnessModelsQueryForClient(
+          fixture.client,
+          "opencode",
+          null,
+          { enabled: true, subscribed: true },
+        ),
+      }),
+      { wrapper: fixture.Wrapper },
+    );
+    // The cached-only entry tracks the SHARED slot's fetch state, so the
+    // in-flight targeted fetch shows as loading on the catalog entry too...
+    await waitFor(() => {
+      const entry = result.current.catalog.harnesses.find(
+        (harness) => harness.id === "opencode",
+      );
+      expect(entry?.modelsLoading).toBe(true);
+    });
+    // ...while a slot nothing is filling stays honestly not-loading.
+    const claudeDuring = result.current.catalog.harnesses.find(
+      (harness) => harness.id === "claude",
+    );
+    expect(claudeDuring?.modelsLoading).toBe(false);
+    release();
+    await waitFor(() => {
+      const entry = result.current.catalog.harnesses.find(
+        (harness) => harness.id === "opencode",
+      );
+      expect(entry?.models).toHaveLength(1);
+      expect(entry?.modelsLoading).toBe(false);
+    });
+  });
+
+  it("useGuiHarnessModelsWarmup fetches its one subject harness exactly once, and nothing for a null subject", async () => {
+    const fixture = createScopedFixture(["opencode", "claude"], null);
+    const noSubject = renderHook(
+      () =>
+        useGuiHarnessModelsWarmup(fixture.client, null, {
+          enabled: true,
+          subscribed: true,
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fixture.modelCalls).toEqual([]);
+    noSubject.unmount();
+
+    const warm = renderHook(
+      () =>
+        useGuiHarnessModelsWarmup(fixture.client, "claude", {
+          enabled: true,
+          subscribed: true,
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+    await waitFor(() => {
+      expect(fixture.modelCalls).toEqual(["claude"]);
+    });
+    warm.unmount();
+    // Cache-only contract: a warm slot is never re-pulled by a remount.
+    renderHook(
+      () =>
+        useGuiHarnessModelsWarmup(fixture.client, "claude", {
+          enabled: true,
+          subscribed: true,
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fixture.modelCalls).toEqual(["claude"]);
   });
 });

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -42,17 +42,38 @@ import { getConditionPollEpisodeCoordinator } from "@/lib/query/condition-poll-e
 // pays a respawn and resets the host's idle clock, which is what kept a spawned
 // server effectively unreapable.
 //
-// Models therefore refresh in exactly three places:
-//   - the app-load fill (`HarnessCatalogPrefetcher`), which populates the cache
-//     once per app session; every surface renders from that cache, including
-//     while a refresh is in flight (a background refetch keeps the previous
-//     data, so `isPending` stays false and no surface blanks);
+// `staleTime: Infinity` still leaves one hole: TanStack's NO-DATA path ignores
+// it, so a fan-out whose observers are enabled fetches every harness with no
+// cached entry. On the app-wide default host the prefetcher fills those slots
+// at app load and the hole never shows - but a composer pinned to another host
+// reads that HOST's cache slots, which nothing prefetched, so a picker or
+// palette subpage mounting there cold-started `listModels` for every available
+// harness at once: one spawned provider server per rail entry, on a host the
+// user had merely opened a picker on. `modelsFetch` (below) closes that hole:
+// only `"all-harnesses"` (the prefetcher's app-load fill) may fan out; every
+// other surface is `"cached-only"` and warms exactly the harness it is about
+// via its own targeted query on the shared cache slot.
+//
+// Models therefore refresh in exactly four places:
+//   - the app-load fill (`HarnessCatalogPrefetcher`), the ONLY fan-out
+//     (`modelsFetch: "all-harnesses"`), which populates the default host's
+//     cache once per app session; every surface renders from that cache,
+//     including while a refresh is in flight (a background refetch keeps the
+//     previous data, so `isPending` stays false and no surface blanks);
 //   - the picker's intent edges - popover open, harness selection - which
 //     refresh ONLY the selected harness, and only once its cached entry is
 //     older than `HARNESS_CATALOG_REFRESH_AFTER_MS`
 //     (`harnessCatalogEntryNeedsRefresh`);
+//   - targeted per-harness fetches on their surface's own gate: the picker's
+//     selected-harness and browsed-provider queries
+//     (`useGuiHarnessModelsQueryForClient`), and label surfaces warming their
+//     one subject harness (`useGuiHarnessModelsWarmup`) - each fetching a
+//     single harness's slot on the composer's / owner's host, never the rail;
 //   - the picker's manual refresh button (`useRefreshHarnessCatalog`), whose
-//     `invalidateQueries` beats `staleTime: Infinity` and re-fetches everything.
+//     `invalidateQueries` beats `staleTime: Infinity` and re-fetches every
+//     ACTIVE query (on a non-default host that is the picker's own targeted
+//     queries; a cached-only entry re-pulls when next browsed, since
+//     invalidation survives `staleTime: Infinity` at that enabled-mount edge).
 //
 // Matching that refresh threshold to the host's 15-min idle timeout is what
 // keeps the two clocks from fighting: a picker opened inside the window reuses
@@ -76,6 +97,7 @@ const HARNESS_AVAILABILITY_REFRESH_MS = 15 * 60 * 1000;
 export interface HarnessCatalogEntryFreshness {
   readonly dataUpdatedAt: number;
   readonly isError: boolean;
+  readonly isFetching: boolean;
 }
 
 /**
@@ -86,6 +108,13 @@ export interface HarnessCatalogEntryFreshness {
  * `listModels` - and respawn a reaped OpenCode server - on every popover open,
  * however fresh the cache was.
  *
+ * A fetch already in flight is never due: it IS the fresh data coming, and the
+ * imperative `refetch()` defaults to `cancelRefetch: true`, so answering "due"
+ * would cancel and re-issue that request - a doubled RPC on exactly the cold
+ * edges where an enabled-transition fetch and an intent edge race (browsing a
+ * provider on a cold host commits the selection in the same commit that
+ * enables its first fetch).
+ *
  * An entry that never loaded (`dataUpdatedAt === 0`) or whose last fetch failed
  * is always due: with no background retry left, the intent edges are also the
  * error-recovery path.
@@ -93,6 +122,7 @@ export interface HarnessCatalogEntryFreshness {
 export function harnessCatalogEntryNeedsRefresh(
   entry: HarnessCatalogEntryFreshness,
 ): boolean {
+  if (entry.isFetching) return false;
   if (entry.isError || entry.dataUpdatedAt === 0) return true;
   return Date.now() - entry.dataUpdatedAt >= HARNESS_CATALOG_REFRESH_AFTER_MS;
 }
@@ -106,6 +136,26 @@ export function harnessCatalogEntryNeedsRefresh(
 export interface QueryActivityOptions {
   readonly enabled: boolean;
   readonly subscribed: boolean;
+}
+
+/**
+ * Catalog activity: `QueryActivityOptions` plus the model fan-out scope.
+ *
+ * `modelsFetch` decides whether this observer may FETCH model lists it has no
+ * cache for - it never affects what the catalog SURFACES (cached entries render
+ * either way, and keep tracking cache updates):
+ *   - `"all-harnesses"`: the model fan-out fetches every available harness with
+ *     no cached entry. Reserved for the app-load fill; on a cold host this is
+ *     one spawned provider server per rail entry, so no user-facing surface
+ *     gets to be the trigger.
+ *   - `"cached-only"`: the fan-out never fetches - entries surface whatever the
+ *     shared cache slots hold. A surface that needs a specific harness resolved
+ *     on a cold host owns a targeted query for it
+ *     (`useGuiHarnessModelsQueryForClient` / `useGuiHarnessModelsWarmup`),
+ *     whose result lands in the same slot this catalog reads.
+ */
+export interface CatalogQueryActivityOptions extends QueryActivityOptions {
+  readonly modelsFetch: "all-harnesses" | "cached-only";
 }
 
 export interface GuiHarnessCatalogEntry extends GuiHarnessOption {
@@ -232,6 +282,46 @@ export function useGuiHarnessModelsQueryForClient(
   });
 }
 
+/**
+ * Targeted single-harness model warmup: fetches `agent.gui.listModels` for
+ * exactly one harness into the same cache slot the catalog's entries read,
+ * without the all-harness fan-out. For a label surface that pairs a
+ * `"cached-only"` catalog with one known subject harness (e.g. the worktree
+ * owner header labeling the tuple its owner runs), so that subject still
+ * resolves on a cold host at the cost of one provider - never the whole rail.
+ *
+ * `harnessId === null` (no subject yet) mounts no query at all - deliberately
+ * not a disabled observer on a junk `null`-keyed slot. Same cache-only
+ * contract as `useGuiHarnessModelsQueryForClient`: a warm slot is never
+ * re-pulled, and the last verified list is never garbage-collected.
+ */
+export function useGuiHarnessModelsWarmup(
+  client: HostClient<HostRpcRegistry> | null,
+  harnessId: GuiHarnessId | null,
+  activity: QueryActivityOptions,
+): void {
+  const requests = useMemo(() => {
+    if (harnessId === null) return EMPTY_GUI_MODEL_REQUESTS;
+    return [
+      {
+        method: "agent.gui.listModels" as const,
+        params: { harnessId, workingDirectory: null },
+      },
+    ];
+  }, [harnessId]);
+  useHostQueries<HostRpcRegistry, "agent.gui.listModels">({
+    client,
+    cacheKeyIdentity: undefined,
+    requests,
+    options: {
+      enabled: activity.enabled,
+      subscribed: activity.subscribed,
+      staleTime: Infinity,
+      gcTime: Infinity,
+    },
+  });
+}
+
 export function useGuiHarnessCommandsQuery(
   client: HostClient<HostRpcRegistry> | null,
   harnessId: GuiHarnessId,
@@ -262,7 +352,7 @@ export function useGuiHarnessCommandsQuery(
 
 export function useGuiHarnessCatalog(
   workingDirectory: string | null,
-  activity: QueryActivityOptions,
+  activity: CatalogQueryActivityOptions,
 ): GuiHarnessCatalog {
   return useGuiHarnessCatalogForClient(
     useDefaultHostClient(),
@@ -279,7 +369,7 @@ export function useGuiHarnessCatalog(
 export function useGuiHarnessCatalogForClient(
   client: HostClient<HostRpcRegistry> | null,
   workingDirectory: string | null,
-  activity: QueryActivityOptions,
+  activity: CatalogQueryActivityOptions,
 ): GuiHarnessCatalog {
   const harnessesQuery = useGuiHarnessesQueryForClient(client, activity);
   // Fetching is gated by `enabled` (inside the sub-query hooks); the projection
@@ -312,7 +402,14 @@ export function useGuiHarnessCatalogForClient(
     cacheKeyIdentity: undefined,
     requests,
     options: {
-      enabled: activity.enabled,
+      // Only the app-load fill may fan out (see `CatalogQueryActivityOptions`):
+      // TanStack's no-data path ignores `staleTime`, so an enabled observer on
+      // a cold host's cache slot IS a fetch - and on a non-default host every
+      // slot is cold, which made a picker/palette mount there spawn every
+      // provider's server at once. A `"cached-only"` observer never fetches;
+      // it still surfaces and tracks the shared slots, which the surface's own
+      // targeted per-harness queries fill.
+      enabled: activity.enabled && activity.modelsFetch === "all-harnesses",
       // Cache-only (see the module header). These observers are created and
       // destroyed as each surface activates, so a finite staleTime turned every
       // picker open / chat-tile reveal / palette subpage mount past the window
@@ -343,7 +440,13 @@ export function useGuiHarnessCatalogForClient(
             return {
               ...harness,
               models: modelQuery?.data?.models ?? EMPTY_GUI_MODEL_OPTIONS,
-              modelsLoading: modelQuery?.isPending ?? false,
+              // "Loading" must mean a fetch is actually happening. Raw
+              // `isPending` is true for ANY no-data slot - including one a
+              // `"cached-only"` observer will never fetch - which would read
+              // as an eternal spinner. `isLoading` (`isPending && isFetching`)
+              // reflects the query's shared fetch state, so it also turns true
+              // while a surface's own targeted query fills this same slot.
+              modelsLoading: modelQuery?.isLoading ?? false,
               modelsError:
                 modelQuery?.error instanceof HostRpcError
                   ? modelQuery.error
@@ -353,8 +456,10 @@ export function useGuiHarnessCatalogForClient(
         : EMPTY_GUI_HARNESS_CATALOG_ENTRIES,
     [attached, harnessesQuery.data, queryByHarnessId],
   );
+  // Same predicate as the per-entry flag above: a slot nothing will fetch is
+  // not "loading", however empty it is.
   const modelsLoading = useMemo(
-    () => modelQueries.some((query) => query.isPending),
+    () => modelQueries.some((query) => query.isLoading),
     [modelQueries],
   );
   // "Loading" means a fetch is actually coming. With no client the harness

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -290,16 +290,25 @@ export function useGuiHarnessModelsQueryForClient(
  * owner header labeling the tuple its owner runs), so that subject still
  * resolves on a cold host at the cost of one provider - never the whole rail.
  *
+ * Callers gate `enabled` on the subject's AVAILABILITY as well as their own
+ * activity (mirroring the picker's fetch gates and the fan-out, which only
+ * ever fetched available harnesses): a subject persisted by a historical
+ * chat/TUI agent can name a harness that is now disabled or unavailable, and
+ * an availability-blind warmup would hit that provider's `listModels` - and
+ * retry the failure on every later mount, since an errored query refetches on
+ * the next enabled mount.
+ *
  * `harnessId === null` (no subject yet) mounts no query at all - deliberately
- * not a disabled observer on a junk `null`-keyed slot. Same cache-only
- * contract as `useGuiHarnessModelsQueryForClient`: a warm slot is never
- * re-pulled, and the last verified list is never garbage-collected.
+ * not a disabled observer on a junk `null`-keyed slot; the result is then an
+ * empty array. Same cache-only contract as
+ * `useGuiHarnessModelsQueryForClient`: a warm slot is never re-pulled, and
+ * the last verified list is never garbage-collected.
  */
 export function useGuiHarnessModelsWarmup(
   client: HostClient<HostRpcRegistry> | null,
   harnessId: GuiHarnessId | null,
   activity: QueryActivityOptions,
-): void {
+): Array<UseQueryResult<ListGuiAgentModelsResponse, HostRpcError>> {
   const requests = useMemo(() => {
     if (harnessId === null) return EMPTY_GUI_MODEL_REQUESTS;
     return [
@@ -309,7 +318,7 @@ export function useGuiHarnessModelsWarmup(
       },
     ];
   }, [harnessId]);
-  useHostQueries<HostRpcRegistry, "agent.gui.listModels">({
+  return useHostQueries<HostRpcRegistry, "agent.gui.listModels">({
     client,
     cacheKeyIdentity: undefined,
     requests,

--- a/clients/gui-app/src/lib/commands/sources/composer.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/composer.source.ts
@@ -318,10 +318,16 @@ const MODEL_SUBPAGE: CommandSubpage = {
 function useFocusedComposerCatalog(): GuiHarnessCatalog {
   const entry = useFocusedComposerEntry();
   const defaultClient = useDefaultHostClient();
+  // `"cached-only"`: opening a palette subpage must not cold-start every
+  // provider on the focused composer's host. The subpages list what the host's
+  // cache already holds - on the default host that is the prefetcher's full
+  // fill; on a cold remote host it is at least the focused composer's selected
+  // harness, which its own picker's standalone query warms on mount, growing
+  // as the user browses providers in that picker.
   return useGuiHarnessCatalogForClient(
     entry === null ? defaultClient : entry.hostClient,
     null,
-    { enabled: true, subscribed: true },
+    { enabled: true, subscribed: true, modelsFetch: "cached-only" },
   );
 }
 

--- a/clients/gui-app/src/providers/harness-catalog-prefetcher.tsx
+++ b/clients/gui-app/src/providers/harness-catalog-prefetcher.tsx
@@ -5,10 +5,22 @@ import { useHostCompatibility } from "@/lib/host";
  * Renderer-side warmup for the GUI harness catalog. The host already
  * prewarms availability and provider servers; this keeps TanStack Query's
  * model catalog warm before the user opens a new-chat picker.
+ *
+ * The ONLY `"all-harnesses"` mount in the app: this is the app-load fill the
+ * cache-only model contract leans on (see `use-gui-harness-catalog.ts`), and
+ * it fans out on the app-wide DEFAULT host - the one whose provider servers
+ * the host process prewarms anyway. Every user-facing surface reads
+ * `"cached-only"` and warms specific harnesses on its own intent edges, so a
+ * composer pinned to a cold remote host never spawns that host's entire
+ * provider fleet just by opening a picker.
  */
 export function HarnessCatalogPrefetcher() {
   const compatibility = useHostCompatibility();
   const active = compatibility.status === "compatible";
-  useGuiHarnessCatalog(null, { enabled: active, subscribed: active });
+  useGuiHarnessCatalog(null, {
+    enabled: active,
+    subscribed: active,
+    modelsFetch: "all-harnesses",
+  });
   return null;
 }


### PR DESCRIPTION
## What

Narrows the model picker's all-harness `listModels` fan-out so a cold (non-default, usually remote) host no longer spawns **every provider's server on first picker open**. Follow-up to #1206, where this was verified during review and filed as a known cost.

## Why

The catalog's batched `listModels` fan-out mounted enabled observers on every surface that read it, and TanStack's no-data path ignores `staleTime: Infinity`. On the app-wide default host the app-load prefetcher fills every slot, so the hole never showed — but a composer pinned to another host reads *that host's* (empty) cache slots, so opening a picker or a ⌘K Pick-model subpage there cold-started `listModels` for every available harness at once: one spawned provider server per rail entry.

## How

- **`CatalogQueryActivityOptions.modelsFetch`** (`"all-harnesses" | "cached-only"`), declared explicitly at every call site. Only `HarnessCatalogPrefetcher` (the app-load fill, default host) keeps the fan-out; the picker, palette subpages, chat-tile labels and the worktree owner header become cache readers — disabled observers still surface and track the shared slots.
- **Picker**: a new browsed-provider query (`useBrowsedProviderCatalogEntry`) fetches the rail entry the user is looking at, gated on availability + popover open. The selected harness was already covered by its standalone query; browse==selection dedupes onto one cache key. Cold open = 1 fetch; each rail browse = at most 1 more.
- **Worktree owner header**: `useGuiHarnessModelsWarmup` fetches exactly the subject tuple's harness, preserving its documented cold-host self-sufficiency at 1/N the cost.
- **Honesty fixes**: entry `modelsLoading` now uses `isLoading` (a cached-only observer on a never-fetched slot is `isPending` forever — an eternal spinner for a fetch that never starts), and `harnessCatalogEntryNeedsRefresh` treats an in-flight fetch as not-due (`refetch()` defaults to `cancelRefetch`, so the cold browse-commit race would cancel + re-issue a request the host already received).

## Testing

- `use-gui-harness-catalog.test.tsx`: cached-only issues **zero** `listModels` on a cold cache (with an all-harnesses positive control on the same fixture); targeted queries fill the shared slots the catalog surfaces; in-flight `modelsLoading` tracks exactly the harness being filled; warmup fetches its one subject once (and nothing for `null`); freshness-predicate unit tests including the in-flight arm (not provable through the mocked transport, which honors the abort before its handler runs).
- `harness-model-picker-intent-rpc.test.tsx` (real hooks over a mocked transport): cold open fetches **only** the selected harness across a 3-provider rail; browsing fetches exactly that provider once; the aged open/selection edges still refresh only the selection.
- All three mechanisms mutation-probed: reverting the `modelsFetch` gate kills 5 tests, `isPending` regression kills 3, dropping the in-flight guard kills the predicate unit test.
- Full reachable set green: 26 files / 434 tests, `tsc -b` clean, eslint `--max-warnings 0` + prettier clean.

## Accepted trade-offs

- The palette's Pick-model subpage on a cold remote host lists what's cached (at least the focused composer's selected harness, warmed on composer mount) instead of every provider.
- The picker's manual refresh on a non-default host re-fetches active queries (harness list, selected/browsed models, commands); other cached entries re-pull when next browsed via the invalidation-beats-staleTime mount edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)