### PR TITLE
feat(gui-app): add a notifications keybinding and keyboard feed traversal

### DIFF
--- a/clients/gui-app/src/components/notifications/__tests__/notifications-bell.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-bell.test.tsx
@@ -17,6 +17,7 @@ import {
   dispatchAction,
   type KeybindingRouter,
 } from "@/lib/keybindings/dispatch";
+import { isMac } from "@/lib/keybindings/platform";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { StreamRuntimeContext } from "@/lib/host/stream-runtime-context";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
@@ -244,13 +245,16 @@ const DYNAMIC_ACTION_ROUTER: KeybindingRouter = {
   canGoForward: () => false,
 };
 
-/** The default `app.notifications.open` chord as a keyboard event. `metaKey`
- * matches the platform-primary modifier on macOS and off it alike. */
+/** The default `app.notifications.open` chord as a keyboard event, pressed the
+ * way a user on THIS platform presses it. `hasPlatformModKey` accepts
+ * `metaKey || ctrlKey` off macOS, so a Command press would match there too -
+ * and would leave the Ctrl half, the one every Windows/Linux user actually
+ * hits, untested. */
 function pressNotificationsChord(): void {
   fireEvent.keyDown(window, {
     key: "N",
     code: "KeyN",
-    metaKey: true,
+    ...(isMac() ? { metaKey: true } : { ctrlKey: true }),
     shiftKey: true,
   });
 }

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-bell.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-bell.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Y from "yjs";
@@ -12,6 +13,10 @@ import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-ru
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
 import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  dispatchAction,
+  type KeybindingRouter,
+} from "@/lib/keybindings/dispatch";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { StreamRuntimeContext } from "@/lib/host/stream-runtime-context";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
@@ -223,6 +228,33 @@ function createRunnerHost(): MockRunnerHost {
   });
 }
 
+const DYNAMIC_ACTION_ROUTER: KeybindingRouter = {
+  getPathname: () => "/",
+  navigateHome: () => undefined,
+  navigateSettings: () => undefined,
+  navigateToEpic: () => undefined,
+  navigateToEpicTab: () => undefined,
+  navigateToEpicList: () => undefined,
+  navigateSettingsSection: () => undefined,
+  navigateToTabIntent: () => undefined,
+  goBack: () => undefined,
+  goForward: () => undefined,
+  isHistoryNavAvailable: () => false,
+  canGoBack: () => false,
+  canGoForward: () => false,
+};
+
+/** The default `app.notifications.open` chord as a keyboard event. `metaKey`
+ * matches the platform-primary modifier on macOS and off it alike. */
+function pressNotificationsChord(): void {
+  fireEvent.keyDown(window, {
+    key: "N",
+    code: "KeyN",
+    metaKey: true,
+    shiftKey: true,
+  });
+}
+
 function expectNoBellIndicators(): void {
   expect(screen.queryByTestId("notifications-attention-badge")).toBeNull();
   expect(screen.queryByTestId("notifications-quiet-dot")).toBeNull();
@@ -270,6 +302,79 @@ describe("NotificationsBell", () => {
 
     expect(screen.queryByTestId("notifications-popover")).toBeNull();
     expect(useNotificationsPopoverStore.getState().open).toBe(false);
+  });
+
+  it("opens through the notifications keybinding action and focuses the heading", async () => {
+    const runnerHost = createRunnerHost();
+    mountBell(runnerHost, undefined);
+
+    expect(screen.queryByTestId("notifications-popover")).toBeNull();
+    act(() => {
+      expect(
+        dispatchAction("app.notifications.open", DYNAMIC_ACTION_ROUTER),
+      ).toBe(true);
+    });
+
+    expect(await screen.findByTestId("notifications-popover")).not.toBeNull();
+    expect(useNotificationsPopoverStore.getState().open).toBe(true);
+    expect(document.activeElement).toBe(
+      screen.getByRole("heading", { name: "Notifications" }),
+    );
+  });
+
+  it("toggles the open center closed on a second chord press and returns focus to the bell", async () => {
+    const runnerHost = createRunnerHost();
+    mountBell(runnerHost, undefined);
+
+    act(() => {
+      dispatchAction("app.notifications.open", DYNAMIC_ACTION_ROUTER);
+    });
+    expect(await screen.findByTestId("notifications-popover")).not.toBeNull();
+    expect(document.activeElement).toBe(
+      screen.getByRole("heading", { name: "Notifications" }),
+    );
+
+    // Dispatch can't deliver the second press: an open Radix popover is a
+    // `role="dialog"`, which the keybinding provider treats as a chord
+    // barrier. The bell's own window listener is what closes it.
+    act(() => {
+      pressNotificationsChord();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("notifications-popover")).toBeNull();
+    });
+    expect(useNotificationsPopoverStore.getState().open).toBe(false);
+    // Identity by testid, not ref: the tooltip may remount the trigger node.
+    await waitFor(() => {
+      expect(document.activeElement?.getAttribute("data-testid")).toBe(
+        "notifications-bell",
+      );
+    });
+  });
+
+  it("does not steal focus when the chord closes a center the pointer opened", async () => {
+    const runnerHost = createRunnerHost();
+    mountBell(runnerHost, undefined);
+
+    const bell = screen.getByTestId("notifications-bell");
+    fireEvent.pointerDown(bell);
+    fireEvent.click(bell);
+    expect(await screen.findByTestId("notifications-popover")).not.toBeNull();
+
+    const outside = document.createElement("input");
+    document.body.appendChild(outside);
+    outside.focus();
+
+    act(() => {
+      pressNotificationsChord();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("notifications-popover")).toBeNull();
+    });
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
   });
 
   it("suppresses title-bar dragging only while the popover is open", async () => {

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover-feed-controls.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover-feed-controls.test.tsx
@@ -1996,4 +1996,98 @@ describe("NotificationsPopover feed controls (T05)", () => {
       trackSpy.mockRestore();
     });
   });
