### PR TITLE
feat(gui-app): cycle History search matches with the arrow keys

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "@tanstack/react-router";
 import {
   cleanup,
+  createEvent,
   fireEvent,
   render,
   screen,
@@ -1439,5 +1440,63 @@ describe("<EpicsListPanel />", () => {
       await screen.findByTestId("epics-list-filtered-empty"),
     ).not.toBeNull();
     expect(screen.queryByTestId("epics-list-filter-loading")).toBeNull();
+  });
+
+  it("cycles the matches with the arrow keys and returns to the query", async () => {
+    testState.items = [
+      historyItem({}),
+      historyItem({
+        id: "history-epic-2",
+        epicId: "epic-second",
+        title: "Second match",
+      }),
+    ];
+
+    renderPanel("page", "/");
+    const input = await screen.findByRole("searchbox", {
+      name: "Search tasks",
+    });
+    const first = screen.getByRole("link", {
+      name: "Open task Open from landing",
+    });
+    const second = screen.getByRole("link", { name: "Open task Second match" });
+    input.focus();
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(first);
+
+    fireEvent.keyDown(first, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(second);
+
+    // The last row is the floor - Down there holds rather than wrapping around
+    // to the top, so a held key settles on the end of the list.
+    fireEvent.keyDown(second, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(second);
+
+    fireEvent.keyDown(second, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(first);
+
+    // Up off the first row is the way back to refining the query.
+    fireEvent.keyDown(first, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("leaves ArrowDown to the caret when the query matches nothing", async () => {
+    testState.items = [];
+    useHistorySearchStore.setState({
+      search: { ...DEFAULT_HISTORY_SEARCH, query: "no-such-task" },
+    });
+
+    renderPanel("page", "/");
+    const input = await screen.findByRole("searchbox", {
+      name: "Search tasks",
+    });
+    input.focus();
+
+    const event = createEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent(input, event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1,6 +1,7 @@
 import {
   memo,
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useMemo,
@@ -79,6 +80,7 @@ import {
 } from "@/components/home/data/home-page.data";
 import { EpicsFilterPopover } from "@/components/epics/epics-filter-popover";
 import { EpicsSortMenu } from "@/components/epics/epics-sort-menu";
+import { useHistoryListKeyboardNav } from "@/components/epics/use-history-list-keyboard-nav";
 import { NotificationIndicatorIcon } from "@/components/notifications/notification-indicator-icon";
 import { useSurfaceNotificationIndicatorState } from "@/components/notifications/notification-indicator-context";
 import { NotificationIndicatorsProvider } from "@/components/notifications/notification-indicators-provider";
@@ -511,6 +513,13 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
   const showPageSearch = variant === "page";
   const showToolbarSearch = variant === "picker";
 
+  // ArrowDown out of the search box walks the results; ArrowUp off the first
+  // row lands back in the query. At most one of the two search placements is
+  // ever mounted, so a single ref covers whichever one is live.
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const keyboardNav = useHistoryListKeyboardNav(searchInputRef, listRef);
+
   return (
     <TooltipProvider>
       <section
@@ -522,10 +531,12 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
       >
         {showPageSearch ? (
           <PanelSearchInput
+            inputRef={searchInputRef}
             value={search.query}
             onChange={(next) => {
               updateSearch({ query: next });
             }}
+            onKeyDown={keyboardNav.onSearchKeyDown}
             isFetching={isFetching}
             focusOnMount={props.autoFocusSearch}
             placement="page"
@@ -535,10 +546,12 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
           leading={
             showToolbarSearch ? (
               <PanelSearchInput
+                inputRef={searchInputRef}
                 value={search.query}
                 onChange={(next) => {
                   updateSearch({ query: next });
                 }}
+                onKeyDown={keyboardNav.onSearchKeyDown}
                 isFetching={isFetching}
                 focusOnMount={props.autoFocusSearch}
                 placement="toolbar"
@@ -615,6 +628,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
               openInNewWindowAvailable={openInNewWindowFlow.isAvailable}
               worktreesByEpicId={worktreesByEpicId}
               openEpicIds={openEpicIdSet}
+              listRef={listRef}
+              onRowKeyDown={keyboardNav.onRowKeyDown}
             />
           </div>
         </NotificationIndicatorsProvider>
@@ -655,15 +670,18 @@ function hasActiveHistoryFilters(search: HistorySearchState): boolean {
 }
 
 interface PanelSearchInputProps {
+  /** Owned by the panel body so ArrowUp off the first row can return here. */
+  readonly inputRef: RefObject<HTMLInputElement | null>;
   readonly value: string;
   readonly onChange: (next: string) => void;
+  readonly onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   readonly isFetching: boolean;
   readonly focusOnMount: boolean;
   readonly placement: "page" | "toolbar";
 }
 
 function PanelSearchInput(props: PanelSearchInputProps): ReactNode {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const { inputRef } = props;
   // Defer the focus to the next frame so it lands after Radix Dialog's
   // own mount focus-trap runs (the modal host wraps this surface). A
   // synchronous focus here would be clobbered by the dialog's
@@ -677,7 +695,7 @@ function PanelSearchInput(props: PanelSearchInputProps): ReactNode {
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [focusOnMount]);
+  }, [focusOnMount, inputRef]);
   return (
     <div
       className={cn(
@@ -704,6 +722,7 @@ function PanelSearchInput(props: PanelSearchInputProps): ReactNode {
           onChange={(event) => {
             props.onChange(event.target.value);
           }}
+          onKeyDown={props.onKeyDown}
           placeholder="Search by title, repo, branch, or PR"
           aria-label="Search tasks"
         />
@@ -949,6 +968,9 @@ interface EpicsListBodyProps {
     readonly WorktreeHostEntryV12[]
   >;
   readonly openEpicIds: ReadonlySet<string>;
+  /** Anchors the arrow-key traversal: DOM order inside it is row order. */
+  readonly listRef: RefObject<HTMLUListElement | null>;
+  readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 }
 
 function EpicsListBody(props: EpicsListBodyProps): ReactNode {
@@ -976,6 +998,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     openInNewWindowAvailable,
     worktreesByEpicId,
     openEpicIds,
+    listRef,
+    onRowKeyDown,
   } = props;
 
   if (error !== null) {
@@ -1000,7 +1024,11 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
   return (
     <>
       {items.length > 0 ? (
-        <ul className="flex flex-col gap-2" data-testid="epics-list-rows">
+        <ul
+          ref={listRef}
+          className="flex flex-col gap-2"
+          data-testid="epics-list-rows"
+        >
           {items.map((item) => (
             <EpicsListRow
               key={item.id}
@@ -1019,6 +1047,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
               openInNewWindowAvailable={openInNewWindowAvailable}
               worktrees={worktreesByEpicId.get(item.epicId) ?? EMPTY_WORKTREES}
               isOpen={openEpicIds.has(item.epicId)}
+              onRowKeyDown={onRowKeyDown}
             />
           ))}
         </ul>
@@ -1093,6 +1122,8 @@ interface EpicsListRowProps {
   readonly openInNewWindowAvailable: boolean;
   readonly worktrees: readonly WorktreeHostEntryV12[];
   readonly isOpen: boolean;
+  /** Arrow-key traversal, bound to whichever control covers the whole card. */
+  readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 }
 
 function HistoryRowTrailingMetadata(props: {
@@ -1161,6 +1192,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     openInNewWindowAvailable,
     worktrees,
     isOpen,
+    onRowKeyDown,
   } = props;
   const isPhase = item.taskType === "phase";
   const rowSweep = useHistoryRowSweep({
@@ -1353,6 +1385,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       deleteDisabledTooltip={deleteDisabledTooltip}
       onToggleSelection={toggleEpicSelection}
       onBlockUnavailableDelete={blockUnavailableDeleteAction}
+      onRowKeyDown={onRowKeyDown}
     />
   ) : (
     <Link
@@ -1367,7 +1400,9 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
         focusTileInstanceId: undefined,
       }}
       onClick={openEpicRow}
+      onKeyDown={onRowKeyDown}
       aria-label={`Open task ${displayTitle}`}
+      data-history-row-target=""
       className="absolute inset-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
     />
   );
@@ -1781,14 +1816,17 @@ function HistorySelectionOverlay(props: {
   readonly onBlockUnavailableDelete: (
     event: React.MouseEvent<HTMLElement>,
   ) => void;
+  readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 }): ReactNode {
   if (props.canDeleteItem) {
     return (
       <button
         type="button"
         aria-label={`Toggle selection for ${historyItemDisplayTitle(props.item)}`}
+        data-history-row-target=""
         className="absolute inset-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
         onClick={props.onToggleSelection}
+        onKeyDown={props.onRowKeyDown}
       />
     );
   }
@@ -1799,8 +1837,10 @@ function HistorySelectionOverlay(props: {
           type="button"
           aria-disabled="true"
           aria-label={`Cannot select ${historyItemDisplayTitle(props.item)}`}
+          data-history-row-target=""
           className="absolute inset-0 cursor-not-allowed rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           onClick={props.onBlockUnavailableDelete}
+          onKeyDown={props.onRowKeyDown}
         />
       </TooltipTrigger>
       <TooltipContent>{props.deleteDisabledTooltip}</TooltipContent>

--- a/clients/gui-app/src/components/epics/use-history-list-keyboard-nav.ts
+++ b/clients/gui-app/src/components/epics/use-history-list-keyboard-nav.ts
@@ -1,0 +1,84 @@
+import { useCallback, type KeyboardEvent, type RefObject } from "react";
+
+/**
+ * `data-history-row-target` marks a row's full-card activation control in
+ * `epics-list-panel.tsx` - the `<Link>` overlay in normal mode, the toggle
+ * `<button>` in selection mode. Both already sit at
+ * `absolute inset-0`, so focusing one IS "this row is focused" for every visual
+ * the row already keys off `group-focus-within/list-row` (pin, PR pills) plus
+ * the control's own focus ring. Roving real DOM focus rather than
+ * `aria-activedescendant`: the rows are rich (link, checkbox, pin, delete,
+ * context menu), not listbox options, so virtual focus would have to reimplement
+ * activation that Enter on the anchor already does natively.
+ */
+const ROW_TARGET_SELECTOR = "[data-history-row-target]";
+
+export interface HistoryListKeyboardNav {
+  /** Bind to the search box: ArrowDown drops into the first result. */
+  readonly onSearchKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  /**
+   * Bind to each row's activation control: ArrowUp/ArrowDown walk the rows.
+   * On the control rather than on the list container so the listener sits on an
+   * interactive element - a non-interactive `<ul>` carrying key handlers is
+   * exactly what `jsx-a11y/no-noninteractive-element-interactions` rejects, and
+   * the row overlays have no focusable children to intercept anything.
+   */
+  readonly onRowKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+}
+
+function rowTargets(list: HTMLUListElement | null): ReadonlyArray<HTMLElement> {
+  if (list === null) return [];
+  return Array.from(list.querySelectorAll<HTMLElement>(ROW_TARGET_SELECTOR));
+}
+
+/**
+ * Arrow-key traversal from the history search box into its results.
+ *
+ * The DOM order of the rendered rows is the traversal order, read fresh on each
+ * keystroke - no index state to drift out of sync when the query refines the
+ * list mid-cycle, and "Show more" rows join the sequence the moment they mount.
+ */
+export function useHistoryListKeyboardNav(
+  searchInputRef: RefObject<HTMLInputElement | null>,
+  listRef: RefObject<HTMLUListElement | null>,
+): HistoryListKeyboardNav {
+  const onSearchKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== "ArrowDown") return;
+      const targets = rowTargets(listRef.current);
+      if (targets.length === 0) return;
+      // Only claim the key once there is somewhere to go, so an empty result
+      // set leaves the caret's own ArrowDown behaviour intact.
+      event.preventDefault();
+      targets[0].focus();
+    },
+    [listRef],
+  );
+
+  const onRowKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const targets = rowTargets(listRef.current);
+      const index = targets.indexOf(event.currentTarget);
+      // The row unmounted from the list this keystroke resolves against (a
+      // refetch landed mid-cycle) - drop the key rather than jumping somewhere
+      // arbitrary.
+      if (index < 0) return;
+      event.preventDefault();
+      if (event.key === "ArrowDown") {
+        targets[Math.min(index + 1, targets.length - 1)].focus();
+        return;
+      }
+      if (index === 0) {
+        // Back out to the query rather than trapping at the top: refining a
+        // near-miss search is the common next move after cycling the matches.
+        searchInputRef.current?.focus();
+        return;
+      }
+      targets[index - 1].focus();
+    },
+    [listRef, searchInputRef],
+  );
+
+  return { onSearchKeyDown, onRowKeyDown };
+}


### PR DESCRIPTION
## Summary

Typing in the History search box narrowed the list but left no way to reach it from the keyboard — the caret stayed in the input and the only route to a match was the mouse. **ArrowDown** now steps out of the query into the results, **ArrowUp/ArrowDown** walk them, and **ArrowUp off the first row** lands back in the query.

Sibling to #1270 (keyboard traversal of the notifications feed), for the History list.

## Traversal

Row order is read fresh from the DOM on every keystroke rather than held as an index, so a refetch or a refined query that reshuffles the list mid-cycle cannot leave the cursor pointing at a row that moved, and the rows "Show more" appends join the sequence with no extra bookkeeping.

**Real DOM focus roves, rather than `aria-activedescendant`.** History rows are rich cards (link, checkbox, pin, delete, context menu), not listbox options — so `Enter` activates natively on the anchor, and the existing `group-focus-within/list-row` reveals (pin, PR pills) plus the control's own focus ring light up with no new visual state to maintain.

The handler binds to each row's full-card activation control — the `<Link>` overlay normally, the toggle `<button>` in selection mode — rather than to the list container: a keydown listener on a non-interactive `<ul>` is exactly what `jsx-a11y/no-noninteractive-element-interactions` rejects in app code, and those overlays have no focusable children to intercept.

Two deliberate edges:

- ArrowDown is only claimed (`preventDefault`) once there is a row to move to, so an empty result set leaves the caret's own behaviour intact.
- ArrowDown on the last row holds rather than wrapping, matching the `epic-sidebar-artifact-search` combobox already in the codebase.

Lands for the History modal and the `/epics` route (both `variant="page"`) plus the destination picker's toolbar search.

## Test plan

- [x] `bun run test src/components/epics/__tests__/epics-list-panel.test.tsx` — 46 passed, across both the plain and React-Compiler vitest projects
- [x] `bun run compile` for the gui-app workspace
- [x] ESLint clean on all three files (`--max-warnings 0`)
- [x] Ablation-verified: removing the row keydown binding turns the new cycle test red; restoring it turns it green

Two new tests — the full down/down/up/up-to-input cycle, and a guard that an empty result set does not swallow the key.
