### PR TITLE
fix(gui): stop the fork dialog waiting forever, and block a doomed submit

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-cross-host.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-cross-host.test.tsx
@@ -1149,7 +1149,16 @@ describe("ChatForkDialog cross-host routing", () => {
     expect(dialogMocks.createMutate).not.toHaveBeenCalled();
   });
 
-  it("boundarySyncing: notice speaks, rows stay selectable, submit stays enabled", async () => {
+  it("boundarySyncing: notice speaks, rows stay selectable, submit is blocked", () => {
+    // Clicking OTHER_HOST_ID makes this a CROSS-HOST fork, and
+    // `chatForkTargetVerdict` only reaches the `boundaryUncovered` arm (→
+    // `boundarySyncing`) when `isCrossHost` is true — a same-host fork
+    // short-circuits to `allowed` before this check ever runs (see the
+    // sibling first-paint test below, which stays same-host). `boundarySyncing`
+    // is no longer exempt from `verdictAllowsSubmit`: the host's coverage
+    // check is presence-only, so an uncovered boundary can be ACCEPTED and
+    // seed a truncated turn, and submit must block on it like every other
+    // refusal now.
     advertiseSourcePublication();
     dialogMocks.publicationQuery = {
       data: {
@@ -1165,26 +1174,38 @@ describe("ChatForkDialog cross-host routing", () => {
 
     const notice = screen.getByTestId("chat-fork-publication-notice");
     expect(notice.textContent).toContain(
-      "Still syncing this turn — retry shortly.",
+      "Still syncing this turn to the cloud — forking to another machine unlocks as soon as it lands.",
     );
     expect(selectedUnselectableExceptHostId()).toBeNull();
     expect(selectedRefusalWord(OTHER_HOST_ID)).toBeUndefined();
 
+    // The distinction this state carries is over the ROW, not the button:
+    // the row stays selectable because nothing is wrong with the host and
+    // the wait is seconds long, so killing the row would throw away the
+    // configuration the user is about to be allowed to submit.
     const otherRow = screen.getByTestId(`fork-host-${OTHER_HOST_ID}`);
     expect(otherRow instanceof HTMLButtonElement && otherRow.disabled).toBe(
       false,
     );
-    expect(forkButton().disabled).toBe(false);
+    expect(forkButton().disabled).toBe(true);
 
-    const request = await submitFork();
-    expect(request.hostId).toBe(OTHER_HOST_ID);
+    fireEvent.click(forkButton());
+    expect(dialogMocks.createMutate).not.toHaveBeenCalled();
   });
 
   it("boundarySyncing sentence is on first paint with no host selected", () => {
     // Sibling of the unpublished first-paint case. The class resolver
-    // returns `syncing` with no `isCrossHost` input, so the sentence must
-    // not wait for a highlight. The post-click test above would still pass
-    // if it did.
+    // (`chatForkRemoteClassState`) returns `syncing` with no `isCrossHost`
+    // input, so the sentence must not wait for a highlight.
+    //
+    // No host is selected here, so the highlighted target is the tab's own
+    // host and this is a SAME-HOST fork. `chatForkTargetVerdict` short-
+    // circuits `!isCrossHost` to `{ kind: "allowed" }` before it ever looks
+    // at `publication` (chat-fork-target.ts:403), so the submit gate never
+    // sees `boundarySyncing` here and the button stays enabled — unlike the
+    // sibling test above, which selects OTHER_HOST_ID, makes the fork
+    // cross-host, and gets blocked. The two are not contradicting each
+    // other: this pair is what pins the same-host exemption.
     advertiseSourcePublication();
     dialogMocks.publicationQuery = {
       data: {
@@ -1198,7 +1219,7 @@ describe("ChatForkDialog cross-host routing", () => {
 
     const notice = screen.getByTestId("chat-fork-publication-notice");
     expect(notice.textContent).toContain(
-      "Still syncing this turn — retry shortly.",
+      "Still syncing this turn to the cloud — forking to another machine unlocks as soon as it lands.",
     );
     expect(selectedUnselectableExceptHostId()).toBeNull();
     const otherRow = screen.getByTestId(`fork-host-${OTHER_HOST_ID}`);

--- a/clients/gui-app/src/components/chat/__tests__/chat-fork-target.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-fork-target.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   BOUNDARY_SYNCING_NOTICE,
+  CHAT_BACKUP_HALTED_NOTICE,
+  CHAT_BACKUP_UNAVAILABLE_NOTICE,
+  CHAT_DELETED_NOTICE,
   CHAT_FORK_NEEDS_UPDATE_WORD,
+  CHAT_LINEAGE_SUPERSEDED_NOTICE,
   CHAT_NOT_BACKED_UP_NOTICE,
   chatForkHostRefusals,
   chatForkTargetSupport,
@@ -280,13 +284,21 @@ describe("publication gate treatment follows how long the condition lasts", () =
     expect(verdictAllowsSubmit(unpublished)).toBe(false);
     expect(verdictNotice(unpublished)).toBe(CHAT_NOT_BACKED_UP_NOTICE);
 
-    // Speaks without blocking: if this were silently downgraded to `allowed`
-    // the notice would vanish and the non-blocking half would still pass.
+    // Blocks submit while leaving the row selectable - the two halves are
+    // independent, deliberately. Production INVERTED this: the host's old
+    // coverage check is presence-only (`containsMessageId`), so a boundary
+    // turn published mid-stream and since finalized locally reads as covered
+    // at its partial version. Leaving submit enabled here would let a fork
+    // sail through Layer 2 and seed a silently TRUNCATED turn - the poll
+    // lane this method carries is what makes the row worth keeping
+    // selectable instead of a dead end (see `boundarySyncing`'s own note in
+    // chat-fork-target.ts). A future reader must not "fix" this back to
+    // `true`.
     expect(syncing.kind).toBe("boundarySyncing");
     expect(
       remoteClassIsUnreachable(chatForkRemoteClassState(BOUNDARY_UNCOVERED)),
     ).toBe(false);
-    expect(verdictAllowsSubmit(syncing)).toBe(true);
+    expect(verdictAllowsSubmit(syncing)).toBe(false);
     expect(verdictNotice(syncing)).toBe(BOUNDARY_SYNCING_NOTICE);
 
     expect(refused.kind).toBe("hostRefused");
@@ -339,5 +351,193 @@ describe("publicationStateFromResponse", () => {
         boundaryCovered: true,
       }),
     ).toEqual(COVERED);
+  });
+});
+
+describe("publicationStateFromResponse layers `definitive` on top of the ordinary reading", () => {
+  const COVERED_RESPONSE = { published: true, boundaryCovered: true } as const;
+
+  it("chat-deleted invalidates an otherwise-covered head", () => {
+    expect(
+      publicationStateFromResponse({
+        ...COVERED_RESPONSE,
+        definitive: "chat-deleted",
+      }),
+    ).toEqual({ kind: "definitivelyUnavailable", reason: "chat-deleted" });
+  });
+
+  it("lineage-superseded invalidates an otherwise-covered head", () => {
+    expect(
+      publicationStateFromResponse({
+        ...COVERED_RESPONSE,
+        definitive: "lineage-superseded",
+      }),
+    ).toEqual({
+      kind: "definitivelyUnavailable",
+      reason: "lineage-superseded",
+    });
+  });
+
+  // Counterfactual for the two blocks above: same base fixture, only the
+  // reason changes. `backup-halted` is the pure freeze - publication
+  // stopped, but whatever had already been acknowledged is still there to be
+  // pulled - so it must NOT contradict the coverage fact this client already
+  // read.
+  it("backup-halted does NOT invalidate an otherwise-covered head", () => {
+    expect(
+      publicationStateFromResponse({
+        ...COVERED_RESPONSE,
+        definitive: "backup-halted",
+      }),
+    ).toEqual(COVERED);
+  });
+
+  // Same counterfactual again: an unrecognised reason is a licence to stop
+  // polling (see chat-publication-definitive.test.ts), never a licence to
+  // contradict a coverage fact this client actually read.
+  it("an unrecognised reason does NOT invalidate an otherwise-covered head either", () => {
+    expect(
+      publicationStateFromResponse({
+        ...COVERED_RESPONSE,
+        definitive: "a-reason-this-build-does-not-know",
+      }),
+    ).toEqual(COVERED);
+  });
+
+  it("counterfactual: the same base fixture with definitive: null stays covered", () => {
+    expect(
+      publicationStateFromResponse({
+        ...COVERED_RESPONSE,
+        definitive: null,
+      }),
+    ).toEqual(COVERED);
+  });
+
+  it("keeps boundaryCovered: null uncollapsed when a definitive field is also present", () => {
+    // Guards the tri-state discipline against the new field: `definitive:
+    // null` must not be mistaken for a boundaryCovered value, and must not
+    // itself collapse the tri-state to false.
+    expect(
+      publicationStateFromResponse({
+        published: true,
+        boundaryCovered: null,
+        definitive: null,
+      }),
+    ).toEqual(COVERED);
+  });
+
+  it("a definitive reason freezes an unpublished or uncovered answer too", () => {
+    expect(
+      publicationStateFromResponse({
+        published: false,
+        boundaryCovered: null,
+        definitive: "chat-deleted",
+      }),
+    ).toEqual({ kind: "definitivelyUnavailable", reason: "chat-deleted" });
+    expect(
+      publicationStateFromResponse({
+        published: true,
+        boundaryCovered: false,
+        definitive: "backup-halted",
+      }),
+    ).toEqual({ kind: "definitivelyUnavailable", reason: "backup-halted" });
+  });
+});
+
+describe("chatForkTargetVerdict with a definitively unavailable publication", () => {
+  const DEFINITIVELY_DELETED: ChatForkPublicationState = {
+    kind: "definitivelyUnavailable",
+    reason: "chat-deleted",
+  };
+  const DEFINITIVELY_SUPERSEDED: ChatForkPublicationState = {
+    kind: "definitivelyUnavailable",
+    reason: "lineage-superseded",
+  };
+  const DEFINITIVELY_HALTED: ChatForkPublicationState = {
+    kind: "definitivelyUnavailable",
+    reason: "backup-halted",
+  };
+  const DEFINITIVELY_UNEXPLAINED: ChatForkPublicationState = {
+    kind: "definitivelyUnavailable",
+    reason: "unexplained",
+  };
+
+  it.each([
+    { publication: DEFINITIVELY_DELETED, notice: CHAT_DELETED_NOTICE },
+    {
+      publication: DEFINITIVELY_SUPERSEDED,
+      notice: CHAT_LINEAGE_SUPERSEDED_NOTICE,
+    },
+    { publication: DEFINITIVELY_HALTED, notice: CHAT_BACKUP_HALTED_NOTICE },
+    {
+      publication: DEFINITIVELY_UNEXPLAINED,
+      notice: CHAT_BACKUP_UNAVAILABLE_NOTICE,
+    },
+  ])(
+    "names the reason-specific notice, blocks submit, and marks the row unreachable ($publication.reason)",
+    ({ publication, notice }) => {
+      const verdict = chatForkTargetVerdict({
+        isCrossHost: true,
+        version: SUPPORTED,
+        publication,
+      });
+      expect(verdict).toEqual({ kind: "chatUnavailable", notice });
+      expect(verdictAllowsSubmit(verdict)).toBe(false);
+      expect(verdictNotice(verdict)).toBe(notice);
+      expect(
+        remoteClassIsUnreachable(chatForkRemoteClassState(publication)),
+      ).toBe(true);
+    },
+  );
+
+  it("outranks a per-host build refusal - a frozen source-chat fact is universal, a build fact is per-row", () => {
+    const verdict = chatForkTargetVerdict({
+      isCrossHost: true,
+      version: REFUSED,
+      publication: DEFINITIVELY_DELETED,
+    });
+    expect(verdict.kind).toBe("chatUnavailable");
+  });
+});
+
+describe("verdictAllowsSubmit is true only for the allowed verdict", () => {
+  it.each<{ name: string; verdict: ChatForkTargetVerdict; allows: boolean }>([
+    { name: "allowed", verdict: ALLOWED, allows: true },
+    { name: "chatUnpublished", verdict: UNPUBLISHED_VERDICT, allows: false },
+    { name: "boundarySyncing", verdict: SYNCING_VERDICT, allows: false },
+    { name: "hostRefused", verdict: refusedVerdict(), allows: false },
+    {
+      name: "chatUnavailable",
+      verdict: { kind: "chatUnavailable", notice: CHAT_DELETED_NOTICE },
+      allows: false,
+    },
+  ])("$name -> allows=$allows", ({ verdict, allows }) => {
+    expect(verdictAllowsSubmit(verdict)).toBe(allows);
+  });
+
+  it("keeps the permissive publication states allowing submit - an unsupported or unreachable source host must not start blocking the fork", () => {
+    // `unknown` publication is what a source host that predates
+    // `epic.chatPublicationState`, or one that is currently unreachable,
+    // resolves to (see use-chat-publication-state-query.ts's "every failure
+    // resolves to unknown"). Neither must be swept into the blocking
+    // behaviour added for `boundarySyncing` and `definitivelyUnavailable`.
+    expect(
+      verdictAllowsSubmit(
+        chatForkTargetVerdict({
+          isCrossHost: true,
+          version: SUPPORTED,
+          publication: PUB_UNKNOWN,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      verdictAllowsSubmit(
+        chatForkTargetVerdict({
+          isCrossHost: true,
+          version: UNKNOWN,
+          publication: PUB_UNKNOWN,
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -325,8 +325,12 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
   // still keyed to the selection.
   const remoteClass = chatForkRemoteClassState(publication);
   const publicationNotice = remoteClassNotice(remoteClass);
-  // The remote CLASS goes unselectable on an unpublished chat - no remote host
-  // can serve it - while the rows themselves stay silent.
+  // The remote CLASS goes unselectable on the DURABLE answers - a chat that has
+  // never been published, and one the host has called definitively over - since
+  // no remote host can serve either, while the rows themselves stay silent. A
+  // boundary that is merely still syncing is not one of them: it blocks submit
+  // but keeps the rows live, because the wait is seconds long and the rows are
+  // where the fork is configured meanwhile.
   const remoteRowsUnselectable = remoteClassIsUnreachable(remoteClass);
 
   // A REFUSAL parks this dialog's host reads, which is the one consumer shape
@@ -503,7 +507,12 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
     hasStagedPreselection: stagedIntentForKey !== null,
     createPending: createChat.isPending,
     hostClientResolved: selectedHostClient !== null,
-    hostSupportsFork: verdictAllowsSubmit(targetVerdict),
+    // Not a host-build fact any more, and the name says so. This one boolean
+    // now carries the SOURCE CHAT's publication too - a frozen publication and
+    // a boundary the published head does not cover both hold Fork shut, the
+    // second of them transiently and with a poll lane behind it that reopens
+    // the button on its own.
+    verdictAllowsSubmit: verdictAllowsSubmit(targetVerdict),
     // The A/B pre-selection gate waits for a staging round-trip that only
     // happens when there IS a seed to override. Cross-host there is none, so
     // keeping the gate would leave Fork permanently disabled.
@@ -702,10 +711,11 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
       hostClient: selectedHostClient,
       onSelect: selectHostId,
       refusalByHostId: hostRefusals,
-      // The remote CLASS, not a per-row word: an unpublished source chat is one
-      // fact about the chat, so the rows stay silent and the dialog says it once
-      // below. `sourceHostId` is what tells the picker which row is exempt — a
-      // same-host fork needs no publication at all.
+      // The remote CLASS, not a per-row word: an unpublished or definitively
+      // unavailable source chat is one fact about the chat, so the rows stay
+      // silent and the dialog says it once below. `sourceHostId` is what tells
+      // the picker which row is exempt — a same-host fork needs no publication
+      // at all.
       unselectableExceptHostId: remoteRowsUnselectable ? tabHostId : null,
     }),
     [
@@ -1008,8 +1018,13 @@ function canSubmitFork(input: {
   readonly createPending: boolean;
   /** The selected host resolved to a client this app can actually dial. */
   readonly hostClientResolved: boolean;
-  /** The selected host's build can serve this fork - see `chat-fork-target`. */
-  readonly hostSupportsFork: boolean;
+  /**
+   * The combined Layer-1 verdict allows a submit - see `chat-fork-target`. It
+   * spans BOTH subjects the dialog gates on: the selected host's build, and the
+   * source chat's publication (never backed up, frozen, or not yet covering the
+   * chosen boundary).
+   */
+  readonly verdictAllowsSubmit: boolean;
   readonly requiresStagedPreselection: boolean;
 }): boolean {
   if (input.target === null) return false;
@@ -1017,7 +1032,7 @@ function canSubmitFork(input: {
   if (!input.modelResolved) return false;
   if (input.createPending) return false;
   if (!input.hostClientResolved) return false;
-  if (!input.hostSupportsFork) return false;
+  if (!input.verdictAllowsSubmit) return false;
   if (input.requiresStagedPreselection && !input.hasStagedPreselection) {
     return false;
   }

--- a/clients/gui-app/src/components/chat/chat-fork-target.ts
+++ b/clients/gui-app/src/components/chat/chat-fork-target.ts
@@ -1,4 +1,9 @@
 import type { NegotiatedMethodVersion } from "@/hooks/host/use-host-negotiated-method-version";
+import {
+  chatPublicationDefinitiveReason,
+  definitiveInvalidatesPublishedHead,
+  type ChatPublicationDefinitiveReason,
+} from "@/lib/chats/chat-publication-definitive";
 
 /**
  * Whether a host can serve the fork this dialog is about to send, decided from
@@ -144,8 +149,13 @@ export type ChatForkPublicationState =
    * No answer. The source host predates `epic.chatPublicationState` (the
    * optional-capability refusal `E_HOST_UNSUPPORTED`), is unreachable, or the
    * read is still in flight. Deliberately permissive, exactly like an unknown
-   * version: unknown is not "unpublished", and Layer 2's typed refusal is the
-   * backstop.
+   * version: unknown is not "unpublished", so nothing here may block.
+   *
+   * The host is then the only authority left, which is a description of THIS
+   * arm rather than a general backstop this file may lean on: the host's own
+   * coverage check is presence-only, so it does not refuse every fork this gate
+   * declines to block. That is why a KNOWN-uncovered boundary is handled here
+   * instead — see the `boundarySyncing` verdict.
    */
   | { readonly kind: "unknown" }
   /** Never published — no remote host can pull this transcript at all. */
@@ -155,6 +165,20 @@ export type ChatForkPublicationState =
    * by construction: it clears within a publish sweep.
    */
   | { readonly kind: "boundaryUncovered" }
+  /**
+   * The host named a `definitive` reason, so this answer is FROZEN: waiting
+   * cannot change it and re-asking cannot either. Distinct from `unknown` in
+   * the direction that matters — `unknown` is "we never learned", this is "we
+   * learned that it is over" — and distinct from `unpublished` in that it also
+   * covers a chat published only PART of the way to the boundary.
+   *
+   * Deliberately NOT reachable from a frozen `covered`: see
+   * `publicationStateFromResponse` and `definitiveInvalidatesPublishedHead`.
+   */
+  | {
+      readonly kind: "definitivelyUnavailable";
+      readonly reason: ChatPublicationDefinitiveReason;
+    }
   /** Published, and the boundary is inside the published head. */
   | { readonly kind: "covered" };
 
@@ -163,7 +187,7 @@ export type ChatForkPublicationState =
  *
  * The two gates have different subjects and therefore different presentations,
  * which is exactly why they are resolved together in one place rather than
- * `&&`-ed at each render site: nine (version × publication) cells decided once,
+ * `&&`-ed at each render site: every (version × publication) cell decided once,
  * with the precedence rule stated where it can be read.
  *
  * **Precedence: the more fundamental KNOWN fact leads; an unknown never
@@ -191,35 +215,110 @@ export type ChatForkTargetVerdict =
    */
   | { readonly kind: "chatUnpublished"; readonly notice: string }
   /**
-   * Also a source-chat fact, but TRANSIENT — it clears on its own in seconds.
+   * A source-chat fact like `chatUnpublished`, and durable for a reason the
+   * HOST named rather than one this client inferred from a snapshot: the
+   * publication answer is frozen (`definitive`), so no amount of waiting or
+   * re-asking moves it.
    *
-   * It blocks NOTHING. The row stays selectable AND submit stays enabled; this
-   * verdict only speaks. Two reasons, and the first is the load-bearing one:
+   * Separate from `chatUnpublished` because the two say different things to a
+   * user and only one of them is honest here. "It backs up automatically — try
+   * again shortly" is exactly the sentence this verdict exists to stop showing;
+   * the notice it carries is per-reason and never promises a wait.
+   */
+  | { readonly kind: "chatUnavailable"; readonly notice: string }
+  /**
+   * Also a source-chat fact, but TRANSIENT — it clears on its own within a
+   * publish sweep.
    *
-   * 1. **Blocking here would make Layer 1 authoritative for a case the design
-   *    says it is not.** Layer 1 is pre-submit UX; Layer 2 — the host's typed
-   *    refusal — is the authority. A notice is precise pre-submit UX on its
-   *    own; blocking is not required to deliver it, and claiming the block
-   *    inverts the layering.
-   * 2. It would be a dead end. The Fork button IS the retry affordance, so
-   *    disabling it leaves the user reading "retry shortly" with nothing to
-   *    press, waiting on a background refetch. The cost of not blocking is one
-   *    cheap doomed round trip that comes back as `E_FORK_BOUNDARY_NOT_PUBLISHED`
-   *    and renders inline exactly as it already does; the cost of blocking is a
-   *    new control for a state that resolves itself in seconds.
+   * It BLOCKS SUBMIT, and leaves the row selectable. Both halves are
+   * deliberate, and the block REVERSES an earlier decision this comment used to
+   * defend, so the reversal is recorded here rather than quietly applied.
    *
-   * This does NOT generalize to `chatUnpublished`: that is durable, so there is
-   * nothing to wait through and no dead end — which is why the two publication
-   * states differ in BOTH row and submit treatment, for the same underlying
-   * reason of how long each lasts.
+   * **What the old reasoning got wrong.** It left submit enabled on the premise
+   * that Layer 2 — the host's typed refusal — is the authority for an uncovered
+   * boundary, so the worst case was one cheap doomed round trip answered by
+   * `E_FORK_BOUNDARY_NOT_PUBLISHED`. That premise is false. The host's coverage
+   * check is PRESENCE-only (`containsMessageId`), so a boundary turn that was
+   * published mid-stream and has since finalized locally IS present in the
+   * published head — at its partial version. The fork is then accepted, 200 OK,
+   * and seeds a silently TRUNCATED turn. So the cost of not blocking was never
+   * a visible error the user could act on; it was a wrong result that looks
+   * right, which is the one outcome no amount of Layer 2 backstopping recovers.
+   * (A host-side refusal for exactly this case lands alongside this change.
+   * This half is what keeps the user out of the round trip to begin with.)
+   *
+   * **And the dead end it worried about is gone.** The second objection was
+   * that the Fork button IS the retry affordance, so disabling it strands the
+   * user with nothing to press. That held only while nothing re-asked. This
+   * method now carries a CONDITION POLL LANE
+   * (`CHAT_PUBLICATION_WAIT_POLL_LANE` in `host-method-policy-table.ts`) that
+   * re-asks precisely while the answer is transient, so the button re-enables
+   * on its own when the sweep lands. There is nothing to press because there is
+   * nothing for the user to do — which is what the copy now says instead of
+   * "retry shortly".
+   *
+   * The row stays SELECTABLE, unlike `chatUnpublished`. Nothing is wrong with
+   * any host, the state is seconds long, and the row is where the user
+   * configures the fork they are about to be allowed to make; making it inert
+   * would throw that configuration away for a wait that outlasts it.
    */
   | { readonly kind: "boundarySyncing"; readonly notice: string };
 
 export const CHAT_NOT_BACKED_UP_NOTICE =
   "This chat hasn't been backed up yet, so another machine can't read its history. It backs up automatically — try again shortly.";
 
+/**
+ * Describes a WAIT, not a retry.
+ *
+ * "Retry shortly" was written when this state left Fork enabled, so it named an
+ * action the user had. Now that it blocks submit (see the `boundarySyncing`
+ * variant), the same words would point at a button that is greyed out — the
+ * dead end the old comment predicted. The poll lane is what makes the promise
+ * true, so the sentence says what will happen rather than what to press.
+ */
 export const BOUNDARY_SYNCING_NOTICE =
-  "Still syncing this turn — retry shortly.";
+  "Still syncing this turn to the cloud — forking to another machine unlocks as soon as it lands.";
+
+/**
+ * The four terminal sentences, one per `definitive` reason.
+ *
+ * None of them tells the user to wait, and that is the whole point: the state
+ * they describe cannot clear on this connection, so "try again shortly" — the
+ * copy every one of these used to be indistinguishable from — is false for all
+ * four. Each says what is actually true of its own reason instead, and names
+ * the one thing that COULD change it where such a thing exists.
+ */
+export const CHAT_DELETED_NOTICE =
+  "This agent was deleted on its host, so its history can't be forked to another machine.";
+
+export const CHAT_LINEAGE_SUPERSEDED_NOTICE =
+  "Another copy of this agent took over its cloud backup, so this one's history can't be forked to another machine. Fork from that copy instead.";
+
+/**
+ * Honest about the one recovery that exists. The publisher will not retry
+ * within this host process, so waiting on this connection genuinely never
+ * clears it — but a host restart can, and the user is the person who can do
+ * that.
+ */
+export const CHAT_BACKUP_HALTED_NOTICE =
+  "This agent's cloud backup has stopped, so this turn can't be forked to another machine. Waiting won't restart it — restarting the host might.";
+
+/**
+ * A reason a newer host named that this build has no copy for. Says only what
+ * this client actually knows — the backup will not finish and waiting will not
+ * help — rather than guessing at a cause.
+ */
+export const CHAT_BACKUP_UNAVAILABLE_NOTICE =
+  "This agent's cloud backup can't finish, so this turn can't be forked to another machine. Waiting won't change that.";
+
+export function chatPublicationDefinitiveNotice(
+  reason: ChatPublicationDefinitiveReason,
+): string {
+  if (reason === "chat-deleted") return CHAT_DELETED_NOTICE;
+  if (reason === "lineage-superseded") return CHAT_LINEAGE_SUPERSEDED_NOTICE;
+  if (reason === "backup-halted") return CHAT_BACKUP_HALTED_NOTICE;
+  return CHAT_BACKUP_UNAVAILABLE_NOTICE;
+}
 
 /**
  * What is true of EVERY remote target, independent of which host is currently
@@ -239,11 +338,19 @@ export const BOUNDARY_SYNCING_NOTICE =
 export type ChatForkRemoteClassState =
   | { readonly kind: "open" }
   | { readonly kind: "unpublished"; readonly notice: string }
+  /** Frozen by a host-named `definitive` reason. Durable, like `unpublished`. */
+  | { readonly kind: "unavailable"; readonly notice: string }
   | { readonly kind: "syncing"; readonly notice: string };
 
 export function chatForkRemoteClassState(
   publication: ChatForkPublicationState,
 ): ChatForkRemoteClassState {
+  if (publication.kind === "definitivelyUnavailable") {
+    return {
+      kind: "unavailable",
+      notice: chatPublicationDefinitiveNotice(publication.reason),
+    };
+  }
   if (publication.kind === "unpublished") {
     return { kind: "unpublished", notice: CHAT_NOT_BACKED_UP_NOTICE };
   }
@@ -253,11 +360,20 @@ export function chatForkRemoteClassState(
   return { kind: "open" };
 }
 
-/** Whether the remote class is out of reach — durable refusals only. */
+/**
+ * Whether the remote class is out of reach — durable refusals only.
+ *
+ * This is the ROW-INERTNESS question, and it is narrower than "can this be
+ * submitted". `syncing` blocks submit (see the `boundarySyncing` variant) yet
+ * deliberately stays selectable: the wait is seconds long and the row is where
+ * the user configures the fork the poll lane is about to unblock, so killing
+ * the row would discard that work. The two durable states have nothing to wait
+ * through, so there is no configuration worth preserving.
+ */
 export function remoteClassIsUnreachable(
   state: ChatForkRemoteClassState,
 ): boolean {
-  return state.kind === "unpublished";
+  return state.kind === "unpublished" || state.kind === "unavailable";
 }
 
 /** The dialog-level sentence for the class, or `null` when it has none. */
@@ -285,7 +401,17 @@ export function chatForkTargetVerdict(input: {
   // submittable even when the chat has never been backed up - blocking a LOCAL
   // fork on a CLOUD fact would be the subject error in its most damaging form.
   if (!input.isCrossHost) return { kind: "allowed" };
-  // Known and universal first: no choice of target can make an unpublished
+  // Frozen first, ahead of `unpublished`: it is the same universal subject and
+  // strictly more informative. A chat the host has called definitively over is
+  // one no target and no wait can help, and saying "it backs up automatically"
+  // about it is the exact falsehood this arm was added to retire.
+  if (input.publication.kind === "definitivelyUnavailable") {
+    return {
+      kind: "chatUnavailable",
+      notice: chatPublicationDefinitiveNotice(input.publication.reason),
+    };
+  }
+  // Known and universal next: no choice of target can make an unpublished
   // chat readable, so it outranks a per-host build fact even a known one.
   if (input.publication.kind === "unpublished") {
     return { kind: "chatUnpublished", notice: CHAT_NOT_BACKED_UP_NOTICE };
@@ -298,9 +424,10 @@ export function chatForkTargetVerdict(input: {
       detail: support.detail,
     };
   }
-  // Transient last among the knowns, and it blocks NOTHING - it only speaks.
-  // Layer 1 is pre-submit UX; the host's typed refusal is the authority, so
-  // claiming a block here would move that authority. See the variant's note.
+  // Transient last among the knowns. It BLOCKS SUBMIT while leaving the row
+  // selectable - the host's presence-only coverage check means an uncovered
+  // boundary can be ACCEPTED and seed a truncated turn, so Layer 2 is not the
+  // backstop this branch once assumed. See the variant's note.
   if (input.publication.kind === "boundaryUncovered") {
     return { kind: "boundarySyncing", notice: BOUNDARY_SYNCING_NOTICE };
   }
@@ -310,13 +437,15 @@ export function chatForkTargetVerdict(input: {
 /**
  * Whether this verdict lets the fork be submitted.
  *
- * `boundarySyncing` is deliberately submittable — see the variant's own note.
- * Only the two DURABLE refusals block: a target whose build cannot carry the
- * fork, and a chat no remote host can read at all. Both are conditions that
- * waiting does not fix.
+ * EVERY refusal blocks now, including the transient one. `boundarySyncing` used
+ * to be exempt on the ground that the host would refuse an uncovered boundary
+ * anyway; it does not — its check is presence-only, so an uncovered boundary
+ * can be ACCEPTED and seed a truncated turn. See the variant's own note for the
+ * full reversal. The distinction the two durable refusals still carry is over
+ * the ROW, not the button: `remoteClassIsUnreachable`.
  */
 export function verdictAllowsSubmit(verdict: ChatForkTargetVerdict): boolean {
-  return verdict.kind === "allowed" || verdict.kind === "boundarySyncing";
+  return verdict.kind === "allowed";
 }
 
 /**
@@ -326,6 +455,7 @@ export function verdictAllowsSubmit(verdict: ChatForkTargetVerdict): boolean {
  */
 export function verdictNotice(verdict: ChatForkTargetVerdict): string | null {
   if (verdict.kind === "chatUnpublished") return verdict.notice;
+  if (verdict.kind === "chatUnavailable") return verdict.notice;
   if (verdict.kind === "boundarySyncing") return verdict.notice;
   return null;
 }
@@ -347,11 +477,50 @@ export function verdictNotice(verdict: ChatForkTargetVerdict): string | null {
  * `publishedThroughTs` is deliberately unread: it is display metadata, and no
  * clock comparison exists anywhere in this feature.
  */
-export function publicationStateFromResponse(response: {
+function ordinaryPublicationState(response: {
   readonly published: boolean;
   readonly boundaryCovered: boolean | null;
 }): ChatForkPublicationState {
   if (!response.published) return { kind: "unpublished" };
   if (response.boundaryCovered === false) return { kind: "boundaryUncovered" };
   return { kind: "covered" };
+}
+
+/**
+ * The whole read of the wire response: the ordinary three-way above, plus the
+ * one field that says whether it can still move.
+ *
+ * `definitive` is applied ON TOP of the ordinary reading rather than instead of
+ * it, and the ordering is the point. The field means "this ANSWER is frozen",
+ * not "this chat is finished", so a chat frozen at `covered` is a chat a remote
+ * host can still pull — short-circuiting on `definitive` before reading
+ * `published` / `boundaryCovered` would refuse that fork on the strength of
+ * good news. The two reasons that DO invalidate the head whatever it covers are
+ * named by `definitiveInvalidatesPublishedHead`, next to the protocol wording
+ * they come from.
+ *
+ * The tri-state discipline is untouched underneath: `published` is still read
+ * first, and `boundaryCovered: null` still never collapses to `false`.
+ *
+ * `definitive` is widened to `string` rather than typed as the wire enum, and
+ * declared OPTIONAL, for the two compatibility reasons documented on
+ * `chatPublicationDefinitiveReason`. The optionality is not laxness: a host
+ * built before the field negotiates the same method version, so its response
+ * takes the un-parsed same-version path and genuinely arrives without the key.
+ * An absent field is the ordinary reading, never a reason.
+ */
+export function publicationStateFromResponse(response: {
+  readonly published: boolean;
+  readonly boundaryCovered: boolean | null;
+  readonly definitive?: string | null;
+}): ChatForkPublicationState {
+  const ordinary = ordinaryPublicationState(response);
+  const reason = chatPublicationDefinitiveReason(response.definitive);
+  if (reason === null) return ordinary;
+  if (
+    ordinary.kind === "covered" &&
+    !definitiveInvalidatesPublishedHead(reason)
+  )
+    return ordinary;
+  return { kind: "definitivelyUnavailable", reason };
 }

--- a/clients/gui-app/src/hooks/chats/use-chat-publication-state-query.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-publication-state-query.ts
@@ -27,6 +27,12 @@ const UNKNOWN: ChatForkPublicationState = { kind: "unknown" };
  * discipline the negotiated-version read follows, and the reason Layer 2's
  * typed host-side refusal exists as the backstop.
  *
+ * `unknown` is also the one state that must not be confused with the response's
+ * `definitive` reasons, which travel the opposite way: those are answers, and
+ * terminal ones. Not knowing is permissive and resolves itself; being told the
+ * publication is over is neither. `publicationStateFromResponse` keeps them
+ * apart, and only a real response can produce the terminal state.
+ *
  * Gated on `useHostSupportsMethod` rather than fired-and-caught: against an old
  * host the capability gate means no request is issued at all, so the common
  * mixed-fleet case costs nothing and produces no error noise.
@@ -34,11 +40,19 @@ const UNKNOWN: ChatForkPublicationState = { kind: "unknown" };
  * Its unknown -> false collapse is safe HERE, and for a reason that does not
  * depend on any claim about traffic elsewhere: an unresolved capability
  * disables the query, the gate reads `unknown`, and `unknown` is PERMISSIVE.
- * Nothing parks on it — the fork proceeds and Layer 2 remains the authority —
- * so the worst case of never learning the answer is exactly the post-A4
+ * Nothing parks on it — the fork proceeds and the host is the only authority
+ * left — so the worst case of never learning the answer is exactly the post-A4
  * behaviour, not a deadlock. That is what distinguishes this from a surface
  * that gates its affordances on a `false` and thereby switches off the reads
  * that would refresh it.
+ *
+ * "The host is the only authority left" is a statement about the UNKNOWN path
+ * specifically, and it is not a general claim that the host backstops whatever
+ * this gate declines to block. It does not: its boundary-coverage check is
+ * presence-only, so a KNOWN-uncovered boundary can be accepted and seed a
+ * truncated turn. That is why the gate blocks submit on a known `false` while
+ * staying permissive on a `null` or an unanswered read — see
+ * `chat-fork-target.ts`'s `boundarySyncing` note.
  */
 export function useChatPublicationState(args: {
   /** The SOURCE host's client — the tab client in the fork dialog. */

--- a/clients/gui-app/src/lib/chats/__tests__/chat-publication-definitive.test.ts
+++ b/clients/gui-app/src/lib/chats/__tests__/chat-publication-definitive.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatPublicationDefinitiveReason,
+  definitiveInvalidatesPublishedHead,
+  type ChatPublicationDefinitiveReason,
+} from "../chat-publication-definitive";
+
+describe("chatPublicationDefinitiveReason", () => {
+  it("reads null as the ordinary reading - the answer may still move", () => {
+    expect(chatPublicationDefinitiveReason(null)).toBeNull();
+  });
+
+  it("reads an absent (undefined) field as the ordinary reading too, NOT as a reason", () => {
+    // A host built before `definitive` was added negotiates the same method
+    // version, so its response takes the un-parsed same-version path in
+    // ws-rpc-client.ts and the field genuinely arrives missing at runtime,
+    // despite the static type saying it cannot be. Reading that absence as a
+    // reason would mark every pre-field host permanently halted and retire
+    // its wait lane - the very hang this field exists to fix, inverted.
+    expect(chatPublicationDefinitiveReason(undefined)).toBeNull();
+  });
+
+  it("recognises each of the three named wire reasons", () => {
+    expect(chatPublicationDefinitiveReason("chat-deleted")).toBe(
+      "chat-deleted",
+    );
+    expect(chatPublicationDefinitiveReason("lineage-superseded")).toBe(
+      "lineage-superseded",
+    );
+    expect(chatPublicationDefinitiveReason("backup-halted")).toBe(
+      "backup-halted",
+    );
+  });
+
+  it("maps an unrecognised reason to the client's own terminal-but-unexplained arm, not to null", () => {
+    // Forward compatibility: a host ahead of this build can name a reason
+    // that is not in the enum this build was compiled against. The only safe
+    // reading is terminal - mapping it to `null` would reintroduce the
+    // infinite wait for exactly the fleet that had something new to say.
+    expect(
+      chatPublicationDefinitiveReason("a-reason-this-build-does-not-know"),
+    ).toBe("unexplained");
+  });
+});
+
+describe("definitiveInvalidatesPublishedHead", () => {
+  // All four reasons, pinned individually: the two identity reasons hold
+  // however far the published head reached, and the two progress reasons
+  // must NOT contradict a coverage fact this client actually read.
+  it.each<{ reason: ChatPublicationDefinitiveReason; invalidates: boolean }>([
+    { reason: "chat-deleted", invalidates: true },
+    { reason: "lineage-superseded", invalidates: true },
+    { reason: "backup-halted", invalidates: false },
+    { reason: "unexplained", invalidates: false },
+  ])("$reason invalidates=$invalidates", ({ reason, invalidates }) => {
+    expect(definitiveInvalidatesPublishedHead(reason)).toBe(invalidates);
+  });
+});

--- a/clients/gui-app/src/lib/chats/chat-publication-definitive.ts
+++ b/clients/gui-app/src/lib/chats/chat-publication-definitive.ts
@@ -1,0 +1,97 @@
+/**
+ * The client's one reading of `epic.chatPublicationState`'s `definitive` field.
+ *
+ * Shared because exactly two surfaces must agree about it and they sit on
+ * opposite sides of the app's layering: the condition poll lane in
+ * `lib/host-rpc-policy/host-method-policy-table.ts` (may this answer still
+ * move?) and the fork dialog's verdict and copy in
+ * `components/chat/chat-fork-target.ts` (what do we tell the user?). A
+ * disagreement between those two IS the defect this field exists to remove —
+ * a surface that keeps polling an answer it has already called terminal, or
+ * one that stops polling while still promising the wait resolves itself.
+ *
+ * The protocol's rule, restated here because both call sites depend on it and
+ * neither can see the other: a non-null reason means WAITING CANNOT CHANGE
+ * THIS ANSWER. The caller must stop polling and must not present the state as
+ * transient.
+ */
+
+/**
+ * A reason the source chat's publication answer is frozen.
+ *
+ * `"unexplained"` is this client's own arm, not a wire value: a host ahead of
+ * this build can name a reason that is not in the enum this build was compiled
+ * against, and the only safe reading of it is terminal-but-unexplained. Mapping
+ * it back to "no reason" would reintroduce the infinite wait for exactly the
+ * fleet that had something new to say.
+ */
+export type ChatPublicationDefinitiveReason =
+  "chat-deleted" | "lineage-superseded" | "backup-halted" | "unexplained";
+
+/**
+ * `null` when the ordinary reading applies and the state may still move on its
+ * own; otherwise the reason, terminal by definition.
+ *
+ * The parameter is widened to `string | null | undefined` deliberately, and
+ * BOTH widenings carry weight:
+ *
+ * - `string`, for the forward-compatibility rule above. An unrecognised reason
+ *   is terminal-but-unexplained, never `null`.
+ * - `undefined`, which is the load-bearing half. `definitive` was added to
+ *   `epic.chatPublicationState` v1.0 IN PLACE, so a host built before it
+ *   negotiates the same 1.0 and its response takes the same-version path in
+ *   `ws-rpc-client.ts` — which casts rather than parses, because only a version
+ *   MISMATCH runs the payload through a response schema. The field therefore
+ *   arrives missing at runtime while the static type says it cannot be. Reading
+ *   that absence as a reason would mark every pre-field host permanently halted
+ *   and retire its wait lane, which is this very hang inverted: the answer that
+ *   really does resolve itself would be the one nobody re-asks.
+ *
+ * This is the opposite trade from the `status: string` widening trap in the
+ * providers poll classifier, and the difference is worth naming so neither gets
+ * "fixed" into the other. There, widening broke a POSITIVE match: a rename
+ * upstream silently produced `false` and dropped a live download onto the
+ * fifteen-minute lane, so a precise wire type was the safe direction. Here an
+ * unmatched value falls to `"unexplained"`, which is TERMINAL — the
+ * conservative answer — so precision buys better copy, never correctness.
+ */
+export function chatPublicationDefinitiveReason(
+  definitive: string | null | undefined,
+): ChatPublicationDefinitiveReason | null {
+  if (definitive === null || definitive === undefined) return null;
+  if (definitive === "chat-deleted") return "chat-deleted";
+  if (definitive === "lineage-superseded") return "lineage-superseded";
+  if (definitive === "backup-halted") return "backup-halted";
+  return "unexplained";
+}
+
+/**
+ * Whether the reason invalidates the published head ITSELF, rather than merely
+ * freezing how far that head reaches.
+ *
+ * The distinction is what keeps a terminal answer from over-blocking. A frozen
+ * answer is still an answer, and `definitive` says only that it will not move:
+ * a chat frozen at "the boundary IS covered" is a chat a remote host can still
+ * pull, so blocking it would refuse a fork on the strength of good news.
+ *
+ * Two of the three wire reasons are not about progress at all, though — they
+ * are about the identity the publication belongs to, and they hold however far
+ * the head reached:
+ *
+ * - `chat-deleted` — the source is a tombstone on its own host, and the fork
+ *   would be refused whatever the receipt says.
+ * - `lineage-superseded` — the receipt this host holds describes a row a fork
+ *   of THIS chat id will never fetch, so coverage of it is beside the point.
+ *
+ * `backup-halted` is the pure freeze: publication stopped, and whatever had
+ * already been acknowledged is still there to be pulled. `"unexplained"` sits
+ * with it on purpose. An unrecognised reason is a licence to stop waiting, not
+ * a licence to contradict a coverage fact this client actually read; if a
+ * future reason really does invalidate the head, Layer 2 refuses the fork and
+ * this build learns the arm on its next release.
+ */
+export function definitiveInvalidatesPublishedHead(
+  reason: ChatPublicationDefinitiveReason,
+): boolean {
+  return reason === "chat-deleted" || reason === "lineage-superseded";
+}

--- a/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import {
+  CHAT_PUBLICATION_WAIT_POLL_LANE,
   GIT_DIRTY_SUBMODULE_POLL_LANE,
   GIT_INITIAL_ERROR_POLL_LANE,
   GIT_STALE_ERROR_POLL_LANE,
@@ -654,5 +655,77 @@ describe("host method poll policy table", () => {
     expect(policy.staleDataErrorLane).toBe(
       NOTIFICATION_INDICATOR_ERROR_POLL_LANE,
     );
+  });
+});
+
+// The defect that mattered: without reading `definitive` first, a
+// permanently halted publication reports `published: false` - byte for byte
+// what a chat mid-first-sweep reports - so the client re-asks every 30s
+// forever while telling the user to wait. See chat-publication-definitive.ts
+// and epic.chatPublicationState's own doc for the wire contract this
+// classifier depends on.
+describe("epic.chatPublicationState poll lane terminates on `definitive`", () => {
+  const policy = HOST_METHOD_POLL_TABLE["epic.chatPublicationState"].poll;
+
+  it("polls while unpublished or the boundary is uncovered, with definitive: null", () => {
+    expect(
+      policy.classify({
+        published: false,
+        boundaryCovered: null,
+        definitive: null,
+      }),
+    ).toBe(CHAT_PUBLICATION_WAIT_POLL_LANE);
+    expect(
+      policy.classify({
+        published: true,
+        boundaryCovered: false,
+        definitive: null,
+      }),
+    ).toBe(CHAT_PUBLICATION_WAIT_POLL_LANE);
+  });
+
+  it("stops polling once `definitive` names a reason, for every reason including one this build does not recognise", () => {
+    // Same base fixture (published: false) that would otherwise poll forever
+    // - only `definitive` varies across the four cases, isolating it as the
+    // cause of the lane dropping rather than some other field.
+    for (const definitive of [
+      "chat-deleted",
+      "lineage-superseded",
+      "backup-halted",
+      "a-reason-this-build-does-not-know",
+    ]) {
+      expect(
+        policy.classify({
+          published: false,
+          boundaryCovered: null,
+          definitive,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does NOT stop polling when `definitive` is merely absent - a pre-field host", () => {
+    // A host built before `definitive` negotiates the same method version,
+    // so its response takes the un-parsed same-version path and the field
+    // genuinely arrives missing at runtime. Reading that absence as
+    // terminal would mark every older host permanently halted - the same
+    // hang inverted. This is the same fixture as the polling case above
+    // with the key omitted entirely rather than set to null.
+    expect(policy.classify({ published: false, boundaryCovered: null })).toBe(
+      CHAT_PUBLICATION_WAIT_POLL_LANE,
+    );
+    expect(policy.classify({ published: true, boundaryCovered: false })).toBe(
+      CHAT_PUBLICATION_WAIT_POLL_LANE,
+    );
+  });
+
+  it("stays terminal for an already-covered boundary regardless of a null definitive", () => {
+    expect(
+      policy.classify({
+        published: true,
+        boundaryCovered: true,
+        definitive: null,
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -11,6 +11,7 @@ import type {
   ProviderManagedInstallState,
   ProviderManagedVersions,
 } from "@traycer/protocol/host/provider-schemas";
+import { chatPublicationDefinitiveReason } from "@/lib/chats/chat-publication-definitive";
 
 const SECOND_MS = 1_000;
 const MINUTE_MS = 60 * SECOND_MS;
@@ -297,6 +298,11 @@ export const NOTIFICATION_INDICATOR_ERROR_POLL_LANE: ConditionPollLane = {
  * transport fault - it lands when it lands, and the dialog is a foreground
  * surface someone is looking at, so the first few asks are the ones worth
  * making promptly.
+ *
+ * Entered ONLY while the answer can still move. A publication the host has
+ * called `definitive` never reaches this lane: it has no attempt cap, so a lane
+ * entered on a frozen answer is an unbounded poll of a fact, under copy that
+ * tells the user the wait is enough.
  */
 export const CHAT_PUBLICATION_WAIT_POLL_LANE: ConditionPollLane = {
   id: "epic-chat-publication-state.waiting",
@@ -789,17 +795,32 @@ export const HOST_METHOD_POLL_TABLE = {
     ...LATEST_SCHEDULING,
     // Polled only while the answer is one the FORK DIALOG'S COPY promises will
     // resolve on its own - "It backs up automatically - try again shortly" and
-    // "Still syncing this turn - retry shortly". `staleTime` alone only marks
-    // the cache stale and issues nothing for a mounted, idle observer, so an
-    // open dialog sitting on either answer would wait forever on a sentence
-    // that told the user waiting was enough.
+    // the boundary-syncing sentence. `staleTime` alone only marks the cache
+    // stale and issues nothing for a mounted, idle observer, so an open dialog
+    // sitting on either answer would wait forever on a sentence that told the
+    // user waiting was enough.
     //
     // `false` for a covered chat: that is terminal for this boundary, and a
     // host too old to answer at all never gets here (the read is gated on
     // `useHostSupportsMethod`).
+    //
+    // This lane has no attempt cap and no terminal lane of its own, which is
+    // exactly why `definitive` has to be read BEFORE the other two fields. A
+    // permanently halted publication reports `published: false` - byte for byte
+    // what a chat mid-first-sweep reports - so without that read the wait lane
+    // is entered forever on a state nothing will ever move, under copy that
+    // promises it will.
     poll: defineConditionPolicy("epic.chatPublicationState", {
       classify: (data) => {
         if (data === undefined) return false;
+        // Terminal, and it outranks both readings below: `definitive` names a
+        // reason waiting cannot clear, so re-asking cannot clear it either. Any
+        // reason counts, including one this build does not recognise; the
+        // shared reader is also what keeps a host that predates the field
+        // (`undefined`, not `null`) in the wait lane where it belongs.
+        if (chatPublicationDefinitiveReason(data.definitive) !== null) {
+          return false;
+        }
         if (!data.published) return CHAT_PUBLICATION_WAIT_POLL_LANE;
         return data.boundaryCovered === false
           ? CHAT_PUBLICATION_WAIT_POLL_LANE

--- a/protocol/src/host/epic/__tests__/chat-publication-state-compat.test.ts
+++ b/protocol/src/host/epic/__tests__/chat-publication-state-compat.test.ts
@@ -93,7 +93,15 @@ describe("chatPublicationStateResponseSchema", () => {
       boundaryCovered: true,
       publishedThroughTs: 1_700_000_000_000,
     };
-    expect(chatPublicationStateResponseSchema.parse(wire)).toEqual(wire);
+    // `wire` omits `definitive` on purpose: that is what a host that
+    // predates the field sends. The schema's `.default(null)` is what lets
+    // a new client read that absence as "no terminal cause known" instead
+    // of failing the parse, so the parsed side gains a key the wire side
+    // never had.
+    expect(chatPublicationStateResponseSchema.parse(wire)).toEqual({
+      ...wire,
+      definitive: null,
+    });
   });
 
   it("round-trips an unpublished response", () => {
@@ -102,7 +110,13 @@ describe("chatPublicationStateResponseSchema", () => {
       boundaryCovered: null,
       publishedThroughTs: null,
     };
-    expect(chatPublicationStateResponseSchema.parse(wire)).toEqual(wire);
+    // Same reasoning as above: an old-host payload has no `definitive` key,
+    // and the parsed result defaults it to `null` rather than leaving it
+    // absent.
+    expect(chatPublicationStateResponseSchema.parse(wire)).toEqual({
+      ...wire,
+      definitive: null,
+    });
   });
 
   it("preserves boundaryCovered: null as null, never as false", () => {
@@ -140,6 +154,46 @@ describe("chatPublicationStateResponseSchema", () => {
       chatPublicationStateResponseSchema.safeParse({
         published: true,
         publishedThroughTs: null,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("chatPublicationStateResponseSchema definitive", () => {
+  // `definitive` is the "stop polling, this will never resolve" mechanism:
+  // any caller that treats an unrecognised value as `null` reintroduces the
+  // infinite wait, so this coverage pins the round-trip for every known
+  // reason plus the explicit-null and rejection cases.
+  const base = {
+    published: false,
+    boundaryCovered: null,
+    publishedThroughTs: null,
+  };
+
+  it.each([
+    "chat-deleted",
+    "lineage-superseded",
+    "backup-halted",
+  ] as const)("round-trips definitive: %s", (reason) => {
+    const wire = { ...base, definitive: reason };
+    expect(chatPublicationStateResponseSchema.parse(wire)).toEqual(wire);
+  });
+
+  it("keeps an explicitly-sent null as null", () => {
+    const wire = { ...base, definitive: null };
+    expect(chatPublicationStateResponseSchema.parse(wire)).toEqual(wire);
+  });
+
+  // z.enum(...).nullable().default(null) only substitutes the default when
+  // the field is UNDEFINED (see the omitted-key round-trips above). A
+  // present-but-unrecognised string is neither a member of the enum nor
+  // `null`, so it fails validation outright rather than being coerced to
+  // `null` - verified here rather than assumed.
+  it("rejects an unrecognized definitive reason", () => {
+    expect(
+      chatPublicationStateResponseSchema.safeParse({
+        ...base,
+        definitive: "some-future-reason",
       }).success,
     ).toBe(false);
   });

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -1311,15 +1311,49 @@ export type ChatPublicationStateRequest = z.infer<
  * One deliberate indistinguishability, so a future reader does not treat it as
  * a leak to be fixed: a boundary withheld by fork arbitration reports
  * `{ published: true, boundaryCovered: false }`, exactly like a boundary the
- * sweep has not reached yet. The client's action is identical in both cases -
- * surface it as retryable and let the host's typed refusal be the authority -
- * so distinguishing them would leak host-side arbitration state for no
- * behavioural gain.
+ * sweep has not reached yet. Both are retryable and the client's action is the
+ * same, so distinguishing them would leak host-side arbitration state for no
+ * behavioural gain. This holds only while the condition really is transient -
+ * a lineage that has been SUPERSEDED is not, and reports through `definitive`
+ * below rather than hiding here.
  */
 export const chatPublicationStateResponseSchema = z.object({
   published: z.boolean(),
   boundaryCovered: z.boolean().nullable(),
   publishedThroughTs: z.number().nullable(),
+  /**
+   * Set when waiting CANNOT change this answer. `null` means the ordinary
+   * reading applies and the state may still move on its own.
+   *
+   * ## Why a separate field rather than more values on the other three
+   *
+   * Every other answer here is a snapshot of a moving process, and the client
+   * polls precisely because it expects movement. Nothing in `published` /
+   * `boundaryCovered` can express "stop asking": `published: false` is what a
+   * chat mid-first-sweep reports, and it is also what a chat whose publication
+   * halted on an unresolvable conflict reports. The client cannot tell them
+   * apart, so it re-asks every 30s forever and tells the user "it backs up
+   * automatically - try again shortly", which is false and never resolves.
+   *
+   * A caller MUST stop polling when this is non-null and MUST NOT present the
+   * state as transient. Treating an unrecognised reason as terminal-but-
+   * unexplained is correct and forward-compatible; treating it as `null` is
+   * not, and reintroduces the infinite wait.
+   *
+   * - `chat-deleted` - the source chat is a tombstone on its own host. It will
+   *   not come back, and the fork would be refused anyway.
+   * - `lineage-superseded` - this chat lost an arbitrated fork, so its
+   *   publications now land under a different cloud identity. The receipt this
+   *   host holds describes a row a fork of THIS id will never fetch.
+   * - `backup-halted` - publication stopped for a reason the sweep does not
+   *   retry within the process lifetime (an unresolvable conflict, an
+   *   escalation, an unprovable head). A host restart may clear it; waiting on
+   *   this connection will not.
+   */
+  definitive: z
+    .enum(["chat-deleted", "lineage-superseded", "backup-halted"])
+    .nullable()
+    .default(null),
 });
 export type ChatPublicationStateResponse = z.infer<
   typeof chatPublicationStateResponseSchema


### PR DESCRIPTION
Client half of a cold review of the cross-host chat fork feature. The host half is internal #5014; this PR carries the protocol field it answers with and the two client behaviours that read it.

Follows #1227.

## `definitive` — a way to say "never"

`epic.chatPublicationState` gains `definitive`, set when waiting **cannot** change the answer. Three host states needed it and none could be expressed before:

| Reason | State |
| --- | --- |
| `chat-deleted` | the source chat is a tombstone on its own host |
| `lineage-superseded` | the chat lost an arbitrated fork; its publications land under a different cloud identity |
| `backup-halted` | publication stopped for a reason the sweep does not retry within the process lifetime |

All three previously reported byte-identically to *"the sweep has not reached it yet"*, so the condition poll re-asked every 30s forever while the dialog said **"It backs up automatically — try again shortly."** and kept submit blocked. The poll now terminates, and each reason gets copy that is true for it.

Two cases that look symmetric and are not:

- an **unrecognised** reason is treated as terminal-but-unexplained, so a newer host cannot reintroduce the infinite wait;
- an **absent** one is not. The field was added to an unreleased method in place, so a host built before it takes the un-parsed same-version path and the key genuinely arrives missing. Reading that as a reason would mark every older host permanently halted — the same hang, inverted.

## Submit no longer stays enabled on an uncovered boundary

`verdictAllowsSubmit` previously allowed submit while `boundaryCovered === false`, documented as safe because *"Layer 2 — the host's typed refusal — is the authority"*.

That premise was false. The host's check was presence-only, so a boundary turn published mid-stream is *present* in the head at its partial version: the fork returned 200 OK and seeded a **silently truncated turn**.

The host-side currency check lands alongside this in #5014. Both halves are wanted rather than either alone — the publication hook reports `UNKNOWN` during background refetches, so the gate blinks open for one RTT per poll cycle, and the host refusal is what makes that blink a wasted round trip instead of a hole.

## Preserved deliberately

- `boundaryCovered: null` is still never collapsed to `false` — `null` means the question was not answered, and blocking on it would refuse a fork on a question nobody asked.
- The permissive `unknown` path for hosts that predate the method stays permissive; an unsupported or unreachable host does not start blocking.

## Tests

84 tests across three suites, including four mutation probes — disabling the `definitive`-first check, treating `undefined` as a reason, disabling the invalidates-published-head gate, and reverting the submit block — each confirmed caught, with production restored and `diff`-verified byte-identical afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)