+
+  describe("keyboard traversal", () => {
+    /** The feed id of the row that currently holds focus, if any. */
+    function focusedRowId(): string | undefined {
+      const active = document.activeElement;
+      if (!(active instanceof HTMLElement)) return undefined;
+      return active.dataset.notificationId;
+    }
+
+    function seedTraversalFeed(): void {
+      applyHostSnapshot({
+        entries: [
+          hostPrompt("prompt", 100),
+          hostDone("done-unread", 90, null),
+          hostDone("done-read", 80, 10),
+        ],
+        summary: { unreadCount: 2, attentionCount: 1 },
+        recentCursor: null,
+        attentionCursor: null,
+      });
+      // Read AND payload-less: nothing inside this row is focusable, so it is
+      // exactly the row a control-focusing traversal would silently skip.
+      useAppLocalNotificationsStore.getState().activateIdentity("user-a");
+      useAppLocalNotificationsStore.getState().upsert({
+        id: "sys-read",
+        updatedAt: 70,
+        readAt: 75,
+        kind: "stream.transport.error",
+        sourceRef: "sys-read",
+        payload: null,
+        message: "Worktree failed",
+        detail: null,
+      });
+    }
+
+    it("walks every row with Down/Up and wraps at both ends", async () => {
+      seedTraversalFeed();
+      renderPopover();
+
+      await screen.findByText("Needs attention");
+      const shell = screen.getByTestId("notifications-popover");
+      const ids = notificationIds(screen.getAllByTestId("notification-entry"));
+      expect(ids).toHaveLength(4);
+
+      for (const id of ids) {
+        fireEvent.keyDown(shell, { key: "ArrowDown" });
+        expect(focusedRowId()).toBe(id);
+      }
+      // Past the last row, back to the first.
+      fireEvent.keyDown(shell, { key: "ArrowDown" });
+      expect(focusedRowId()).toBe(ids[0]);
+      // And back off the top to the last.
+      fireEvent.keyDown(shell, { key: "ArrowUp" });
+      expect(focusedRowId()).toBe(ids[ids.length - 1]);
+
+      fireEvent.keyDown(shell, { key: "Home" });
+      expect(focusedRowId()).toBe(ids[0]);
+      fireEvent.keyDown(shell, { key: "End" });
+      expect(focusedRowId()).toBe(ids[ids.length - 1]);
+    });
+
+    it("reaches a read row that has no focusable control of its own", async () => {
+      seedTraversalFeed();
+      renderPopover();
+
+      await screen.findByText("Needs attention");
+      const shell = screen.getByTestId("notifications-popover");
+      const rows = screen.getAllByTestId("notification-entry");
+      const unfocusable = rows.find(
+        (row) => row.dataset.notificationId === "app-local:sys-read",
+      );
+      if (unfocusable === undefined) throw new Error("missing app-local row");
+      expect(unfocusable.querySelector("button")).toBeNull();
+
+      const visited = new Set<string | undefined>();
+      for (let step = 0; step < rows.length; step += 1) {
+        fireEvent.keyDown(shell, { key: "ArrowDown" });
+        visited.add(focusedRowId());
+      }
+      expect(visited.has("app-local:sys-read")).toBe(true);
+    });
+
+    it("leaves modified arrows to the rest of the app", async () => {
+      seedTraversalFeed();
+      renderPopover();
+
+      await screen.findByText("Needs attention");
+      const shell = screen.getByTestId("notifications-popover");
+      fireEvent.keyDown(shell, { key: "ArrowDown", metaKey: true });
+      expect(focusedRowId()).toBeUndefined();
+      fireEvent.keyDown(shell, { key: "ArrowDown", altKey: true });
+      expect(focusedRowId()).toBeUndefined();
+    });
+  });
 });

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -1712,6 +1712,45 @@ describe("NotificationsPopover", () => {
     ).toBeTypeOf("number");
   });
 
