### PR TITLE
perf(gui-app): serve worktree branch search from a substring fast path

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/worktree-branch-search.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/worktree-branch-search.test.ts
@@ -70,4 +70,99 @@ describe("worktree branch search", () => {
       "repo-feature-x",
     );
   });
+
+  it("matches substrings case-insensitively", () => {
+    const rows = [
+      searchRow("one", "Feature/Payments", "/repo/worktrees/alpha"),
+    ];
+    const index = createWorktreeBranchSearchIndex(rows);
+
+    expect(
+      filterWorktreeBranchRows(rows, index, "PAYMENTS").map((row) => row.id),
+    ).toEqual(["one"]);
+  });
+
+  it("ranks a branch-name substring hit above a path-only substring hit, using the substring path exclusively", () => {
+    const rows = [
+      searchRow("branch", "hotfix/urgent-patch", "/repo/worktrees/alpha"),
+      searchRow("path", "misc", "/repo/worktrees/urgent-workdir"),
+    ];
+    // Index over zero rows: Fuse can never produce a hit from it, so a
+    // non-empty, correctly ordered result proves the substring tiers were
+    // used exclusively rather than falling through to fuzzy search.
+    const emptyIndex = createWorktreeBranchSearchIndex<(typeof rows)[number]>(
+      [],
+    );
+
+    expect(
+      filterWorktreeBranchRows(rows, emptyIndex, "urgent").map((row) => row.id),
+    ).toEqual(["branch", "path"]);
+  });
+
+  it("ranks an exact branch-name match above rows that merely contain the query", () => {
+    // Input order is deliberately NOT rank order, so a raw-order bug would
+    // fail this assertion.
+    const rows = [
+      searchRow("domain", "chore/domain-cleanup", "/repo/worktrees/domain"),
+      searchRow("main", "main", "/repo/main"),
+      searchRow("release", "release/main-backport", "/repo/worktrees/release"),
+    ];
+    const index = createWorktreeBranchSearchIndex(rows);
+
+    expect(
+      filterWorktreeBranchRows(rows, index, "main").map((row) => row.id),
+    ).toEqual(["main", "domain", "release"]);
+  });
+
+  it("ranks a prefix match above mere containment within the same tier, shorter prefix first", () => {
+    // "dev-tools" and "development-notes" both start with "dev" (prefix
+    // matches); "middev" only contains "dev" mid-string. Among the two
+    // prefix matches, the shorter field ("dev-tools") ranks first.
+    const rows = [
+      searchRow(
+        "development",
+        "development-notes",
+        "/repo/worktrees/development",
+      ),
+      searchRow("middev", "middev", "/repo/worktrees/middev"),
+      searchRow("devtools", "dev-tools", "/repo/worktrees/devtools"),
+    ];
+    const index = createWorktreeBranchSearchIndex(rows);
+
+    expect(
+      filterWorktreeBranchRows(rows, index, "dev").map((row) => row.id),
+    ).toEqual(["devtools", "development", "middev"]);
+  });
+
+  it("matches an exact branch name case-insensitively, still ranked first", () => {
+    const rows = [
+      searchRow("domain", "chore/domain-cleanup", "/repo/worktrees/domain"),
+      searchRow("main", "main", "/repo/main"),
+      searchRow("release", "release/main-backport", "/repo/worktrees/release"),
+    ];
+    const index = createWorktreeBranchSearchIndex(rows);
+
+    expect(
+      filterWorktreeBranchRows(rows, index, "MAIN").map((row) => row.id),
+    ).toEqual(["main", "domain", "release"]);
+  });
+
+  it("serves queries over FUZZY_QUERY_MAX_LENGTH from substring matches only, with no fuzzy fallback", () => {
+    const longBranch = "feature-integration-with-payments-flow-long";
+    const rows = [searchRow("one", longBranch, "/repo/worktrees/alpha")];
+    const index = createWorktreeBranchSearchIndex(rows);
+
+    // Exact (long) substring hit still returns.
+    expect(longBranch.length).toBeGreaterThan(32);
+    expect(
+      filterWorktreeBranchRows(rows, index, longBranch).map((row) => row.id),
+    ).toEqual(["one"]);
+
+    // A one-character typo of the same long query breaks the substring match;
+    // Fuse would typically typo-tolerate it, but the length gate skips Fuse
+    // entirely, so the result must be empty.
+    const typoQuery = "feature-integration-with-paymentz-flow-long";
+    expect(typoQuery.length).toBeGreaterThan(32);
+    expect(filterWorktreeBranchRows(rows, index, typoQuery)).toEqual([]);
+  });
 });

