### PR TITLE
fix(gui-app): stamp inherited workspace seeds with host identity

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -842,11 +842,17 @@ function TerminalAgentPreLaunchToolbar(
     const seed = buildForkWorkspaceSeed({
       binding,
       stagedIntent: sourceStagedIntent,
+      hostId: toolbarHostId,
     });
     return seed.intent === null
       ? buildForkWorkspaceSeedFromWorkspaceFolders(props.agent.workspaceFolders)
       : seed;
-  }, [binding, props.agent.workspaceFolders, sourceStagedIntent]);
+  }, [
+    binding,
+    props.agent.workspaceFolders,
+    sourceStagedIntent,
+    toolbarHostId,
+  ]);
   const forkDisabled =
     props.hostClient === null ||
     props.agent.harnessSessionId === null ||

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -845,7 +845,10 @@ function TerminalAgentPreLaunchToolbar(
       hostId: toolbarHostId,
     });
     return seed.intent === null
-      ? buildForkWorkspaceSeedFromWorkspaceFolders(props.agent.workspaceFolders)
+      ? buildForkWorkspaceSeedFromWorkspaceFolders(
+          props.agent.workspaceFolders,
+          toolbarHostId,
+        )
       : seed;
   }, [
     binding,

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-message-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-message-actions.ts
@@ -285,7 +285,10 @@ export function useChatMessageActions(
       const workspaceSeed =
         mode === "ab-worktree"
           ? buildAbForkWorkspaceSeed(seedInput)
-          : buildForkWorkspaceSeed(seedInput);
+          : buildForkWorkspaceSeed({
+              ...seedInput,
+              hostId: tabHostId,
+            });
       // Seed the fork dialog's picker from the source chat's currently visible
       // workspace (its binding overlaid with any unsent staged choices) so it
       // opens exactly where the source chat's composer is. The dialog applies

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/child-conversation-workspace-seed.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/child-conversation-workspace-seed.test.ts
@@ -32,6 +32,7 @@ describe("child conversation workspace seed", () => {
         binding: null,
         stagedIntent: null,
         fallbackWorkspaceFolders: [],
+        hostId: null,
       }),
     ).toBeNull();
   });
