### PR TITLE
fix(gui-app): clear terminal retry state after recovery

### DIFF
--- a/clients/gui-app/src/hooks/agent/__tests__/use-terminal-tile-bootstrap-refetch-stability.test.tsx
+++ b/clients/gui-app/src/hooks/agent/__tests__/use-terminal-tile-bootstrap-refetch-stability.test.tsx
@@ -208,4 +208,54 @@ describe("useTerminalTileBootstrap handle gate across list refetches", () => {
 
     expect(lastHandleArgs().enabled).toBe(false);
   });
+
+  it("clears a retained retry error when the refetch finds the session running", async () => {
+    mockList.data = { sessions: [] };
+    mockCreate.isError = true;
+    mockCreate.isIdle = false;
+    mockCreate.error = new Error("response lost");
+    mockCreate.reset = () => {
+      mockCreate.isError = false;
+      mockCreate.isIdle = true;
+      mockCreate.error = null;
+    };
+    let resolveRefetch:
+      | ((result: {
+          readonly data: {
+            readonly sessions: ReadonlyArray<Record<string, unknown>>;
+          };
+        }) => void)
+      | null = null;
+    mockList.refetch = () => {
+      mockList.isFetching = true;
+      return new Promise((resolve) => {
+        resolveRefetch = resolve;
+      });
+    };
+    const { result, rerender } = runBootstrap();
+    act(() => {
+      result.current.reportMeasuredGrid(120, 40);
+      result.current.retry();
+    });
+    expect(result.current.createRetryIsPending).toBe(true);
+
+    const runningListData = {
+      sessions: [
+        { sessionId: "term-1", sessionKind: "terminal", status: "running" },
+      ],
+    };
+    mockList.data = runningListData;
+    mockList.isFetching = false;
+    await act(() => {
+      resolveRefetch?.({ data: runningListData });
+      return Promise.resolve();
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.createRetryIsPending).toBe(false);
+      expect(lastHandleArgs().enabled).toBe(true);
+    });
+    expect(mockCreate.mutate).not.toHaveBeenCalled();
+  });
 });

--- a/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
+++ b/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
@@ -415,13 +415,26 @@ export function useTerminalTileBootstrap(
   }, [handle, sessionId]);
 
   const resetPrepare = input.resetPrepare;
+  const retrySessionId = input.sessionId;
+  const retrySessionKind = input.sessionKind;
   const retry = useCallback(() => {
     hasDispatchedRef.current = false;
     setCreateRetryError(create.error);
     create.reset();
     if (resetPrepare !== undefined) resetPrepare();
-    void list.refetch();
-  }, [create, list, resetPrepare]);
+    void list.refetch().then((result) => {
+      if (
+        result.data?.sessions.some(
+          (session) =>
+            session.sessionId === retrySessionId &&
+            session.sessionKind === retrySessionKind &&
+            session.status === "running",
+        ) === true
+      ) {
+        setCreateRetryError(null);
+      }
+    });
+  }, [create, list, resetPrepare, retrySessionId, retrySessionKind]);
 
   return {
     hostHasSession,


### PR DESCRIPTION
## Summary
- clear retained terminal retry errors when a settled list refetch finds the original create succeeded remotely
- avoid leaving landing terminals stuck on a disabled Retry state when no replacement create is needed
- add focused coverage for the failed-response/live-session recovery path

Follow-up to #1264, which merged while this final review fix was being committed.

## Test plan
- [x] `bun run test src/hooks/agent/__tests__/use-terminal-tile-bootstrap-refetch-stability.test.tsx src/components/home/terminal-panel/__tests__/landing-terminal-error-retry.test.tsx`
- [x] pre-commit affected build, compile, lint, and format checks

Made with [Cursor](https://cursor.com)