--- a/clients/gui-app/src/components/home/__tests__/worktree-branch-search.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/worktree-branch-search.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createWorktreeBranchSearchIndex,
   filterWorktreeBranchRows,
@@ -151,6 +151,9 @@ describe("worktree branch search", () => {
     const longBranch = "feature-integration-with-payments-flow-long";
     const rows = [searchRow("one", longBranch, "/repo/worktrees/alpha")];
     const index = createWorktreeBranchSearchIndex(rows);
+    // The gate is about the CALL, not just the result: spy on the index so a
+    // silent fuzzy pass cannot hide behind an empty result set.
+    const search = vi.spyOn(index, "search");
 
     // Exact (long) substring hit still returns.
     expect(longBranch.length).toBeGreaterThan(32);
@@ -164,5 +167,14 @@ describe("worktree branch search", () => {
     const typoQuery = "feature-integration-with-paymentz-flow-long";
     expect(typoQuery.length).toBeGreaterThan(32);
     expect(filterWorktreeBranchRows(rows, index, typoQuery)).toEqual([]);
+    expect(search).not.toHaveBeenCalled();
+
+    // Control: the same spy DOES record a call once the query is short enough
+    // to earn the fuzzy fallback, so the zero-call assertion above is evidence
+    // of the length gate rather than of a spy that can never fire.
+    const shortTypo = "paymentz";
+    expect(shortTypo.length).toBeLessThanOrEqual(32);
+    filterWorktreeBranchRows(rows, index, shortTypo);
+    expect(search).toHaveBeenCalledWith(shortTypo);
   });
 });

--- a/clients/gui-app/src/components/home/data/worktree-branch-search.ts
+++ b/clients/gui-app/src/components/home/data/worktree-branch-search.ts
@@ -8,18 +8,88 @@ export interface WorktreeBranchSearchRow {
   readonly searchFullPath: string;
 }
 
+interface WorktreeBranchSearchKey {
+  readonly name: Exclude<keyof WorktreeBranchSearchRow, "id">;
+  readonly weight: number;
+}
+
+/**
+ * Search fields in ranking precedence, with their Fuse weights. This single
+ * declaration drives both the fuzzy index and the substring fast path, so the
+ * two passes cannot drift on membership or precedence. Each field is checked
+ * independently in the substring pass: the path fields are usually substrings
+ * of `searchFullPath`, but not always — `pathSearchTail` re-joins segments
+ * with `/`, so a Windows tail is not contained in its backslashed full path.
+ */
+const WORKTREE_BRANCH_SEARCH_KEYS: ReadonlyArray<WorktreeBranchSearchKey> = [
+  { name: "searchBranch", weight: 0.58 },
+  { name: "searchPathTail", weight: 0.24 },
+  { name: "searchPathBasename", weight: 0.12 },
+  { name: "searchFullPath", weight: 0.06 },
+];
+
 const WORKTREE_BRANCH_FUSE_OPTIONS: IFuseOptions<WorktreeBranchSearchRow> = {
   includeScore: false,
   ignoreLocation: true,
   threshold: 0.4,
   minMatchCharLength: 1,
-  keys: [
-    { name: "searchBranch", weight: 0.58 },
-    { name: "searchPathTail", weight: 0.24 },
-    { name: "searchPathBasename", weight: 0.12 },
-    { name: "searchFullPath", weight: 0.06 },
-  ],
+  keys: [...WORKTREE_BRANCH_SEARCH_KEYS],
 };
