### PR TITLE
fix(gui-app): close terminal authority review gaps

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-plain-terminal-tombstone-reconciler.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-plain-terminal-tombstone-reconciler.test.tsx
@@ -47,8 +47,10 @@ describe("EpicPlainTerminalTombstoneReconciler", () => {
     });
 
     const store = useEpicCanvasStore.getState();
-    const tabId = store.openEpicTab("epic-1", "Epic");
+    let openedTabId = "";
     act(() => {
+      const tabId = store.openEpicTab("epic-1", "Epic");
+      openedTabId = tabId;
       useEpicCanvasStore.setState((state) => ({
         closedTilePayloadsByTabId: {
           ...state.closedTilePayloadsByTabId,
@@ -86,6 +88,7 @@ describe("EpicPlainTerminalTombstoneReconciler", () => {
         },
       }));
     });
+    const tabId = openedTabId;
 
     await waitFor(() => {
       expect(

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-close-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-close-navigation.test.tsx
@@ -100,6 +100,7 @@ vi.mock("@/hooks/terminal/use-epic-terminal-authority", () => ({
     migrationPending: false,
     migrationError: null,
     retryMigration: () => undefined,
+    create: {},
     ensureRunning: {},
     rename: {},
     close: {},

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-report-issue.test.tsx
@@ -69,6 +69,7 @@ vi.mock("@/hooks/terminal/use-epic-terminal-authority", () => ({
     migrationPending: false,
     migrationError: null,
     retryMigration: () => undefined,
+    create: {},
     ensureRunning: {},
     rename: {},
     close: {},

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -545,6 +545,27 @@ describe("terminal sidebar Close", () => {
     expect(legacyRenameMutate).not.toHaveBeenCalled();
   });
 
+  it("disables sidebar rename for a capable host compatibility row while canMutate is false", () => {
+    durableAuthority.capability = "capable";
+    durableAuthority.canMutate = false;
+    durableAuthority.collectionIncludesSession = false;
+    const { getByTestId, queryByTestId } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+    );
+
+    const rename = getByTestId(`epic-terminal-sidebar-rename-${SESSION_ID}`);
+    expect(rename.getAttribute("disabled")).not.toBeNull();
+    fireEvent.click(rename);
+    fireEvent.doubleClick(
+      getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`),
+    );
+    expect(
+      queryByTestId(`epic-terminal-sidebar-rename-input-${SESSION_ID}`),
+    ).toBeNull();
+    expect(durableRenameMutate).not.toHaveBeenCalled();
+    expect(legacyRenameMutate).not.toHaveBeenCalled();
+  });
+
   it("keeps legacy rename for a capable host's compatibility row", () => {
     // Setup and provider-login shells stay `terminal.list` rows and never
     // enter the durable collection. The host still serves `terminal.rename`

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -545,6 +545,38 @@ describe("terminal sidebar Close", () => {
     expect(legacyRenameMutate).not.toHaveBeenCalled();
   });
 
+  it("keeps legacy rename for a capable host's compatibility row", () => {
+    // Setup and provider-login shells stay `terminal.list` rows and never
+    // enter the durable collection. The host still serves `terminal.rename`
+    // for them, so a capable host must not strand them with rename disabled.
+    durableAuthority.capability = "capable";
+    durableAuthority.canMutate = true;
+    durableAuthority.collectionIncludesSession = false;
+    const { getByTestId } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+    );
+
+    expect(
+      getByTestId(`epic-terminal-sidebar-rename-${SESSION_ID}`).getAttribute(
+        "disabled",
+      ),
+    ).toBeNull();
+    fireEvent.doubleClick(
+      getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`),
+    );
+    const input = getByTestId(
+      `epic-terminal-sidebar-rename-input-${SESSION_ID}`,
+    );
+    fireEvent.change(input, { target: { value: "Compatibility title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(legacyRenameMutate.mock.calls[0]?.[0]).toEqual({
+      sessionId: SESSION_ID,
+      title: "Compatibility title",
+    });
+    expect(durableRenameMutate).not.toHaveBeenCalled();
+  });
+
   it("retains legacy sidebar rename only for a positively known old host", () => {
     const { getByTestId } = render(
       wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
@@ -586,13 +618,6 @@ describe("terminal sidebar Close", () => {
       capability: "capable",
       canMutate: false,
       includesSession: true,
-      renamePending: false,
-    },
-    {
-      name: "missing fresh projection",
-      capability: "capable",
-      canMutate: true,
-      includesSession: false,
       renamePending: false,
     },
     {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-durable-projection.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-durable-projection.test.tsx
@@ -5,7 +5,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PlainTerminalProjection } from "@traycer/protocol/host/terminal/plain-schemas";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SnapshotLoadingProvider } from "@/components/epic-canvas/snapshots/snapshot-loading-context";
-import type { PlainTerminalCollection } from "@/lib/terminals/plain-terminal-authority";
+import {
+  replacePlainTerminalSnapshot,
+  setPlainTerminalStreamStatus,
+  settlePlainTerminalSnapshot,
+  type PlainTerminalCollection,
+} from "@/lib/terminals/plain-terminal-authority";
 
 const EPIC_ID = "epic-1";
 const HOST_ID = "host-1";
@@ -42,19 +47,12 @@ function epicRunningPlainTerminal(terminalId: string): PlainTerminalProjection {
 function freshPlainCollection(
   terminals: readonly PlainTerminalProjection[],
 ): PlainTerminalCollection {
-  return {
-    terminalsById: Object.fromEntries(
-      terminals.map((terminal) => [terminal.record.terminalId, terminal]),
+  return setPlainTerminalStreamStatus(
+    settlePlainTerminalSnapshot(
+      replacePlainTerminalSnapshot(undefined, terminals),
     ),
-    deletedRevisionById: {},
-    pendingPresentationDeletionRevisionById: {},
-    projectionSequence: 1,
-    snapshotEpoch: 1,
-    lastStreamSequenceById: {},
-    streamStatus: "open",
-    streamCompatibility: "compatible",
-    streamSnapshotFresh: true,
-  };
+    "open",
+  );
 }
 
 const durableCollection = vi.hoisted(() => ({

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -368,11 +368,11 @@ function resolveTerminalSidebarRenameMode(args: {
 }): TerminalSidebarRenameMode {
   if (args.capability === "legacy") return "legacy";
   if (args.capability !== "capable") return "disabled";
+  if (!args.canMutate) return "disabled";
   // A row with no durable projection is a `terminal.list` compatibility row
   // (setup / provider-login shell). The host still serves `terminal.rename`
   // for it, so keep the legacy path instead of disabling rename.
   if (!args.hasProjection) return "legacy";
-  if (!args.canMutate) return "disabled";
   return "capable";
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -367,9 +367,12 @@ function resolveTerminalSidebarRenameMode(args: {
   readonly hasProjection: boolean;
 }): TerminalSidebarRenameMode {
   if (args.capability === "legacy") return "legacy";
-  if (args.capability !== "capable" || !args.canMutate || !args.hasProjection) {
-    return "disabled";
-  }
+  if (args.capability !== "capable") return "disabled";
+  // A row with no durable projection is a `terminal.list` compatibility row
+  // (setup / provider-login shell). The host still serves `terminal.rename`
+  // for it, so keep the legacy path instead of disabling rename.
+  if (!args.hasProjection) return "legacy";
+  if (!args.canMutate) return "disabled";
   return "capable";
 }
 
@@ -652,7 +655,9 @@ function TerminalRow(props: TerminalRowProps) {
   };
   const rowMenuEntries = terminalRowMenuEntries({
     sessionId: session.sessionId,
-    closePending:
+    // Not a pending flag: it also encodes "not permitted" (unsupported future
+    // ref, unknown capability, no mutation authority).
+    closeDisabled:
       hasUnsupportedFutureRef ||
       closeCapability === "unknown" ||
       (closeCapability === "capable"
@@ -755,7 +760,7 @@ function TerminalRow(props: TerminalRowProps) {
 
 interface TerminalRowMenuEntriesProps {
   readonly sessionId: string;
-  readonly closePending: boolean;
+  readonly closeDisabled: boolean;
   readonly onStartRename: () => void;
   readonly renameDisabled: boolean;
   readonly onRequestClose: () => void;
@@ -785,7 +790,7 @@ function terminalRowMenuEntries(
       id: "close",
       label: "Close",
       icon: <Trash2 className="size-3.5" />,
-      disabled: props.closePending,
+      disabled: props.closeDisabled,
       disabledTooltip: null,
       variant: "destructive",
       testIds: {

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-bound-host-reconciliation.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-bound-host-reconciliation.test.tsx
@@ -167,13 +167,13 @@ describe("<LandingTerminalBoundHostReconciliationFleet />", () => {
     const importA = vi.fn(() => Promise.reject(new Error("wrong host")));
     const closeA = vi.fn(() => Promise.resolve());
     const closeB = vi.fn(() => Promise.resolve());
+    // Recorded rather than asserted inline: a thrown assertion inside the
+    // mock would surface as a rejected `importLegacy`, which the component
+    // reads as a host failure and reports much later as "importB not called
+    // once" instead of naming the field that broke.
+    const importBRequests: ImportLegacyPlainTerminalRequest[] = [];
     const importB = vi.fn((request: ImportLegacyPlainTerminalRequest) => {
-      expect(request).toMatchObject({
-        hostId: "host-b",
-        terminalId: "legacy-b",
-        cwd: "/legacy/b",
-        name: "Local B",
-      });
+      importBRequests.push(request);
       queryClient.setQueryData(
         hostQueryKeys.plainTerminals("host-b", SCOPE),
         freshCollection([hostBWinner, hostBDiscovered], undefined),
@@ -211,6 +211,12 @@ describe("<LandingTerminalBoundHostReconciliationFleet />", () => {
       expect(
         useLandingTerminalStore.getState().tabs.map((tab) => tab.sessionId),
       ).toEqual(["terminal-a", "legacy-b", "discovered-b"]);
+    });
+    expect(importBRequests[0]).toMatchObject({
+      hostId: "host-b",
+      terminalId: "legacy-b",
+      cwd: "/legacy/b",
+      name: "Local B",
     });
     let state = useLandingTerminalStore.getState();
     expect(state.tabs[1]).toMatchObject({

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-capable-reconciliation.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-capable-reconciliation.test.ts
@@ -303,6 +303,89 @@ describe("capable landing-terminal reconciliation", () => {
     expect(useLandingTerminalStore.getState().tabs).toEqual([]);
   });
 
+  it("returns snapshot-not-fresh before closing a pending kill against a stale collection", async () => {
+    const canonical = {
+      ...tab({
+        instanceId: "local-instance",
+        terminalId: "terminal-close",
+        name: "Host title",
+      }),
+      hostAuthorityAcknowledged: true,
+    };
+    const projection = terminal({
+      terminalId: "terminal-close",
+      manualTitle: "Host title",
+      revision: 3,
+      runtime: "running",
+    });
+    useLandingTerminalStore.getState().addTab(canonical);
+    useLandingTerminalStore
+      .getState()
+      .closeTab(LANDING_PAGE_ID, canonical.instanceId);
+    const tabsBefore = useLandingTerminalStore.getState().tabs;
+    const pendingKillsBefore = useLandingTerminalStore.getState().pendingKills;
+    queryClient.setQueryData(
+      hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
+      staleCollection([projection]),
+    );
+    const closeTerminal = vi.fn(() => Promise.resolve());
+
+    await expect(
+      reconcileCapableLandingTerminals({
+        activeHostId: HOST_ID,
+        landingPageId: LANDING_PAGE_ID,
+        capability: CAPABILITY,
+        canMutate: true,
+        closeTerminal,
+        importLegacyTerminal: () =>
+          Promise.reject(new Error("unexpected import")),
+        queryClient,
+      }),
+    ).resolves.toBe("snapshot-not-fresh");
+
+    expect(closeTerminal).not.toHaveBeenCalled();
+    expect(useLandingTerminalStore.getState().tabs).toEqual(tabsBefore);
+    expect(useLandingTerminalStore.getState().pendingKills).toEqual(
+      pendingKillsBefore,
+    );
+  });
+
+  it("returns snapshot-not-fresh before importing legacy evidence against a stale collection", async () => {
+    const legacy = tab({
+      instanceId: "local-instance",
+      terminalId: "terminal-1",
+      name: "Local title",
+    });
+    useLandingTerminalStore.getState().addTab(legacy);
+    const tabsBefore = useLandingTerminalStore.getState().tabs;
+    const pendingKillsBefore = useLandingTerminalStore.getState().pendingKills;
+    queryClient.setQueryData(
+      hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
+      staleCollection([]),
+    );
+    const importLegacy = vi.fn(() =>
+      Promise.reject(new Error("unexpected import")),
+    );
+
+    await expect(
+      reconcileCapableLandingTerminals({
+        activeHostId: HOST_ID,
+        landingPageId: LANDING_PAGE_ID,
+        capability: CAPABILITY,
+        canMutate: true,
+        closeTerminal: () => Promise.resolve(),
+        importLegacyTerminal: importLegacy,
+        queryClient,
+      }),
+    ).resolves.toBe("snapshot-not-fresh");
+
+    expect(importLegacy).not.toHaveBeenCalled();
+    expect(useLandingTerminalStore.getState().tabs).toEqual(tabsBefore);
+    expect(useLandingTerminalStore.getState().pendingKills).toEqual(
+      pendingKillsBefore,
+    );
+  });
+
   it("returns reconciled after a successful pass", async () => {
     queryClient.setQueryData(
       hostQueryKeys.plainTerminals(HOST_ID, SCOPE),

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-capable-reconciliation.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-capable-reconciliation.test.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ImportLegacyPlainTerminalRequest,
@@ -96,6 +97,20 @@ function staleCollection(
     replacePlainTerminalSnapshot(undefined, terminals),
     "open",
   );
+}
+
+function deferred<Value>(): {
+  readonly promise: Promise<Value>;
+  readonly resolve: (value: Value) => void;
+} {
+  let resolvePromise: ((value: Value) => void) | null = null;
+  const promise = new Promise<Value>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (value) => resolvePromise?.(value),
+  };
 }
 
 describe("capable landing-terminal reconciliation", () => {
@@ -384,6 +399,67 @@ describe("capable landing-terminal reconciliation", () => {
     expect(useLandingTerminalStore.getState().pendingKills).toEqual(
       pendingKillsBefore,
     );
+  });
+
+  it("does not import legacy evidence when freshness is lost during a pending close", async () => {
+    const canonical = {
+      ...tab({
+        instanceId: "canonical-instance",
+        terminalId: "terminal-close",
+        name: "Host title",
+      }),
+      hostAuthorityAcknowledged: true,
+    };
+    const legacy = tab({
+      instanceId: "legacy-instance",
+      terminalId: "terminal-import",
+      name: "Local title",
+    });
+    const projection = terminal({
+      terminalId: "terminal-close",
+      manualTitle: "Host title",
+      revision: 3,
+      runtime: "running",
+    });
+    const store = useLandingTerminalStore.getState();
+    store.addTab(canonical);
+    store.addTab(legacy);
+    store.closeTab(LANDING_PAGE_ID, canonical.instanceId);
+    queryClient.setQueryData(
+      hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
+      freshCollection([projection]),
+    );
+    const pendingClose = deferred<unknown>();
+    const closeTerminal = vi.fn(() => pendingClose.promise);
+    const importLegacy = vi.fn(() =>
+      Promise.reject(new Error("unexpected import")),
+    );
+
+    const reconciliation = reconcileCapableLandingTerminals({
+      activeHostId: HOST_ID,
+      landingPageId: LANDING_PAGE_ID,
+      capability: CAPABILITY,
+      canMutate: true,
+      closeTerminal,
+      importLegacyTerminal: importLegacy,
+      queryClient,
+    });
+    await waitFor(() => expect(closeTerminal).toHaveBeenCalledTimes(1));
+
+    queryClient.setQueryData(
+      hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
+      staleCollection([projection]),
+    );
+    pendingClose.resolve(undefined);
+
+    await expect(reconciliation).resolves.toBe("snapshot-not-fresh");
+    expect(importLegacy).not.toHaveBeenCalled();
+    expect(
+      useLandingTerminalStore
+        .getState()
+        .tabs.find((candidate) => candidate.instanceId === legacy.instanceId)
+        ?.hostAuthorityAcknowledged,
+    ).not.toBe(true);
   });
 
   it("returns reconciled after a successful pass", async () => {

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-capable-reconciliation.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-capable-reconciliation.test.ts
@@ -88,6 +88,16 @@ function freshCollection(
   );
 }
 
+/** An open stream that has not yet settled a snapshot in this connection episode. */
+function staleCollection(
+  terminals: readonly PlainTerminalProjection[],
+): PlainTerminalCollection {
+  return setPlainTerminalStreamStatus(
+    replacePlainTerminalSnapshot(undefined, terminals),
+    "open",
+  );
+}
+
 describe("capable landing-terminal reconciliation", () => {
   let queryClient: QueryClient;
 
@@ -269,5 +279,47 @@ describe("capable landing-terminal reconciliation", () => {
         hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
       )?.deletedRevisionById["terminal-1"],
     ).toBe(2);
+  });
+
+  it("returns snapshot-not-fresh instead of throwing while the stream has not settled", async () => {
+    queryClient.setQueryData(
+      hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
+      staleCollection([]),
+    );
+
+    await expect(
+      reconcileCapableLandingTerminals({
+        activeHostId: HOST_ID,
+        landingPageId: LANDING_PAGE_ID,
+        capability: CAPABILITY,
+        canMutate: true,
+        closeTerminal: () => Promise.resolve(),
+        importLegacyTerminal: () =>
+          Promise.reject(new Error("unexpected import")),
+        queryClient,
+      }),
+    ).resolves.toBe("snapshot-not-fresh");
+    // A wait, not a failure: nothing in the store should be touched.
+    expect(useLandingTerminalStore.getState().tabs).toEqual([]);
+  });
+
+  it("returns reconciled after a successful pass", async () => {
+    queryClient.setQueryData(
+      hostQueryKeys.plainTerminals(HOST_ID, SCOPE),
+      freshCollection([]),
+    );
+
+    await expect(
+      reconcileCapableLandingTerminals({
+        activeHostId: HOST_ID,
+        landingPageId: LANDING_PAGE_ID,
+        capability: CAPABILITY,
+        canMutate: true,
+        closeTerminal: () => Promise.resolve(),
+        importLegacyTerminal: () =>
+          Promise.reject(new Error("unexpected import")),
+        queryClient,
+      }),
+    ).resolves.toBe("reconciled");
   });
 });

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-durable-bootstrap.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-durable-bootstrap.test.ts
@@ -183,8 +183,12 @@ describe("durable landing-terminal bootstrap", () => {
     expect(adopt).toHaveBeenCalledTimes(1);
   });
 
-  it("does not loop on a stable dormant failure and retries explicitly", async () => {
-    const dispatch = vi.fn(() => Promise.reject(new Error("offline")));
+  it("retains the error presentation while an explicit retry is pending", async () => {
+    const retryRequest = deferred<PlainTerminalProjection>();
+    const dispatch = vi
+      .fn<() => Promise<PlainTerminalProjection>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockReturnValueOnce(retryRequest.promise);
     const rendered = renderHook(() =>
       useLandingTerminalDurableLifecycle({
         projectionStatus: "dormant",
@@ -204,6 +208,17 @@ describe("durable landing-terminal bootstrap", () => {
 
     act(() => rendered.result.current.retry());
     await waitFor(() => expect(dispatch).toHaveBeenCalledTimes(2));
+    expect(rendered.result.current.requestError?.message).toBe("offline");
+    expect(rendered.result.current.requestPending).toBe(true);
+
+    await act(() => {
+      retryRequest.resolve(projection("running"));
+      return Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(rendered.result.current.requestPending).toBe(false),
+    );
+    expect(rendered.result.current.requestError).toBeNull();
   });
 
   it("ignores stale responses after a runtime transition and unmount", async () => {

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-durable-bootstrap.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-durable-bootstrap.test.ts
@@ -153,6 +153,36 @@ describe("durable landing-terminal bootstrap", () => {
     await waitFor(() => expect(dispatch).toHaveBeenCalledTimes(2));
   });
 
+  it("exposes requestPending while a deferred dispatch is in flight and clears it after settlement", async () => {
+    const pending = deferred<PlainTerminalProjection>();
+    const dispatch = vi.fn(() => pending.promise);
+    const adopt = vi.fn();
+    const rendered = renderHook(() =>
+      useLandingTerminalDurableLifecycle({
+        projectionStatus: "dormant",
+        pendingCreate: false,
+        active: true,
+        canMutate: true,
+        gridReady: true,
+        dispatch,
+        adopt,
+      }),
+    );
+    await waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+    expect(rendered.result.current.requestPending).toBe(true);
+    expect(rendered.result.current.requestSettled).toBe(false);
+
+    await act(() => {
+      pending.resolve(projection("running"));
+      return Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(rendered.result.current.requestPending).toBe(false),
+    );
+    expect(rendered.result.current.requestSettled).toBe(true);
+    expect(adopt).toHaveBeenCalledTimes(1);
+  });
+
   it("does not loop on a stable dormant failure and retries explicitly", async () => {
     const dispatch = vi.fn(() => Promise.reject(new Error("offline")));
     const rendered = renderHook(() =>

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-error-retry.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-error-retry.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { LandingTerminalErrorState } from "@/components/home/terminal-panel/landing-terminal-tile";
+
+describe("LandingTerminalErrorState retry pending UX", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the Retry label and disables the button with an inline spinner while pending", () => {
+    const onRetry = vi.fn();
+    render(
+      <LandingTerminalErrorState
+        message="Could not start terminal."
+        isPending
+        onRetry={onRetry}
+      />,
+    );
+
+    screen.getByText("Could not start terminal.");
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toHaveProperty("disabled", true);
+    expect(
+      retry.querySelector('[data-testid="landing-terminal-retry-pending"]'),
+    ).not.toBeNull();
+    fireEvent.click(retry);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("invokes retry when the request is not pending", () => {
+    const onRetry = vi.fn();
+    render(
+      <LandingTerminalErrorState
+        message="Could not start terminal."
+        isPending={false}
+        onRetry={onRetry}
+      />,
+    );
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toHaveProperty("disabled", false);
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-error-retry.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-error-retry.test.tsx
@@ -1,10 +1,82 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { LandingTerminalErrorState } from "@/components/home/terminal-panel/landing-terminal-tile";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { LandingTerminalTabRef } from "@/stores/home/landing-terminal-store";
+
+const bootstrapState = vi.hoisted(() => ({
+  createIsError: true,
+  createIsPending: false,
+  createRetryIsPending: false,
+  createIsSuccess: false,
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => ({
+    status: "reachable",
+    hostLabel: "Host A",
+    unavailability: null,
+  }),
+}));
+
+vi.mock("@/hooks/agent/use-terminal-tile-bootstrap", () => ({
+  TerminalXtermHost: () => null,
+  MEASURE_GRID_TIMEOUT_MS: 100,
+  useTerminalTileBootstrap: () => ({
+    hostHasSession: false,
+    hostSessionExited: false,
+    handle: null,
+    createIsError: bootstrapState.createIsError,
+    createIsPending: bootstrapState.createIsPending,
+    createRetryIsPending: bootstrapState.createRetryIsPending,
+    createIsSuccess: bootstrapState.createIsSuccess,
+    createError: bootstrapState.createIsError
+      ? { message: "Could not start terminal." }
+      : null,
+    createRetryError: bootstrapState.createRetryIsPending
+      ? { message: "Could not start terminal." }
+      : null,
+    retry: () => {
+      bootstrapState.createIsError = false;
+      bootstrapState.createIsPending = true;
+      bootstrapState.createRetryIsPending = true;
+    },
+    reportMeasuredGrid: () => undefined,
+  }),
+}));
+
+vi.mock(
+  "@/components/epic-canvas/renderers/terminal-grid-measure-probe",
+  () => ({
+    TerminalGridMeasureProbe: () => null,
+  }),
+);
+
+import {
+  LandingTerminalErrorState,
+  LandingTerminalLegacyBootstrap,
+} from "@/components/home/terminal-panel/landing-terminal-tile";
+
+const TAB: LandingTerminalTabRef = {
+  instanceId: "instance-1",
+  sessionId: "terminal-1",
+  hostId: "host-a",
+  cwd: "/workspace/project",
+  name: "project",
+  titleSource: "default",
+};
 
 describe("LandingTerminalErrorState retry pending UX", () => {
   afterEach(() => {
     cleanup();
+    bootstrapState.createIsError = true;
+    bootstrapState.createIsPending = false;
+    bootstrapState.createRetryIsPending = false;
+    bootstrapState.createIsSuccess = false;
   });
 
   it("keeps the Retry label and disables the button with an inline spinner while pending", () => {
@@ -41,5 +113,55 @@ describe("LandingTerminalErrorState retry pending UX", () => {
     expect(retry).toHaveProperty("disabled", false);
     fireEvent.click(retry);
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the legacy caller's error surface mounted through retry settlement", async () => {
+    const rendered = render(
+      <LandingTerminalLegacyBootstrap
+        landingPageId="landing-1"
+        tab={TAB}
+        active
+        createEnabled
+        authorityEntry={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    rendered.rerender(
+      <LandingTerminalLegacyBootstrap
+        landingPageId="landing-1"
+        tab={TAB}
+        active
+        createEnabled
+        authorityEntry={null}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Retry" })).toHaveProperty(
+        "disabled",
+        true,
+      ),
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "Retry" })
+        .querySelector('[data-testid="landing-terminal-retry-pending"]'),
+    ).not.toBeNull();
+
+    bootstrapState.createIsPending = false;
+    bootstrapState.createRetryIsPending = false;
+    bootstrapState.createIsSuccess = true;
+    rendered.rerender(
+      <LandingTerminalLegacyBootstrap
+        landingPageId="landing-1"
+        tab={TAB}
+        active
+        createEnabled
+        authorityEntry={null}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull(),
+    );
   });
 });

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -784,3 +784,135 @@ describe("closeAllTabs", () => {
     ).toBe(true);
   });
 });
+
+describe("adoptHostTerminal", () => {
+  beforeEach(() => {
+    useLandingTerminalStore.getState().resetForTests();
+  });
+
+  it("rekeys a tab to the canonical terminal id returned by a capable host", () => {
+    useLandingTerminalStore.getState().addTab(
+      tab({
+        instanceId: "local",
+        sessionId: "legacy-evidence",
+        hostId: HOST_A,
+      }),
+    );
+    const canonical = plainTerminal({
+      terminalId: "canonical-terminal",
+      hostId: HOST_A,
+      launchCwd: "/host/launch",
+      manualTitle: "Host title",
+      runtime: {
+        status: "running",
+        currentCwd: "/host/live",
+        activeProcessName: "bun",
+      },
+    });
+
+    // Matched on instanceId + hostId only: importLegacy's canonical winner may
+    // carry a different terminalId than the legacy evidence sent, and this is
+    // exactly the pointer swap `adoptHostTerminal` must still perform.
+    useLandingTerminalStore.getState().adoptHostTerminal("local", canonical);
+
+    expect(useLandingTerminalStore.getState().tabs).toEqual([
+      {
+        instanceId: "local",
+        sessionId: "canonical-terminal",
+        hostId: HOST_A,
+        cwd: "/host/launch",
+        name: "Host title",
+        titleSource: "manual",
+        hostAuthorityAcknowledged: true,
+        pendingCreate: false,
+        sourceStoreVersion: 1,
+      },
+    ]);
+  });
+
+  it("leaves a tab bound to a different host untouched", () => {
+    const otherHostTab = tab({
+      instanceId: "local",
+      sessionId: "legacy-evidence",
+      hostId: HOST_B,
+    });
+    useLandingTerminalStore.getState().addTab(otherHostTab);
+    const canonical = plainTerminal({
+      terminalId: "canonical-terminal",
+      hostId: HOST_A,
+      launchCwd: "/host/launch",
+      manualTitle: null,
+      runtime: { status: "dormant" },
+    });
+
+    useLandingTerminalStore.getState().adoptHostTerminal("local", canonical);
+
+    expect(useLandingTerminalStore.getState().tabs).toEqual([otherHostTab]);
+  });
+});
+
+describe("reconcileHostAuthoritativeLandingTerminalTabs identity reuse", () => {
+  it("returns the original tab reference when acknowledged fields are unchanged", () => {
+    const seed = tab({
+      instanceId: "shared",
+      sessionId: "terminal-1",
+      hostId: HOST_A,
+    });
+    const projection = plainTerminal({
+      terminalId: "terminal-1",
+      hostId: HOST_A,
+      launchCwd: "/host/launch",
+      manualTitle: "Host title",
+      runtime: {
+        status: "running",
+        currentCwd: "/host/live",
+        activeProcessName: "bun",
+      },
+    });
+    const first = reconcileHostAuthoritativeLandingTerminalTabs({
+      tabs: [seed],
+      activeInstanceId: "shared",
+      hostId: HOST_A,
+      terminals: [projection],
+      excludedTerminalKeys: new Set(),
+      mintInstanceId: () => "unused",
+    }).tabs[0];
+
+    const second = reconcileHostAuthoritativeLandingTerminalTabs({
+      tabs: [first],
+      activeInstanceId: "shared",
+      hostId: HOST_A,
+      terminals: [projection],
+      excludedTerminalKeys: new Set(),
+      mintInstanceId: () => "unused",
+    });
+
+    // Stream frames bump `projectionSequence` constantly, so an object
+    // rebuilt on every pass would re-render every tab consumer for data that
+    // never actually changed.
+    expect(second.tabs[0]).toBe(first);
+
+    const renamed = plainTerminal({
+      terminalId: "terminal-1",
+      hostId: HOST_A,
+      launchCwd: "/host/launch",
+      manualTitle: "Renamed on host",
+      runtime: {
+        status: "running",
+        currentCwd: "/host/live",
+        activeProcessName: "bun",
+      },
+    });
+    const afterRename = reconcileHostAuthoritativeLandingTerminalTabs({
+      tabs: [first],
+      activeInstanceId: "shared",
+      hostId: HOST_A,
+      terminals: [renamed],
+      excludedTerminalKeys: new Set(),
+      mintInstanceId: () => "unused",
+    });
+
+    expect(afterRename.tabs[0]).not.toBe(first);
+    expect(afterRename.tabs[0]?.name).toBe("Renamed on host");
+  });
+});

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -1043,11 +1043,81 @@ describe("<LandingTerminalPanel />", () => {
     const plus = await screen.findByRole("button", { name: "New terminal" });
     expect(plus.getAttribute("aria-disabled")).toBe("true");
     fireEvent.click(plus);
-    fireEvent.click(screen.getByRole("button", { name: "Close Cached title" }));
+    const closeButton = screen.getByRole("button", {
+      name: "Close Cached title",
+    });
+    expect(
+      closeButton instanceof HTMLButtonElement && closeButton.disabled,
+    ).toBe(true);
+    fireEvent.click(closeButton);
 
     expect(useLandingTerminalStore.getState().tabs).toEqual([local]);
     expect(mocks.plainCloseAsync).not.toHaveBeenCalled();
     expect(mocks.kill).not.toHaveBeenCalled();
+  });
+
+  it("enables the close button once a capable host's authority is ready", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.clientActiveHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = emptyList("/Users/dev");
+    mocks.freshProbeData = mocks.probeData;
+    mocks.plainAuthorityStatus = "capable";
+    mocks.plainCanMutate = true;
+    const projection = plainTerminal({
+      terminalId: "terminal-ready",
+      manualTitle: "Ready title",
+      runtime: "running",
+    });
+    mocks.plainCollection = freshPlainCollection([projection]);
+    const local = {
+      instanceId: "ready-instance",
+      sessionId: "terminal-ready",
+      hostId: "host-a",
+      cwd: "/legacy",
+      name: "Legacy title",
+      titleSource: "manual" as const,
+      hostAuthorityAcknowledged: true,
+    };
+    useLandingTerminalStore.getState().addTab(local);
+    useLandingTerminalStore.getState().setPanelOpen(TEST_LANDING_PAGE_ID, true);
+    render(panelUi());
+
+    const closeButton = await screen.findByRole("button", {
+      name: "Close Ready title",
+    });
+    expect(
+      closeButton instanceof HTMLButtonElement && closeButton.disabled,
+    ).toBe(false);
+  });
+
+  it("blocks terminal creation while the host's capability probe is unresolved", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.clientActiveHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = emptyList("/Users/dev");
+    mocks.freshProbeData = mocks.probeData;
+    mocks.plainAuthorityStatus = "unknown";
+    useLandingTerminalStore.getState().setPanelOpen(TEST_LANDING_PAGE_ID, true);
+    render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    const plus = await screen.findByRole("button", { name: "New terminal" });
+    expect(plus.getAttribute("aria-disabled")).toBe("true");
+    fireEvent.click(plus);
+    // Bypasses the disabled "+" affordance: before the fix, every creation
+    // path funneled into `addTerminalTab` without consulting the host's
+    // authority readiness, so a chord could still persist a tab that looked
+    // exactly like legacy import evidence for a terminal never created on any
+    // host.
+    act(() => {
+      dispatchAction("tab.new", router);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(useLandingTerminalStore.getState().tabs).toHaveLength(0);
   });
 
   it("closes every terminal from the context menu, tombstoning before killing", async () => {

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-bound-host-reconciliation.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-bound-host-reconciliation.tsx
@@ -88,6 +88,11 @@ function LandingTerminalBoundHostReconciliation(props: {
     if (reconciliationRef.current === reconciliationKey) return;
     reconciliationRef.current = reconciliationKey;
     let disposed = false;
+    const releaseLatch = (): void => {
+      if (!disposed && reconciliationRef.current === reconciliationKey) {
+        reconciliationRef.current = null;
+      }
+    };
 
     void reconcileCapableLandingTerminals({
       activeHostId: hostId,
@@ -98,11 +103,16 @@ function LandingTerminalBoundHostReconciliation(props: {
       importLegacyTerminal: (request) =>
         entry.mutations.importLegacy.mutateAsync(request),
       queryClient,
-    }).catch(() => {
-      if (!disposed && reconciliationRef.current === reconciliationKey) {
-        reconciliationRef.current = null;
-      }
-    });
+    }).then(
+      (outcome) => {
+        // A non-fresh snapshot no longer rejects, so release the latch for it
+        // too - otherwise this key would stay claimed and the pass that the
+        // returning snapshot should re-run would be skipped.
+        if (outcome === "reconciled") return;
+        releaseLatch();
+      },
+      () => releaseLatch(),
+    );
 
     return () => {
       disposed = true;

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-durable-bootstrap.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-durable-bootstrap.ts
@@ -99,7 +99,6 @@ export function useLandingTerminalDurableLifecycle(args: {
     dispatchedEpisodeRef.current = episode;
     const requestGeneration = requestGenerationRef.current + 1;
     requestGenerationRef.current = requestGeneration;
-    setRequestError(null);
     setPendingRequestGenerations((current) => [...current, requestGeneration]);
     void dispatch(action).then(
       (terminal) => {
@@ -108,6 +107,7 @@ export function useLandingTerminalDurableLifecycle(args: {
         );
         if (requestGenerationRef.current !== requestGeneration) return;
         adopt(terminal);
+        setRequestError(null);
         setRequestSettled(true);
       },
       (error: unknown) => {
@@ -137,7 +137,6 @@ export function useLandingTerminalDurableLifecycle(args: {
     requestGenerationRef.current += 1;
     dispatchedEpisodeRef.current = null;
     setRequestSettled(false);
-    setRequestError(null);
     setRetryGeneration((current) => current + 1);
   };
 

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-durable-bootstrap.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-durable-bootstrap.ts
@@ -21,6 +21,7 @@ export function resolveLandingTerminalDurableBootstrapAction(input: {
 export interface LandingTerminalDurableLifecycleResult {
   readonly requestSettled: boolean;
   readonly requestError: Error | null;
+  readonly requestPending: boolean;
   readonly retry: () => void;
 }
 
@@ -57,6 +58,9 @@ export function useLandingTerminalDurableLifecycle(args: {
   const [retryGeneration, setRetryGeneration] = useState(0);
   const [requestSettled, setRequestSettled] = useState(false);
   const [requestError, setRequestError] = useState<Error | null>(null);
+  const [pendingRequestGenerations, setPendingRequestGenerations] = useState<
+    readonly number[]
+  >([]);
 
   useEffect(() => {
     if (canMutate) return;
@@ -96,13 +100,20 @@ export function useLandingTerminalDurableLifecycle(args: {
     const requestGeneration = requestGenerationRef.current + 1;
     requestGenerationRef.current = requestGeneration;
     setRequestError(null);
+    setPendingRequestGenerations((current) => [...current, requestGeneration]);
     void dispatch(action).then(
       (terminal) => {
+        setPendingRequestGenerations((current) =>
+          current.filter((generation) => generation !== requestGeneration),
+        );
         if (requestGenerationRef.current !== requestGeneration) return;
         adopt(terminal);
         setRequestSettled(true);
       },
       (error: unknown) => {
+        setPendingRequestGenerations((current) =>
+          current.filter((generation) => generation !== requestGeneration),
+        );
         if (requestGenerationRef.current !== requestGeneration) return;
         setRequestError(
           error instanceof Error
@@ -130,5 +141,6 @@ export function useLandingTerminalDurableLifecycle(args: {
     setRetryGeneration((current) => current + 1);
   };
 
-  return { requestSettled, requestError, retry };
+  const requestPending = pendingRequestGenerations.length > 0;
+  return { requestSettled, requestError, requestPending, retry };
 }

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -100,6 +100,29 @@ interface LandingTerminalDirectoryRequest {
   readonly selectedTarget: LandingTerminalTarget | null;
 }
 
+/**
+ * Whether this host's authority can back a tab mutation right now - the single
+ * predicate behind create, close, close-all, and rename.
+ *
+ * A missing or `"unknown"` entry means the capability probe has not answered,
+ * so neither branch of the tile lifecycle can be chosen yet; a `"capable"`
+ * host that cannot mutate has a stale or reconnecting list stream. `"legacy"`
+ * needs no stream - its tiles create and kill through the session RPCs.
+ *
+ * Creation gates on this too, and must: a tab persisted while the probe is
+ * unresolved lands as `hostAuthorityAcknowledged: false, pendingCreate: false`,
+ * which is precisely the shape of LEGACY evidence. The next capable pass then
+ * tries to `importLegacy` a terminal that was never created on any host.
+ */
+function landingTerminalAuthorityReady(
+  entry: LandingTerminalAuthorityEntry | null | undefined,
+): entry is LandingTerminalAuthorityEntry {
+  if (entry === null || entry === undefined) return false;
+  const capability = entry.authority.capability;
+  if (capability.status === "legacy") return true;
+  return capability.status === "capable" && entry.authority.canMutate;
+}
+
 function directoryRequestFor(
   target: LandingTerminalTarget,
   mode: LandingTerminalDirectoryRequestMode,
@@ -139,7 +162,7 @@ function settleDirectoryRequest(args: {
   readonly request: LandingTerminalDirectoryRequest | null;
   readonly generation: number;
   readonly context: LandingTerminalHostContext;
-  readonly addTerminalTab: (hostId: string, cwd: string) => string;
+  readonly addTerminalTab: (hostId: string, cwd: string) => string | null;
   readonly replaceDirectoryRequest: (
     request: LandingTerminalDirectoryRequest | null,
   ) => void;
@@ -175,7 +198,7 @@ function settleDirectoryRequest(args: {
 
   const shouldFocusTerminal = args.ownsFocus();
   const state = useLandingTerminalStore.getState();
-  let instanceId: string;
+  let instanceId: string | null;
   if (request.mode === "always-create") {
     instanceId = args.addTerminalTab(hostId, launchCwd);
   } else {
@@ -193,6 +216,18 @@ function settleDirectoryRequest(args: {
         state.activateTab(existing.instanceId);
       }
     }
+  }
+  // Creation refused: the host's authority went unready between this
+  // generation's reconciliation and its settlement. Surface the same
+  // recoverable state as an unusable target rather than consuming the
+  // selection silently - the picker stays up and the choice can be remade.
+  if (instanceId === null) {
+    args.replaceDirectoryRequest({
+      ...request,
+      selectedTarget: null,
+      error: "The terminal directory could not be opened.",
+    });
+    return true;
   }
   args.replaceDirectoryRequest(null);
   args.clearPending();
@@ -321,8 +356,16 @@ export function LandingTerminalPanel(): ReactNode {
     [landingPageId, setPanelMaximizedForPage],
   );
 
+  // The single creation point every path funnels through - the "+", the
+  // `app.terminal.new` / `tab.new` chords, the directory picker's settlement,
+  // and reconciliation's auto-spawn - so the authority gate lives here rather
+  // than being restated at each caller. `null` means "not created": the host's
+  // authority is not ready, and a tab written now would be indistinguishable
+  // from legacy evidence.
   const addTerminalTab = useCallback(
-    (hostId: string, cwd: string): string => {
+    (hostId: string, cwd: string): string | null => {
+      const authority = authorityEntries[hostId];
+      if (!landingTerminalAuthorityReady(authority)) return null;
       const instanceId = `landing-terminal-${uuidv4()}`;
       addTab({
         instanceId,
@@ -336,8 +379,7 @@ export function LandingTerminalPanel(): ReactNode {
         }),
         titleSource: "default",
         hostAuthorityAcknowledged: false,
-        pendingCreate:
-          authorityEntries[hostId]?.authority.capability.status === "capable",
+        pendingCreate: authority.authority.capability.status === "capable",
       });
       return instanceId;
     },
@@ -600,6 +642,13 @@ export function LandingTerminalPanel(): ReactNode {
         clearIfPending();
         return;
       }
+      // Creation can be refused (the host's authority went unready between
+      // this generation's reconciliation and its settlement), so the focus
+      // hand-off is conditional on a tab actually existing.
+      const spawnAndFocus = (focus: boolean): void => {
+        const created = addTerminalTab(context.hostId, launchCwd);
+        if (focus && created !== null) focusTerminalInstance(created);
+      };
       if (state.tabs.length === 0) {
         // Empty-panel auto-spawn is pinned to the opening draft. A gesture
         // spawns its captured draft; a gesture-less live settlement (post-clear,
@@ -610,8 +659,7 @@ export function LandingTerminalPanel(): ReactNode {
           clearIfPending();
           return;
         }
-        const created = addTerminalTab(context.hostId, launchCwd);
-        if (pending) focusTerminalInstance(created);
+        spawnAndFocus(pending);
         clearIfPending();
         return;
       }
@@ -623,8 +671,7 @@ export function LandingTerminalPanel(): ReactNode {
         launchCwd,
       );
       if (existing === undefined) {
-        const created = addTerminalTab(context.hostId, launchCwd);
-        focusTerminalInstance(created);
+        spawnAndFocus(true);
         clearIfPending();
         return;
       }
@@ -697,19 +744,21 @@ export function LandingTerminalPanel(): ReactNode {
     onSettled: handleReconciliationSettled,
   });
 
+  // One predicate for every tab mutation, so the affordance and the action it
+  // fires can never disagree. Before this, close silently no-oped behind an
+  // enabled button whenever authority was not ready, with nothing said.
+  const canMutateTab = useCallback(
+    (tab: LandingTerminalTabRef): boolean =>
+      landingTerminalAuthorityReady(authorityEntries[tab.hostId]),
+    [authorityEntries],
+  );
+
   const closeTerminalTab = useCallback(
     (tab: LandingTerminalTabRef) => {
       replaceDirectoryRequest(null);
       clearPending();
       const authorityEntry = authorityEntries[tab.hostId];
-      if (
-        authorityEntry === undefined ||
-        authorityEntry.authority.capability.status === "unknown" ||
-        (authorityEntry.authority.capability.status === "capable" &&
-          !authorityEntry.authority.canMutate)
-      ) {
-        return;
-      }
+      if (!landingTerminalAuthorityReady(authorityEntry)) return;
       const closed = closeTab(landingPageId, tab.instanceId);
       if (closed === null) return;
       if (authorityEntry.authority.capability.status === "capable") {
@@ -753,23 +802,13 @@ export function LandingTerminalPanel(): ReactNode {
     // durably tombstoned in one write before the first kill is dispatched.
     replaceDirectoryRequest(null);
     clearPending();
-    const closable = useLandingTerminalStore.getState().tabs.filter((tab) => {
-      const entry = authorityEntries[tab.hostId];
-      return (
-        entry?.authority.capability.status === "legacy" ||
-        (entry?.authority.capability.status === "capable" &&
-          entry.authority.canMutate)
-      );
-    });
+    const closable = useLandingTerminalStore
+      .getState()
+      .tabs.filter(canMutateTab);
     closable.forEach(closeTerminalTab);
     clearPendingTerminalFocus(null);
     focusActiveComposer();
-  }, [
-    clearPending,
-    authorityEntries,
-    closeTerminalTab,
-    replaceDirectoryRequest,
-  ]);
+  }, [canMutateTab, clearPending, closeTerminalTab, replaceDirectoryRequest]);
 
   const togglePanel = useCallback(() => {
     if (panelOpen) {
@@ -862,19 +901,15 @@ export function LandingTerminalPanel(): ReactNode {
       .tabs.find((entry) => entry.instanceId === instanceId);
     if (tab === undefined) return;
     const entry = authorityEntries[tab.hostId];
-    if (entry?.authority.capability.status === "legacy") {
+    if (!landingTerminalAuthorityReady(entry)) return;
+    if (entry.authority.capability.status === "legacy") {
       renameTab(instanceId, name);
       return;
     }
-    if (
-      entry?.authority.capability.status === "capable" &&
-      entry.authority.canMutate
-    ) {
-      entry.mutations.rename.mutate({
-        terminalId: tab.sessionId,
-        manualTitle: name.trim(),
-      });
-    }
+    entry.mutations.rename.mutate({
+      terminalId: tab.sessionId,
+      manualTitle: name.trim(),
+    });
   };
 
   return (
@@ -915,14 +950,8 @@ export function LandingTerminalPanel(): ReactNode {
           onCloseTab={closeTerminalTab}
           onCloseAllTabs={closeAllTerminalTabs}
           onRenameTab={renameTerminalTab}
-          canRenameTab={(tab) => {
-            const entry = authorityEntries[tab.hostId];
-            return (
-              entry?.authority.capability.status === "legacy" ||
-              (entry?.authority.capability.status === "capable" &&
-                entry.authority.canMutate)
-            );
-          }}
+          canRenameTab={canMutateTab}
+          canCloseTab={canMutateTab}
           authorityEntries={authorityEntries}
           terminalViewModels={terminalViewModels}
         />
@@ -958,6 +987,7 @@ interface LandingTerminalPanelContentsProps {
   readonly onCloseAllTabs: () => void;
   readonly onRenameTab: (instanceId: string, name: string) => void;
   readonly canRenameTab: (tab: LandingTerminalTabRef) => boolean;
+  readonly canCloseTab: (tab: LandingTerminalTabRef) => boolean;
   readonly authorityEntries: LandingTerminalAuthorityEntries;
   readonly terminalViewModels: Readonly<
     Partial<Record<string, PlainTerminalViewModel>>
@@ -1089,6 +1119,7 @@ function LandingTerminalPanelContents(
           onCloseAll={props.onCloseAllTabs}
           onRename={props.onRenameTab}
           canRename={props.canRenameTab}
+          canClose={props.canCloseTab}
           terminalViewModels={props.terminalViewModels}
         />
         <LandingTerminalPanelBody
@@ -1132,12 +1163,9 @@ function landingTerminalCreateDisabledReason(args: {
   if (args.availability !== "supported") {
     return "Connecting to the selected host…";
   }
-  if (
-    args.authority === null ||
-    args.authority.authority.capability.status === "unknown" ||
-    (args.authority.authority.capability.status === "capable" &&
-      !args.authority.authority.canMutate)
-  ) {
+  // Same predicate `addTerminalTab` enforces, so the "+" cannot look live for
+  // a host whose authority would refuse the create.
+  if (!landingTerminalAuthorityReady(args.authority)) {
     return "Connecting to the selected host…";
   }
   if (args.primaryWorkspacePath !== null) return null;

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -177,7 +177,13 @@ export function reconcileHostAuthoritativeLandingTerminalTabs(
       return [tab];
     }
     matchedTerminalIds.add(projection.record.terminalId);
-    return [hostAcknowledgedTab(tab, projection)];
+    const acknowledged = hostAcknowledgedTab(tab, projection);
+    // Reuse the existing reference when nothing derived actually moved, the
+    // same way the legacy pass above reuses `tab` on an unchanged name. Stream
+    // frames bump `projectionSequence` constantly, and every new object here
+    // becomes a fresh `tabs` array in the store - re-rendering every tab
+    // consumer and re-serializing the persisted slot for identical data.
+    return [landingTerminalTabsEqual(tab, acknowledged) ? tab : acknowledged];
   });
 
   const adoptedTabs = input.terminals.flatMap((terminal) => {
@@ -212,6 +218,29 @@ export function reconcileHostAuthoritativeLandingTerminalTabs(
     exitedInstanceIds: removedInstanceIds,
     collapseWhenEmpty: nextTabs.length === 0 && removedInstanceIds.length > 0,
   };
+}
+
+/**
+ * Every field `hostAcknowledgedTab` writes, plus the identity it preserves.
+ * Extend this together with that helper: a field compared here but not written
+ * there is harmless, one written there but missed here silently re-pins the
+ * stale value by reusing the old reference.
+ */
+function landingTerminalTabsEqual(
+  left: LandingTerminalTabRef,
+  right: LandingTerminalTabRef,
+): boolean {
+  return (
+    left.instanceId === right.instanceId &&
+    left.sessionId === right.sessionId &&
+    left.hostId === right.hostId &&
+    left.cwd === right.cwd &&
+    left.name === right.name &&
+    left.titleSource === right.titleSource &&
+    left.hostAuthorityAcknowledged === right.hostAuthorityAcknowledged &&
+    left.pendingCreate === right.pendingCreate &&
+    left.sourceStoreVersion === right.sourceStoreVersion
+  );
 }
 
 function defaultLandingTerminalTitle(

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tab-strip.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tab-strip.tsx
@@ -41,6 +41,12 @@ export interface LandingTerminalTabStripProps {
   readonly onCloseAll: () => void;
   readonly onRename: (instanceId: string, name: string) => void;
   readonly canRename: (tab: LandingTerminalTabRef) => boolean;
+  /**
+   * Whether this tab's host can currently be asked to close it. `onClose`
+   * refuses on its own when authority is not ready, so an always-enabled "x"
+   * was a control that swallowed the click and said nothing.
+   */
+  readonly canClose: (tab: LandingTerminalTabRef) => boolean;
   readonly terminalViewModels: Readonly<
     Partial<Record<string, PlainTerminalViewModel>>
   >;
@@ -60,6 +66,9 @@ export function LandingTerminalTabStrip(
 ): ReactNode {
   const { createDisabledReason, onAdd } = props;
   const canCreate = createDisabledReason === null;
+  // "Close All" closes only the tabs whose host can be asked to, so it is dead
+  // exactly when none of them can.
+  const canCloseAll = props.tabs.some(props.canClose);
   const handleStripDoubleClick = (event: MouseEvent<HTMLDivElement>): void => {
     if (!canCreate) return;
     // Only the empty strip background opens a terminal. A double-click that
@@ -91,6 +100,8 @@ export function LandingTerminalTabStrip(
               onCloseAll={props.onCloseAll}
               onRename={props.onRename}
               canRename={props.canRename(tab)}
+              canClose={props.canClose(tab)}
+              canCloseAll={canCloseAll}
               viewModel={props.terminalViewModels[tab.instanceId] ?? null}
             />
           ))}
@@ -173,6 +184,8 @@ function LandingTerminalTab(props: {
   readonly onCloseAll: () => void;
   readonly onRename: (instanceId: string, name: string) => void;
   readonly canRename: boolean;
+  readonly canClose: boolean;
+  readonly canCloseAll: boolean;
   readonly viewModel: PlainTerminalViewModel | null;
 }): ReactNode {
   const { tab, active, onActivate, onRename } = props;
@@ -256,6 +269,7 @@ function LandingTerminalTab(props: {
             variant="ghost"
             size="icon-sm"
             aria-label={`Close ${displayName}`}
+            disabled={!props.canClose}
             className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
             onClick={(event) => {
               event.stopPropagation();
@@ -275,10 +289,18 @@ function LandingTerminalTab(props: {
           Rename
         </ContextMenuItem>
         <ContextMenuSeparator />
-        <ContextMenuItem onSelect={() => props.onClose(tab)}>
+        <ContextMenuItem
+          disabled={!props.canClose}
+          onSelect={() => props.onClose(tab)}
+        >
           Close
         </ContextMenuItem>
-        <ContextMenuItem onSelect={props.onCloseAll}>Close All</ContextMenuItem>
+        <ContextMenuItem
+          disabled={!props.canCloseAll}
+          onSelect={props.onCloseAll}
+        >
+          Close All
+        </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
@@ -196,19 +196,10 @@ function LandingTerminalLegacyBootstrap(
   }
   if (bootstrap.createIsError) {
     return (
-      <div className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-3 bg-canvas p-4 text-center text-ui-sm text-destructive">
-        <span>
-          {bootstrap.createError?.message ?? "Could not start terminal."}
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={bootstrap.retry}
-        >
-          Retry
-        </Button>
-      </div>
+      <LandingTerminalErrorState
+        message={bootstrap.createError?.message ?? "Could not start terminal."}
+        onRetry={bootstrap.retry}
+      />
     );
   }
   if (bootstrap.handle === null) {
@@ -256,10 +247,10 @@ function LandingTerminalDurableBootstrap(
     readonly rows: number;
   } | null>(null);
   const [measureTimedOut, setMeasureTimedOut] = useState(false);
-  const reportMeasuredGrid = (cols: number, rows: number): void => {
+  const reportMeasuredGrid = useCallback((cols: number, rows: number): void => {
     if (cols <= 0 || rows <= 0) return;
     setMeasuredGrid({ cols, rows });
-  };
+  }, []);
 
   useEffect(() => {
     if (measuredGrid !== null || measureTimedOut) return;
@@ -277,28 +268,49 @@ function LandingTerminalDurableBootstrap(
       rows: TERMINAL_DEFAULT_ROWS,
     };
   const runtimeRunning = projection?.runtime.status === "running";
-  const dispatch = async (action: "create" | "ensure-running") => {
-    const response =
-      action === "create"
-        ? await entry.mutations.create.mutateAsync({
-            terminalId: props.tab.sessionId,
-            scope: INDEPENDENT_SCOPE,
-            cwd: props.tab.cwd,
-            cols: openingGrid.cols,
-            rows: openingGrid.rows,
-          })
-        : await entry.mutations.ensureRunning.mutateAsync({
-            terminalId: props.tab.sessionId,
-            cols: openingGrid.cols,
-            rows: openingGrid.rows,
-          });
-    return response.terminal;
-  };
-  const adopt = (terminal: PlainTerminalProjection): void => {
-    useLandingTerminalStore
-      .getState()
-      .adoptHostTerminal(props.tab.instanceId, terminal);
-  };
+  // Memoized because `useLandingTerminalDurableLifecycle` lists both in its
+  // effect deps: fresh identities every render re-run that effect on every
+  // render, leaving its dispatched-episode ref as the only thing standing
+  // between a re-render and a duplicate create. `mutateAsync` is referentially
+  // stable (the authority fleet already depends on it that way), so the real
+  // inputs are the request fields.
+  const createTerminal = entry.mutations.create.mutateAsync;
+  const ensureTerminalRunning = entry.mutations.ensureRunning.mutateAsync;
+  const dispatch = useCallback(
+    async (action: "create" | "ensure-running") => {
+      const response =
+        action === "create"
+          ? await createTerminal({
+              terminalId: props.tab.sessionId,
+              scope: INDEPENDENT_SCOPE,
+              cwd: props.tab.cwd,
+              cols: openingGrid.cols,
+              rows: openingGrid.rows,
+            })
+          : await ensureTerminalRunning({
+              terminalId: props.tab.sessionId,
+              cols: openingGrid.cols,
+              rows: openingGrid.rows,
+            });
+      return response.terminal;
+    },
+    [
+      createTerminal,
+      ensureTerminalRunning,
+      openingGrid.cols,
+      openingGrid.rows,
+      props.tab.cwd,
+      props.tab.sessionId,
+    ],
+  );
+  const adopt = useCallback(
+    (terminal: PlainTerminalProjection): void => {
+      useLandingTerminalStore
+        .getState()
+        .adoptHostTerminal(props.tab.instanceId, terminal);
+    },
+    [props.tab.instanceId],
+  );
   const lifecycle = useLandingTerminalDurableLifecycle({
     projectionStatus:
       projection === undefined ? "missing" : projection.runtime.status,
@@ -364,22 +376,27 @@ function LandingTerminalDurableState(props: {
   }
   if (
     props.reachability.status === "checking" ||
-    props.reachability.status === "host-starting" ||
-    !props.canMutate
+    props.reachability.status === "host-starting"
   ) {
     return <LandingTerminalWaiting />;
   }
   if (props.requestError !== null) {
     return (
-      <div className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-3 bg-canvas p-4 text-center text-ui-sm text-destructive">
-        <span>{props.requestError.message}</span>
-        <Button type="button" variant="outline" size="sm" onClick={props.retry}>
-          Retry
-        </Button>
-      </div>
+      <LandingTerminalErrorState
+        message={props.requestError.message}
+        onRetry={props.retry}
+      />
     );
   }
   if (props.handle === null) {
+    // `canMutate` tracks LIST-STREAM freshness, not terminal liveness - the
+    // authority hook drops it on every `reconnecting` status and restores it
+    // only once a fresh snapshot lands. Gating the whole tile on it swapped a
+    // running terminal (and the input focus in it) for a skeleton on each
+    // reconnect, which the legacy branch never does. It only means "cannot
+    // dispatch a mutation yet", so it belongs here, where there is nothing to
+    // tear down.
+    if (!props.canMutate) return <LandingTerminalWaiting />;
     return (
       <div className="relative flex h-full min-h-0 w-full flex-col bg-canvas">
         <div className="relative min-h-0 flex-1">
@@ -513,6 +530,25 @@ function LandingTerminalTileLive(props: {
           />
         </Suspense>
       </div>
+    </div>
+  );
+}
+
+/**
+ * The tile replaced by a failed start and its retry. Shared by the legacy and
+ * durable branches so the two failures stay one visual state - only the
+ * message source differs.
+ */
+function LandingTerminalErrorState(props: {
+  readonly message: string;
+  readonly onRetry: () => void;
+}): ReactNode {
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-3 bg-canvas p-4 text-center text-ui-sm text-destructive">
+      <span>{props.message}</span>
+      <Button type="button" variant="outline" size="sm" onClick={props.onRetry}>
+        Retry
+      </Button>
     </div>
   );
 }

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
@@ -113,7 +113,7 @@ function LandingTerminalTileBody(props: LandingTerminalTileProps): ReactNode {
   return <LandingTerminalWaiting />;
 }
 
-function LandingTerminalLegacyBootstrap(
+export function LandingTerminalLegacyBootstrap(
   props: LandingTerminalTileProps,
 ): ReactNode {
   const removeExitedTab = useLandingTerminalStore(
@@ -195,11 +195,15 @@ function LandingTerminalLegacyBootstrap(
     // this tile used to render the dead state for both.
     return <LandingTerminalWaiting />;
   }
-  if (bootstrap.createIsError) {
+  if (bootstrap.createIsError || bootstrap.createRetryIsPending) {
     return (
       <LandingTerminalErrorState
-        message={bootstrap.createError?.message ?? "Could not start terminal."}
-        isPending={bootstrap.createIsPending}
+        message={
+          bootstrap.createRetryError?.message ??
+          bootstrap.createError?.message ??
+          "Could not start terminal."
+        }
+        isPending={bootstrap.createRetryIsPending}
         onRetry={bootstrap.retry}
       />
     );

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
@@ -27,6 +27,7 @@ import type {
 import type { TerminalScope } from "@traycer/protocol/host/terminal/unary-schemas";
 import type { PlainTerminalProjection } from "@traycer/protocol/host/terminal/plain-schemas";
 import { Button } from "@/components/ui/button";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import type { HostUnavailability } from "@traycer-clients/shared/host-client/remote-fetcher";
 import {
   useHostReachability,
@@ -198,6 +199,7 @@ function LandingTerminalLegacyBootstrap(
     return (
       <LandingTerminalErrorState
         message={bootstrap.createError?.message ?? "Could not start terminal."}
+        isPending={bootstrap.createIsPending}
         onRetry={bootstrap.retry}
       />
     );
@@ -343,6 +345,7 @@ function LandingTerminalDurableBootstrap(
       reachability={reachability}
       canMutate={entry.authority.canMutate}
       requestError={lifecycle.requestError}
+      requestPending={lifecycle.requestPending}
       retry={lifecycle.retry}
       handle={handle}
       tab={props.tab}
@@ -360,6 +363,7 @@ function LandingTerminalDurableState(props: {
   readonly reachability: HostReachability;
   readonly canMutate: boolean;
   readonly requestError: Error | null;
+  readonly requestPending: boolean;
   readonly retry: () => void;
   readonly handle: TerminalSessionStoreHandle | null;
   readonly tab: LandingTerminalTabRef;
@@ -384,6 +388,7 @@ function LandingTerminalDurableState(props: {
     return (
       <LandingTerminalErrorState
         message={props.requestError.message}
+        isPending={props.requestPending}
         onRetry={props.retry}
       />
     );
@@ -539,14 +544,28 @@ function LandingTerminalTileLive(props: {
  * durable branches so the two failures stay one visual state - only the
  * message source differs.
  */
-function LandingTerminalErrorState(props: {
+export function LandingTerminalErrorState(props: {
   readonly message: string;
+  readonly isPending: boolean;
   readonly onRetry: () => void;
 }): ReactNode {
   return (
     <div className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-3 bg-canvas p-4 text-center text-ui-sm text-destructive">
       <span>{props.message}</span>
-      <Button type="button" variant="outline" size="sm" onClick={props.onRetry}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={props.isPending}
+        onClick={props.onRetry}
+      >
+        {props.isPending ? (
+          <AgentSpinningDots
+            className="shrink-0"
+            testId="landing-terminal-retry-pending"
+            variant={undefined}
+          />
+        ) : null}
         Retry
       </Button>
     </div>

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -248,34 +248,46 @@ export function useLandingTerminalReconciliation(
       const initial = useLandingTerminalStore.getState();
 
       if (plainAuthority.authority.capability.status === "capable") {
+        // A read-only authority is a reconnecting list stream, not a failed
+        // fetch. `onError` clears the picker's selected target and reports
+        // "The terminal directory could not be opened.", which is simply
+        // untrue here - and destroys a directory choice the user must then
+        // make again. The reconciliation latch keys on `canMutate`, so this
+        // pass re-runs by itself the moment mutability returns.
         if (!plainAuthority.authority.canMutate) {
-          onError();
           releaseLatch();
           return;
         }
-        const reconciled = await reconcileCapableLandingTerminals({
-          activeHostId,
-          landingPageId,
-          capability: plainAuthority.authority.capability,
-          canMutate: plainAuthority.authority.canMutate,
-          closeTerminal: (request) =>
-            plainAuthority.mutations.close.mutateAsync(request),
-          importLegacyTerminal: (request) =>
-            plainAuthority.mutations.importLegacy.mutateAsync(request),
-          queryClient,
-        }).then(
-          () => true,
-          () => false,
-        );
+        const outcome: CapableLandingTerminalReconciliationOutcome | "failed" =
+          await reconcileCapableLandingTerminals({
+            activeHostId,
+            landingPageId,
+            capability: plainAuthority.authority.capability,
+            canMutate: plainAuthority.authority.canMutate,
+            closeTerminal: (request) =>
+              plainAuthority.mutations.close.mutateAsync(request),
+            importLegacyTerminal: (request) =>
+              plainAuthority.mutations.importLegacy.mutateAsync(request),
+            queryClient,
+          }).then(
+            (settled) => settled,
+            (): "failed" => "failed",
+          );
+        // Same reasoning as the read-only guard above: a snapshot that went
+        // non-fresh mid-pass is a wait, not a fetch failure, and only a real
+        // rejection may surface the directory error.
+        if (outcome !== "reconciled") {
+          if (outcome === "failed") onError();
+          releaseLatch();
+          return;
+        }
         if (
-          !reconciled ||
           reconciliationGenerationIsStale(
             controller.signal,
             client,
             activeHostId,
           )
         ) {
-          if (!reconciled) onError();
           releaseLatch();
           return;
         }
@@ -366,6 +378,15 @@ export function useLandingTerminalReconciliation(
   ]);
 }
 
+/**
+ * `"snapshot-not-fresh"` is a wait, not a failure: the list stream is
+ * reconnecting or its snapshot has been invalidated, so this pass has nothing
+ * authoritative to classify against and the next fresh projection re-runs it.
+ * Genuine failures (a rejected close or import) still reject.
+ */
+export type CapableLandingTerminalReconciliationOutcome =
+  "reconciled" | "snapshot-not-fresh";
+
 export async function reconcileCapableLandingTerminals(args: {
   readonly activeHostId: string;
   readonly landingPageId: string;
@@ -378,7 +399,7 @@ export async function reconcileCapableLandingTerminals(args: {
     request: ImportLegacyPlainTerminalRequest,
   ) => Promise<ImportLegacyPlainTerminalResponse>;
   readonly queryClient: QueryClient;
-}): Promise<void> {
+}): Promise<CapableLandingTerminalReconciliationOutcome> {
   const { activeHostId, queryClient } = args;
   const queryKey = hostQueryKeys.plainTerminals(
     activeHostId,
@@ -475,7 +496,7 @@ export async function reconcileCapableLandingTerminals(args: {
   const collection =
     queryClient.getQueryData<PlainTerminalCollection>(queryKey);
   if (collection?.streamSnapshotFresh !== true) {
-    throw new Error("Landing terminal authority snapshot is not fresh");
+    return "snapshot-not-fresh";
   }
   const current = useLandingTerminalStore.getState();
   const excludedTerminalKeys = new Set(
@@ -497,4 +518,5 @@ export async function reconcileCapableLandingTerminals(args: {
     reconciliation.activeInstanceId,
     reconciliation.collapseWhenEmpty,
   );
+  return "reconciled";
 }

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -428,6 +428,12 @@ export async function reconcileCapableLandingTerminals(args: {
     }),
   );
 
+  const postKillCollection =
+    queryClient.getQueryData<PlainTerminalCollection>(queryKey);
+  if (postKillCollection?.streamSnapshotFresh !== true) {
+    return "snapshot-not-fresh";
+  }
+
   const legacyTabs = useLandingTerminalStore
     .getState()
     .tabs.filter(

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -405,6 +405,11 @@ export async function reconcileCapableLandingTerminals(args: {
     activeHostId,
     INDEPENDENT_SCOPE,
   );
+  const initialCollection =
+    queryClient.getQueryData<PlainTerminalCollection>(queryKey);
+  if (initialCollection?.streamSnapshotFresh !== true) {
+    return "snapshot-not-fresh";
+  }
   const store = useLandingTerminalStore.getState();
   const pendingKills = store.pendingKills.filter(
     (pending) => pending.hostId === activeHostId,

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host-tombstone-restore.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host-tombstone-restore.test.tsx
@@ -131,17 +131,19 @@ describe("<TopLevelTabHost /> evicted epic tombstone restore", () => {
     expect(useEpicCanvasStore.getState().openTabOrder).toContain("epic-0");
 
     const evictedTabId = "epic-0";
-    useEpicCanvasStore.setState((state) => ({
-      canvasByTabId: {
-        ...state.canvasByTabId,
-        [evictedTabId]: {
-          root: pane("pane-0", []),
-          activePaneId: "pane-0",
-          tilesByInstanceId: {},
-          sizesByGroupId: {},
+    act(() => {
+      useEpicCanvasStore.setState((state) => ({
+        canvasByTabId: {
+          ...state.canvasByTabId,
+          [evictedTabId]: {
+            root: pane("pane-0", []),
+            activePaneId: "pane-0",
+            tilesByInstanceId: {},
+            sizesByGroupId: {},
+          },
         },
-      },
-    }));
+      }));
+    });
     expect(
       commitPlainTerminalDeletion({
         queryClient,
@@ -180,16 +182,18 @@ describe("<TopLevelTabHost /> evicted epic tombstone restore", () => {
       titleSource: "manual",
       cwd: "/other",
     };
-    useEpicCanvasStore.setState((state) => ({
-      closedTilePayloadsByTabId: {
-        ...state.closedTilePayloadsByTabId,
-        [evictedTabId]: {
-          [legacy.instanceId]: { node: legacy, pendingCreate: false },
-          [future.instanceId]: { node: future, pendingCreate: false },
-          [otherId.instanceId]: { node: otherId, pendingCreate: false },
+    act(() => {
+      useEpicCanvasStore.setState((state) => ({
+        closedTilePayloadsByTabId: {
+          ...state.closedTilePayloadsByTabId,
+          [evictedTabId]: {
+            [legacy.instanceId]: { node: legacy, pendingCreate: false },
+            [future.instanceId]: { node: future, pendingCreate: false },
+            [otherId.instanceId]: { node: otherId, pendingCreate: false },
+          },
         },
-      },
-    }));
+      }));
+    });
     expect(
       useEpicCanvasStore.getState().closedTilePayloadsByTabId[evictedTabId]?.[
         legacy.instanceId
@@ -202,7 +206,7 @@ describe("<TopLevelTabHost /> evicted epic tombstone restore", () => {
       1,
     );
     vi.spyOn(history, "go").mockImplementation(() => {});
-    goBack({ history });
+    act(() => goBack({ history }));
 
     expect(
       useEpicCanvasStore.getState().canvasByTabId[evictedTabId]

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -2334,24 +2334,11 @@ describe("ResourceMonitorPopover", () => {
 
   it("cannot reopen a resource owner after terminal invalidation prunes its closed payload", async () => {
     routerMock.pathname = "/epics/epic-1/tab-1";
-    canvasMock.state.closedTilePayloadsByTabId["tab-closed"] = {
-      "tile-term-tombstoned": {
-        node: {
-          id: "term-tombstoned",
-          instanceId: "tile-term-tombstoned",
-          type: "terminal",
-          name: "Tombstoned Build",
-          titleSource: "manual",
-          hostId: "host-1",
-          cwd: "/work/background",
-        },
-        pendingCreate: false,
-      },
-    };
-    Reflect.deleteProperty(
-      canvasMock.state.closedTilePayloadsByTabId["tab-closed"] ?? {},
-      "tile-term-tombstoned",
-    );
+    // The canvas store is mocked here, so the real invalidation fanout cannot
+    // reach it. Terminal invalidation having already pruned the tile's closed
+    // payload is the precondition under test - stated directly rather than
+    // written and then deleted, which read as pruning but was a no-op pair.
+    canvasMock.state.closedTilePayloadsByTabId["tab-closed"] = {};
     const stub = installStubFactory();
     renderPopover();
 

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -123,6 +123,7 @@ import {
   type DesktopAppResourceUsage,
 } from "@/lib/resources/desktop-app-resource-usage";
 import { queryClient } from "@/lib/query-client";
+import type { PlainTerminalCollection } from "@/lib/terminals/plain-terminal-authority";
 import {
   rejectClosedPlainTerminalRestore,
   retainedPlainTerminalTombstoneBlocksClosedRestore,
@@ -1248,7 +1249,13 @@ function ResourceMonitorPanel(props: {
     ],
   );
 
-  const canvasIndex = useMemo(() => buildCanvasResourceIndex(canvas), [canvas]);
+  const tombstoneEvidence = usePlainTerminalTombstoneEvidence();
+  const canvasIndex = useMemo(() => {
+    // Not read by the builder directly - it is the Query-side input the
+    // builder's tombstone gate reads, so the index has to re-derive with it.
+    void tombstoneEvidence;
+    return buildCanvasResourceIndex(canvas);
+  }, [canvas, tombstoneEvidence]);
   const recordByOwner = useMemo(() => buildRecordByOwner(canvas), [canvas]);
   const epicTitleById = useMemo(() => buildEpicTitleById(tasks), [tasks]);
   const taskRows = useMemo(
@@ -3938,6 +3945,51 @@ function filterOwnerProcessRowsForSearch(
     rootRows: includeRoots ? rows : processRows.rootRows,
     canExpand: rows.length > 0,
   };
+}
+
+/**
+ * Retained-tombstone evidence that `buildCanvasResourceIndex` consults through
+ * `retainedPlainTerminalTombstoneBlocksClosedRestore`. It lives in Query, not
+ * in the canvas snapshot, so the index has to observe it separately: a
+ * tombstone that arrives before its presentation fanout leaves the closed-tile
+ * row visible while `openResourceOwner` already rejects it, which reads to the
+ * user as a click that does nothing. Only the tombstoned ids and the live
+ * revision that could overtake them are folded in, so an ordinary projection
+ * tick does not churn the index.
+ */
+function plainTerminalTombstoneEvidence(): string {
+  const parts: string[] = [];
+  for (const [queryKey, collection] of queryClient.getQueriesData<
+    PlainTerminalCollection | undefined
+  >({
+    predicate: (query) => query.queryKey[2] === "terminal.plain.list",
+  })) {
+    if (collection === undefined) continue;
+    for (const [terminalId, revision] of Object.entries(
+      collection.deletedRevisionById,
+    )) {
+      const live = collection.terminalsById[terminalId]?.record.revision ?? -1;
+      parts.push(
+        `${String(queryKey[1])}:${terminalId}:${String(revision)}:${String(live)}`,
+      );
+    }
+  }
+  return parts.sort().join("|");
+}
+
+function subscribeToPlainTerminalTombstones(
+  onStoreChange: () => void,
+): () => void {
+  return queryClient.getQueryCache().subscribe(onStoreChange);
+}
+
+function usePlainTerminalTombstoneEvidence(): string {
+  // A string snapshot, so an unrelated cache event re-derives it but does not
+  // re-render. This panel only mounts while the popover is open.
+  return useSyncExternalStore(
+    subscribeToPlainTerminalTombstones,
+    plainTerminalTombstoneEvidence,
+  );
 }
 
 function buildCanvasResourceIndex(

--- a/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
+++ b/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
@@ -137,8 +137,13 @@ export interface TerminalTileBootstrapResult {
   readonly handle: TerminalSessionStoreHandle | null;
   readonly createIsError: boolean;
   readonly createIsPending: boolean;
+  readonly createRetryIsPending: boolean;
   readonly createIsSuccess: boolean;
   readonly createError: {
+    readonly message?: string;
+    readonly code?: string;
+  } | null;
+  readonly createRetryError: {
     readonly message?: string;
     readonly code?: string;
   } | null;
@@ -163,6 +168,10 @@ export function useTerminalTileBootstrap(
   const hostClient = useHostClientFor(hostEntry);
   const list = useTerminalList(input.scope, hostClient);
   const create = useTerminalCreate(hostClient);
+  const [createRetryError, setCreateRetryError] = useState<{
+    readonly message?: string;
+    readonly code?: string;
+  } | null>(null);
 
   // Measure-before-subscribe state. `measuredGrid` holds the probe's latest
   // report (last write wins - the freshest measurement should seed the
@@ -318,22 +327,29 @@ export function useTerminalTileBootstrap(
           measuredGrid ??
           peekXtermHostGrid(input.instanceId) ??
           peekXtermHostGridForSession(input.sessionId);
-        createMutateRef.current({
-          scope: input.scope,
-          sessionKind: input.sessionKind,
-          tuiHarnessId: payload.tuiHarnessId,
-          desiredSessionId: input.sessionId,
-          cols: openingGrid !== null ? openingGrid.cols : TERMINAL_DEFAULT_COLS,
-          rows: openingGrid !== null ? openingGrid.rows : TERMINAL_DEFAULT_ROWS,
-          cwd: payload.cwd,
-          shellCommand: payload.shellCommand,
-          shellArgs: payload.shellArgs === null ? null : [...payload.shellArgs],
-          worktreeBusyPaths: [...payload.worktreeBusyPaths],
-        });
+        createMutateRef.current(
+          {
+            scope: input.scope,
+            sessionKind: input.sessionKind,
+            tuiHarnessId: payload.tuiHarnessId,
+            desiredSessionId: input.sessionId,
+            cols:
+              openingGrid !== null ? openingGrid.cols : TERMINAL_DEFAULT_COLS,
+            rows:
+              openingGrid !== null ? openingGrid.rows : TERMINAL_DEFAULT_ROWS,
+            cwd: payload.cwd,
+            shellCommand: payload.shellCommand,
+            shellArgs:
+              payload.shellArgs === null ? null : [...payload.shellArgs],
+            worktreeBusyPaths: [...payload.worktreeBusyPaths],
+          },
+          { onSettled: () => setCreateRetryError(null) },
+        );
       })
       .catch(() => {
         // The upstream prepare hook surfaces the error via its own state;
         // keep the latch closed so we do not retry without `retry()`.
+        setCreateRetryError(null);
       });
   }, [
     enabled,
@@ -401,6 +417,7 @@ export function useTerminalTileBootstrap(
   const resetPrepare = input.resetPrepare;
   const retry = useCallback(() => {
     hasDispatchedRef.current = false;
+    setCreateRetryError(create.error);
     create.reset();
     if (resetPrepare !== undefined) resetPrepare();
     void list.refetch();
@@ -412,8 +429,10 @@ export function useTerminalTileBootstrap(
     handle,
     createIsError: create.isError,
     createIsPending: create.isPending,
+    createRetryIsPending: createRetryError !== null,
     createIsSuccess: create.isSuccess,
     createError: create.error,
+    createRetryError,
     retry,
     reportMeasuredGrid,
   };

--- a/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
+++ b/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
@@ -136,6 +136,7 @@ export interface TerminalTileBootstrapResult {
   readonly hostSessionExited: boolean;
   readonly handle: TerminalSessionStoreHandle | null;
   readonly createIsError: boolean;
+  readonly createIsPending: boolean;
   readonly createIsSuccess: boolean;
   readonly createError: {
     readonly message?: string;
@@ -410,6 +411,7 @@ export function useTerminalTileBootstrap(
     hostSessionExited,
     handle,
     createIsError: create.isError,
+    createIsPending: create.isPending,
     createIsSuccess: create.isSuccess,
     createError: create.error,
     retry,

--- a/clients/gui-app/src/hooks/providers/__tests__/use-provider-terminal-login.test.tsx
+++ b/clients/gui-app/src/hooks/providers/__tests__/use-provider-terminal-login.test.tsx
@@ -257,23 +257,21 @@ describe("useProviderTerminalLogin", () => {
     });
     unmount();
 
-    await act(async () => {
-      pending.resolve({
-        sessionId: "term-new",
-        replacedSessionId: OLD_TERMINAL.id,
-      });
-      await Promise.resolve();
-      await Promise.resolve();
+    pending.resolve({
+      sessionId: "term-new",
+      replacedSessionId: OLD_TERMINAL.id,
     });
 
-    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
-    if (canvas === undefined) throw new Error("expected view tab canvas");
-    expect(canvas.tilesByInstanceId[OLD_TERMINAL.instanceId]).toBeUndefined();
-    expect(
-      Object.values(canvas.tilesByInstanceId).some(
-        (tile) => tile?.type === "terminal" && tile.id === "term-new",
-      ),
-    ).toBe(true);
+    await waitFor(() => {
+      const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+      if (canvas === undefined) throw new Error("expected view tab canvas");
+      expect(canvas.tilesByInstanceId[OLD_TERMINAL.instanceId]).toBeUndefined();
+      expect(
+        Object.values(canvas.tilesByInstanceId).some(
+          (tile) => tile?.type === "terminal" && tile.id === "term-new",
+        ),
+      ).toBe(true);
+    });
   });
 
   // Row 4b: "Start again" on a dead sign-in tile passes its OWN tile as

--- a/clients/gui-app/src/hooks/terminal/use-epic-terminal-authority.ts
+++ b/clients/gui-app/src/hooks/terminal/use-epic-terminal-authority.ts
@@ -111,6 +111,14 @@ export function useEpicTerminalAuthority(args: {
           },
         },
       )
+      .then((outcome) => {
+        // A later automatic re-run that reaches a conclusion retires the
+        // earlier failure, so the tile does not keep rendering a resolved
+        // error until the user presses Retry. A `preserved` outcome made no
+        // attempt, so it leaves the previous error standing.
+        if (disposed || outcome.status === "preserved") return;
+        setMigrationError(null);
+      })
       .catch((error: unknown) => {
         if (disposed) return;
         setMigrationError(

--- a/clients/gui-app/src/hooks/terminal/use-plain-terminal-authority.ts
+++ b/clients/gui-app/src/hooks/terminal/use-plain-terminal-authority.ts
@@ -40,7 +40,6 @@ import {
 } from "@/lib/host/stream-runtime-context";
 import { hostQueryKeys } from "@/lib/query-keys/host-query-keys";
 import {
-  PLAIN_TERMINAL_RPC_METHODS,
   PLAIN_TERMINAL_STREAM_METHOD,
   capturePlainTerminalProjectionBarrier,
   markPlainTerminalStreamIncompatible,
@@ -56,6 +55,7 @@ import {
   type PlainTerminalCapability,
   type PlainTerminalCollection,
   type PlainTerminalProjectionBarrier,
+  type PlainTerminalRpcMethod,
 } from "@/lib/terminals/plain-terminal-authority";
 import {
   acknowledgedPlainTerminalPresentationIdsForScope,
@@ -112,11 +112,13 @@ function pushHostEpicPresentationId(args: {
   readonly instanceId: string;
   readonly ref: EpicCanvasTileRef | null | undefined;
   readonly hostId: string;
+  readonly tombstonedIds: ReadonlySet<string>;
 }): void {
   if (
     args.ref?.type === "terminal" &&
     !isUnsupportedEpicTerminalRef(args.ref) &&
-    args.ref.hostId === args.hostId
+    args.ref.hostId === args.hostId &&
+    args.tombstonedIds.has(args.ref.id)
   ) {
     args.ids.push(
       `${args.prefix}:${args.tabId}:${args.instanceId}:${args.ref.id}`,
@@ -124,10 +126,21 @@ function pushHostEpicPresentationId(args: {
   }
 }
 
-function epicPresentationSignatureForHost(
+/**
+ * Change token for the retained-tombstone sweep, not a general presentation
+ * signature. The sweep can only ever act on a tombstoned id, so the token
+ * ignores every other ref - and short-circuits entirely while no tombstone is
+ * retained, which is the steady state. That keeps this out of the hot path:
+ * a Zustand selector runs on every store commit, including the pane-focus,
+ * layout and tile-state commits that have nothing to do with terminals, and
+ * every mounted authority in the cohort pays for it.
+ */
+function epicTombstonePresentationTokenForHost(
   hostId: string,
+  tombstonedIds: ReadonlySet<string>,
   state: Pick<EpicCanvasStore, "canvasByTabId" | "closedTilePayloadsByTabId">,
 ): string {
+  if (tombstonedIds.size === 0) return "";
   const ids: string[] = [];
   for (const [tabId, canvas] of Object.entries(state.canvasByTabId)) {
     for (const [instanceId, ref] of Object.entries(
@@ -140,6 +153,7 @@ function epicPresentationSignatureForHost(
         instanceId,
         ref,
         hostId,
+        tombstonedIds,
       });
     }
   }
@@ -154,18 +168,21 @@ function epicPresentationSignatureForHost(
         instanceId,
         ref: payload?.node,
         hostId,
+        tombstonedIds,
       });
     }
   }
   return ids.sort().join("|");
 }
 
-function landingPresentationSignatureForHost(
+function landingTombstonePresentationTokenForHost(
   hostId: string,
+  tombstonedIds: ReadonlySet<string>,
   tabs: readonly LandingTerminalTabRef[],
 ): string {
+  if (tombstonedIds.size === 0) return "";
   return tabs
-    .filter((tab) => tab.hostId === hostId)
+    .filter((tab) => tab.hostId === hostId && tombstonedIds.has(tab.sessionId))
     .map((tab) => `${tab.instanceId}:${tab.sessionId}`)
     .sort()
     .join("|");
@@ -183,11 +200,20 @@ function useRetainedPlainTerminalTombstoneReconciliation(args: {
     Readonly<Partial<Record<string, number>>> | undefined;
 }): void {
   const queryClient = useQueryClient();
-  const epicSignature = useEpicCanvasStore((state) =>
-    epicPresentationSignatureForHost(args.hostId, state),
+  const deletedRevisionById = args.deletedRevisionById;
+  const tombstonedIds = useMemo(
+    () => new Set(Object.keys(deletedRevisionById ?? {})),
+    [deletedRevisionById],
   );
-  const landingSignature = useLandingTerminalStore((state) =>
-    landingPresentationSignatureForHost(args.hostId, state.tabs),
+  const epicToken = useEpicCanvasStore((state) =>
+    epicTombstonePresentationTokenForHost(args.hostId, tombstonedIds, state),
+  );
+  const landingToken = useLandingTerminalStore((state) =>
+    landingTombstonePresentationTokenForHost(
+      args.hostId,
+      tombstonedIds,
+      state.tabs,
+    ),
   );
   useEffect(() => {
     reconcileRetainedPlainTerminalTombstones({
@@ -200,8 +226,8 @@ function useRetainedPlainTerminalTombstoneReconciliation(args: {
     args.queryKey,
     args.hostId,
     args.deletedRevisionById,
-    epicSignature,
-    landingSignature,
+    epicToken,
+    landingToken,
   ]);
 }
 
@@ -342,17 +368,22 @@ export function usePlainTerminalAuthority(args: {
     args.hostId,
     "terminal.plain.importLegacy",
   );
-  const versions: Readonly<Record<string, SchemaVersion | null>> = {
-    [PLAIN_TERMINAL_RPC_METHODS[0]]: createVersion,
-    [PLAIN_TERMINAL_RPC_METHODS[1]]: listVersion,
-    [PLAIN_TERMINAL_RPC_METHODS[2]]: renameVersion,
-    [PLAIN_TERMINAL_RPC_METHODS[3]]: ensureVersion,
-    [PLAIN_TERMINAL_RPC_METHODS[4]]: closeVersion,
-    [PLAIN_TERMINAL_RPC_METHODS[5]]: importVersion,
+  // Keyed by method-name literal so a reorder or extension of
+  // `PLAIN_TERMINAL_RPC_METHODS` cannot silently bind a version to the wrong
+  // method. `PlainTerminalRpcMethod` keeps the map exhaustive at compile time.
+  const versions: Readonly<
+    Record<PlainTerminalRpcMethod, SchemaVersion | null>
+  > = {
+    "terminal.plain.create": createVersion,
+    "terminal.plain.list": listVersion,
+    "terminal.plain.rename": renameVersion,
+    "terminal.plain.ensureRunning": ensureVersion,
+    "terminal.plain.close": closeVersion,
+    "terminal.plain.importLegacy": importVersion,
   };
   const unaryCapability = resolvePlainTerminalCapability({
     manifestKnown: listSupport !== null,
-    versionFor: (method) => versions[method] ?? null,
+    versionFor: (method) => versions[method],
   });
 
   useHostCapabilityProbe({
@@ -552,6 +583,7 @@ export function usePlainTerminalAuthority(args: {
                   queryClient,
                   queryKey,
                   hostId: args.hostId,
+                  scope: stableScope,
                   terminalId,
                   snapshotEpoch: pending.snapshotEpoch,
                 });

--- a/clients/gui-app/src/hooks/terminal/use-plain-terminal-mutations.ts
+++ b/clients/gui-app/src/hooks/terminal/use-plain-terminal-mutations.ts
@@ -122,7 +122,7 @@ export function usePlainTerminalMutations(args: {
       onSuccess: (response, _request, captured) => {
         writeCanonicalTerminal(queryClient, {
           hostId: captured.hostId,
-          scope: response.terminal.record.scope,
+          scope: captured.scope,
           terminal: response.terminal,
           barrier: captured.barrier,
         });
@@ -165,7 +165,7 @@ export function usePlainTerminalMutations(args: {
       onSuccess: (response, _request, captured) => {
         writeCanonicalTerminal(queryClient, {
           hostId: captured.hostId,
-          scope: response.terminal.record.scope,
+          scope: captured.scope,
           terminal: response.terminal,
           barrier: captured.barrier,
         });
@@ -190,7 +190,7 @@ export function usePlainTerminalMutations(args: {
       onSuccess: (response, _request, captured) => {
         writeCanonicalTerminal(queryClient, {
           hostId: captured.hostId,
-          scope: response.terminal.record.scope,
+          scope: captured.scope,
           terminal: response.terminal,
           barrier: captured.barrier,
         });
@@ -269,7 +269,7 @@ export function usePlainTerminalMutations(args: {
         }
         writeCanonicalTerminal(queryClient, {
           hostId: captured.hostId,
-          scope: response.terminal.record.scope,
+          scope: captured.scope,
           terminal: response.terminal,
           barrier: captured.barrier,
         });
@@ -301,6 +301,12 @@ export function useHostPlainTerminalMutations(
   });
 }
 
+/**
+ * The scope must be the one `onMutate` captured, because the barrier was
+ * captured from that cache slot. Writing a response scope instead would apply
+ * an ordering barrier belonging to a different slot and lose the guarantee for
+ * both. The deletion paths capture the same way.
+ */
 function writeCanonicalTerminal(
   queryClient: QueryClient,
   args: {

--- a/clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts
@@ -892,7 +892,7 @@ describe("goBack / goForward — preview-reopen closed sub-tabs", () => {
     ).toBeUndefined();
   });
 
-  it("cannot restore a closed durable terminal after the accepted tombstone prunes its payload", () => {
+  it("cannot restore a closed durable terminal while a retained tombstone is still in Query", () => {
     const hostId = bindActiveHost();
     const store = useEpicCanvasStore.getState();
     const tabId = store.openEpicTab("e1", "Task");
@@ -911,9 +911,23 @@ describe("goBack / goForward — preview-reopen closed sub-tabs", () => {
     };
     store.openTileInTab(tabId, ref);
     const paneId = requirePaneId(tabId);
-    // Durable close gestures are intentionally retained until host ack, so
-    // seed the already-closed history cache directly to exercise the later
-    // conclusive-deletion invalidation boundary.
+    // The tombstone lands under the real epic-scoped plain-terminal key, which
+    // is what `rejectClosedPlainTerminalRestore` reads. Its presentation fanout
+    // is key-independent, so the closed payload is seeded AFTER the commit -
+    // otherwise the fanout prunes it first and `goBack` has nothing to reject.
+    expect(
+      commitPlainTerminalDeletion({
+        queryClient,
+        queryKey: hostQueryKeys.plainTerminals(hostId, {
+          kind: "epic",
+          epicId: "e1",
+        }),
+        hostId,
+        terminalId: ref.id,
+        evidence: { kind: "stream", revision: 1 },
+        deferPresentation: false,
+      }),
+    ).toBe(true);
     useEpicCanvasStore.setState((state) => ({
       closedTilePayloadsByTabId: {
         ...state.closedTilePayloadsByTabId,
@@ -928,28 +942,17 @@ describe("goBack / goForward — preview-reopen closed sub-tabs", () => {
       ],
     ).toBeDefined();
 
-    expect(
-      commitPlainTerminalDeletion({
-        queryClient,
-        queryKey: ["history-terminal-tombstone"],
-        hostId,
-        terminalId: ref.id,
-        evidence: { kind: "stream", revision: 1 },
-        deferPresentation: false,
-      }),
-    ).toBe(true);
-    expect(
-      useEpicCanvasStore.getState().closedTilePayloadsByTabId[tabId]?.[
-        ref.instanceId
-      ],
-    ).toBeUndefined();
-
     const landing = nestedHref("e1", tabId, paneId, ref.instanceId);
     const history = seedPersistentHistory([landing, `/epics/e1/${tabId}`], 1);
     vi.spyOn(history, "go").mockImplementation(() => {});
     goBack({ history });
 
     expect(tileByContentId(tabId, ref.id)).toBeUndefined();
+    expect(
+      useEpicCanvasStore.getState().closedTilePayloadsByTabId[tabId]?.[
+        ref.instanceId
+      ],
+    ).toBeUndefined();
   });
 
   it("cannot restore a closed legacy terminal when a retained tombstone is still in Query", () => {

--- a/clients/gui-app/src/lib/terminals/__tests__/plain-terminal-presentation-invalidation.test.ts
+++ b/clients/gui-app/src/lib/terminals/__tests__/plain-terminal-presentation-invalidation.test.ts
@@ -62,6 +62,9 @@ describe("plain terminal presentation invalidation", () => {
   afterEach(() => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useLandingTerminalStore.getState().resetForTests();
+    // The GUI Vitest config does not restore mocks automatically, so the
+    // store-action `vi.spyOn` wrappers below would otherwise leak forward.
+    vi.restoreAllMocks();
   });
 
   it("sweeps both scopes by host and terminal without touching future authority, another host, another terminal, or terminal-agent", () => {
@@ -316,13 +319,13 @@ describe("plain terminal presentation invalidation", () => {
       "landing-other-host",
     );
     expect(
-      Object.values(
-        useEpicCanvasStore.getState().closedTilePayloadsByTabId,
-      ).flatMap((forTab) => Object.keys(forTab ?? {})),
+      Object.values(useEpicCanvasStore.getState().closedTilePayloadsByTabId)
+        .flatMap((forTab) => Object.keys(forTab ?? {}))
+        .sort(),
     ).toEqual([
       "closed-agent-ref",
-      "closed-other-host-ref",
       "closed-future-ref",
+      "closed-other-host-ref",
       "closed-other-terminal-ref",
     ]);
   });
@@ -1084,6 +1087,7 @@ describe("plain terminal presentation invalidation", () => {
             queryClient,
             queryKey,
             hostId: TARGET_HOST_ID,
+            scope,
             terminalId,
             snapshotEpoch: settled.snapshotEpoch,
           });

--- a/clients/gui-app/src/lib/terminals/plain-terminal-authority.ts
+++ b/clients/gui-app/src/lib/terminals/plain-terminal-authority.ts
@@ -17,6 +17,9 @@ export const PLAIN_TERMINAL_RPC_METHODS = [
   "terminal.plain.importLegacy",
 ] as const;
 
+export type PlainTerminalRpcMethod =
+  (typeof PLAIN_TERMINAL_RPC_METHODS)[number];
+
 export const PLAIN_TERMINAL_STREAM_METHOD =
   "terminal.plain.subscribeList" as const;
 
@@ -34,7 +37,7 @@ export type PlainTerminalCapability =
  */
 export function resolvePlainTerminalCapability(input: {
   readonly manifestKnown: boolean;
-  readonly versionFor: (method: string) => SchemaVersion | null;
+  readonly versionFor: (method: PlainTerminalRpcMethod) => SchemaVersion | null;
 }): PlainTerminalCapability {
   if (!input.manifestKnown) return { status: "unknown" };
   for (const method of PLAIN_TERMINAL_RPC_METHODS) {
@@ -361,12 +364,9 @@ export function setPlainTerminalStreamStatus(
   return {
     ...base,
     streamStatus: status,
-    streamSnapshotFresh:
-      status === "connecting" ||
-      status === "reconnecting" ||
-      status === "closed"
-        ? false
-        : base.streamSnapshotFresh,
+    // Only an open connection carries snapshot freshness forward. Any other
+    // status - including one added later - must invalidate it.
+    streamSnapshotFresh: status === "open" ? base.streamSnapshotFresh : false,
   };
 }
 

--- a/clients/gui-app/src/lib/terminals/plain-terminal-presentation-invalidation.ts
+++ b/clients/gui-app/src/lib/terminals/plain-terminal-presentation-invalidation.ts
@@ -426,11 +426,22 @@ export function commitPlainTerminalDeferredDeletion(args: {
   return true;
 }
 
-/** Commits one absence proved by a settled snapshot initialization epoch. */
+/**
+ * Commits one absence proved by a settled snapshot initialization epoch.
+ *
+ * Snapshot absence proves deletion only for host-acknowledged pointers: an
+ * unacknowledged ref or a pending create is legitimately absent from the
+ * host's snapshot, so absence alone must never destroy it. That precondition
+ * is enforced here through `acknowledgedPlainTerminalPresentationIdsForScope`
+ * rather than left to the caller, because both exports are public and a caller
+ * that passes a raw terminal id would otherwise delete a user's pending
+ * terminal.
+ */
 export function commitPlainTerminalSnapshotOmission(args: {
   readonly queryClient: QueryClient;
   readonly queryKey: QueryKey;
   readonly hostId: string;
+  readonly scope: PlainTerminalScope;
   readonly terminalId: string;
   readonly snapshotEpoch: number;
 }): boolean {
@@ -441,6 +452,14 @@ export function commitPlainTerminalSnapshotOmission(args: {
     collection?.streamSnapshotFresh !== true ||
     collection.snapshotEpoch !== args.snapshotEpoch ||
     collection.terminalsById[args.terminalId] !== undefined
+  ) {
+    return false;
+  }
+  if (
+    !acknowledgedPlainTerminalPresentationIdsForScope(
+      args.hostId,
+      args.scope,
+    ).has(args.terminalId)
   ) {
     return false;
   }

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/actions.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/actions.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { PlainTerminalProjection } from "@traycer/protocol/host/terminal/plain-schemas";
 import {
+  adoptHostTerminalProjection,
   closeAllTabs,
   closeOtherTabs,
   closePane,
@@ -1392,5 +1394,91 @@ describe("openTile no-op short-circuits (same reference)", () => {
     expect(next).not.toBe(state);
     expect(next.root).toBe(state.root);
     expect(next.activePaneId).toBe(holdingPaneId);
+  });
+});
+
+describe("adoptHostTerminalProjection", () => {
+  const TERMINAL_ID = "terminal-adopt";
+
+  function projection(overrides: {
+    readonly manualTitle?: string | null;
+    readonly cwd?: string;
+    readonly shellArgs?: string[];
+  }): PlainTerminalProjection {
+    return {
+      record: {
+        terminalId: TERMINAL_ID,
+        hostId: TEST_HOST_ID,
+        scope: { kind: "epic", epicId: "epic-1" },
+        launch: {
+          cwd: overrides.cwd ?? "/work",
+          shellCommand: "/bin/zsh",
+          shellArgs: overrides.shellArgs ?? ["-l"],
+        },
+        manualTitle: overrides.manualTitle ?? null,
+        revision: 1,
+        createdAt: "2026-08-16T10:00:00.000Z",
+        updatedAt: "2026-08-16T10:00:00.000Z",
+      },
+      runtime: {
+        status: "running",
+        sessionId: TERMINAL_ID,
+        currentCwd: "/work",
+        activeProcessName: "bun",
+        cols: 100,
+        rows: 30,
+      },
+    };
+  }
+
+  const LEGACY_REF: EpicCanvasTileRef = {
+    id: TERMINAL_ID,
+    instanceId: "instance-adopt",
+    type: "terminal",
+    name: "Shell",
+    hostId: TEST_HOST_ID,
+    titleSource: "default",
+    cwd: "/work",
+  };
+
+  it("adopts a legacy ref once and then leaves the canvas identity alone", () => {
+    const state = openPinned(createEmptyCanvas(), LEGACY_REF);
+    const adopted = adoptHostTerminalProjection(
+      state,
+      TEST_HOST_ID,
+      projection({}),
+    );
+    expect(adopted).not.toBe(state);
+    const adoptedRef = adopted.tilesByInstanceId[LEGACY_REF.instanceId];
+    expect(adoptedRef?.type === "terminal" && adoptedRef.authority).toBe(
+      "host",
+    );
+
+    // A repeated stream projection carrying the same values must not mint a
+    // new canvas identity, or every tick re-renders every canvas subscriber.
+    const again = adoptHostTerminalProjection(
+      adopted,
+      TEST_HOST_ID,
+      projection({}),
+    );
+    expect(again).toBe(adopted);
+    expect(again.tilesByInstanceId[LEGACY_REF.instanceId]).toBe(adoptedRef);
+  });
+
+  it("still re-projects when a projected field actually changes", () => {
+    const state = adoptHostTerminalProjection(
+      openPinned(createEmptyCanvas(), LEGACY_REF),
+      TEST_HOST_ID,
+      projection({}),
+    );
+    for (const changed of [
+      projection({ manualTitle: "Renamed" }),
+      projection({ cwd: "/elsewhere" }),
+      projection({ shellArgs: ["-l", "-i"] }),
+    ]) {
+      expect(
+        adoptHostTerminalProjection(state, TEST_HOST_ID, changed),
+      ).not.toBe(state);
+    }
   });
 });

--- a/clients/gui-app/src/stores/epics/canvas/actions.ts
+++ b/clients/gui-app/src/stores/epics/canvas/actions.ts
@@ -1363,6 +1363,18 @@ function sizesEqual(
   return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
+function shellArgsEqual(
+  left: ReadonlyArray<string> | undefined,
+  right: ReadonlyArray<string> | undefined,
+): boolean {
+  if (left === right) return true;
+  if (left === undefined || right === undefined) return false;
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
 /**
  * Commit a group's child fractions (clamped + normalized). Touches ONLY
  * `sizesByGroupId` - the tree object is untouched, so layout subscribers
@@ -1514,6 +1526,26 @@ export function adoptHostTerminalProjection(
       if (isUnsupportedEpicTerminalRef(ref)) return ref;
       const fallbackName =
         terminal.record.manualTitle ?? DEFAULT_TERMINAL_TITLE;
+      const titleSource =
+        terminal.record.manualTitle === null ? "default" : "manual";
+      // `updateTilesWhere` treats any new object as a change, so an already
+      // adopted ref that matches the projection byte-for-byte would still mint
+      // a new canvas identity on every stream tick - re-rendering every canvas
+      // subscriber and invalidating the persist cache for every tab.
+      if (
+        isHostEpicTerminalRef(ref) &&
+        ref.legacyFallback.name === fallbackName &&
+        ref.legacyFallback.titleSource === titleSource &&
+        ref.legacyFallback.cwd === terminal.record.launch.cwd &&
+        ref.legacyFallback.shellCommand ===
+          terminal.record.launch.shellCommand &&
+        shellArgsEqual(
+          ref.legacyFallback.shellArgs,
+          terminal.record.launch.shellArgs,
+        )
+      ) {
+        return ref;
+      }
       return {
         id: ref.id,
         instanceId: ref.instanceId,
@@ -1523,8 +1555,7 @@ export function adoptHostTerminalProjection(
         authority: "host",
         legacyFallback: {
           name: fallbackName,
-          titleSource:
-            terminal.record.manualTitle === null ? "default" : "manual",
+          titleSource,
           cwd: terminal.record.launch.cwd,
           shellCommand: terminal.record.launch.shellCommand,
           shellArgs: terminal.record.launch.shellArgs,

--- a/clients/gui-app/src/stores/home/landing-terminal-store.ts
+++ b/clients/gui-app/src/stores/home/landing-terminal-store.ts
@@ -376,12 +376,18 @@ export const useLandingTerminalStore = create<LandingTerminalStoreState>()(
             tab.instanceId === instanceId ? { ...tab, sessionId } : tab,
           ),
         })),
+      // Matched on instance + host only. The canonical terminal a capable host
+      // returns for `importLegacy` ("existing"/"imported") may carry a
+      // DIFFERENT terminalId than the legacy evidence we sent - the response
+      // contract permits it - and rekeying that pointer is exactly what
+      // `hostAcknowledgedTab` is for. Also demanding the ids already match
+      // dropped the acknowledgement, left the tab unacknowledged beside a
+      // freshly adopted canonical duplicate, and re-imported on the next pass.
       adoptHostTerminal: (instanceId, terminal) =>
         set((state) => ({
           tabs: state.tabs.map((tab) =>
             tab.instanceId === instanceId &&
-            tab.hostId === terminal.record.hostId &&
-            tab.sessionId === terminal.record.terminalId
+            tab.hostId === terminal.record.hostId
               ? hostAcknowledgedTab(tab, terminal)
               : tab,
           ),

--- a/clients/shared/host-transport/plain-terminal-list-stream-client.ts
+++ b/clients/shared/host-transport/plain-terminal-list-stream-client.ts
@@ -110,6 +110,14 @@ export class PlainTerminalListStreamClient {
       case "pong": {
         return;
       }
+      default: {
+        const unhandled: never = frame;
+        console.warn(
+          `[stream] terminal.plain.subscribeList unhandled frame kind; dropping frame`,
+          unhandled,
+        );
+        return;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep landing and epic terminal lifecycle controls aligned with host authority readiness and reconnect state
- strengthen tombstone reconciliation, mutation ordering, and projection identity handling
- harden affected tests and external-store subscriptions against asynchronous and cache-ordering races

## Test plan
- [x] pre-commit affected build, compile, lint, and format checks
- [x] focused landing terminal reconciliation and lifecycle tests
- [x] focused authority, canvas, tombstone, and transport tests

Made with [Cursor](https://cursor.com)