### PR TITLE
fix(gui-app): make the usage-dialog skeleton visible in preset themes

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -437,6 +437,17 @@ describe("<EpicUsageDialog />", () => {
     expect(screen.getByTestId("usage-window-7")).toBeTruthy();
     expect(screen.getByTestId("epic-usage-view-full-dashboard")).toBeTruthy();
 
+    // Every block must override the primitive's `bg-muted`: preset themes
+    // define `--muted` identical to `--popover` (the dialog surface), which
+    // made the whole skeleton render invisibly. A foreground-alpha fill is
+    // the surface-independent guarantee.
+    const blocks = status.querySelectorAll('[data-slot="skeleton"]');
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block.className).toContain("bg-foreground/10");
+      expect(block.className).not.toContain("bg-muted");
+    }
+
     await screen.findByTestId("usage-cost-figure");
     expect(screen.queryByTestId("usage-dialog-skeleton")).toBeNull();
   });

--- a/clients/gui-app/src/components/usage-analytics/usage-dialog-states.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-dialog-states.tsx
@@ -10,6 +10,21 @@ export interface UsageDialogSkeletonProps {
 }
 
 /**
+ * `Skeleton`'s default `bg-muted` fill is invisible on this dialog: the
+ * surface is the primitive's `bg-popover`, and most preset themes define
+ * `--muted` IDENTICAL to `--popover` (amoled, dracula, catppuccin,
+ * tokyo-night, github, nord, gruvbox, ayu, everforest, traycer-green - only
+ * the default light/dark pair separates them). A foreground-alpha fill
+ * contrasts with whatever surface it sits on, in every theme, by
+ * construction.
+ */
+const SKELETON_ON_POPOVER = "bg-foreground/10";
+
+function DialogSkeleton(props: { readonly className: string }): ReactNode {
+  return <Skeleton className={cn(SKELETON_ON_POPOVER, props.className)} />;
+}
+
+/**
  * Loading fill that mirrors the loaded layout - the same hero grid, chart
  * clamp, and row rhythm as the data that replaces it, so nothing shifts
  * when it lands. Deliberately not a spinner (and outside the
@@ -55,26 +70,26 @@ function EpicUsageSkeletonBlocks(): ReactNode {
       <div className="grid grid-cols-1 gap-4 @min-[40rem]:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]">
         <div className="flex min-w-0 flex-col gap-3">
           <div className="flex flex-col gap-2">
-            <Skeleton className="h-8 w-1/3" />
-            <Skeleton className="h-3 w-1/2" />
+            <DialogSkeleton className="h-8 w-1/3" />
+            <DialogSkeleton className="h-3 w-1/2" />
           </div>
           <div className="flex flex-col gap-2.5">
-            <Skeleton className="h-3.5 w-full" />
-            <Skeleton className="h-3.5 w-full" />
+            <DialogSkeleton className="h-3.5 w-full" />
+            <DialogSkeleton className="h-3.5 w-full" />
           </div>
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
+          <DialogSkeleton className="h-16" />
+          <DialogSkeleton className="h-16" />
+          <DialogSkeleton className="h-16" />
+          <DialogSkeleton className="h-16" />
         </div>
       </div>
-      <Skeleton className="h-[clamp(11rem,26vh,16rem)] w-full" />
+      <DialogSkeleton className="h-[clamp(11rem,26vh,16rem)] w-full" />
       <div className="flex flex-col gap-2.5">
-        <Skeleton className="h-3.5 w-full" />
-        <Skeleton className="h-3.5 w-full" />
-        <Skeleton className="h-3.5 w-2/3" />
+        <DialogSkeleton className="h-3.5 w-full" />
+        <DialogSkeleton className="h-3.5 w-full" />
+        <DialogSkeleton className="h-3.5 w-2/3" />
       </div>
     </>
   );
@@ -85,13 +100,13 @@ function ChatUsageSkeletonBlocks(): ReactNode {
   return (
     <>
       <div className="flex flex-col gap-2">
-        <Skeleton className="h-8 w-1/3" />
-        <Skeleton className="h-3 w-1/2" />
+        <DialogSkeleton className="h-8 w-1/3" />
+        <DialogSkeleton className="h-3 w-1/2" />
       </div>
       <div className="flex flex-col gap-2.5">
-        <Skeleton className="h-3.5 w-full" />
-        <Skeleton className="h-3.5 w-full" />
-        <Skeleton className="h-3.5 w-2/3" />
+        <DialogSkeleton className="h-3.5 w-full" />
+        <DialogSkeleton className="h-3.5 w-full" />
+        <DialogSkeleton className="h-3.5 w-2/3" />
       </div>
     </>
   );
@@ -119,7 +134,10 @@ export function UsageDialogEmpty(props: UsageDialogEmptyProps): ReactNode {
       className="flex h-full min-h-0 flex-col items-center justify-center gap-3 px-4 py-6 text-center"
       data-testid="usage-dialog-empty"
     >
-      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+      {/* `bg-foreground/10`, not `bg-muted`, for the SKELETON_ON_POPOVER
+          reason: preset themes collapse `--muted` into `--popover`, which
+          would leave the icon floating without its ring. */}
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-foreground/10 text-muted-foreground">
         <LineChart className="size-5" aria-hidden />
       </div>
       <div className="space-y-1">


### PR DESCRIPTION
## Problem

Testing #1212's usage dialogs against a live host showed a completely blank body while the summary was being fetched — no skeleton, just the fixed-height frame.

The skeleton was rendering, invisibly. `UsageDialogSkeleton`'s blocks used the `Skeleton` primitive's default `bg-muted` fill, the dialog surface is the primitive's `bg-popover`, and most preset themes in `index.css` define `--muted` **identical** to `--popover`: amoled `#1a1a1a`, dracula `#343746`, catppuccin `#313244`, tokyo-night `#24283b`, github `#161b22`, plus nord, gruvbox, ayu, everforest, traycer-green. Only the default light/dark pair separates the two tokens (`oklch(0.269)` vs `oklch(0.205)` in dark), which is why the state looked fine during development.

## Fix

- Skeleton blocks get a local `DialogSkeleton` wrapper that overrides the fill with `bg-foreground/10` — a foreground-alpha fill contrasts with whatever surface it sits on, in every theme, by construction (tailwind-merge drops the primitive's `bg-muted` for the later background utility).
- The empty state's icon ring had the same `bg-muted`-on-popover defect (icon floating without its circle in preset themes) — same fix.
- The existing skeleton test now pins that every `[data-slot="skeleton"]` block carries `bg-foreground/10` and none retains `bg-muted`.

Deliberately scoped to the usage dialogs: the `Skeleton` primitive's `bg-muted` default is fine on `bg-background` surfaces (presets keep those distinct) but has the same invisibility on other popover/card surfaces (e.g. `remote-folder-picker-dialog`, `rate-limit-popover`) — pre-existing, and an app-wide primitive change deserves its own visual pass.

## Verification

- `epic-usage-dialog.test.tsx` + `chat-usage-dialog.test.tsx`: 18 tests pass (plus the react-compiler second pass).
- `bg-foreground/10` already emits in this app (4 existing call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)