### PR TITLE
Phase 0 — protocol foundation (TE-18..25)

### DIFF
--- a/protocol/src/host/agent/__tests__/durable-inbox-flow.test.ts
+++ b/protocol/src/host/agent/__tests__/durable-inbox-flow.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it } from "vitest";
+import {
+  INBOX_MAX_ACK_BATCH_SIZE,
+  INBOX_MAX_DELIVERY_ATTEMPTS,
+  inboxMessageRowSchema,
+  simulateAckFlow,
+  simulateDeliveryAttempt,
+  simulateSubscribeDrain,
+  type InboxMessageRow,
+} from "@traycer/protocol/host/agent/inbox-spec";
+import {
+  agentInboxAckRequestSchema,
+  agentInboxMessageSchemaV12,
+  agentInboxSubscribeServerFrameSchemaV10,
+  agentInboxSubscribeServerFrameSchemaV12,
+  type AgentInboxMessage,
+  type AgentInboxMessageV12,
+  type AgentInboxSubscribeServerFrame,
+} from "@traycer/protocol/host/agent/inbox";
+
+/**
+ * Integration test for the durable inbox envelope lifecycle (Task 7,
+ * Phase 0). Composes the REAL wire schemas from `inbox.ts`
+ * (`agentInboxMessageSchemaV12`, the `@1.2` subscribe frame tree,
+ * `agent.inbox.ack@1.0`) with the reference pure flows from `inbox-spec.ts`
+ * (`simulateSubscribeDrain` / `simulateDeliveryAttempt` / `simulateAckFlow`)
+ * to prove the full envelope lifecycle — enqueue, deliver, replay, dead-letter,
+ * ack, remove — holds across the contract boundary, with no mocks and no host.
+ *
+ * The reference functions are version-agnostic by design; the delivery
+ * guarantee is enforced by the COMPOSITION of the wire schema (whether a
+ * frame carries `eventId`) and the resolver rule (server-side auto-ack when
+ * it does not), which is exactly what these tests pin together.
+ */
+
+const EPIC_ID = "epic-1";
+const AGENT_ID = "agent-1";
+
+/** A canonical durable inbox row; overrides fill the fields a scenario varies. */
+function makeRow(overrides: Partial<InboxMessageRow>): InboxMessageRow {
+  return {
+    eventId: "event-1",
+    agentId: AGENT_ID,
+    epicId: EPIC_ID,
+    fromAgentId: "agent-2",
+    prompt: "hello",
+    responseId: "thread-1",
+    expectReply: true,
+    senderTitle: "Agent Two",
+    senderHarnessId: "claude",
+    enqueuedAt: 1_000,
+    deliveryCount: 0,
+    lastDeliveredAt: null,
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * The projection a host resolver applies when delivering a durable row over
+ * `agent.inbox.subscribe@1.2`: row fields map onto
+ * `agentInboxMessageSchemaV12`, with the `reply` discriminator derived from
+ * `expectReply` / `responseId`. A reply-bearing row always carries a
+ * broker-minted thread id, so `expectReply: true` with a null `responseId`
+ * is not wire-representable.
+ */
+function rowToWireMessage(row: InboxMessageRow): AgentInboxMessageV12 {
+  return {
+    reply:
+      row.expectReply && row.responseId !== null
+        ? { expectsReply: true, responseId: row.responseId }
+        : { expectsReply: false },
+    fromAgentId: row.fromAgentId,
+    senderTitle: row.senderTitle,
+    senderHarnessId: row.senderHarnessId,
+    epicId: row.epicId,
+    prompt: row.prompt,
+    enqueuedAt: row.enqueuedAt,
+    eventId: row.eventId,
+  };
+}
+
+/** Wrap a row's wire message in the real @1.2 server "message" frame. */
+function rowToMessageFrame(row: InboxMessageRow): {
+  kind: "message";
+  hasBinaryPayload: false;
+  item: AgentInboxMessageV12;
+} {
+  return {
+    kind: "message",
+    hasBinaryPayload: false,
+    item: rowToWireMessage(row),
+  };
+}
+
+/**
+ * Narrow a parsed `agent.inbox.subscribe` frame to its "message" member so
+ * TypeScript sees `item`; a frame of any other kind here is a test failure.
+ */
+function expectMessageFrame(
+  frame: AgentInboxSubscribeServerFrame,
+): AgentInboxMessageV12 {
+  if (frame.kind !== "message") {
+    throw new Error(`expected a message frame, got kind "${frame.kind}"`);
+  }
+  return frame.item;
+}
+
+describe("Scenario 1 — enqueue → deliver → ack → remove", () => {
+  it("carries one envelope through the real wire schemas and retires it by eventId", () => {
+    // Enqueue: the canonical stored row validates against the row schema.
+    const row = inboxMessageRowSchema.parse(
+      makeRow({ eventId: "event-abc", prompt: "peer message body" }),
+    );
+
+    // Deliver: the resolver projects the row onto the @1.2 wire message and
+    // serializes the full server frame through the real contract schema.
+    const deliveredItem = expectMessageFrame(
+      agentInboxSubscribeServerFrameSchemaV12.parse(rowToMessageFrame(row)),
+    );
+    expect(deliveredItem).toEqual(rowToWireMessage(row));
+    expect(deliveredItem.eventId).toBe("event-abc");
+
+    // The delivery is counted on the durable row, but the row is NOT retired
+    // until acked — at-least-once.
+    const attempted = simulateDeliveryAttempt([row], ["event-abc"], 2_000);
+    expect(attempted.rows[0]?.deliveryCount).toBe(1);
+    expect(attempted.rows[0]?.lastDeliveredAt).toBe(2_000);
+
+    // Ack: the monitor echoes the wire eventId back through the real
+    // `agent.inbox.ack@1.0` request schema, and the reference flow retires it.
+    const ackRequest = agentInboxAckRequestSchema.parse({
+      epicId: EPIC_ID,
+      agentId: AGENT_ID,
+      eventIds: [deliveredItem.eventId],
+    });
+    const acked = simulateAckFlow(attempted.rows, ackRequest.eventIds);
+    expect(acked.removed).toEqual(["event-abc"]);
+    expect(acked.remaining).toEqual([]);
+    expect(acked.deadLetter).toEqual([]);
+  });
+
+  it("projects a reply-free row onto the wire with no responseId", () => {
+    const row = makeRow({
+      eventId: "event-noreply",
+      expectReply: false,
+      responseId: null,
+    });
+    const parsed = agentInboxMessageSchemaV12.parse(rowToWireMessage(row));
+    expect(parsed.reply).toEqual({ expectsReply: false });
+    expect(parsed.eventId).toBe("event-noreply");
+  });
+
+  it("keeps the broker-minted thread id on the wire for reply-bearing rows", () => {
+    const row = makeRow({
+      eventId: "event-reply",
+      expectReply: true,
+      responseId: "thread-9",
+    });
+    const parsed = agentInboxMessageSchemaV12.parse(rowToWireMessage(row));
+    expect(parsed.reply).toEqual({
+      expectsReply: true,
+      responseId: "thread-9",
+    });
+  });
+});
+
+describe("Scenario 2 — subscribe drain replay", () => {
+  it("replays unacked rows oldest-first and skips expired + dead-lettered rows", () => {
+    const now = 10_000;
+    const rows = [
+      makeRow({
+        eventId: "e-dead",
+        enqueuedAt: 1_000,
+        deliveryCount: INBOX_MAX_DELIVERY_ATTEMPTS,
+      }),
+      makeRow({ eventId: "e-expired", enqueuedAt: 2_000, expiresAt: 5_000 }),
+      makeRow({
+        eventId: "e-delivered-unacked",
+        enqueuedAt: 3_000,
+        deliveryCount: 1,
+        lastDeliveredAt: 9_000,
+      }),
+      makeRow({ eventId: "e-oldest", enqueuedAt: 1_500 }),
+      makeRow({ eventId: "e-newest", enqueuedAt: 4_000 }),
+    ];
+
+    const { deliverable, deadLetter, expired } = simulateSubscribeDrain(
+      rows,
+      now,
+    );
+
+    // Unacknowledged rows replay oldest-first by enqueuedAt; a row that was
+    // delivered but never acked still replays (at-least-once); expired and
+    // dead-lettered rows are skipped into their audit buckets.
+    expect(deliverable.map((row) => row.eventId)).toEqual([
+      "e-oldest",
+      "e-delivered-unacked",
+      "e-newest",
+    ]);
+    expect(deadLetter.map((row) => row.eventId)).toEqual(["e-dead"]);
+    expect(expired.map((row) => row.eventId)).toEqual(["e-expired"]);
+
+    // Every replayed row is representable on the real @1.2 wire frame, and
+    // the frame carries the row key the monitor would ack.
+    for (const row of deliverable) {
+      const item = expectMessageFrame(
+        agentInboxSubscribeServerFrameSchemaV12.parse(rowToMessageFrame(row)),
+      );
+      expect(item.eventId).toBe(row.eventId);
+    }
+  });
+});
+
+describe("Scenario 3 — delivery count → dead-letter", () => {
+  it("dead-letters a row on the 5th attempt, skips it on drains, and lets an ack retire it", () => {
+    let state = [makeRow({ eventId: "e-doomed", deliveryCount: 4 })];
+
+    // Attempt 5: deliveryCount 4 → 5, crossing the cap. The 5th attempt IS a
+    // real delivery, so the resolver reports the row in both `delivered` and
+    // `deadLetter` so it can move it to the audit set.
+    const attempt = simulateDeliveryAttempt(state, ["e-doomed"], 10_000);
+    state = attempt.rows;
+    expect(attempt.delivered[0]?.deliveryCount).toBe(
+      INBOX_MAX_DELIVERY_ATTEMPTS,
+    );
+    expect(attempt.deadLetter.map((row) => row.eventId)).toEqual(["e-doomed"]);
+
+    // A fresh subscribe skips the dead-lettered row entirely.
+    const drain = simulateSubscribeDrain(state, 20_000);
+    expect(drain.deliverable).toEqual([]);
+    expect(drain.deadLetter.map((row) => row.eventId)).toEqual(["e-doomed"]);
+    expect(drain.expired).toEqual([]);
+
+    // The row is retained for audit, but an ack still retires it — acked
+    // dead-lettered rows are removed, not kept.
+    const acked = simulateAckFlow(state, ["e-doomed"]);
+    expect(acked.removed).toEqual(["e-doomed"]);
+    expect(acked.remaining).toEqual([]);
+    expect(acked.deadLetter).toEqual([]);
+  });
+});
+
+describe("Scenario 4 — batch ack (max 500)", () => {
+  it("retires exactly 500 rows from a 600-row inbox in one ack call", () => {
+    const rows = Array.from({ length: 600 }, (_, index) =>
+      makeRow({ eventId: `e-${index}`, enqueuedAt: index }),
+    );
+    const firstBatch = rows
+      .slice(0, INBOX_MAX_ACK_BATCH_SIZE)
+      .map((row) => row.eventId);
+
+    // The batch validates against the real `agent.inbox.ack@1.0` wire schema —
+    // the cap the pure flow delegates to the wire (`simulateAckFlow` does not
+    // re-validate the batch itself).
+    const ackRequest = agentInboxAckRequestSchema.parse({
+      epicId: EPIC_ID,
+      agentId: AGENT_ID,
+      eventIds: firstBatch,
+    });
+    expect(ackRequest.eventIds).toHaveLength(INBOX_MAX_ACK_BATCH_SIZE);
+
+    const result = simulateAckFlow(rows, ackRequest.eventIds);
+    expect(result.removed).toHaveLength(INBOX_MAX_ACK_BATCH_SIZE);
+    expect(result.remaining).toHaveLength(100);
+    expect(result.deadLetter).toEqual([]);
+  });
+
+  it("rejects a 501-id batch at the wire schema — the spec constant's twin", () => {
+    const overCap = Array.from(
+      { length: INBOX_MAX_ACK_BATCH_SIZE + 1 },
+      (_, index) => `e-${index}`,
+    );
+    expect(
+      agentInboxAckRequestSchema.safeParse({
+        epicId: EPIC_ID,
+        agentId: AGENT_ID,
+        eventIds: overCap,
+      }).success,
+    ).toBe(false);
+    expect(INBOX_MAX_ACK_BATCH_SIZE).toBe(500);
+  });
+});
+
+/**
+ * Scenario 5 — at-least-once (@1.2+ monitors) vs at-most-once (<@1.2).
+ *
+ * A `@1.2`+ monitor negotiates `agentInboxMessageSchemaV12`, which carries
+ * `eventId`. Its deliveries are AT-LEAST-ONCE: a delivered-but-unacked row
+ * survives host restart and monitor reconnect, and the resolver replays it
+ * on the next `agent.inbox.subscribe` open. The monitor retires the row
+ * exactly once by echoing the `eventId` back through `agent.inbox.ack`.
+ *
+ * A `<@1.2` monitor negotiates the older frozen frame tree, which has NO
+ * `eventId` field at all, so it structurally cannot call `agent.inbox.ack`.
+ * Rather than leave the durable row queued forever for an ack that can never
+ * arrive, the resolver applies a SERVER-SIDE compatibility ack immediately
+ * after a successful send, retiring the row itself — AT-MOST-ONCE, the
+ * pre-durable-inbox behavior those monitors were always built against.
+ *
+ * The reference functions do not know about protocol minors: the guarantee
+ * is enforced by the composition of the wire schema (whether a frame carries
+ * `eventId`) and the resolver rule (auto-ack when it does not), which these
+ * tests simulate with the pure flows.
+ */
+describe("Scenario 5 — at-least-once vs at-most-once semantics", () => {
+  it("@1.2+: an unacked delivery survives and replays on the next subscribe", () => {
+    const row = makeRow({ eventId: "e-survivor", prompt: "must not be lost" });
+    const delivered = simulateDeliveryAttempt([row], ["e-survivor"], 5_000);
+    expect(delivered.rows[0]?.deliveryCount).toBe(1);
+
+    // No ack arrives — the durable row is the source of truth, so a
+    // reconnect (or host restart) replays it.
+    const replay = simulateSubscribeDrain(delivered.rows, 9_999);
+    expect(replay.deliverable.map((replayed) => replayed.eventId)).toEqual([
+      "e-survivor",
+    ]);
+
+    // The replayed frame still carries eventId, so the monitor can ack it.
+    const survivor = replay.deliverable[0];
+    expect(survivor?.eventId).toBe("e-survivor");
+    if (survivor) {
+      const item = expectMessageFrame(
+        agentInboxSubscribeServerFrameSchemaV12.parse(
+          rowToMessageFrame(survivor),
+        ),
+      );
+      expect(item.eventId).toBe("e-survivor");
+    }
+
+    // Once acked, the row is gone and the next subscribe finds nothing.
+    const acked = simulateAckFlow(replay.deliverable, ["e-survivor"]);
+    const afterAck = simulateSubscribeDrain(acked.remaining, 10_000);
+    expect(afterAck.deliverable).toEqual([]);
+  });
+
+  it("<@1.2: the older frame tree has no eventId, so the server auto-acks and never replays", () => {
+    const row = makeRow({
+      eventId: "e-legacy",
+      prompt: "legacy body",
+      expectReply: false,
+      responseId: null,
+    });
+
+    // The same bytes parse through the frozen @1.0 frame tree: zod is
+    // non-strict, so the extra `eventId` is silently stripped. A <@1.2
+    // monitor literally cannot see the durable row key.
+    const legacyFrame = agentInboxSubscribeServerFrameSchemaV10.parse(
+      rowToMessageFrame(row),
+    );
+    if (legacyFrame.kind !== "message") {
+      throw new Error("expected a message frame");
+    }
+    const legacyItem: AgentInboxMessage = legacyFrame.item;
+    expect(legacyItem).not.toHaveProperty("eventId");
+
+    // Because the monitor cannot ack, the resolver applies the server-side
+    // compatibility ack right after a successful send...
+    const acked = simulateAckFlow([row], [row.eventId]);
+    expect(acked.removed).toEqual(["e-legacy"]);
+    expect(acked.remaining).toEqual([]);
+
+    // ...so a later subscribe (even after a restart) replays nothing: the
+    // legacy monitor sees at-most-once delivery, exactly as before the
+    // durable inbox existed.
+    const replay = simulateSubscribeDrain(acked.remaining, 9_999);
+    expect(replay.deliverable).toEqual([]);
+    expect(replay.deadLetter).toEqual([]);
+    expect(replay.expired).toEqual([]);
+  });
+});

--- a/protocol/src/host/agent/__tests__/inbox-spec.test.ts
+++ b/protocol/src/host/agent/__tests__/inbox-spec.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import {
+  INBOX_MAX_ACK_BATCH_SIZE,
+  INBOX_MAX_DELIVERY_ATTEMPTS,
+  inboxMessageRowSchema,
+  simulateAckFlow,
+  simulateDeliveryAttempt,
+  simulateSubscribeDrain,
+  type InboxMessageRow,
+} from "@traycer/protocol/host/agent/inbox-spec";
+
+/**
+ * Reference tests for the durable inbox wire-format specification (Task 5,
+ * Phase 0). They pin the canonical `InboxMessageRow` schema and the delivery
+ * semantics a host must match: at-least-once replay for `@1.2`+ monitors,
+ * dead-lettering after `INBOX_MAX_DELIVERY_ATTEMPTS`, expiry without counting
+ * an attempt, oldest-first drain, and ack-by-`eventId` retirement.
+ */
+
+function makeRow(overrides: Partial<InboxMessageRow>): InboxMessageRow {
+  return {
+    eventId: "event-1",
+    agentId: "agent-1",
+    epicId: "epic-1",
+    fromAgentId: "agent-2",
+    prompt: "hello",
+    responseId: "thread-1",
+    expectReply: true,
+    senderTitle: "Agent Two",
+    senderHarnessId: "claude",
+    enqueuedAt: 1_000,
+    deliveryCount: 0,
+    lastDeliveredAt: null,
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+describe("InboxMessageRow reference schema", () => {
+  it("parses a fully-populated row with all documented columns", () => {
+    const row = makeRow({});
+    const parsed = inboxMessageRowSchema.parse(row);
+    expect(parsed).toEqual(row);
+    expect(parsed.deliveryCount).toBe(0);
+    expect(parsed.enqueuedAt).toBeTypeOf("number");
+    expect(parsed.expectReply).toBe(true);
+  });
+
+  it("accepts null for every nullable column and a reply-free message", () => {
+    const row = makeRow({
+      responseId: null,
+      senderTitle: null,
+      senderHarnessId: null,
+      lastDeliveredAt: null,
+      expiresAt: null,
+      expectReply: false,
+    });
+    expect(inboxMessageRowSchema.parse(row)).toEqual(row);
+  });
+
+  it("rejects rows missing required columns", () => {
+    const row = makeRow({});
+    for (const key of [
+      "eventId",
+      "agentId",
+      "epicId",
+      "fromAgentId",
+      "prompt",
+      "expectReply",
+      "enqueuedAt",
+      "deliveryCount",
+    ] as const) {
+      const { [key]: _omitted, ...without } = row;
+      expect(inboxMessageRowSchema.safeParse(without).success).toBe(false);
+    }
+  });
+
+  it("rejects non-integer epoch fields and negative delivery counts", () => {
+    expect(
+      inboxMessageRowSchema.safeParse(makeRow({ enqueuedAt: 1.5 })).success,
+    ).toBe(false);
+    expect(
+      inboxMessageRowSchema.safeParse(makeRow({ lastDeliveredAt: 1.5 }))
+        .success,
+    ).toBe(false);
+    expect(
+      inboxMessageRowSchema.safeParse(makeRow({ deliveryCount: -1 })).success,
+    ).toBe(false);
+  });
+
+  it("pins the contract constants the wire layer depends on", () => {
+    // agentInboxAckRequestSchema caps eventIds at 500; the spec constant is
+    // that same cap, so a future schema change cannot drift from the spec.
+    expect(INBOX_MAX_ACK_BATCH_SIZE).toBe(500);
+    expect(INBOX_MAX_DELIVERY_ATTEMPTS).toBe(5);
+  });
+});
+
+describe("simulateSubscribeDrain — replay on subscribe", () => {
+  it("drains unacknowledged rows oldest-first by enqueuedAt", () => {
+    const rows = [
+      makeRow({ eventId: "e-newer", enqueuedAt: 3_000 }),
+      makeRow({ eventId: "e-older", enqueuedAt: 1_000 }),
+      makeRow({ eventId: "e-middle", enqueuedAt: 2_000 }),
+    ];
+    const { deliverable } = simulateSubscribeDrain(rows, 9_999);
+    expect(deliverable.map((row) => row.eventId)).toEqual([
+      "e-older",
+      "e-middle",
+      "e-newer",
+    ]);
+  });
+
+  it("skips dead-lettered rows (deliveryCount >= 5) but retains them for audit", () => {
+    const active = makeRow({ eventId: "e-active" });
+    const dead = makeRow({
+      eventId: "e-dead",
+      deliveryCount: INBOX_MAX_DELIVERY_ATTEMPTS,
+    });
+    const { deliverable, deadLetter } = simulateSubscribeDrain(
+      [dead, active],
+      9_999,
+    );
+    expect(deliverable.map((row) => row.eventId)).toEqual(["e-active"]);
+    expect(deadLetter.map((row) => row.eventId)).toEqual(["e-dead"]);
+  });
+
+  it("skips expired rows without counting a delivery attempt", () => {
+    const expired = makeRow({
+      eventId: "e-expired",
+      expiresAt: 500,
+      deliveryCount: 2,
+    });
+    const live = makeRow({ eventId: "e-live", expiresAt: 2_000 });
+    const { deliverable, expired: expiredRows } = simulateSubscribeDrain(
+      [expired, live],
+      1_000,
+    );
+    expect(deliverable.map((row) => row.eventId)).toEqual(["e-live"]);
+    expect(expiredRows).toEqual([expired]);
+    // Skipped, not counted: the row's deliveryCount is untouched and the
+    // drain does not report it as delivered.
+    expect(expiredRows[0]?.deliveryCount).toBe(2);
+  });
+
+  it("treats expiresAt === null as no TTL and expiresAt === now as still live", () => {
+    const noTtl = makeRow({ eventId: "e-no-ttl", expiresAt: null });
+    const atBoundary = makeRow({
+      eventId: "e-boundary",
+      expiresAt: 1_000,
+    });
+    const { deliverable, expired } = simulateSubscribeDrain(
+      [noTtl, atBoundary],
+      1_000,
+    );
+    expect(deliverable.map((row) => row.eventId)).toEqual([
+      "e-no-ttl",
+      "e-boundary",
+    ]);
+    expect(expired).toEqual([]);
+  });
+
+  it("dead-letter wins over expiry: a dead-lettered row stays in the audit bucket", () => {
+    const deadAndExpired = makeRow({
+      eventId: "e-dead-expired",
+      deliveryCount: INBOX_MAX_DELIVERY_ATTEMPTS,
+      expiresAt: 100,
+    });
+    const { deliverable, deadLetter, expired } = simulateSubscribeDrain(
+      [deadAndExpired],
+      1_000,
+    );
+    expect(deliverable).toEqual([]);
+    expect(deadLetter).toEqual([deadAndExpired]);
+    expect(expired).toEqual([]);
+  });
+});
+
+describe("simulateDeliveryAttempt — count incrementing and dead-lettering", () => {
+  it("increments deliveryCount and stamps lastDeliveredAt without mutating input", () => {
+    const before = makeRow({ eventId: "e-1" });
+
+    const { rows, delivered } = simulateDeliveryAttempt(
+      [before],
+      ["e-1"],
+      2_000,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.deliveryCount).toBe(1);
+    expect(rows[0]?.lastDeliveredAt).toBe(2_000);
+    expect(delivered.map((item) => item.eventId)).toEqual(["e-1"]);
+    // Pure: the input row is unchanged.
+    expect(before.deliveryCount).toBe(0);
+    expect(before.lastDeliveredAt).toBeNull();
+  });
+
+  it("leaves non-target rows untouched and ignores unknown eventIds", () => {
+    const target = makeRow({ eventId: "e-target", deliveryCount: 1 });
+    const other = makeRow({ eventId: "e-other", deliveryCount: 3 });
+    const { rows, delivered } = simulateDeliveryAttempt(
+      [target, other],
+      ["e-target", "e-unknown"],
+      2_000,
+    );
+    expect(rows.find((item) => item.eventId === "e-other")?.deliveryCount).toBe(
+      3,
+    );
+    expect(delivered.map((item) => item.eventId)).toEqual(["e-target"]);
+  });
+
+  it("dead-letters a row on the 5th delivery attempt (count 4 -> 5)", () => {
+    let state = [makeRow({ eventId: "e-1", deliveryCount: 3 })];
+    const deliveredCounts: number[] = [];
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const result = simulateDeliveryAttempt(state, ["e-1"], 1_000 + attempt);
+      state = result.rows;
+      deliveredCounts.push(result.delivered[0]?.deliveryCount ?? -1);
+    }
+
+    // Attempt 4 lands on count 4 (still live), attempt 5 lands on count 5.
+    expect(deliveredCounts).toEqual([4, 5]);
+
+    const { deliverable, deadLetter } = simulateSubscribeDrain(state, 9_999);
+    expect(deliverable).toEqual([]);
+    expect(deadLetter.map((item) => item.eventId)).toEqual(["e-1"]);
+    expect(deadLetter[0]?.deliveryCount).toBe(INBOX_MAX_DELIVERY_ATTEMPTS);
+  });
+});
+
+describe("simulateAckFlow — agent.inbox.ack@1.0", () => {
+  it("removes acked rows by eventId and keeps the rest in remaining", () => {
+    const rows = [
+      makeRow({ eventId: "e-ack" }),
+      makeRow({ eventId: "e-keep" }),
+    ];
+    const result = simulateAckFlow(rows, ["e-ack"]);
+    expect(result.removed).toEqual(["e-ack"]);
+    expect(result.remaining.map((row) => row.eventId)).toEqual(["e-keep"]);
+    expect(result.deadLetter).toEqual([]);
+  });
+
+  it("an empty ack retires nothing and returns every row as remaining", () => {
+    const rows = [makeRow({ eventId: "e-1" }), makeRow({ eventId: "e-2" })];
+    const result = simulateAckFlow(rows, []);
+    expect(result.removed).toEqual([]);
+    expect(result.remaining).toHaveLength(2);
+    expect(result.deadLetter).toEqual([]);
+  });
+
+  it("ignores unknown eventIds", () => {
+    const rows = [makeRow({ eventId: "e-1" })];
+    const result = simulateAckFlow(rows, ["e-unknown"]);
+    expect(result.removed).toEqual([]);
+    expect(result.remaining.map((row) => row.eventId)).toEqual(["e-1"]);
+  });
+
+  it("separates dead-lettered rows (skipped but retained) from remaining", () => {
+    const rows = [
+      makeRow({ eventId: "e-active" }),
+      makeRow({
+        eventId: "e-dead",
+        deliveryCount: INBOX_MAX_DELIVERY_ATTEMPTS,
+      }),
+    ];
+    const result = simulateAckFlow(rows, []);
+    expect(result.remaining.map((row) => row.eventId)).toEqual(["e-active"]);
+    expect(result.deadLetter.map((row) => row.eventId)).toEqual(["e-dead"]);
+  });
+
+  it("an ack retires a dead-lettered row instead of retaining it", () => {
+    const rows = [
+      makeRow({
+        eventId: "e-dead",
+        deliveryCount: INBOX_MAX_DELIVERY_ATTEMPTS,
+      }),
+    ];
+    const result = simulateAckFlow(rows, ["e-dead"]);
+    expect(result.removed).toEqual(["e-dead"]);
+    expect(result.deadLetter).toEqual([]);
+    expect(result.remaining).toEqual([]);
+  });
+
+  it("is pure: the input row set and rows are not mutated", () => {
+    const rows = [
+      makeRow({ eventId: "e-1" }),
+      makeRow({ eventId: "e-dead", deliveryCount: 5 }),
+    ];
+    const before = rows.map((row) => ({ ...row }));
+    simulateAckFlow(rows, ["e-1"]);
+    expect(rows).toEqual(before);
+  });
+
+  it("accepts up to the wire cap of 500 eventIds in one call", () => {
+    const eventIds = Array.from(
+      { length: INBOX_MAX_ACK_BATCH_SIZE },
+      (_, index) => `e-${index}`,
+    );
+    const rows = eventIds.map((eventId) => makeRow({ eventId }));
+    const result = simulateAckFlow(rows, eventIds);
+    expect(result.removed).toHaveLength(INBOX_MAX_ACK_BATCH_SIZE);
+    expect(result.remaining).toEqual([]);
+  });
+});

--- a/protocol/src/host/agent/inbox-spec.ts
+++ b/protocol/src/host/agent/inbox-spec.ts
@@ -1,0 +1,277 @@
+/**
+ * Canonical REFERENCE SPECIFICATION for the durable agent inbox — the wire
+ * format, stored row shape, and delivery semantics a Traycer host
+ * implementer must match when building the closed-source broker's durable
+ * inbox. This module is a typed document, not a migration and not host code:
+ * it defines the canonical row (`InboxMessageRow`), the delivery contract,
+ * and pure functions that simulate the drain / attempt / ack flows so the
+ * semantics are provable end-to-end without a host (the same pattern as
+ * `host/policy/defaults.ts` and `host/policy/registry.ts`).
+ *
+ * Wire surface this spec pins down (all in `inbox.ts`):
+ *
+ *   - `agent.inbox.subscribe@1.2` — "message" frames carry `eventId` from
+ *     `agentInboxMessageSchemaV12`, the durable row key the monitor echoes
+ *     back in `agent.inbox.ack`.
+ *   - `agent.inbox.ack@1.0` — batch ack by `eventId`; the wire schema caps
+ *     the batch at {@link INBOX_MAX_ACK_BATCH_SIZE} entries per call.
+ *   - `agent.inbox.read@2.0` — cursor-paged durable-inbox reads; the `after`
+ *     cursor `{ createdAt, eventId }` maps onto the row's
+ *     `enqueuedAt` / `eventId` so paging follows the same oldest-first order
+ *     as replay.
+ *
+ * Delivery guarantees:
+ *
+ *   - **At-least-once for `@1.2`+ monitors.** A row that is delivered but not
+ *     acknowledged survives host restart and monitor reconnect; the resolver
+ *     replays unacknowledged rows on every subscribe open. A monitor should
+ *     ack promptly after it has safely surfaced a message to the agent (e.g.
+ *     after printing it), and the row is retired exactly once the ack
+ *     arrives. The durable row is the source of truth for
+ *     `agent.inbox.subscribe`, not the in-memory queue.
+ *   - **At-most-once for `<@1.2` monitors.** A monitor that negotiated below
+ *     `@1.2` has no `eventId` field at all and structurally cannot call
+ *     `agent.inbox.ack`. Rather than leave the durable row queued forever for
+ *     an ack that can never arrive, the resolver applies a SERVER-SIDE
+ *     compatibility ack: immediately after successfully sending a "message"
+ *     frame to such a connection, it retires the row itself. This mirrors the
+ *     pre-durable-inbox behavior those monitors were always built against —
+ *     no regression, no replay for them.
+ *   - **Replay on subscribe.** On `agent.inbox.subscribe@1.2` open, the
+ *     resolver drains unacknowledged rows ordered by `enqueuedAt` ASC
+ *     (oldest first), skipping rows that are expired or dead-lettered (see
+ *     {@link simulateSubscribeDrain}).
+ *   - **Dead-lettering.** After {@link INBOX_MAX_DELIVERY_ATTEMPTS} (5)
+ *     delivery attempts — `deliveryCount >= 5` — a row is skipped by every
+ *     future drain, but retained for audit. It is never deleted by the
+ *     delivery path itself; only an ack (or host-side TTL cleanup) removes
+ *     it. See {@link simulateAckFlow} and {@link simulateSubscribeDrain}.
+ *   - **Expiry.** A row with `expiresAt < now` is skipped without counting as
+ *     a delivery attempt; `expiresAt === null` means no TTL. Expired rows are
+ *     returned alongside the drain for audit and host-side cleanup.
+ *   - **Ack.** `agent.inbox.ack@1.0` removes rows by `eventId` (max
+ *     {@link INBOX_MAX_ACK_BATCH_SIZE} per call). Acked rows are gone — not
+ *     retained, not dead-lettered. Acking an already-dead-lettered row also
+ *     retires it.
+ *
+ * Canonical stored row (typed reference schema — NOT a SQL migration):
+ *
+ * | Column            | Type     | Nullable | Meaning                                    |
+ * |-------------------|----------|----------|--------------------------------------------|
+ * | `eventId`         | string   | no       | Broker-minted uuid; durable row PK.        |
+ * | `agentId`         | string   | no       | Receiver of the message.                   |
+ * | `epicId`          | string   | no       | Epic the receiver belongs to.              |
+ * | `fromAgentId`     | string   | no       | Sender of the message.                     |
+ * | `prompt`          | string   | no       | Full message body.                         |
+ * | `responseId`      | string   | yes      | Broker-minted thread id for reply-bearing  |
+ * |                   |          |          | messages; null otherwise.                  |
+ * | `expectReply`     | boolean  | no       | Whether the sender expects a reply.        |
+ * | `senderTitle`     | string   | yes      | Sender display title, when known.          |
+ * | `senderHarnessId` | string   | yes      | Sender harness id (claude/codex/…), when   |
+ * |                   |          |          | bound.                                     |
+ * | `enqueuedAt`      | number   | no       | Epoch millis the broker received it.       |
+ * | `deliveryCount`   | number   | no       | Delivery attempts so far; starts at 0.     |
+ * | `lastDeliveredAt` | number   | yes      | Epoch millis of the most recent attempt.   |
+ * | `expiresAt`       | number   | yes      | Epoch millis TTL; null = no expiry.        |
+ */
+import { z } from "zod";
+
+/** Delivery attempts before a row is dead-lettered (`deliveryCount >= 5`). */
+export const INBOX_MAX_DELIVERY_ATTEMPTS = 5;
+
+/** Max `eventId`s accepted by one `agent.inbox.ack@1.0` call. */
+export const INBOX_MAX_ACK_BATCH_SIZE = 500;
+
+/**
+ * Reference schema for one durable inbox row. This is the canonical stored
+ * shape — the broker's SQLite table is an implementation of it, not the other
+ * way around. The wire schemas in `inbox.ts` carry the *delivered* projection
+ * (`agentInboxMessageSchemaV12` plus the `reply` discriminator); this row adds
+ * the delivery bookkeeping (`deliveryCount`, `lastDeliveredAt`, `expiresAt`)
+ * that the resolver uses to enforce the contract.
+ */
+export const inboxMessageRowSchema = z.object({
+  /**
+   * Broker-minted uuid, the durable row's primary key. Surfaced to `@1.2`+
+   * monitors as `agentInboxMessageSchemaV12.eventId` and echoed back in
+   * `agent.inbox.ack`.
+   */
+  eventId: z.string(),
+  /** Receiver the message is addressed to (the inbox owner). */
+  agentId: z.string(),
+  /** Epic the receiver belongs to. */
+  epicId: z.string(),
+  /** Sender of the message. */
+  fromAgentId: z.string(),
+  /** Full message body (the same body `agent.sendMessage` carried). */
+  prompt: z.string(),
+  /**
+   * Broker-minted thread id the receiver must echo back when replying.
+   * Null for messages sent without `expectReply` — those carry no thread.
+   */
+  responseId: z.string().nullable(),
+  /** Whether the sender expects a reply (drives the inactivity watchdog). */
+  expectReply: z.boolean(),
+  /** Sender's display title (chat or TUI title), or null when unknown. */
+  senderTitle: z.string().nullable(),
+  /** Sender's harness id (claude/codex/cursor/opencode), or null when unbound. */
+  senderHarnessId: z.string().nullable(),
+  /** Epoch millis the broker received the envelope. Replay order key. */
+  enqueuedAt: z.number().int(),
+  /**
+   * Delivery attempts so far, starting at 0. A row with
+   * `deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS` is dead-lettered: skipped
+   * by every drain, retained for audit.
+   */
+  deliveryCount: z.number().int().min(0),
+  /** Epoch millis of the most recent delivery attempt, or null before any. */
+  lastDeliveredAt: z.number().int().nullable(),
+  /**
+   * Epoch millis TTL. Once `expiresAt < now` the row is skipped without
+   * counting as a delivery attempt. Null means the row never expires.
+   */
+  expiresAt: z.number().int().nullable(),
+});
+export type InboxMessageRow = z.infer<typeof inboxMessageRowSchema>;
+
+/**
+ * Replay-on-subscribe projection: the rows the resolver would hand to a
+ * `@1.2`+ monitor on `agent.inbox.subscribe` open, and the rows it skips.
+ *
+ * Delivery order is `enqueuedAt` ASC — oldest first, matching
+ * `agent.inbox.read@2.0` paging. A row is excluded from `deliverable` if:
+ *
+ *   - `deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS` → dead-lettered: skipped
+ *     but retained for audit (reported in `deadLetter`). Dead-letter wins over
+ *     expiry so a dead-lettered row stays in the dead-letter audit bucket even
+ *     after its TTL passes.
+ *   - `expiresAt !== null && expiresAt < now` → expired: skipped WITHOUT
+ *     counting as a delivery attempt (reported in `expired`).
+ *
+ * Pure: input rows are never mutated; ordering happens on a new array.
+ */
+export function simulateSubscribeDrain(
+  rows: readonly InboxMessageRow[],
+  now: number,
+): {
+  /** Rows the resolver would deliver now, oldest `enqueuedAt` first. */
+  deliverable: InboxMessageRow[];
+  /** Rows with `deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS`, retained for audit. */
+  deadLetter: InboxMessageRow[];
+  /** Rows past `expiresAt`, skipped without counting as an attempt. */
+  expired: InboxMessageRow[];
+} {
+  const deliverable: InboxMessageRow[] = [];
+  const deadLetter: InboxMessageRow[] = [];
+  const expired: InboxMessageRow[] = [];
+
+  for (const row of rows) {
+    if (row.deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS) {
+      deadLetter.push(row);
+    } else if (row.expiresAt !== null && row.expiresAt < now) {
+      expired.push(row);
+    } else {
+      deliverable.push(row);
+    }
+  }
+
+  deliverable.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
+  return { deliverable, deadLetter, expired };
+}
+
+/**
+ * Pure projection of one delivery attempt: increments `deliveryCount` and
+ * stamps `lastDeliveredAt` on exactly the rows whose `eventId` is in
+ * `eventIds` (the rows the resolver actually sent this cycle). Returns the
+ * next inbox state as a NEW array — the input is never mutated.
+ *
+ * A row that crosses `deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS` on this
+ * attempt WAS delivered (the 5th attempt is real) and is also reported in
+ * `deadLetter` so the caller can move it out of the live drain and into the
+ * audit/retention set. Unknown `eventIds` are ignored.
+ */
+export function simulateDeliveryAttempt(
+  rows: readonly InboxMessageRow[],
+  eventIds: readonly string[],
+  now: number,
+): {
+  /** The full next inbox state (new array). */
+  rows: InboxMessageRow[];
+  /** The rows delivered this attempt, post-increment. */
+  delivered: InboxMessageRow[];
+  /** Delivered rows that crossed the dead-letter cap this attempt. */
+  deadLetter: InboxMessageRow[];
+} {
+  const target = new Set(eventIds);
+  const next: InboxMessageRow[] = [];
+  const delivered: InboxMessageRow[] = [];
+  const deadLetter: InboxMessageRow[] = [];
+
+  for (const row of rows) {
+    if (!target.has(row.eventId)) {
+      next.push(row);
+      continue;
+    }
+    const attempted: InboxMessageRow = {
+      ...row,
+      deliveryCount: row.deliveryCount + 1,
+      lastDeliveredAt: now,
+    };
+    next.push(attempted);
+    delivered.push(attempted);
+    if (attempted.deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS) {
+      deadLetter.push(attempted);
+    }
+  }
+
+  return { rows: next, delivered, deadLetter };
+}
+
+/**
+ * Pure simulation of the `agent.inbox.ack@1.0` flow over a durable row set:
+ * retires the rows whose `eventId` is in `ackEventIds`, partitions the rest
+ * into still-active rows and dead-lettered rows, and leaves the input
+ * untouched.
+ *
+ * Semantics (a host implements these in SQL):
+ *
+ *   - `removed` — every `eventId` that was acked, whether the row was active
+ *     or already dead-lettered. Acked rows are gone, not retained.
+ *   - `remaining` — rows still eligible for delivery: unacked and not
+ *     dead-lettered (`deliveryCount < INBOX_MAX_DELIVERY_ATTEMPTS`).
+ *   - `deadLetter` — unacked rows with `deliveryCount >=
+ *     INBOX_MAX_DELIVERY_ATTEMPTS`: skipped by every future drain, retained
+ *     for audit.
+ *
+ * The `INBOX_MAX_ACK_BATCH_SIZE` cap is a WIRE constraint enforced by
+ * `agentInboxAckRequestSchema` (`.max(500)`), so this function does not
+ * re-validate the batch — it simulates the flow for whatever ids it is given.
+ */
+export function simulateAckFlow(
+  rows: readonly InboxMessageRow[],
+  ackEventIds: readonly string[],
+): {
+  /** Unacked, non-dead-lettered rows still in the live inbox. */
+  remaining: InboxMessageRow[];
+  /** `eventId`s retired by this ack, in row order. */
+  removed: string[];
+  /** Unacked dead-lettered rows, retained for audit. */
+  deadLetter: InboxMessageRow[];
+} {
+  const acked = new Set(ackEventIds);
+  const remaining: InboxMessageRow[] = [];
+  const removed: string[] = [];
+  const deadLetter: InboxMessageRow[] = [];
+
+  for (const row of rows) {
+    if (acked.has(row.eventId)) {
+      removed.push(row.eventId);
+    } else if (row.deliveryCount >= INBOX_MAX_DELIVERY_ATTEMPTS) {
+      deadLetter.push(row);
+    } else {
+      remaining.push(row);
+    }
+  }
+
+  return { remaining, removed, deadLetter };
+}

--- a/protocol/src/host/agent/index.ts
+++ b/protocol/src/host/agent/index.ts
@@ -2,6 +2,7 @@ export * from "./shared";
 export * from "./contracts";
 export * from "./roles";
 export * from "./inbox";
+export * from "./inbox-spec";
 export * from "./activity";
 export * from "./profiles";
 export * from "./gui";

--- a/protocol/src/host/epic/__tests__/epic-communication-graph-subscribe.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-communication-graph-subscribe.test.ts
@@ -6,15 +6,20 @@ import {
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/index";
 import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
 import {
+  downgradeEpicCommunicationGraphEventV11ToV10,
   epicCommunicationGraphEventSchema,
+  epicCommunicationGraphEventSchemaV11,
   epicCommunicationGraphSubscribeClientFrameSchema,
   epicCommunicationGraphSubscribeOpenRequestSchema,
   epicCommunicationGraphSubscribeServerFrameSchema,
+  epicCommunicationGraphSubscribeServerFrameSchemaV11,
   epicCommunicationGraphSubscribeV10,
+  epicCommunicationGraphSubscribeV11,
+  upgradeEpicCommunicationGraphEventV10ToV11,
 } from "@traycer/protocol/host/epic/communication-graph";
 
 /**
- * `epic.communicationGraph.subscribe@1.0` contract fixtures + the
+ * `epic.communicationGraph.subscribe@1.0`/`@1.1` contract fixtures + the
  * optional-method degrade guard.
  *
  * The degrade case is the load-bearing one: this method ships AFTER
@@ -27,6 +32,12 @@ import {
  * backlog, so frame kind carries no activity semantics - these fixtures are
  * written to reflect that rather than the older "snapshot = everything, events
  * = live" reading.
+ *
+ * On the minors: `@1.1` adds four event kinds and their nullable per-kind
+ * fields; `@1.0` stays FROZEN and INSTALLED, and the resolver projects each
+ * subscription to the minor it negotiated (streams have no version bridges -
+ * see the module doc). The tests below pin both the `@1.0` freeze and the
+ * `@1.1` additive shape.
  */
 
 const METHOD = "epic.communicationGraph.subscribe";
@@ -47,16 +58,23 @@ const A2A_MESSAGE_EVENT = {
   originRefId: "block-7",
 } as const;
 
-describe("epic.communicationGraph.subscribe@1.0 contract", () => {
-  it("declares the method at 1.0 and registers it in the stream registry", () => {
+describe("epic.communicationGraph.subscribe contract minors", () => {
+  it("keeps @1.0 frozen at 1.0 while the registry's latest minor is 1.1", () => {
     expect(epicCommunicationGraphSubscribeV10.method).toBe(METHOD);
     expect(epicCommunicationGraphSubscribeV10.schemaVersion).toEqual({
       major: 1,
       minor: 0,
     });
+    expect(epicCommunicationGraphSubscribeV11.method).toBe(METHOD);
+    expect(epicCommunicationGraphSubscribeV11.schemaVersion).toEqual({
+      major: 1,
+      minor: 1,
+    });
+    // The manifest advertises the LATEST installed minor; `@1.0` peers still
+    // connect - the host serves them resolver-projected `@1.0` frames.
     expect(buildStreamManifest(hostStreamRpcRegistry)[METHOD]).toEqual({
       major: 1,
-      minor: 0,
+      minor: 1,
     });
   });
 
@@ -229,6 +247,384 @@ describe("epic.communicationGraph.subscribe@1.0 frames", () => {
         kind: "artifact_write",
       }).success,
     ).toBe(false);
+  });
+});
+
+describe("epic.communicationGraph.subscribe@1.1 rows", () => {
+  // The @1.1 event is the frozen @1.0 object plus 17 required-nullable
+  // per-kind fields. `V11_EMPTY_EVENT` is the "@1.0 row upgraded" baseline;
+  // each fixture below fills only the fields its kind owns.
+  const V11_EMPTY_EVENT = {
+    ...A2A_MESSAGE_EVENT,
+    toolName: null,
+    toolInput: null,
+    durationMs: null,
+    success: null,
+    tokenCost: null,
+    approvalId: null,
+    status: null,
+    targetAction: null,
+    agentId: null,
+    previousState: null,
+    newState: null,
+    trigger: null,
+    hostId: null,
+    resourceType: null,
+    metricValue: null,
+    threshold: null,
+    breach: null,
+  } as const;
+
+  it("parses a tool_call row with its per-kind fields populated", () => {
+    const row = epicCommunicationGraphEventSchemaV11.parse({
+      ...V11_EMPTY_EVENT,
+      id: 101,
+      kind: "tool_call",
+      senderAgentId: "agent-builder",
+      receiverAgentId: null,
+      responseId: null,
+      inReplyTo: null,
+      expectReply: null,
+      messageText: null,
+      toolName: "read_file",
+      toolInput: "read protocol/src/host/epic/communication-graph.ts",
+      durationMs: 312,
+      success: true,
+      tokenCost: 1542,
+    });
+    expect(row.kind).toBe("tool_call");
+    expect(row.toolName).toBe("read_file");
+    expect(row.durationMs).toBe(312);
+    expect(row.success).toBe(true);
+    expect(row.tokenCost).toBe(1542);
+    // Fields owned by other kinds stay null on this row.
+    expect(row.approvalId).toBeNull();
+    expect(row.hostId).toBeNull();
+    expect(row.agentId).toBeNull();
+  });
+
+  it("parses an approval row with its per-kind fields populated", () => {
+    const row = epicCommunicationGraphEventSchemaV11.parse({
+      ...V11_EMPTY_EVENT,
+      id: 102,
+      kind: "approval",
+      senderAgentId: "agent-builder",
+      receiverAgentId: null,
+      responseId: null,
+      inReplyTo: null,
+      expectReply: null,
+      messageText: null,
+      approvalId: "approval-9",
+      status: "granted",
+      targetAction: "agent.stop",
+      originKind: "gui_message",
+      originChatId: "chat-1",
+      originRefId: "block-9",
+    });
+    expect(row.kind).toBe("approval");
+    expect(row.approvalId).toBe("approval-9");
+    expect(row.status).toBe("granted");
+    expect(row.targetAction).toBe("agent.stop");
+    // Source traceability rides the existing origin fields.
+    expect(row.originRefId).toBe("block-9");
+  });
+
+  it("parses a lifecycle row with its per-kind fields populated", () => {
+    const row = epicCommunicationGraphEventSchemaV11.parse({
+      ...V11_EMPTY_EVENT,
+      id: 103,
+      kind: "lifecycle",
+      senderAgentId: null,
+      receiverAgentId: null,
+      responseId: null,
+      inReplyTo: null,
+      expectReply: null,
+      messageText: null,
+      agentId: "agent-reviewer",
+      previousState: "active",
+      newState: "stopped",
+      trigger: "user",
+    });
+    expect(row.kind).toBe("lifecycle");
+    expect(row.agentId).toBe("agent-reviewer");
+    expect(row.previousState).toBe("active");
+    expect(row.newState).toBe("stopped");
+    expect(row.trigger).toBe("user");
+  });
+
+  it("parses a resource_event row with its per-kind fields populated", () => {
+    const row = epicCommunicationGraphEventSchemaV11.parse({
+      ...V11_EMPTY_EVENT,
+      id: 104,
+      kind: "resource_event",
+      senderAgentId: null,
+      receiverAgentId: null,
+      responseId: null,
+      inReplyTo: null,
+      expectReply: null,
+      messageText: null,
+      hostId: "host-1",
+      resourceType: "memory",
+      metricValue: 87.4,
+      threshold: 80,
+      breach: true,
+    });
+    expect(row.kind).toBe("resource_event");
+    expect(row.hostId).toBe("host-1");
+    expect(row.resourceType).toBe("memory");
+    expect(row.metricValue).toBe(87.4);
+    expect(row.threshold).toBe(80);
+    expect(row.breach).toBe(true);
+  });
+
+  it("still parses a @1.0-shaped row once the @1.1 fields are present as nulls", () => {
+    // The upgrade transform's output - the "every @1.0 row is a valid @1.1
+    // row" property that makes the minor purely additive at the data level.
+    const row = epicCommunicationGraphEventSchemaV11.parse(V11_EMPTY_EVENT);
+    expect(row.kind).toBe("a2a_message");
+    expect(row.messageText).toBe("Review the protocol contract.");
+    expect(row.toolName).toBeNull();
+    expect(row.breach).toBeNull();
+  });
+
+  it("accepts a status value invented after the minor froze (open string)", () => {
+    // Same historical-log argument as `noticeReason`: `status`/`trigger`/
+    // `resourceType` annotate a row whose kind already renders, so unknown
+    // values degrade to raw strings instead of unreadable rows.
+    expect(
+      epicCommunicationGraphEventSchemaV11.parse({
+        ...V11_EMPTY_EVENT,
+        kind: "approval",
+        approvalId: "approval-9",
+        status: "escalated",
+        targetAction: "agent.stop",
+      }).status,
+    ).toBe("escalated");
+  });
+
+  it("requires every @1.1 field, per the required-nullable convention", () => {
+    const { toolName: _omittedToolName, ...withoutToolName } = V11_EMPTY_EVENT;
+    expect(
+      epicCommunicationGraphEventSchemaV11.safeParse(withoutToolName).success,
+    ).toBe(false);
+  });
+
+  it("keeps the @1.0 schema closed: it still rejects every new kind", () => {
+    for (const kind of ["tool_call", "approval", "lifecycle", "resource_event"]) {
+      expect(
+        epicCommunicationGraphEventSchema.safeParse({
+          ...A2A_MESSAGE_EVENT,
+          kind,
+        }).success,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("epic.communicationGraph.subscribe@1.1 frames", () => {
+  const V11_TOOL_CALL_EVENT = {
+    id: 101,
+    kind: "tool_call",
+    timestamp: 1_753_000_000_001,
+    senderAgentId: "agent-builder",
+    receiverAgentId: null,
+    responseId: null,
+    inReplyTo: null,
+    expectReply: null,
+    messageText: null,
+    noticeReason: null,
+    originKind: null,
+    originChatId: null,
+    originRefId: null,
+    toolName: "read_file",
+    toolInput: null,
+    durationMs: 312,
+    success: true,
+    tokenCost: 1542,
+    approvalId: null,
+    status: null,
+    targetAction: null,
+    agentId: null,
+    previousState: null,
+    newState: null,
+    trigger: null,
+    hostId: null,
+    resourceType: null,
+    metricValue: null,
+    threshold: null,
+    breach: null,
+  } as const;
+
+  it("parses a snapshot frame carrying a new-kind row", () => {
+    const parsed = epicCommunicationGraphSubscribeServerFrameSchemaV11.parse({
+      kind: "snapshot",
+      epicId: "epic-1",
+      events: [V11_TOOL_CALL_EVENT],
+      headId: V11_TOOL_CALL_EVENT.id,
+      hasBinaryPayload: false,
+    });
+
+    expect(parsed.kind).toBe("snapshot");
+    if (parsed.kind === "snapshot") {
+      expect(parsed.events[0].kind).toBe("tool_call");
+      expect(parsed.events[0].toolName).toBe("read_file");
+    }
+  });
+
+  it("parses an event frame carrying a new-kind row", () => {
+    const parsed = epicCommunicationGraphSubscribeServerFrameSchemaV11.parse({
+      kind: "event",
+      epicId: "epic-1",
+      event: V11_TOOL_CALL_EVENT,
+      hasBinaryPayload: false,
+    });
+
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") {
+      expect(parsed.event.kind).toBe("tool_call");
+    }
+  });
+
+  it("reuses the @1.0 open request and client frames verbatim", () => {
+    expect(epicCommunicationGraphSubscribeV11.openRequestSchema).toBe(
+      epicCommunicationGraphSubscribeOpenRequestSchema,
+    );
+    expect(epicCommunicationGraphSubscribeV11.clientFrameSchema).toBe(
+      epicCommunicationGraphSubscribeClientFrameSchema,
+    );
+  });
+});
+
+describe("epic.communicationGraph.subscribe@1.0 ↔ @1.1 row transforms", () => {
+  it("upgrades a @1.0 row to @1.1 by filling the new fields with null", () => {
+    const upgraded = upgradeEpicCommunicationGraphEventV10ToV11(
+      epicCommunicationGraphEventSchema.parse(A2A_MESSAGE_EVENT),
+    );
+
+    expect(epicCommunicationGraphEventSchemaV11.parse(upgraded).kind).toBe(
+      "a2a_message",
+    );
+    expect(upgraded.id).toBe(A2A_MESSAGE_EVENT.id);
+    expect(upgraded.messageText).toBe("Review the protocol contract.");
+    expect(upgraded.toolName).toBeNull();
+    expect(upgraded.breach).toBeNull();
+  });
+
+  it("downgrades a representable @1.1 row by stripping the @1.1 fields", () => {
+    const upgraded = upgradeEpicCommunicationGraphEventV10ToV11(
+      epicCommunicationGraphEventSchema.parse(A2A_MESSAGE_EVENT),
+    );
+    const result = downgradeEpicCommunicationGraphEventV11ToV10(upgraded);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Stripped shape parses under the FROZEN @1.0 schema.
+      expect(epicCommunicationGraphEventSchema.parse(result.value).kind).toBe(
+        "a2a_message",
+      );
+      expect(result.value).not.toHaveProperty("toolName");
+      expect(result.value).not.toHaveProperty("breach");
+      expect(result.value.id).toBe(A2A_MESSAGE_EVENT.id);
+    }
+  });
+
+  it("refuses to downgrade a new-kind row: the @1.0 peer must SKIP it", () => {
+    const toolCall = epicCommunicationGraphEventSchemaV11.parse({
+      id: 101,
+      kind: "tool_call",
+      timestamp: 1_753_000_000_001,
+      senderAgentId: "agent-builder",
+      receiverAgentId: null,
+      responseId: null,
+      inReplyTo: null,
+      expectReply: null,
+      messageText: null,
+      noticeReason: null,
+      originKind: null,
+      originChatId: null,
+      originRefId: null,
+      toolName: "read_file",
+      toolInput: null,
+      durationMs: 312,
+      success: true,
+      tokenCost: 1542,
+      approvalId: null,
+      status: null,
+      targetAction: null,
+      agentId: null,
+      previousState: null,
+      newState: null,
+      trigger: null,
+      hostId: null,
+      resourceType: null,
+      metricValue: null,
+      threshold: null,
+      breach: null,
+    });
+
+    const result = downgradeEpicCommunicationGraphEventV11ToV10(toolCall);
+    expect(result).toEqual({ ok: false, reason: "unrepresentable-kind" });
+  });
+});
+
+describe("epic.communicationGraph.subscribe@1.1 negotiated-minor compat", () => {
+  it("keeps a @1.0 peer compatible: the @1.0 minor stays installed", () => {
+    // The host's registry manifests 1.1; a client whose manifest still says
+    // 1.0 must connect. The host serves it resolver-projected @1.0 frames
+    // (streams have no bridges - compat is installed-minor negotiation).
+    const hostManifest = buildStreamManifest(hostStreamRpcRegistry);
+    const clientManifest = { ...hostManifest, [METHOD]: { major: 1, minor: 0 } };
+
+    expect(
+      checkStreamMethodCompatibility(
+        hostStreamRpcRegistry,
+        hostManifest,
+        clientManifest,
+        "host",
+        METHOD,
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("skips new-kind rows for a @1.0 peer instead of failing the stream", () => {
+    // The resolver's projection path: for every stored row it consults the
+    // downgrade; `unrepresentable-kind` means skip (cursor advances, nothing
+    // is held back) - exactly the representability policy's contract.
+    const newKindEvent = epicCommunicationGraphEventSchemaV11.parse({
+      id: 101,
+      kind: "resource_event",
+      timestamp: 1_753_000_000_001,
+      senderAgentId: null,
+      receiverAgentId: null,
+      responseId: null,
+      inReplyTo: null,
+      expectReply: null,
+      messageText: null,
+      noticeReason: null,
+      originKind: null,
+      originChatId: null,
+      originRefId: null,
+      toolName: null,
+      toolInput: null,
+      durationMs: null,
+      success: null,
+      tokenCost: null,
+      approvalId: null,
+      status: null,
+      targetAction: null,
+      agentId: null,
+      previousState: null,
+      newState: null,
+      trigger: null,
+      hostId: "host-1",
+      resourceType: "cpu",
+      metricValue: 92,
+      threshold: 90,
+      breach: true,
+    });
+
+    const result = downgradeEpicCommunicationGraphEventV11ToV10(newKindEvent);
+    expect(result).toEqual({ ok: false, reason: "unrepresentable-kind" });
   });
 });
 

--- a/protocol/src/host/epic/communication-graph.ts
+++ b/protocol/src/host/epic/communication-graph.ts
@@ -46,6 +46,36 @@
  * on it; the skip is the interim behaviour that keeps an old client working
  * against a newer host, not a substitute for that minor.
  *
+ * @1.1 (minor 1) does exactly that: it adds four event kinds - `tool_call`,
+ * `approval`, `lifecycle`, `resource_event` - to the closed set, plus the
+ * nullable per-kind fields that carry them. Compat is the standard stream
+ * minor story, with the representability skip applied by NEGOTIATED VERSION
+ * rather than by schema failure:
+ *
+ *   - The `@1.0` schema tree stays FROZEN and INSTALLED (a `@1.0` peer must
+ *     keep rejecting the new kinds - that rejection is what the resolver
+ *     keys on). The `@1.1` schema is purely additive at the DATA level:
+ *     every `@1.0` row upgrades to a valid `@1.1` row by filling the new
+ *     fields with null, and the host emits each connection the frozen shape
+ *     of the minor it negotiated - a `@1.0` peer never receives a `@1.1`
+ *     frame and a `@1.1` peer always does (the required-nullable convention
+ *     pins this, exactly like `git.subscribeStatus@1.1`).
+ *   - The resolver projects each subscription to the minor it negotiated: a
+ *     `@1.0` peer receives only the three original kinds, with the `@1.1`
+ *     fields stripped (the downgrade below); a `@1.1` peer receives
+ *     everything. A new-kind row is never "downgraded" into an old kind -
+ *     it is skipped for the `@1.0` peer, exactly as the representability
+ *     policy dictates for rows the peer has no schema for.
+ *
+ * Streams have no version bridges (see `framework/versioned-stream-rpc.ts`:
+ * compat is installed-minor negotiation + resolver-side projection, the
+ * `git.subscribeStatus@1.1` precedent), so the @1.0↔@1.1 row transforms
+ * live in this module as plain typed helpers
+ * (`upgradeEpicCommunicationGraphEventV10ToV11` /
+ * `downgradeEpicCommunicationGraphEventV11ToV10`) for the resolver to call
+ * during projection. They are NOT registered with the framework - there is
+ * no bridge slot in the stream registry to register them in.
+ *
  * FRAME KIND CARRIES NO ACTIVITY SEMANTICS. An `event` frame does NOT mean
  * "something just happened": it is equally how a reconnect gap-fill and how
  * snapshot overflow (pre-existing backlog past the snapshot's bound) reach the
@@ -120,7 +150,9 @@ const textFrameFields = {
  * unknown kind has no way to render it at all. A stored row whose kind the
  * serving host cannot represent here is therefore skipped outright (see the
  * representability exception in the module doc), and adding a kind is a NEW
- * MINOR, never a silent widening.
+ * MINOR, never a silent widening. `@1.1` does that in
+ * `epicCommunicationGraphEventKindSchemaV11` below; this `@1.0` set must
+ * stay frozen so a `@1.0` peer keeps rejecting the new kinds.
  */
 export const epicCommunicationGraphEventKindSchema = z.enum([
   "a2a_message",
@@ -129,6 +161,39 @@ export const epicCommunicationGraphEventKindSchema = z.enum([
 ]);
 export type EpicCommunicationGraphEventKind = z.infer<
   typeof epicCommunicationGraphEventKindSchema
+>;
+
+/**
+ * `@1.1` kind set - the frozen `@1.0` set plus the four kinds Phase 0 adds:
+ *
+ * - `tool_call`      - an agent invoked a tool (captured at the host's tool
+ *   dispatch choke point). `senderAgentId` is the invoking agent.
+ * - `approval`       - an approval was requested or resolved (granted /
+ *   denied). `senderAgentId` is the REQUESTER.
+ * - `lifecycle`      - an agent's lifecycle state changed (created, forked,
+ *   stopped, archived, errored).
+ * - `resource_event` - a host resource-pressure reading crossed a threshold
+ *   (CPU, memory, disk, rate-limit).
+ *
+ * Closed, exactly like the `@1.0` set: `kind` still decides which fields on
+ * the row mean anything, so a client handed an unknown kind cannot render
+ * it at all. This is a NEW enum object, never a mutation of the frozen
+ * `@1.0` schema - a `@1.0` peer must keep rejecting the new kinds so the
+ * resolver can project by negotiated version (see the module doc). If the
+ * set ever grows again, it grows in yet another minor, never by widening
+ * this one.
+ */
+export const epicCommunicationGraphEventKindSchemaV11 = z.enum([
+  "a2a_message",
+  "a2a_notice",
+  "agent_created",
+  "tool_call",
+  "approval",
+  "lifecycle",
+  "resource_event",
+]);
+export type EpicCommunicationGraphEventKindV11 = z.infer<
+  typeof epicCommunicationGraphEventKindSchemaV11
 >;
 
 /**
@@ -221,6 +286,84 @@ export const epicCommunicationGraphEventSchema = z.object({
 });
 export type EpicCommunicationGraphEvent = z.infer<
   typeof epicCommunicationGraphEventSchema
+>;
+
+/**
+ * `@1.1` row shape - the frozen `@1.0` object plus the nullable per-kind
+ * fields Phase 0 adds. Same flat single-object discipline as `@1.0`: no
+ * discriminated union per row, one uniform type for the client's merged
+ * timeline, and the resolver projects a stored row to the negotiated
+ * minor's shape (see the module doc). Which of the new fields are populated
+ * follows from `kind`:
+ *
+ * - `tool_call`      - `toolName`, `toolInput` (summary/ref; the full input
+ *   lives in the chat transcript), `durationMs`, `success`, `tokenCost`.
+ * - `approval`       - `approvalId`, `status` (`pending` | `granted` |
+ *   `denied`), `targetAction`.
+ * - `lifecycle`      - `agentId` (the agent whose state transitioned),
+ *   `previousState`, `newState`, `trigger` (`user` | `auto` | `timeout` |
+ *   `error`).
+ * - `resource_event` - `hostId` (the host that reported the reading),
+ *   `resourceType` (`cpu` | `memory` | `disk` | `rate-limit`),
+ *   `metricValue`, `threshold`, `breach`.
+ *
+ * `status`, `trigger`, and `resourceType` are deliberately open `string`s,
+ * NOT closed enums - the same historical-log argument as `noticeReason`
+ * above: a value added after this minor froze must not make old rows
+ * unreadable. Consumers switch on the values they know and fall back to
+ * showing the raw string. Every new kind also uses the existing
+ * `originKind`/`originChatId`/`originRefId` fields for source traceability.
+ *
+ * Built with `.extend()` over the frozen `@1.0` object (the `agentInbox`
+ * `@1.2` precedent) so the shared fields cannot drift.
+ */
+export const epicCommunicationGraphEventSchemaV11 =
+  epicCommunicationGraphEventSchema.extend({
+    kind: epicCommunicationGraphEventKindSchemaV11,
+    /** `tool_call` ONLY: the tool the agent invoked (e.g. `read_file`). */
+    toolName: z.string().nullable(),
+    /** `tool_call` ONLY: summary or reference to the tool input. The full
+     * payload lives in the chat transcript / session log; this log carries
+     * metadata, never the payload. */
+    toolInput: z.string().nullable(),
+    /** `tool_call` ONLY: elapsed wall time of the invocation, millis. */
+    durationMs: z.number().nonnegative().nullable(),
+    /** `tool_call` ONLY: whether the invocation completed successfully. */
+    success: z.boolean().nullable(),
+    /** `tool_call` ONLY: token cost of the invocation, when the host can
+     * attribute it. */
+    tokenCost: z.number().nonnegative().nullable(),
+    /** `approval` ONLY: the broker-minted approval request id. */
+    approvalId: z.string().nullable(),
+    /** `approval` ONLY: `pending` | `granted` | `denied`. Open string (see
+     * the schema doc above for why). */
+    status: z.string().nullable(),
+    /** `approval` ONLY: the action the approval gates (e.g. `agent.create`,
+     * `agent.stop`). */
+    targetAction: z.string().nullable(),
+    /** `lifecycle` ONLY: the agent whose state transitioned. */
+    agentId: z.string().nullable(),
+    /** `lifecycle` ONLY: the state the agent left. */
+    previousState: z.string().nullable(),
+    /** `lifecycle` ONLY: the state the agent entered. */
+    newState: z.string().nullable(),
+    /** `lifecycle` ONLY: `user` | `auto` | `timeout` | `error`. Open string
+     * (see the schema doc above for why). */
+    trigger: z.string().nullable(),
+    /** `resource_event` ONLY: the host that reported the pressure reading. */
+    hostId: z.string().nullable(),
+    /** `resource_event` ONLY: `cpu` | `memory` | `disk` | `rate-limit`.
+     * Open string (see the schema doc above for why). */
+    resourceType: z.string().nullable(),
+    /** `resource_event` ONLY: the measured value of the metric. */
+    metricValue: z.number().nullable(),
+    /** `resource_event` ONLY: the threshold the reading is compared against. */
+    threshold: z.number().nullable(),
+    /** `resource_event` ONLY: true when the reading crossed the threshold. */
+    breach: z.boolean().nullable(),
+  });
+export type EpicCommunicationGraphEventV11 = z.infer<
+  typeof epicCommunicationGraphEventSchemaV11
 >;
 
 export const epicCommunicationGraphSubscribeOpenRequestSchema = z.object({
@@ -333,6 +476,142 @@ export const epicCommunicationGraphSubscribeV10 = defineStreamRpcContract({
   serverFrameSchema: epicCommunicationGraphSubscribeServerFrameSchema,
   clientFrameSchema: epicCommunicationGraphSubscribeClientFrameSchema,
 });
+
+/**
+ * `@1.1` server frames - the identical snapshot/event/pong shape with the
+ * `@1.1` row schema inside. The open request and client frames are the
+ * `@1.0` schemas VERBATIM (the `git.subscribeStatus@1.1` precedent): there
+ * is no client knob to add - the host always computes the full row and the
+ * resolver projects each frame to the connection's negotiated minor.
+ */
+export const epicCommunicationGraphSubscribeServerFrameSchemaV11 =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("snapshot"),
+      epicId: z.string(),
+      events: z.array(epicCommunicationGraphEventSchemaV11),
+      headId: z.number().int().positive().nullable(),
+      ...textFrameFields,
+    }),
+    z.object({
+      kind: z.literal("event"),
+      epicId: z.string(),
+      event: epicCommunicationGraphEventSchemaV11,
+      ...textFrameFields,
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      ...textFrameFields,
+    }),
+  ]);
+export type EpicCommunicationGraphSubscribeServerFrameV11 = z.infer<
+  typeof epicCommunicationGraphSubscribeServerFrameSchemaV11
+>;
+
+/**
+ * `epic.communicationGraph.subscribe@1.1` - additive minor that grows the
+ * closed event-kind set to include `tool_call`, `approval`, `lifecycle`,
+ * and `resource_event`, plus their nullable per-kind fields. Registered
+ * alongside the FROZEN `@1.0` contract in the stream registry: a peer that
+ * negotiated `@1.0` receives resolver-projected rows of the three original
+ * kinds only (new-kind rows are skipped per the representability policy),
+ * and a `@1.1` peer receives everything. Streams have no version bridges -
+ * see the module doc and `git-contracts.ts` - so compat is negotiation +
+ * projection, with the row transforms below as the projection primitives.
+ */
+export const epicCommunicationGraphSubscribeV11 = defineStreamRpcContract({
+  method: "epic.communicationGraph.subscribe",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: epicCommunicationGraphSubscribeOpenRequestSchema,
+  serverFrameSchema: epicCommunicationGraphSubscribeServerFrameSchemaV11,
+  clientFrameSchema: epicCommunicationGraphSubscribeClientFrameSchema,
+});
+
+/**
+ * True when `kind` is representable in the frozen `@1.0` set. The resolver
+ * uses this to decide whether a stored row may be projected down for a
+ * `@1.0` peer - a new-kind row fails the guard and is SKIPPED under the
+ * representability policy, never relabelled into an old kind.
+ */
+export function isEpicCommunicationGraphEventKindV10(
+  kind: EpicCommunicationGraphEventKindV11,
+): kind is EpicCommunicationGraphEventKind {
+  return epicCommunicationGraphEventKindSchema.safeParse(kind).success;
+}
+
+/**
+ * Result of projecting a `@1.1` row down to the `@1.0` shape.
+ * `unrepresentable-kind` means the row's `kind` has no `@1.0` meaning at
+ * all - the resolver must SKIP it for that peer, not fail the stream.
+ */
+export type EpicCommunicationGraphEventV11ToV10Result =
+  | { ok: true; value: EpicCommunicationGraphEvent }
+  | { ok: false; reason: "unrepresentable-kind" };
+
+/**
+ * `@1.0` → `@1.1` row transform: the `@1.1` schema is purely additive, so
+ * every `@1.0` row upgrades by filling the new per-kind fields with null.
+ * (Streams have no framework bridges - this is the resolver projection
+ * primitive, not a registered upgrade path; see the module doc.)
+ */
+export function upgradeEpicCommunicationGraphEventV10ToV11(
+  event: EpicCommunicationGraphEvent,
+): EpicCommunicationGraphEventV11 {
+  return {
+    ...event,
+    toolName: null,
+    toolInput: null,
+    durationMs: null,
+    success: null,
+    tokenCost: null,
+    approvalId: null,
+    status: null,
+    targetAction: null,
+    agentId: null,
+    previousState: null,
+    newState: null,
+    trigger: null,
+    hostId: null,
+    resourceType: null,
+    metricValue: null,
+    threshold: null,
+    breach: null,
+  };
+}
+
+/**
+ * `@1.1` → `@1.0` row transform: for a row whose kind the `@1.0` set can
+ * represent, strip the `@1.1`-only fields (a `@1.0` peer must never see
+ * them - its schema rejects the new kinds and ignores unknown fields, and
+ * the resolver must not rely on either). For a new-kind row, return
+ * `{ ok: false, reason: "unrepresentable-kind" }` so the resolver skips it
+ * per the representability policy.
+ */
+export function downgradeEpicCommunicationGraphEventV11ToV10(
+  event: EpicCommunicationGraphEventV11,
+): EpicCommunicationGraphEventV11ToV10Result {
+  if (!isEpicCommunicationGraphEventKindV10(event.kind)) {
+    return { ok: false, reason: "unrepresentable-kind" };
+  }
+  return {
+    ok: true,
+    value: {
+      id: event.id,
+      kind: event.kind,
+      timestamp: event.timestamp,
+      senderAgentId: event.senderAgentId,
+      receiverAgentId: event.receiverAgentId,
+      responseId: event.responseId,
+      inReplyTo: event.inReplyTo,
+      expectReply: event.expectReply,
+      messageText: event.messageText,
+      noticeReason: event.noticeReason,
+      originKind: event.originKind,
+      originChatId: event.originChatId,
+      originRefId: event.originRefId,
+    },
+  };
+}
 
 /**
  * `host.communicationGraph.subscribe@1.0` - the CLOUD-relayed

--- a/protocol/src/host/index.ts
+++ b/protocol/src/host/index.ts
@@ -23,6 +23,7 @@ export * from "./pr-contracts";
 export * from "./pr-schemas";
 export * from "./rate-limit";
 export * from "./released-floor";
+export * from "./remote";
 export * from "./restart";
 export * from "./runtime-capabilities";
 export * from "./speech";

--- a/protocol/src/host/index.ts
+++ b/protocol/src/host/index.ts
@@ -18,6 +18,7 @@ export * from "./migration";
 export * from "./mention-contracts";
 export * from "./mention-schemas";
 export * from "./notifications";
+export * from "./policy";
 export * from "./pr-contracts";
 export * from "./pr-schemas";
 export * from "./rate-limit";

--- a/protocol/src/host/policy/__tests__/policy-contracts.test.ts
+++ b/protocol/src/host/policy/__tests__/policy-contracts.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+import type { PermissionMode } from "@traycer/protocol/persistence/epic/foundation";
+import {
+  policyActionSchema,
+  policyImpactSchema,
+  policyResourceSchema,
+  policyRuleModeSchema,
+  policyRuleSchema,
+  type PolicyAction,
+  type PolicyResource,
+} from "@traycer/protocol/host/policy/types";
+import {
+  policyEnvironmentSchema,
+  policyEvaluationRequestSchema,
+  policyEvaluationResultSchema,
+  type PolicyEvaluationRequest,
+} from "@traycer/protocol/host/policy/contracts";
+import {
+  defaultPolicyRulesForPermissionMode,
+  matchingPolicyRules,
+  resolvePolicyDecision,
+} from "@traycer/protocol/host/policy/defaults";
+
+/**
+ * `protocol/src/host/policy` contract fixtures - Task 3 of Phase 0.
+ *
+ * The module is contracts-only: schemas, the in-process registry interface,
+ * and the pure default rule sets. `resolvePolicyDecision` is the pure
+ * matching semantics the host resolver will apply, which is what makes the
+ * "full_access allows everything / supervised denies high-impact actions"
+ * acceptance criteria testable without any host wiring.
+ *
+ * NOTE on conditions: the pure helpers match on `action` + `resource` only -
+ * condition strings are opaque to the protocol (the host resolver evaluates
+ * them). The defaults use `"always"` for unconditional rules and defer the
+ * few conditional ones (supervised's exempt-tool allowlist, auto_accept_edits'
+ * self-stop exemption) to the resolver; the tests below pin the pure
+ * decision, not the resolver's condition refinement.
+ */
+
+function makeRequest(
+  action: PolicyAction,
+  resource: PolicyResource,
+  permissionMode: PermissionMode,
+): PolicyEvaluationRequest {
+  return {
+    agentId: "agent-a",
+    epicId: "epic-1",
+    action,
+    resource,
+    resourceId: null,
+    environment: { permissionMode, harnessId: null, isRemote: false },
+  };
+}
+
+const MODES: readonly PermissionMode[] = [
+  "full_access",
+  "supervised",
+  "auto_accept_edits",
+];
+
+describe("policy enums", () => {
+  it("accepts every documented action and rejects unknown ones", () => {
+    for (const action of [
+      "agent.create",
+      "agent.stop",
+      "agent.fork",
+      "tool.execute",
+      "agent.sendMessage",
+      "agent.archive",
+    ]) {
+      expect(policyActionSchema.parse(action)).toBe(action);
+    }
+    expect(policyActionSchema.safeParse("agent.destroy").success).toBe(false);
+  });
+
+  it("accepts every documented resource and rejects unknown ones", () => {
+    for (const resource of [
+      "agent",
+      "tool",
+      "epic",
+      "workspace",
+      "secret",
+      "host",
+    ]) {
+      expect(policyResourceSchema.parse(resource)).toBe(resource);
+    }
+    expect(policyResourceSchema.safeParse("cluster").success).toBe(false);
+  });
+
+  it("accepts every documented impact and rejects unknown ones", () => {
+    for (const impact of ["none", "low", "medium", "high", "critical"]) {
+      expect(policyImpactSchema.parse(impact)).toBe(impact);
+    }
+    expect(policyImpactSchema.safeParse("severe").success).toBe(false);
+  });
+
+  it("accepts every documented rule mode and rejects unknown ones", () => {
+    for (const mode of ["allow", "deny", "require_approval"]) {
+      expect(policyRuleModeSchema.parse(mode)).toBe(mode);
+    }
+    expect(policyRuleModeSchema.safeParse("escalate").success).toBe(false);
+  });
+});
+
+describe("policyRuleSchema", () => {
+  it("parses a complete rule and defaults priority to 0", () => {
+    const rule = policyRuleSchema.parse({
+      ruleId: "r1",
+      action: "agent.stop",
+      resource: "agent",
+      impact: "high",
+      condition: "target agent differs from the acting agent",
+      mode: "require_approval",
+    });
+    expect(rule.ruleId).toBe("r1");
+    expect(rule.mode).toBe("require_approval");
+    expect(rule.priority).toBe(0);
+  });
+
+  it("parses an explicit priority and a non-always condition", () => {
+    const rule = policyRuleSchema.parse({
+      ruleId: "r2",
+      action: "tool.execute",
+      resource: "tool",
+      impact: "medium",
+      condition: "tool is not on the exempt allowlist",
+      mode: "deny",
+      priority: 10,
+    });
+    expect(rule.priority).toBe(10);
+    expect(rule.condition).toBe("tool is not on the exempt allowlist");
+  });
+
+  it("rejects a rule missing required fields", () => {
+    expect(
+      policyRuleSchema.safeParse({ ruleId: "r3", action: "agent.stop" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects a rule with an out-of-enum value", () => {
+    expect(
+      policyRuleSchema.safeParse({
+        ruleId: "r4",
+        action: "agent.stop",
+        resource: "agent",
+        impact: "high",
+        condition: "always",
+        mode: "allow_everything",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("policyEvaluationRequestSchema", () => {
+  it("validates for every action × resource combo", () => {
+    for (const action of policyActionSchema.options) {
+      for (const resource of policyResourceSchema.options) {
+        const parsed = policyEvaluationRequestSchema.parse(
+          makeRequest(action, resource, "full_access"),
+        );
+        expect(parsed.action).toBe(action);
+        expect(parsed.resource).toBe(resource);
+      }
+    }
+  });
+
+  it("defaults isRemote to false and accepts a concrete resourceId", () => {
+    const parsed = policyEvaluationRequestSchema.parse({
+      agentId: "agent-a",
+      epicId: "epic-1",
+      action: "tool.execute",
+      resource: "tool",
+      resourceId: "read_file",
+      environment: {
+        permissionMode: "supervised",
+        harnessId: "claude",
+      },
+    });
+    expect(parsed.environment.isRemote).toBe(false);
+    expect(parsed.environment.harnessId).toBe("claude");
+    expect(parsed.resourceId).toBe("read_file");
+  });
+
+  it("requires permissionMode, action and resource", () => {
+    expect(
+      policyEvaluationRequestSchema.safeParse({
+        agentId: "agent-a",
+        epicId: "epic-1",
+        action: "agent.stop",
+        resource: "agent",
+        resourceId: null,
+        environment: { harnessId: null },
+      }).success,
+    ).toBe(false);
+    expect(
+      policyEvaluationRequestSchema.safeParse({
+        agentId: "agent-a",
+        epicId: "epic-1",
+        resource: "agent",
+        resourceId: null,
+        environment: { permissionMode: "full_access", harnessId: null },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("validates the environment schema standalone", () => {
+    expect(
+      policyEnvironmentSchema.parse({
+        permissionMode: "auto_accept_edits",
+        harnessId: null,
+        isRemote: true,
+      }).isRemote,
+    ).toBe(true);
+  });
+});
+
+describe("policyEvaluationResultSchema", () => {
+  it("parses an allowed result", () => {
+    const result = policyEvaluationResultSchema.parse({
+      allowed: true,
+      reason: "always",
+      ruleId: "default:allow:agent.sendMessage:agent",
+      evaluatedAt: 1_753_000_000_000,
+      effectivePermissionMode: "full_access",
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.effectivePermissionMode).toBe("full_access");
+    expect(result.ruleId).toBe("default:allow:agent.sendMessage:agent");
+  });
+
+  it("parses a denied result with a null rule (default-deny no-match)", () => {
+    const result = policyEvaluationResultSchema.parse({
+      allowed: false,
+      reason: "no matching policy rule",
+      ruleId: null,
+      evaluatedAt: 1_753_000_000_001,
+      effectivePermissionMode: "supervised",
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.ruleId).toBeNull();
+  });
+
+  it("rejects an out-of-enum effectivePermissionMode", () => {
+    expect(
+      policyEvaluationResultSchema.safeParse({
+        allowed: true,
+        reason: null,
+        ruleId: null,
+        evaluatedAt: 1_753_000_000_000,
+        effectivePermissionMode: "everything",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("default policy rule sets", () => {
+  it("full_access allows every action × resource and nothing else", () => {
+    const rules = defaultPolicyRulesForPermissionMode("full_access");
+    // 6 actions × 6 resources, all allow, no overrides.
+    expect(rules).toHaveLength(6 * 6);
+    expect(rules.every((rule) => rule.mode === "allow")).toBe(true);
+
+    for (const action of policyActionSchema.options) {
+      for (const resource of policyResourceSchema.options) {
+        expect(
+          resolvePolicyDecision(
+            makeRequest(action, resource, "full_access"),
+            rules,
+          )?.mode,
+        ).toBe("allow");
+      }
+    }
+  });
+
+  it("supervised denies the high-impact actions and tool.execute", () => {
+    const rules = defaultPolicyRulesForPermissionMode("supervised");
+
+    // agent.stop / agent.fork / agent.archive are high-impact (archive is
+    // covered by the "denies high-impact actions" criterion even though the
+    // brief's explicit list names stop/fork); tool.execute is medium but has
+    // a wider blast radius and is denied with an exempt-allowlist condition.
+    for (const [action, resource] of [
+      ["agent.stop", "agent"],
+      ["agent.fork", "agent"],
+      ["agent.archive", "agent"],
+      ["tool.execute", "tool"],
+    ] as const) {
+      expect(
+        resolvePolicyDecision(
+          makeRequest(action, resource, "supervised"),
+          rules,
+        )?.mode,
+      ).toBe("deny");
+    }
+
+    // Non-destructive actions remain allowed.
+    for (const [action, resource] of [
+      ["agent.create", "agent"],
+      ["agent.sendMessage", "agent"],
+    ] as const) {
+      expect(
+        resolvePolicyDecision(
+          makeRequest(action, resource, "supervised"),
+          rules,
+        )?.mode,
+      ).toBe("allow");
+    }
+  });
+
+  it("auto_accept_edits requires approval for agent.stop on an agent and allows the rest", () => {
+    const rules = defaultPolicyRulesForPermissionMode("auto_accept_edits");
+    expect(
+      resolvePolicyDecision(
+        makeRequest("agent.stop", "agent", "auto_accept_edits"),
+        rules,
+      )?.mode,
+    ).toBe("require_approval");
+    expect(
+      resolvePolicyDecision(
+        makeRequest("agent.create", "agent", "auto_accept_edits"),
+        rules,
+      )?.mode,
+    ).toBe("allow");
+    expect(
+      resolvePolicyDecision(
+        makeRequest("tool.execute", "tool", "auto_accept_edits"),
+        rules,
+      )?.mode,
+    ).toBe("allow");
+  });
+
+  it("every default rule validates against policyRuleSchema", () => {
+    for (const mode of MODES) {
+      const rules = defaultPolicyRulesForPermissionMode(mode);
+      expect(rules.length).toBeGreaterThan(0);
+      for (const rule of rules) {
+        expect(policyRuleSchema.safeParse(rule).success).toBe(true);
+      }
+    }
+  });
+
+  it("returns a fresh array per call (callers may mutate their copy)", () => {
+    const first = defaultPolicyRulesForPermissionMode("full_access");
+    const second = defaultPolicyRulesForPermissionMode("full_access");
+    expect(first).not.toBe(second);
+  });
+
+  it("matchingPolicyRules returns only action + resource matches, in order", () => {
+    const rules = defaultPolicyRulesForPermissionMode("supervised");
+    const matches = matchingPolicyRules(
+      makeRequest("agent.stop", "agent", "supervised"),
+      rules,
+    );
+    expect(matches.length).toBeGreaterThan(0);
+    expect(
+      matches.every(
+        (rule) => rule.action === "agent.stop" && rule.resource === "agent",
+      ),
+    ).toBe(true);
+  });
+});

--- a/protocol/src/host/policy/__tests__/policy-registry-e2e.test.ts
+++ b/protocol/src/host/policy/__tests__/policy-registry-e2e.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it } from "vitest";
+import type { PermissionMode } from "@traycer/protocol/persistence/epic/foundation";
+import {
+  epicCommunicationGraphEventSchemaV11,
+  type EpicCommunicationGraphEventV11,
+} from "@traycer/protocol/host/epic/communication-graph";
+import {
+  policyEvaluationRequestSchema,
+  policyEvaluationResultSchema,
+  type PolicyEvaluationRequest,
+} from "@traycer/protocol/host/policy/contracts";
+import {
+  defaultPolicyRulesForPermissionMode,
+  resolvePolicyDecision,
+} from "@traycer/protocol/host/policy/defaults";
+import {
+  ReferencePolicyRegistry,
+  buildPolicyAuditEvent,
+} from "@traycer/protocol/host/policy/registry";
+import {
+  policyActionSchema,
+  policyResourceSchema,
+  type PolicyAction,
+  type PolicyResource,
+  type PolicyRule,
+} from "@traycer/protocol/host/policy/types";
+
+/**
+ * Policy lifecycle end-to-end (Task 8, Phase 0) - protocol-layer integration
+ * test over the REAL reference implementation. No host process, no SQLite,
+ * no mocks: `types.ts` schemas → `contracts.ts` request/result → `defaults.ts`
+ * rule sets + pure decision helpers → `registry.ts`
+ * `ReferencePolicyRegistry` + `buildPolicyAuditEvent` + `auditSink`.
+ *
+ * This is the protocol-side proof that a closed host can vendor the
+ * reference registry and get correct per-mode gating and comm-graph
+ * `approval` @1.1 audit rows without inventing any policy semantics of its
+ * own - exactly the composition the Task 9 two-host acceptance will run.
+ */
+
+const MODES: readonly PermissionMode[] = [
+  "full_access",
+  "supervised",
+  "auto_accept_edits",
+];
+
+function makeRequest(
+  action: PolicyAction,
+  resource: PolicyResource,
+  permissionMode: PermissionMode,
+): PolicyEvaluationRequest {
+  return {
+    agentId: "agent-a",
+    epicId: "epic-1",
+    action,
+    resource,
+    resourceId: null,
+    environment: { permissionMode, harnessId: null, isRemote: false },
+  };
+}
+
+describe("1. full_access: every action × resource is allowed", () => {
+  it("allows all 36 combinations with the allow rule as the verdict", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+
+    let evaluated = 0;
+    for (const action of policyActionSchema.options) {
+      for (const resource of policyResourceSchema.options) {
+        const request = makeRequest(action, resource, "full_access");
+        // The request and the result are both valid contract rows.
+        expect(policyEvaluationRequestSchema.parse(request).action).toBe(
+          action,
+        );
+
+        const result = registry.evaluate(request);
+        expect(policyEvaluationResultSchema.parse(result).allowed).toBe(true);
+        expect(result.allowed).toBe(true);
+        expect(result.effectivePermissionMode).toBe("full_access");
+        expect(result.ruleId).toBe(`default:allow:${action}:${resource}`);
+        expect(result.reason).toBe("always");
+        evaluated += 1;
+      }
+    }
+    expect(evaluated).toBe(6 * 6);
+  });
+});
+
+describe("2. supervised: high-impact actions are denied, reasons carry the condition text", () => {
+  const DENIED: ReadonlyArray<readonly [PolicyAction, PolicyResource]> = [
+    ["agent.stop", "agent"],
+    ["agent.fork", "agent"],
+    ["agent.archive", "agent"],
+    ["tool.execute", "tool"],
+  ];
+
+  it("denies stop/fork/archive/tool.execute and cites the governing deny rule", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+
+    for (const [action, resource] of DENIED) {
+      const result = registry.evaluate(
+        makeRequest(action, resource, "supervised"),
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.effectivePermissionMode).toBe("supervised");
+      expect(result.ruleId).toBe(`default:supervised:deny:${action}`);
+
+      // The reason IS the winning deny rule's condition text.
+      const denyRule = defaultPolicyRulesForPermissionMode("supervised").find(
+        (candidate) =>
+          candidate.action === action &&
+          candidate.resource === resource &&
+          candidate.mode === "deny",
+      );
+      expect(result.reason).toBe(denyRule?.condition ?? null);
+    }
+  });
+
+  it("tool.execute's denial reason names the exempt-allowlist condition", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+    const tool = registry.evaluate(
+      makeRequest("tool.execute", "tool", "supervised"),
+    );
+    expect(tool.reason).toBe("tool is not on the exempt allowlist");
+  });
+
+  it("allows the non-destructive actions sendMessage and create", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+    for (const [action, resource] of [
+      ["agent.sendMessage", "agent"],
+      ["agent.create", "agent"],
+    ] as const) {
+      const result = registry.evaluate(
+        makeRequest(action, resource, "supervised"),
+      );
+      expect(result.allowed).toBe(true);
+      expect(result.ruleId).toBe(`default:allow:${action}:${resource}`);
+    }
+  });
+});
+
+describe("3. auto_accept_edits: agent.stop requires approval on ANY resource", () => {
+  it("gates agent.stop on every resource class and allows every other action", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "auto_accept_edits",
+    });
+
+    for (const action of policyActionSchema.options) {
+      for (const resource of policyResourceSchema.options) {
+        const result = registry.evaluate(
+          makeRequest(action, resource, "auto_accept_edits"),
+        );
+        if (action === "agent.stop") {
+          // The stop gate is resource-class-independent.
+          expect(result.allowed).toBe(false);
+          expect(result.reason).toContain("requires approval");
+          expect(result.ruleId).toContain(
+            "default:auto_accept_edits:require_approval:agent.stop",
+          );
+        } else {
+          expect(result.allowed).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("the agent-resource stop keeps its stable ruleId and full reason", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "auto_accept_edits",
+    });
+    const result = registry.evaluate(
+      makeRequest("agent.stop", "agent", "auto_accept_edits"),
+    );
+    expect(result.ruleId).toBe(
+      "default:auto_accept_edits:require_approval:agent.stop",
+    );
+    expect(result.reason).toBe(
+      "requires approval: target agent differs from the acting agent",
+    );
+  });
+});
+
+describe("4. plugin rule override beats the default deny by priority", () => {
+  const PLUGIN_ALLOW_STOP: PolicyRule = {
+    ruleId: "plugin:allow:agent.stop",
+    action: "agent.stop",
+    resource: "agent",
+    impact: "high",
+    condition: "operator granted a one-off stop exemption",
+    mode: "allow",
+    priority: 20,
+  };
+
+  it("a priority-20 allow rule overrides the supervised priority-10 deny", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+    // Baseline: the default deny governs.
+    expect(
+      registry.evaluate(makeRequest("agent.stop", "agent", "supervised"))
+        .allowed,
+    ).toBe(false);
+
+    registry.register(PLUGIN_ALLOW_STOP);
+
+    // The plugin rule's higher priority flips the verdict.
+    const result = registry.evaluate(
+      makeRequest("agent.stop", "agent", "supervised"),
+    );
+    expect(result.allowed).toBe(true);
+    expect(result.ruleId).toBe(PLUGIN_ALLOW_STOP.ruleId);
+    expect(result.reason).toBe(PLUGIN_ALLOW_STOP.condition);
+  });
+
+  it("unregistering the plugin restores the default deny", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+    registry.register(PLUGIN_ALLOW_STOP);
+    registry.unregister(PLUGIN_ALLOW_STOP.ruleId);
+    expect(
+      registry.evaluate(makeRequest("agent.stop", "agent", "supervised"))
+        .allowed,
+    ).toBe(false);
+  });
+});
+
+describe("5. buildPolicyAuditEvent constructs comm-graph @1.1 approval events", () => {
+  it("maps a denied decision to a valid approval/denied event with requester identity", () => {
+    const request = makeRequest("agent.stop", "agent", "supervised");
+    const decision = resolvePolicyDecision(
+      request,
+      defaultPolicyRulesForPermissionMode("supervised"),
+    );
+    const result = {
+      allowed: false,
+      reason: decision?.rule.condition ?? null,
+      ruleId: decision?.rule.ruleId ?? null,
+      evaluatedAt: 1_753_000_000_000,
+      effectivePermissionMode: "supervised" as const,
+    };
+    const event = buildPolicyAuditEvent({ id: 1, request, result, decision });
+
+    // The approval @1.1 shape: kind, requester identity, approvalId, status,
+    // and the gated action.
+    expect(event.kind).toBe("approval");
+    expect(event.senderAgentId).toBe(request.agentId);
+    expect(event.approvalId).toBeTruthy();
+    expect(event.approvalId).toContain("policy:");
+    expect(event.status).toBe("denied");
+    expect(event.targetAction).toBe("agent.stop");
+
+    // Validates as a comm-graph @1.1 row and keeps the decision's timestamp.
+    expect(epicCommunicationGraphEventSchemaV11.parse(event).kind).toBe(
+      "approval",
+    );
+    expect(event.timestamp).toBe(result.evaluatedAt);
+
+    // Fields owned by other @1.1 kinds stay null.
+    expect(event.toolName).toBeNull();
+    expect(event.agentId).toBeNull();
+    expect(event.hostId).toBeNull();
+    expect(event.resourceType).toBeNull();
+  });
+
+  it("maps every decision status: granted / pending / denied", () => {
+    const cases: ReadonlyArray<{
+      request: PolicyEvaluationRequest;
+      expected: "granted" | "pending" | "denied";
+    }> = [
+      {
+        request: makeRequest("agent.create", "agent", "full_access"),
+        expected: "granted",
+      },
+      {
+        request: makeRequest("agent.stop", "agent", "auto_accept_edits"),
+        expected: "pending",
+      },
+      {
+        request: makeRequest("agent.stop", "agent", "supervised"),
+        expected: "denied",
+      },
+    ];
+
+    cases.forEach(({ request, expected }, index) => {
+      const decision = resolvePolicyDecision(
+        request,
+        defaultPolicyRulesForPermissionMode(request.environment.permissionMode),
+      );
+      const result = {
+        allowed: decision !== null && decision.mode === "allow",
+        reason: decision?.rule.condition ?? null,
+        ruleId: decision?.rule.ruleId ?? null,
+        evaluatedAt: 1_753_000_000_000 + index,
+        effectivePermissionMode: request.environment.permissionMode,
+      };
+      const event = buildPolicyAuditEvent({
+        id: index + 1,
+        request,
+        result,
+        decision,
+      });
+
+      expect(event.status).toBe(expected);
+      expect(event.targetAction).toBe(request.action);
+      expect(event.senderAgentId).toBe(request.agentId);
+      expect(event.approvalId).toContain("policy:");
+      expect(
+        epicCommunicationGraphEventSchemaV11.safeParse(event).success,
+      ).toBe(true);
+    });
+  });
+});
+
+describe("6. audit sink integration: one valid approval event per evaluation", () => {
+  it("emits exactly one event per evaluation, in order, matching each decision", () => {
+    const events: EpicCommunicationGraphEventV11[] = [];
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+      auditSink: (event) => events.push(event),
+    });
+
+    const stop = registry.evaluate(
+      makeRequest("agent.stop", "agent", "supervised"),
+    );
+    const create = registry.evaluate(
+      makeRequest("agent.create", "agent", "supervised"),
+    );
+    const tool = registry.evaluate(
+      makeRequest("tool.execute", "tool", "supervised"),
+    );
+
+    expect(events).toHaveLength(3);
+
+    // Every emitted event is a valid comm-graph @1.1 approval row.
+    for (const event of events) {
+      expect(
+        epicCommunicationGraphEventSchemaV11.safeParse(event).success,
+      ).toBe(true);
+      expect(event.kind).toBe("approval");
+      expect(event.senderAgentId).toBe("agent-a");
+      expect(event.approvalId).toBeTruthy();
+      expect(event.status).not.toBeNull();
+    }
+
+    // One event per evaluation, in evaluation order, with the right status,
+    // action, and the registry's provisional id (= evaluatedAt).
+    const [stopEvent, createEvent, toolEvent] = events;
+    expect(stopEvent.status).toBe("denied");
+    expect(stopEvent.targetAction).toBe("agent.stop");
+    expect(stopEvent.timestamp).toBe(stop.evaluatedAt);
+    expect(stopEvent.approvalId).toBe(`policy:agent-a:${stop.evaluatedAt}`);
+
+    expect(createEvent.status).toBe("granted");
+    expect(createEvent.targetAction).toBe("agent.create");
+    expect(createEvent.timestamp).toBe(create.evaluatedAt);
+
+    expect(toolEvent.status).toBe("denied");
+    expect(toolEvent.targetAction).toBe("tool.execute");
+    expect(toolEvent.timestamp).toBe(tool.evaluatedAt);
+  });
+});
+
+// Sanity anchor: every default rule set still validates and resolves.
+describe("contract composition across types, contracts, defaults and registry", () => {
+  it("every default rule set is schema-valid and decides via the pure helper", () => {
+    for (const mode of MODES) {
+      const rules = defaultPolicyRulesForPermissionMode(mode);
+      const registry = new ReferencePolicyRegistry({
+        defaultPermissionMode: mode,
+      });
+      expect(registry.list().length).toBe(rules.length);
+
+      for (const rule of rules) {
+        expect(rule).toEqual(
+          expect.objectContaining({
+            action: expect.stringMatching(/^agent\.|^tool\./),
+            resource: expect.stringMatching(/^[a-z]+$/),
+          }),
+        );
+      }
+
+      // The registry's verdict for a sample request agrees with the pure
+      // decision helper over the same rule set - contract composition holds.
+      const request = makeRequest("agent.stop", "agent", mode);
+      const pure = resolvePolicyDecision(request, rules);
+      const viaRegistry = registry.evaluate(request);
+      const expectedAllowed = pure !== null ? pure.mode === "allow" : false;
+      expect(viaRegistry.allowed).toBe(expectedAllowed);
+      expect(viaRegistry.ruleId).toBe(pure?.rule.ruleId ?? null);
+    }
+  });
+});

--- a/protocol/src/host/policy/__tests__/registry.test.ts
+++ b/protocol/src/host/policy/__tests__/registry.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "vitest";
+import type { PermissionMode } from "@traycer/protocol/persistence/epic/foundation";
+import {
+  epicCommunicationGraphEventSchemaV11,
+  type EpicCommunicationGraphEventV11,
+} from "@traycer/protocol/host/epic/communication-graph";
+import type {
+  PolicyEvaluationRequest,
+  PolicyRegistry,
+} from "@traycer/protocol/host/policy/contracts";
+import {
+  defaultPolicyRulesForPermissionMode,
+  resolvePolicyDecision,
+} from "@traycer/protocol/host/policy/defaults";
+import {
+  ReferencePolicyRegistry,
+  buildPolicyAuditEvent,
+} from "@traycer/protocol/host/policy/registry";
+import {
+  policyActionSchema,
+  policyResourceSchema,
+  type PolicyAction,
+  type PolicyResource,
+  type PolicyRule,
+} from "@traycer/protocol/host/policy/types";
+
+/**
+ * Reference `PolicyRegistry` implementation fixtures - the protocol-side
+ * registry a closed host vendors or replaces (Task 6, Phase 0, reframed as
+ * "reference-6").
+ *
+ * The reference model: `evaluate()` treats the request's
+ * `environment.permissionMode` as the AUTHORITATIVE baseline (one registry
+ * follows an agent whose mode changes), layers plugin rules over that mode's
+ * defaults, and maps the winning rule's mode to the result
+ * (allow → allowed, deny / require_approval → not allowed). `list()` shows
+ * the seed mode's defaults + plugin rules.
+ */
+
+const MODES: readonly PermissionMode[] = [
+  "full_access",
+  "supervised",
+  "auto_accept_edits",
+];
+
+function makeRequest(
+  action: PolicyAction,
+  resource: PolicyResource,
+  permissionMode: PermissionMode,
+): PolicyEvaluationRequest {
+  return {
+    agentId: "agent-a",
+    epicId: "epic-1",
+    action,
+    resource,
+    resourceId: null,
+    environment: { permissionMode, harnessId: null, isRemote: false },
+  };
+}
+
+describe("ReferencePolicyRegistry implements the interface", () => {
+  it("is assignable to PolicyRegistry and seeds defaults from its mode", () => {
+    const registry: PolicyRegistry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+    expect(registry).toBeInstanceOf(ReferencePolicyRegistry);
+    // 6 actions × 6 resources, all allow.
+    expect(registry.list()).toHaveLength(36);
+    expect(registry.list().every((rule) => rule.mode === "allow")).toBe(true);
+  });
+
+  it("loads the supervised deny overrides from defaults.ts", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+    const denyIds = registry
+      .list()
+      .filter((rule) => rule.mode === "deny")
+      .map((rule) => rule.ruleId);
+    expect(denyIds).toEqual(
+      expect.arrayContaining([
+        "default:supervised:deny:agent.stop",
+        "default:supervised:deny:agent.fork",
+        "default:supervised:deny:agent.archive",
+        "default:supervised:deny:tool.execute",
+      ]),
+    );
+  });
+
+  it("list() returns a fresh array (callers may not corrupt the registry)", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+    const first = registry.list();
+    first.length = 0;
+    expect(registry.list()).toHaveLength(36);
+  });
+});
+
+describe("ReferencePolicyRegistry.evaluate", () => {
+  it("allows every action × resource under full_access", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+    for (const action of policyActionSchema.options) {
+      for (const resource of policyResourceSchema.options) {
+        const result = registry.evaluate(
+          makeRequest(action, resource, "full_access"),
+        );
+        expect(result.allowed).toBe(true);
+        expect(result.effectivePermissionMode).toBe("full_access");
+        expect(result.ruleId).toBe(`default:allow:${action}:${resource}`);
+      }
+    }
+  });
+
+  it("denies the high-impact actions and tool.execute under supervised", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+
+    const denied = registry.evaluate(
+      makeRequest("agent.stop", "agent", "supervised"),
+    );
+    expect(denied.allowed).toBe(false);
+    expect(denied.ruleId).toBe("default:supervised:deny:agent.stop");
+    expect(denied.effectivePermissionMode).toBe("supervised");
+
+    for (const [action, resource] of [
+      ["agent.fork", "agent"],
+      ["agent.archive", "agent"],
+      ["tool.execute", "tool"],
+    ] as const) {
+      expect(
+        registry.evaluate(makeRequest(action, resource, "supervised")).allowed,
+      ).toBe(false);
+    }
+
+    // Non-destructive actions remain allowed.
+    expect(
+      registry.evaluate(makeRequest("agent.create", "agent", "supervised"))
+        .allowed,
+    ).toBe(true);
+    expect(
+      registry.evaluate(makeRequest("agent.sendMessage", "agent", "supervised"))
+        .allowed,
+    ).toBe(true);
+  });
+
+  it("requires approval for agent.stop on an agent under auto_accept_edits", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "auto_accept_edits",
+    });
+    const result = registry.evaluate(
+      makeRequest("agent.stop", "agent", "auto_accept_edits"),
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.ruleId).toBe(
+      "default:auto_accept_edits:require_approval:agent.stop",
+    );
+    expect(result.reason).toContain("requires approval");
+
+    expect(
+      registry.evaluate(
+        makeRequest("agent.create", "agent", "auto_accept_edits"),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("follows the request's permissionMode baseline (mode changes need no rebuild)", () => {
+    // Seeded supervised, but the request carries full_access: the registry
+    // evaluates against full_access defaults and echoes that baseline.
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+    });
+    const escalated = registry.evaluate(
+      makeRequest("agent.stop", "agent", "full_access"),
+    );
+    expect(escalated.allowed).toBe(true);
+    expect(escalated.effectivePermissionMode).toBe("full_access");
+  });
+});
+
+describe("ReferencePolicyRegistry plugin rules", () => {
+  const SECRET_SEND_DENY: PolicyRule = {
+    ruleId: "plugin:deny:secret.sendMessage",
+    action: "agent.sendMessage",
+    resource: "secret",
+    impact: "high",
+    condition: "always",
+    mode: "deny",
+    priority: 10,
+  };
+
+  it("register() overrides the allow-all baseline; unregister() restores it", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+    expect(
+      registry.evaluate(
+        makeRequest("agent.sendMessage", "secret", "full_access"),
+      ).allowed,
+    ).toBe(true);
+
+    registry.register(SECRET_SEND_DENY);
+    const denied = registry.evaluate(
+      makeRequest("agent.sendMessage", "secret", "full_access"),
+    );
+    expect(denied.allowed).toBe(false);
+    expect(denied.ruleId).toBe(SECRET_SEND_DENY.ruleId);
+
+    registry.unregister(SECRET_SEND_DENY.ruleId);
+    expect(
+      registry.evaluate(
+        makeRequest("agent.sendMessage", "secret", "full_access"),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("register() upserts by ruleId and unregister() removes the single entry", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+    registry.register(SECRET_SEND_DENY);
+    // Re-register with a different condition: replaces, not appends.
+    registry.register({ ...SECRET_SEND_DENY, condition: "v2" });
+    expect(
+      registry.list().filter((rule) => rule.ruleId === SECRET_SEND_DENY.ruleId),
+    ).toHaveLength(1);
+
+    registry.unregister(SECRET_SEND_DENY.ruleId);
+    expect(
+      registry.list().filter((rule) => rule.ruleId === SECRET_SEND_DENY.ruleId),
+    ).toHaveLength(0);
+    expect(
+      registry.evaluate(
+        makeRequest("agent.sendMessage", "secret", "full_access"),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("unregister() of an unknown id is a no-op", () => {
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "full_access",
+    });
+    expect(() => registry.unregister("does-not-exist")).not.toThrow();
+    expect(registry.list()).toHaveLength(36);
+  });
+});
+
+describe("policy audit events", () => {
+  it("builds a valid approval event for a denied decision", () => {
+    const request = makeRequest("agent.stop", "agent", "supervised");
+    const decision = resolvePolicyDecision(
+      request,
+      defaultPolicyRulesForPermissionMode("supervised"),
+    );
+    const result = {
+      allowed: false,
+      reason: decision?.rule.condition ?? null,
+      ruleId: decision?.rule.ruleId ?? null,
+      evaluatedAt: 1_753_000_000_000,
+      effectivePermissionMode: "supervised" as const,
+    };
+    const event = buildPolicyAuditEvent({ id: 1, request, result, decision });
+
+    // The event shape must be a valid comm-graph @1.1 row.
+    expect(epicCommunicationGraphEventSchemaV11.parse(event).kind).toBe(
+      "approval",
+    );
+    expect(event.status).toBe("denied");
+    expect(event.senderAgentId).toBe("agent-a");
+    expect(event.targetAction).toBe("agent.stop");
+    expect(event.approvalId).toContain("policy:");
+    // Fields owned by other @1.1 kinds stay null.
+    expect(event.toolName).toBeNull();
+    expect(event.hostId).toBeNull();
+    expect(event.agentId).toBeNull();
+  });
+
+  it("maps require_approval to pending and allow to granted", () => {
+    const request = makeRequest("agent.stop", "agent", "auto_accept_edits");
+    const decision = resolvePolicyDecision(
+      request,
+      defaultPolicyRulesForPermissionMode("auto_accept_edits"),
+    );
+    const base = {
+      id: 2,
+      request,
+      decision,
+      result: {
+        allowed: false,
+        reason: `requires approval: ${decision?.rule.condition ?? ""}`,
+        ruleId: decision?.rule.ruleId ?? null,
+        evaluatedAt: 1_753_000_000_001,
+        effectivePermissionMode: "auto_accept_edits" as const,
+      },
+    };
+    expect(buildPolicyAuditEvent(base).status).toBe("pending");
+
+    const allowedRequest = makeRequest(
+      "agent.create",
+      "agent",
+      "auto_accept_edits",
+    );
+    const allowedDecision = resolvePolicyDecision(
+      allowedRequest,
+      defaultPolicyRulesForPermissionMode("auto_accept_edits"),
+    );
+    expect(
+      buildPolicyAuditEvent({
+        id: 3,
+        request: allowedRequest,
+        decision: allowedDecision,
+        result: {
+          allowed: true,
+          reason: allowedDecision?.rule.condition ?? null,
+          ruleId: allowedDecision?.rule.ruleId ?? null,
+          evaluatedAt: 1_753_000_000_002,
+          effectivePermissionMode: "auto_accept_edits" as const,
+        },
+      }).status,
+    ).toBe("granted");
+  });
+
+  it("a registry with an auditSink emits one valid event per evaluation", () => {
+    const events: EpicCommunicationGraphEventV11[] = [];
+    const registry = new ReferencePolicyRegistry({
+      defaultPermissionMode: "supervised",
+      auditSink: (event) => events.push(event),
+    });
+
+    registry.evaluate(makeRequest("agent.stop", "agent", "supervised"));
+    registry.evaluate(makeRequest("agent.create", "agent", "supervised"));
+
+    expect(events).toHaveLength(2);
+    for (const event of events) {
+      expect(
+        epicCommunicationGraphEventSchemaV11.safeParse(event).success,
+      ).toBe(true);
+    }
+    expect(events[0].status).toBe("denied");
+    expect(events[1].status).toBe("granted");
+  });
+});

--- a/protocol/src/host/policy/contracts.ts
+++ b/protocol/src/host/policy/contracts.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { permissionModeSchema } from "@traycer/protocol/persistence/epic/foundation";
+import {
+  policyActionSchema,
+  policyResourceSchema,
+  type PolicyRule,
+} from "./types";
+
+/**
+ * Runtime context the evaluator keys on, beyond the action/resource pair.
+ *
+ * `permissionMode` is the chat/agent's effective baseline
+ * (`supervised` / `auto_accept_edits` / `full_access`); the default rule
+ * sets in `defaults.ts` are selected FROM it, and the evaluation result
+ * echoes it as `effectivePermissionMode` so the caller can see which
+ * baseline produced the decision.
+ */
+export const policyEnvironmentSchema = z.object({
+  permissionMode: permissionModeSchema,
+  harnessId: z.string().nullable(),
+  /** True when the acting agent runs on a remote host (cross-host action). */
+  isRemote: z.boolean().default(false),
+});
+export type PolicyEnvironment = z.infer<typeof policyEnvironmentSchema>;
+
+/** What gets evaluated. */
+export const policyEvaluationRequestSchema = z.object({
+  /** The agent attempting the action. */
+  agentId: z.string(),
+  /** Epic the action happens in - scopes every rule's provenance check. */
+  epicId: z.string(),
+  action: policyActionSchema,
+  resource: policyResourceSchema,
+  /** Concrete target id (e.g. the tool name, the target agent id). Null when
+   * the request is about the class, not one instance. */
+  resourceId: z.string().nullable(),
+  environment: policyEnvironmentSchema,
+});
+export type PolicyEvaluationRequest = z.infer<
+  typeof policyEvaluationRequestSchema
+>;
+
+/** The result of one evaluation. */
+export const policyEvaluationResultSchema = z.object({
+  allowed: z.boolean(),
+  /** Human-readable justification (rule condition, or why nothing matched). */
+  reason: z.string().nullable(),
+  /** The rule that decided, or null when no rule matched (default deny). */
+  ruleId: z.string().nullable(),
+  /** Host wall clock at evaluation, epoch millis. */
+  evaluatedAt: z.number().int(),
+  /** Which permission mode was the effective baseline. */
+  effectivePermissionMode: permissionModeSchema,
+});
+export type PolicyEvaluationResult = z.infer<
+  typeof policyEvaluationResultSchema
+>;
+
+/**
+ * Registry contract - typed but NOT RPC (in-process). The host wires a
+ * concrete implementation in a later task; this interface is the seam the
+ * action-dispatch hook (Task 8) will evaluate through.
+ */
+export interface PolicyRegistry {
+  register(rule: PolicyRule): void;
+  unregister(ruleId: string): void;
+  evaluate(request: PolicyEvaluationRequest): PolicyEvaluationResult;
+  list(): PolicyRule[];
+}

--- a/protocol/src/host/policy/defaults.ts
+++ b/protocol/src/host/policy/defaults.ts
@@ -26,9 +26,12 @@ import type { PolicyEvaluationRequest } from "./contracts";
  *   actions (`agent.stop`, `agent.fork`, `agent.archive`) and
  *   `tool.execute` (medium impact, wider blast radius; the condition defers
  *   an exempt-tool allowlist to the resolver).
- * - `auto_accept_edits` - baseline + a REQUIRE_APPROVAL override for
- *   `agent.stop` on an agent when the target is not the acting agent (the
- *   self-stop exemption is a resolver-side condition refinement).
+ * - `auto_accept_edits` - baseline + REQUIRE_APPROVAL overrides for
+ *   `agent.stop` across EVERY resource class when the target is not the
+ *   acting agent (the self-stop exemption is a resolver-side condition
+ *   refinement). `agent.stop` is high-impact regardless of the resource
+ *   class the request names, so an exotic `agent.stop` request must not
+ *   slip past the approval gate merely by targeting a non-agent resource.
  *
  * `condition` strings are opaque to the protocol (see `types.ts`): the pure
  * helpers match on `action` + `resource` only, so an override whose condition
@@ -120,18 +123,31 @@ const SUPERVISED_DENY_RULES: readonly PolicyRule[] = [
 /**
  * `auto_accept_edits` override: stopping ANOTHER agent is a high-impact,
  * possibly irreversible action, so it requires approval even though most
- * actions are auto-accepted. The condition defers the self-stop exemption
- * (target IS the acting agent) to the resolver.
+ * actions are auto-accepted. The override covers EVERY resource class:
+ * `agent.stop` stays high-impact no matter what the request names as its
+ * target class, so gating only the `agent` resource would let an exotic
+ * `agent.stop` request through the baseline allow-all. The condition defers
+ * the self-stop exemption (target IS the acting agent) to the resolver.
+ *
+ * The `agent` resource keeps the original bare ruleId
+ * (`default:auto_accept_edits:require_approval:agent.stop`); the other
+ * resource classes append `:<resource>` so existing ruleId references stay
+ * stable.
  */
-const AUTO_ACCEPT_EDITS_STOP_RULE: PolicyRule = {
-  ruleId: "default:auto_accept_edits:require_approval:agent.stop",
-  action: "agent.stop",
-  resource: "agent",
-  impact: "high",
-  condition: "target agent differs from the acting agent",
-  mode: "require_approval",
-  priority: OVERRIDE_PRIORITY,
-};
+const AUTO_ACCEPT_EDITS_STOP_RULES: readonly PolicyRule[] = ALL_RESOURCES.map(
+  (resource) => ({
+    ruleId:
+      resource === "agent"
+        ? "default:auto_accept_edits:require_approval:agent.stop"
+        : `default:auto_accept_edits:require_approval:agent.stop:${resource}`,
+    action: "agent.stop",
+    resource,
+    impact: "high",
+    condition: "target agent differs from the acting agent",
+    mode: "require_approval",
+    priority: OVERRIDE_PRIORITY,
+  }),
+);
 
 /** Canonical default rule set per permission mode. */
 export const DEFAULT_POLICY_RULES_BY_MODE: Record<
@@ -140,7 +156,7 @@ export const DEFAULT_POLICY_RULES_BY_MODE: Record<
 > = {
   full_access: allowAllRules(),
   supervised: [...allowAllRules(), ...SUPERVISED_DENY_RULES],
-  auto_accept_edits: [...allowAllRules(), AUTO_ACCEPT_EDITS_STOP_RULE],
+  auto_accept_edits: [...allowAllRules(), ...AUTO_ACCEPT_EDITS_STOP_RULES],
 };
 
 /** The default rule set for one permission mode (a fresh array each call). */

--- a/protocol/src/host/policy/defaults.ts
+++ b/protocol/src/host/policy/defaults.ts
@@ -1,0 +1,191 @@
+import type { PermissionMode } from "@traycer/protocol/persistence/epic/foundation";
+import {
+  policyActionSchema,
+  policyResourceSchema,
+  type PolicyAction,
+  type PolicyImpact,
+  type PolicyResource,
+  type PolicyRule,
+  type PolicyRuleMode,
+} from "./types";
+import type { PolicyEvaluationRequest } from "./contracts";
+
+/**
+ * Default rule sets that map the existing `permissionMode` strings to
+ * concrete `PolicyRule` lists - the "default implementations" the host
+ * registry seeds from. Pure data plus two pure decision helpers; there is no
+ * resolver here (that is a later task), but `resolvePolicyDecision` is the
+ * exact matching semantics the resolver will apply, so the defaults are
+ * testable end-to-end without host wiring.
+ *
+ * Layering: every mode starts from an allow-all baseline at `priority: 0`,
+ * then a mode-specific override at `OVERRIDE_PRIORITY` narrows it:
+ *
+ * - `full_access`       - baseline only: everything allowed.
+ * - `supervised`        - baseline + DENY overrides for the high-impact
+ *   actions (`agent.stop`, `agent.fork`, `agent.archive`) and
+ *   `tool.execute` (medium impact, wider blast radius; the condition defers
+ *   an exempt-tool allowlist to the resolver).
+ * - `auto_accept_edits` - baseline + a REQUIRE_APPROVAL override for
+ *   `agent.stop` on an agent when the target is not the acting agent (the
+ *   self-stop exemption is a resolver-side condition refinement).
+ *
+ * `condition` strings are opaque to the protocol (see `types.ts`): the pure
+ * helpers match on `action` + `resource` only, so an override whose condition
+ * is not `"always"` still governs the pure decision - the HOST resolver
+ * applies the condition before acting on it.
+ */
+
+const ALL_ACTIONS: readonly PolicyAction[] = policyActionSchema.options;
+const ALL_RESOURCES: readonly PolicyResource[] = policyResourceSchema.options;
+
+/** Baseline blast-radius of each action, used to weight gating decisions. */
+const ACTION_IMPACT: Record<PolicyAction, PolicyImpact> = {
+  "agent.create": "medium",
+  "agent.stop": "high",
+  "agent.fork": "medium",
+  "tool.execute": "medium",
+  "agent.sendMessage": "low",
+  "agent.archive": "high",
+};
+
+const OVERRIDE_PRIORITY = 10;
+
+/** Every action × every resource, all `allow` at priority 0. */
+function allowAllRules(): PolicyRule[] {
+  const rules: PolicyRule[] = [];
+  for (const action of ALL_ACTIONS) {
+    for (const resource of ALL_RESOURCES) {
+      rules.push({
+        ruleId: `default:allow:${action}:${resource}`,
+        action,
+        resource,
+        impact: ACTION_IMPACT[action],
+        condition: "always",
+        mode: "allow",
+        priority: 0,
+      });
+    }
+  }
+  return rules;
+}
+
+/**
+ * `supervised` overrides: deny the actions a supervised session must not take
+ * unilaterally. `agent.archive` is included with `agent.stop`/`agent.fork`
+ * because it is equally high-impact - the brief's explicit deny list names
+ * the first three, and the "denies high-impact actions" acceptance criterion
+ * covers `agent.archive` too. `tool.execute` is denied at medium impact with
+ * an exempt-allowlist condition (the resolver owns the exemption).
+ */
+const SUPERVISED_DENY_RULES: readonly PolicyRule[] = [
+  {
+    ruleId: "default:supervised:deny:agent.stop",
+    action: "agent.stop",
+    resource: "agent",
+    impact: "high",
+    condition: "always",
+    mode: "deny",
+    priority: OVERRIDE_PRIORITY,
+  },
+  {
+    ruleId: "default:supervised:deny:agent.fork",
+    action: "agent.fork",
+    resource: "agent",
+    impact: "medium",
+    condition: "always",
+    mode: "deny",
+    priority: OVERRIDE_PRIORITY,
+  },
+  {
+    ruleId: "default:supervised:deny:agent.archive",
+    action: "agent.archive",
+    resource: "agent",
+    impact: "high",
+    condition: "always",
+    mode: "deny",
+    priority: OVERRIDE_PRIORITY,
+  },
+  {
+    ruleId: "default:supervised:deny:tool.execute",
+    action: "tool.execute",
+    resource: "tool",
+    impact: "medium",
+    condition: "tool is not on the exempt allowlist",
+    mode: "deny",
+    priority: OVERRIDE_PRIORITY,
+  },
+];
+
+/**
+ * `auto_accept_edits` override: stopping ANOTHER agent is a high-impact,
+ * possibly irreversible action, so it requires approval even though most
+ * actions are auto-accepted. The condition defers the self-stop exemption
+ * (target IS the acting agent) to the resolver.
+ */
+const AUTO_ACCEPT_EDITS_STOP_RULE: PolicyRule = {
+  ruleId: "default:auto_accept_edits:require_approval:agent.stop",
+  action: "agent.stop",
+  resource: "agent",
+  impact: "high",
+  condition: "target agent differs from the acting agent",
+  mode: "require_approval",
+  priority: OVERRIDE_PRIORITY,
+};
+
+/** Canonical default rule set per permission mode. */
+export const DEFAULT_POLICY_RULES_BY_MODE: Record<
+  PermissionMode,
+  readonly PolicyRule[]
+> = {
+  full_access: allowAllRules(),
+  supervised: [...allowAllRules(), ...SUPERVISED_DENY_RULES],
+  auto_accept_edits: [...allowAllRules(), AUTO_ACCEPT_EDITS_STOP_RULE],
+};
+
+/** The default rule set for one permission mode (a fresh array each call). */
+export function defaultPolicyRulesForPermissionMode(
+  mode: PermissionMode,
+): PolicyRule[] {
+  return [...DEFAULT_POLICY_RULES_BY_MODE[mode]];
+}
+
+/**
+ * All rules that match a request's `action` + `resource`, in registration
+ * order. Conditions are NOT evaluated here - they are opaque to the protocol
+ * and the host resolver applies them (see `types.ts`).
+ */
+export function matchingPolicyRules(
+  request: PolicyEvaluationRequest,
+  rules: readonly PolicyRule[],
+): PolicyRule[] {
+  return rules.filter(
+    (rule) =>
+      rule.action === request.action && rule.resource === request.resource,
+  );
+}
+
+/**
+ * The governing decision for a request against a rule set: the matching rule
+ * with the highest `priority` (ties break by registration order), or null
+ * when nothing matches. The caller treats null as default-DENY.
+ *
+ * This is the pure matching semantics the host resolver will apply; it does
+ * not itself implement condition evaluation, approval escalation, or the
+ * audit-trail write.
+ */
+export function resolvePolicyDecision(
+  request: PolicyEvaluationRequest,
+  rules: readonly PolicyRule[],
+): { mode: PolicyRuleMode; rule: PolicyRule } | null {
+  let best: { mode: PolicyRuleMode; rule: PolicyRule } | null = null;
+  for (const rule of rules) {
+    if (rule.action !== request.action || rule.resource !== request.resource) {
+      continue;
+    }
+    if (best === null || rule.priority > best.rule.priority) {
+      best = { mode: rule.mode, rule };
+    }
+  }
+  return best;
+}

--- a/protocol/src/host/policy/index.ts
+++ b/protocol/src/host/policy/index.ts
@@ -1,3 +1,4 @@
 export * from "./contracts";
 export * from "./defaults";
+export * from "./registry";
 export * from "./types";

--- a/protocol/src/host/policy/index.ts
+++ b/protocol/src/host/policy/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts";
+export * from "./defaults";
+export * from "./types";

--- a/protocol/src/host/policy/registry.ts
+++ b/protocol/src/host/policy/registry.ts
@@ -1,0 +1,247 @@
+import type { PermissionMode } from "@traycer/protocol/persistence/epic/foundation";
+import type { EpicCommunicationGraphEventV11 } from "@traycer/protocol/host/epic/communication-graph";
+import {
+  policyEvaluationRequestSchema,
+  type PolicyEvaluationRequest,
+  type PolicyEvaluationResult,
+  type PolicyRegistry,
+} from "./contracts";
+import {
+  defaultPolicyRulesForPermissionMode,
+  resolvePolicyDecision,
+} from "./defaults";
+import {
+  policyRuleSchema,
+  type PolicyRule,
+  type PolicyRuleMode,
+} from "./types";
+
+/**
+ * REFERENCE IMPLEMENTATION of the `PolicyRegistry` interface from
+ * `contracts.ts` - the canonical in-memory registry a Traycer host VENDORS
+ * or replaces per-host. It is deliberately protocol-side so the policy
+ * semantics are provable end-to-end without the closed host, and so Task 9's
+ * two-host acceptance can run against the protocol layer alone.
+ *
+ * What this is NOT: the production host resolver. It has no SQLite, no
+ * action-dispatch hook, and no comm-graph transport. A host wires emission
+ * by passing an `auditSink` (or by calling `buildPolicyAuditEvent` itself
+ * and handing the row to its own log writer).
+ *
+ * Evaluation model (the semantics a vendoring host must match):
+ *
+ *   - The request's `environment.permissionMode` is the AUTHORITATIVE
+ *     baseline: `evaluate()` selects `defaultPolicyRulesForPermissionMode`
+ *     for THAT mode (so one registry follows an agent whose permission mode
+ *     changes, without reconstruction) and layers plugin rules on top.
+ *     The constructor's `defaultPermissionMode` seeds the rule set shown by
+ *     `list()` before any evaluation.
+ *   - `resolvePolicyDecision` picks the highest-`priority` matching rule
+ *     (ties break by registration order). The winning mode maps to the
+ *     result as: `allow` → `allowed: true`; `deny` → `allowed: false`;
+ *     `require_approval` → `allowed: false` (the caller escalates, see
+ *     Task 8) with a "requires approval: …" reason. No match → default-deny.
+ *   - Every `evaluate()` optionally hands an `approval`-kind comm-graph
+ *     event to the `auditSink` (status `granted` / `denied` / `pending`).
+ */
+
+export type ReferencePolicyRegistryOptions = {
+  /** The agent's permission mode at registry creation. Seeds the default
+   * rule set; `evaluate()` follows the request's mode at call time. */
+  defaultPermissionMode: PermissionMode;
+  /**
+   * Optional sink receiving one comm-graph audit event per evaluation
+   * (kind `approval`, status `granted` / `denied` / `pending`). The
+   * reference registry MINTs the event with a provisional `id` equal to
+   * `evaluatedAt`; a vendoring host must replace it with its own log
+   * sequence before persisting. Omit for a registry that only decides.
+   */
+  auditSink?: (event: EpicCommunicationGraphEventV11) => void;
+};
+
+export class ReferencePolicyRegistry implements PolicyRegistry {
+  private readonly defaultPermissionMode: PermissionMode;
+  private readonly auditSink:
+    ((event: EpicCommunicationGraphEventV11) => void) | undefined;
+  /** Rules registered by plugins/harnesses - mode-independent overrides
+   * layered on top of the per-mode defaults. */
+  private readonly pluginRules: PolicyRule[] = [];
+
+  constructor(options: ReferencePolicyRegistryOptions) {
+    this.defaultPermissionMode = options.defaultPermissionMode;
+    this.auditSink = options.auditSink;
+  }
+
+  /**
+   * Registers a plugin/harness rule. Validated against
+   * `policyRuleSchema`; a ruleId already present is REPLACED (upsert), so
+   * re-registration on hot reload is safe.
+   */
+  register(rule: PolicyRule): void {
+    const parsed = policyRuleSchema.parse(rule);
+    const existing = this.pluginRules.findIndex(
+      (candidate) => candidate.ruleId === parsed.ruleId,
+    );
+    if (existing >= 0) {
+      this.pluginRules[existing] = parsed;
+    } else {
+      this.pluginRules.push(parsed);
+    }
+  }
+
+  /**
+   * Removes a PLUGIN rule by id. Default rules are re-seeded from
+   * `defaults.ts` on every evaluation and cannot be unregistered; an unknown
+   * id is a no-op.
+   */
+  unregister(ruleId: string): void {
+    const existing = this.pluginRules.findIndex(
+      (candidate) => candidate.ruleId === ruleId,
+    );
+    if (existing >= 0) {
+      this.pluginRules.splice(existing, 1);
+    }
+  }
+
+  evaluate(request: PolicyEvaluationRequest): PolicyEvaluationResult {
+    const parsed = policyEvaluationRequestSchema.parse(request);
+    const effectivePermissionMode = parsed.environment.permissionMode;
+    const rules = [
+      ...defaultPolicyRulesForPermissionMode(effectivePermissionMode),
+      ...this.pluginRules,
+    ];
+    const decision = resolvePolicyDecision(parsed, rules);
+    const evaluatedAt = Date.now();
+
+    let result: PolicyEvaluationResult;
+    if (decision === null) {
+      result = {
+        allowed: false,
+        reason: "no matching policy rule",
+        ruleId: null,
+        evaluatedAt,
+        effectivePermissionMode,
+      };
+    } else if (decision.mode === "allow") {
+      result = {
+        allowed: true,
+        reason: decision.rule.condition,
+        ruleId: decision.rule.ruleId,
+        evaluatedAt,
+        effectivePermissionMode,
+      };
+    } else if (decision.mode === "require_approval") {
+      result = {
+        allowed: false,
+        reason: `requires approval: ${decision.rule.condition}`,
+        ruleId: decision.rule.ruleId,
+        evaluatedAt,
+        effectivePermissionMode,
+      };
+    } else {
+      // deny
+      result = {
+        allowed: false,
+        reason: decision.rule.condition,
+        ruleId: decision.rule.ruleId,
+        evaluatedAt,
+        effectivePermissionMode,
+      };
+    }
+
+    if (this.auditSink !== undefined) {
+      this.auditSink(
+        buildPolicyAuditEvent({
+          id: result.evaluatedAt,
+          request: parsed,
+          result,
+          decision,
+        }),
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * The current rule set: defaults for the registry's seed mode plus all
+   * registered plugin rules, in registration order. A fresh array each call;
+   * callers may inspect but should not mutate it.
+   */
+  list(): PolicyRule[] {
+    return [
+      ...defaultPolicyRulesForPermissionMode(this.defaultPermissionMode),
+      ...this.pluginRules,
+    ];
+  }
+}
+
+export type PolicyAuditEventInput = {
+  /** The host's log row id for this event (autoincrement, positive). The
+   * reference registry passes `evaluatedAt` as a provisional value; a
+   * vendoring host passes its own sequence. */
+  id: number;
+  request: PolicyEvaluationRequest;
+  result: PolicyEvaluationResult;
+  /** The governing decision from `resolvePolicyDecision`, or null for the
+   * default-deny no-match case. */
+  decision: { mode: PolicyRuleMode; rule: PolicyRule } | null;
+};
+
+/**
+ * Constructs the comm-graph `approval` @1.1 audit event for one policy
+ * evaluation - the event shape only; it does NOT emit (a host hands the
+ * result to its log writer / `auditSink`).
+ *
+ * Kind is `approval` (not `lifecycle`): a policy evaluation is an approval
+ * decision, and the `approval` kind carries exactly the right fields -
+ * `senderAgentId` is the REQUESTER (`request.agentId`), `status` maps
+ * `granted` / `denied` / `pending`, and `targetAction` is the gated action.
+ * The event validates against `epicCommunicationGraphEventSchemaV11`.
+ */
+export function buildPolicyAuditEvent(
+  input: PolicyAuditEventInput,
+): EpicCommunicationGraphEventV11 {
+  const { id, request, result, decision } = input;
+  const status: "pending" | "granted" | "denied" =
+    decision === null
+      ? "denied"
+      : decision.mode === "allow"
+        ? "granted"
+        : decision.mode === "require_approval"
+          ? "pending"
+          : "denied";
+
+  return {
+    id,
+    kind: "approval",
+    timestamp: result.evaluatedAt,
+    senderAgentId: request.agentId,
+    receiverAgentId: null,
+    responseId: null,
+    inReplyTo: null,
+    expectReply: null,
+    messageText: null,
+    noticeReason: null,
+    originKind: null,
+    originChatId: null,
+    originRefId: null,
+    toolName: null,
+    toolInput: null,
+    durationMs: null,
+    success: null,
+    tokenCost: null,
+    approvalId: `policy:${request.agentId}:${result.evaluatedAt}`,
+    status,
+    targetAction: request.action,
+    agentId: null,
+    previousState: null,
+    newState: null,
+    trigger: null,
+    hostId: null,
+    resourceType: null,
+    metricValue: null,
+    threshold: null,
+    breach: null,
+  };
+}

--- a/protocol/src/host/policy/types.ts
+++ b/protocol/src/host/policy/types.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+/**
+ * `protocol/src/host/policy/` - the policy evaluation wire contract for
+ * Traycer Enhanced Phase 0 (Task 3).
+ *
+ * This module is CONTRACTS ONLY: zod schemas, the in-process registry
+ * interface, and the pure default rule sets. There is deliberately no host
+ * resolver, no SQLite, and no action-dispatch hook here - those are later
+ * tasks (6 and 8). The policy audit trail will eventually surface as
+ * comm-graph `approval` / `lifecycle` @1.1 events (Task 1), but nothing in
+ * this module depends on the communication graph.
+ *
+ * Evaluation model (encoded in `defaults.ts`, applied by the resolver):
+ * the registry matches a request's `action` + `resource` against its rules,
+ * picks the HIGHEST-`priority` match (ties break by registration order),
+ * and the winning rule's `mode` is the decision. `condition` strings are
+ * human-readable predicates evaluated by the HOST resolver - the protocol
+ * treats them as opaque (only `"always"` is meaningful to the pure helpers
+ * in `defaults.ts`).
+ */
+
+/**
+ * The action an agent is attempting. CLOSED enum: the registry matches
+ * requests against rules by this exact value, so an unknown action can never
+ * be evaluated - the evaluator treats it as no-match, which defaults to deny.
+ * Adding an action is a reviewed schema change with every consumer, never a
+ * silent widening.
+ */
+export const policyActionSchema = z.enum([
+  "agent.create",
+  "agent.stop",
+  "agent.fork",
+  "tool.execute",
+  "agent.sendMessage",
+  "agent.archive",
+]);
+export type PolicyAction = z.infer<typeof policyActionSchema>;
+
+/** The resource class the action targets. Closed for the same reason. */
+export const policyResourceSchema = z.enum([
+  "agent",
+  "tool",
+  "epic",
+  "workspace",
+  "secret",
+  "host",
+]);
+export type PolicyResource = z.infer<typeof policyResourceSchema>;
+
+/**
+ * Impact level - used for gating decisions:
+ *
+ * - `none`      - no observable effect
+ * - `low`       - reversible, narrow scope
+ * - `medium`    - reversible but wider blast radius
+ * - `high`      - possibly irreversible or expensive
+ * - `critical`  - destructive - confirm/reject only
+ */
+export const policyImpactSchema = z.enum([
+  "none",
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+export type PolicyImpact = z.infer<typeof policyImpactSchema>;
+
+/** How a matching rule disposes of the request. */
+export const policyRuleModeSchema = z.enum([
+  "allow",
+  "deny",
+  "require_approval",
+]);
+export type PolicyRuleMode = z.infer<typeof policyRuleModeSchema>;
+
+/**
+ * One policy rule: a predicate the registry evaluates.
+ *
+ * `priority` is the disambiguation key: when several rules match a request,
+ * the highest `priority` wins and ties break by registration order. The
+ * default rule sets in `defaults.ts` use this to layer mode-specific
+ * overrides (priority 10) on top of an allow-all baseline (priority 0).
+ */
+export const policyRuleSchema = z.object({
+  ruleId: z.string(),
+  action: policyActionSchema,
+  resource: policyResourceSchema,
+  impact: policyImpactSchema,
+  /**
+   * Human-readable description of the predicate, evaluated by the host
+   * resolver (e.g. "agent belongs to the calling user's epic"). Opaque to
+   * the protocol: the pure decision helpers in `defaults.ts` treat `"always"`
+   * as unconditional and defer every other condition to the resolver.
+   */
+  condition: z.string(),
+  mode: policyRuleModeSchema,
+  priority: z.number().int().default(0),
+});
+export type PolicyRule = z.infer<typeof policyRuleSchema>;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -452,6 +452,7 @@ import { worktreeDeleteByPathStreamV10 } from "@traycer/protocol/host/worktree-d
 import { worktreeChangedV10 } from "@traycer/protocol/host/worktree-changed-stream";
 import {
   epicCommunicationGraphSubscribeV10,
+  epicCommunicationGraphSubscribeV11,
   hostCommunicationGraphCloudFeedSubscribeV10,
 } from "@traycer/protocol/host/epic/communication-graph";
 import { hostChatRecordsSubscribeV10 } from "@traycer/protocol/host/epic/chat-records";
@@ -7985,12 +7986,23 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   // `unsupported` and that host's agents render with a "no edge data"
   // affordance while every other host in the epic keeps streaming. Never add
   // it to the unary released floor - that list is fail-closed on the name set.
+  //
+  // @1.1 adds the `tool_call` / `approval` / `lifecycle` / `resource_event`
+  // kinds and their nullable per-kind fields. @1.0 stays installed and
+  // FROZEN: a peer that negotiated it receives resolver-projected rows of the
+  // three original kinds only (new-kind rows are skipped under the
+  // representability policy), and the resolver gates emission on the
+  // negotiated version - streams have no bridges, so projection is the whole
+  // compat mechanism (see `git.subscribeStatus@1.1` and the module doc).
   "epic.communicationGraph.subscribe": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: epicCommunicationGraphSubscribeV10,
+        },
+        1: {
+          contract: epicCommunicationGraphSubscribeV11,
         },
       },
     },

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -456,6 +456,7 @@ import {
   hostCommunicationGraphCloudFeedSubscribeV10,
 } from "@traycer/protocol/host/epic/communication-graph";
 import { hostChatRecordsSubscribeV10 } from "@traycer/protocol/host/epic/chat-records";
+import { hostRemoteCapabilitiesSubscribeV10 } from "@traycer/protocol/host/remote/capabilities";
 import { editorOpenPathsV10 } from "@traycer/protocol/host/editor/contracts";
 import {
   gitListChangedFilesV10,
@@ -8039,6 +8040,26 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
       versions: {
         0: {
           contract: hostChatRecordsSubscribeV10,
+        },
+      },
+    },
+  },
+  // Additive, post-v1.0.0 OPTIONAL stream method: remote host capability
+  // discovery - a client opens a subscription for ONE remote `hostId` and
+  // receives exactly one REPLACE-WHOLE `snapshot` of that host's capability
+  // set, then `update` frames (full capability, never a patch) when the set
+  // changes. Text frames only. A host that predates it never advertises it,
+  // and the client's subscription degrades to `unsupported`, whose contract
+  // is simply that cross-host actions proceed WITHOUT a capability pre-flight
+  // (today's behavior) - the remote host's own per-method checks still apply.
+  // Never add it to the unary released floor - that list is fail-closed on
+  // the name set.
+  "host.remote.capabilities.subscribe": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: hostRemoteCapabilitiesSubscribeV10,
         },
       },
     },

--- a/protocol/src/host/remote/__tests__/capabilities.test.ts
+++ b/protocol/src/host/remote/__tests__/capabilities.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStreamManifest,
+  checkStreamMethodCompatibility,
+} from "@traycer/protocol/framework/stream-compat";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/index";
+import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
+import {
+  hostRemoteCapabilitiesSubscribeV10,
+  remoteCapabilitiesSubscribeClientFrameSchema,
+  remoteCapabilitiesSubscribeOpenRequestSchema,
+  remoteCapabilitiesSubscribeServerFrameSchema,
+  remoteCapabilitySchema,
+} from "@traycer/protocol/host/remote/capabilities";
+
+/**
+ * `host.remote.capabilities.subscribe@1.0` contract fixtures + the
+ * optional-method degrade guard.
+ *
+ * The degrade case is the load-bearing one, exactly as for
+ * `epic.communicationGraph.subscribe`: this method ships AFTER host-v1.0.0,
+ * so a host in the field may not advertise it at all. Stream compatibility
+ * is evaluated per method at subscribe time, so a missing method is a
+ * per-feature "capabilities unknown" degrade, never a handshake failure.
+ *
+ * On the frames: `snapshot` is the one authoritative REPLACE-WHOLE baseline
+ * emitted on open; `update` carries the FULL capability (never a patch), and
+ * every frame is text-only (`hasBinaryPayload: false`).
+ */
+
+const METHOD = "host.remote.capabilities.subscribe";
+
+const REMOTE_CAPABILITY = {
+  hostId: "host-remote-1",
+  version: "1.4.2",
+  supportedStreamMethods: [
+    "epic.communicationGraph.subscribe@1.0@1",
+    "host.remote.capabilities.subscribe@1.0@0",
+  ],
+  supportedUnaryMethods: ["agent.list@1.0@0", "epic.listTasks@1.1@0"],
+  persistenceType: "sqlite",
+  harnesses: ["claude", "codex"],
+  features: ["durable-inbox", "policy-eval"],
+} as const;
+
+describe("host.remote.capabilities.subscribe contract identity", () => {
+  it("defines the method at schema version 1.0 and advertises it", () => {
+    expect(hostRemoteCapabilitiesSubscribeV10.method).toBe(METHOD);
+    expect(hostRemoteCapabilitiesSubscribeV10.schemaVersion).toEqual({
+      major: 1,
+      minor: 0,
+    });
+    expect(buildStreamManifest(hostStreamRpcRegistry)[METHOD]).toEqual({
+      major: 1,
+      minor: 0,
+    });
+  });
+
+  it("stays out of the unary released floor", () => {
+    // The floor is fail-closed on the method-name set; an entry there would
+    // make every RPC fail against a peer that predates this method.
+    expect(RELEASED_FLOOR_METHOD_NAMES).not.toContain(METHOD);
+  });
+});
+
+describe("remoteCapabilitySchema", () => {
+  it("parses a full sample capability", () => {
+    const parsed = remoteCapabilitySchema.parse(REMOTE_CAPABILITY);
+
+    expect(parsed.hostId).toBe("host-remote-1");
+    expect(parsed.version).toBe("1.4.2");
+    expect(parsed.supportedStreamMethods).toContain(
+      "epic.communicationGraph.subscribe@1.0@1",
+    );
+    expect(parsed.supportedUnaryMethods).toContain("agent.list@1.0@0");
+    expect(parsed.persistenceType).toBe("sqlite");
+    expect(parsed.harnesses).toEqual(["claude", "codex"]);
+    expect(parsed.features).toEqual(["durable-inbox", "policy-eval"]);
+  });
+
+  it("rejects an unknown persistenceType", () => {
+    expect(
+      remoteCapabilitySchema.safeParse({
+        ...REMOTE_CAPABILITY,
+        persistenceType: "postgres",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a missing hostId", () => {
+    const { hostId: _omittedHostId, ...withoutHostId } = REMOTE_CAPABILITY;
+    expect(
+      remoteCapabilitySchema.safeParse(withoutHostId).success,
+    ).toBe(false);
+  });
+
+  it("accepts capability values invented after the minor froze (open lists)", () => {
+    // The lists are open strings so a NEWER remote host's values still parse;
+    // an unknown entry degrades to "not supported", never an unreadable frame.
+    const parsed = remoteCapabilitySchema.parse({
+      ...REMOTE_CAPABILITY,
+      supportedStreamMethods: [
+        "some.futureMethod.subscribe@1.0@0",
+      ],
+      harnesses: ["future-harness"],
+      features: ["future-feature"],
+    });
+
+    expect(parsed.supportedStreamMethods[0]).toBe(
+      "some.futureMethod.subscribe@1.0@0",
+    );
+    expect(parsed.harnesses).toEqual(["future-harness"]);
+    expect(parsed.features).toEqual(["future-feature"]);
+  });
+});
+
+describe("host.remote.capabilities.subscribe open request", () => {
+  it("parses an open request naming the remote host", () => {
+    const parsed = remoteCapabilitiesSubscribeOpenRequestSchema.parse({
+      hostId: "host-remote-1",
+    });
+
+    expect(parsed.hostId).toBe("host-remote-1");
+  });
+
+  it("rejects an open request without a hostId", () => {
+    expect(
+      remoteCapabilitiesSubscribeOpenRequestSchema.safeParse({}).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty hostId", () => {
+    expect(
+      remoteCapabilitiesSubscribeOpenRequestSchema.safeParse({
+        hostId: "",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("host.remote.capabilities.subscribe server frames", () => {
+  it("parses the initial snapshot frame (REPLACE-WHOLE baseline)", () => {
+    const parsed = remoteCapabilitiesSubscribeServerFrameSchema.parse({
+      kind: "snapshot",
+      capability: REMOTE_CAPABILITY,
+      hasBinaryPayload: false,
+    });
+
+    expect(parsed.kind).toBe("snapshot");
+    if (parsed.kind === "snapshot") {
+      expect(parsed.capability.hostId).toBe("host-remote-1");
+      expect(parsed.capability.persistenceType).toBe("sqlite");
+    }
+  });
+
+  it("parses an update frame carrying the FULL capability, not a patch", () => {
+    const parsed = remoteCapabilitiesSubscribeServerFrameSchema.parse({
+      kind: "update",
+      capability: {
+        ...REMOTE_CAPABILITY,
+        version: "1.5.0",
+        features: ["durable-inbox", "policy-eval", "remote-sessions"],
+      },
+      hasBinaryPayload: false,
+    });
+
+    expect(parsed.kind).toBe("update");
+    if (parsed.kind === "update") {
+      // Replace-wholesale: every field is present on the frame, so a consumer
+      // never patches field-wise.
+      expect(parsed.capability.version).toBe("1.5.0");
+      expect(parsed.capability.hostId).toBe("host-remote-1");
+      expect(parsed.capability.features).toEqual([
+        "durable-inbox",
+        "policy-eval",
+        "remote-sessions",
+      ]);
+    }
+  });
+
+  it("parses the heartbeat frame", () => {
+    expect(
+      remoteCapabilitiesSubscribeServerFrameSchema.parse({
+        kind: "pong",
+        hasBinaryPayload: false,
+      }).kind,
+    ).toBe("pong");
+  });
+
+  it("rejects an unknown server frame kind", () => {
+    expect(
+      remoteCapabilitiesSubscribeServerFrameSchema.safeParse({
+        kind: "event",
+        hasBinaryPayload: false,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a binary-payload frame", () => {
+    // Text frames only - this contract has no binary side channel.
+    expect(
+      remoteCapabilitiesSubscribeServerFrameSchema.safeParse({
+        kind: "snapshot",
+        capability: REMOTE_CAPABILITY,
+        hasBinaryPayload: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires hasBinaryPayload on every server frame", () => {
+    const { hasBinaryPayload: _omitted, ...withoutBinaryFlag } = {
+      kind: "snapshot",
+      capability: REMOTE_CAPABILITY,
+      hasBinaryPayload: false,
+    };
+
+    expect(
+      remoteCapabilitiesSubscribeServerFrameSchema.safeParse(
+        withoutBinaryFlag,
+      ).success,
+    ).toBe(false);
+  });
+});
+
+describe("host.remote.capabilities.subscribe client frames", () => {
+  it("parses the ping frame", () => {
+    expect(
+      remoteCapabilitiesSubscribeClientFrameSchema.parse({
+        kind: "ping",
+        hasBinaryPayload: false,
+      }).kind,
+    ).toBe("ping");
+  });
+
+  it("rejects a binary-payload client frame", () => {
+    expect(
+      remoteCapabilitiesSubscribeClientFrameSchema.safeParse({
+        kind: "ping",
+        hasBinaryPayload: true,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("host.remote.capabilities.subscribe degrades against an older host", () => {
+  it("fails only this method's subscribe, leaving every other stream method compatible", () => {
+    const currentManifest = buildStreamManifest(hostStreamRpcRegistry);
+    // A host that predates the method simply omits it from its manifest.
+    const olderHostManifest = Object.fromEntries(
+      Object.entries(currentManifest).filter(([method]) => method !== METHOD),
+    );
+
+    const caps = checkStreamMethodCompatibility(
+      hostStreamRpcRegistry,
+      currentManifest,
+      olderHostManifest,
+      "client",
+      METHOD,
+    );
+    expect(caps.ok).toBe(false);
+    if (!caps.ok) {
+      // The client turns this into `onMethodSupport(method, "unsupported")`
+      // and the cross-host surface degrades to "capabilities unknown".
+      expect(caps.details.incompatibleMethods).toEqual([
+        expect.objectContaining({ method: METHOD }),
+      ]);
+    }
+
+    for (const method of ["epic.subscribe", "chat.subscribe"]) {
+      expect(
+        checkStreamMethodCompatibility(
+          hostStreamRpcRegistry,
+          currentManifest,
+          olderHostManifest,
+          "client",
+          method,
+        ).ok,
+      ).toBe(true);
+    }
+  });
+});

--- a/protocol/src/host/remote/capabilities.ts
+++ b/protocol/src/host/remote/capabilities.ts
@@ -1,0 +1,192 @@
+/**
+ * `host.remote.capabilities.subscribe@1.0` - versioned streaming-RPC contract
+ * for REMOTE HOST CAPABILITY DISCOVERY. A client opens a subscription against
+ * the host it is connected to and asks what capabilities a REMOTE host - a
+ * different Traycer host the user is signed into, a peer in a multi-host epic,
+ * a session target resolved through the attach-grant seam - declares for
+ * itself, BEFORE (or while) taking cross-host actions such as opening a remote
+ * session or attempting a cross-host method call.
+ *
+ * Shape follows the snapshot-first stream pattern established by
+ * `epic.communicationGraph.subscribe`: the client opens with `{ hostId }`
+ * naming the remote host it is asking about, and the serving host emits
+ * EXACTLY ONE `snapshot` frame carrying that host's FULL capability set, then
+ * `update` frames whenever a capability changes while the subscription is
+ * open. Changes are RARE - a host build's capability set is stable for the
+ * lifetime of that build - which is what makes this a cheap long-lived
+ * subscription rather than a poll.
+ *
+ * WHY A STREAM RATHER THAN A UNARY READ: the consumer's question ("what can
+ * this remote host do?") has a lifetime, not a moment - the client keeps the
+ * capability view open for as long as it is reasoning about the remote host,
+ * and an `update` frame is the only way it learns that a session target
+ * changed (host upgraded, feature toggled, persistence mode switched) without
+ * polling or re-reading on every cross-host action. A unary read would turn
+ * every such action into either a stale assumption or a fresh round trip.
+ *
+ * WHAT THE FRAMES MEAN:
+ *
+ *   - `snapshot` is AUTHORITATIVE and REPLACE-WHOLE. Exactly one arrives
+ *     first, and the client REPLACES any capability it holds for that host
+ *     with the frame's payload - never merges, never reconciles field-wise.
+ *     It is also how a reconnect re-syncs: because the capability set is
+ *     small and change is rare, resume is a fresh snapshot, not a delta.
+ *   - `update` carries the FULL capability object, NOT a delta or a field
+ *     patch. The client applies it by REPLACING its stored copy for the
+ *     subscription's `hostId` wholesale. A partial-update design would
+ *     reintroduce ordering bugs (two fields changing in two frames applied
+ *     out of order) for zero bandwidth gain on a payload this small, so the
+ *     wire never asks a consumer to patch.
+ *   - The capability's `hostId` MUST equal the open request's `hostId`. A
+ *     frame that carries a different id is a serving-host bug; a consumer
+ *     should treat it as a protocol error (log, drop the frame) rather than
+ *     start a second implicit subscription.
+ *   - Text frames only. Every frame - server and client - carries
+ *     `hasBinaryPayload: false`; there is no binary side channel in this
+ *     contract.
+ *
+ * WHAT A CAPABILITY IS - a POINT-IN-TIME DECLARATION, not a promise:
+ * `supportedStreamMethods` / `supportedUnaryMethods` list the remote host's
+ * advertised method surface (its `/stream` and `/rpc` manifests, in the
+ * manifest's own `method@major.minor` spelling), `persistenceType` names its
+ * durable store, `harnesses` the harnesses it can run agents on, and
+ * `features` its feature flags (e.g. `durable-inbox`, `policy-eval`). The
+ * client uses this to PRE-FLIGHT cross-host actions - "does the target
+ * support the method I am about to call / the harness I want / the
+ * persistence I need" - and to degrade gracefully when it does not. It does
+ * not replace the per-method stream compat check: `supportedStreamMethods`
+ * answers "does the remote host ADVERTISE this method at all", and the
+ * actual subscribe still negotiates the minor pair.
+ *
+ * COMPAT POSTURE - additive, post-v1.0.0 OPTIONAL stream method. A host that
+ * predates this method simply does not advertise it in its `/stream`
+ * manifest, and stream compatibility is checked PER METHOD at subscribe time
+ * (`checkStreamMethodCompatibility`), so the client's subscription resolves
+ * to `onMethodSupport(method, "unsupported")` and the cross-host surface
+ * degrades to "capabilities unknown" - the client falls back to attempting
+ * the cross-host action without a pre-flight, exactly as it did before this
+ * method existed. This is the `resources.subscribe` / 
+ * `epic.communicationGraph.subscribe` precedent, and it is why the method
+ * must never be added to the unary released floor (`released-floor.ts`),
+ * which is fail-closed on the name set.
+ */
+import { z } from "zod";
+import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
+
+const textFrameFields = {
+  hasBinaryPayload: z.literal(false),
+} as const;
+
+/**
+ * What a remote host declares about itself. Deliberately FLAT and
+ * point-in-time: each field is the remote host's own self-report, relayed
+ * without interpretation by the host serving this subscription. The lists are
+ * open `string` arrays (NOT closed enums) for the same reason the
+ * communication-graph log fields are open strings - a value invented by a
+ * NEWER remote host after this contract froze must still parse and render,
+ * and the consumer's contract for an unknown entry is "show the raw string /
+ * treat as not-supported", never "the frame is unreadable".
+ */
+export const remoteCapabilitySchema = z.object({
+  /** The remote host this capability describes; must equal the open
+   * request's `hostId`. */
+  hostId: z.string().min(1),
+  /** Host version string, e.g. `1.4.2`. Display/provenance metadata only. */
+  version: z.string(),
+  /**
+   * The remote host's advertised `/stream` method surface, in the manifest's
+   * `method@major.minor` spelling, e.g. `"epic.communicationGraph.subscribe@1.0@1"`.
+   * A client pre-flights a cross-host subscription against this list; the
+   * actual subscribe still negotiates the minor pair.
+   */
+  supportedStreamMethods: z.array(z.string()),
+  /** The remote host's advertised `/rpc` method surface, in
+   * `method@major.minor` spelling. */
+  supportedUnaryMethods: z.array(z.string()),
+  /** What the remote host persists to: `sqlite` (local durable store),
+   * `memory` (RAM-only), or `cloud` (cloud-tier backing). */
+  persistenceType: z.enum(["sqlite", "memory", "cloud"]),
+  /** Harness ids the remote host can run agents on, e.g. `claude`, `codex`. */
+  harnesses: z.array(z.string()),
+  /** Feature flags the remote host advertises, e.g. `durable-inbox`,
+   * `policy-eval`. */
+  features: z.array(z.string()),
+});
+export type RemoteCapability = z.infer<typeof remoteCapabilitySchema>;
+
+/**
+ * Stream open request: WHICH remote host to query. One subscription covers
+ * exactly one remote host - there is no "give me everything" variant, because
+ * a capability view is something a client holds per target it is reasoning
+ * about, and multiplexing several hosts onto one stream would force every
+ * consumer to filter frames that belong to someone else.
+ */
+export const remoteCapabilitiesSubscribeOpenRequestSchema = z.object({
+  /** The remote host to report capabilities for. Required - the serving
+   * host refuses a subscription that does not name its target. */
+  hostId: z.string().min(1),
+});
+export type RemoteCapabilitiesSubscribeOpenRequest = z.infer<
+  typeof remoteCapabilitiesSubscribeOpenRequestSchema
+>;
+
+export const remoteCapabilitiesSubscribeServerFrameSchema =
+  z.discriminatedUnion("kind", [
+    /**
+     * Exactly one per subscription, emitted first: the remote host's FULL
+     * capability set at open time. Authoritative and REPLACE-WHOLE - the
+     * client replaces any capability it holds for this host with this
+     * payload, and treats the frame as the baseline every later `update`
+     * builds on. Also the reconnect re-sync: on a new open the host re-sends
+     * a fresh snapshot, never a delta.
+     */
+    z.object({
+      kind: z.literal("snapshot"),
+      capability: remoteCapabilitySchema,
+      ...textFrameFields,
+    }),
+    /**
+     * A capability changed while the subscription was open (host upgraded,
+     * feature toggled, persistence switched) - RARE. Carries the FULL
+     * capability object, never a field patch: the client REPLACES its
+     * stored copy for the subscription's `hostId` wholesale. The capability's
+     * `hostId` must equal the open request's `hostId`; a mismatch is a
+     * serving-host bug and the consumer should treat the frame as a protocol
+     * error, not start a second subscription.
+     */
+    z.object({
+      kind: z.literal("update"),
+      capability: remoteCapabilitySchema,
+      ...textFrameFields,
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      ...textFrameFields,
+    }),
+  ]);
+export type RemoteCapabilitiesSubscribeServerFrame = z.infer<
+  typeof remoteCapabilitiesSubscribeServerFrameSchema
+>;
+
+export const remoteCapabilitiesSubscribeClientFrameSchema =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("ping"),
+      ...textFrameFields,
+    }),
+  ]);
+export type RemoteCapabilitiesSubscribeClientFrame = z.infer<
+  typeof remoteCapabilitiesSubscribeClientFrameSchema
+>;
+
+/**
+ * `host.remote.capabilities.subscribe@1.0` - see the module doc. Snapshot-
+ * first, text-frames-only, one remote host per subscription.
+ */
+export const hostRemoteCapabilitiesSubscribeV10 = defineStreamRpcContract({
+  method: "host.remote.capabilities.subscribe",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: remoteCapabilitiesSubscribeOpenRequestSchema,
+  serverFrameSchema: remoteCapabilitiesSubscribeServerFrameSchema,
+  clientFrameSchema: remoteCapabilitiesSubscribeClientFrameSchema,
+});

--- a/protocol/src/host/remote/index.ts
+++ b/protocol/src/host/remote/index.ts
@@ -1,0 +1,1 @@
+export * from "./capabilities";


### PR DESCRIPTION
**Phase 0 protocol layer — closes TE-18, TE-19, TE-20, TE-21, TE-22, TE-23, TE-24, TE-25**

Branch: `te-phase-0-foundation` pushed to `ranjith-sp-0310/traycer` (forked from `traycerai/traycer`).

**Shipped (all in `protocol/`, closed-source host vendors or replaces):**

- **TE-18** — @1.1 comm-graph event kinds: `tool_call`/`approval`/`lifecycle`/`resource_event` (closed enum extend, downgrade-skip for @1.0 peers)
- **TE-19** — @1.2 inbox durability fields (pre-existing, verified — `eventId` + `agent.inbox.ack`)
- **TE-20** — `protocol/src/host/policy/{types,contracts,defaults}` — `PolicyRule`, `PolicyEvaluationRequest/Result`, `PolicyRegistry` interface, `DEFAULT_POLICY_RULES_BY_MODE` + `resolvePolicyDecision` (priority wins, fail-closed)
- **TE-21** — `protocol/src/host/remote/capabilities.ts` — `host.remote.capabilities.subscribe@1.0` (snapshot-first, text frames)
- **TE-22** — `protocol/src/host/agent/inbox-spec.ts` — `InboxMessageRow`, `simulateAckFlow`/`simulateSubscribeDrain`/`simulateDeliveryAttempt`, delivery contract (at-least-once @1.2+, at-most-once <@1.2, dead-letter 5)
- **TE-23 (reference-6)** — `protocol/src/host/policy/registry.ts` — `ReferencePolicyRegistry` (+ audit `approval` event via comm-graph @1.1)

**Integration tests (protocol reference, in-memory, no host):**

- **TE-24** — `protocol/src/host/agent/__tests__/durable-inbox-flow.test.ts` (9)
- **TE-25** — `protocol/src/host/policy/__tests__/policy-registry-e2e.test.ts` (12)

Full suite: 2636+ passed (31 pre-existing Windows shell-detection failures in `config/adversarial-*` only). `bun run build`/`compile` pass, lint/format clean.

Remaining: TE-26 final protocol-layer end-to-end acceptance (Tasks 7+8).