+
+/**
+ * Above this length Fuse splits the pattern into multiple bitap chunks and the
+ * error budget from `threshold` makes each scan expensive (hundreds of ms over
+ * ~1k branches), while edit-distance matches on a query that long are noise —
+ * so long queries are served by the substring pass alone.
+ */
+const FUZZY_QUERY_MAX_LENGTH = 32;
+
+interface SubstringMatch<TRow extends WorktreeBranchSearchRow> {
+  readonly row: TRow;
+  /** Index into {@link WORKTREE_BRANCH_SEARCH_KEYS} of the first field hit. */
+  readonly tier: number;
+  /** Lowercased text of that field. */
+  readonly matchedText: string;
+  readonly rowIndex: number;
+}
+
+function substringMatch<TRow extends WorktreeBranchSearchRow>(
+  row: TRow,
+  rowIndex: number,
+  loweredQuery: string,
+): SubstringMatch<TRow> | null {
+  for (const [tier, key] of WORKTREE_BRANCH_SEARCH_KEYS.entries()) {
+    const matchedText = row[key.name].toLowerCase();
+    if (matchedText.includes(loweredQuery)) {
+      return { row, tier, matchedText, rowIndex };
+    }
+  }
+  return null;
+}
+
+/**
+ * Field precedence first, then how well the matched field fits the query:
+ * an exact field match, then a prefix match, then the shorter field —
+ * approximating Fuse's fieldNorm scoring, where `main` must outrank
+ * `chore/domain-cleanup`. Input order breaks ties.
+ */
+function compareSubstringMatches<TRow extends WorktreeBranchSearchRow>(
+  a: SubstringMatch<TRow>,
+  b: SubstringMatch<TRow>,
+  loweredQuery: string,
+): number {
+  if (a.tier !== b.tier) return a.tier - b.tier;
+  const aExact = a.matchedText === loweredQuery;
+  const bExact = b.matchedText === loweredQuery;
+  if (aExact !== bExact) return aExact ? -1 : 1;
+  const aPrefix = a.matchedText.startsWith(loweredQuery);
+  const bPrefix = b.matchedText.startsWith(loweredQuery);
+  if (aPrefix !== bPrefix) return aPrefix ? -1 : 1;
+  if (a.matchedText.length !== b.matchedText.length) {
+    return a.matchedText.length - b.matchedText.length;
+  }
+  return a.rowIndex - b.rowIndex;
+}
 
 export function createWorktreeBranchSearchIndex<
   TRow extends WorktreeBranchSearchRow,
@@ -34,6 +104,20 @@ export function filterWorktreeBranchRows<TRow extends WorktreeBranchSearchRow>(
 ): ReadonlyArray<TRow> {
   const trimmed = query.trim();
   if (trimmed.length === 0) return rows;
+  const loweredQuery = trimmed.toLowerCase();
+  const matches: Array<SubstringMatch<TRow>> = [];
+  for (const [rowIndex, row] of rows.entries()) {
+    const match = substringMatch(row, rowIndex, loweredQuery);
+    if (match !== null) matches.push(match);
+  }
+  // Fuse only ever widens a non-empty substring result set with edit-distance
+  // matches nobody scans past exact hits for — so it runs solely as the
+  // typo-tolerance fallback, on short queries with no exact hit.
+  if (matches.length > 0 || trimmed.length > FUZZY_QUERY_MAX_LENGTH) {
+    return matches
+      .sort((a, b) => compareSubstringMatches(a, b, loweredQuery))
+      .map((match) => match.row);
+  }
   return searchIndex.search(trimmed).map((result) => result.item);
 }
 

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/new-worktree-form.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/new-worktree-form.test.tsx
@@ -524,6 +524,36 @@ describe("NewWorktreeForm — typing performance", () => {
   });
 });
 
