### PR TITLE
fix(gui-app): keep paused comm-graph playback static and auto-pan to senders

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-timeline.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-timeline.test.tsx
@@ -433,6 +433,21 @@ describe("CommGraphTile projection", () => {
     });
   });
 
+  it("keeps a held playback cursor static while paused", async () => {
+    await renderTile();
+    deliverSnapshot([
+      halfEdge({ id: 1, timestamp: 100 }),
+      message({ id: 2, timestamp: 200 }),
+    ]);
+
+    await seekToIndex(0);
+
+    await waitFor(() => {
+      expect(pulsingOf(CHAT_ID)).toBe("false");
+    });
+    expect(screen.getByRole("button", { name: "Play timeline" })).toBeDefined();
+  });
+
   it("pulses a row that ARRIVES while live, without flashing the initial snapshot", async () => {
     await renderTile();
     // The snapshot draws this host's initialization line; it is history this

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
@@ -178,7 +178,11 @@ function setCanvasSize(element: HTMLElement): void {
 }
 
 function playbackPulse(): CommGraphPulse {
-  return { kind: "agent", agentId: AGENT.id };
+  return { kind: "agent", agentId: AGENT.id, senderAgentId: AGENT.id };
+}
+
+function receiverOnlyPulse(senderAgentId: string): CommGraphPulse {
+  return { kind: "agent", agentId: AGENT.id, senderAgentId };
 }
 
 afterEach(() => {
@@ -233,6 +237,21 @@ describe("CommGraphCanvas viewport", () => {
         { zoom: 0.75, duration: 250 },
       );
     });
+  });
+
+  it("does not pan to the receiver when the sender is not rendered", () => {
+    const result = renderCanvas(DEFAULT_COMM_GRAPH_VIEW, {
+      playing: true,
+      pulse: receiverOnlyPulse("offscreen-sender"),
+    });
+    setCanvasSize(result.getByTestId("comm-graph-canvas"));
+    const { setCenter } = installFlowInstance({
+      x: -10_000,
+      y: -10_000,
+      zoom: 0.5,
+    });
+
+    expect(setCenter).not.toHaveBeenCalled();
   });
 
   it("does not move when the playback sender already intersects the viewport", () => {

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
@@ -16,10 +16,28 @@ vi.mock("@/lib/epic-selectors", () => ({
   useEpicAgentActivityTiers: () => new Map(),
 }));
 
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import type {
+  ReactFlowInstance,
+  ReactFlowProps,
+  Viewport,
+} from "@xyflow/react";
 import { CommGraphCanvas } from "@/components/epic-canvas/comm-graph/comm-graph-canvas";
+import type { CommGraphAgentFlowNode } from "@/components/epic-canvas/comm-graph/comm-graph-agent-node";
+import type { CommGraphFlowEdge } from "@/components/epic-canvas/comm-graph/comm-graph-edge";
+import {
+  COMM_GRAPH_NODE_HEIGHT,
+  COMM_GRAPH_NODE_WIDTH,
+} from "@/lib/comm-graph/comm-graph-layout";
 import type { CommGraphAgentNode } from "@/lib/comm-graph/comm-graph-model";
+import type { CommGraphPulse } from "@/lib/comm-graph/comm-graph-timeline";
 import { DEFAULT_COMM_GRAPH_VIEW } from "@/stores/epics/canvas/tile-schema/comm-graph-tile";
 import type { CommGraphTileViewState } from "@/stores/epics/canvas/types";
 
@@ -34,8 +52,15 @@ const AGENT: CommGraphAgentNode = {
   createdAt: 1,
 };
 
-function renderCanvas(view: CommGraphTileViewState): void {
-  render(
+interface RenderCanvasOptions {
+  readonly playing: boolean;
+  readonly pulse: CommGraphPulse | null;
+}
+
+const STATIC_CANVAS: RenderCanvasOptions = { playing: false, pulse: null };
+
+function canvas(view: CommGraphTileViewState, options: RenderCanvasOptions) {
+  return (
     <CommGraphCanvas
       epicId="epic-1"
       agents={[AGENT]}
@@ -43,7 +68,8 @@ function renderCanvas(view: CommGraphTileViewState): void {
       events={[]}
       hosts={[]}
       initialHistoryCaughtUp={false}
-      pulse={null}
+      playing={options.playing}
+      pulse={options.pulse}
       view={view}
       onViewChange={vi.fn()}
       canOpenAgentForEvent={() => true}
@@ -54,18 +80,116 @@ function renderCanvas(view: CommGraphTileViewState): void {
       canJumpToCreated={() => false}
       onJumpToCreated={vi.fn()}
       onOpenAgent={vi.fn()}
-    />,
+    />
   );
+}
+
+function renderCanvas(
+  view: CommGraphTileViewState,
+  options: RenderCanvasOptions,
+) {
+  return render(canvas(view, options));
+}
+
+function latestReactFlowProps(): ReactFlowProps<
+  CommGraphAgentFlowNode,
+  CommGraphFlowEdge
+> {
+  const props = reactFlowMock.mock.lastCall?.[0];
+  if (typeof props !== "object" || props === null) {
+    throw new Error("ReactFlow was not rendered");
+  }
+  return props;
+}
+
+function firstFlowNode(): CommGraphAgentFlowNode {
+  const nodes = latestReactFlowProps().nodes;
+  if (nodes === undefined || nodes.length === 0) {
+    throw new Error("Expected at least one comm-graph node");
+  }
+  return nodes[0];
+}
+
+type FlowSetCenter = ReactFlowInstance<
+  CommGraphAgentFlowNode,
+  CommGraphFlowEdge
+>["setCenter"];
+
+function createFlowInstanceStub(
+  viewport: Viewport,
+  setCenter: Mock<FlowSetCenter>,
+): ReactFlowInstance<CommGraphAgentFlowNode, CommGraphFlowEdge> {
+  const noop = vi.fn();
+  const noopArray = vi.fn((): CommGraphAgentFlowNode[] => []);
+  const noopEdges = vi.fn((): CommGraphFlowEdge[] => []);
+  return {
+    getViewport: vi.fn(() => viewport),
+    setCenter,
+    getNodes: noopArray,
+    setNodes: noop,
+    addNodes: noop,
+    getNode: vi.fn(() => undefined),
+    getInternalNode: vi.fn(() => undefined),
+    getEdges: noopEdges,
+    setEdges: noop,
+    addEdges: noop,
+    getEdge: vi.fn(() => undefined),
+    toObject: vi.fn(() => ({ nodes: [], edges: [], viewport })),
+    deleteElements: vi.fn(() =>
+      Promise.resolve({ deletedNodes: [], deletedEdges: [] }),
+    ),
+    getIntersectingNodes: noopArray,
+    isNodeIntersecting: vi.fn(() => false),
+    updateNode: noop,
+    updateNodeData: noop,
+    updateEdge: noop,
+    updateEdgeData: noop,
+    getNodesBounds: vi.fn(() => ({ x: 0, y: 0, width: 0, height: 0 })),
+    getHandleConnections: vi.fn(() => []),
+    getNodeConnections: vi.fn(() => []),
+    fitView: vi.fn(() => Promise.resolve(false)),
+    zoomIn: vi.fn(() => Promise.resolve(true)),
+    zoomOut: vi.fn(() => Promise.resolve(true)),
+    zoomTo: vi.fn(() => Promise.resolve(true)),
+    getZoom: vi.fn(() => viewport.zoom),
+    setViewport: vi.fn(() => Promise.resolve(true)),
+    fitBounds: vi.fn(() => Promise.resolve(true)),
+    screenToFlowPosition: vi.fn(() => ({ x: 0, y: 0 })),
+    flowToScreenPosition: vi.fn(() => ({ x: 0, y: 0 })),
+    viewportInitialized: true,
+  };
+}
+
+function installFlowInstance(viewport: Viewport): {
+  readonly setCenter: Mock<FlowSetCenter>;
+} {
+  const setCenter = vi.fn<FlowSetCenter>(() => Promise.resolve(true));
+  const instance = createFlowInstanceStub(viewport, setCenter);
+  act(() => {
+    latestReactFlowProps().onInit?.(instance);
+  });
+  return { setCenter };
+}
+
+function setCanvasSize(element: HTMLElement): void {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue(
+    DOMRect.fromRect({ width: 600, height: 400 }),
+  );
+}
+
+function playbackPulse(): CommGraphPulse {
+  return { kind: "agent", agentId: AGENT.id };
 }
 
 afterEach(() => {
   cleanup();
   reactFlowMock.mockClear();
+  vi.restoreAllMocks();
 });
 
 describe("CommGraphCanvas viewport", () => {
   it("fits every node on first open and permits a full-graph overview", () => {
-    renderCanvas(DEFAULT_COMM_GRAPH_VIEW);
+    renderCanvas(DEFAULT_COMM_GRAPH_VIEW, STATIC_CANVAS);
 
     expect(reactFlowMock.mock.lastCall?.[0]).toEqual(
       expect.objectContaining({
@@ -78,7 +202,7 @@ describe("CommGraphCanvas viewport", () => {
 
   it("restores a user-positioned viewport instead of fitting it again", () => {
     const persistedView = { x: 120, y: -80, zoom: 0.75 };
-    renderCanvas(persistedView);
+    renderCanvas(persistedView, STATIC_CANVAS);
 
     expect(reactFlowMock.mock.lastCall?.[0]).toEqual(
       expect.objectContaining({
@@ -87,5 +211,84 @@ describe("CommGraphCanvas viewport", () => {
         minZoom: 0.1,
       }),
     );
+  });
+
+  it("centers an offscreen playback sender without changing zoom", async () => {
+    const result = renderCanvas(DEFAULT_COMM_GRAPH_VIEW, {
+      playing: true,
+      pulse: playbackPulse(),
+    });
+    setCanvasSize(result.getByTestId("comm-graph-canvas"));
+    const sender = firstFlowNode();
+    const { setCenter } = installFlowInstance({
+      x: -10_000,
+      y: -10_000,
+      zoom: 0.75,
+    });
+
+    await waitFor(() => {
+      expect(setCenter).toHaveBeenCalledWith(
+        sender.position.x + COMM_GRAPH_NODE_WIDTH / 2,
+        sender.position.y + COMM_GRAPH_NODE_HEIGHT / 2,
+        { zoom: 0.75, duration: 250 },
+      );
+    });
+  });
+
+  it("does not move when the playback sender already intersects the viewport", () => {
+    const result = renderCanvas(DEFAULT_COMM_GRAPH_VIEW, {
+      playing: true,
+      pulse: playbackPulse(),
+    });
+    setCanvasSize(result.getByTestId("comm-graph-canvas"));
+    const sender = firstFlowNode();
+    const { setCenter } = installFlowInstance({
+      x: 100 - sender.position.x,
+      y: 100 - sender.position.y,
+      zoom: 1,
+    });
+
+    expect(setCenter).not.toHaveBeenCalled();
+  });
+
+  it("stops following after manual interaction and re-arms on the next Play", async () => {
+    const firstPulse = playbackPulse();
+    const result = renderCanvas(DEFAULT_COMM_GRAPH_VIEW, {
+      playing: true,
+      pulse: firstPulse,
+    });
+    const canvasElement = result.getByTestId("comm-graph-canvas");
+    setCanvasSize(canvasElement);
+    const { setCenter } = installFlowInstance({
+      x: -10_000,
+      y: -10_000,
+      zoom: 0.5,
+    });
+    await waitFor(() => {
+      expect(setCenter).toHaveBeenCalledTimes(1);
+    });
+    setCenter.mockClear();
+
+    fireEvent.pointerDown(canvasElement);
+    result.rerender(
+      canvas(DEFAULT_COMM_GRAPH_VIEW, {
+        playing: true,
+        pulse: playbackPulse(),
+      }),
+    );
+    expect(setCenter).not.toHaveBeenCalled();
+
+    result.rerender(
+      canvas(DEFAULT_COMM_GRAPH_VIEW, { playing: false, pulse: null }),
+    );
+    result.rerender(
+      canvas(DEFAULT_COMM_GRAPH_VIEW, {
+        playing: true,
+        pulse: playbackPulse(),
+      }),
+    );
+    await waitFor(() => {
+      expect(setCenter).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
@@ -10,12 +10,14 @@
  * just the cursor being live. The transport that MOVES the cursor is docked at
  * the bottom of this canvas.
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   Controls,
   ReactFlow,
+  type OnMove,
   type NodeMouseHandler,
+  type ReactFlowInstance,
   type Viewport,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -67,6 +69,7 @@ const EDGE_TYPES = { [COMM_GRAPH_EDGE_TYPE]: CommGraphEdgeView };
 const PRO_OPTIONS = { hideAttribution: true };
 // React Flow defaults to 0.5, which is too close for a wide agent graph to fit.
 const COMM_GRAPH_MIN_ZOOM = 0.1;
+const COMM_GRAPH_AUTO_PAN_MS = 250;
 
 /** Which detail surface the canvas has open, if any. */
 type CommGraphSelectedDetail =
@@ -91,6 +94,8 @@ export interface CommGraphCanvasProps {
   readonly hosts: ReadonlyArray<CommGraphHostState>;
   /** Every source has delivered its initial bounded history. */
   readonly initialHistoryCaughtUp: boolean;
+  /** Whether the detached timeline cursor is currently advancing. */
+  readonly playing: boolean;
   /** What the cursor event lights up, or null when it lights up nothing. */
   readonly pulse: CommGraphPulse | null;
   readonly view: CommGraphTileViewState;
@@ -132,6 +137,11 @@ function nodeHostStatus(
   return byHost.get(hostId) ?? "connecting";
 }
 
+function pulseSenderAgentId(pulse: CommGraphPulse | null): string | null {
+  if (pulse === null) return null;
+  return pulse.kind === "edge" ? pulse.fromAgentId : pulse.agentId;
+}
+
 export function CommGraphCanvas(props: CommGraphCanvasProps) {
   // ReactFlow must create its own provider from the computed nodes below. An
   // empty outer provider would make it reuse a store initialized before those
@@ -164,6 +174,7 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
     onJumpToSender,
     onOpenAgent,
     onViewChange,
+    playing,
     pulse,
     view,
   } = props;
@@ -171,6 +182,13 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
   // vice versa, so the canvas never has two competing explanations beside it.
   const [selectedDetail, setSelectedDetail] =
     useState<CommGraphSelectedDetail | null>(null);
+  const [flowInstance, setFlowInstance] = useState<ReactFlowInstance<
+    CommGraphAgentFlowNode,
+    CommGraphFlowEdge
+  > | null>(null);
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const autoPanEnabledRef = useRef(true);
+  const wasPlayingRef = useRef(playing);
   // React Flow paints its own chrome (background dots, zoom controls) outside
   // the Tailwind cascade, so it needs the resolved mode handed to it.
   const { resolvedTheme } = useResolvedTheme();
@@ -310,6 +328,59 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
     [aggregated, edgeInteraction, handleSelectEdge, travelFor],
   );
 
+  // Pressing Play is an explicit request to follow the action again. Pause
+  // leaves the current choice alone; only the next false -> true transition
+  // re-arms after a person has taken manual control of the canvas.
+  useEffect(() => {
+    if (playing && !wasPlayingRef.current) {
+      autoPanEnabledRef.current = true;
+    }
+    wasPlayingRef.current = playing;
+  }, [playing]);
+
+  const stopAutoPan = () => {
+    autoPanEnabledRef.current = false;
+  };
+  const handleMoveStart: OnMove = (event) => {
+    // React Flow uses `null` for programmatic viewport changes, including our
+    // own `setCenter`; a real interaction event means the person took over.
+    if (event !== null) stopAutoPan();
+  };
+
+  const senderAgentId = pulseSenderAgentId(pulse);
+  useEffect(() => {
+    if (
+      !playing ||
+      !autoPanEnabledRef.current ||
+      senderAgentId === null ||
+      flowInstance === null
+    ) {
+      return;
+    }
+    const canvas = canvasRef.current;
+    const sender = nodes.find((node) => node.id === senderAgentId);
+    if (canvas === null || sender === undefined) return;
+
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    const viewport = flowInstance.getViewport();
+    const left = sender.position.x * viewport.zoom + viewport.x;
+    const top = sender.position.y * viewport.zoom + viewport.y;
+    const right = left + COMM_GRAPH_NODE_WIDTH * viewport.zoom;
+    const bottom = top + COMM_GRAPH_NODE_HEIGHT * viewport.zoom;
+    const intersectsViewport =
+      right >= 0 && left <= rect.width && bottom >= 0 && top <= rect.height;
+    if (intersectsViewport) return;
+
+    void flowInstance.setCenter(
+      sender.position.x + COMM_GRAPH_NODE_WIDTH / 2,
+      sender.position.y + COMM_GRAPH_NODE_HEIGHT / 2,
+      { zoom: viewport.zoom, duration: COMM_GRAPH_AUTO_PAN_MS },
+    );
+    // `pulse` is intentionally a dependency even when two consecutive rows
+    // share a sender: every cursor step gets its own visibility decision.
+  }, [flowInstance, nodes, playing, pulse, senderAgentId]);
+
   const selectedEdge =
     selectedDetail?.kind === "pair"
       ? (aggregated.find((edge) => edge.id === selectedDetail.edgeId) ?? null)
@@ -355,7 +426,13 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
     // The canvas fills the tile: the timeline lives in the epic sidebar now, so
     // the only thing sharing this row is the edge click-through.
     <div className="flex h-full min-h-0 w-full min-w-0">
-      <div className="min-h-0 min-w-0 flex-1" data-testid="comm-graph-canvas">
+      <div
+        ref={canvasRef}
+        className="min-h-0 min-w-0 flex-1"
+        data-testid="comm-graph-canvas"
+        onPointerDownCapture={stopAutoPan}
+        onWheelCapture={stopAutoPan}
+      >
         <ReactFlow
           nodes={[...nodes]}
           edges={[...edges]}
@@ -367,6 +444,8 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
           // a persisted pan/zoom still restores exactly as the user left it.
           fitView={isDefaultView(view)}
           minZoom={COMM_GRAPH_MIN_ZOOM}
+          onInit={setFlowInstance}
+          onMoveStart={handleMoveStart}
           onMoveEnd={handleMoveEnd}
           // REQUIRED, and not merely as a tidier click path. React Flow's
           // `NodeWrapper` computes

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
@@ -139,7 +139,7 @@ function nodeHostStatus(
 
 function pulseSenderAgentId(pulse: CommGraphPulse | null): string | null {
   if (pulse === null) return null;
-  return pulse.kind === "edge" ? pulse.fromAgentId : pulse.agentId;
+  return pulse.kind === "edge" ? pulse.fromAgentId : pulse.senderAgentId;
 }
 
 export function CommGraphCanvas(props: CommGraphCanvasProps) {

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/use-comm-graph-timeline.ts
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/use-comm-graph-timeline.ts
@@ -12,8 +12,9 @@
  * too, so "an event frame arrived" says nothing about whether anything just
  * happened.
  *
- * PULSES HAVE TWO SOURCES, ONE PER MODE. While detached, the pulse is the row
- * the cursor is HELD on. While live there is no held row, so the pulse is
+ * PULSES HAVE TWO SOURCES, ONE PER MODE. During detached PLAYBACK, the pulse is
+ * the row the moving cursor is held on; pausing keeps the projection at that row
+ * but makes the canvas static. While live there is no held row, so the pulse is
  * ARRIVAL - and which row that is belongs to the subscription layer, which owns
  * the per-host initialization boundaries that define it
  * (`CommGraphSnapshot.lastArrival`). The projection hook only decides how long
@@ -36,13 +37,16 @@ import {
   commGraphPulseForEvent,
   type CommGraphPulse,
 } from "@/lib/comm-graph/comm-graph-timeline";
-import { useCommGraphCursor } from "@/stores/epics/comm-graph-timeline-store";
+import {
+  useCommGraphCursor,
+  useCommGraphPlaying,
+} from "@/stores/epics/comm-graph-timeline-store";
 
 /**
- * How long an arrival pulse stays lit in live mode. A held cursor pulses for as
- * long as it is held; an arrival has no such anchor, so it decays - otherwise
- * the newest row would sit lit indefinitely and read as "happening now" hours
- * after it happened.
+ * How long an arrival pulse stays lit in live mode. Playback pulses are anchored
+ * to each moving cursor step; an arrival has no such anchor, so it decays -
+ * otherwise the newest row would sit lit indefinitely and read as "happening
+ * now" hours after it happened.
  */
 const LIVE_PULSE_MS = 1_400;
 
@@ -55,6 +59,8 @@ export interface CommGraphTimelineProjection {
    * one fall back to `createdAt`.
    */
   readonly visibleAgentIds: ReadonlySet<string>;
+  /** Drives playback-only canvas behavior; live and paused are both false. */
+  readonly playing: boolean;
   readonly pulse: CommGraphPulse | null;
 }
 
@@ -70,6 +76,7 @@ export function useCommGraphTimelineProjection(
   lastArrival: CommGraphEvent | null,
 ): CommGraphTimelineProjection {
   const cursor = useCommGraphCursor(epicId);
+  const playing = useCommGraphPlaying(epicId);
 
   const asOfEvents = useMemo(
     () => commGraphEventsAsOfCursor(events, cursor),
@@ -109,18 +116,19 @@ export function useCommGraphTimelineProjection(
       : null;
 
   // The as-of prefix ends exactly on the cursor row when that row exists, so
-  // this is a tail check rather than another scan.
-  const heldPulseEvent = useMemo(() => {
-    if (cursor === null) return null;
-    if (asOfEvents.length === 0) return null;
+  // this is a tail check rather than another scan. A paused media transport
+  // freezes both progression and animation; retaining the held row only keeps
+  // the graph's as-of projection in place.
+  const heldPulseEvent = (() => {
+    if (cursor === null || !playing || asOfEvents.length === 0) return null;
     const last = asOfEvents[asOfEvents.length - 1];
     return commGraphCursorMatchesEvent(cursor, last) ? last : null;
-  }, [asOfEvents, cursor]);
+  })();
   const pulseEvent = cursor === null ? arrivalPulseEvent : heldPulseEvent;
   const pulse = useMemo(
     () => commGraphPulseForEvent(pulseEvent, visibleAgentIds),
     [pulseEvent, visibleAgentIds],
   );
 
-  return { asOfEvents, visibleAgentIds, pulse };
+  return { asOfEvents, visibleAgentIds, playing, pulse };
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/comm-graph-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/comm-graph-tile.tsx
@@ -82,6 +82,7 @@ export function CommGraphTile(props: CommGraphTileProps) {
           events={projection.asOfEvents}
           hosts={snapshot.hosts}
           initialHistoryCaughtUp={snapshot.initialHistoryCaughtUp}
+          playing={projection.playing}
           pulse={projection.pulse}
           view={node.view}
           onViewChange={handleViewChange}

--- a/clients/gui-app/src/lib/comm-graph/__tests__/comm-graph-timeline.test.ts
+++ b/clients/gui-app/src/lib/comm-graph/__tests__/comm-graph-timeline.test.ts
@@ -274,7 +274,21 @@ describe("commGraphPulseForEvent", () => {
         a2a({ id: 1, timestamp: 10, receiverAgentId: "outside" }),
         VISIBLE,
       ),
-    ).toEqual({ kind: "agent", agentId: "a" });
+    ).toEqual({ kind: "agent", agentId: "a", senderAgentId: "a" });
+  });
+
+  it("carries sender identity when only the receiver is on canvas", () => {
+    expect(
+      commGraphPulseForEvent(
+        a2a({
+          id: 1,
+          timestamp: 10,
+          senderAgentId: "outside",
+          receiverAgentId: "a",
+        }),
+        new Set(["a"]),
+      ),
+    ).toEqual({ kind: "agent", agentId: "a", senderAgentId: "outside" });
   });
 
   it("pulses nothing when neither endpoint is on the canvas", () => {

--- a/clients/gui-app/src/lib/comm-graph/__tests__/comm-graph-travel.test.ts
+++ b/clients/gui-app/src/lib/comm-graph/__tests__/comm-graph-travel.test.ts
@@ -45,7 +45,12 @@ describe("commGraphEdgeTravel", () => {
 
   it("is null for a node pulse - a half-edge has no path to travel", () => {
     expect(
-      commGraphEdgeTravel({ kind: "agent", agentId: "a" }, EDGE_ID, "a", "b"),
+      commGraphEdgeTravel(
+        { kind: "agent", agentId: "a", senderAgentId: "a" },
+        EDGE_ID,
+        "a",
+        "b",
+      ),
     ).toBeNull();
   });
 

--- a/clients/gui-app/src/lib/comm-graph/comm-graph-timeline.ts
+++ b/clients/gui-app/src/lib/comm-graph/comm-graph-timeline.ts
@@ -225,7 +225,12 @@ export type CommGraphPulse =
       readonly fromAgentId: string;
       readonly toAgentId: string;
     }
-  | { readonly kind: "agent"; readonly agentId: string };
+  | {
+      readonly kind: "agent";
+      readonly agentId: string;
+      /** Who sent the message — may differ from `agentId` on half-edges. */
+      readonly senderAgentId: string;
+    };
 
 function a2aPulseKind(event: CommGraphEvent): CommGraphPulseKind {
   if (event.kind === "a2a_notice") return "notice";
@@ -258,10 +263,14 @@ export function commGraphPulseForEvent(
     };
   }
   if (receiver !== null && visibleAgentIds.has(receiver)) {
-    return { kind: "agent", agentId: receiver };
+    return {
+      kind: "agent",
+      agentId: receiver,
+      senderAgentId: sender ?? receiver,
+    };
   }
   if (sender !== null && visibleAgentIds.has(sender)) {
-    return { kind: "agent", agentId: sender };
+    return { kind: "agent", agentId: sender, senderAgentId: sender };
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Pause stops the pulse animation on the communication graph canvas so playback stays visually static while paused.
- During playback, the viewport auto-pans to center offscreen senders (preserving zoom) until the user manually pans, zooms, or clicks the canvas; Play re-arms auto-pan.

## Test plan
- [x] `comm-graph-timeline.test.tsx` — paused cursor stays static (no held pulse)
- [x] `comm-graph-viewport.test.tsx` — offscreen sender centering, visible sender no-op, manual interaction disables follow until Play
- [ ] Manual: open comm graph playback, pause → no pulsing; play with offscreen sender → viewport follows; pan/zoom → follow stops; press Play again → follow resumes


Made with [Cursor](https://cursor.com)