### PR TITLE
fix(gui-app): keep a forked agent's title instead of "Untitled agent"

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-cross-host.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-cross-host.test.tsx
@@ -40,6 +40,7 @@ const ABSENT_HOST_ID = "absent-host-id";
 
 interface ChatForkCreateInput {
   readonly hostId: string;
+  readonly title: string;
   readonly worktreeIntent: WorktreeIntent | null;
   readonly forkSource: {
     readonly boundary: "assistantMessage";
@@ -1401,5 +1402,65 @@ describe("ChatForkDialog cross-host routing", () => {
     expect(otherRow instanceof HTMLButtonElement && otherRow.disabled).toBe(
       false,
     );
+  });
+
+  it('untitled source: empty input, "Untitled agent" placeholder, submit enabled, sends title ""', async () => {
+    renderDialog(forkTarget({ sourceChatTitle: "" }), ignoreOpenChange);
+
+    const input = screen.getByRole<HTMLInputElement>("textbox", {
+      name: "Fork agent title",
+    });
+    expect(input.value).toBe("");
+    expect(input.getAttribute("placeholder")).toBe("Untitled agent");
+    // No fillTitle() here on purpose: an untitled source must not need one.
+    expect(forkButton().disabled).toBe(false);
+
+    fireEvent.click(forkButton());
+    await waitFor(() => {
+      expect(dialogMocks.createMutate).toHaveBeenCalled();
+    });
+    const request = dialogMocks.createMutate.mock.calls[0][0];
+    expect(request.title).toBe("");
+  });
+
+  it("untitled source with a user-typed title still sends the typed title", async () => {
+    renderDialog(forkTarget({ sourceChatTitle: "" }), ignoreOpenChange);
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Fork agent title" }),
+      { target: { value: "My chosen name" } },
+    );
+    expect(forkButton().disabled).toBe(false);
+
+    fireEvent.click(forkButton());
+    await waitFor(() => {
+      expect(dialogMocks.createMutate).toHaveBeenCalled();
+    });
+    const request = dialogMocks.createMutate.mock.calls[0][0];
+    expect(request.title).toBe("My chosen name");
+  });
+
+  it("titled source: prefills 'Fork - <title>' and clearing the field disables submit", () => {
+    // The default title is only computed on an open TRANSITION (`if (open
+    // !== dialogState.open)`), not on an initial mount that is already
+    // `open`. Mounting closed and then flipping to open, like the
+    // boundary-notice tests above, is what actually exercises the prefill.
+    const target = forkTarget({ sourceChatTitle: "Source chat" });
+    const view = render(
+      <ChatForkDialog {...dialogProps(target, ignoreOpenChange, false)} />,
+    );
+    view.rerender(
+      <ChatForkDialog {...dialogProps(target, ignoreOpenChange, true)} />,
+    );
+
+    const input = screen.getByRole<HTMLInputElement>("textbox", {
+      name: "Fork agent title",
+    });
+    expect(input.value).toBe("Fork - Source chat");
+    expect(input.getAttribute("placeholder")).toBe("");
+    expect(forkButton().disabled).toBe(false);
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(forkButton().disabled).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -192,8 +192,15 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
     };
   }, []);
 
+  // The rare case where the source itself is still untitled: there is no name
+  // to inherit, so the dialog defaults to EMPTY instead of baking the
+  // "Untitled agent" render fallback into a permanent stored title. An empty
+  // submit stores "" and the fork is AI-titled from its first message, same
+  // as the automatic fork paths; the input's placeholder says what happens.
+  const sourceUntitled =
+    target !== null && target.sourceChatTitle.trim().length === 0;
   const defaultTitle =
-    target === null
+    target === null || sourceUntitled
       ? ""
       : `${forkModeTitlePrefix(target.forkMode)} - ${displayChatTitle(target.sourceChatTitle)}`;
 
@@ -503,6 +510,7 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
   const canSubmit = canSubmitFork({
     target,
     trimmedTitle,
+    sourceUntitled,
     modelResolved,
     hasStagedPreselection: stagedIntentForKey !== null,
     createPending: createChat.isPending,
@@ -789,6 +797,7 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
               }}
               disabled={createChat.isPending}
               aria-label="Fork agent title"
+              placeholder={sourceUntitled ? "Untitled agent" : ""}
             />
           </label>
           <section className="flex min-w-0 flex-col gap-2">