+  it("activates the same target from Enter on a keyboard-focused row", async () => {
+    const captured: TargetCapture = {
+      epicId: null,
+      tabId: null,
+      focusArtifactId: null,
+      focusThreadId: null,
+    };
+    const onNavigate = vi.fn();
+    const { router } = buildRouterWithCapture(captured, onNavigate);
+
+    openNotificationsStream((callbacks) => {
+      act(() => {
+        seedEntries(callbacks, [
+          threadEntry("route-key", "epic-key", "art-8", "thread-3"),
+        ]);
+      });
+      return { applyUpdate: () => {}, close: () => {} };
+    }, null);
+
+    renderRouter(router);
+
+    // The row itself is the arrow-key focus target, so Enter on it must do
+    // what clicking its body button does - not nothing.
+    const entry = await screen.findByTestId("notification-entry");
+    entry.focus();
+    expect(document.activeElement).toBe(entry);
+
+    await act(async () => {
+      fireEvent.keyDown(entry, { key: "Enter" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(captured.epicId).toBe("epic-key");
+    expect(captured.focusArtifactId).toBe("art-8");
+    expect(captured.focusThreadId).toBe("thread-3");
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
   it("navigates a TUI completion row to its terminal agent", async () => {
     applyHostSnapshot(
       [

--- a/clients/gui-app/src/components/notifications/notification-row.tsx
+++ b/clients/gui-app/src/components/notifications/notification-row.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import { m, useReducedMotion } from "motion/react";
 import {
   Bell,
@@ -196,6 +196,21 @@ export function NotificationRow(props: NotificationRowProps): ReactNode {
     shouldReduceMotion,
   });
 
+  // Same condition the navigable body button renders under, so keyboard
+  // activation of a focused row and a click on that button are the same act.
+  const canActivate =
+    packPresentation.isNavigable && originUnavailability === null;
+  // Only the row's OWN key events - a keydown bubbling up from one of its
+  // controls has already been handled by that control (Enter on the trailing
+  // tick acknowledges; it must not also activate the row).
+  const onRowKeyDown = (event: KeyboardEvent<HTMLLIElement>): void => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    if (!canActivate) return;
+    event.preventDefault();
+    props.onActivate(row);
+  };
+
   return (
     <m.li
       layout={motionProps.layout}
@@ -214,8 +229,14 @@ export function NotificationRow(props: NotificationRowProps): ReactNode {
       // Remote pack-store entries stay fully listed (needs_action evidence)
       // but are visually de-emphasised so this machine's actionable items
       // lead — de-emphasis, not filter-out (D7).
+      //
+      // `tabIndex={-1}` makes the row itself the arrow-key landing spot
+      // (see `notification-feed-keyboard-navigation.ts`) without adding a Tab
+      // stop: Tab order still runs through the row's controls only.
+      tabIndex={-1}
+      onKeyDown={onRowKeyDown}
       className={cn(
-        "relative flex items-start gap-2.5 border-b border-border/60 py-2.5 pr-4 pl-6 last:border-b-0 hover:bg-foreground/6 has-[:focus-visible]:bg-foreground/6",
+        "relative flex items-start gap-2.5 border-b border-border/60 py-2.5 pr-4 pl-6 outline-none last:border-b-0 hover:bg-foreground/6 focus-visible:bg-foreground/6 focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:ring-inset has-[:focus-visible]:bg-foreground/6",
         packPresentation.packRemote && "opacity-60",
       )}
       data-testid="notification-entry"

--- a/clients/gui-app/src/components/notifications/notifications-bell.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-bell.tsx
@@ -18,6 +18,12 @@ import {
 } from "@/stores/notifications/merged-notifications";
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
 import { useTitleBarDragSuppression } from "@/stores/layout/title-bar-drag-store";
+import { registerDynamicActionHandler } from "@/lib/keybindings/dispatch";
+import {
+  chordMatchesEvent,
+  formatChordForDisplay,
+} from "@/lib/keybindings/chord";
+import { useBindingForAction } from "@/stores/settings/keybinding-store";
 import { cn } from "@/lib/utils";
 import {
   Analytics,
@@ -25,6 +31,9 @@ import {
   analyticsCountBucket,
   type AnalyticsNotificationEntryPoint,
 } from "@/lib/analytics";
+
+/** The center's own surface, marked by `NotificationsPopover`. */
+const NOTIFICATION_CENTER_SELECTOR = "[data-notification-center]";
 
 /**
  * Top-level notifications trigger in the app header. Shows an unread-count
@@ -95,6 +104,51 @@ export function NotificationsBell() {
     [lifecycle],
   );
 
+  const chord = useBindingForAction("app.notifications.open");
+  const markKeyboardDismiss = lifecycle.markKeyboardDismiss;
+  // Opening goes through the normal dispatch path. A chord open is a
+  // deliberate interaction with the app, so it is attributed to `direct_ui`
+  // like a bell click - `notification` means "arrived from a native
+  // notification", which would be a false claim here.
+  useEffect(
+    () =>
+      registerDynamicActionHandler("app.notifications.open", () => {
+        openEntryPointRef.current = "direct_ui";
+        useNotificationsPopoverStore.getState().setOpen(true);
+      }),
+    [],
+  );
+
+  // Closing does NOT: an open Radix popover is a `role="dialog"`, and the
+  // keybinding provider deliberately stops dispatching chords behind one
+  // (`isAnyDialogOpen`), so the dynamic handler above can never see the
+  // second press. This window listener is mounted only while the center is
+  // open and matches the live binding itself, which also keeps the toggle
+  // working when the center was opened by pointer or by a native-notification
+  // click (focus outside the surface, so no in-surface handler would fire).
+  //
+  // Focus returns to the bell only when the center's own surface still holds
+  // it: a pointer-opened center leaves focus wherever the user was typing,
+  // and yanking that into the header would be the worse bug. That question is
+  // asked of the focused element itself (`data-notification-center`, set by
+  // the popover) rather than of the shell ref, which belongs to the geometry
+  // lock and must not be read from render.
+  useEffect(() => {
+    if (!open || chord === null) return;
+    const onKeyDown = (event: globalThis.KeyboardEvent): void => {
+      if (!chordMatchesEvent(chord, event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const active = document.activeElement;
+      if (active !== null && active.closest(NOTIFICATION_CENTER_SELECTOR)) {
+        markKeyboardDismiss();
+      }
+      useNotificationsPopoverStore.getState().setOpen(false);
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [chord, markKeyboardDismiss, open]);
+
   // Fires exactly once per open cycle - edge-triggered on the `open`
   // boolean's false -> true transition, so it covers every way the center
   // can open (bell click/keyboard AND a native-notification-driven
@@ -123,10 +177,14 @@ export function NotificationsBell() {
   }, [open, bellState, hostState.isPartial, unreadCount]);
 
   const ariaLabel = notificationBellAccessibleLabel(bellState);
+  const tooltip =
+    chord === null
+      ? "Notifications"
+      : `Notifications (${formatChordForDisplay(chord)})`;
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <TooltipWrapper
-        label={open ? null : "Notifications"}
+        label={open ? null : tooltip}
         side="top"
         sideOffset={6}
         align={undefined}

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -42,6 +42,7 @@ import {
   type NotificationCategory,
 } from "@/lib/notifications/notification-category";
 import { classifyNotificationLifecycle } from "@/lib/notifications/notification-lifecycle";
+import { useNotificationFeedKeyboardNavigation } from "@/hooks/notifications/use-notification-feed-keyboard-navigation";
 import { activationResultHandler } from "@/lib/notifications/notification-activation-result";
 import { cn } from "@/lib/utils";
 import {
@@ -270,6 +271,10 @@ export function NotificationsPopover(
     isAtTop,
     scrollToTop,
   } = useNotificationCenterScrollAnchor({ orderedFeedIds });
+  // Feed traversal is bound to the shell, not the scrollport, so Up/Down also
+  // enter the list from the header - including the heading a keyboard or chord
+  // open focuses.
+  useNotificationFeedKeyboardNavigation(shellRef);
 
   // Full, unfiltered occurrence order is the identity source for live-arrival
   // detection, so a Recent filter can never blind the arrival set to a row it
@@ -421,10 +426,15 @@ export function NotificationsPopover(
 
   return (
     <TooltipProvider delayDuration={300}>
+      {/* `data-notification-center` marks this surface for code that must ask
+          "is focus inside the center right now?" without reaching for the
+          shell ref (the keybinding chord's toggle-close, in
+          `notifications-bell.tsx`). */}
       <div
         ref={shellRef}
         style={shellStyle}
         className="flex w-[min(90vw,34rem)] min-w-0 flex-col gap-0 overflow-hidden"
+        data-notification-center=""
         data-testid="notifications-popover"
       >
         <NotificationsPopoverHeader

--- a/clients/gui-app/src/hooks/notifications/use-notification-center-open-lifecycle.ts
+++ b/clients/gui-app/src/hooks/notifications/use-notification-center-open-lifecycle.ts
@@ -13,6 +13,14 @@ export interface NotificationCenterOpenLifecycle {
   readonly onContentOpenAutoFocus: (event: Event) => void;
   readonly onContentEscapeKeyDown: () => void;
   readonly onContentCloseAutoFocus: (event: Event) => void;
+  /**
+   * Marks the close that is about to happen as keyboard-driven, so focus
+   * returns to the trigger exactly as it does for Escape. Called by the
+   * keybinding chord when it toggles a center closed whose own surface
+   * currently holds focus - without it that focus would be destroyed with
+   * the popover and land on `<body>`.
+   */
+  readonly markKeyboardDismiss: () => void;
 }
 
 /**
@@ -66,9 +74,11 @@ export function useNotificationCenterOpenLifecycle(
     [input.headingRef],
   );
 
-  const onContentEscapeKeyDown = useCallback(() => {
+  const markKeyboardDismiss = useCallback(() => {
     closeReasonRef.current = "escape";
   }, []);
+
+  const onContentEscapeKeyDown = markKeyboardDismiss;
 
   const onContentCloseAutoFocus = useCallback(
     (event: Event) => {
@@ -87,5 +97,6 @@ export function useNotificationCenterOpenLifecycle(
     onContentOpenAutoFocus,
     onContentEscapeKeyDown,
     onContentCloseAutoFocus,
+    markKeyboardDismiss,
   };
 }

--- a/clients/gui-app/src/hooks/notifications/use-notification-feed-keyboard-navigation.ts
+++ b/clients/gui-app/src/hooks/notifications/use-notification-feed-keyboard-navigation.ts
@@ -1,0 +1,27 @@
+import { useEffect, type RefObject } from "react";
+import { handleNotificationFeedKeyboardNavigation } from "@/lib/notifications/notification-feed-keyboard-navigation";
+
+/**
+ * Binds feed traversal (Up/Down/Home/End) to the notification center's shell.
+ *
+ * Attached natively rather than through a JSX `onKeyDown`: the shell is a
+ * layout container, and hanging a key handler on it as a prop makes it a
+ * static element with interactions - a genuine a11y smell for anything that
+ * IS an interactive widget, and the wrong shape here, where the interactive
+ * things are the rows the traversal moves focus between. Listening on the
+ * element keeps the container inert in the accessibility tree while still
+ * catching keys from anywhere inside the surface.
+ */
+export function useNotificationFeedKeyboardNavigation(
+  shellRef: RefObject<HTMLDivElement | null>,
+): void {
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (shell === null) return;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      handleNotificationFeedKeyboardNavigation(shell, event);
+    };
+    shell.addEventListener("keydown", onKeyDown);
+    return () => shell.removeEventListener("keydown", onKeyDown);
+  }, [shellRef]);
+}

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -50,6 +50,7 @@ export const ACTION_IDS = [
   "nav.forward",
   "app.resources.open",
   "app.rate-limits.open",
+  "app.notifications.open",
   "app.history.open",
   "app.settings.open",
   "app.settings.section.byDigit",
@@ -389,6 +390,17 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+shift+u",
+  },
+  "app.notifications.open": {
+    id: "app.notifications.open",
+    label: "Open notifications",
+    description:
+      "Open the notification center, then use Up/Down to move between notifications. Pressing the chord again closes it.",
+    category: "app",
+    kind: "chord",
+    // ⌘⇧N - N for notifications, in the same ⌘⇧ family as the other global
+    // panel openers (⌘⇧U usage limits). ⌘N is taken by "New task".
+    defaultChord: "mod+shift+n",
   },
   "app.history.open": {
     id: "app.history.open",

--- a/clients/gui-app/src/lib/notifications/notification-feed-keyboard-navigation.ts
+++ b/clients/gui-app/src/lib/notifications/notification-feed-keyboard-navigation.ts
@@ -1,0 +1,67 @@
+/**
+ * Rows are located by the same `data-notification-id` attribute the scroll
+ * anchor measures with, so traversal order is exactly the rendered feed order
+ * (Needs attention, then Recent activity) with no second source of truth to
+ * drift.
+ */
+const ROW_SELECTOR = "[data-notification-id]";
+
+type FeedNavigationKey = "ArrowDown" | "ArrowUp" | "Home" | "End";
+
+function navigationKey(key: string): FeedNavigationKey | null {
+  if (key === "ArrowDown" || key === "ArrowUp") return key;
+  if (key === "Home" || key === "End") return key;
+  return null;
+}
+
+function nextRowIndex(
+  key: FeedNavigationKey,
+  currentIndex: number,
+  count: number,
+): number {
+  if (key === "Home") return 0;
+  if (key === "End") return count - 1;
+  // Wraps at both ends, so holding one arrow cycles the whole feed rather
+  // than dead-ending. `currentIndex === -1` means focus is somewhere in the
+  // surface that isn't a row (the heading a keyboard open lands on, a header
+  // control): Down enters at the top, Up enters at the bottom.
+  if (key === "ArrowDown") {
+    return currentIndex === -1 ? 0 : (currentIndex + 1) % count;
+  }
+  return currentIndex === -1 ? count - 1 : (currentIndex - 1 + count) % count;
+}
+
+/**
+ * Up/Down/Home/End traversal of the notification feed. Bound to the center's
+ * shell (see `useNotificationFeedKeyboardNavigation`) so it works from
+ * anywhere inside the surface, including the heading a keyboard open focuses.
+ *
+ * Focus lands on the row element itself (`tabIndex={-1}`), not on one of its
+ * controls, so every row is reachable - a read, non-navigable row has no
+ * focusable control at all and would otherwise be skipped straight over. Tab
+ * order is untouched: the rows are not tab stops, and their controls still
+ * are.
+ *
+ * Bare keys only. A modified arrow belongs to whatever else claims it (the
+ * global keybinding map runs in the capture phase and never reaches here).
+ */
+export function handleNotificationFeedKeyboardNavigation(
+  shell: HTMLElement,
+  event: KeyboardEvent,
+): void {
+  if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+  const key = navigationKey(event.key);
+  if (key === null) return;
+  const rows = Array.from(shell.querySelectorAll<HTMLElement>(ROW_SELECTOR));
+  if (rows.length === 0) return;
+  const active = document.activeElement;
+  const currentIndex = rows.findIndex(
+    (row) => row === active || row.contains(active),
+  );
+  const target = rows[nextRowIndex(key, currentIndex, rows.length)];
+  // Claims the key from the scrollport, which would otherwise scroll under
+  // the row we just moved focus to.
+  event.preventDefault();
+  target.focus();
+  target.scrollIntoView({ block: "nearest" });
+}

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
@@ -250,6 +250,13 @@ describe("dispatchAction", () => {
     expect(findActionForChord("mod+shift+u")).toBe("app.rate-limits.open");
   });
 
+  it("registers a default binding for the notification center", () => {
+    const defaults = getDefaultBindings();
+
+    expect(defaults["app.notifications.open"]).toBe("mod+shift+n");
+    expect(findActionForChord("mod+shift+n")).toBe("app.notifications.open");
+  });
+
   it("app.sidebar.toggle no-ops when no bridge is registered", () => {
     const { router } = buildRouter("/epics/e1");
     const fired = dispatchAction("app.sidebar.toggle", router);


### PR DESCRIPTION
Binds the notification center to a keyboard chord and makes the open feed navigable with the arrow keys.

## Keybinding

New `app.notifications.open` action, default **⌘⇧N / Ctrl+Shift+N**. It sits with the other global panel openers (⌘⇧U usage limits, ⌘Y history); ⌘N is already "New task", so the plain chord was unavailable. Being an ordinary `ACTION_META` entry, it shows up in Settings → Keybindings and the command palette for free, and new ids inherit their default through `getDefaultBindings()`, so no store migration is needed.

The bell tooltip now reads `Notifications (⌘⇧N)` off the live binding, so a rebind or an unbind is reflected without extra wiring.

### Why closing needs its own listener

Opening dispatches through the normal dynamic-handler path, the same as Resource Monitor and usage limits. Closing cannot: an open Radix popover is a `role="dialog"`, and the keybinding provider deliberately stops dispatching chords behind one (`isAnyDialogOpen`), so the second press never reaches that handler. The bell instead mounts a capture-phase window listener **only while the center is open** and matches the live binding itself. That also keeps the toggle working for pointer and native-notification opens, where focus sits outside the surface entirely.

Focus returns to the bell only when the center's own surface still holds it — a pointer-opened center leaves focus wherever the user was typing, and yanking that into the header would be the worse bug. The check asks the focused element (`data-notification-center`), not the shell ref, which belongs to the geometry lock and must not be read from render.

## Keyboard traversal

Up/Down/Home/End move between rows and wrap at both ends, bound to the popover shell so they also work from the heading a keyboard or chord open focuses.

Focus lands on the **row element itself** (`tabIndex={-1}`) rather than on one of its controls: a read, non-navigable row has no focusable control at all, so a control-focusing traversal would silently skip straight over it. Enter/Space on a focused row activates it under exactly the condition its body button renders under, and only for the row's own key events — Enter on the trailing tick still just acknowledges. Rows are not tab stops, so Tab order is unchanged.

The listener is attached natively (`useNotificationFeedKeyboardNavigation`) rather than as a JSX `onKeyDown`, which would make the layout container a static element with interactions.

## Tests

- Traversal across all rows, wrap at both ends, Home/End, and modified arrows passing through
- A read row with no focusable control of its own is still reached
- Chord open focuses the heading; second press toggles closed and restores focus to the bell
- No focus steal when the chord closes a pointer-opened center
- Enter on a keyboard-focused row routes to the same target as clicking its body
- Default binding registration and chord→action resolution