@@ -51,6 +52,7 @@ describe("child conversation workspace seed", () => {
       },
       stagedIntent: null,
       fallbackWorkspaceFolders: ["/legacy/local"],
+      hostId: null,
     });
 
     expect(seed?.intent).toEqual({
@@ -71,6 +73,7 @@ describe("child conversation workspace seed", () => {
       binding: null,
       stagedIntent: null,
       fallbackWorkspaceFolders: ["/workspace/a", "/workspace/b"],
+      hostId: null,
     });
 
     expect(seed?.intent).toEqual({
@@ -105,6 +108,7 @@ describe("child conversation workspace seed", () => {
         ],
       },
       fallbackWorkspaceFolders: ["/workspace/a"],
+      hostId: null,
     });
 
     expect(seed?.intent).toEqual({
@@ -127,6 +131,7 @@ describe("child conversation workspace seed", () => {
       binding: null,
       stagedIntent: null,
       fallbackWorkspaceFolders: ["/workspace/a"],
+      hostId: null,
     });
 
     // Must be non-null: a `null` seed makes the picker fall back to the global
@@ -146,6 +151,7 @@ describe("child conversation workspace seed", () => {
       binding: null,
       stagedIntent: null,
       fallbackWorkspaceFolders: ["/workspace/a"],
+      hostId: null,
     });
 
     expect(seed).toBeNull();
@@ -159,6 +165,7 @@ describe("child conversation workspace seed", () => {
       binding: null,
       stagedIntent: null,
       fallbackWorkspaceFolders: ["/workspace/a"],
+      hostId: null,
     });
 
     expect(seed?.intent).toEqual({

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/child-conversation-workspace-seed.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/child-conversation-workspace-seed.test.ts
@@ -73,7 +73,7 @@ describe("child conversation workspace seed", () => {
       binding: null,
       stagedIntent: null,
       fallbackWorkspaceFolders: ["/workspace/a", "/workspace/b"],
-      hostId: null,
+      hostId: "host-source",
     });
 
     expect(seed?.intent).toEqual({
@@ -92,6 +92,9 @@ describe("child conversation workspace seed", () => {
         },
       ],
     });
+    expect(seed?.workspace.folderInfoByPath["/workspace/a"]?.hostId).toBe(
+      "host-source",
+    );
   });
 
   it("ignores stale staged owner intent when no parent binding exists", () => {

--- a/clients/gui-app/src/hooks/worktree/use-latest-conversation-workspace-seed.ts
+++ b/clients/gui-app/src/hooks/worktree/use-latest-conversation-workspace-seed.ts
@@ -90,6 +90,7 @@ export function useLatestConversationWorkspaceSeed(
     const seed = buildForkWorkspaceSeed({
       binding,
       stagedIntent,
+      hostId: seedHostId,
     });
     if (seed.intent === null) return null;
     return {
@@ -97,7 +98,7 @@ export function useLatestConversationWorkspaceSeed(
       sourceOwnerId: latestOwner.id,
       sourceOwnerKind: latestOwner.ownerKind,
     };
-  }, [binding, canReadBinding, latestOwner, stagedIntent]);
+  }, [binding, canReadBinding, latestOwner, seedHostId, stagedIntent]);
 }
 
 export function latestCreatedConversationOwner(

--- a/clients/gui-app/src/hooks/worktree/use-owner-workspace-inheritance-seed.ts
+++ b/clients/gui-app/src/hooks/worktree/use-owner-workspace-inheritance-seed.ts
@@ -38,6 +38,7 @@ export function resolveOwnerWorkspaceInheritanceSeed(input: {
   readonly binding: WorktreeBinding | null;
   readonly stagedIntent: WorktreeIntent | null;
   readonly fallbackWorkspaceFolders: readonly string[];
+  readonly hostId: string | null;
 }): ForkWorkspaceSeed | null {
   if (!input.enabled) return null;
   if (input.bindingReadEnabled && !input.bindingResultReady) {
@@ -47,6 +48,7 @@ export function resolveOwnerWorkspaceInheritanceSeed(input: {
     binding: input.binding,
     stagedIntent: input.stagedIntent,
     fallbackWorkspaceFolders: input.fallbackWorkspaceFolders,
+    hostId: input.hostId,
   });
 }
 
@@ -105,10 +107,12 @@ export function useOwnerWorkspaceInheritanceSeed(args: {
         binding: bindingQuery.data?.binding ?? null,
         stagedIntent,
         fallbackWorkspaceFolders: args.fallbackWorkspaceFolders,
+        hostId: args.hostId,
       }),
     [
       args.enabled,
       args.fallbackWorkspaceFolders,
+      args.hostId,
       bindingReadEnabled,
       bindingResultReady,
       bindingQuery.data?.binding,

--- a/clients/gui-app/src/lib/worktree/__tests__/fork-workspace-seed.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/fork-workspace-seed.test.ts
@@ -181,10 +181,10 @@ describe("buildForkWorkspaceSeed", () => {
   });
 
   it("builds a local fallback seed from persisted terminal-agent folders", () => {
-    const seed = buildForkWorkspaceSeedFromWorkspaceFolders([
-      "/Users/me/traycer",
-      "/Users/me/project/some-pkg",
-    ]);
+    const seed = buildForkWorkspaceSeedFromWorkspaceFolders(
+      ["/Users/me/traycer", "/Users/me/project/some-pkg"],
+      "host-source",
+    );
 
     expect(seed.intent).toEqual({
       entries: [
@@ -206,5 +206,8 @@ describe("buildForkWorkspaceSeed", () => {
       "/Users/me/traycer",
       "/Users/me/project/some-pkg",
     ]);
+    expect(seed.workspace.folderInfoByPath["/Users/me/traycer"].hostId).toBe(
+      "host-source",
+    );
   });
 });

--- a/clients/gui-app/src/lib/worktree/__tests__/fork-workspace-seed.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/fork-workspace-seed.test.ts
@@ -163,6 +163,7 @@ describe("buildForkWorkspaceSeed", () => {
         ],
       },
       stagedIntent: null,
+      hostId: null,
     });
 
     expect(seed.workspace).toEqual({

--- a/clients/gui-app/src/lib/worktree/__tests__/inherited-local-workspace-seed-availability.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/inherited-local-workspace-seed-availability.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { WorktreeBinding } from "@traycer/protocol/host/worktree-schemas";
+import { projectWorkspaceFolderForHost } from "@/hooks/workspace/use-resolved-workspace-folders-query";
+import {
+  deriveFolderlessAllowedWorkspaceAvailability,
+  UNRESOLVED_WORKSPACE_FOLDER_HINT,
+} from "@/lib/composer/workspace-composer-availability";
+import {
+  buildForkWorkspaceSeed,
+  type ForkWorkspaceSeed,
+} from "@/lib/worktree/fork-workspace-seed";
+
+const EMPTY_RESOLVED_BY_KEY = new Map<string, ReadonlySet<string>>();
+const SOURCE_HOST_ID = "host-source";
+const OTHER_HOST_ID = "host-other";
+const WORKSPACE_PATH = "/Users/me/projects/scratch";
+
+function localBindingWithoutRepoIdentifier(): WorktreeBinding {
+  return {
+    entries: [
+      {
+        workspacePath: WORKSPACE_PATH,
+        mode: "local",
+        repoIdentifier: null,
+        worktreePath: null,
+        branch: "main",
+        isPrimary: true,
+        isImported: false,
+        setupState: "not_required",
+        setupTerminalSessionId: null,
+        setupExitCode: null,
+        setupFailedAt: null,
+        createdAt: 0,
+        ownedSubmodules: [],
+      },
+    ],
+  };
+}
+
+function projectSeedForHost(seed: ForkWorkspaceSeed, boundHostId: string) {
+  const folders = seed.workspace.folders.flatMap((path) => {
+    if (!Object.hasOwn(seed.workspace.folderInfoByPath, path)) {
+      return [];
+    }
+    return [
+      projectWorkspaceFolderForHost(
+        seed.workspace.folderInfoByPath[path],
+        EMPTY_RESOLVED_BY_KEY,
+        boundHostId,
+      ),
+    ];
+  });
+  return {
+    folders,
+    availability: deriveFolderlessAllowedWorkspaceAvailability(
+      folders,
+      false,
+      false,
+    ),
+  };
+}
+
+describe("inherited local workspace seed availability", () => {
+  it("is ready on the stamped source host and unresolved on a foreign host or when unstamped", () => {
+    const binding = localBindingWithoutRepoIdentifier();
+
+    const knownHostSeed = buildForkWorkspaceSeed({
+      binding,
+      stagedIntent: null,
+      hostId: SOURCE_HOST_ID,
+    });
+    const onSource = projectSeedForHost(knownHostSeed, SOURCE_HOST_ID);
+    expect(onSource.folders.map((folder) => folder.kind)).toEqual([
+      "local-only",
+    ]);
+    expect(onSource.availability).toEqual({
+      status: "ready",
+      disabledHint: null,
+    });
+
+    const onOther = projectSeedForHost(knownHostSeed, OTHER_HOST_ID);
+    expect(onOther.folders.map((folder) => folder.kind)).toEqual([
+      "unresolved",
+    ]);
+    expect(onOther.availability).toEqual({
+      status: "blocked",
+      disabledHint: UNRESOLVED_WORKSPACE_FOLDER_HINT,
+    });
+
+    // B6: a producer that does not know the source host must not mint a
+    // local-only row. Null is "unstamped", never "this host".
+    const unstampedSeed = buildForkWorkspaceSeed({
+      binding,
+      stagedIntent: null,
+      hostId: null,
+    });
+    const unstampedOnSource = projectSeedForHost(unstampedSeed, SOURCE_HOST_ID);
+    expect(unstampedOnSource.folders.map((folder) => folder.kind)).toEqual([
+      "unresolved",
+    ]);
+    expect(unstampedOnSource.availability).toEqual({
+      status: "blocked",
+      disabledHint: UNRESOLVED_WORKSPACE_FOLDER_HINT,
+    });
+  });
+});

--- a/clients/gui-app/src/lib/worktree/effective-worktree-intent.ts
+++ b/clients/gui-app/src/lib/worktree/effective-worktree-intent.ts
@@ -25,7 +25,8 @@ export function effectiveWorktreeIntent(input: {
 }): WorktreeIntent | null {
   const fallback =
     input.seedIntent ??
-    buildForkWorkspaceSeedFromWorkspaceFolders(input.workspace.folders).intent;
+    buildForkWorkspaceSeedFromWorkspaceFolders(input.workspace.folders, null)
+      .intent;
   const resolvedPrimary = resolvePrimaryPath(
     input.workspace.folders,
     input.workspace.primaryPath,

--- a/clients/gui-app/src/lib/worktree/fork-workspace-seed.ts
+++ b/clients/gui-app/src/lib/worktree/fork-workspace-seed.ts
@@ -17,11 +17,14 @@ export interface ForkWorkspaceSeed {
 export function buildForkWorkspaceSeed(input: {
   readonly binding: WorktreeBinding | null;
   readonly stagedIntent: WorktreeIntent | null;
+  // Stamp only when this producer actually read the binding from that host.
+  // Null stays unresolved for local-only rows (B6). Never infer "this host".
+  readonly hostId: string | null;
 }): ForkWorkspaceSeed {
   const intent = visibleWorktreeIntent(input.binding, input.stagedIntent);
   return {
     intent,
-    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent),
+    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent, input.hostId),
   };
 }
 
@@ -57,7 +60,7 @@ export function buildAbForkWorkspaceSeed(input: {
         };
   return {
     intent,
-    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent),
+    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent, null),
   };
 }
 
@@ -77,7 +80,7 @@ export function buildForkWorkspaceSeedFromWorkspaceFolders(
         };
   return {
     intent,
-    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent),
+    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent, null),
   };
 }
 
@@ -114,6 +117,7 @@ function mergeVisibleEntries(
 
 function worktreeIntentToLandingWorkspaceSnapshot(
   intent: WorktreeIntent | null,
+  hostId: string | null,
 ): LandingDraftWorkspaceSnapshot {
   // An entry-less intent is the empty workspace. Every producer above already
   // collapses that to `null`, but checking it here is what lets the primary
@@ -126,7 +130,7 @@ function worktreeIntentToLandingWorkspaceSnapshot(
   >(
     (accumulator, entry) => ({
       ...accumulator,
-      [entry.workspacePath]: folderIntentToWorkspaceFolderInfo(entry),
+      [entry.workspacePath]: folderIntentToWorkspaceFolderInfo(entry, hostId),
     }),
     {},
   );
@@ -144,15 +148,12 @@ function worktreeIntentToLandingWorkspaceSnapshot(
 
 function folderIntentToWorkspaceFolderInfo(
   intent: WorktreeFolderIntent,
+  hostId: string | null,
 ): WorkspaceFolderInfo {
   return {
     path: intent.workspacePath,
     name: workspaceFolderName(intent.workspacePath),
     repoIdentifier: intent.repoIdentifier,
-    // Fork seed inherits the chat's bound host via the fork flow; hostId is
-    // stamped when folders are re-prepared on a host. Null here is safe —
-    // git-backed rows resolve via repoIdentifier; local-only rows without
-    // hostId stay unresolved under multi-host (B6).
-    hostId: null,
+    hostId,
   };
 }

--- a/clients/gui-app/src/lib/worktree/fork-workspace-seed.ts
+++ b/clients/gui-app/src/lib/worktree/fork-workspace-seed.ts
@@ -66,6 +66,7 @@ export function buildAbForkWorkspaceSeed(input: {
 
 export function buildForkWorkspaceSeedFromWorkspaceFolders(
   workspaceFolders: readonly string[],
+  hostId: string | null,
 ): ForkWorkspaceSeed {
   const intent =
     workspaceFolders.length === 0
@@ -80,7 +81,7 @@ export function buildForkWorkspaceSeedFromWorkspaceFolders(
         };
   return {
     intent,
-    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent, null),
+    workspace: worktreeIntentToLandingWorkspaceSnapshot(intent, hostId),
   };
 }
 

--- a/clients/gui-app/src/lib/worktree/owner-workspace-inheritance-seed.ts
+++ b/clients/gui-app/src/lib/worktree/owner-workspace-inheritance-seed.ts
@@ -12,6 +12,7 @@ export function buildOwnerWorkspaceInheritanceSeed(input: {
   readonly binding: WorktreeBinding | null;
   readonly stagedIntent: WorktreeIntent | null;
   readonly fallbackWorkspaceFolders: readonly string[];
+  readonly hostId: string | null;
 }): ForkWorkspaceSeed | null {
   const stagedIntent =
     input.binding === null || input.binding.entries.length === 0
@@ -20,6 +21,7 @@ export function buildOwnerWorkspaceInheritanceSeed(input: {
   const bindingSeed = buildForkWorkspaceSeed({
     binding: input.binding,
     stagedIntent,
+    hostId: input.hostId,
   });
   if (bindingSeed.intent !== null) return bindingSeed;
   if (input.fallbackWorkspaceFolders.length === 0) return null;

--- a/clients/gui-app/src/lib/worktree/owner-workspace-inheritance-seed.ts
+++ b/clients/gui-app/src/lib/worktree/owner-workspace-inheritance-seed.ts
@@ -27,5 +27,6 @@ export function buildOwnerWorkspaceInheritanceSeed(input: {
   if (input.fallbackWorkspaceFolders.length === 0) return null;
   return buildForkWorkspaceSeedFromWorkspaceFolders(
     input.fallbackWorkspaceFolders,
+    input.hostId,
   );
 }


### PR DESCRIPTION
## Summary

Inherited local workspace rows were created with `hostId: null`, so the projector correctly marked them unresolved and disabled sending in the new-agent modal. This stamps fork seeds with the authoritative host at known-host callers while preserving null for genuinely unstamped producers and B6 foreign-host rejection.

## Verification

- Focused regression test passed.
- Related focused GUI set: 10 tests passed.
- Affected pre-commit checks passed: lint, format, compile, and build.
- `git diff --check` passed.

Signed-off-by: anurag <anurag@traycer.ai>