### PR TITLE
fix(gui-app): keep artifact minimap ticks within gutter

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-heading-items.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-heading-items.test.ts
@@ -13,6 +13,7 @@ import {
   measureArtifactHeadingTops,
   resolveArtifactHeadingActiveIndex,
   resolveArtifactHeadingHitStripWidth,
+  resolveArtifactHeadingTickWidth,
   sameArtifactHeadingOutline,
   toArtifactHeadingOutline,
   type ArtifactHeadingOutlineEntry,
@@ -342,6 +343,24 @@ describe("resolveArtifactHeadingHitStripWidth", () => {
         scrollerLeft: 0,
       }),
     ).toBe(0);
+  });
+});
+
+describe("resolveArtifactHeadingTickWidth", () => {
+  it("uses the full 24px/12px hierarchy when the gutter is wide enough", () => {
+    expect(resolveArtifactHeadingTickWidth(40, 1)).toBe(24);
+    expect(resolveArtifactHeadingTickWidth(40, 2)).toBe(12);
+  });
+
+  it("scales both heading levels into a narrow gutter", () => {
+    expect(resolveArtifactHeadingTickWidth(12, 1)).toBe(12);
+    expect(resolveArtifactHeadingTickWidth(12, 2)).toBe(6);
+  });
+
+  it("hides ticks when no finite positive gutter remains", () => {
+    expect(resolveArtifactHeadingTickWidth(0, 1)).toBe(0);
+    expect(resolveArtifactHeadingTickWidth(-1, 2)).toBe(0);
+    expect(resolveArtifactHeadingTickWidth(Number.NaN, 1)).toBe(0);
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-heading-minimap.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-heading-minimap.test.tsx
@@ -195,6 +195,35 @@ describe("ArtifactHeadingMinimap", () => {
     ]);
   });
 
+  it("scales painted ticks to the measured safe gutter", async () => {
+    const editor = makeEditor(THREE_HEADING_CONTENT);
+    // px-6 leaves 24px before the artifact body in a narrow pane. With the
+    // rail inset 12px from the edge, only 12px remain before text begins.
+    editor.view.dom.getBoundingClientRect = () => rectAt({ top: 0, left: 24 });
+    const scroller = makeScroller({
+      top: 0,
+      left: 0,
+      scrollTop: 0,
+      clientHeight: 400,
+      scrollHeight: 700,
+    });
+    stubHeadingTops(editor, [0, 300, 600]);
+
+    render(
+      <ArtifactHeadingMinimap
+        editor={editor}
+        scroller={scroller.element}
+        refreshRef={makeRefreshRef()}
+      />,
+    );
+    await flushFrame();
+
+    const ticks = screen.getAllByTestId("artifact-heading-minimap-tick");
+    expect(ticks[0].style.width).toBe("12px");
+    expect(ticks[1].style.width).toBe("6px");
+    expect(ticks[2].style.width).toBe("6px");
+  });
+
   it("keeps the card absent until hover, then shows one row per heading with the deeper indent on level-2 rows", async () => {
     await mountThreeHeadingRail();
     expect(screen.queryByTestId("artifact-heading-minimap-card")).toBeNull();

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-heading-items.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-heading-items.ts
@@ -197,6 +197,9 @@ export const ARTIFACT_HEADING_SCROLL_PADDING = 24;
 /** Matches the rail's `left-3` inset. */
 export const ARTIFACT_HEADING_RAIL_EDGE_INSET = 12;
 export const ARTIFACT_HEADING_HIT_STRIP_MAX_WIDTH = 40;
+/** Painted widths at full size; narrower gutters retain the 2:1 hierarchy. */
+const ARTIFACT_HEADING_LEVEL_ONE_TICK_MAX_WIDTH = 24;
+const ARTIFACT_HEADING_LEVEL_TWO_TICK_MAX_WIDTH = 12;
 
 /**
  * Width of the transparent pointer target, capped to the real gutter between
@@ -221,4 +224,25 @@ export function resolveArtifactHeadingHitStripWidth(input: {
       Math.floor(gutter - ARTIFACT_HEADING_RAIL_EDGE_INSET),
     ),
   );
+}
+
+/**
+ * Keeps every painted tick inside the same measured gutter as its hit target.
+ *
+ * The full-size 24px h1 marker used to extend past the narrow-pane gutter and
+ * over artifact text even though the transparent hit target was correctly
+ * capped. Scale both levels together until their normal 24px/12px widths fit;
+ * zero available width naturally hides the rail when no safe gutter remains.
+ */
+export function resolveArtifactHeadingTickWidth(
+  availableWidth: number,
+  level: ArtifactHeadingLevel,
+): number {
+  if (!Number.isFinite(availableWidth) || availableWidth <= 0) return 0;
+  const maxWidth =
+    level === 1
+      ? ARTIFACT_HEADING_LEVEL_ONE_TICK_MAX_WIDTH
+      : ARTIFACT_HEADING_LEVEL_TWO_TICK_MAX_WIDTH;
+  const scaledWidth = level === 1 ? availableWidth : availableWidth / 2;
+  return Math.min(maxWidth, scaledWidth);
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-heading-minimap.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-heading-minimap.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   ARTIFACT_HEADING_MIN_ITEMS,
+  resolveArtifactHeadingTickWidth,
   type ArtifactHeadingOutlineEntry,
 } from "./artifact-heading-items";
 import { useArtifactHeadingMetrics } from "./use-artifact-heading-metrics";
@@ -226,8 +227,7 @@ export function ArtifactHeadingMinimap(props: ArtifactHeadingMinimapProps) {
             <span
               aria-hidden="true"
               className={cn(
-                "pointer-events-none absolute left-0 -translate-y-1/2 rounded-full transition-[background-color,height,opacity] duration-150",
-                entry.level === 1 ? "w-6" : "w-3",
+                "pointer-events-none absolute left-0 -translate-y-1/2 rounded-full transition-[background-color,height,opacity,width] duration-150",
                 index === activeIndex
                   ? "h-[3px] bg-foreground/90"
                   : "h-0.5 bg-muted-foreground/35",
@@ -245,6 +245,10 @@ export function ArtifactHeadingMinimap(props: ArtifactHeadingMinimapProps) {
                   index,
                   outline.length,
                   ARTIFACT_HEADING_END_HIT_PADDING,
+                ),
+                width: resolveArtifactHeadingTickWidth(
+                  hitStripWidth,
+                  entry.level,
                 ),
               }}
             />


### PR DESCRIPTION
## Summary
- scale artifact heading ticks to the measured safe gutter
- preserve H1/H2 visual hierarchy without covering narrow-pane text
- add narrow-gutter unit and component regression coverage

## Validation
- @traycer-clients/gui-app test: (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
@traycer-clients/gui-app test:   - `__dirname` (vitest.config.ts:36:46). Use `import.meta.dirname` instead
@traycer-clients/gui-app test: Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test:  RUN  v4.1.10 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-prancing-leopard-98f8f7c3432c/traycer/clients/gui-app
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test: (node:17759) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
@traycer-clients/gui-app test: (Use `node --trace-warnings ...` to show where the warning was created)
@traycer-clients/gui-app test: (node:17758) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
@traycer-clients/gui-app test: (Use `node --trace-warnings ...` to show where the warning was created)
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test:  Test Files  2 passed (2)
@traycer-clients/gui-app test:       Tests  47 passed (47)
@traycer-clients/gui-app test:    Start at  14:41:36
@traycer-clients/gui-app test:    Duration  9.27s (transform 9.88s, setup 381ms, import 15.13s, tests 705ms, environment 1.54s)
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test: (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
@traycer-clients/gui-app test:   - import "./vitest.config" without a file extension (vitest.react-compiler.config.ts:4:24). Add the file extension
@traycer-clients/gui-app test:   - `__dirname` (vitest.config.ts:36:46). Use `import.meta.dirname` instead
@traycer-clients/gui-app test: Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test:  RUN  v4.1.10 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-prancing-leopard-98f8f7c3432c/traycer/clients/gui-app
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test: (node:18366) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
@traycer-clients/gui-app test: (Use `node --trace-warnings ...` to show where the warning was created)
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test:  Test Files  1 passed (1)
@traycer-clients/gui-app test:       Tests  10 passed (10)
@traycer-clients/gui-app test:    Start at  14:41:46
@traycer-clients/gui-app test:    Duration  2.11s (transform 1.26s, setup 238ms, import 1.23s, tests 65ms, environment 469ms)
@traycer-clients/gui-app test: 
@traycer-clients/gui-app test: Exited with code 0
- pre-commit affected-workspace lint, compile, build, format, and DCO checks