### PR TITLE
fix(protocol): make residual capture idempotent; heal nested legacy bags on decode

### DIFF
--- a/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
+++ b/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
@@ -1,0 +1,322 @@
+import { chatSyncRunSettingsSchema } from "@traycer/protocol/persistence/chat-sync/core";
+import {
+  canonicalJsonStringify,
+  isJsonObject,
+  type JsonObject,
+  type JsonValue,
+} from "@traycer/protocol/persistence/chat-sync/json";
+import {
+  CHAT_SNAPSHOT_RESIDUAL_KEY,
+  captureResidualKeys,
+} from "@traycer/protocol/persistence/chat-sync/residual";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Residual capture is IDEMPOTENT, and a legacy nest heals on the way through.
+ *
+ * The property this pins is not an abstraction. `core.settings` is a captured
+ * level whose emission does not spread its bag back out - the host re-offers
+ * `state.settings` whole, in post-capture form - so every decode→encode cycle
+ * used to wrap the bag one level deeper. The field consequence was a chat's
+ * inline surface drifting by an empty wrapper per reconcile until a fresh fold
+ * of the same op log no longer reproduced the acked head, which halted the
+ * publisher's proving recut on essentially every long-lived chat.
+ *
+ * Depth is therefore the thing under test, and the depths here are the ones
+ * observed on real heads (1, 4, 8, 19). A fix that merged only ONE level would
+ * pass a naive round-trip test and still leave those chats unprovable.
+ */
+
+const DECLARED = ["alpha", "beta"] as const;
+const capture = captureResidualKeys(DECLARED);
+
+/** The post-capture object, as the object schema would receive it. */
+function capturedObject(raw: JsonValue): JsonObject {
+  const result = capture(raw);
+  if (!isJsonObject(result)) {
+    throw new Error("expected capture to produce a JSON object");
+  }
+  return result;
+}
+
+function bagOf(raw: JsonValue): JsonValue {
+  const captured = capturedObject(raw);
+  const descriptor = Object.getOwnPropertyDescriptor(
+    captured,
+    CHAT_SNAPSHOT_RESIDUAL_KEY,
+  );
+  if (descriptor === undefined) throw new Error("expected a residual bag");
+  return descriptor.value;
+}
+
+/** How many `residual` wrappers deep the bag is nested. */
+function bagDepth(value: JsonValue): number {
+  let depth = 0;
+  let level: JsonValue = value;
+
+  while (isJsonObject(level)) {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      level,
+      CHAT_SNAPSHOT_RESIDUAL_KEY,
+    );
+    if (descriptor === undefined || !isJsonObject(descriptor.value)) break;
+    depth += 1;
+    level = descriptor.value;
+  }
+
+  return depth;
+}
+
+/**
+ * A plain object carrying `value` under `residual`, `nesting` levels down.
+ * Built with `defineProperty` on a null-prototype target for the same reason
+ * the canonicalizer does: so a `__proto__` key inside the payload survives.
+ */
+function nestResidual(value: JsonObject, nesting: number): JsonObject {
+  let built: JsonObject = value;
+  for (let level = 0; level < nesting; level += 1) {
+    const wrapper: JsonObject = Object.create(null);
+    Object.defineProperty(wrapper, CHAT_SNAPSHOT_RESIDUAL_KEY, {
+      value: built,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    built = wrapper;
+  }
+  return built;
+}
+
+// The raw wire objects a capture site actually meets: declared-only, declared
+// plus unmodeled keys, and either of those already carrying a prior bag at
+// several nesting depths. Canonical strings compare them, so key ORDER (which
+// capture normalizes away) never decides a case.
+const RAW_INPUTS: readonly JsonObject[] = (() => {
+  const bases: readonly JsonObject[] = [
+    { alpha: 1, beta: "b" },
+    { alpha: 1, beta: "b", futureField: { added: "by a newer minor" } },
+    { alpha: 1, beta: "b", futureField: null, anotherFuture: [1, 2, 3] },
+    // Declared fields missing entirely: capture runs ahead of the object
+    // schema, so it must not assume a well-formed level.
+    { futureField: "orphan" },
+  ];
+  const priors: readonly JsonObject[] = [
+    {},
+    { carried: "from an older cycle" },
+    { carried: "from an older cycle", deep: { nested: true } },
+  ];
+
+  const inputs: JsonObject[] = [...bases];
+  for (const base of bases) {
+    for (const prior of priors) {
+      for (const nesting of [1, 2, 4, 8, 19]) {
+        inputs.push({
+          ...base,
+          [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(prior, nesting - 1),
+        });
+      }
+    }
+  }
+  return inputs;
+})();
+
+describe("residual capture is idempotent", () => {
+  it("re-capturing a post-capture object changes nothing", () => {
+    // The exact cycle the host performs: decode produces the post-capture
+    // domain object, the adapter re-offers it whole, and capture runs again.
+    for (const raw of RAW_INPUTS) {
+      const once = capturedObject(raw);
+      const twice = capturedObject(once);
+      expect(canonicalJsonStringify(twice)).toBe(canonicalJsonStringify(once));
+    }
+  });
+
+  it("stays depth-stable over many cycles, not just one", () => {
+    // One merge level would pass the test above and still ratchet. Ten cycles
+    // is well past the depths seen in the field.
+    for (const raw of RAW_INPUTS) {
+      const once = capturedObject(raw);
+      let cycled = once;
+      for (let cycle = 0; cycle < 10; cycle += 1)
+        cycled = capturedObject(cycled);
+
+      expect(bagDepth(bagOf(raw))).toBe(0);
+      expect(canonicalJsonStringify(cycled)).toBe(canonicalJsonStringify(once));
+    }
+  });
+
+  it("flattens a legacy nest to the depth-0 parse of the same content", () => {
+    const content: JsonObject = { carried: "from an older cycle" };
+    const flat = bagOf({ alpha: 1, beta: "b", ...content });
+
+    for (const nesting of [1, 4, 8, 19]) {
+      const nested = bagOf({
+        alpha: 1,
+        beta: "b",
+        [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(content, nesting - 1),
+      });
+      expect(nested).toEqual(flat);
+    }
+  });
+});
+
+describe("residual capture reads a prior bag exactly as far as it should", () => {
+  it("keeps a NON-object residual as ordinary data", () => {
+    // A bag this module produced is always an object, so anything else under
+    // that key came from a writer and is data. Losing it would be the same
+    // silent strip the whole mechanism exists to stop.
+    for (const value of ["a string", 7, true, null, [1, 2], []] as const) {
+      const bag = bagOf({
+        alpha: 1,
+        [CHAT_SNAPSHOT_RESIDUAL_KEY]: value as JsonValue,
+      });
+      expect(bag).toEqual({ [CHAT_SNAPSHOT_RESIDUAL_KEY]: value });
+    }
+  });
+
+  it("stops descending at the first non-object residual", () => {
+    const bag = bagOf({
+      alpha: 1,
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: {
+        carried: "level one",
+        [CHAT_SNAPSHOT_RESIDUAL_KEY]: "not a bag",
+      },
+    });
+    expect(bag).toEqual({
+      carried: "level one",
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: "not a bag",
+    });
+  });
+
+  it("lets the shallower key win a collision", () => {
+    // Outermost is this cycle's reading of the object; each level down is an
+    // older copy. The own key of `raw` is shallower than any bag level.
+    const bag = bagOf({
+      alpha: 1,
+      shared: "newest",
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: {
+        shared: "middle",
+        onlyMiddle: 1,
+        [CHAT_SNAPSHOT_RESIDUAL_KEY]: {
+          shared: "oldest",
+          onlyMiddle: 2,
+          onlyOldest: 3,
+        },
+      },
+    });
+
+    expect(bag).toEqual({
+      shared: "newest",
+      onlyMiddle: 1,
+      onlyOldest: 3,
+    });
+  });
+
+  it("does not let a prior bag overwrite a declared key", () => {
+    // Declared keys are read off `raw` before the bag is absorbed, and a bag
+    // key that shadows one must not reach the modeled field.
+    const captured = capturedObject({
+      alpha: "declared",
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: { alpha: "from a stale bag" },
+    });
+
+    expect(captured.alpha).toBe("declared");
+    // And it is not merely shadowed: the bag's invariant is that it holds only
+    // UNMODELED keys, so the stale copy is dropped outright. `mergeResidual`
+    // would give the declared field precedence anyway, so the wire is the same
+    // either way - what this pins is that the bag does not start accumulating
+    // shadow copies of modeled fields.
+    expect(captured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
+  });
+
+  it("carries a __proto__ key through the merge as an own key", () => {
+    const prior: JsonObject = Object.create(null);
+    Object.defineProperty(prior, "__proto__", {
+      value: { polluted: true },
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const bag = bagOf({
+      alpha: 1,
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(prior, 3),
+    });
+    if (!isJsonObject(bag)) throw new Error("expected a JSON object");
+
+    const descriptor = Object.getOwnPropertyDescriptor(bag, "__proto__");
+    expect(descriptor?.value).toEqual({ polluted: true });
+    expect(Object.prototype).not.toHaveProperty("polluted");
+    expect(canonicalJsonStringify(bag)).toBe('{"__proto__":{"polluted":true}}');
+  });
+
+  it("prefers a shallower __proto__ over a deeper one", () => {
+    // The collision check reads own descriptors rather than using `in`, which
+    // would resolve `__proto__` through the prototype chain and answer wrong.
+    const outer: JsonObject = Object.create(null);
+    Object.defineProperty(outer, "__proto__", {
+      value: "newest",
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    const inner: JsonObject = Object.create(null);
+    Object.defineProperty(inner, "__proto__", {
+      value: "oldest",
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(outer, CHAT_SNAPSHOT_RESIDUAL_KEY, {
+      value: inner,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const bag = bagOf({ alpha: 1, [CHAT_SNAPSHOT_RESIDUAL_KEY]: outer });
+    expect(canonicalJsonStringify(bag)).toBe('{"__proto__":"newest"}');
+  });
+});
+
+describe("core.settings heals a nested lineage", () => {
+  // The staging shape: a settings object whose bag was re-wrapped once per
+  // reconcile. `5f496021` was 19 deep with an empty bag at the bottom.
+  const settings: JsonObject = {
+    harnessId: "claude",
+    model: "claude-opus-5",
+    permissionMode: "full_access",
+    reasoningEffort: null,
+    serviceTier: null,
+    agentMode: "regular",
+    profileId: null,
+  };
+
+  it("parses a depth-19 settings object to the same value as a flat one", () => {
+    const flat = chatSyncRunSettingsSchema.parse(settings);
+    const nested = chatSyncRunSettingsSchema.parse({
+      ...settings,
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual({}, 18),
+    });
+
+    expect(nested).toEqual(flat);
+    expect(nested.residual).toEqual({});
+  });
+
+  it("keeps a real unmodeled settings key while flattening around it", () => {
+    // Non-vacuity: the healing must be surgical, not "the bag is always empty".
+    const nested = chatSyncRunSettingsSchema.parse({
+      ...settings,
+      futureSetting: "from a newer minor",
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(
+        { olderSetting: "from a newer minor, one cycle ago" },
+        7,
+      ),
+    });
+
+    expect(nested.residual).toEqual({
+      futureSetting: "from a newer minor",
+      olderSetting: "from a newer minor, one cycle ago",
+    });
+  });
+});

--- a/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
+++ b/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
@@ -229,6 +229,154 @@ describe("residual capture reads a prior bag exactly as far as it should", () =>
     expect(captured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
   });
 
+  it("descends a hostile 2,000-deep chain without re-validating each suffix", () => {
+    // Depth alone is not the hazard - the walk terminating in ONE pass is. A
+    // per-level `isJsonObject` re-validates the whole remaining suffix, making
+    // the descent quadratic: at depth 10,000 that occupied the decoder for
+    // ~2.8 SECONDS on a value under 130 KB, which a corrupt or hostile document
+    // reaches for free. It is ~1 ms now. Deliberately NO wall-clock assertion -
+    // a timing pin flakes in CI. The bound is structural, and this fixture is
+    // here so a future edit that reintroduces the deep check has something that
+    // exercises the path.
+    //
+    // 2,000 rather than 10,000, and the ceiling is NOT this code: `isJsonValue`
+    // / `isJsonObject` recurse per level (`json.ts`), so the entry validation
+    // every capture already performed blows the stack somewhere between 5,000
+    // and 6,000 inside a vitest worker - and lower as ambient stack depth
+    // grows, which is what makes a pin up there flaky rather than strict. That
+    // recursion predates this fix and strikes any deep chat-sync value, residual
+    // chain or not; outside the worker this same chain flattens fine at 10,000.
+    const bag = bagOf({
+      alpha: 1,
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(
+        { carried: "at the bottom of 2,000 wrappers" },
+        1_999,
+      ),
+    });
+
+    expect(bag).toEqual({ carried: "at the bottom of 2,000 wrappers" });
+  });
+});
+
+/**
+ * The bag can hold the ONLY copy of a field the current schema now models.
+ *
+ * A 1.0 reader bags a 1.1 writer's `newSetting` and has no top-level copy of
+ * it, because it never had one to write. That post-capture shape is a supported
+ * CARRIER - a clone seed passes `core.settings` verbatim, the host's settings
+ * adapter re-offers its opaque settings whole - so a 1.1 schema really does
+ * meet it again, with `newSetting` declared by then. Dropping the bag copy
+ * there destroys the field: silently for a defaulted one, as a parse failure
+ * for a required one.
+ *
+ * Two declared sets are what make this observable at all; a fixed-schema test
+ * cannot witness it, which is how the first cut of this fix shipped the drop.
+ */
+describe("residual capture promotes a since-modeled field out of the bag", () => {
+  const oldSchema = captureResidualKeys(["alpha"]);
+  const newSchema = captureResidualKeys(["alpha", "newSetting"]);
+
+  function captureWith(
+    capturer: (raw: unknown) => unknown,
+    raw: JsonValue,
+  ): JsonObject {
+    const result = capturer(raw);
+    if (!isJsonObject(result)) {
+      throw new Error("expected capture to produce a JSON object");
+    }
+    return result;
+  }
+
+  it("promotes it when the carrier has no modeled copy", () => {
+    // Step 1: the old schema bags a field it does not model.
+    const carried = captureWith(oldSchema, {
+      alpha: 1,
+      newSetting: "written by a newer minor",
+    });
+    expect(carried[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({
+      newSetting: "written by a newer minor",
+    });
+    expect(carried.newSetting).toBeUndefined();
+
+    // Step 2: the new schema meets that carrier and now declares the field.
+    const recaptured = captureWith(newSchema, carried);
+    expect(recaptured.newSetting).toBe("written by a newer minor");
+    expect(recaptured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
+  });
+
+  it("promotes it from under legacy wrappers too", () => {
+    // The nesting and the skew are independent, and a lineage that accumulated
+    // wrappers is exactly the population this fix exists for - so the promotion
+    // has to reach through them rather than only reading the top bag.
+    for (const depth of [2, 4, 19]) {
+      const recaptured = captureWith(newSchema, {
+        alpha: 1,
+        [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(
+          { newSetting: "written by a newer minor" },
+          depth - 1,
+        ),
+      });
+      expect(recaptured.newSetting).toBe("written by a newer minor");
+      expect(recaptured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
+    }
+  });
+
+  it("promotes the SHALLOWEST copy when the chain holds several", () => {
+    // Same precedence as retention: the outermost bag is the newest cycle's
+    // reading, and promotion must not reach past it to an older value.
+    const recaptured = captureWith(newSchema, {
+      alpha: 1,
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: {
+        newSetting: "newest",
+        [CHAT_SNAPSHOT_RESIDUAL_KEY]: {
+          newSetting: "older",
+          [CHAT_SNAPSHOT_RESIDUAL_KEY]: { newSetting: "oldest" },
+        },
+      },
+    });
+
+    expect(recaptured.newSetting).toBe("newest");
+    expect(recaptured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
+  });
+
+  it("still prefers the carrier's own modeled copy over a bagged one", () => {
+    // The complement, and what keeps promotion from becoming "the bag wins":
+    // when the carrier DOES have a top-level copy it is authoritative, and the
+    // stale bagged one is dropped rather than promoted over it.
+    const recaptured = captureWith(newSchema, {
+      alpha: 1,
+      newSetting: "the carrier's own value",
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: { newSetting: "a stale bagged copy" },
+    });
+
+    expect(recaptured.newSetting).toBe("the carrier's own value");
+    expect(recaptured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
+  });
+
+  it("stays idempotent across the promotion", () => {
+    // Promotion moves a key between homes, which is exactly the shape of edit
+    // that could reintroduce a per-cycle drift. Re-capturing the healed output
+    // must change nothing.
+    const healed = captureWith(newSchema, {
+      alpha: 1,
+      [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(
+        { newSetting: "written by a newer minor", stillUnmodeled: [1, 2] },
+        7,
+      ),
+    });
+
+    let cycled = healed;
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      cycled = captureWith(newSchema, cycled);
+    }
+
+    expect(canonicalJsonStringify(cycled)).toBe(canonicalJsonStringify(healed));
+    expect(cycled.newSetting).toBe("written by a newer minor");
+    expect(cycled[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({
+      stillUnmodeled: [1, 2],
+    });
+  });
+
   it("carries a __proto__ key through the merge as an own key", () => {
     const prior: JsonObject = Object.create(null);
     Object.defineProperty(prior, "__proto__", {

--- a/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
+++ b/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
@@ -77,9 +77,12 @@ type VisitCounter = { count: number };
  * `isJsonObject`'s prototype / symbol / descriptor checks and to the walk: what
  * is measured is the real algorithm on a real input, not a stub of it.
  *
- * `get`, `getOwnPropertyDescriptor` and `ownKeys` are the three traps capture
- * can reach - `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols`
- * both route through `ownKeys`.
+ * Four traps, which between them are every way capture can reach a level:
+ * `get`, `getOwnPropertyDescriptor`, `ownKeys` (both
+ * `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols` route
+ * through it), and `getPrototypeOf` - `isJsonObject` takes exactly one of
+ * those per level it deep-validates, so omitting it undercounts the
+ * validation-driven half of the work by 1 per level.
  */
 function countingProxy(target: JsonObject, visits: VisitCounter): JsonObject {
   return new Proxy(target, {
@@ -94,6 +97,10 @@ function countingProxy(target: JsonObject, visits: VisitCounter): JsonObject {
     ownKeys(object) {
       visits.count += 1;
       return Reflect.ownKeys(object);
+    },
+    getPrototypeOf(object) {
+      visits.count += 1;
+      return Reflect.getPrototypeOf(object);
     },
   });
 }

--- a/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
+++ b/protocol/src/persistence/chat-sync/__tests__/chat-sync-residual-idempotence.test.ts
@@ -67,6 +67,57 @@ function bagDepth(value: JsonValue): number {
   return depth;
 }
 
+/** Counts reflection traps taken against a wrapped input. */
+type VisitCounter = { count: number };
+
+/**
+ * A TRANSPARENT proxy that counts how many times capture reflects on it.
+ *
+ * Every trap forwards through `Reflect`, so the wrapper is invisible to
+ * `isJsonObject`'s prototype / symbol / descriptor checks and to the walk: what
+ * is measured is the real algorithm on a real input, not a stub of it.
+ *
+ * `get`, `getOwnPropertyDescriptor` and `ownKeys` are the three traps capture
+ * can reach - `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols`
+ * both route through `ownKeys`.
+ */
+function countingProxy(target: JsonObject, visits: VisitCounter): JsonObject {
+  return new Proxy(target, {
+    get(object, key, receiver) {
+      visits.count += 1;
+      return Reflect.get(object, key, receiver);
+    },
+    getOwnPropertyDescriptor(object, key) {
+      visits.count += 1;
+      return Reflect.getOwnPropertyDescriptor(object, key);
+    },
+    ownKeys(object) {
+      visits.count += 1;
+      return Reflect.ownKeys(object);
+    },
+  });
+}
+
+/** `nestResidual`, with every level wrapped in a counting proxy. */
+function countingNest(
+  value: JsonObject,
+  nesting: number,
+  visits: VisitCounter,
+): JsonObject {
+  let built: JsonObject = countingProxy(value, visits);
+  for (let level = 0; level < nesting; level += 1) {
+    const wrapper: JsonObject = Object.create(null);
+    Object.defineProperty(wrapper, CHAT_SNAPSHOT_RESIDUAL_KEY, {
+      value: built,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    built = countingProxy(wrapper, visits);
+  }
+  return built;
+}
+
 /**
  * A plain object carrying `value` under `residual`, `nesting` levels down.
  * Built with `defineProperty` on a null-prototype target for the same reason
@@ -229,15 +280,46 @@ describe("residual capture reads a prior bag exactly as far as it should", () =>
     expect(captured[CHAT_SNAPSHOT_RESIDUAL_KEY]).toEqual({});
   });
 
+  it("visits each chain level a constant number of times, not N of them", () => {
+    // THE DETECTOR for the quadratic form, and it works by instrumenting the
+    // INPUT rather than the module - so nothing had to be exported, injected or
+    // otherwise widened to make a performance property assertable.
+    //
+    // A per-level `isJsonObject` re-validates the whole remaining suffix, so a
+    // chain of depth N is reflected on N + (N-1) + … + 1 times. Wrapping every
+    // level in a transparent counting proxy makes that difference a COUNT
+    // instead of a duration: linear work touches each level a fixed number of
+    // times, quadratic work touches it once per level above it. Deterministic,
+    // and with no wall clock anywhere near it.
+    //
+    // Measured at this depth: ~6N visits one-pass, ~2N² if the deep check comes
+    // back - 1,200 against 81,600. The cap below is deliberately loose; the
+    // point is separating 6N from 2N², not freezing the constant, so ordinary
+    // refactors of the walk have room while the quadratic form cannot fit.
+    const DEPTH = 200;
+    const visits: VisitCounter = { count: 0 };
+    const chain = countingNest(
+      { carried: "at the bottom of the chain" },
+      DEPTH - 1,
+      visits,
+    );
+
+    visits.count = 0;
+    const bag = bagOf({ alpha: 1, [CHAT_SNAPSHOT_RESIDUAL_KEY]: chain });
+    const observed = visits.count;
+
+    // Correct FIRST: a walk that flattened nothing would also be cheap.
+    expect(bag).toEqual({ carried: "at the bottom of the chain" });
+    expect(observed).toBeLessThanOrEqual(DEPTH * 20);
+  });
+
   it("descends a hostile 2,000-deep chain without re-validating each suffix", () => {
-    // Depth alone is not the hazard - the walk terminating in ONE pass is. A
-    // per-level `isJsonObject` re-validates the whole remaining suffix, making
-    // the descent quadratic: at depth 10,000 that occupied the decoder for
-    // ~2.8 SECONDS on a value under 130 KB, which a corrupt or hostile document
-    // reaches for free. It is ~1 ms now. Deliberately NO wall-clock assertion -
-    // a timing pin flakes in CI. The bound is structural, and this fixture is
-    // here so a future edit that reintroduces the deep check has something that
-    // exercises the path.
+    // Not a detector - the pin above is. This one documents the STACK-BUDGET
+    // margin: it is the deepest chain the decoder is expected to meet and
+    // survive, and it would still pass if the quadratic form returned, merely
+    // slower (~2.8 SECONDS at depth 10,000 on a value under 130 KB, which a
+    // corrupt or hostile document reaches for free; ~1 ms now). No wall-clock
+    // assertion here on purpose - a timing pin flakes in CI.
     //
     // 2,000 rather than 10,000, and the ceiling is NOT this code: `isJsonValue`
     // / `isJsonObject` recurse per level (`json.ts`), so the entry validation
@@ -245,7 +327,8 @@ describe("residual capture reads a prior bag exactly as far as it should", () =>
     // and 6,000 inside a vitest worker - and lower as ambient stack depth
     // grows, which is what makes a pin up there flaky rather than strict. That
     // recursion predates this fix and strikes any deep chat-sync value, residual
-    // chain or not; outside the worker this same chain flattens fine at 10,000.
+    // chain or not (ticket 58); outside the worker this same chain flattens
+    // fine at 10,000.
     const bag = bagOf({
       alpha: 1,
       [CHAT_SNAPSHOT_RESIDUAL_KEY]: nestResidual(

--- a/protocol/src/persistence/chat-sync/residual.ts
+++ b/protocol/src/persistence/chat-sync/residual.ts
@@ -78,6 +78,11 @@ import { z } from "zod";
  * capture cycle's reading of the object, and deeper ones are older copies of
  * the same thing.
  *
+ * Merging routes each key to the home the CURRENT schema gives it: a key the
+ * schema now declares is promoted out of the bag and into the modeled fields,
+ * because after a version skew the bag can hold that field's only copy. See
+ * `absorbPriorResidual` for the sequence that produces one.
+ *
  * The wire is unchanged by any of this - the encoder still emits one bag - so
  * this is a decode-side rule only.
  */
@@ -97,23 +102,65 @@ function defineOwn(target: JsonObject, key: string, value: unknown): void {
 }
 
 /**
- * Merges an already-captured bag into the one being built, descending through
- * however many times the pre-idempotence encoder wrapped it.
+ * Is this value a JSON OBJECT rather than an array, a primitive or `null`?
  *
- * Written first-wins because the caller has already put the object's OWN
- * unmodeled keys in `into`: those are this cycle's reading of the level, and
- * each level down is an older copy of the same key. Descent stops at the first
+ * PRECONDITION: `value` has already been deep-validated as JSON, by an
+ * `isJsonObject` call on an ancestor. Sound only under that precondition, which
+ * is why it is local to this module and not exported beside `isJsonObject` -
+ * as a general validator it would accept a `Date` or a class instance.
+ *
+ * It exists because the chain walk below would otherwise be QUADRATIC.
+ * `isJsonObject` validates every descendant, so calling it once per level
+ * re-validates the whole remaining suffix: a chain of depth N costs
+ * N + (N-1) + … + 1. Capture already validated the entire raw tree on entry, so
+ * every prior bag in the chain is a descendant of an object that was checked -
+ * re-deriving that is work with no question attached to it. At depth 10,000 the
+ * quadratic form occupied the decoder for seconds on a value under 130 KB.
+ */
+function isJsonObjectKind(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Merges an already-captured bag into the object being built, descending
+ * through however many times the pre-idempotence encoder wrapped it.
+ *
+ * Written first-wins because the caller has already read the object's OWN keys
+ * into `kept` and `into`: those are this cycle's reading of the level, and each
+ * level down is an older copy of the same key. Descent stops at the first
  * `residual` that is not an object - that one is data, and it lands as data.
  *
- * A DECLARED key found in a prior bag is dropped rather than merged. The bag's
- * standing invariant is that it holds only unmodeled keys - the split puts
- * declared ones in `kept` - and a stale copy of a since-modeled field must not
- * start appearing in it. Nothing is lost by dropping it: `mergeResidual` gives
- * the declared field precedence on the way back out, so the emitted wire is
- * the same either way.
+ * ## Where a declared key found in a bag goes
+ *
+ * To `kept`, not to the bag - and this is the subtle half. The rule cannot be
+ * "drop it", even though the bag's standing invariant is that it holds only
+ * unmodeled keys, because the bag can hold the SOLE copy of a now-modeled
+ * field. That is an ordinary same-major version skew, not a corrupt input:
+ *
+ * 1. A 1.1 writer puts `newSetting: V` on the wire.
+ * 2. A 1.0 reader does not declare it, so capture bags it:
+ *    `{…, residual: { newSetting: V }}`. There is no top-level copy - the 1.0
+ *    reader never had one to write.
+ * 3. That post-capture shape is a supported CARRIER, not a foreign format: a
+ *    clone seed carries `core.settings` verbatim, and the host's settings
+ *    adapter re-offers its opaque settings object whole.
+ * 4. A 1.1 schema re-captures it. `newSetting` is declared now, and the bag is
+ *    the only place it exists.
+ *
+ * Dropping there destroys the newer writer's field - silently for a defaulted
+ * one like `serviceTier` or `profileId`, and as a hard parse failure for a
+ * required one. Either way it contradicts the mechanically-lossless promise at
+ * the top of this module, in exactly the case the bag exists to serve.
+ *
+ * So each bag key is routed to the home it belongs in - `kept` if the current
+ * schema declares it, the bag otherwise - and shallowest still wins in both. A
+ * declared key that `kept` ALREADY holds is therefore skipped, which keeps the
+ * stale-shadow behaviour: an own modeled value is never overwritten by a bagged
+ * copy of itself, the same precedence `mergeResidual` applies on the way out.
  */
 function absorbPriorResidual(
   into: JsonObject,
+  kept: JsonObject,
   prior: JsonObject,
   declared: ReadonlySet<string>,
 ): void {
@@ -128,19 +175,19 @@ function absorbPriorResidual(
 
       if (
         key === CHAT_SNAPSHOT_RESIDUAL_KEY &&
-        isJsonObject(descriptor.value)
+        isJsonObjectKind(descriptor.value)
       ) {
         deeper = descriptor.value;
         continue;
       }
 
-      if (declared.has(key)) continue;
-
-      // Shallower wins. `getOwnPropertyDescriptor` rather than `in` or a
-      // truthiness check so a legal `__proto__` key is tested as the own key it
-      // is, and a present-but-null value still counts as present.
-      if (Object.getOwnPropertyDescriptor(into, key) !== undefined) continue;
-      defineOwn(into, key, descriptor.value);
+      const target = declared.has(key) ? kept : into;
+      // Shallower wins, for promotion as for retention.
+      // `getOwnPropertyDescriptor` rather than `in` or a truthiness check so a
+      // legal `__proto__` key is tested as the own key it is, and a
+      // present-but-null value still counts as present.
+      if (Object.getOwnPropertyDescriptor(target, key) !== undefined) continue;
+      defineOwn(target, key, descriptor.value);
     }
 
     level = deeper;
@@ -181,9 +228,12 @@ export function captureResidualKeys(
         continue;
       }
 
+      // `isJsonObjectKind`, not `isJsonObject`: the guard above already
+      // deep-validated `raw`, so re-validating this subtree would be the first
+      // step of the quadratic walk the chain descent exists to avoid.
       if (
         key === CHAT_SNAPSHOT_RESIDUAL_KEY &&
-        isJsonObject(descriptor.value)
+        isJsonObjectKind(descriptor.value)
       ) {
         prior = descriptor.value;
         continue;
@@ -192,7 +242,7 @@ export function captureResidualKeys(
       defineOwn(residual, key, descriptor.value);
     }
 
-    if (prior !== null) absorbPriorResidual(residual, prior, declared);
+    if (prior !== null) absorbPriorResidual(residual, kept, prior, declared);
 
     defineOwn(
       kept,

--- a/protocol/src/persistence/chat-sync/residual.ts
+++ b/protocol/src/persistence/chat-sync/residual.ts
@@ -53,11 +53,33 @@ import { z } from "zod";
  * optional. `storageProjection` below exists for exactly that gap; the frozen
  * `storage` surface is generated from it, not from these schemas.
  *
- * ## Reserved name
+ * ## Reserved name, and why capture is idempotent
  *
  * `residual` is reserved at every captured level: a future modeled field must
- * not be called that. A persisted key of that name still round-trips (it lands
- * in the bag and is re-emitted from there), it just reads oddly.
+ * not be called that. It is reserved in a stronger sense than "do not use it",
+ * because capture READS it: an own `residual` key whose value is a JSON OBJECT
+ * is taken to be a PRIOR BAG and its contents are merged into the new one,
+ * recursively, rather than re-bagged under a second `residual` key.
+ *
+ * That is what makes `capture` idempotent -
+ * `capture(capture(x)) === capture(x)` - and idempotence is not cosmetic here.
+ * A capturing level whose emission does not spread the bag back out re-offers
+ * its own POST-CAPTURE object on the next decode. Without this rule each cycle
+ * would wrap the bag one level deeper (`{residual: R}` →
+ * `{residual: {residual: R}}` → …), so a chat's inline surface would drift by
+ * an empty wrapper per reconcile and stop matching a fresh fold of the same
+ * state. It did exactly that in the field, to depth 19. Reading a prior bag
+ * back also HEALS an already-nested lineage on its next parse, with no repair
+ * pass.
+ *
+ * A NON-object `residual` (string, number, array, `null`) cannot be a bag this
+ * module produced, so it survives as ordinary data under the key `residual`.
+ * On collision the SHALLOWER key wins: the outermost keys are the newest
+ * capture cycle's reading of the object, and deeper ones are older copies of
+ * the same thing.
+ *
+ * The wire is unchanged by any of this - the encoder still emits one bag - so
+ * this is a decode-side rule only.
  */
 
 export const CHAT_SNAPSHOT_RESIDUAL_KEY = "residual";
@@ -75,8 +97,65 @@ function defineOwn(target: JsonObject, key: string, value: unknown): void {
 }
 
 /**
+ * Merges an already-captured bag into the one being built, descending through
+ * however many times the pre-idempotence encoder wrapped it.
+ *
+ * Written first-wins because the caller has already put the object's OWN
+ * unmodeled keys in `into`: those are this cycle's reading of the level, and
+ * each level down is an older copy of the same key. Descent stops at the first
+ * `residual` that is not an object - that one is data, and it lands as data.
+ *
+ * A DECLARED key found in a prior bag is dropped rather than merged. The bag's
+ * standing invariant is that it holds only unmodeled keys - the split puts
+ * declared ones in `kept` - and a stale copy of a since-modeled field must not
+ * start appearing in it. Nothing is lost by dropping it: `mergeResidual` gives
+ * the declared field precedence on the way back out, so the emitted wire is
+ * the same either way.
+ */
+function absorbPriorResidual(
+  into: JsonObject,
+  prior: JsonObject,
+  declared: ReadonlySet<string>,
+): void {
+  let level: JsonObject | null = prior;
+
+  while (level !== null) {
+    let deeper: JsonObject | null = null;
+
+    for (const key of Object.getOwnPropertyNames(level)) {
+      const descriptor = Object.getOwnPropertyDescriptor(level, key);
+      if (descriptor === undefined) continue;
+
+      if (
+        key === CHAT_SNAPSHOT_RESIDUAL_KEY &&
+        isJsonObject(descriptor.value)
+      ) {
+        deeper = descriptor.value;
+        continue;
+      }
+
+      if (declared.has(key)) continue;
+
+      // Shallower wins. `getOwnPropertyDescriptor` rather than `in` or a
+      // truthiness check so a legal `__proto__` key is tested as the own key it
+      // is, and a present-but-null value still counts as present.
+      if (Object.getOwnPropertyDescriptor(into, key) !== undefined) continue;
+      defineOwn(into, key, descriptor.value);
+    }
+
+    level = deeper;
+  }
+}
+
+/**
  * Splits `raw`'s own keys into the declared ones and a canonicalized
  * `residual` bag, ahead of the object schema that will parse the result.
+ *
+ * Idempotent: an own `residual` key holding a JSON OBJECT is read as a prior
+ * bag and merged in rather than re-bagged, so re-capturing an object this
+ * function already produced is a no-op and a legacy nest flattens on the way
+ * through. See the "Reserved name" note above for why that matters and what it
+ * costs (an object-valued `residual` on the wire is no longer ordinary data).
  *
  * A non-object input is handed straight through so the inner schema produces
  * the normal type error rather than this step swallowing it.
@@ -91,12 +170,29 @@ export function captureResidualKeys(
 
     const kept: JsonObject = Object.create(null);
     const residual: JsonObject = Object.create(null);
+    let prior: JsonObject | null = null;
 
     for (const key of Object.getOwnPropertyNames(raw)) {
       const descriptor = Object.getOwnPropertyDescriptor(raw, key);
       if (descriptor === undefined) continue;
-      defineOwn(declared.has(key) ? kept : residual, key, descriptor.value);
+
+      if (declared.has(key)) {
+        defineOwn(kept, key, descriptor.value);
+        continue;
+      }
+
+      if (
+        key === CHAT_SNAPSHOT_RESIDUAL_KEY &&
+        isJsonObject(descriptor.value)
+      ) {
+        prior = descriptor.value;
+        continue;
+      }
+
+      defineOwn(residual, key, descriptor.value);
     }
+
+    if (prior !== null) absorbPriorResidual(residual, prior, declared);
 
     defineOwn(
       kept,


### PR DESCRIPTION
## The ratchet

`captureResidualKeys` split every undeclared own key into the `residual` bag — including an incoming key literally named `residual`. That is harmless for a level that meets a wire object once and spreads its bag back out on emit. It is not harmless for a level whose decoded, POST-CAPTURE object is re-offered to the schema on the next cycle, which is exactly what `core.settings` is: the host stores it as an opaque object and hands it back whole, so each decode→encode cycle wrapped the bag one level deeper (`{residual: R}` → `{residual: {residual: R}}` → …). Nothing about any chat changed — every bag was empty at the bottom — but a head's inline content surface is the canonical JSON of its `core`, and an extra `{}` in there is a different string. A fresh fold of the same op log performs exactly one capture pass and is therefore always flat, so it stopped reproducing the acknowledged head, and the publisher's ancestry proof halted `content-differs` on chats that had merely been alive a while. Depth counts reconcile cycles, not publishes, which is why a 44k-op chat sat at depth 1 while an 825-op chat parked for two days sat at 19.

Observed on four chats, all four bags empty at the bottom, no real data differing anywhere:

| chat | acked seq | refold | published |
| --- | --- | --- | --- |
| A | 44,316 | `{}` | depth 1 |
| B | 12,774 | `{}` | depth 4 |
| C | 896 | `{}` | depth 8 |
| D | 825 | `{}` | depth 19 |

Verified end to end against those four before and after: the inline surfaces compare unequal on the current build and equal with this change, with the only differing field being `core.settings.residual`.

## The capture contract now

Decode-side only. On meeting an own `residual` key:

- **An OBJECT value is a PRIOR BAG.** Its contents are merged into the new bag and the own-`residual` chain is followed down, so a legacy nest of any depth flattens in one pass. `capture(capture(x))` is now a no-op, and an already-nested lineage HEALS on its next parse — no repair pass, no migration.
- **A NON-object value** (string, number, array, `null`) cannot be a bag this module produced, so it survives as ordinary data under the key `residual`, and the descent stops there.
- **Each merged key is routed to the home the CURRENT schema gives it** — modeled fields if it is declared now, the bag otherwise. The promotion is load-bearing rather than tidiness: after an ordinary same-major skew the bag can hold a now-modeled field's ONLY copy (an older reader bagged a newer writer's field and never had a top-level copy to write, and that post-capture shape is a supported carrier). Dropping it there would destroy the field — silently for one that defaults, as a parse failure for one that is required.
- **Shallowest wins**, for promotion and for retention alike: the outermost keys are the newest cycle's reading, deeper ones are older copies. A declared key the raw object already carries is authoritative, so a stale bagged shadow is discarded rather than promoted over it.
- **`__proto__` safety is preserved end to end** — the merge routes through the same `defineOwn` / `canonicalizeJsonObject` machinery as the split, so a legal `__proto__` key stays an own key and never reaches the prototype setter.

Only a fixed-declared-key test can miss the promotion case, so the regressions capture under one declared set and re-capture under another.

## Wire format

**Unchanged.** The encoder still emits exactly one bag; this only changes what decode makes of a bag it is handed. No `CHAT_SYNC_SCHEMA_VERSION` bump, no change to the frozen storage surface, and the captured-levels manifest is untouched — checked explicitly for anything pinning the old nesting behaviour, and nothing did.

## The detector test

The walk had a second problem: it avoided recursive self-calls but called `isJsonObject` per level, and that validates every descendant — so a chain of depth N re-validated the whole remaining suffix, N + (N-1) + … + 1. Capture already deep-validates the entire raw tree on entry, so every prior bag is a descendant of something already checked; the walk now uses a shallow object-kind check, sound precisely because of that entry validation.

Pinning a performance property without a flaky wall clock normally means injecting a counter into the module under test. This does it the other way round: it instruments the **input**. Every level of the fixture chain is wrapped in a transparent `Proxy` that forwards all traps through `Reflect` and counts `get` / `getOwnPropertyDescriptor` / `ownKeys` / `getPrototypeOf` visits. The wrapper is invisible to `isJsonObject`'s prototype, symbol and descriptor checks, so what is measured is the real algorithm on a real input — and linear-vs-quadratic becomes a deterministic COUNT rather than a duration. At depth 200:

| walk | visits | per level |
| --- | --- | --- |
| one-pass (this PR) | 1,200 | 6 |
| deep per-level check | 81,600 | 408 |

The assertion caps visits at `depth × 20`; it fails `expected 81600 to be less than or equal to 4000` if the deep check returns. Correctness is asserted first, since a walk that flattened nothing would also be cheap. No module surface was widened to make this assertable.

A separate depth-2,000 fixture documents the stack-budget margin and says in its comment that it is documentation rather than a detector. It is capped at 2,000 rather than higher because `isJsonValue` / `isJsonObject` recurse per level, so the entry validation every capture already performs overflows the stack between 5,000 and 6,000 inside a Vitest worker — and lower as ambient stack depth grows, which is what would make a deeper pin flaky rather than strict. That recursion predates this change and affects any deeply-nested chat-sync value, residual chain or not; it is tracked separately.

## Notes for reviewers

- Commits are kept separate for review (fix → promotion fix → detector → measurement correction) and will squash on merge.
- The host-side regression pins land in the internal repo alongside the submodule bump; the driving ticket is internal, at `artifacts/chat-sync-v2/tickets/57-settings-residual-nesting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