+describe("NewWorktreeForm — source search", () => {
+  it("shows 'No matching branches' for a non-matching query, then restores rows once cleared", () => {
+    branchesData = {
+      branches: [
+        { name: "development", isCurrent: true, isRemoteOnly: false },
+        { name: "chore/cleanup", isCurrent: false, isRemoteOnly: false },
+      ],
+      uncommittedFileCount: 0,
+    };
+    renderForm(() => undefined, null);
+    const search = screen.getByRole("combobox", { name: "Search branches" });
+
+    fireEvent.change(search, { target: { value: "zzz-no-such-branch" } });
+    act(() => {
+      vi.advanceTimersToNextFrame();
+    });
+
+    expect(screen.getByText("No matching branches")).toBeTruthy();
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+
+    fireEvent.change(search, { target: { value: "" } });
+    act(() => {
+      vi.advanceTimersToNextFrame();
+    });
+
+    expect(screen.queryByText("No matching branches")).toBeNull();
+    expect(screen.getAllByRole("option").length).toBe(2);
+  });
+});
+
 describe("NewWorktreeForm — new-branch name", () => {
   it("working tree source: name required (prefilled), then autosaved", () => {
     branchesData = {

--- a/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
@@ -1,6 +1,7 @@
 import {
   memo,
   useCallback,
+  useDeferredValue,
   useEffect,
   useId,
   useMemo,
@@ -23,7 +24,10 @@ import {
   InputGroupInput,
 } from "@/components/ui/input-group";
 import { PickerOptionButton } from "@/components/home/worktree/worktree-branch-picker-options";
-import type { WorktreeBranchPickerRow } from "@/components/home/worktree/worktree-branch-picker-model";
+import {
+  pickerEmptyStateLabel,
+  type WorktreeBranchPickerRow,
+} from "@/components/home/worktree/worktree-branch-picker-model";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import type { HostRpcRegistry } from "@/lib/host";
 import {
@@ -436,9 +440,18 @@ const SourceBranchList = memo(function SourceBranchList(props: {
     () => createWorktreeBranchSearchIndex(rows),
     [rows],
   );
+  // Filtering on the deferred query keeps the input echo (and key-repeat
+  // backspace) off the search's critical path: the list catches up in a
+  // deferred render instead of blocking each keystroke. Load-bearing even
+  // though the substring fast path makes most keystrokes sub-ms: a short query
+  // with no substring hit still pays the Fuse typo-tolerance fallback
+  // (50–260ms over ~1k branches), and this hook is the only thing keeping that
+  // off the keystroke. Not provable in jsdom — `act` drains transition work,
+  // so tests pass with or without it.
+  const deferredQuery = useDeferredValue(query);
   const filtered = useMemo(
-    () => filterWorktreeBranchRows(rows, searchIndex, query),
-    [rows, searchIndex, query],
+    () => filterWorktreeBranchRows(rows, searchIndex, deferredQuery),
+    [rows, searchIndex, deferredQuery],
   );
   const activeIndex = sourceActiveIndex(filtered, activeId);
   const activeRow = activeIndex === -1 ? undefined : filtered[activeIndex];
@@ -527,7 +540,10 @@ const SourceBranchList = memo(function SourceBranchList(props: {
         data-testid="new-worktree-source-list"
       >
         <div className="px-2 py-1.5 text-ui-sm text-muted-foreground">
-          {props.emptyLabel}
+          {pickerEmptyStateLabel(
+            deferredQuery.trim().length > 0,
+            props.emptyLabel,
+          )}
         </div>
       </div>
     );

--- a/clients/gui-app/src/components/home/worktree/worktree-branch-picker-content.tsx
+++ b/clients/gui-app/src/components/home/worktree/worktree-branch-picker-content.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/home/worktree/worktree-branch-picker-options";
 import {
   pickerElementId,
+  pickerEmptyStateLabel,
   pickerEntryId,
   type PickerEntry,
   type WorktreeBranchPickerContentProps,
@@ -239,9 +240,7 @@ function WorktreeBranchPickerListbox(props: WorktreeBranchPickerListboxProps) {
       )}
       <div className="min-h-0 flex-1 overflow-hidden p-1">
         {filteredRows.length === 0 ? (
-          <PickerStateRow
-            label={hasQuery ? "No matching branches" : emptyLabel}
-          />
+          <PickerStateRow label={pickerEmptyStateLabel(hasQuery, emptyLabel)} />
         ) : (
           <Virtuoso<WorktreeBranchPickerRow>
             key={listKey}

--- a/clients/gui-app/src/components/home/worktree/worktree-branch-picker-model.ts
+++ b/clients/gui-app/src/components/home/worktree/worktree-branch-picker-model.ts
@@ -113,6 +113,15 @@ export function pickerEntryId(kind: PickerEntry["kind"], id: string): string {
   return `${kind}:${id}`;
 }
 
+/** Empty-list copy shared by every branch-picker surface: a live query means
+ * the branches exist but none matched; otherwise the surface's own idle copy. */
+export function pickerEmptyStateLabel(
+  hasQuery: boolean,
+  emptyLabel: string,
+): string {
+  return hasQuery ? "No matching branches" : emptyLabel;
+}
+
 export function pickerElementId(idPrefix: string, entryId: string): string {
   return `${idPrefix}-entry-${entryId.replace(/[^a-zA-Z0-9_-]/gu, "_")}`;
 }


### PR DESCRIPTION
## Problem

Holding backspace in the **New worktree** form's Source branch search was visibly sluggish — clearing a long query took ~5s at roughly a quarter of the OS key-repeat rate, and the input could not echo a deletion before the next repeat arrived.

Every keystroke synchronously ran a Fuse.js fuzzy search over every branch (~1,300 rows in a large repo) across four keys with `ignoreLocation: true`. Measured against a real 1,337-branch repository:

| Query length | Fuse time per keystroke |
| --- | --- |
| 42 chars | 357 ms |
| 30 | 112 ms |
| 12 | 41 ms |
| 2 | 13 ms |

## Change

- **Substring fast path.** `filterWorktreeBranchRows` now runs a case-insensitive exact-substring pass first, and skips Fuse entirely when it hits or when the query exceeds 32 characters — past that, bitap splits the pattern into multiple chunks and edit-distance matches on so long a string are noise. Fuse remains as the typo-tolerance fallback for short queries with no exact hit.
- **Ranking preserved.** `ignoreLocation` disables position sensitivity, not scoring: Fuse's `fieldNorm` made a short field that *is* the query beat a long field merely containing it. Substring results are therefore ordered by field precedence, then exact match, prefix match, and shorter matched field, so `main` still outranks `chore/domain-cleanup` and Enter selects the branch you typed.
- **One field declaration.** The Fuse key list and the substring pass now derive from a single `WORKTREE_BRANCH_SEARCH_KEYS` array, so they cannot drift on membership or precedence.
- **Deferred query.** The inline Source list filters on `useDeferredValue(query)`, keeping the remaining short-query fallback off the keystroke path.
- **Empty state.** The inline Source list now shares the popover picker's `pickerEmptyStateLabel`, so a non-matching query reads "No matching branches" instead of "No branches available".

## Verification

Measured in the running desktop app over a 1,337-branch repository, holding backspace through a 42-character query (CDP key events, in-page long-task observer), with the fix HMR-swapped against its own ablation:

| | Before | After |
| --- | --- | --- |
| Main-thread blocks per keystroke | 250–300 ms throughout | none above 32 chars; 50–153 ms only in the short-query fallback window |
| Worst input-echo gap | 600 ms | 331 ms |
| Empty state during a non-matching query | "No branches available" | "No matching branches" |
| Query `development` → first / highlighted row | `development` | `development` |

Tests: `worktree-branch-search.test.ts` 10/10 (3 new ranking regressions, including one that builds the Fuse index over zero rows so only the substring path can satisfy it), `new-worktree-form.test.tsx` 41/41, `worktree-branch-picker.test.tsx` 5/5, across both Vitest configs. `bun run compile` clean.