@@ -1013,6 +1022,10 @@ function ChatForkHostCapabilityProbe(props: {
 function canSubmitFork(input: {
   readonly target: ChatForkDialogTarget | null;
   readonly trimmedTitle: string;
+  /** The source chat's stored title is empty - the one case an empty title
+   *  field may submit: it stores "" and the fork is AI-titled on its first
+   *  send, instead of freezing the "Untitled agent" render fallback. */
+  readonly sourceUntitled: boolean;
   readonly modelResolved: boolean;
   readonly hasStagedPreselection: boolean;
   readonly createPending: boolean;
@@ -1028,7 +1041,7 @@ function canSubmitFork(input: {
   readonly requiresStagedPreselection: boolean;
 }): boolean {
   if (input.target === null) return false;
-  if (input.trimmedTitle.length === 0) return false;
+  if (input.trimmedTitle.length === 0 && !input.sourceUntitled) return false;
   if (!input.modelResolved) return false;
   if (input.createPending) return false;
   if (!input.hostClientResolved) return false;

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-clone-host-freeze.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-clone-host-freeze.test.tsx
@@ -80,6 +80,7 @@ const ARGS = {
   chatId: "chat-1",
   sourceHostId: "host-source",
   sourceSettings: null,
+  sourceTitle: "",
   sourceOwnerUserId: null,
 };
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/use-chat-clone-on-host-switch.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/use-chat-clone-on-host-switch.test.tsx
@@ -47,6 +47,7 @@ const ARGS = {
   chatId: "chat-1",
   sourceHostId: "host-A",
   sourceSettings: null,
+  sourceTitle: "",
   sourceOwnerUserId: "user-1",
 };
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -541,6 +541,9 @@ export function ChatDeadTileBannerContainer(
     chatId: props.chatId,
     sourceHostId: props.sourceHostId,
     sourceSettings: chatRecord?.settings ?? null,
+    // Raw stored title, `""` when this dead tile has no record left to read
+    // one from - the host's fork-seed gap-fill names the clone in that case.
+    sourceTitle: chatRecord?.title ?? "",
     sourceOwnerUserId,
   });
   return (

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-clone-on-host-switch.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-clone-on-host-switch.ts
@@ -21,6 +21,12 @@ export interface UseChatCloneOnHostSwitchArgs {
   readonly chatId: string;
   readonly sourceHostId: string;
   readonly sourceSettings: ChatRunSettings | null;
+  /** The source chat's RAW stored title, or `""` when this banner has no
+   *  record to read one from - a dead tile whose record was retracted is
+   *  exactly that case. Empty leaves the clone's name to the host's
+   *  fork-seed gap-fill, which reads the title off the copy the history
+   *  came from. */
+  readonly sourceTitle: string;
   /** The owner this banner was showing, or `null` when it does not know. */
   readonly sourceOwnerUserId: string | null;
 }
@@ -98,6 +104,7 @@ export function useChatCloneOnHostSwitch(args: UseChatCloneOnHostSwitchArgs): {
       sourceChatId: args.chatId,
       sourceOwnerUserId: args.sourceOwnerUserId,
       sourceHostId: args.sourceHostId,
+      sourceTitle: args.sourceTitle,
       targetHostId: cloneTargetHostId,
       directory: binding.directory,
       sourceSettings: args.sourceSettings,
@@ -140,6 +147,7 @@ export function useChatCloneOnHostSwitch(args: UseChatCloneOnHostSwitchArgs): {
     args.sourceOwnerUserId,
     args.sourceHostId,
     args.sourceSettings,
+    args.sourceTitle,
   ]);
 
   return { clone, cloning };

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -2266,6 +2266,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       sourceChatId: surface.ownerId,
       sourceOwnerUserId,
       sourceHostId: surface.hostId,
+      sourceTitle: sourceChatRecord?.title ?? "",
       targetHostId: pendingCloneHostId,
       directory: binding.directory,
       sourceSettings: sourceChatRecord?.settings ?? null,

--- a/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
@@ -216,6 +216,7 @@ describe("new chat command actions", () => {
       hostId: "test-host",
       source: "direct_ui",
       worktreeIntent: null,
+      title: "",
       settings: null,
       forkSource: null,
       onCreateError: () => undefined,
@@ -257,6 +258,7 @@ describe("new chat command actions", () => {
       hostId: "test-host",
       source: "direct_ui",
       worktreeIntent: SEEDED_WORKTREE_INTENT,
+      title: "",
       settings: null,
       forkSource: null,
       onCreateError: () => undefined,
@@ -267,6 +269,27 @@ describe("new chat command actions", () => {
     expect(createChat.calls[0].request.worktreeIntent).toBe(
       SEEDED_WORKTREE_INTENT,
     );
+  });
+
+  it("sends the caller-supplied title on the create request (clone-on-host-switch keeps its name)", () => {
+    const createChat = createChatRecorder();
+    const opened = openIntentsRecorder();
+
+    openNewChatInActiveTile({
+      epicId: EPIC_ID,
+      tabId: TAB_ID,
+      hostId: "test-host",
+      source: "direct_ui",
+      worktreeIntent: null,
+      title: "Cloned chat title",
+      settings: null,
+      forkSource: null,
+      onCreateError: () => undefined,
+      createChat: createChat.createChat,
+      openWhenProjected: opened.openWhenProjected,
+    });
+
+    expect(createChat.calls[0].request.title).toBe("Cloned chat title");
   });
 
   it("opens an active-tile tab only after the host-created chat appears in projection", () => {
@@ -480,6 +503,7 @@ describe("new chat command actions", () => {
         hostId: "test-host",
         source: "direct_ui",
         worktreeIntent: null,
+        title: "",
         settings: null,
         forkSource: null,
         onCreateError: () => undefined,
@@ -504,6 +528,7 @@ describe("new chat command actions", () => {
         hostId: "test-host",
         source: "direct_ui",
         worktreeIntent: null,
+        title: "",
         settings: null,
         forkSource: null,
         onCreateError: () => undefined,

--- a/clients/gui-app/src/lib/commands/actions/__tests__/profile-durability-clone-host-switch-edges.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/profile-durability-clone-host-switch-edges.test.ts
@@ -17,6 +17,7 @@ import type {
 import type { CreateChatCommand } from "@/lib/commands/actions/new-chat";
 import {
   cloneChatOnHostSwitch,
+  cloneChatTitle,
   type CloneChatOnHostSwitchArgs,
 } from "@/lib/commands/actions/clone-chat-on-host-switch";
 import {
@@ -225,6 +226,7 @@ function baseCloneArgs(
     // so they answer it the way a surface that does not know does.
     sourceOwnerUserId: null,
     sourceHostId: "source-host",
+    sourceTitle: "",
     targetHostId: "target-host",
     directory: fakeDirectory([]),
     createChat: vi.fn<CreateChatCommand>(),
@@ -507,6 +509,76 @@ describe("cloneChatOnHostSwitch: history-carrying fork and its retry", () => {
       // the request still states that explicitly rather than omitting it.
       sourceOwnerUserId: null,
     });
+  });
+
+  it("stamps a fork-decorated sourceTitle (prefix + target host label) as the request's title, so a clone keeps its name", async () => {
+    const createChat = vi.fn<CreateChatCommand>();
+
+    cloneChatOnHostSwitch(
+      baseCloneArgs({
+        directory: TARGET_DIRECTORY,
+        createChat,
+        sourceSettings: null,
+        sourceTitle: "Source chat title",
+      }),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(createChat).toHaveBeenCalledTimes(1);
+    const [request] = createChat.mock.calls[0];
+    expect(request.title).toBe("Fork - Source chat title (Target)");
+  });
+
+  it("carries the decorated title through to the settings-only retry too, where no fork seed exists to gap-fill it", async () => {
+    // The fork BOUNDARY rather than the whole `forkSource`: it is the only
+    // part this test is about, and recording the discriminator keeps the
+    // assertion a plain value comparison (an `expect.objectContaining` here
+    // would be an `any` assignment).
+    const calls: Array<{
+      readonly boundary: string | null;
+      readonly title: string;
+    }> = [];
+    const createChat: CreateChatCommand = (request, callbacks) => {
+      const forkSource = request.forkSource ?? null;
+      calls.push({
+        boundary: forkSource === null ? null : forkSource.boundary,
+        title: request.title,
+      });
+      if (forkSource !== null) {
+        callbacks.onError(checkpointUnavailableError());
+        return;
+      }
+      callbacks.onSuccess({ chatId: "cloned-chat" });
+    };
+
+    cloneChatOnHostSwitch(
+      baseCloneArgs({
+        directory: TARGET_DIRECTORY,
+        createChat,
+        sourceSettings: null,
+        sourceTitle: "Source chat title",
+      }),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toEqual([
+      { boundary: "latest", title: "Fork - Source chat title (Target)" },
+      { boundary: null, title: "Fork - Source chat title (Target)" },
+    ]);
+  });
+
+  it("cloneChatTitle: untitled source stays empty (AI-titling eligible); a vanished target drops only the label", () => {
+    expect(cloneChatTitle("", "Target")).toBe("");
+    expect(cloneChatTitle("   ", "Target")).toBe("");
+    expect(cloneChatTitle("My agent", null)).toBe("Fork - My agent");
+    expect(cloneChatTitle("My agent", "Target")).toBe(
+      "Fork - My agent (Target)",
+    );
   });
 
   it("retries settings-only exactly once on a checkpoint-unavailable refusal, and reports it exactly once", async () => {

--- a/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
+++ b/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
@@ -86,6 +86,13 @@ export interface CloneChatOnHostSwitchArgs {
    */
   readonly sourceOwnerUserId: string | null;
   readonly sourceHostId: string;
+  /** The source chat's RAW stored title from the local projection - `""` for
+   *  a still-untitled source, never the rendered "Untitled agent" fallback.
+   *  Decorated into the clone's stamped title by {@link cloneChatTitle};
+   *  passed client-side (not left to the host's fork-seed gap-fill) so the
+   *  title survives the settings-only retry, where no fork seed exists at
+   *  all. */
+  readonly sourceTitle: string;
   readonly targetHostId: string;
   readonly directory: IHostDirectoryService;
   readonly createChat: CreateChatCommand;
@@ -120,9 +127,51 @@ export interface CloneChatOnHostSwitchArgs {
   readonly navigateNestedFocus: NavigateNestedFocus | null;
 }
 
+/**
+ * The title stamped on the clone: the manual fork dialog's `Fork - ` prefix
+ * (a clone IS a fork, and the sidebar should say so) plus the target host's
+ * label, which is the one fact that tells two clones of the same chat onto
+ * different machines apart. A still-untitled source stays `""` so the clone
+ * remains eligible for AI titling on its first send, exactly like a fresh
+ * chat; a target that has vanished from the directory (the flow proceeds
+ * anyway, into ambient fallback) just drops the label.
+ */
+export function cloneChatTitle(
+  sourceTitle: string,
+  targetHostLabel: string | null,
+): string {
+  if (sourceTitle.trim() === "") return "";
+  return targetHostLabel === null
+    ? `Fork - ${sourceTitle}`
+    : `Fork - ${sourceTitle} (${targetHostLabel})`;
+}
+
+/** See the title computation in {@link cloneChatOnHostSwitch} for why this
+ *  swallows instead of propagating. */
+function lookupHostLabelOrNull(
+  directory: IHostDirectoryService,
+  hostId: string,
+): string | null {
+  try {
+    return directory.findById(hostId)?.label ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function cloneChatOnHostSwitch(
   args: CloneChatOnHostSwitchArgs,
 ): CancelFn {
+  // Fixed once for both attempts: the fork attempt and the settings-only
+  // retry must land under the same name. The label lookup is best-effort -
+  // a directory seam that throws must end this flow through the settings
+  // resolution's own catch arm (-> onCloneFailed), not as a synchronous
+  // throw out of this call; the title just drops the label.
+  const title = cloneChatTitle(
+    args.sourceTitle,
+    lookupHostLabelOrNull(args.directory, args.targetHostId),
+  );
+
   let cancelled = false;
   let innerCancel: CancelFn | null = null;
 
@@ -142,6 +191,7 @@ export function cloneChatOnHostSwitch(
       tabId: args.tabId,
       hostId: args.targetHostId,
       worktreeIntent: null,
+      title,
       settings,
       forkSource,
       source: "direct_ui",

--- a/clients/gui-app/src/lib/commands/actions/new-chat.ts
+++ b/clients/gui-app/src/lib/commands/actions/new-chat.ts
@@ -106,6 +106,13 @@ export interface OpenNewChatInActiveTileArgs {
   readonly tabId: string;
   readonly hostId: string;
   readonly worktreeIntent: WorktreeIntent | null;
+  /** Stored title for the new chat - `""` for an ordinary empty chat (the
+   *  "no title yet" convention; AI titling fills it on the first send). The
+   *  clone flow passes a `Fork - <source> (<target host>)` title (see
+   *  `cloneChatTitle`) so a clone keeps its name even when the create
+   *  degrades to the settings-only retry, where no fork seed exists for the
+   *  host to gap-fill from. */
+  readonly title: string;
   /** Per-chat run settings to stamp on the new chat - `null` starts the chat
    *  with host defaults (today's behavior for every caller but the clone
    *  flow, which carries the source chat's own settings forward). */
@@ -140,6 +147,7 @@ export function openNewChatInActiveTile(
       // the mutation fires.
       hostId: args.hostId,
       worktreeIntent: args.worktreeIntent,
+      title: args.title,
       settings: args.settings,
       forkSource: args.forkSource,
     }),
@@ -284,19 +292,22 @@ function buildCreateChatRequest(args: {
   readonly epicId: string;
   readonly hostId: string;
   readonly worktreeIntent: WorktreeIntent | null;
+  readonly title: string;
   readonly settings: ChatRunSettings | null;
   readonly forkSource: CreateChatMutationInput["forkSource"] | null;
 }): CreateChatMutationInput {
-  const { epicId, hostId, worktreeIntent, settings, forkSource } = args;
+  const { epicId, hostId, worktreeIntent, title, settings, forkSource } = args;
   return {
     epicId,
     hostId,
     parentId: null,
-    // Agents are created with an empty stored title ("no title yet"); the
-    // "Untitled agent" fallback is applied at render via the display helper,
-    // never baked into the stored title. The AI-generated title overwrites the
-    // empty store only while it is still empty.
-    title: "",
+    // Ordinary chats are created with an empty stored title ("no title yet");
+    // the "Untitled agent" fallback is applied at render via the display
+    // helper, never baked into the stored title. The AI-generated title
+    // overwrites the empty store only while it is still empty. The clone flow
+    // passes a fork-decorated source title instead, which (when non-empty)
+    // also correctly blocks AI titling from renaming the continuation.
+    title,
     chatId: uuidv4(),
     workspaceMode: deriveWorkspaceMode(1, worktreeIntent),
     worktreeIntent,


### PR DESCRIPTION
## Problem

Cloning an agent onto another host via **Open on new host** produced a fully history-seeded clone named **Untitled agent**, even when the source had a title.

Three things compose into it:

- The clone flow shares its request builder with ordinary chat creation, which hardcodes `title: ""` — the "no title yet" convention.
- The host stamps that title verbatim; the fork seed carried history and settings, never the title.
- Chat titles are generated only when a first user message lands via `chat.sendMessage`. A history-seeded clone never receives one, so nothing ever titles it.

## Change

**Clone flow** — the clone names itself `Fork - <source title> (<target host label>)`. The fork prefix matches the manual fork dialog's convention; the host label is the one fact that tells two clones of the same agent onto different machines apart.

Passed client-side rather than relying on the host-side fork-seed gap-fill (companion internal-repo PR), because:

- the settings-only retry after a recoverable fork refusal sends no `forkSource` at all — there is no seed for the host to fill from;
- it works against hosts that predate the gap-fill.

An untitled source still clones as `""`, so the clone stays eligible for AI titling exactly like a fresh chat instead of carrying a `Fork -  (host)` husk that would permanently block it. A target that vanished from the directory mid-flow drops only the label.

**Fork dialog** — same reasoning for the one case where there is nothing to inherit. It used to bake the "Untitled agent" *render fallback* into a permanent stored title. For an untitled source only, the title field now defaults to empty with an "Untitled agent" placeholder and `canSubmitFork` accepts it, so the fork is AI-titled from its first message. A titled source is unchanged: prefilled `<mode> - <title>`, empty field still blocks submit.

## Scenarios

| Surface | Source title | Before | After |
| --- | --- | --- | --- |
| Clone (fork attempt) | "S3 Chats Backend" | Untitled agent forever | Fork - S3 Chats Backend (tgill-popos) |
| Clone (settings-only retry) | "S3 Chats Backend" | Untitled agent forever | same — host has no seed here |
| Clone | "" | Untitled agent, AI-titles on first send | unchanged (deliberate) |
| Fork dialog | "My agent" | Fork - My agent | unchanged |
| Fork dialog | "" | stored "Fork - Untitled agent" forever | stores "" → AI-titled on first send |

## Tests

- `new-chat.test.ts` — the caller-supplied title reaches the create request.
- `profile-durability-clone-host-switch-edges.test.ts` — the decorated title is stamped on both the fork attempt and the settings-only retry; `cloneChatTitle` unit cases (untitled source, missing host label).
- `chat-fork-dialog-cross-host.test.tsx` — untitled source: empty input, placeholder, submit enabled, sends `title: ""`; typed title still wins; titled source unchanged.

All touched suites pass locally (36 + 28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)