### PR TITLE
fix(protocol,gui-app): carry the declared union discriminator; retain a dirty live handle on an involuntary release

### DIFF
--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-activity-status.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-activity-status.test.tsx
@@ -181,7 +181,7 @@ describe("useEpicActivityStatus", () => {
     expect(result.current).toBe("idle");
 
     act(() => {
-      __getOpenEpicRegistryForTests().release(EPIC_ID, "discard");
+      __getOpenEpicRegistryForTests().release(EPIC_ID, "discard", null);
     });
 
     expect(result.current).toBe("turn");

--- a/clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts
@@ -286,7 +286,7 @@ afterEach(() => {
   window.localStorage.clear();
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   for (const handle of liveEpicHandles.splice(0)) {
-    getOpenEpicRegistry().release(handle.epicId, "discard");
+    getOpenEpicRegistry().release(handle.epicId, "discard", null);
   }
   boundHostClient.value = null;
   queryClient.clear();

--- a/clients/gui-app/src/lib/registries/__tests__/release-if-unused.test.ts
+++ b/clients/gui-app/src/lib/registries/__tests__/release-if-unused.test.ts
@@ -76,7 +76,7 @@ describe("releaseOpenEpicSessionIfUnused", () => {
     // legitimately-open second view of the same epic.
     openTabFor("epic-1");
 
-    releaseOpenEpicSessionIfUnused("epic-1", "keep");
+    releaseOpenEpicSessionIfUnused("epic-1", "keep", null);
 
     expect(__getOpenEpicRegistryForTests().peek("epic-1")).not.toBeNull();
   });
@@ -90,7 +90,7 @@ describe("releaseOpenEpicSessionIfUnused", () => {
     mountSession("epic-1");
     closeAllTabs();
 
-    releaseOpenEpicSessionIfUnused("epic-1", "keep");
+    releaseOpenEpicSessionIfUnused("epic-1", "keep", null);
 
     expect(__getOpenEpicRegistryForTests().peek("epic-1")).toBeNull();
   });
@@ -99,7 +99,7 @@ describe("releaseOpenEpicSessionIfUnused", () => {
     mountSession("epic-1");
     openTabFor("epic-2");
 
-    releaseOpenEpicSessionIfUnused("epic-1", "keep");
+    releaseOpenEpicSessionIfUnused("epic-1", "keep", null);
 
     expect(__getOpenEpicRegistryForTests().peek("epic-1")).toBeNull();
   });

--- a/clients/gui-app/src/lib/registries/epic-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/epic-session-registry.ts
@@ -2,6 +2,7 @@ import { createContext } from "react";
 import {
   DEFAULT_MAX_LIVE_EPICS,
   OpenEpicSessionRegistry,
+  type RetainedHandleIdentity,
   type UnsyncedEditsEntry,
 } from "@/stores/epics/open-epic/session-registry";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -157,7 +158,9 @@ export function releaseOpenEpicSession(epicId: string): void {
   // Tab close is the one release path where a decision was offered: the close
   // confirmation reads `epicHasUnsyncedEdits`, which covers retained buffers,
   // so reaching here means the user has already answered for them too.
-  registry.release(epicId, "discard");
+  // The user was ASKED about these edits, so the live handle goes with them:
+  // "discard" is the answer to a question, not an involuntary teardown.
+  registry.release(epicId, "discard", null);
 }
 
 /**
@@ -180,13 +183,14 @@ export function releaseOpenEpicSession(epicId: string): void {
 export function releaseOpenEpicSessionIfUnused(
   epicId: string,
   retainedBuffers: "discard" | "keep",
+  dirtyLiveHandle: RetainedHandleIdentity | null,
 ): void {
   const state = useEpicCanvasStore.getState();
   const stillOpen = state.openTabOrder.some(
     (tabId) => state.tabsById[tabId]?.epicId === epicId,
   );
   if (stillOpen) return;
-  registry.release(epicId, retainedBuffers);
+  registry.release(epicId, retainedBuffers, dirtyLiveHandle);
 }
 
 /**

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -1558,7 +1558,11 @@ describe("<EpicSessionProvider />", () => {
     expect(streams).toHaveLength(1);
 
     act(() => {
-      __getOpenEpicRegistryForTests().release("epic-session-test", "discard");
+      __getOpenEpicRegistryForTests().release(
+        "epic-session-test",
+        "discard",
+        null,
+      );
     });
     await waitFor(() => {
       expect(calls.releases).toEqual(["epic-session-test"]);

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -269,7 +269,12 @@ export function EpicSessionProvider(
       // line, disposing the live session under a tab that was never denied
       // anything. `discardTabState(tabId)` above has already removed this tab,
       // so the question this asks is exactly "does another one still hold it".
-      releaseOpenEpicSessionIfUnused(epicId, "keep");
+      // `null`: this window lost the epic to ANOTHER window, which opens its
+      // own session against the same room, and a retention here would surface
+      // in this window's quit sheet as work it can never flush - it has no
+      // ownership left to flush with. Deliberately unchanged by the rotation
+      // fix below, whose loss had no such continuation.
+      releaseOpenEpicSessionIfUnused(epicId, "keep", null);
       await desktopBridge.requestFocus(claim.currentOwner);
       void navigate({ to: "/epics", replace: true });
     })();
@@ -507,9 +512,23 @@ export function EpicSessionProvider(
       // while the retained buffers can belong to others, so discarding here
       // would delete host A's unsynced work because host B rotated.
       if (current !== null) {
+        const discarding = current.handle.userId !== sessionUserId;
         registry.release(
           epicId,
-          current.handle.userId !== sessionUserId ? "discard" : "keep",
+          discarding ? "discard" : "keep",
+          // A ROTATION is not a user change: the same person is still at the
+          // keyboard, nothing was shown to them, and the live handle can hold
+          // unsynced edits. Retaining it under the identity it was built for -
+          // the OLD owner key, which is the room those edits belong to - is
+          // what keeps the re-enrollment from destroying work the user was
+          // never asked about. A user change takes `null`: no prior identity's
+          // document may survive it, exactly as `disposeAll` does at sign-out.
+          discarding
+            ? null
+            : {
+                hostStamp: current.hostId,
+                ownerIdentityKey: current.ownerIdentityKey,
+              },
         );
       }
       const nextHandle = registry.acquireMounted(epicId, createHandle);

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
@@ -312,7 +312,7 @@ describe("OpenEpicSessionRegistry", () => {
     const registry = new OpenEpicSessionRegistry({ maxLive: 5 });
     const th = buildTestHandle("e0", false);
     registry.acquire("e0", () => h(th));
-    registry.release("e0", "discard");
+    registry.release("e0", "discard", null);
     expect(th.disposed).toBe(true);
     expect(registry.get("e0")).toBeNull();
   });
@@ -568,7 +568,7 @@ describe("retained unsynced buffers across a host re-point (F10)", () => {
     repoint(registry, previous.handle, next.handle, IDENTITY_A);
     expect(registry.getUnsyncedEdits()).toHaveLength(1);
 
-    registry.release(EPIC, "discard");
+    registry.release(EPIC, "discard", null);
 
     // `prune()` cannot reach retentions and must not, so tab close is one of
     // the few real reclamation paths. It is also the point where the user has
@@ -625,12 +625,73 @@ describe("release states its meaning for retained buffers", () => {
     // Deleting it here would be strictly more destructive than the
     // cross-identity MERGE `findMergeTarget` refuses, and would happen with
     // no decision and no log.
-    registry.release(EPIC, "keep");
+    registry.release(EPIC, "keep", null);
 
     expect(registry.retainedCountForTests(EPIC)).toBe(1);
     const rows = registry.getUnsyncedEdits();
     expect(rows).toHaveLength(1);
     expect(rows[0]?.queueSize).toBe(6);
+  });
+
+  it("retains the DIRTY LIVE handle when an owner-identity rotation releases it", () => {
+    // Codex #1243 post-merge. `"keep"` spared only buffers ALREADY retained;
+    // the live handle - the one actually holding the user's unsynced edits -
+    // was disposed either way. An owner-identity rotation leaves `userId`
+    // unchanged, so the provider takes this arm, and a same-host
+    // re-enrollment therefore destroyed a dirty Y.Doc with no confirmation
+    // and no retention.
+    const registry = new OpenEpicSessionRegistry({ maxLive: 5 });
+    const live = buildRetentionHandle(EPIC, true, 4);
+    registry.acquireMounted(EPIC, () => live.handle);
+    expect(registry.getUnsyncedEdits()).toHaveLength(1);
+
+    registry.release(EPIC, "keep", {
+      hostStamp: "host-a",
+      ownerIdentityKey: "key-before-rotation",
+    });
+
+    // The live session is gone, but its edits are not: they are now a
+    // retained buffer, reachable through the same projection every close and
+    // quit gate reads.
+    expect(registry.get(EPIC)).toBeNull();
+    expect(registry.retainedCountForTests(EPIC)).toBe(1);
+    const rows = registry.getUnsyncedEdits();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.queueSize).toBe(4);
+    // Retained, not destroyed - and its transport is detached so it stops
+    // dialing a host this window has left.
+    expect(live.closed()).toBe(true);
+  });
+
+  it("disposes a CLEAN live handle on the same path rather than retaining an empty buffer", () => {
+    // The control: retention is for unsynced edits, not for every release.
+    // Retaining a clean handle would put an empty row in the quit sheet and
+    // nothing would ever retire it.
+    const registry = new OpenEpicSessionRegistry({ maxLive: 5 });
+    const live = buildRetentionHandle(EPIC, false, 0);
+    registry.acquireMounted(EPIC, () => live.handle);
+
+    registry.release(EPIC, "keep", {
+      hostStamp: "host-a",
+      ownerIdentityKey: "key-before-rotation",
+    });
+
+    expect(registry.retainedCountForTests(EPIC)).toBe(0);
+    expect(registry.getUnsyncedEdits()).toHaveLength(0);
+  });
+
+  it("destroys the dirty live handle when the caller names NO identity, which is how a user change stays a security boundary", () => {
+    // `null` is the decision the user-change arm takes: another person is at
+    // the keyboard and no prior identity's document may survive it. The
+    // rotation arm above is the one that must not.
+    const registry = new OpenEpicSessionRegistry({ maxLive: 5 });
+    const live = buildRetentionHandle(EPIC, true, 4);
+    registry.acquireMounted(EPIC, () => live.handle);
+
+    registry.release(EPIC, "keep", null);
+
+    expect(registry.retainedCountForTests(EPIC)).toBe(0);
+    expect(registry.getUnsyncedEdits()).toHaveLength(0);
   });
 
   it("still reclaims on tab close, where the user answered for the buffer", () => {
@@ -644,7 +705,7 @@ describe("release states its meaning for retained buffers", () => {
       editsTransferredToReplacement: false,
     });
 
-    registry.release(EPIC, "discard");
+    registry.release(EPIC, "discard", null);
 
     // The control for the arm above: `"keep"` must not have made reclamation
     // unreachable, or the retention would simply leak instead.

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/unsynced-edits-agreement.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/unsynced-edits-agreement.test.ts
@@ -156,7 +156,7 @@ describe("hasUnsyncedEdits agrees with getUnsyncedEdits", () => {
     // gate means the work is discarded without asking.
     //
     // Reached through a real product path, not by poking internals:
-    // `release(epicId, "keep")` is the ownership-denial arm, which drops the
+    // `release(epicId, "keep", null)` is the ownership-denial arm, which drops the
     // live entry and deliberately preserves retained buffers.
     const registry = __getOpenEpicRegistryForTests();
     const outgoing = makeHandle("epic-orphaned", "Orphaned");
@@ -172,7 +172,7 @@ describe("hasUnsyncedEdits agrees with getUnsyncedEdits", () => {
         editsTransferredToReplacement: false,
       },
     );
-    registry.release("epic-orphaned", "keep");
+    registry.release("epic-orphaned", "keep", null);
 
     // Premise, positively: the live entry really is gone and the retention
     // really did survive. Without this the arm below could pass for the wrong

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -262,7 +262,9 @@ function findMergeTarget(
  *   - `acquire(epicId, factory)` returns the existing handle or constructs a
  *     new one via `factory(epicId)`; recency is bumped on every call so the
  *     most-recently-interacted Epic stays alive.
- *   - `release(epicId)` disposes that entry unconditionally (tab closed).
+ *   - `release(epicId, retainedBuffers, dirtyLiveHandle)` ends that entry (tab
+ *     closed): disposed, or retained as an unsynced buffer when it is dirty
+ *     and the caller named an identity to retain it under.
  *   - `prune()` is run after every acquire; it disposes the least-recently
  *     used clean/inactive entries until size <= maxLive, skipping dirty or
  *     active entries.
@@ -573,7 +575,34 @@ export class OpenEpicSessionRegistry {
    * methods up on the grounds that the result has no owner it could honestly
    * flush to.
    */
-  release(epicId: string, retainedBuffers: "discard" | "keep"): void {
+  /**
+   * `dirtyLiveHandle` is the identity to RETAIN the live entry under when it
+   * holds unsynced edits, or `null` to destroy it with them.
+   *
+   * It exists because `"keep"` used to mean only "spare the buffers already
+   * retained", while the LIVE handle - the one actually holding the user's
+   * unsynced edits - was disposed either way. On an involuntary path that is
+   * exactly the silent loss the flag's own doc says it prevents: an
+   * owner-identity rotation leaves `userId` unchanged, so a dirty session was
+   * destroyed with no confirmation and no retention, and the edits were gone.
+   *
+   * Retention here follows the rule `replaceMounted` already follows for a
+   * re-point - never destroy a session holding unsynced edits - and produces
+   * the same kind of buffer: transport detached, reachable through the
+   * unsynced-edits projection, merged into an existing retention only on
+   * positive proof of the same epic, host and owner identity.
+   *
+   * `null` is a DECISION, not a default, which is why it is a required
+   * argument: a caller that has shown the user a decision (`"discard"`), or
+   * one whose loss is deliberate, says so at the call site rather than
+   * inheriting it. `"discard"` ignores it - the user was asked about these
+   * edits.
+   */
+  release(
+    epicId: string,
+    retainedBuffers: "discard" | "keep",
+    dirtyLiveHandle: RetainedHandleIdentity | null,
+  ): void {
     const entry = this.entries.get(epicId);
     if (retainedBuffers === "discard") {
       // Ordered before the early return: a retention must not outlive the tab
@@ -585,7 +614,21 @@ export class OpenEpicSessionRegistry {
       return;
     }
     this.entries.delete(epicId);
-    this.disposeEntry(entry, true);
+    const retainsLiveEdits =
+      retainedBuffers === "keep" &&
+      dirtyLiveHandle !== null &&
+      entry.handle.store.getState().isDirty;
+    if (retainsLiveEdits) {
+      this.retainDirtyHandle(entry, dirtyLiveHandle);
+      // Still announced: the live SESSION is gone either way, and the listener
+      // it drives releases this window's desktop ownership of the epic. A
+      // retained buffer has no transport and claims nothing, so holding that
+      // ownership open for it would pin the epic to a window that can no
+      // longer serve it.
+      this.releaseListener?.(epicId);
+    } else {
+      this.disposeEntry(entry, true);
+    }
     this.emit();
   }
 

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -1341,7 +1341,9 @@ export class TabCommandCoordinator {
         // retention argument. `"discard"` preserves this path's existing
         // behaviour and is not a fresh adjudication of it.
         epicIds.forEach((epicId) =>
-          releaseOpenEpicSessionIfUnused(epicId, "discard"),
+          // `null` for the same reason as `"discard"`: the user answered for
+          // these edits, live handle included.
+          releaseOpenEpicSessionIfUnused(epicId, "discard", null),
         );
       },
     });
@@ -1581,7 +1583,7 @@ export class TabCommandCoordinator {
       const tab = useEpicCanvasStore.getState().tabsById[ref.id];
       // `"discard"` preserves this path's existing behaviour.
       if (tab !== undefined)
-        releaseOpenEpicSessionIfUnused(tab.epicId, "discard");
+        releaseOpenEpicSessionIfUnused(tab.epicId, "discard", null);
       return;
     }
     if (ref.kind === "draft") {

--- a/protocol/src/framework/__tests__/json-schema-fingerprint.test.ts
+++ b/protocol/src/framework/__tests__/json-schema-fingerprint.test.ts
@@ -20,6 +20,42 @@ function fingerprint(schema: z.ZodType) {
  * replacements - at ANY depth), lenient where stripping or a designed
  * refusal handles it (additions and widenings - at ANY depth).
  */
+describe("toJsonSchemaFingerprint - the declared discriminator", () => {
+  // POSITIVE CONTROL for the one thing in this file that reads zod's internal
+  // `def`. `z.toJSONSchema` renders a discriminated union as `oneOf` and drops
+  // WHICH field was declared, so the fingerprint stamps it during conversion -
+  // and `findDiscriminatedSuccessor` needs it, because with two qualifying
+  // tags an edit and a replacement are structurally identical.
+  //
+  // The read degrades silently by design (an unrecognised shape leaves the
+  // node unstamped and identity falls back to the inferred tuple), so a zod
+  // upgrade that moves the field would quietly restore the old defect. This
+  // test is what makes that loud.
+  it("carries the field a discriminated union was declared on", () => {
+    const declared = fingerprint(
+      z.discriminatedUnion("kind", [
+        z.object({ kind: z.literal("a"), value: z.string() }),
+        z.object({ kind: z.literal("b") }),
+      ]),
+    );
+    expect(declared.type).toBe("anyOf");
+    if (declared.type !== "anyOf") throw new Error("unreachable");
+    expect(declared.discriminator).toBe("kind");
+  });
+
+  it("carries null for a plain union, which declares nothing", () => {
+    const plain = fingerprint(
+      z.union([
+        z.object({ kind: z.literal("a") }),
+        z.object({ id: z.string() }),
+      ]),
+    );
+    expect(plain.type).toBe("anyOf");
+    if (plain.type !== "anyOf") throw new Error("unreachable");
+    expect(plain.discriminator).toBeNull();
+  });
+});
+
 describe("findAdditivityViolation - projection-feasibility semantics", () => {
   describe("additions are legal at any depth", () => {
     it("accepts a new top-level optional field", () => {

--- a/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
@@ -537,6 +537,71 @@ describe("validateVersionedRpcRegistry (Zod-level compatibility)", () => {
     );
   });
 
+  it("does not let the discriminator STAMP alone justify a major bump", () => {
+    // `x-traycer-discriminator` is metadata this framework writes onto the
+    // emitted schema so arm identity can be resolved; it constrains no value.
+    // A union that merely moves its declaration between two equally valid tag
+    // columns accepts and emits byte-identical JSON - so it is NOT a breaking
+    // change, and the major must still be rejected as "could have shipped as a
+    // minor". Compared raw, the stamp differs and would have justified a major
+    // on our own bookkeeping.
+    const stampV10 = defineRpcContract({
+      method: "stampOnly",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("a"), outcome: z.literal("x") }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const stampV20 = defineRpcContract({
+      method: "stampOnly",
+      schemaVersion: { major: 2, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        // Identical arms; only the DECLARED column moved. `outcome` is just as
+        // valid a tag here - each arm pins it to its own literal.
+        row: z.discriminatedUnion("outcome", [
+          z.object({ kind: z.literal("a"), outcome: z.literal("x") }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const stampUpgrade = defineUpgradePath<typeof stampV10, typeof stampV20>({
+      from: stampV10.schemaVersion,
+      to: stampV20.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({ row: response.row }),
+    });
+    const registry = {
+      stampOnly: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: stampV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+        2: {
+          latestMinor: 0,
+          versions: {
+            0: {
+              contract: stampV20,
+              upgradeFromPreviousVersion: stampUpgrade,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Major bump 1 -> 2 for method 'stampOnly' is not a breaking change (could have shipped as a minor)",
+    );
+  });
+
   it("accepts a major bump that adds a newly required field", () => {
     const requiredV10 = defineRpcContract({
       method: "required",
@@ -1265,6 +1330,83 @@ describe("response-lane value-growth strictness", () => {
     // dropped FIELD by declaring it ahead of the moved tag.
     expect(() => validateVersionedRpcRegistry(registry)).toThrow(
       "Minor 1.1 for method 'declaredTagEdit' response drops enum value 'x' from 1.0",
+    );
+  });
+
+  it("honours a declared discriminator whose arm groups SEVERAL tag values", () => {
+    // A declared tag may legitimately group values in one arm - this repo does
+    // it with `kind: z.enum(["subagent", "monitor"])` in `agent/gui/subscribe`.
+    // INFERENCE has to reject such a column (nothing distinguishes a deliberate
+    // grouping from an ordinary enum field), so requiring the declared field to
+    // survive inference dropped every multi-value union back onto the
+    // incidental-tuple fallback - i.e. straight back into the defect the two
+    // arms above pin. Here `kind` is unchanged, a secondary literal moves, and
+    // a field is dropped: an EDIT, and its reduction must be reported rather
+    // than exempted as an arm replacement.
+    const groupedV10 = defineRpcContract({
+      method: "declaredTagGrouped",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.enum(["subagent", "monitor"]),
+            outcome: z.literal("x"),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("command"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const groupedV11 = defineRpcContract({
+      method: "declaredTagGrouped",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          // Same arm - the `kind` VALUE SET is untouched - with the secondary
+          // literal moved and `value` dropped.
+          z.object({
+            kind: z.enum(["subagent", "monitor"]),
+            outcome: z.literal("z"),
+          }),
+          z.object({ kind: z.literal("command"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const groupedUpgrade = defineUpgradePath<
+      typeof groupedV10,
+      typeof groupedV11
+    >({
+      from: groupedV10.schemaVersion,
+      to: groupedV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "command"
+            ? response.row
+            : { kind: response.row.kind, outcome: "z" as const },
+      }),
+    });
+    const registry = {
+      declaredTagGrouped: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: groupedV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: groupedV11,
+              upgradeFromPreviousVersion: groupedUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Minor 1.1 for method 'declaredTagGrouped' response drops enum value 'x' from 1.0",
     );
   });
 

--- a/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
@@ -1186,6 +1186,216 @@ describe("response-lane value-growth strictness", () => {
     );
   });
 
+  it("rejects a gated minor that drops a field from an arm whose DECLARED discriminator is unchanged, even though a secondary literal moved", () => {
+    // The other side of the incidental-literal coin, and the one the inferred
+    // tuple got wrong. `kind` and `outcome` BOTH qualify as tags on both
+    // sides, so the tuple identity of the old "a" arm was ("a","x") - which
+    // matches nothing once `outcome` moves to "z". The arm then read as
+    // REPLACED, and the exemption swallowed the dropped `value` silently.
+    //
+    // Structurally this is indistinguishable from the permitted replacement
+    // two tests up: one qualifying field agrees and one differs in BOTH. Only
+    // the DECLARATION separates them - `z.discriminatedUnion("kind", ...)`
+    // says `kind` is identity, so here the arm survived and was edited, and
+    // there it did not.
+    const declaredV10 = defineRpcContract({
+      method: "declaredTagEdit",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.literal("a"),
+            outcome: z.literal("x"),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const declaredV11 = defineRpcContract({
+      method: "declaredTagEdit",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          // Same arm - `kind` is still "a" - with a moved secondary literal
+          // and `value` dropped.
+          z.object({ kind: z.literal("a"), outcome: z.literal("z") }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const declaredUpgrade = defineUpgradePath<
+      typeof declaredV10,
+      typeof declaredV11
+    >({
+      from: declaredV10.schemaVersion,
+      to: declaredV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "a"
+            ? { kind: "a" as const, outcome: "z" as const }
+            : response.row,
+      }),
+    });
+    const registry = {
+      declaredTagEdit: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: declaredV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: declaredV11,
+              upgradeFromPreviousVersion: declaredUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    // The FIRST reduction the property walk meets on the now-matched arm is
+    // the moved literal itself (`outcome` is walked before `value`), and it is
+    // a real one: an old peer expecting "x" cannot project "z". What matters
+    // is that the arm was matched as an EDIT at all - under the tuple it was
+    // unmatchable, so NOTHING on it was reported. The arm below pins the
+    // dropped FIELD by declaring it ahead of the moved tag.
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Minor 1.1 for method 'declaredTagEdit' response drops enum value 'x' from 1.0",
+    );
+  });
+
+  it("reports the DROPPED FIELD on that same arm when it is walked before the moved tag", () => {
+    const orderedV10 = defineRpcContract({
+      method: "declaredTagEditOrdered",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        // `value` declared BEFORE `outcome`, so the property walk reaches the
+        // dropped field first. Same defect, different first witness.
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.literal("a"),
+            value: z.string(),
+            outcome: z.literal("x"),
+          }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const orderedV11 = defineRpcContract({
+      method: "declaredTagEditOrdered",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("a"), outcome: z.literal("z") }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const orderedUpgrade = defineUpgradePath<
+      typeof orderedV10,
+      typeof orderedV11
+    >({
+      from: orderedV10.schemaVersion,
+      to: orderedV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "a"
+            ? { kind: "a" as const, outcome: "z" as const }
+            : response.row,
+      }),
+    });
+    const registry = {
+      declaredTagEditOrdered: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: orderedV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: orderedV11,
+              upgradeFromPreviousVersion: orderedUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Minor 1.1 for method 'declaredTagEditOrdered' response drops field 'row.value' from 1.0",
+    );
+  });
+
+  it("still permits the replacement when the DECLARED discriminator itself moves, with the same secondary literal shared", () => {
+    // The mirror of the arm above, and the reason the fix had to be the
+    // declaration rather than a looser match: identical structure - one
+    // qualifying field agrees (`outcome`), one differs (`kind`) - but here the
+    // field that differs is the declared one, so the arm genuinely has no
+    // successor and the gated exemption applies.
+    const swapV10 = defineRpcContract({
+      method: "declaredTagSwap",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.literal("a"),
+            outcome: z.literal("x"),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const swapV11 = defineRpcContract({
+      method: "declaredTagSwap",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("c"), outcome: z.literal("x") }),
+          z.object({ kind: z.literal("b"), outcome: z.literal("y") }),
+        ]),
+      }),
+    });
+    const swapUpgrade = defineUpgradePath<typeof swapV10, typeof swapV11>({
+      from: swapV10.schemaVersion,
+      to: swapV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "a"
+            ? { kind: "c" as const, outcome: "x" as const }
+            : response.row,
+      }),
+    });
+    const registry = {
+      declaredTagSwap: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: swapV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: swapV11,
+              upgradeFromPreviousVersion: swapUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
+  });
+
   it("rejects a projection-gated minor whose reduced surviving arm comes AFTER a replaced arm", () => {
     // Order independence on top of the "REDUCES a surviving union arm" test
     // above: that test's reduced arm happens to come FIRST, so it would still

--- a/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
@@ -602,6 +602,62 @@ describe("validateVersionedRpcRegistry (Zod-level compatibility)", () => {
     );
   });
 
+  it("still justifies a major from a keyword that is annotation-only for a LEAF", () => {
+    // The mirror of the arm above, and the reason the stamp is stripped by
+    // itself rather than through `constrainingShape`. That helper drops all of
+    // `NON_CONSTRAINING_SCHEMA_KEYS`, which answers a different question - what
+    // constrains a LEAF's accepted values in the additivity walk - and `default`
+    // sits in it. `.catch([])` renders as `default`, so dropping the catch turns
+    // a payload that used to parse into one that fails outright. Strip it here
+    // and this real major reads as "could have shipped as a minor".
+    const catchV10 = defineRpcContract({
+      method: "catchTolerance",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        tags: z.array(z.string()).catch([]),
+      }),
+    });
+    const catchV20 = defineRpcContract({
+      method: "catchTolerance",
+      schemaVersion: { major: 2, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        // The ONLY change: the tolerance is gone.
+        tags: z.array(z.string()),
+      }),
+    });
+    const catchUpgrade = defineUpgradePath<typeof catchV10, typeof catchV20>({
+      from: catchV10.schemaVersion,
+      to: catchV20.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({ tags: response.tags }),
+    });
+    const registry = {
+      catchTolerance: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: catchV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+        2: {
+          latestMinor: 0,
+          versions: {
+            0: {
+              contract: catchV20,
+              upgradeFromPreviousVersion: catchUpgrade,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
+  });
+
   it("accepts a major bump that adds a newly required field", () => {
     const requiredV10 = defineRpcContract({
       method: "required",
@@ -1407,6 +1463,270 @@ describe("response-lane value-growth strictness", () => {
 
     expect(() => validateVersionedRpcRegistry(registry)).toThrow(
       "Minor 1.1 for method 'declaredTagGrouped' response drops enum value 'x' from 1.0",
+    );
+  });
+
+  it("keeps the arm's identity when its grouped tag set GROWS", () => {
+    // Matching a grouped tag by set EQUALITY made a growing arm unmatchable,
+    // and unmatchable is the PERMISSIVE outcome: no successor means "replaced",
+    // and under `responseGrowthProjectionGated` a replacement is exempt. So the
+    // dropped field below - which still breaks every response pinned to the
+    // values the arm KEPT - sailed through. Identity is a SHARED value.
+    const grownV10 = defineRpcContract({
+      method: "declaredTagGrown",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.enum(["subagent", "monitor"]),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const grownV11 = defineRpcContract({
+      method: "declaredTagGrown",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          // Same arm, one more tag value - and `value` dropped. A response with
+          // `kind: "subagent"` still lands here and has lost a field.
+          z.object({ kind: z.enum(["subagent", "monitor", "worker"]) }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const grownUpgrade = defineUpgradePath<typeof grownV10, typeof grownV11>({
+      from: grownV10.schemaVersion,
+      to: grownV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "command"
+            ? response.row
+            : { kind: response.row.kind },
+      }),
+    });
+    const registry = {
+      declaredTagGrown: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: grownV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: grownV11,
+              upgradeFromPreviousVersion: grownUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Minor 1.1 for method 'declaredTagGrown' response drops field 'row.value' from 1.0",
+    );
+  });
+
+  it("keeps BOTH halves' identity when a grouped arm SPLITS", () => {
+    // The case a first-match index still misses, and the reason identity is a
+    // LIST. One arm becomes two, each taking part of the tag set; both still
+    // carry traffic the old arm carried. Matching only the first leaves the
+    // second free to reduce - here `monitor` drops `value` while `subagent`
+    // keeps it, so the walk must look past its first successful match.
+    const splitV10 = defineRpcContract({
+      method: "declaredTagSplit",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.enum(["subagent", "monitor"]),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const splitV11 = defineRpcContract({
+      method: "declaredTagSplit",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          // Matched FIRST and perfectly clean.
+          z.object({ kind: z.literal("subagent"), value: z.string() }),
+          // The half that reduced.
+          z.object({ kind: z.literal("monitor") }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const splitUpgrade = defineUpgradePath<typeof splitV10, typeof splitV11>({
+      from: splitV10.schemaVersion,
+      to: splitV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "command"
+            ? response.row
+            : response.row.kind === "subagent"
+              ? { kind: "subagent" as const, value: response.row.value }
+              : { kind: "monitor" as const },
+      }),
+    });
+    const registry = {
+      declaredTagSplit: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: splitV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: splitV11,
+              upgradeFromPreviousVersion: splitUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Minor 1.1 for method 'declaredTagSplit' response drops field 'row.value' from 1.0",
+    );
+  });
+
+  it("permits a split that drops NOTHING, rather than reading each half's narrower tag as a loss", () => {
+    // The false witness that matching every successor introduces, and the
+    // reason the declared column is ALIGNED before the comparison. Each half of
+    // a split pins a narrower slice of the old tag set, so compared as-is the
+    // clean `subagent` half reports "drops enum value 'monitor'" - even though
+    // the sibling arm took `monitor` and the union accepts exactly what it did
+    // before. Nothing is lost here and nothing may be reported.
+    const cleanV10 = defineRpcContract({
+      method: "declaredTagSplitClean",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.enum(["subagent", "monitor"]),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const cleanV11 = defineRpcContract({
+      method: "declaredTagSplitClean",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          // Split in two, both halves carrying everything the grouped arm did.
+          z.object({ kind: z.literal("subagent"), value: z.string() }),
+          z.object({ kind: z.literal("monitor"), value: z.string() }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const cleanUpgrade = defineUpgradePath<typeof cleanV10, typeof cleanV11>({
+      from: cleanV10.schemaVersion,
+      to: cleanV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "command"
+            ? response.row
+            : response.row.kind === "subagent"
+              ? { kind: "subagent" as const, value: response.row.value }
+              : { kind: "monitor" as const, value: response.row.value },
+      }),
+    });
+    const registry = {
+      declaredTagSplitClean: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: cleanV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: cleanV11,
+              upgradeFromPreviousVersion: cleanUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
+  });
+
+  it("still reports a tag value that NO arm took after a split", () => {
+    // The other side of alignment: it applies only when the whole old tag set
+    // is still handled somewhere. Here `monitor` is simply gone - no sibling
+    // absorbs it - so the arm's own column stays in place and reports it.
+    const lostV10 = defineRpcContract({
+      method: "declaredTagLost",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({
+            kind: z.enum(["subagent", "monitor"]),
+            value: z.string(),
+          }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const lostV11 = defineRpcContract({
+      method: "declaredTagLost",
+      schemaVersion: { major: 1, minor: 1 } as const,
+      requestSchema: z.object({ id: z.string() }),
+      responseSchema: z.object({
+        row: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("subagent"), value: z.string() }),
+          z.object({ kind: z.literal("command"), label: z.string() }),
+        ]),
+      }),
+    });
+    const lostUpgrade = defineUpgradePath<typeof lostV10, typeof lostV11>({
+      from: lostV10.schemaVersion,
+      to: lostV11.schemaVersion,
+      upgradeRequest: (request) => ({ id: request.id }),
+      upgradeResponse: (response) => ({
+        row:
+          response.row.kind === "command"
+            ? response.row
+            : { kind: "subagent" as const, value: response.row.value },
+      }),
+    });
+    const registry = {
+      declaredTagLost: {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: { contract: lostV10, upgradeFromPreviousVersion: null },
+            1: {
+              contract: lostV11,
+              upgradeFromPreviousVersion: lostUpgrade,
+              responseGrowthProjectionGated: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "Minor 1.1 for method 'declaredTagLost' response drops enum value 'monitor' from 1.0",
     );
   });
 

--- a/protocol/src/framework/json-schema-fingerprint.ts
+++ b/protocol/src/framework/json-schema-fingerprint.ts
@@ -909,15 +909,26 @@ function discriminantValues(
   return new Set(classified.values);
 }
 
-function sameValueSet(
+/**
+ * Whether two declared tag value sets name the SAME arm - i.e. share at least
+ * one value.
+ *
+ * OVERLAP, not equality. A grouped tag may gain or lose a value while remaining
+ * the same arm, and under equality such an arm read as REPLACED - handing every
+ * reduction inside it straight back to the exemption this whole mechanism
+ * exists to close. A value the old arm carried and the new side still routes is
+ * the honest identity: responses pinned to it projected through the old arm and
+ * now project through the new one. Matching on the survivors does not lose the
+ * dropped values - the arms' own enum comparison still reports those.
+ */
+function sharesValue(
   a: ReadonlySet<string | number | boolean>,
   b: ReadonlySet<string | number | boolean>,
 ): boolean {
-  if (a.size !== b.size) return false;
   for (const value of a) {
-    if (!b.has(value)) return false;
+    if (b.has(value)) return true;
   }
-  return true;
+  return false;
 }
 
 /**
@@ -950,8 +961,54 @@ function declaredTagIdentifies(
 }
 
 /**
- * The index of the next variant that IS this previous variant - the same arm,
- * edited - or `-1` when the arm genuinely has no successor.
+ * One next variant that IS this previous variant - the same arm, edited -
+ * paired with the previous arm as it should be COMPARED against that variant.
+ */
+interface DiscriminatedSuccessor {
+  readonly index: number;
+  readonly previous: unknown;
+}
+
+/**
+ * The previous arm rewritten so its declared tag column reads as the
+ * successor's - used ONLY when every value the arm carried is still handled
+ * somewhere in the new union.
+ *
+ * WHY. A grouped arm may SPLIT, and each half then pins a narrower slice of the
+ * old tag set. Compared as-is, the half reads as "drops enum value 'monitor'"
+ * even though the sibling arm took that value and the union's accepted set is
+ * unchanged - so a perfectly benign split would fail the gate. Alignment
+ * removes exactly that false witness: every OTHER property still compares
+ * as-is, so a reduction hiding in either half is reported as before.
+ *
+ * Only when FULLY covered. A value no next arm took really is gone, and leaving
+ * the arm's own column in place is what still reports it.
+ */
+function alignDeclaredColumn(
+  previousVariant: unknown,
+  nextVariant: unknown,
+  declared: string,
+): unknown {
+  if (typeof previousVariant !== "object" || previousVariant === null)
+    return previousVariant;
+  const next = classifySchemaNode(nextVariant);
+  if (next.kind !== "object") return previousVariant;
+  const previousRecord = previousVariant as Record<string, unknown>;
+  const previousProperties = previousRecord["properties"];
+  if (typeof previousProperties !== "object" || previousProperties === null)
+    return previousVariant;
+  return {
+    ...previousRecord,
+    properties: {
+      ...(previousProperties as Record<string, unknown>),
+      [declared]: next.properties[declared],
+    },
+  };
+}
+
+/**
+ * Every next variant that IS this previous variant - the same arm, edited -
+ * or an empty list when the arm genuinely has no successor.
  *
  * WHY THIS EXISTS. The survival loop above can only answer "is any next
  * variant compatible with this previous one", and every NO used to fall into
@@ -990,14 +1047,14 @@ function declaredTagIdentifies(
  * more than one property qualifies, identity is the whole tuple: an arm whose
  * tuple changed is not the same arm.
  */
-function findDiscriminatedSuccessor(
+function findDiscriminatedSuccessors(
   previousVariant: unknown,
   previousVariants: readonly unknown[],
   nextVariants: readonly unknown[],
   declared: string | null,
-): number {
+): readonly DiscriminatedSuccessor[] {
   const previous = classifySchemaNode(previousVariant);
-  if (previous.kind !== "object") return -1;
+  if (previous.kind !== "object") return [];
   // The DECLARED field wins outright when the union names one and that field
   // still tells the arms apart on both sides. Identity is then that field
   // ALONE: a secondary literal moving on an arm whose declared tag is
@@ -1013,19 +1070,57 @@ function findDiscriminatedSuccessor(
   // no inference: the union already named the column. Requiring it to survive
   // inference therefore silently dropped every multi-value union straight back
   // onto the incidental-tuple fallback, i.e. back into this exact defect.
+  //
+  // Matched by SHARED value, and to EVERY next arm that shares one. A grouped
+  // arm moves in ways a single literal cannot, and each is a way for a
+  // reduction to escape if identity is one index matched on the whole set:
+  //
+  //   grown   ["a","b"] -> ["a","b","c"]   same arm, one more value
+  //   shrunk  ["a","b"] -> ["a"]           same arm; the dropped value is
+  //                                        reported by the arms' enum compare
+  //   merged  ["a"] + ["b"] -> ["a","b"]   both old arms project onto it
+  //   split   ["a","b"] -> ["a"] + ["b"]   BOTH halves still carry old traffic
+  //
+  // Only the split needs the LIST. `declaredTagIdentifies` forbids a value
+  // shared by two arms on one side, so any single value lands in at most one
+  // next arm - but a previous arm holding several values can have them land in
+  // several, and a reduction in the second is invisible to a first-match index.
   if (
     declared !== null &&
     declaredTagIdentifies(previousVariants, declared) &&
     declaredTagIdentifies(nextVariants, declared)
   ) {
     const previousValues = discriminantValues(previous.properties[declared]);
-    if (previousValues === null) return -1;
-    return nextVariants.findIndex((nextVariant) => {
+    if (previousValues === null) return [];
+    // Coverage is asked of the WHOLE next union, not of the matched arm: after
+    // a split it is the siblings that hold the rest of the old tag set, and a
+    // value none of them holds is the one real drop.
+    const covered = new Set<string | number | boolean>();
+    for (const nextVariant of nextVariants) {
       const next = classifySchemaNode(nextVariant);
-      if (next.kind !== "object") return false;
+      if (next.kind !== "object") continue;
       const nextValues = discriminantValues(next.properties[declared]);
-      return nextValues !== null && sameValueSet(previousValues, nextValues);
-    });
+      if (nextValues === null) continue;
+      for (const value of nextValues) covered.add(value);
+    }
+    const fullyCovered = [...previousValues].every((value) =>
+      covered.has(value),
+    );
+    const successors: DiscriminatedSuccessor[] = [];
+    for (const [index, nextVariant] of nextVariants.entries()) {
+      const next = classifySchemaNode(nextVariant);
+      if (next.kind !== "object") continue;
+      const nextValues = discriminantValues(next.properties[declared]);
+      if (nextValues === null) continue;
+      if (!sharesValue(previousValues, nextValues)) continue;
+      successors.push({
+        index,
+        previous: fullyCovered
+          ? alignDeclaredColumn(previousVariant, nextVariant, declared)
+          : previousVariant,
+      });
+    }
+    return successors;
   }
   const nextFields = new Set(discriminatorFields(nextVariants));
   const inferred = discriminatorFields(previousVariants).filter((field) =>
@@ -1035,17 +1130,23 @@ function findDiscriminatedSuccessor(
   // union whose declared column stopped telling the arms apart is no longer
   // answering the identity question either.
   const fields = inferred;
-  if (fields.length === 0) return -1;
+  if (fields.length === 0) return [];
   const identity = fields.map(
     (field) => [field, discriminantValue(previous.properties[field])] as const,
   );
-  return nextVariants.findIndex((nextVariant) => {
+  // At most one match, so no list to build: every field here is a SINGLE-value
+  // column that `discriminatorFields` already proved unique across the arms, so
+  // the tuple names one arm or none. No alignment either - a single-value tag
+  // cannot be split across arms, so the arm's own column is never a false
+  // witness.
+  const index = nextVariants.findIndex((nextVariant) => {
     const next = classifySchemaNode(nextVariant);
     if (next.kind !== "object") return false;
     return identity.every(
       ([field, value]) => discriminantValue(next.properties[field]) === value,
     );
   });
+  return index === -1 ? [] : [{ index, previous: previousVariant }];
 }
 
 /**
@@ -1194,6 +1295,28 @@ function constrainingRecord(node: unknown): Record<string, unknown> | null {
   return out;
 }
 
+/**
+ * The node with ONLY this file's own discriminator stamp removed, everything
+ * else - key order included - left exactly as `z.toJSONSchema` emitted it.
+ *
+ * For callers asking "was this schema CHANGED at all", where the answer must
+ * not turn on metadata we wrote ourselves, but must still turn on every
+ * keyword the peer's contract actually carries. {@link constrainingShape} is
+ * the wrong tool for that: it also drops `default` and friends, which are
+ * non-constraining for a LEAF's accepted values yet decide whether a payload
+ * parses at all.
+ */
+function withoutDeclaredDiscriminator(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(withoutDeclaredDiscriminator);
+  if (typeof node !== "object" || node === null) return node;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (key === DECLARED_DISCRIMINATOR_KEY) continue;
+    out[key] = withoutDeclaredDiscriminator(value);
+  }
+  return out;
+}
+
 function constrainingShape(node: unknown): string {
   if (typeof node !== "object" || node === null)
     return JSON.stringify(node) ?? String(node);
@@ -1250,8 +1373,8 @@ function findNodeAdditivityViolation(
       // the old form by discriminator was the old form EDITED, so its
       // reduction is what gets reported - only an old form with no successor
       // is the replacement the exemption covers.
-      const successorIndex = allowUnionArmReplacement
-        ? findDiscriminatedSuccessor(
+      const successors = allowUnionArmReplacement
+        ? findDiscriminatedSuccessors(
             previous,
             [previous],
             nextNode.variants,
@@ -1261,17 +1384,24 @@ function findNodeAdditivityViolation(
             // old single form happened to pin.
             nextNode.discriminator,
           )
-        : -1;
-      if (successorIndex !== -1) {
-        return findNodeAdditivityViolation(
-          previous,
-          nextNode.variants[successorIndex],
-          path,
-          mode,
-          previousInput,
-          nextWideningArms[successorIndex] ?? null,
-          allowUnionArmReplacement,
-        );
+        : [];
+      if (successors.length > 0) {
+        // EVERY successor, not the first: a grouped tag can split the old form
+        // across several new arms, and a reduction in any of them breaks the
+        // traffic that arm still carries.
+        for (const successor of successors) {
+          const edited = findNodeAdditivityViolation(
+            successor.previous,
+            nextNode.variants[successor.index],
+            path,
+            mode,
+            previousInput,
+            nextWideningArms[successor.index] ?? null,
+            allowUnionArmReplacement,
+          );
+          if (edited !== null) return edited;
+        }
+        return null;
       }
       return unionArmReplacementViolation(
         snippet(previous),
@@ -1299,12 +1429,12 @@ function findNodeAdditivityViolation(
         // an arm with no successor is a replacement the exemption covers.
         if (
           allowUnionArmReplacement &&
-          findDiscriminatedSuccessor(
+          findDiscriminatedSuccessors(
             variant,
             previousNode.variants,
             [next],
             previousNode.discriminator,
-          ) === 0
+          ).length > 0
         ) {
           return violation;
         }
@@ -1514,8 +1644,8 @@ function findNodeAdditivityViolation(
       // `union-variant` violation below is already the honest answer, and
       // swapping it for a nested detail would change the error every
       // non-gated minor reports.
-      const successorIndex = allowUnionArmReplacement
-        ? findDiscriminatedSuccessor(
+      const successors = allowUnionArmReplacement
+        ? findDiscriminatedSuccessors(
             previousVariant,
             previousNode.variants,
             nextNode.variants,
@@ -1527,24 +1657,30 @@ function findNodeAdditivityViolation(
               ? previousNode.discriminator
               : null,
           )
-        : -1;
-      if (successorIndex !== -1) {
-        const edited = findNodeAdditivityViolation(
-          previousVariant,
-          nextNode.variants[successorIndex],
-          path,
-          mode,
-          previousArmInput,
-          nextInputArms[successorIndex] ?? null,
-          // Passed through, NOT forced off: a union nested inside this arm may
-          // still have had one of ITS arms genuinely replaced under the same
-          // declaration, and that is what the exemption is for. What must not
-          // survive is this arm's own reduction, and that returns a
-          // `required-field` / `enum-value` / `schema-kind` violation, none of
-          // which consult the flag.
-          allowUnionArmReplacement,
-        );
-        if (edited !== null) return edited;
+        : [];
+      if (successors.length > 0) {
+        // EVERY successor, not the first. A grouped declared tag can SPLIT one
+        // old arm across several new ones, and each of them still carries the
+        // traffic pinned to the values it took, so a reduction in the second
+        // half breaks old clients exactly as the first half would.
+        for (const successor of successors) {
+          const edited = findNodeAdditivityViolation(
+            successor.previous,
+            nextNode.variants[successor.index],
+            path,
+            mode,
+            previousArmInput,
+            nextInputArms[successor.index] ?? null,
+            // Passed through, NOT forced off: a union nested inside this arm
+            // may still have had one of ITS arms genuinely replaced under the
+            // same declaration, and that is what the exemption is for. What
+            // must not survive is this arm's own reduction, and that returns a
+            // `required-field` / `enum-value` / `schema-kind` violation, none
+            // of which consult the flag.
+            allowUnionArmReplacement,
+          );
+          if (edited !== null) return edited;
+        }
         continue;
       }
       const replaced = unionArmReplacementViolation(
@@ -1769,16 +1905,24 @@ export function findBreakingChange(
       };
     }
     for (const field of Object.keys(previous.properties)) {
-      // `constrainingShape`, not raw `JSON.stringify`: this decides whether a
-      // MAJOR is justified, and the raw node carries annotation-only keywords
-      // plus our own `x-traycer-discriminator` stamp. A nested union that
-      // moves its declaration between two equally valid tag columns emits
-      // identical JSON, and comparing raw would have called that
-      // `schema-changed` and justified a major on metadata this file wrote
-      // itself.
+      // Raw `JSON.stringify` MINUS our own stamp - not `constrainingShape`.
+      // This decides whether a MAJOR is justified, and the stamp must never
+      // justify one: a nested union that moves its declaration between two
+      // equally valid tag columns emits identical JSON, and comparing raw
+      // called that `schema-changed` on metadata this file wrote itself.
+      //
+      // But `constrainingShape` was the wrong instrument for stripping it. It
+      // drops all of `NON_CONSTRAINING_SCHEMA_KEYS`, a set that answers a
+      // DIFFERENT question - "does this keyword constrain the values a LEAF
+      // accepts" in the additivity walk - and some of those keywords do justify
+      // a major here. `.catch([])` renders as `default`, so dropping the catch
+      // makes a payload that used to parse fail outright; strip `default` and
+      // that major reads as "could have shipped as a minor".
       if (
-        constrainingShape(previous.properties[field]) !==
-        constrainingShape(next.properties[field])
+        JSON.stringify(
+          withoutDeclaredDiscriminator(previous.properties[field]),
+        ) !==
+        JSON.stringify(withoutDeclaredDiscriminator(next.properties[field]))
       ) {
         return { kind: "field", detail: field, reason: "schema-changed" };
       }

--- a/protocol/src/framework/json-schema-fingerprint.ts
+++ b/protocol/src/framework/json-schema-fingerprint.ts
@@ -39,6 +39,19 @@ export type EnumJsonSchema = {
 export type AnyOfJsonSchema = {
   readonly type: "anyOf";
   readonly variants: readonly JsonSchemaFingerprint[];
+  /**
+   * The field `z.discriminatedUnion(...)` was DECLARED on, or `null` for a
+   * plain `z.union(...)`.
+   *
+   * Carried because arm identity cannot be inferred once more than one field
+   * qualifies as a tag: `{kind:"a",outcome:"x",value}` -> `{kind:"a",outcome:"z"}`
+   * (an EDIT that drops `value`) and `{kind:"a",outcome:"x",value}` ->
+   * `{kind:"b",outcome:"x"}` (a REPLACEMENT) are structurally identical - one
+   * qualifying field agrees, one differs, in both. Only the declaration says
+   * which field is the identity, and JSON Schema does not carry it, so
+   * `toJsonSchemaFingerprint` stamps it during conversion.
+   */
+  readonly discriminator: string | null;
 };
 
 /**
@@ -77,9 +90,57 @@ export function toJsonSchemaFingerprint(
   context: string,
 ): JsonSchemaFingerprint {
   return convertJsonSchemaShape(
-    z.toJSONSchema(schema, { unrepresentable: "any" }),
+    z.toJSONSchema(schema, {
+      unrepresentable: "any",
+      // The ONE thing JSON Schema drops that arm identity needs. `oneOf`
+      // tells us the union was declared discriminated; it does not say on
+      // WHICH field, and no amount of comparing the arms can recover it (see
+      // `AnyOfJsonSchema.discriminator`). Stamped under an `x-` key so a
+      // renderer that round-trips this schema stays valid, and read back by
+      // `declaredDiscriminator` during conversion.
+      override: stampDeclaredDiscriminator,
+    }),
     context,
   );
+}
+
+/** The key `toJsonSchemaFingerprint` stamps the declared discriminator under. */
+const DECLARED_DISCRIMINATOR_KEY = "x-traycer-discriminator";
+
+interface ZodDiscriminatedUnionInternals {
+  readonly _zod?: { readonly def?: { readonly discriminator?: unknown } };
+}
+
+interface SchemaConversionContext {
+  readonly zodSchema: unknown;
+  readonly jsonSchema: Record<string, unknown>;
+}
+
+/**
+ * Writes `z.discriminatedUnion`'s declared field onto the emitted union node.
+ *
+ * Reads zod's internal `def` because the public surface exposes no accessor
+ * for it, and it is read DEFENSIVELY: a shape that does not answer with a
+ * string simply leaves the node unstamped, and identity falls back to the
+ * inferred tuple - the behaviour before this existed. A zod upgrade that moves
+ * the field therefore degrades to the old inference rather than throwing, and
+ * the fixture in `json-schema-fingerprint.test.ts` fails loudly if it does.
+ */
+function stampDeclaredDiscriminator(context: SchemaConversionContext): void {
+  const schema = context.zodSchema;
+  if (typeof schema !== "object" || schema === null) return;
+  const internals = schema as ZodDiscriminatedUnionInternals;
+  const declared = internals._zod?.def?.discriminator;
+  if (typeof declared !== "string" || declared.length === 0) return;
+  context.jsonSchema[DECLARED_DISCRIMINATOR_KEY] = declared;
+}
+
+/** The stamped discriminator on a RAW JSON Schema union node, if any. */
+function declaredDiscriminator(node: {
+  readonly [DECLARED_DISCRIMINATOR_KEY]?: unknown;
+}): string | null {
+  const declared = node[DECLARED_DISCRIMINATOR_KEY];
+  return typeof declared === "string" && declared.length > 0 ? declared : null;
 }
 
 /**
@@ -330,6 +391,7 @@ function convertJsonSchemaShape(
     anyOf?: readonly unknown[];
     oneOf?: readonly unknown[];
     items?: unknown;
+    [DECLARED_DISCRIMINATOR_KEY]?: unknown;
   };
 
   if (node.type === "object" && node.properties !== undefined) {
@@ -359,6 +421,7 @@ function convertJsonSchemaShape(
       variants: node.anyOf.map((variant, index) =>
         convertJsonSchemaShape(variant, `${context}.anyOf[${index}]`),
       ),
+      discriminator: declaredDiscriminator(node),
     };
   }
 
@@ -378,6 +441,7 @@ function convertJsonSchemaShape(
       variants: node.oneOf.map((variant, index) =>
         convertJsonSchemaShape(variant, `${context}.oneOf[${index}]`),
       ),
+      discriminator: declaredDiscriminator(node),
     };
   }
 
@@ -635,7 +699,12 @@ type ClassifiedSchemaNode =
       readonly representation: EnumJsonSchema["representation"];
       readonly values: readonly (string | number | boolean)[];
     }
-  | { readonly kind: "anyOf"; readonly variants: readonly unknown[] }
+  | {
+      readonly kind: "anyOf";
+      readonly variants: readonly unknown[];
+      /** See {@link AnyOfJsonSchema.discriminator}; `null` for a plain union. */
+      readonly discriminator: string | null;
+    }
   | { readonly kind: "array"; readonly items: unknown }
   | { readonly kind: "opaque"; readonly node: unknown };
 
@@ -657,6 +726,11 @@ function classifySchemaNode(node: unknown): ClassifiedSchemaNode {
     anyOf?: readonly unknown[];
     oneOf?: readonly unknown[];
     items?: unknown;
+    // Two carriers, because this classifier sees BOTH forms: a normalized
+    // fingerprint node (`type:"anyOf"`, discriminator already converted) and
+    // a raw JSON Schema node nested below one (still carrying the stamp).
+    discriminator?: unknown;
+    [DECLARED_DISCRIMINATOR_KEY]?: unknown;
   };
   const requiredFields = Array.isArray(shape.required)
     ? shape.required.filter(
@@ -679,7 +753,15 @@ function classifySchemaNode(node: unknown): ClassifiedSchemaNode {
     };
   }
   if (shape.type === "anyOf" && Array.isArray(shape.variants)) {
-    return { kind: "anyOf", variants: shape.variants };
+    return {
+      kind: "anyOf",
+      variants: shape.variants,
+      discriminator:
+        typeof shape.discriminator === "string" &&
+        shape.discriminator.length > 0
+          ? shape.discriminator
+          : null,
+    };
   }
 
   // Raw JSON Schema forms, mirroring `convertJsonSchemaShape`'s branch
@@ -731,7 +813,11 @@ function classifySchemaNode(node: unknown): ClassifiedSchemaNode {
         values: literalEnum.values,
       };
     }
-    return { kind: "anyOf", variants: unionVariants };
+    return {
+      kind: "anyOf",
+      variants: unionVariants,
+      discriminator: declaredDiscriminator(shape),
+    };
   }
   if (
     "const" in shape &&
@@ -830,13 +916,23 @@ function findDiscriminatedSuccessor(
   previousVariant: unknown,
   previousVariants: readonly unknown[],
   nextVariants: readonly unknown[],
+  declared: string | null,
 ): number {
   const previous = classifySchemaNode(previousVariant);
   if (previous.kind !== "object") return -1;
   const nextFields = new Set(discriminatorFields(nextVariants));
-  const fields = discriminatorFields(previousVariants).filter((field) =>
+  const inferred = discriminatorFields(previousVariants).filter((field) =>
     nextFields.has(field),
   );
+  // The DECLARED field wins outright when the union names one and that field
+  // still tells the arms apart on both sides. Identity is then that field
+  // ALONE: a secondary literal moving on an arm whose declared tag is
+  // unchanged is an EDIT to that arm, and folding it into a tuple made the
+  // arm unmatchable - which handed its dropped fields to the replacement
+  // exemption. The tuple survives only as the fallback for a plain
+  // `z.union(...)`, where nothing declares which field carries identity.
+  const fields =
+    declared !== null && inferred.includes(declared) ? [declared] : inferred;
   if (fields.length === 0) return -1;
   const identity = fields.map(
     (field) => [field, discriminantValue(previous.properties[field])] as const,
@@ -1047,7 +1143,16 @@ function findNodeAdditivityViolation(
       // reduction is what gets reported - only an old form with no successor
       // is the replacement the exemption covers.
       const successorIndex = allowUnionArmReplacement
-        ? findDiscriminatedSuccessor(previous, [previous], nextNode.variants)
+        ? findDiscriminatedSuccessor(
+            previous,
+            [previous],
+            nextNode.variants,
+            // The previous node is not a union here (a single form GREW into
+            // one), so only the new union declares anything. Taking its
+            // declaration is what keeps identity from being every literal the
+            // old single form happened to pin.
+            nextNode.discriminator,
+          )
         : -1;
       if (successorIndex !== -1) {
         return findNodeAdditivityViolation(
@@ -1086,8 +1191,12 @@ function findNodeAdditivityViolation(
         // an arm with no successor is a replacement the exemption covers.
         if (
           allowUnionArmReplacement &&
-          findDiscriminatedSuccessor(variant, previousNode.variants, [next]) ===
-            0
+          findDiscriminatedSuccessor(
+            variant,
+            previousNode.variants,
+            [next],
+            previousNode.discriminator,
+          ) === 0
         ) {
           return violation;
         }
@@ -1302,6 +1411,13 @@ function findNodeAdditivityViolation(
             previousVariant,
             previousNode.variants,
             nextNode.variants,
+            // Both sides must call identity the same thing. A minor that
+            // re-declares the union on a DIFFERENT field has not edited its
+            // arms, it has redefined what an arm is, and the inferred tuple
+            // is the honest answer there.
+            previousNode.discriminator === nextNode.discriminator
+              ? previousNode.discriminator
+              : null,
           )
         : -1;
       if (successorIndex !== -1) {

--- a/protocol/src/framework/json-schema-fingerprint.ts
+++ b/protocol/src/framework/json-schema-fingerprint.ts
@@ -892,6 +892,64 @@ function discriminantValue(
 }
 
 /**
+ * Every literal value a property pins, or `null` when it pins none.
+ *
+ * {@link discriminantValue}'s multi-value sibling, and used ONLY for a
+ * DECLARED discriminator. Inference must keep rejecting a multi-value column
+ * (nothing tells it apart from an ordinary enum field that happens to differ
+ * per arm), but a declared tag is not inferred - the union named it - so a
+ * grouped arm like `kind: z.enum(["subagent", "monitor"])` is a perfectly
+ * good identity.
+ */
+function discriminantValues(
+  property: unknown,
+): ReadonlySet<string | number | boolean> | null {
+  const classified = classifySchemaNode(property);
+  if (classified.kind !== "enum" || classified.values.length === 0) return null;
+  return new Set(classified.values);
+}
+
+function sameValueSet(
+  a: ReadonlySet<string | number | boolean>,
+  b: ReadonlySet<string | number | boolean>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Whether `declared` actually tells THIS side's arms apart: pinned to at least
+ * one literal on every object arm, with no value shared between two of them.
+ *
+ * The same qualification {@link discriminatorFields} applies, minus the
+ * one-value-per-arm restriction. When it fails, the declaration has stopped
+ * answering the identity question on this side and the inferred tuple is the
+ * honest fallback.
+ */
+function declaredTagIdentifies(
+  variants: readonly unknown[],
+  declared: string,
+): boolean {
+  const seen = new Set<string | number | boolean>();
+  let objectArms = 0;
+  for (const variant of variants) {
+    const classified = classifySchemaNode(variant);
+    if (classified.kind !== "object") continue;
+    objectArms += 1;
+    const values = discriminantValues(classified.properties[declared]);
+    if (values === null) return false;
+    for (const value of values) {
+      if (seen.has(value)) return false;
+      seen.add(value);
+    }
+  }
+  return objectArms > 0;
+}
+
+/**
  * The index of the next variant that IS this previous variant - the same arm,
  * edited - or `-1` when the arm genuinely has no successor.
  *
@@ -940,19 +998,43 @@ function findDiscriminatedSuccessor(
 ): number {
   const previous = classifySchemaNode(previousVariant);
   if (previous.kind !== "object") return -1;
-  const nextFields = new Set(discriminatorFields(nextVariants));
-  const inferred = discriminatorFields(previousVariants).filter((field) =>
-    nextFields.has(field),
-  );
   // The DECLARED field wins outright when the union names one and that field
   // still tells the arms apart on both sides. Identity is then that field
   // ALONE: a secondary literal moving on an arm whose declared tag is
   // unchanged is an EDIT to that arm, and folding it into a tuple made the
   // arm unmatchable - which handed its dropped fields to the replacement
-  // exemption. The tuple survives only as the fallback for a plain
-  // `z.union(...)`, where nothing declares which field carries identity.
-  const fields =
-    declared !== null && inferred.includes(declared) ? [declared] : inferred;
+  // exemption.
+  //
+  // Matched as a VALUE SET, not a single literal. A declared tag may
+  // legitimately group several values in ONE arm - this repo does it with
+  // `kind: z.enum(["subagent", "monitor"])` in `agent/gui/subscribe.ts` - and
+  // `discriminatorFields` cannot see such a column, because INFERENCE has to
+  // reject it (nothing says the grouping is deliberate). A declared tag needs
+  // no inference: the union already named the column. Requiring it to survive
+  // inference therefore silently dropped every multi-value union straight back
+  // onto the incidental-tuple fallback, i.e. back into this exact defect.
+  if (
+    declared !== null &&
+    declaredTagIdentifies(previousVariants, declared) &&
+    declaredTagIdentifies(nextVariants, declared)
+  ) {
+    const previousValues = discriminantValues(previous.properties[declared]);
+    if (previousValues === null) return -1;
+    return nextVariants.findIndex((nextVariant) => {
+      const next = classifySchemaNode(nextVariant);
+      if (next.kind !== "object") return false;
+      const nextValues = discriminantValues(next.properties[declared]);
+      return nextValues !== null && sameValueSet(previousValues, nextValues);
+    });
+  }
+  const nextFields = new Set(discriminatorFields(nextVariants));
+  const inferred = discriminatorFields(previousVariants).filter((field) =>
+    nextFields.has(field),
+  );
+  // The tuple is the fallback: a plain `z.union(...)` declares nothing, and a
+  // union whose declared column stopped telling the arms apart is no longer
+  // answering the identity question either.
+  const fields = inferred;
   if (fields.length === 0) return -1;
   const identity = fields.map(
     (field) => [field, discriminantValue(previous.properties[field])] as const,
@@ -1025,6 +1107,12 @@ const NON_CONSTRAINING_SCHEMA_KEYS = new Set([
   "readOnly",
   "writeOnly",
   "$comment",
+  // OUR OWN metadata, not the peer's contract. It records which column a
+  // union was DECLARED on so arm identity can be resolved; it constrains no
+  // value, and two schemas differing only in it accept and emit byte-identical
+  // JSON. Left in, a union that merely moves its declaration from one valid
+  // tag column to another reads as a changed schema.
+  DECLARED_DISCRIMINATOR_KEY,
 ]);
 
 /**
@@ -1681,9 +1769,16 @@ export function findBreakingChange(
       };
     }
     for (const field of Object.keys(previous.properties)) {
+      // `constrainingShape`, not raw `JSON.stringify`: this decides whether a
+      // MAJOR is justified, and the raw node carries annotation-only keywords
+      // plus our own `x-traycer-discriminator` stamp. A nested union that
+      // moves its declaration between two equally valid tag columns emits
+      // identical JSON, and comparing raw would have called that
+      // `schema-changed` and justified a major on metadata this file wrote
+      // itself.
       if (
-        JSON.stringify(previous.properties[field]) !==
-        JSON.stringify(next.properties[field])
+        constrainingShape(previous.properties[field]) !==
+        constrainingShape(next.properties[field])
       ) {
         return { kind: "field", detail: field, reason: "schema-changed" };
       }

--- a/protocol/src/framework/json-schema-fingerprint.ts
+++ b/protocol/src/framework/json-schema-fingerprint.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import type {
+  $ZodDiscriminatedUnionDef,
+  ToJSONSchemaContext,
+} from "zod/v4/core";
 
 /**
  * Normalized JSON-Schema fingerprint shared by the versioned-record
@@ -107,32 +111,48 @@ export function toJsonSchemaFingerprint(
 /** The key `toJsonSchemaFingerprint` stamps the declared discriminator under. */
 const DECLARED_DISCRIMINATOR_KEY = "x-traycer-discriminator";
 
-interface ZodDiscriminatedUnionInternals {
-  readonly _zod?: { readonly def?: { readonly discriminator?: unknown } };
-}
+/**
+ * The exact object zod hands the `override` hook, taken from zod's own
+ * context type instead of restated here. A hand-written mirror of it would go
+ * on compiling after an upgrade changed the real one, which is the failure
+ * mode this whole stamp exists to avoid.
+ */
+type SchemaOverrideContext = Parameters<ToJSONSchemaContext["override"]>[0];
 
-interface SchemaConversionContext {
-  readonly zodSchema: unknown;
-  readonly jsonSchema: Record<string, unknown>;
+/**
+ * Narrows zod's base def to a discriminated union's, against zod's OWN
+ * exported def type rather than a local restatement of its shape.
+ *
+ * The runtime string check is load-bearing, not belt-and-braces. `_zod.def`
+ * is internal and the public surface exposes no accessor for it, so an
+ * upgrade that renames or retypes `discriminator` must leave the node
+ * UNSTAMPED - identity then falls back to the inferred tuple, the behaviour
+ * before this existed - rather than stamp `undefined` as though some field
+ * had been declared. Structural, so it is a narrowing and not a cast.
+ */
+function isDiscriminatedUnionDef(
+  def: object,
+): def is $ZodDiscriminatedUnionDef {
+  return (
+    "discriminator" in def &&
+    typeof def.discriminator === "string" &&
+    def.discriminator.length > 0
+  );
 }
 
 /**
  * Writes `z.discriminatedUnion`'s declared field onto the emitted union node.
  *
- * Reads zod's internal `def` because the public surface exposes no accessor
- * for it, and it is read DEFENSIVELY: a shape that does not answer with a
- * string simply leaves the node unstamped, and identity falls back to the
- * inferred tuple - the behaviour before this existed. A zod upgrade that moves
- * the field therefore degrades to the old inference rather than throwing, and
- * the fixture in `json-schema-fingerprint.test.ts` fails loudly if it does.
+ * A plain `z.union` has no `discriminator` in its def and is left alone, which
+ * is the honest answer: nothing was declared, so identity stays the inferred
+ * tuple. `json-schema-fingerprint.test.ts` pins the stamp as a positive
+ * control, so a zod upgrade that silently stops producing it fails loudly
+ * there instead of quietly restoring the defect this closes.
  */
-function stampDeclaredDiscriminator(context: SchemaConversionContext): void {
-  const schema = context.zodSchema;
-  if (typeof schema !== "object" || schema === null) return;
-  const internals = schema as ZodDiscriminatedUnionInternals;
-  const declared = internals._zod?.def?.discriminator;
-  if (typeof declared !== "string" || declared.length === 0) return;
-  context.jsonSchema[DECLARED_DISCRIMINATOR_KEY] = declared;
+function stampDeclaredDiscriminator(context: SchemaOverrideContext): void {
+  const def = context.zodSchema._zod.def;
+  if (!isDiscriminatedUnionDef(def)) return;
+  context.jsonSchema[DECLARED_DISCRIMINATOR_KEY] = def.discriminator;
 }
 
 /** The stamped discriminator on a RAW JSON Schema union node, if any. */


### PR DESCRIPTION
Follow-up to #1243, which merged before these two review comments landed. Both are real; both are fixed here with probed regression arms.

## 1. Protocol — carry the declared union discriminator (P2)

[Thread](https://github.com/traycerai/traycer/pull/1243#discussion_r3807970687)

`findDiscriminatedSuccessor` used the whole tuple of qualifying tag fields as arm identity. With more than one such field, an arm whose **declared** discriminator was unchanged but whose secondary literal moved matched nothing, read as *replaced*, and the `responseGrowthProjectionGated` exemption then accepted its dropped field silently:

```ts
// 1.0                                        1.1
{ kind: "a", outcome: "x", value: string }    { kind: "a", outcome: "z" }   // value silently dropped
{ kind: "b", outcome: "y" }                   { kind: "b", outcome: "y" }
```

**Why the fix has to be the declaration.** That case is structurally identical to the replacement the previous fix protects — `{kind:"success",outcome:"done",value}` → `{kind:"failure",outcome:"done"}`. One qualifying field agrees and one differs in *both*; only which one is the declared tag separates an edit from a replacement, and no comparison of the arms can recover that. A looser match (any field agrees) re-breaks the replacement case; a stricter one keeps this hole.

`z.toJSONSchema` renders a discriminated union as `oneOf` and drops which field was declared, so `toJsonSchemaFingerprint` stamps it during conversion via zod's `override` hook and `AnyOfJsonSchema` carries it. Identity is then that field alone; the inferred tuple survives as the fallback for a plain `z.union`, and for a union whose two sides declare *different* fields — that is a redefinition, not an edit.

The read of zod's internal `def` is deliberately soft: an unrecognised shape leaves the node unstamped and identity falls back to the tuple, so a zod upgrade degrades to the old inference rather than throwing. That would silently restore this defect, so there is a positive control pinning the stamp.

No effect on the released-baseline compat gate: `dump-protocol-surface.ts` has its own serializer and does not go through the fingerprint.

## 2. gui-app — retain a dirty live handle on an involuntary release (P1)

[Thread](https://github.com/traycerai/traycer/pull/1243#discussion_r3807970694)

`release(epicId, "keep")` spared only the buffers *already* retained; the live handle — the one actually holding the user's unsynced edits — was disposed either way. An owner-identity rotation leaves `userId` unchanged, so the provider takes exactly that arm, and a same-host re-enrollment destroyed a dirty `Y.Doc` with no confirmation and no retention. The flag's own doc says `"keep"` exists so an involuntary path cannot cause a silent loss; this is the case where it did.

`release` now takes a third argument: the identity to retain a dirty live handle under, or `null` to destroy it. Retention follows the rule `replaceMounted` already follows for a re-point, and produces the same kind of buffer — transport detached, visible through the unsynced-edits projection, merged only on positive proof of same epic + host + owner identity.

`null` is required rather than defaulted, so all 14 call sites state their decision:

| Path | Value | Why |
| --- | --- | --- |
| Owner-identity rotation | old `{hostStamp, ownerIdentityKey}` | Same person, nothing shown — the edits belong to the pre-rotation room |
| User change | `null` | Another person at the keyboard; the same policy `disposeAll` applies at sign-out |
| `"discard"` paths | `null` | The user was asked about these edits |
| Ownership denial | `null` | **Unchanged, deliberately** — another window continues that epic, so a retention here is work this window can never flush |

## Verification

- `bun run compile` 5/5; eslint `--max-warnings 0` + prettier clean on all touched files.
- protocol 266/266 (13 files), gui-app registry/provider/tab/command suites green.
- Mutation-probed: reverting only the declared-key preference reds exactly the two new protocol arms; reverting only the retention branch reds exactly the new registry arm.
