### PR TITLE
feat(protocol,gui-app): Cursor account rate-limit indicator

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -1262,6 +1262,7 @@ describe("CursorRateLimitView", () => {
     includedLimitUsd: 400,
     usedUsd: 325.37,
     remainingUsd: 74.63,
+    bonusUsedUsd: null,
     onDemandLimitType: "user",
     onDemandLimitUsd: 1,
     onDemandUsedUsd: 0.25,
@@ -1304,6 +1305,34 @@ describe("CursorRateLimitView", () => {
     expect(screen.getByText("On-demand limit")).toBeTruthy();
     expect(screen.getByText("$1.00")).toBeTruthy();
     expect(screen.queryByText("$100.00")).toBeNull();
+  });
+
+  it("shows overflow honestly once spend runs past the purchased allowance", () => {
+    // Past $400 the account is on Cursor's bonus grant - nothing is limited
+    // and nothing is billed, so the meter must NOT dress this up as a limit
+    // event: fill pins at 100% in the amber running-low tone (red stays
+    // reserved for the bucket bars, the actual gates), the detail keeps the
+    // REAL spend, "left" clamps at $0.00 instead of going negative, and the
+    // bonus spend gets its own row.
+    const { container } = render(
+      <CursorRateLimitView
+        data={{
+          ...cursor,
+          usedUsd: 412.1,
+          remainingUsd: -12.1,
+          bonusUsedUsd: 12.1,
+        }}
+        variant="popover-overview"
+      />,
+    );
+    expect(screen.getByText("$412.10 / $400.00")).toBeTruthy();
+    expect(screen.getByText("Included usage left")).toBeTruthy();
+    expect(screen.getByText("$0.00")).toBeTruthy();
+    expect(screen.queryByText("-$12.10")).toBeNull();
+    expect(screen.getByText("Bonus usage")).toBeTruthy();
+    expect(screen.getByText("$12.10")).toBeTruthy();
+    expect(container.querySelector(".bg-amber-500")).toBeTruthy();
+    expect(container.querySelector(".bg-red-500")).toBeNull();
   });
 
   it("falls back to the billing-cycle range when no bucket was reported", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -14,6 +14,7 @@ import { RunnerHostContext } from "@/providers/runner-host-context";
 import {
   ClaudeRateLimitView,
   CodexRateLimitView,
+  CursorRateLimitView,
   GrokRateLimitView,
   HuggingFaceRateLimitView,
   KiloCodeRateLimitView,
@@ -46,6 +47,7 @@ type OpenRouterRateLimits = Extract<
 >;
 type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
 type GrokRateLimits = Extract<ProviderRateLimits, { provider: "grok" }>;
+type CursorRateLimits = Extract<ProviderRateLimits, { provider: "cursor" }>;
 type HuggingFaceRateLimits = Extract<
   ProviderRateLimits,
   { provider: "huggingface" }
@@ -1237,5 +1239,76 @@ describe("ProviderRateLimitBody (Codex reset action)", () => {
 
     expect(screen.getByText("3 available")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Use reset" })).toBeTruthy();
+  });
+});
+
+describe("CursorRateLimitView", () => {
+  const CYCLE_END = NOW + 29 * 24 * 60 * 60 * 1000;
+  const cursor: CursorRateLimits = {
+    provider: "cursor",
+    available: true,
+    cycleStart: NOW - 2 * 24 * 60 * 60 * 1000,
+    cycleEnd: CYCLE_END,
+    cursorModels: {
+      usedPercent: 6,
+      resetsAt: CYCLE_END,
+      durationMinutes: 31 * 24 * 60,
+    },
+    otherModels: {
+      usedPercent: 40,
+      resetsAt: CYCLE_END,
+      durationMinutes: 31 * 24 * 60,
+    },
+    includedLimitUsd: 400,
+    usedUsd: 325.37,
+    remainingUsd: 74.63,
+    onDemandLimitType: "user",
+    onDemandLimitUsd: 1,
+    onDemandUsedUsd: 0.25,
+    onDemandRemainingUsd: 0.75,
+    displayMessage: "You've used 81% of your included usage",
+  };
+
+  it("keeps the Overview to the two Spending-page bucket bars, with no money", () => {
+    // Live-account regression: the bucket bars are each measured against their
+    // own unpublished limit, while the dollars describe Cursor's BLENDED $400
+    // pool (~81% consumed on the same payload). "$74.63 left of $400" under
+    // bars reading 6% / 40% presents as a broken calculation even though every
+    // number is Cursor's own - so the Overview, the surface compared against
+    // the Spending page, is bars-only, exactly like that page.
+    render(<CursorRateLimitView data={cursor} variant="popover-overview" />);
+    expect(screen.getByText("Cursor Models")).toBeTruthy();
+    expect(screen.getByText("6% used")).toBeTruthy();
+    expect(screen.getByText("Other Models")).toBeTruthy();
+    expect(screen.getByText("40% used")).toBeTruthy();
+    expect(screen.queryByText(/Included usage/)).toBeNull();
+    expect(screen.queryByText("$74.63")).toBeNull();
+  });
+
+  it("anchors the detail's money to Cursor's own sentence about the blended pool", () => {
+    render(<CursorRateLimitView data={cursor} variant="settings" />);
+    // The sentence names the pool's denominator, so the dollars beneath it
+    // cannot read as a wrong computation of the bucket bars above.
+    expect(
+      screen.getByText("You've used 81% of your included usage"),
+    ).toBeTruthy();
+    expect(screen.getByText("Included usage left")).toBeTruthy();
+    expect(screen.getByText("$74.63")).toBeTruthy();
+    expect(screen.getByText("Included usage")).toBeTruthy();
+    expect(screen.getByText("$400.00")).toBeTruthy();
+    // On-demand in real dollars: a $1 limit renders as $1.00, never $100.
+    expect(screen.getByText("On-demand limit")).toBeTruthy();
+    expect(screen.getByText("$1.00")).toBeTruthy();
+    expect(screen.queryByText("$100.00")).toBeNull();
+  });
+
+  it("falls back to the billing-cycle range when no bucket was reported", () => {
+    render(
+      <CursorRateLimitView
+        data={{ ...cursor, cursorModels: null, otherModels: null }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("Billing cycle")).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -1269,33 +1269,37 @@ describe("CursorRateLimitView", () => {
     displayMessage: "You've used 81% of your included usage",
   };
 
-  it("keeps the Overview to the two Spending-page bucket bars, with no money", () => {
-    // Live-account regression: the bucket bars are each measured against their
-    // own unpublished limit, while the dollars describe Cursor's BLENDED $400
-    // pool (~81% consumed on the same payload). "$74.63 left of $400" under
-    // bars reading 6% / 40% presents as a broken calculation even though every
-    // number is Cursor's own - so the Overview, the surface compared against
-    // the Spending page, is bars-only, exactly like that page.
+  it("pairs the Overview's dollars with their own included-usage meter", () => {
+    // Live-account regression, second round: the bucket bars are each
+    // measured against their own unpublished (bonus-inflated) limit, while
+    // the dollars describe Cursor's BLENDED $400 purchased pool (~81%
+    // consumed on the same payload). A bare "$74.63 left of $400" under bars
+    // reading 6% / 40% presented as a broken calculation even though
+    // `remaining` is Cursor's own server-computed field - and dropping the
+    // rows was the wrong fix (the money is the actionable number). The
+    // dollars stay, carried by a credit meter whose fill shares their
+    // denominator, so the row explains itself.
     render(<CursorRateLimitView data={cursor} variant="popover-overview" />);
     expect(screen.getByText("Cursor Models")).toBeTruthy();
     expect(screen.getByText("6% used")).toBeTruthy();
     expect(screen.getByText("Other Models")).toBeTruthy();
     expect(screen.getByText("40% used")).toBeTruthy();
-    expect(screen.queryByText(/Included usage/)).toBeNull();
-    expect(screen.queryByText("$74.63")).toBeNull();
+    expect(screen.getByText("Included usage")).toBeTruthy();
+    expect(screen.getByText("$325.37 / $400.00")).toBeTruthy();
+    expect(screen.getByText("Included usage left")).toBeTruthy();
+    expect(screen.getByText("$74.63")).toBeTruthy();
   });
 
   it("anchors the detail's money to Cursor's own sentence about the blended pool", () => {
     render(<CursorRateLimitView data={cursor} variant="settings" />);
-    // The sentence names the pool's denominator, so the dollars beneath it
-    // cannot read as a wrong computation of the bucket bars above.
+    // The sentence names the pool the meter measures, in Cursor's own words.
     expect(
       screen.getByText("You've used 81% of your included usage"),
     ).toBeTruthy();
     expect(screen.getByText("Included usage left")).toBeTruthy();
     expect(screen.getByText("$74.63")).toBeTruthy();
     expect(screen.getByText("Included usage")).toBeTruthy();
-    expect(screen.getByText("$400.00")).toBeTruthy();
+    expect(screen.getByText("$325.37 / $400.00")).toBeTruthy();
     // On-demand in real dollars: a $1 limit renders as $1.00, never $100.
     expect(screen.getByText("On-demand limit")).toBeTruthy();
     expect(screen.getByText("$1.00")).toBeTruthy();

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1383,16 +1383,16 @@ export function GrokRateLimitView({
  * render, keeping the card meaningful rather than blank - the same fallback
  * grok uses.
  *
- * Overview is bars-only. The money deliberately does NOT ride along: each
- * bucket bar is measured against its own (unpublished) limit, while
- * `remainingUsd`/`includedLimitUsd` describe Cursor's BLENDED $400 pool - a
- * third denominator. Live comparison showed "$76.69 left of $400" (~81%
- * consumed) rendered directly under bars reading 6% / 40%, which reads as a
- * broken calculation even though every number is Cursor's own. Cursor's
- * dashboard never juxtaposes the dollars with the bucket bars either. The
- * detail surfaces keep the money, anchored by `displayMessage` - Cursor's own
- * sentence about that pool ("You've used 81% of your included usage") - so
- * the dollars arrive with the denominator that explains them.
+ * The dollars ride their OWN meter, not the bucket bars. Each bucket bar is
+ * measured against its own (unpublished, bonus-inflated) limit, while
+ * `usedUsd`/`includedLimitUsd`/`remainingUsd` describe Cursor's BLENDED $400
+ * purchased pool - a third denominator, ~81% consumed on the same live
+ * payload that read 6% / 40% on the buckets. A bare "$76.69 left of $400"
+ * row under those bars therefore presented as a broken calculation even
+ * though every number is Cursor's own (server-computed `remaining`). Pairing
+ * the dollars with a credit meter that shows THEIR percentage - the exact
+ * pattern the Hugging Face card uses - keeps the money visible on every
+ * surface while making its denominator visible with it.
  */
 export function CursorRateLimitView({
   data,
@@ -1425,6 +1425,15 @@ export function CursorRateLimitView({
           ) : null}
         </>
       )}
+      <CursorIncludedUsageBar
+        includedLimitUsd={data.includedLimitUsd}
+        usedUsd={data.usedUsd}
+      />
+      <ProviderNumberRow
+        label="Included usage left"
+        value={data.remainingUsd}
+        format={formatProviderCurrency}
+      />
       {!overview ? (
         <>
           {data.displayMessage !== null ? (
@@ -1432,16 +1441,6 @@ export function CursorRateLimitView({
               {data.displayMessage}
             </p>
           ) : null}
-          <ProviderNumberRow
-            label="Included usage left"
-            value={data.remainingUsd}
-            format={formatProviderCurrency}
-          />
-          <ProviderNumberRow
-            label="Included usage"
-            value={data.includedLimitUsd}
-            format={formatProviderCurrency}
-          />
           <ProviderNumberRow
             label="On-demand limit"
             value={data.onDemandLimitUsd}
@@ -1455,6 +1454,34 @@ export function CursorRateLimitView({
         </>
       ) : null}
     </div>
+  );
+}
+
+// Cursor's blended purchased pool as a credit meter, mirroring
+// `HuggingFaceCreditBar`: the fill percentage and the dollar detail share one
+// denominator by construction, so the money can sit under the bucket bars
+// without reading as a wrong computation of them. `usedUsd` can exceed the
+// purchased limit once bonus usage kicks in, so the fill is clamped rather
+// than allowed to overflow the meter.
+function CursorIncludedUsageBar({
+  includedLimitUsd,
+  usedUsd,
+}: {
+  readonly includedLimitUsd: number | null;
+  readonly usedUsd: number | null;
+}): ReactNode {
+  if (includedLimitUsd === null || includedLimitUsd <= 0 || usedUsd === null) {
+    return null;
+  }
+  const consumed = Math.min(Math.max(0, usedUsd), includedLimitUsd);
+  const usedPercent = (consumed / includedLimitUsd) * 100;
+  return (
+    <MeterRow
+      label="Included usage"
+      usedPercent={usedPercent}
+      severity={creditUsageSeverity(usedPercent)}
+      detail={`${formatProviderCurrency(consumed)} / ${formatProviderCurrency(includedLimitUsd)}`}
+    />
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -116,6 +116,7 @@ type OpenRouterRateLimits = Extract<
 >;
 type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
 type GrokRateLimits = Extract<ProviderRateLimits, { provider: "grok" }>;
+type CursorRateLimits = Extract<ProviderRateLimits, { provider: "cursor" }>;
 type HuggingFaceRateLimits = Extract<
   ProviderRateLimits,
   { provider: "huggingface" }
@@ -1236,8 +1237,12 @@ function formatGrokPeriodLabel(
   return formatWindowDuration(durationMinutes);
 }
 
-/** Compact calendar date ("Jul 22, 2026") for a grok billing-period bound. */
-function formatGrokPeriodDate(epochMs: number): string {
+/**
+ * Compact calendar date ("Jul 22, 2026") for a billing-period bound. Shared by
+ * grok's billing period and Cursor's billing cycle - both render a plain epoch
+ * range, so neither provider owns this formatter.
+ */
+function formatBillingRangeDate(epochMs: number): string {
   return new Date(epochMs).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
@@ -1250,12 +1255,12 @@ function formatGrokPeriodDate(epochMs: number): string {
  * in grok's unmeasured-period fallback where there's no usage bar to carry a
  * reset date. `null` unless both bounds are known.
  */
-function formatGrokPeriodRange(
+function formatBillingRange(
   periodStart: number | null,
   periodEnd: number | null,
 ): string | null {
   if (periodStart === null || periodEnd === null) return null;
-  return `${formatGrokPeriodDate(periodStart)} - ${formatGrokPeriodDate(periodEnd)}`;
+  return `${formatBillingRangeDate(periodStart)} - ${formatBillingRangeDate(periodEnd)}`;
 }
 
 /**
@@ -1288,7 +1293,7 @@ function GrokPeriodFallback({
       ) : null}
       <ProviderTextRow
         label="Billing period"
-        value={formatGrokPeriodRange(periodStart, periodEnd)}
+        value={formatBillingRange(periodStart, periodEnd)}
       />
     </>
   );
@@ -1357,6 +1362,72 @@ export function GrokRateLimitView({
           <ProviderNumberRow
             label="On-demand limit"
             value={data.onDemandCap}
+            format={formatProviderCurrency}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Cursor's usage detail. Structurally grok's twin - a synthesized billing-cycle
+ * window plus money rows - so it reuses the same `RateLimitWindowRow`, and its
+ * "% used · Resets <date>" reads identically to codex/claude.
+ *
+ * Two shapes are handled:
+ *
+ * - `cycle` present -> the included-usage bar. Its label is the cycle cadence
+ *   derived from the window duration ("Monthly"), not a provider token, since
+ *   Cursor reports cycle bounds rather than a cadence name.
+ * - `cycle` null -> an account whose plan limit wasn't reported, so no
+ *   percentage is computable. The cycle dates still render, keeping the card
+ *   meaningful rather than blank - the same fallback grok uses.
+ *
+ * Overview keeps the usage bar and the remaining included credits; the spend
+ * limit is single-provider-tab detail, matching how grok/OpenRouter trim.
+ */
+export function CursorRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: CursorRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  const overview = isOverviewVariant(variant);
+  return (
+    <div className="flex flex-col gap-3">
+      {data.cycle !== null ? (
+        <RateLimitWindowRow
+          label={formatWindowDuration(data.cycle.durationMinutes)}
+          window={data.cycle}
+        />
+      ) : (
+        <ProviderTextRow
+          label="Billing cycle"
+          value={formatBillingRange(data.cycleStart, data.cycleEnd)}
+        />
+      )}
+      <ProviderNumberRow
+        label="Included credits left"
+        value={data.remainingUsd}
+        format={formatProviderCurrency}
+      />
+      {!overview ? (
+        <>
+          <ProviderNumberRow
+            label="Included credits"
+            value={data.includedLimitUsd}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spend limit"
+            value={data.spendLimitUsd}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spend limit left"
+            value={data.spendLimitRemainingUsd}
             format={formatProviderCurrency}
           />
         </>
@@ -1524,5 +1595,10 @@ export function ProviderRateLimitDetail({
       return <HuggingFaceRateLimitView data={data} variant={variant} />;
     case "opencode":
       return <OpenCodeRateLimitView data={data} />;
+    // Cursor is windowed, not credit-shaped: its money fields back a real
+    // billing-cycle percentage, so it renders a usage bar like grok rather than
+    // the spend-only layout OpenRouter/Kilo Code/Hugging Face use.
+    case "cursor":
+      return <CursorRateLimitView data={data} variant={variant} />;
   }
 }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1383,9 +1383,16 @@ export function GrokRateLimitView({
  * render, keeping the card meaningful rather than blank - the same fallback
  * grok uses.
  *
- * Overview keeps the bars and the remaining included credits; the included
- * total and on-demand rows are single-provider-tab detail, matching how
- * grok/OpenRouter trim.
+ * Overview is bars-only. The money deliberately does NOT ride along: each
+ * bucket bar is measured against its own (unpublished) limit, while
+ * `remainingUsd`/`includedLimitUsd` describe Cursor's BLENDED $400 pool - a
+ * third denominator. Live comparison showed "$76.69 left of $400" (~81%
+ * consumed) rendered directly under bars reading 6% / 40%, which reads as a
+ * broken calculation even though every number is Cursor's own. Cursor's
+ * dashboard never juxtaposes the dollars with the bucket bars either. The
+ * detail surfaces keep the money, anchored by `displayMessage` - Cursor's own
+ * sentence about that pool ("You've used 81% of your included usage") - so
+ * the dollars arrive with the denominator that explains them.
  */
 export function CursorRateLimitView({
   data,
@@ -1418,15 +1425,20 @@ export function CursorRateLimitView({
           ) : null}
         </>
       )}
-      <ProviderNumberRow
-        label="Included credits left"
-        value={data.remainingUsd}
-        format={formatProviderCurrency}
-      />
       {!overview ? (
         <>
+          {data.displayMessage !== null ? (
+            <p className="text-ui-xs text-muted-foreground">
+              {data.displayMessage}
+            </p>
+          ) : null}
           <ProviderNumberRow
-            label="Included credits"
+            label="Included usage left"
+            value={data.remainingUsd}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Included usage"
             value={data.includedLimitUsd}
             format={formatProviderCurrency}
           />

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1431,7 +1431,17 @@ export function CursorRateLimitView({
       />
       <ProviderNumberRow
         label="Included usage left"
-        value={data.remainingUsd}
+        // Once spend crosses the purchased allowance the wire's remaining may
+        // run negative; "-$12 left" is meaningless to a reader, and the
+        // overflow already shows in the meter's detail and the bonus row.
+        value={
+          data.remainingUsd === null ? null : Math.max(0, data.remainingUsd)
+        }
+        format={formatProviderCurrency}
+      />
+      <ProviderNumberRow
+        label="Bonus usage"
+        value={data.bonusUsedUsd}
         format={formatProviderCurrency}
       />
       {!overview ? (
@@ -1460,9 +1470,16 @@ export function CursorRateLimitView({
 // Cursor's blended purchased pool as a credit meter, mirroring
 // `HuggingFaceCreditBar`: the fill percentage and the dollar detail share one
 // denominator by construction, so the money can sit under the bucket bars
-// without reading as a wrong computation of them. `usedUsd` can exceed the
-// purchased limit once bonus usage kicks in, so the fill is clamped rather
-// than allowed to overflow the meter.
+// without reading as a wrong computation of them.
+//
+// Deliberately NOT `creditUsageSeverity`, and never red: for the credit
+// providers, exhausting the allowance means real billing, so red is earned.
+// Cursor's purchased pool is a VALUE meter - spend runs past it onto the
+// bonus grant ("free usage beyond what you've purchased") with nothing cut
+// off and nothing billed; the enforcing gates are the bucket bars above,
+// which own the red. Past the allowance the fill pins at 100% (MeterRow
+// clamps) while the detail keeps the REAL spend ("$412.10 / $400.00"), so
+// the overflow stays visible instead of dressing up as a limit event.
 function CursorIncludedUsageBar({
   includedLimitUsd,
   usedUsd,
@@ -1473,14 +1490,13 @@ function CursorIncludedUsageBar({
   if (includedLimitUsd === null || includedLimitUsd <= 0 || usedUsd === null) {
     return null;
   }
-  const consumed = Math.min(Math.max(0, usedUsd), includedLimitUsd);
-  const usedPercent = (consumed / includedLimitUsd) * 100;
+  const usedPercent = (Math.max(0, usedUsd) / includedLimitUsd) * 100;
   return (
     <MeterRow
       label="Included usage"
       usedPercent={usedPercent}
-      severity={creditUsageSeverity(usedPercent)}
-      detail={`${formatProviderCurrency(consumed)} / ${formatProviderCurrency(includedLimitUsd)}`}
+      severity={usedPercent > 85 ? "running_low" : "healthy"}
+      detail={`${formatProviderCurrency(Math.max(0, usedUsd))} / ${formatProviderCurrency(includedLimitUsd)}`}
     />
   );
 }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1371,21 +1371,21 @@ export function GrokRateLimitView({
 }
 
 /**
- * Cursor's usage detail. Structurally grok's twin - a synthesized billing-cycle
- * window plus money rows - so it reuses the same `RateLimitWindowRow`, and its
- * "% used · Resets <date>" reads identically to codex/claude.
+ * Cursor's usage detail. Structurally grok's twin - synthesized billing-cycle
+ * windows plus money rows - so it reuses the same `RateLimitWindowRow`, and
+ * its "% used · Resets <date>" reads identically to codex/claude.
  *
- * Two shapes are handled:
+ * The two bars are the two buckets Cursor's own Spending page renders -
+ * "Cursor Models" (Cursor Grok + Composer) and "Other Models" (named
+ * third-party models) - deliberately NOT the blended included-usage
+ * percentage, which appears nowhere on that dashboard and contradicted it in
+ * a live comparison. When neither bucket was reported the cycle dates still
+ * render, keeping the card meaningful rather than blank - the same fallback
+ * grok uses.
  *
- * - `cycle` present -> the included-usage bar. Its label is the cycle cadence
- *   derived from the window duration ("Monthly"), not a provider token, since
- *   Cursor reports cycle bounds rather than a cadence name.
- * - `cycle` null -> an account whose plan limit wasn't reported, so no
- *   percentage is computable. The cycle dates still render, keeping the card
- *   meaningful rather than blank - the same fallback grok uses.
- *
- * Overview keeps the usage bar and the remaining included credits; the spend
- * limit is single-provider-tab detail, matching how grok/OpenRouter trim.
+ * Overview keeps the bars and the remaining included credits; the included
+ * total and on-demand rows are single-provider-tab detail, matching how
+ * grok/OpenRouter trim.
  */
 export function CursorRateLimitView({
   data,
@@ -1397,16 +1397,26 @@ export function CursorRateLimitView({
   const overview = isOverviewVariant(variant);
   return (
     <div className="flex flex-col gap-3">
-      {data.cycle !== null ? (
-        <RateLimitWindowRow
-          label={formatWindowDuration(data.cycle.durationMinutes)}
-          window={data.cycle}
-        />
-      ) : (
+      {data.cursorModels === null && data.otherModels === null ? (
         <ProviderTextRow
           label="Billing cycle"
           value={formatBillingRange(data.cycleStart, data.cycleEnd)}
         />
+      ) : (
+        <>
+          {data.cursorModels !== null ? (
+            <RateLimitWindowRow
+              label="Cursor Models"
+              window={data.cursorModels}
+            />
+          ) : null}
+          {data.otherModels !== null ? (
+            <RateLimitWindowRow
+              label="Other Models"
+              window={data.otherModels}
+            />
+          ) : null}
+        </>
       )}
       <ProviderNumberRow
         label="Included credits left"
@@ -1421,13 +1431,13 @@ export function CursorRateLimitView({
             format={formatProviderCurrency}
           />
           <ProviderNumberRow
-            label="Spend limit"
-            value={data.spendLimitUsd}
+            label="On-demand limit"
+            value={data.onDemandLimitUsd}
             format={formatProviderCurrency}
           />
           <ProviderNumberRow
-            label="Spend limit left"
-            value={data.spendLimitRemainingUsd}
+            label="On-demand used"
+            value={data.onDemandUsedUsd}
             format={formatProviderCurrency}
           />
         </>

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -76,15 +76,17 @@ function fiveHourWindow(
       return rateLimits.primary;
     case "claude-code":
       return rateLimits.fiveHour;
-    // OpenRouter/Kilo Code/Grok/Hugging Face/OpenCode are never queried for a glyph slot
-    // (grok stays out of `GLYPH_PROVIDER_IDS` - its billing period isn't a
-    // short rolling window, and the credit providers report money rather than a
-    // window at all); kept for exhaustiveness over the union.
+    // OpenRouter/Kilo Code/Grok/Hugging Face/OpenCode/Cursor are never queried
+    // for a glyph slot (grok and cursor stay out of `GLYPH_PROVIDER_IDS` - a
+    // monthly billing cycle isn't a short rolling window, and the credit
+    // providers report money rather than a window at all); kept for
+    // exhaustiveness over the union.
     case "openrouter":
     case "kilocode":
     case "grok":
     case "huggingface":
     case "opencode":
+    case "cursor":
       return null;
   }
 }
@@ -104,6 +106,7 @@ function weeklyWindow(
     case "grok":
     case "huggingface":
     case "opencode":
+    case "cursor":
       return null;
   }
 }

--- a/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
+++ b/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
@@ -65,14 +65,24 @@ describe("rateLimitFetchLane", () => {
     expect(rateLimitFetchLane("openrouter")).toBe("httpFetch");
     expect(rateLimitFetchLane("kilocode")).toBe("httpFetch");
   });
+
+  it("maps cursor to the httpFetch lane despite its two round trips", () => {
+    // Cursor mints a dashboard session from the API key before reading usage,
+    // so it costs two requests - but no subprocess, so it stays off the serial
+    // ephemeral queue.
+    expect(rateLimitFetchLane("cursor")).toBe("httpFetch");
+  });
 });
 
 describe("isRateLimitCapableProvider", () => {
-  it("accepts the four rate-limit-capable providers and rejects others", () => {
+  it("accepts rate-limit-capable providers and rejects others", () => {
     expect(isRateLimitCapableProvider("codex")).toBe(true);
     expect(isRateLimitCapableProvider("kilocode")).toBe(true);
-    expect(isRateLimitCapableProvider("cursor")).toBe(false);
+    // Cursor became rate-limit-capable once its dashboard usage arm landed; it
+    // used to be this test's negative example.
+    expect(isRateLimitCapableProvider("cursor")).toBe(true);
     expect(isRateLimitCapableProvider("traycer")).toBe(false);
+    expect(isRateLimitCapableProvider("copilot")).toBe(false);
   });
 });
 

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -256,9 +256,9 @@ export function titleCaseFromToken(value: string): string {
  * A provider's plan/tier label, where one is fetched - the header popover
  * shows this as a chip next to the provider name (Core Flows: "where the
  * provider reports one"). Codex (`planType`), Claude Code (`subscriptionType`),
- * and Grok (`subscriptionTier`) report a plan/tier; OpenRouter, Kilo Code and
- * Hugging Face have no analogous field, so they always resolve to `null` and
- * render no chip.
+ * and Grok (`subscriptionTier`) report a plan/tier; OpenRouter, Kilo Code,
+ * Hugging Face and Cursor have no analogous field, so they always resolve to
+ * `null` and render no chip.
  */
 export function resolveProviderPlanLabel(
   data: AvailableProviderRateLimits,
@@ -279,10 +279,13 @@ export function resolveProviderPlanLabel(
     case "opencode":
       return "Go";
     // None of the credit providers report a tier - Hugging Face's billing-usage
-    // endpoint carries no plan field either - so all three render no chip.
+    // endpoint carries no plan field either, and Cursor's current-period usage
+    // reports the plan's SIZE (an included-credit allowance) but never its
+    // NAME - so all four render no chip.
     case "openrouter":
     case "kilocode":
     case "huggingface":
+    case "cursor":
       return null;
   }
 }

--- a/clients/gui-app/src/lib/rate-limit-providers.ts
+++ b/clients/gui-app/src/lib/rate-limit-providers.ts
@@ -22,7 +22,8 @@ export type RateLimitProviderId = RateLimitCapableProviderId;
  * the polling scheduler branches on:
  *
  * - `"httpFetch"`: the host resolves a credential it already has and issues a
- *   plain GET (openrouter, kilocode, huggingface, opencode). Cheap and safe to
+ *   plain HTTP call (openrouter, kilocode, huggingface, opencode, cursor).
+ *   Cheap and safe to
  *   run concurrently, so
  *   their observers opt into the table-owned fixed cadence and never enter the
  *   serial queue.
@@ -80,6 +81,10 @@ export function rateLimitFetchLane(
     case "kilocode":
     case "huggingface":
     case "opencode":
+    case "cursor":
+      // Two round trips (the API key mints a dashboard session before the
+      // usage read), but still credential-and-fetch - no subprocess - so it
+      // keeps the table-owned fixed cadence rather than the serial queue.
       return "httpFetch";
     case "codex":
     case "claude-code":

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -159,6 +159,7 @@ function cursor(
     includedLimitUsd: null,
     usedUsd: null,
     remainingUsd: null,
+    bonusUsedUsd: null,
     onDemandLimitType: "user",
     onDemandLimitUsd: null,
     onDemandUsedUsd: null,

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -143,23 +143,26 @@ function grok(
 }
 
 function cursor(
-  cycle: ProviderRateLimitWindow | null,
+  otherModels: ProviderRateLimitWindow | null,
+  cursorModels: ProviderRateLimitWindow | null,
 ): Extract<ProviderRateLimits, { provider: "cursor"; available: true }> {
   const cycleEnd = NOW + 31 * 24 * 60 * 60 * 1000;
   return {
     provider: "cursor",
     available: true,
     cycleStart: NOW,
-    cycleEnd: cycle === null ? cycleEnd : cycle.resetsAt,
-    cycle,
-    // A reachable account that reported no plan allowance: proto3 JSON omits
-    // zero-valued fields, so these arrive absent rather than as 0.
+    cycleEnd: otherModels?.resetsAt ?? cursorModels?.resetsAt ?? cycleEnd,
+    cursorModels,
+    otherModels,
+    // A reachable account that reported no bucket percentages: proto3 JSON
+    // omits zero-valued fields, so these arrive absent rather than as 0.
     includedLimitUsd: null,
     usedUsd: null,
     remainingUsd: null,
-    spendLimitType: "user",
-    spendLimitUsd: null,
-    spendLimitRemainingUsd: null,
+    onDemandLimitType: "user",
+    onDemandLimitUsd: null,
+    onDemandUsedUsd: null,
+    onDemandRemainingUsd: null,
     displayMessage: null,
   };
 }
@@ -347,13 +350,16 @@ describe("projectProfileUsage", () => {
     });
   });
 
-  it("projects a cycle-less Cursor snapshot as unmeasured, not unavailable", () => {
-    // Cursor synthesizes its cycle window only when the payload reports a plan
-    // limit, and proto3 JSON omits zero-valued fields - so a reachable account
-    // can legitimately arrive with `cycle: null`. Without the unmeasured arm it
-    // renders as unavailable/`missing_windows`, reading as a fetch or account
-    // failure purely because Cursor reported no allowance to meter.
-    expect(project("ok", NOW, envelope(cursor(null), NOW), false)).toEqual({
+  it("projects a bucket-less Cursor snapshot as unmeasured, not unavailable", () => {
+    // Cursor synthesizes its bucket windows only when the payload reports the
+    // Spending-page percentages, and proto3 JSON omits zero-valued fields - so
+    // a reachable account can legitimately arrive with both windows null.
+    // Without the unmeasured arm it renders as unavailable/`missing_windows`,
+    // reading as a fetch or account failure purely because Cursor reported
+    // nothing to meter.
+    expect(
+      project("ok", NOW, envelope(cursor(null, null), NOW), false),
+    ).toEqual({
       kind: "not_checked",
       severity: "unknown",
       compactWindow: null,
@@ -362,18 +368,24 @@ describe("projectProfileUsage", () => {
     });
   });
 
-  it("still meters a Cursor snapshot that reports a cycle window", () => {
-    // Guards the arm above from over-reaching: a measured cycle must keep its
-    // percentage rather than being swallowed as unmeasured.
+  it("meters both Cursor buckets and headlines the most consumed one", () => {
+    // Guards the unmeasured arm from over-reaching, and pins the live-account
+    // regression: the compact bar must be a Spending-page bucket ("Other
+    // Models" 38%), never the blended included-usage pool (78%) that appears
+    // nowhere on Cursor's dashboard.
     const projection = project(
       "ok",
       NOW,
-      envelope(cursor(window(72, 44_640, NOW + 1)), NOW),
+      envelope(
+        cursor(window(38, 44_640, NOW + 1), window(6, 44_640, NOW + 1)),
+        NOW,
+      ),
       false,
     );
     expect(projection.kind).toBe("detail");
-    expect(projection.windows).toHaveLength(1);
-    expect(projection.compactWindow?.window.usedPercent).toBe(72);
+    expect(projection.windows).toHaveLength(2);
+    expect(projection.compactWindow?.name).toBe("Other Models");
+    expect(projection.compactWindow?.window.usedPercent).toBe(38);
   });
 
   it("selects the most consumed live window and ignores expired windows", () => {

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -142,6 +142,28 @@ function grok(
   };
 }
 
+function cursor(
+  cycle: ProviderRateLimitWindow | null,
+): Extract<ProviderRateLimits, { provider: "cursor"; available: true }> {
+  const cycleEnd = NOW + 31 * 24 * 60 * 60 * 1000;
+  return {
+    provider: "cursor",
+    available: true,
+    cycleStart: NOW,
+    cycleEnd: cycle === null ? cycleEnd : cycle.resetsAt,
+    cycle,
+    // A reachable account that reported no plan allowance: proto3 JSON omits
+    // zero-valued fields, so these arrive absent rather than as 0.
+    includedLimitUsd: null,
+    usedUsd: null,
+    remainingUsd: null,
+    spendLimitType: "user",
+    spendLimitUsd: null,
+    spendLimitRemainingUsd: null,
+    displayMessage: null,
+  };
+}
+
 function envelope(
   data: Extract<ProviderRateLimits, { available: true }>,
   lastGoodAt: number,
@@ -323,6 +345,35 @@ describe("projectProfileUsage", () => {
       windows: [],
       checkedAt: null,
     });
+  });
+
+  it("projects a cycle-less Cursor snapshot as unmeasured, not unavailable", () => {
+    // Cursor synthesizes its cycle window only when the payload reports a plan
+    // limit, and proto3 JSON omits zero-valued fields - so a reachable account
+    // can legitimately arrive with `cycle: null`. Without the unmeasured arm it
+    // renders as unavailable/`missing_windows`, reading as a fetch or account
+    // failure purely because Cursor reported no allowance to meter.
+    expect(project("ok", NOW, envelope(cursor(null), NOW), false)).toEqual({
+      kind: "not_checked",
+      severity: "unknown",
+      compactWindow: null,
+      windows: [],
+      checkedAt: null,
+    });
+  });
+
+  it("still meters a Cursor snapshot that reports a cycle window", () => {
+    // Guards the arm above from over-reaching: a measured cycle must keep its
+    // percentage rather than being swallowed as unmeasured.
+    const projection = project(
+      "ok",
+      NOW,
+      envelope(cursor(window(72, 44_640, NOW + 1)), NOW),
+      false,
+    );
+    expect(projection.kind).toBe("detail");
+    expect(projection.windows).toHaveLength(1);
+    expect(projection.compactWindow?.window.usedPercent).toBe(72);
   });
 
   it("selects the most consumed live window and ignores expired windows", () => {

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -371,18 +371,29 @@ function projectedLiveWindows(
     }
     case "cursor":
       // Cursor rides the shared window path via its synthesized billing-cycle
-      // window, exactly like grok - NOT the credit projection its money-shaped
-      // fields might suggest - so severity and the compact bar come straight
-      // from `classifyProviderRateLimits`. This is also why cursor is absent
-      // from the credit-provider severity exception below: that exception
-      // exists for providers whose `providerRateLimitWindows` is empty by
-      // design, and cursor's is not.
+      // bucket windows, exactly like grok - NOT the credit projection its
+      // money-shaped fields might suggest - so severity and the compact bar
+      // come straight from `classifyProviderRateLimits`. This is also why
+      // cursor is absent from the credit-provider severity exception below:
+      // that exception exists for providers whose `providerRateLimitWindows`
+      // is empty by design, and cursor's is not.
+      //
+      // The two windows mirror Cursor's Spending page buckets; the compact
+      // bar picks the most consumed of the two via `mostConstrainedWindow`,
+      // so the headline number always matches one of the dashboard's bars.
       return [
         windowProjection({
-          id: "cycle",
+          id: "cursor-models",
           role: "primary",
-          name: null,
-          window: rateLimits.cycle,
+          name: "Cursor Models",
+          window: rateLimits.cursorModels,
+          now,
+        }),
+        windowProjection({
+          id: "other-models",
+          role: "secondary",
+          name: "Other Models",
+          window: rateLimits.otherModels,
           now,
         }),
       ].filter((window): window is ProfileUsageWindow => window !== null);
@@ -429,16 +440,18 @@ function emptyDetailProjection(
   // period merely rolled (window present but expired) still falls through to
   // `expired` below, the correct stale framing.
   //
-  // Cursor is the same case for the same reason: its `cycle` is synthesized
-  // only when the payload reports a plan limit, and proto3 JSON omits
-  // zero-valued fields, so a reachable account can legitimately arrive with
-  // `cycle: null`. Without this arm that account renders as unavailable
-  // (`missing_windows`) purely because Cursor reported no allowance to meter.
-  // A cursor snapshot whose cycle merely rolled still falls through to
-  // `expired`, exactly as grok's does.
+  // Cursor is the same case for the same reason: its bucket windows are
+  // synthesized only when the payload reports the bucket percentages, and
+  // proto3 JSON omits zero-valued fields, so a reachable account can
+  // legitimately arrive with both windows null. Without this arm that account
+  // renders as unavailable (`missing_windows`) purely because Cursor reported
+  // nothing to meter. A cursor snapshot whose cycle merely rolled still falls
+  // through to `expired`, exactly as grok's does.
   if (
     (rateLimits.provider === "grok" && rateLimits.period === null) ||
-    (rateLimits.provider === "cursor" && rateLimits.cycle === null)
+    (rateLimits.provider === "cursor" &&
+      rateLimits.cursorModels === null &&
+      rateLimits.otherModels === null)
   ) {
     return {
       kind: "not_checked",

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -369,6 +369,23 @@ function projectedLiveWindows(
       const credits = huggingFaceCreditProjection(rateLimits);
       return credits === null ? [] : [credits];
     }
+    case "cursor":
+      // Cursor rides the shared window path via its synthesized billing-cycle
+      // window, exactly like grok - NOT the credit projection its money-shaped
+      // fields might suggest - so severity and the compact bar come straight
+      // from `classifyProviderRateLimits`. This is also why cursor is absent
+      // from the credit-provider severity exception below: that exception
+      // exists for providers whose `providerRateLimitWindows` is empty by
+      // design, and cursor's is not.
+      return [
+        windowProjection({
+          id: "cycle",
+          role: "primary",
+          name: null,
+          window: rateLimits.cycle,
+          now,
+        }),
+      ].filter((window): window is ProfileUsageWindow => window !== null);
     case "kilocode":
       return [];
   }

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -428,7 +428,18 @@ function emptyDetailProjection(
   // framing, which reads as a fetch/account failure. A grok snapshot whose
   // period merely rolled (window present but expired) still falls through to
   // `expired` below, the correct stale framing.
-  if (rateLimits.provider === "grok" && rateLimits.period === null) {
+  //
+  // Cursor is the same case for the same reason: its `cycle` is synthesized
+  // only when the payload reports a plan limit, and proto3 JSON omits
+  // zero-valued fields, so a reachable account can legitimately arrive with
+  // `cycle: null`. Without this arm that account renders as unavailable
+  // (`missing_windows`) purely because Cursor reported no allowance to meter.
+  // A cursor snapshot whose cycle merely rolled still falls through to
+  // `expired`, exactly as grok's does.
+  if (
+    (rateLimits.provider === "grok" && rateLimits.period === null) ||
+    (rateLimits.provider === "cursor" && rateLimits.cycle === null)
+  ) {
     return {
       kind: "not_checked",
       severity: "unknown",

--- a/protocol/src/agent/__tests__/agent-profile-format.test.ts
+++ b/protocol/src/agent/__tests__/agent-profile-format.test.ts
@@ -190,6 +190,42 @@ describe("detailed rate-limit formatting", () => {
     );
   });
 
+  it("keeps Cursor's known spend when the included limit was not reported", () => {
+    // The money fields are independently nullable (proto3 omits zero-valued
+    // fields), so a payload can carry spend without a limit. A missing
+    // denominator must not hide the spend that IS known - the same spend-only
+    // fallback the Hugging Face arm uses.
+    const response: AgentGetProviderProfileRateLimitsResponse = {
+      rateLimits: {
+        provider: "cursor",
+        available: true,
+        cycleStart: CAPTURED_AT,
+        cycleEnd: Date.UTC(2026, 7, 12, 9, 30, 0),
+        cursorModels: null,
+        otherModels: null,
+        includedLimitUsd: null,
+        usedUsd: 325.37,
+        remainingUsd: null,
+        bonusUsedUsd: null,
+        onDemandLimitType: null,
+        onDemandLimitUsd: null,
+        onDemandUsedUsd: null,
+        onDemandRemainingUsd: null,
+        displayMessage: null,
+      },
+      usageUpdatedAt: CAPTURED_AT,
+    };
+
+    const human = formatAgentProviderProfileRateLimitsResponse(
+      { kind: "ambient" },
+      response,
+    );
+
+    expect(human).toContain("spend: 325.37 this cycle");
+    expect(human).not.toContain("included usage:");
+    expect(human).not.toContain("unknown remaining");
+  });
+
   it("renders the unavailable arm with its reason instead of inventing limits", () => {
     const response: AgentGetProviderProfileRateLimitsResponse = {
       rateLimits: {

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -210,9 +210,14 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
       // DIFFERENT denominator than the bucket windows above (each bucket is
       // measured against its own unpublished limit), so this line reads as
       // money, never as a percentage that could contradict the windows.
-      rateLimits.includedLimitUsd === null
-        ? null
-        : `included usage: ${formatNumber(rateLimits.remainingUsd)}/${formatNumber(rateLimits.includedLimitUsd)} remaining (${formatNumber(rateLimits.usedUsd)} used)`,
+      // Spend-only when the limit was not reported, exactly like the Hugging
+      // Face arm above: the fields are independently nullable, and a missing
+      // denominator must not hide the spend that IS known.
+      rateLimits.includedLimitUsd !== null
+        ? `included usage: ${formatNumber(rateLimits.remainingUsd)}/${formatNumber(rateLimits.includedLimitUsd)} remaining (${formatNumber(rateLimits.usedUsd)} used)`
+        : rateLimits.usedUsd === null && rateLimits.remainingUsd === null
+          ? null
+          : `spend: ${formatNumber(rateLimits.usedUsd)} this cycle${rateLimits.remainingUsd === null ? "" : `, ${formatNumber(rateLimits.remainingUsd)} remaining`}`,
       // Only worth a line when no bucket window already carried the reset -
       // otherwise it restates the instant `formatWindowLine` printed.
       hasBucketWindow ||

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -195,21 +195,30 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
     ].join("\n");
   }
   if (rateLimits.provider === "cursor") {
+    const hasBucketWindow =
+      rateLimits.cursorModels !== null || rateLimits.otherModels !== null;
     return [
-      formatWindowLine("included usage", rateLimits.cycle),
+      // The two buckets Cursor's own Spending page renders; the blended pool
+      // travels as the money line below, never as a percentage.
+      rateLimits.cursorModels === null
+        ? null
+        : formatWindowLine("cursor models", rateLimits.cursorModels),
+      rateLimits.otherModels === null
+        ? null
+        : formatWindowLine("other models", rateLimits.otherModels),
       rateLimits.includedLimitUsd === null
         ? null
         : `included credits: ${formatNumber(rateLimits.remainingUsd)}/${formatNumber(rateLimits.includedLimitUsd)} remaining (${formatNumber(rateLimits.usedUsd)} used)`,
-      // Only worth a line when the cycle window did not already carry the
-      // reset - otherwise it restates the instant `formatWindowLine` printed.
-      rateLimits.cycle !== null ||
+      // Only worth a line when no bucket window already carried the reset -
+      // otherwise it restates the instant `formatWindowLine` printed.
+      hasBucketWindow ||
       rateLimits.cycleStart === null ||
       rateLimits.cycleEnd === null
         ? null
         : `billing cycle: ${formatTimestamp(rateLimits.cycleStart)} - ${formatTimestamp(rateLimits.cycleEnd)}`,
-      rateLimits.spendLimitUsd === null
+      rateLimits.onDemandLimitUsd === null
         ? null
-        : `spend limit${rateLimits.spendLimitType === null ? "" : ` (${rateLimits.spendLimitType})`}: ${formatNumber(rateLimits.spendLimitRemainingUsd)}/${formatNumber(rateLimits.spendLimitUsd)} remaining`,
+        : `on-demand${rateLimits.onDemandLimitType === null ? "" : ` (${rateLimits.onDemandLimitType})`}: ${formatNumber(rateLimits.onDemandUsedUsd)}/${formatNumber(rateLimits.onDemandLimitUsd)} used`,
     ]
       .filter((line): line is string => line !== null)
       .join("\n");

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -206,9 +206,13 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
       rateLimits.otherModels === null
         ? null
         : formatWindowLine("other models", rateLimits.otherModels),
+      // "Included usage" is Cursor's own name for the blended $400 pool - a
+      // DIFFERENT denominator than the bucket windows above (each bucket is
+      // measured against its own unpublished limit), so this line reads as
+      // money, never as a percentage that could contradict the windows.
       rateLimits.includedLimitUsd === null
         ? null
-        : `included credits: ${formatNumber(rateLimits.remainingUsd)}/${formatNumber(rateLimits.includedLimitUsd)} remaining (${formatNumber(rateLimits.usedUsd)} used)`,
+        : `included usage: ${formatNumber(rateLimits.remainingUsd)}/${formatNumber(rateLimits.includedLimitUsd)} remaining (${formatNumber(rateLimits.usedUsd)} used)`,
       // Only worth a line when no bucket window already carried the reset -
       // otherwise it restates the instant `formatWindowLine` printed.
       hasBucketWindow ||

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -194,6 +194,26 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
       `${formatWindowLine("monthly", rateLimits.monthly)} [${rateLimits.monthly.status}]`,
     ].join("\n");
   }
+  if (rateLimits.provider === "cursor") {
+    return [
+      formatWindowLine("included usage", rateLimits.cycle),
+      rateLimits.includedLimitUsd === null
+        ? null
+        : `included credits: ${formatNumber(rateLimits.remainingUsd)}/${formatNumber(rateLimits.includedLimitUsd)} remaining (${formatNumber(rateLimits.usedUsd)} used)`,
+      // Only worth a line when the cycle window did not already carry the
+      // reset - otherwise it restates the instant `formatWindowLine` printed.
+      rateLimits.cycle !== null ||
+      rateLimits.cycleStart === null ||
+      rateLimits.cycleEnd === null
+        ? null
+        : `billing cycle: ${formatTimestamp(rateLimits.cycleStart)} - ${formatTimestamp(rateLimits.cycleEnd)}`,
+      rateLimits.spendLimitUsd === null
+        ? null
+        : `spend limit${rateLimits.spendLimitType === null ? "" : ` (${rateLimits.spendLimitType})`}: ${formatNumber(rateLimits.spendLimitRemainingUsd)}/${formatNumber(rateLimits.spendLimitUsd)} remaining`,
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n");
+  }
   return [
     `credit balance: ${formatNumber(rateLimits.creditBalance)}`,
     `pass: ${rateLimits.passState ?? "unknown"}`,

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -26,6 +26,7 @@ import {
   providerProfileRateLimitStatusSchema,
 } from "@traycer/protocol/host/provider-schemas";
 import {
+  mapCursorAvailableToUnavailable,
   mapGrokAvailableToUnavailable,
   mapOpenCodeAvailableToUnavailable,
   providerRateLimitsSchema,
@@ -668,10 +669,17 @@ export const agentGetProviderProfileRateLimitsDowngradeV40ToV30 =
       // unrepresentable, and this response carries exactly one provider - so
       // fail closed rather than mis-decode. The message names no provider so
       // it stays honest as the enum grows.
+      //
+      // Cursor DOES degrade rather than fail closed: `"cursor"` is in the
+      // frozen v6.0 provider enum, so the unavailable row is representable
+      // here, and an older client is better served by an honest "usage isn't
+      // available" than by an error it cannot act on.
       const parsed =
         agentGetProviderProfileRateLimitsResponseSchemaV3.safeParse({
           ...response,
-          rateLimits: mapOpenCodeAvailableToUnavailable(response.rateLimits),
+          rateLimits: mapCursorAvailableToUnavailable(
+            mapOpenCodeAvailableToUnavailable(response.rateLimits),
+          ),
         });
       if (!parsed.success) {
         return {
@@ -698,11 +706,14 @@ export const agentGetProviderProfileRateLimitsDowngradeV40ToV20 =
     downgradeResponse: (response) => {
       // Same rule as the v4->v3 bridge against the narrower v2.0 enum: the
       // frozen v2.0 union keeps grok, so only post-v5.0 providers (omp,
-      // huggingface) fail closed here.
+      // huggingface) fail closed here. Cursor degrades for the same reason it
+      // does there - `"cursor"` is in the frozen v5.0 provider enum too.
       const parsed =
         agentGetProviderProfileRateLimitsResponseSchemaV2.safeParse({
           ...response,
-          rateLimits: mapOpenCodeAvailableToUnavailable(response.rateLimits),
+          rateLimits: mapCursorAvailableToUnavailable(
+            mapOpenCodeAvailableToUnavailable(response.rateLimits),
+          ),
         });
       if (!parsed.success) {
         return {
@@ -731,9 +742,12 @@ export const agentGetProviderProfileRateLimitsDowngradeV40ToV10 =
       // frozen v1.0 union predates the grok available arm, so a grok-available
       // snapshot becomes the `unsupported_provider` row a v1.0 host returns for
       // grok today (shared map). Post-v4.0 providers (Hermes, omp, huggingface)
-      // stay unrepresentable and still fail closed.
+      // stay unrepresentable and still fail closed. Cursor degrades here too:
+      // `"cursor"` is in the frozen v4.0 provider enum.
       const rateLimits = mapGrokAvailableToUnavailable(
-        mapOpenCodeAvailableToUnavailable(response.rateLimits),
+        mapCursorAvailableToUnavailable(
+          mapOpenCodeAvailableToUnavailable(response.rateLimits),
+        ),
       );
       const parsed =
         agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse({

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -1261,23 +1261,34 @@ describe("cursor rate-limit arm", () => {
   const CYCLE_START = 1786921855000;
   const CYCLE_END = 1789600255000;
 
+  const CYCLE_MINUTES = (CYCLE_END - CYCLE_START) / 60_000;
+
   const cursorAvailable = {
     provider: "cursor",
     available: true,
     cycleStart: CYCLE_START,
     cycleEnd: CYCLE_END,
-    cycle: {
-      usedPercent: 72.115,
+    // The two Spending-page buckets; the blended included-usage pool travels
+    // as the money fields below, never as a window.
+    cursorModels: {
+      usedPercent: 6.0925,
       resetsAt: CYCLE_END,
-      durationMinutes: (CYCLE_END - CYCLE_START) / 60_000,
+      durationMinutes: CYCLE_MINUTES,
+    },
+    otherModels: {
+      usedPercent: 38.446,
+      resetsAt: CYCLE_END,
+      durationMinutes: CYCLE_MINUTES,
     },
     includedLimitUsd: 400,
-    usedUsd: 288.46,
-    remainingUsd: 111.54,
-    spendLimitType: "user",
-    spendLimitUsd: 100,
-    spendLimitRemainingUsd: 100,
-    displayMessage: "You've used 72% of your included usage",
+    usedUsd: 314.08,
+    remainingUsd: 85.92,
+    onDemandLimitType: "user",
+    // Cents on the wire: a $1 on-demand limit arrives as individualLimit 100.
+    onDemandLimitUsd: 1,
+    onDemandUsedUsd: null,
+    onDemandRemainingUsd: 1,
+    displayMessage: "You've used 79% of your included usage",
   } as const;
 
   // The exact row a pre-Cursor host returns for cursor today.
@@ -1307,21 +1318,24 @@ describe("cursor rate-limit arm", () => {
     ).toThrow();
   });
 
-  // The wire-boundary invariant: the host synthesizes the window's reset FROM
-  // the cycle end, so the two can never disagree on the same payload.
-  it("rejects a measured cycle whose resetsAt disagrees with cycleEnd", () => {
-    expect(() =>
-      providerRateLimitsSchema.parse({
-        ...cursorAvailable,
-        cycle: { ...cursorAvailable.cycle, resetsAt: CYCLE_END + 1 },
-      }),
-    ).toThrow();
+  // The wire-boundary invariant: the host synthesizes each window's reset
+  // FROM the cycle end, so they can never disagree on the same payload.
+  it("rejects a measured bucket whose resetsAt disagrees with cycleEnd", () => {
+    for (const key of ["cursorModels", "otherModels"] as const) {
+      expect(() =>
+        providerRateLimitsSchema.parse({
+          ...cursorAvailable,
+          [key]: { ...cursorAvailable[key], resetsAt: CYCLE_END + 1 },
+        }),
+      ).toThrow();
+    }
   });
 
   it("accepts an unmeasured snapshot that keeps only the cycle bounds", () => {
     const unmeasured = {
       ...cursorAvailable,
-      cycle: null,
+      cursorModels: null,
+      otherModels: null,
       includedLimitUsd: null,
       usedUsd: null,
       remainingUsd: null,

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -1283,6 +1283,7 @@ describe("cursor rate-limit arm", () => {
     includedLimitUsd: 400,
     usedUsd: 314.08,
     remainingUsd: 85.92,
+    bonusUsedUsd: null,
     onDemandLimitType: "user",
     // Cents on the wire: a $1 on-demand limit arrives as individualLimit 100.
     onDemandLimitUsd: 1,

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -1256,3 +1256,125 @@ describe("host.getRateLimitUsage v4.0 OpenCode arm + downgrade bridges", () => {
   });
 
 });
+
+describe("cursor rate-limit arm", () => {
+  const CYCLE_START = 1786921855000;
+  const CYCLE_END = 1789600255000;
+
+  const cursorAvailable = {
+    provider: "cursor",
+    available: true,
+    cycleStart: CYCLE_START,
+    cycleEnd: CYCLE_END,
+    cycle: {
+      usedPercent: 72.115,
+      resetsAt: CYCLE_END,
+      durationMinutes: (CYCLE_END - CYCLE_START) / 60_000,
+    },
+    includedLimitUsd: 400,
+    usedUsd: 288.46,
+    remainingUsd: 111.54,
+    spendLimitType: "user",
+    spendLimitUsd: 100,
+    spendLimitRemainingUsd: 100,
+    displayMessage: "You've used 72% of your included usage",
+  } as const;
+
+  // The exact row a pre-Cursor host returns for cursor today.
+  const cursorUnsupported = {
+    provider: "cursor",
+    available: false,
+    reason: "unsupported_provider",
+  } as const;
+
+  it("rides the live 4.0 line but not the frozen 3.0 one", () => {
+    expect(providerRateLimitsSchema.parse(cursorAvailable)).toEqual(
+      cursorAvailable,
+    );
+    expect(
+      rateLimitUsageResponseSchemaV40.parse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: cursorAvailable,
+      }),
+    ).toMatchObject({ providerRateLimits: cursorAvailable });
+    expect(() =>
+      rateLimitUsageResponseSchemaV30.parse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: cursorAvailable,
+      }),
+    ).toThrow();
+  });
+
+  // The wire-boundary invariant: the host synthesizes the window's reset FROM
+  // the cycle end, so the two can never disagree on the same payload.
+  it("rejects a measured cycle whose resetsAt disagrees with cycleEnd", () => {
+    expect(() =>
+      providerRateLimitsSchema.parse({
+        ...cursorAvailable,
+        cycle: { ...cursorAvailable.cycle, resetsAt: CYCLE_END + 1 },
+      }),
+    ).toThrow();
+  });
+
+  it("accepts an unmeasured snapshot that keeps only the cycle bounds", () => {
+    const unmeasured = {
+      ...cursorAvailable,
+      cycle: null,
+      includedLimitUsd: null,
+      usedUsd: null,
+      remainingUsd: null,
+    };
+    expect(providerRateLimitsSchema.parse(unmeasured)).toEqual(unmeasured);
+  });
+
+  it("degrades a cursor-available snapshot through the 4.0 -> 3.0 bridge", () => {
+    const result = hostGetRateLimitUsageDowngradeV4ToV3.downgradeResponse(
+      rateLimitUsageResponseSchemaV40.parse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: cursorAvailable,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providerRateLimits).toEqual(cursorUnsupported);
+    expect(() =>
+      rateLimitUsageResponseSchemaV30.parse(result.value),
+    ).not.toThrow();
+  });
+
+  // `"cursor"` is in every frozen provider enum (it long predates Hermes/omp),
+  // so the degraded row must reparse cleanly all the way down - this is what
+  // lets the arm ride 4.0 instead of forcing a new major.
+  it("degrades cursor down the 4.0 -> 2.1 and 4.0 -> 1.2 bridges too", () => {
+    const response = rateLimitUsageResponseSchemaV40.parse({
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: cursorAvailable,
+    });
+    for (const bridge of [
+      hostGetRateLimitUsageDowngradeV4ToV2,
+      hostGetRateLimitUsageDowngradeV4ToV1,
+    ]) {
+      const result = bridge.downgradeResponse(response);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.providerRateLimits).toEqual(cursorUnsupported);
+    }
+  });
+
+  it("leaves an already-unavailable cursor snapshot untouched", () => {
+    const result = hostGetRateLimitUsageDowngradeV4ToV3.downgradeResponse(
+      rateLimitUsageResponseSchemaV40.parse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: cursorUnsupported,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providerRateLimits).toEqual(cursorUnsupported);
+  });
+});

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -16,6 +16,7 @@ import {
   rateLimitUsageResponseSchemaV21,
   rateLimitUsageResponseSchemaV30,
   rateLimitUsageResponseSchemaV40,
+  mapCursorAvailableToUnavailable,
   mapGrokAvailableToUnavailable,
   mapHuggingFaceAvailableToUnavailable,
   mapOpenCodeAvailableToUnavailable,
@@ -286,12 +287,13 @@ export const hostGetRateLimitUsageUpgradeV30ToV40 = defineUpgradePath<
   upgradeResponse: (response) => response,
 });
 
-// Downgrade bridge 4.0 -> 3.0: request is identity. The Hugging-Face- and
-// OpenCode-available snapshots each degrade to the unavailable
-// `unsupported_provider` shape - neither has an arm in the frozen v3.0 union,
-// and both ride 4.0 since the release collapsed them onto one major. Every
-// other arm - grok included, since v3.0 is where grok landed - is already valid
-// v3.0 and passes through the re-parse unchanged.
+// Downgrade bridge 4.0 -> 3.0: request is identity. The Hugging-Face-,
+// OpenCode- and Cursor-available snapshots each degrade to the unavailable
+// `unsupported_provider` shape - none has an arm in the frozen v3.0 union, and
+// all three ride 4.0 (the release collapsed Hugging Face and OpenCode onto one
+// major, and 4.0 is still unreleased, so Cursor joins them rather than opening
+// a 5.0). Every other arm - grok included, since v3.0 is where grok landed - is
+// already valid v3.0 and passes through the re-parse unchanged.
 export const hostGetRateLimitUsageDowngradeV4ToV3 = defineDowngradePath<
   typeof hostGetRateLimitUsageV40,
   typeof hostGetRateLimitUsageV30
@@ -303,16 +305,18 @@ export const hostGetRateLimitUsageDowngradeV4ToV3 = defineDowngradePath<
     ok: true,
     value: rateLimitUsageResponseSchemaV30.parse({
       ...response,
-      providerRateLimits: mapHuggingFaceAvailableToUnavailable(
-        mapOpenCodeAvailableToUnavailable(response.providerRateLimits),
+      providerRateLimits: mapCursorAvailableToUnavailable(
+        mapHuggingFaceAvailableToUnavailable(
+          mapOpenCodeAvailableToUnavailable(response.providerRateLimits),
+        ),
       ),
     }),
   }),
 });
 
-// Downgrade bridge 4.0 -> 2.1: composes all three available-arm maps before the
+// Downgrade bridge 4.0 -> 2.1: composes all four available-arm maps before the
 // v2.1 re-parse, because the frozen v2.1 union has none of the grok, Hugging
-// Face, or OpenCode arms.
+// Face, OpenCode, or Cursor arms.
 export const hostGetRateLimitUsageDowngradeV4ToV2 = defineDowngradePath<
   typeof hostGetRateLimitUsageV40,
   typeof hostGetRateLimitUsageV21
@@ -325,18 +329,20 @@ export const hostGetRateLimitUsageDowngradeV4ToV2 = defineDowngradePath<
     value: rateLimitUsageResponseSchemaV21.parse({
       ...response,
       providerRateLimits: mapGrokAvailableToUnavailable(
-        mapHuggingFaceAvailableToUnavailable(
-          mapOpenCodeAvailableToUnavailable(response.providerRateLimits),
+        mapCursorAvailableToUnavailable(
+          mapHuggingFaceAvailableToUnavailable(
+            mapOpenCodeAvailableToUnavailable(response.providerRateLimits),
+          ),
         ),
       ),
     }),
   }),
 });
 
-// Downgrade bridge 4.0 -> 1.2: composes all four frozen-line maps. The three
+// Downgrade bridge 4.0 -> 1.2: composes all five frozen-line maps. The four
 // available-arm degrades run before the reason degrade, so a genuinely
-// Hugging-Face-, OpenCode- or grok-available snapshot never lands on the
-// usage-fetch-failed branch. The v1.2 parse also strips v2.1 reset-credit
+// Hugging-Face-, OpenCode-, Cursor- or grok-available snapshot never lands on
+// the usage-fetch-failed branch. The v1.2 parse also strips v2.1 reset-credit
 // detail.
 export const hostGetRateLimitUsageDowngradeV4ToV1 = defineDowngradePath<
   typeof hostGetRateLimitUsageV40,
@@ -351,8 +357,10 @@ export const hostGetRateLimitUsageDowngradeV4ToV1 = defineDowngradePath<
       ...response,
       providerRateLimits: mapUsageFetchFailedToNotAvailable(
         mapGrokAvailableToUnavailable(
-          mapHuggingFaceAvailableToUnavailable(
-            mapOpenCodeAvailableToUnavailable(response.providerRateLimits),
+          mapCursorAvailableToUnavailable(
+            mapHuggingFaceAvailableToUnavailable(
+              mapOpenCodeAvailableToUnavailable(response.providerRateLimits),
+            ),
           ),
         ),
       ),

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -92,6 +92,7 @@ export const rateLimitCapableProviderIdSchema = z.enum([
   "grok",
   "huggingface",
   "opencode",
+  "cursor",
 ]);
 export type RateLimitCapableProviderId = z.infer<
   typeof rateLimitCapableProviderIdSchema
@@ -294,6 +295,75 @@ const grokRateLimitsSchema = z
     }
   });
 
+// Cursor arm - httpFetch-class provider (two plain POSTs, no subprocess).
+//
+// Cursor's API-key-authenticated PUBLIC API carries no account quota at all:
+// it exposes `/v1/me`, `/v1/models`, `/v1/repositories`, `/v1/agents` and a
+// per-AGENT token/cost read, and signals pressure only reactively via
+// `retry-after` on a 429. The account-wide numbers live on the dashboard API
+// the Cursor app itself uses, so the host exchanges the configured API key for
+// a short-lived session token (`/auth/exchange_user_api_key`) and calls
+// `aiserver.v1.DashboardService/GetCurrentPeriodUsage` with it.
+//
+// Deriving the session FROM the same key that runs turns is load-bearing, not
+// incidental: it is what makes the account this arm reports and the account
+// Traycer bills the same account by construction. Reading Cursor's own CLI
+// session out of the OS keychain would report whichever account happened to
+// run `cursor-agent login`, which need not be the key's owner.
+//
+// Hybrid shape, like grok's: a synthesized `cycle` window (so severity
+// rollups, a2a `rateLimitStatus`, and GUI status logic reuse the shared window
+// primitive with no special-casing) plus the raw money fields.
+//
+// Every payload-derived field is nullable because the endpoint speaks proto3
+// JSON, which OMITS zero-valued fields entirely - an account with no
+// usage-based spend simply has no `spendLimitUsage.totalSpend` key rather than
+// a `0`. Absent therefore cannot be distinguished from zero here, and the host
+// sends null rather than inventing either.
+//
+// Money is USD. `planUsage`'s wire values are integer CENTS and the host
+// divides, so no consumer has to know the unit. The spend-limit fields are a
+// deliberate exception: they are reported in whole dollars on the same
+// payload (a `100` spend limit alongside a `40000` plan limit is $100 against
+// $400, not $1), so they are carried through as-is and named to say so.
+const cursorRateLimitsSchema = z
+  .object({
+    provider: z.literal(rateLimitCapableProviderIdSchema.enum.cursor),
+    available: z.literal(true),
+    cycleStart: z.number().nullable(),
+    cycleEnd: z.number().nullable(),
+    cycle: providerRateLimitWindowSchema.nullable(),
+    includedLimitUsd: z.number().nullable(),
+    usedUsd: z.number().nullable(),
+    remainingUsd: z.number().nullable(),
+    spendLimitType: z.string().nullable(),
+    spendLimitUsd: z.number().nullable(),
+    spendLimitRemainingUsd: z.number().nullable(),
+    // Cursor's own rendering of the headline number ("You've used 72% of your
+    // included usage"). Carried so the GUI can show the provider's wording
+    // rather than a second, subtly different sentence derived from `cycle`.
+    displayMessage: z.string().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    // Same invariant grok's arm enforces, for the same reason: the host
+    // synthesizes the window's reset FROM the billing-cycle end, so the two
+    // denote one instant by construction. `cycleEnd` is kept as its own field
+    // so the cycle bounds survive a snapshot whose usage could not be measured
+    // (`cycle` null, `cycleEnd` still known). Enforce it at the wire boundary
+    // so a measured cycle can never omit or disagree with the known reset.
+    if (
+      value.cycleEnd !== null &&
+      value.cycle !== null &&
+      value.cycle.resetsAt !== value.cycleEnd
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "cursor cycle.resetsAt must equal cycleEnd when cycle is set",
+        path: ["cycle", "resetsAt"],
+      });
+    }
+  });
+
 // Closed, Traycer-owned set of reasons a provider pull can fail to report
 // rate limits - unlike a provider's own plan/reached-type tokens (owned by
 // that provider, legitimately forward-compat as a bare string), every one of
@@ -444,6 +514,7 @@ export const providerRateLimitsSchema = z.union([
   grokRateLimitsSchema,
   huggingFaceRateLimitsSchema,
   openCodeRateLimitsSchema,
+  cursorRateLimitsSchema,
   unavailableProviderRateLimitsSchema,
 ]);
 export type ProviderRateLimits = z.infer<typeof providerRateLimitsSchema>;
@@ -513,6 +584,33 @@ export function mapHuggingFaceAvailableToUnavailable(
   ) {
     return {
       provider: "huggingface",
+      available: false,
+      reason: "unsupported_provider",
+    };
+  }
+  return providerRateLimits;
+}
+
+/**
+ * The Cursor analogue of `mapGrokAvailableToUnavailable`, for every bridge
+ * below the live 4.0 line. A cursor-available snapshot has no representation in
+ * any frozen union (Cursor was not a rate-limit-capable provider then), so it
+ * degrades to the unavailable `unsupported_provider` shape - the exact row a
+ * pre-Cursor host returns for it today. `"cursor"` is in EVERY frozen
+ * `provider` enum (it long predates Hermes/omp, and is present in
+ * `providerIdSchemaV40`/`V50`/`V60`), so the result reparses cleanly through
+ * every older union. Any other snapshot (or `null`) passes through unchanged.
+ */
+export function mapCursorAvailableToUnavailable(
+  providerRateLimits: ProviderRateLimits | null,
+): ProviderRateLimits | null {
+  if (
+    providerRateLimits !== null &&
+    providerRateLimits.available &&
+    providerRateLimits.provider === "cursor"
+  ) {
+    return {
+      provider: "cursor",
       available: false,
       reason: "unsupported_provider",
     };

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -348,6 +348,12 @@ const cursorRateLimitsSchema = z
     includedLimitUsd: z.number().nullable(),
     usedUsd: z.number().nullable(),
     remainingUsd: z.number().nullable(),
+    // Spend covered by Cursor's bonus grant ("free usage beyond what you've
+    // purchased") - the payload's `bonusSpend`, expected to populate once
+    // `usedUsd` crosses `includedLimitUsd`. Null until then (proto3 omits
+    // zero-valued fields), so a consumer can distinguish "no bonus consumed"
+    // from a payload that never carried the field.
+    bonusUsedUsd: z.number().nullable(),
     onDemandLimitType: z.string().nullable(),
     onDemandLimitUsd: z.number().nullable(),
     onDemandUsedUsd: z.number().nullable(),

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -311,56 +311,73 @@ const grokRateLimitsSchema = z
 // session out of the OS keychain would report whichever account happened to
 // run `cursor-agent login`, which need not be the key's owner.
 //
-// Hybrid shape, like grok's: a synthesized `cycle` window (so severity
-// rollups, a2a `rateLimitStatus`, and GUI status logic reuse the shared window
-// primitive with no special-casing) plus the raw money fields.
+// Hybrid shape, like grok's: synthesized windows (so severity rollups, a2a
+// `rateLimitStatus`, and GUI status logic reuse the shared window primitive
+// with no special-casing) plus the raw money fields.
+//
+// TWO windows, mirroring the buckets Cursor's own Spending page renders -
+// "Cursor Models" (the payload's `autoPercentUsed`; Cursor Grok + Composer)
+// and "Other Models" (`apiPercentUsed`; named third-party models). The
+// payload ALSO carries a blended included-usage pool (`totalSpend`/`limit`,
+// the number `displayMessage` narrates), but that percentage appears nowhere
+// on Cursor's dashboard, and rendering it produced a rail (78%) that
+// contradicted the Spending page beside it (38%) - a confirmed live-account
+// mismatch. The blended pool therefore travels as MONEY only (`usedUsd` /
+// `includedLimitUsd` / `remainingUsd`), never as a window.
 //
 // Every payload-derived field is nullable because the endpoint speaks proto3
 // JSON, which OMITS zero-valued fields entirely - an account with no
-// usage-based spend simply has no `spendLimitUsage.totalSpend` key rather than
-// a `0`. Absent therefore cannot be distinguished from zero here, and the host
-// sends null rather than inventing either.
+// usage-based spend simply has no `spendLimitUsage.individualUsed` key rather
+// than a `0`. Absent therefore cannot be distinguished from zero here, and
+// the host sends null rather than inventing either.
 //
-// Money is USD. `planUsage`'s wire values are integer CENTS and the host
-// divides, so no consumer has to know the unit. The spend-limit fields are a
-// deliberate exception: they are reported in whole dollars on the same
-// payload (a `100` spend limit alongside a `40000` plan limit is $100 against
-// $400, not $1), so they are carried through as-is and named to say so.
+// ALL money is USD, and EVERY wire money value is integer CENTS the host
+// divides - including the on-demand (spend-limit) fields: a live account with
+// a $1 on-demand limit reports `individualLimit: 100`. (An earlier revision
+// read those as whole dollars and displayed $100; the cents rule has no
+// exceptions.) The on-demand fields carry the dashboard's "On-Demand
+// Spending" numbers and are named for it.
 const cursorRateLimitsSchema = z
   .object({
     provider: z.literal(rateLimitCapableProviderIdSchema.enum.cursor),
     available: z.literal(true),
     cycleStart: z.number().nullable(),
     cycleEnd: z.number().nullable(),
-    cycle: providerRateLimitWindowSchema.nullable(),
+    cursorModels: providerRateLimitWindowSchema.nullable(),
+    otherModels: providerRateLimitWindowSchema.nullable(),
     includedLimitUsd: z.number().nullable(),
     usedUsd: z.number().nullable(),
     remainingUsd: z.number().nullable(),
-    spendLimitType: z.string().nullable(),
-    spendLimitUsd: z.number().nullable(),
-    spendLimitRemainingUsd: z.number().nullable(),
-    // Cursor's own rendering of the headline number ("You've used 72% of your
-    // included usage"). Carried so the GUI can show the provider's wording
-    // rather than a second, subtly different sentence derived from `cycle`.
+    onDemandLimitType: z.string().nullable(),
+    onDemandLimitUsd: z.number().nullable(),
+    onDemandUsedUsd: z.number().nullable(),
+    onDemandRemainingUsd: z.number().nullable(),
+    // Cursor's own rendering of the blended headline ("You've used 79% of
+    // your included usage"). Carried so a consumer can show the provider's
+    // wording for the pool the money fields describe.
     displayMessage: z.string().nullable(),
   })
   .superRefine((value, ctx) => {
     // Same invariant grok's arm enforces, for the same reason: the host
-    // synthesizes the window's reset FROM the billing-cycle end, so the two
+    // synthesizes each window's reset FROM the billing-cycle end, so the two
     // denote one instant by construction. `cycleEnd` is kept as its own field
-    // so the cycle bounds survive a snapshot whose usage could not be measured
-    // (`cycle` null, `cycleEnd` still known). Enforce it at the wire boundary
-    // so a measured cycle can never omit or disagree with the known reset.
-    if (
-      value.cycleEnd !== null &&
-      value.cycle !== null &&
-      value.cycle.resetsAt !== value.cycleEnd
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "cursor cycle.resetsAt must equal cycleEnd when cycle is set",
-        path: ["cycle", "resetsAt"],
-      });
+    // so the cycle bounds survive a snapshot whose usage could not be
+    // measured (both windows null, `cycleEnd` still known). Enforce it at the
+    // wire boundary so a measured window can never omit or disagree with the
+    // known reset.
+    for (const key of ["cursorModels", "otherModels"] as const) {
+      const window = value[key];
+      if (
+        value.cycleEnd !== null &&
+        window !== null &&
+        window.resetsAt !== value.cycleEnd
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `cursor ${key}.resetsAt must equal cycleEnd when the window is set`,
+          path: [key, "resetsAt"],
+        });
+      }
     }
   });
 

--- a/protocol/src/host/rate-limit/semantics.ts
+++ b/protocol/src/host/rate-limit/semantics.ts
@@ -70,6 +70,11 @@ export function providerRateLimitWindows(
       // severity/rollup path. A period-less snapshot (tier + dates only, no
       // usage percentage) carries no window.
       return rateLimits.period !== null ? [rateLimits.period] : [];
+    case "cursor":
+      // Hybrid arm, like grok's: the synthesized billing-cycle window feeds the
+      // shared severity/rollup path. A snapshot whose usage could not be
+      // measured (no plan limit reported) carries no window.
+      return rateLimits.cycle !== null ? [rateLimits.cycle] : [];
     case "opencode":
       return [rateLimits.fiveHour, rateLimits.weekly, rateLimits.monthly];
     case "openrouter":

--- a/protocol/src/host/rate-limit/semantics.ts
+++ b/protocol/src/host/rate-limit/semantics.ts
@@ -71,10 +71,13 @@ export function providerRateLimitWindows(
       // usage percentage) carries no window.
       return rateLimits.period !== null ? [rateLimits.period] : [];
     case "cursor":
-      // Hybrid arm, like grok's: the synthesized billing-cycle window feeds the
+      // Hybrid arm, like grok's: the synthesized per-bucket windows ("Cursor
+      // Models" / "Other Models", mirroring Cursor's Spending page) feed the
       // shared severity/rollup path. A snapshot whose usage could not be
-      // measured (no plan limit reported) carries no window.
-      return rateLimits.cycle !== null ? [rateLimits.cycle] : [];
+      // measured (no bucket percentages reported) carries no windows.
+      return [rateLimits.cursorModels, rateLimits.otherModels].filter(
+        (window): window is ProviderRateLimitWindow => window !== null,
+      );
     case "opencode":
       return [rateLimits.fiveHour, rateLimits.weekly, rateLimits.monthly];
     case "openrouter":


### PR DESCRIPTION
Adds Cursor to the provider rate-limit rail, alongside codex/claude-code/grok/opencode and the credit providers.

## Why this reads a private API

Cursor's API-key-authenticated **public** API carries no account quota. Probed directly, it exposes only `/v1/me`, `/v1/models`, `/v1/repositories`, `/v1/agents`, and a **per-agent** token/cost read; `@cursor/sdk`'s `getUsage()` is scoped to one agent's runs, and the SDK reads only `retry-after` on a 429 — reactive, never forward-looking. There was no data source for a windowed rail.

The account numbers live on `aiserver.v1.DashboardService/GetCurrentPeriodUsage` (`api2.cursor.sh`). Notably `cursor-agent` bundles that method's proto but **never calls it**, so there was no existing call site to copy.

## Credential: exchange, not keychain

The host mints a dashboard session from the **configured API key**:

```
POST /auth/exchange_user_api_key            Bearer <apiKey>      -> { accessToken, refreshToken }
POST DashboardService/GetCurrentPeriodUsage Bearer <accessToken> -> current-period usage
```

Deriving the session *from* the billing key is load-bearing: it makes the account this arm reports and the account Traycer bills the same account **by construction**. The alternative — reading Cursor's own CLI session from the OS keychain — reports whichever account last ran `cursor-agent login`, needs a hand-written identity gate that can drift, and needs WorkOS refresh rotation (the stored token is routinely expired).

## The `totalPercentUsed` trap

The payload offers a ready-made `totalPercentUsed: 11.5384`, and it is **wrong for this purpose**. On the same payload `totalSpend/limit` = 28846/40000 = **72.1%**, and Cursor's own `displayMessage` reads *"You've used 72% of your included usage."* Using the pre-computed field would put a number in the rail contradicting the sentence beside it. `usedPercent` is therefore derived, and a regression test pins it against both 72.115 and not-11.5384.

Two further payload properties the parser respects:
- int64 cycle bounds arrive as **JSON strings**, guarded so a malformed bound can't become `NaN` in a countdown;
- **proto3 JSON omits zero-valued fields**, so absent is indistinguishable from zero — every payload-derived field is nullable, and a missing plan limit yields a `null` window rather than a synthetic 0% (which would render a *healthy* bar for an account whose usage nobody knows).

## Shape and wire

Hybrid like grok's — a synthesized `cycle` window feeding the shared severity rollup plus raw money — **not** credit-shaped like openrouter/kilocode/huggingface, since Cursor's money backs a real billing-cycle percentage. It therefore needs no special-casing in `classifyProviderRateLimits`, and is deliberately absent from the credit-provider severity exception in `profile-usage-projection`.

The arm rides the still-unreleased **4.0** line rather than opening a 5.0: the released baseline tops out at major 3 for both `host.getRateLimitUsage` and `agent.getProviderProfileRateLimits`, so no peer has ever negotiated 4 — the same reasoning that put Hugging Face and OpenCode there. `mapCursorAvailableToUnavailable` degrades the arm on every bridge below 4.0; because `"cursor"` is in every frozen provider-id enum (it predates Hermes/omp), the degraded row reparses cleanly down to v1.2, which also lets the three a2a profile bridges **degrade** instead of failing closed with `DOWNGRADE_UNSUPPORTED`.

Units differ within one payload: `planUsage` money is integer **cents** (divided to USD at the host boundary), while spend-limit fields are whole **dollars**.

## Verification

Endpoint, auth scheme, and response shape confirmed **end to end against a live account** — not inferred from a reference implementation. It remains a private API with no compatibility promise, so parsing is narrow and defensive: an unrecognized 200 degrades each field to `null`, total failure degrades to an explicit unavailable reason. An upstream shape change makes the rail honest, never wrong.

- protocol: 163 files / 2644 tests green
- gui-app rate-limit surface: 16 files / 210 tests green
- new coverage: cursor arm + all four downgrade bridges

The host-side fetcher and dispatch land separately in the internal repo, which will re-pin the gitlink once this merges.
