### PR TITLE
fix(gui-app): tolerate an assistant record that never carried imageResolutions

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages-assistant-images.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages-assistant-images.test.tsx
@@ -722,3 +722,86 @@ describe("useRenderedMessages image resolution stable-row identity", () => {
     ).toBeUndefined();
   });
 });
+
+/**
+ * An assistant record persisted before `imageResolutions` existed, shaped the
+ * way one actually reaches this projection at runtime.
+ *
+ * A snapshot delivered on the live schema line takes `ChatStreamClient`'s
+ * SHALLOW parse path, which validates `chat.messages` with
+ * `z.custom<Message>(isStructuralRecord)` - a structural check that runs none of
+ * the zod defaults, so `imageResolutions: z.array(...).default([])` never fills.
+ * (The DEEP path does fill it, which is why only the live line is exposed; both
+ * halves of that contract are pinned in `chat-stream-client.test.ts`.) The value
+ * arrives typed as present and genuinely `undefined`.
+ *
+ * The single assertion below is how a test states that: the declared type says
+ * the field is always there, and the whole point of this fixture is a runtime
+ * value that disagrees.
+ */
+function assistantMessageWithoutImageResolutions(
+  turnId: string,
+  timestamp: number,
+  blocks: ReadonlyArray<ContentBlock>,
+): Extract<Message, { role: "assistant" }> {
+  const preImage: Omit<
+    Extract<Message, { role: "assistant" }>,
+    "imageResolutions"
+  > = {
+    role: "assistant",
+    messageId: turnId,
+    sender: ASSISTANT_SENDER,
+    blocks: [...blocks],
+    startedAt: timestamp,
+    timestamp,
+    turnId,
+    usage: null,
+    reasoningEffort: null,
+    serviceTier: null,
+    // Deliberately no `imageResolutions` key.
+  };
+  return preImage as Extract<Message, { role: "assistant" }>;
+}
+
+describe("useRenderedMessages pre-image assistant records", () => {
+  it("projects a record whose imageResolutions the shallow snapshot path never filled", () => {
+    const source = "/generated/cat.png";
+    const assistant = assistantMessageWithoutImageResolutions(
+      "turn-pre-image",
+      2000,
+      [textBlock("text-1", 2001, `![cat](${source})`)],
+    );
+
+    // Before the fix this threw "Invalid value used as weak map key" out of
+    // `imageResolutionsIdentityToken` - `WeakMap.set(undefined, …)` - and the
+    // chat tile came down through its error boundary. Rendering at all is the
+    // regression guard; the assertions pin that it degrades to "no resolutions"
+    // rather than to a row that silently drops its prose.
+    const { result } = renderRenderedMessages({ messages: [assistant] });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.role).toBe("assistant");
+    expect(result.current[0]?.id).toContain("turn-pre-image");
+    const context = textSegmentContext(result.current[0]?.segments ?? []);
+    expect(context?.deduplicatedTargetsBySource.get(source)).toBeUndefined();
+  });
+
+  it("keeps a stable memo signature across re-renders when the field is absent", () => {
+    // `imageResolutionsIdentityToken` keys a WeakMap to build the memo
+    // signature, so the absent case has to resolve to ONE shared array. A fresh
+    // `[]` per read would mint a new identity on every projection, changing the
+    // signature each time and defeating the cache - a silent re-render loop
+    // rather than a crash, which is why it gets its own assertion.
+    const assistant = assistantMessageWithoutImageResolutions(
+      "turn-stable",
+      2000,
+      [textBlock("text-1", 2001, "Hello")],
+    );
+
+    const view = renderRenderedMessages({ messages: [assistant] });
+    const first = view.result.current;
+    view.patch({ runStatus: "idle" });
+
+    expect(view.result.current).toBe(first);
+  });
+});

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -2063,7 +2063,7 @@ function addAssistantMessageToAccumulator(
     addAssistantImageProjection(
       existing,
       message.blocks,
-      message.imageResolutions.map((entry) => ({
+      assistantImageResolutions(message).map((entry) => ({
         messageId: message.messageId,
         entry,
       })),
@@ -2111,7 +2111,7 @@ function addAssistantMessageToAccumulator(
   addAssistantImageProjection(
     created,
     message.blocks,
-    message.imageResolutions.map((entry) => ({
+    assistantImageResolutions(message).map((entry) => ({
       messageId: message.messageId,
       entry,
     })),
@@ -2247,6 +2247,54 @@ function blocksIdentityToken(blocks: ReadonlyArray<ContentBlock>): number {
   return blocksIdentityCounter;
 }
 
+/**
+ * The empty list every record without `imageResolutions` shares.
+ *
+ * One module-level array, deliberately not a fresh `[]` per call:
+ * `imageResolutionsIdentityToken` keys a WeakMap on this value to build a memo
+ * signature, so a new array per read would change that signature on every
+ * projection and defeat the cache it exists to feed.
+ *
+ * Distinct from `NO_IMAGE_RESOLUTIONS` below, which is the empty PROJECTION
+ * (`AssistantMarkdownImageResolution`, entries already paired with their owning
+ * message id). This one is the empty PERSISTED list a record carries.
+ */
+const NO_PERSISTED_IMAGE_RESOLUTIONS: AssistantMessage["imageResolutions"] = [];
+
+/**
+ * `imageResolutions` for a persisted assistant record, tolerating one that
+ * never carried the field.
+ *
+ * The type says it is always present, and for a record parsed off the wire it
+ * is. A snapshot on the live schema line takes `ChatStreamClient`'s SHALLOW
+ * parse path, which validates `chat.messages` with
+ * `z.custom<Message>(isStructuralRecord)` - a structural check only, so none of
+ * the zod defaults run and `imageResolutions: z.array(...).default([])` never
+ * fills. A host replaying a record stored before the field existed hands it
+ * straight through, typed as present and genuinely `undefined`. Reading it
+ * blind threw "Invalid value used as weak map key" out of
+ * `imageResolutionsIdentityToken` and took the whole chat tile down through its
+ * error boundary.
+ *
+ * The tolerance belongs here and not in the transport: the shallow path is
+ * structural by design - that is what makes it cheap - and a contract test in
+ * `chat-stream-client.test.ts` pins it to hand a live snapshot's message
+ * through structurally unchanged.
+ */
+function assistantImageResolutions(
+  message: AssistantMessage,
+): AssistantMessage["imageResolutions"] {
+  // Read through `unknown` deliberately. The declared field type is not
+  // optional, so annotating a local `| undefined` does not survive: TypeScript
+  // narrows a `const` to its initializer's type and `no-unnecessary-condition`
+  // then rejects the `??` as dead. `unknown` is the honest declaration here -
+  // the type system cannot express the runtime shape this guards against.
+  const resolutions: unknown = message.imageResolutions;
+  return Array.isArray(resolutions)
+    ? message.imageResolutions
+    : NO_PERSISTED_IMAGE_RESOLUTIONS;
+}
+
 let imageResolutionsIdentityCounter = 0;
 const imageResolutionsIdentity = new WeakMap<
   AssistantMessage["imageResolutions"],
@@ -2266,7 +2314,9 @@ function imageResolutionsIdentityToken(
 }
 
 function assistantRecordSignature(message: AssistantMessage): string {
-  const imageIdentity = imageResolutionsIdentityToken(message.imageResolutions);
+  const imageIdentity = imageResolutionsIdentityToken(
+    assistantImageResolutions(message),
+  );
   const version = message.blocksVersion;
   if (version !== undefined) {
     return `v:${version}#${blocksIdentityToken(message.blocks)}#i:${imageIdentity}`;


### PR DESCRIPTION
A chat tile could crash to its error boundary with `Invalid value used as weak map key`. Reported from the dev desktop app; the fix is lifted out of the host-lifecycle branch (#1243) so it can land on its own rather than waiting on that epic.

## The bug

A snapshot delivered on the live schema line takes `ChatStreamClient`'s **shallow** parse path, which validates `chat.messages` with `z.custom<Message>(isStructuralRecord)`. That is a structural check only — no zod defaults run, so `imageResolutions: z.array(...).default([])` never fills. A host replaying a record persisted before the field existed hands it straight through: typed as present, genuinely `undefined`.

`rendered-messages.ts` then keys a WeakMap on that value to build its memo signature, and `WeakMap.set(undefined, …)` throws. The whole chat tile comes down through its error boundary.

## The fix

Route the three persisted-record reads through `assistantImageResolutions()`, which falls back to one shared module-level empty array.

Sharing that array is load-bearing rather than tidiness: `imageResolutionsIdentityToken` keys a WeakMap on the value to build the memo signature, so a fresh `[]` per read would mint a new identity on every projection and defeat the cache — turning a visible crash into a silent re-render loop. There is a dedicated test for that property.

The live (`LiveAssistantMessage`) reads are deliberately left alone: that type is built in the renderer and its array is always real.

## Why here and not in the transport

An earlier attempt patched `ChatStreamClient` instead and had to rewrite a contract test to fit, which is backwards. The shallow path is structural **by design** — that is what makes it cheap — and `chat-stream-client.test.ts` pins it to hand a live snapshot's message through structurally unchanged. That test is untouched here; the tolerance belongs in the consumer that cannot accept the value.

## Verification

Two regression tests, both checked against the unfixed source — each fails with the exact `TypeError: Invalid value used as weak map key` this repairs, so they guard the behaviour rather than merely passing.

- `rendered-messages-assistant-images.test.tsx`: 14/14 pass
- `traycer-clients-gui-app:compile`: "Successfully ran target compile" (nx cache skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
