### PR TITLE
fix(gui-app): one boot card for every face of a launch

### DIFF
--- a/clients/desktop/src/electron-main/ipc/traycer-cli-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/traycer-cli-ipc.ts
@@ -78,9 +78,11 @@ export function registerTraycerCliIpc(bridge: RunnerIpcBridge): void {
   // `host status` is now a runner-aware command (Native Packaging
   // cutover): it emits the shared NDJSON envelope and integrates Core
   // Flow 7 auto-bootstrap. Desktop always passes `--no-bootstrap` here
-  // because Setup splash and Settings → Host drive the install
-  // pipeline explicitly - host-status from Desktop is informational
-  // only and must never implicitly install the host.
+  // because the launch reconciler (`HostController`) and Settings → Host
+  // drive the install pipeline explicitly - host-status from Desktop is
+  // informational only (the renderer's boot card reads it for its
+  // `Show details` bootstrap.log tail) and must never implicitly install
+  // the host.
   bridge.handleInvoke(RunnerHostInvoke.traycerHostStatus, async () => {
     return runTraycerCliJson(["host", "status", "--no-bootstrap"]);
   });

--- a/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
+++ b/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
@@ -47,8 +47,21 @@ const FACES = [
   "gate-removed",
   "dialog",
 ];
-/** The faces that must not MOVE relative to one another (same top + height). */
-const WAIT_FACES = new Set(["runtime", "attach", "restoring", "narrator-idle"]);
+/**
+ * The faces that must not MOVE relative to one another (same top + height):
+ * every healthy wait, INCLUDING the narrator with a lane reporting at 42% -
+ * a launch crosses all five and the bar is on every one of them, so a lane
+ * starting to report changes the sentence and the fill, not the box.
+ * `narrator-slow` is deliberately not here: it grows a Retry action row,
+ * which is a real state change on its own clock, not a hand-off.
+ */
+const WAIT_FACES = new Set([
+  "runtime",
+  "attach",
+  "restoring",
+  "narrator-idle",
+  "narrator-lane",
+]);
 
 const args = process.argv.slice(2);
 const dark = args.includes("--dark");

--- a/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
+++ b/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
@@ -4,7 +4,7 @@
 //
 // Manual instrument, not a CI gate. Run it when touching the boot-card family:
 //
-//   bun scripts/host-boot-family-gallery-browser.mjs [--out DIR] [--dark]
+//   bun scripts/host-boot-family-gallery-browser.mjs [--out DIR] [--dark] [--viewport WxH]
 //
 // It writes `<face>.png` (and `<face>.dark.png` with --dark) into DIR (default:
 // a fresh temp dir, printed), then prints one row per face: the card's left,
@@ -51,13 +51,31 @@ const FACES = [
 const WAIT_FACES = new Set(["runtime", "attach", "restoring", "narrator-idle"]);
 
 const args = process.argv.slice(2);
-const outFlag = args.indexOf("--out");
 const dark = args.includes("--dark");
-const viewportFlag = args.indexOf("--viewport");
+/** The value after `--flag`, or a usage error - never `undefined` into `split`. */
+const flagValue = (flag) => {
+  const index = args.indexOf(flag);
+  if (index === -1) return null;
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+};
+const viewportValue = flagValue("--viewport");
 const [viewportWidth, viewportHeight] =
-  viewportFlag === -1
+  viewportValue === null
     ? [1200, 900]
-    : args[viewportFlag + 1].split("x").map((n) => Number(n));
+    : viewportValue.split("x").map((n) => Number(n));
+if (
+  !Number.isInteger(viewportWidth) ||
+  !Number.isInteger(viewportHeight) ||
+  viewportWidth <= 0 ||
+  viewportHeight <= 0
+) {
+  throw new Error("--viewport expects WIDTHxHEIGHT, e.g. 1200x900");
+}
+const outValue = flagValue("--out");
 
 const projectRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -67,9 +85,9 @@ const fixtureUrlPath = "/src/__tests__/browser/host-boot-family-gallery.html";
 const chromePath = await findChrome();
 const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-gallery-"));
 const outDir =
-  outFlag === -1
+  outValue === null
     ? await mkdtemp(path.join(tmpdir(), "traycer-boot-gallery-"))
-    : path.resolve(args[outFlag + 1]);
+    : path.resolve(outValue);
 await mkdir(outDir, { recursive: true });
 const vitePort = await freePort();
 let devtoolsPort = await freePort();
@@ -369,9 +387,24 @@ function connectCdp(url) {
       () => reject(new Error("CDP connect timed out")),
       15_000,
     );
-    socket.addEventListener("error", (event) =>
-      reject(new Error(String(event))),
-    );
+    // A socket that dies mid-run must FAIL the run, not hang it: every
+    // in-flight request is rejected on close/error, and a send on a socket
+    // that is not open rejects immediately, so a Chrome crash surfaces as an
+    // error with a message rather than as a driver that never exits.
+    const failAll = (reason) => {
+      for (const [id, request] of pending) {
+        pending.delete(id);
+        request.reject(reason);
+      }
+    };
+    socket.addEventListener("error", (event) => {
+      const error = new Error(`CDP socket error: ${String(event)}`);
+      reject(error);
+      failAll(error);
+    });
+    socket.addEventListener("close", (event) => {
+      failAll(new Error(`CDP socket closed (${event.code})`));
+    });
     socket.addEventListener("message", (event) => {
       const message = JSON.parse(String(event.data));
       if (typeof message.id !== "number") return;
@@ -385,6 +418,11 @@ function connectCdp(url) {
       clearTimeout(connectTimer);
       resolve({
         send(method, params = {}) {
+          if (socket.readyState !== WebSocket.OPEN) {
+            return Promise.reject(
+              new Error(`CDP socket not open for ${method}`),
+            );
+          }
           return new Promise((requestResolve, requestReject) => {
             const id = ++nextId;
             pending.set(id, { resolve: requestResolve, reject: requestReject });

--- a/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
+++ b/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
@@ -1,0 +1,431 @@
+// The boot-family GALLERY: renders every face a launch can show, screenshots
+// each one, and reads the card's box so "one geometry across the launch" is a
+// measured claim rather than a described one.
+//
+// Manual instrument, not a CI gate. Run it when touching the boot-card family:
+//
+//   bun scripts/host-boot-family-gallery-browser.mjs [--out DIR] [--dark]
+//
+// It writes `<face>.png` (and `<face>.dark.png` with --dark) into DIR (default:
+// a fresh temp dir, printed), then prints one row per face: the card's left,
+// top, width and height in CSS px at deviceScaleFactor 1, and whether the face
+// is drawn through the shared `HostBootCard`. The rows a reader should expect:
+//
+//  - every family face has the SAME width (the shared card's `max-w-sm`) and
+//    the SAME left edge - the card does not change shape as the launch hands
+//    off between surfaces;
+//  - the WAIT faces (runtime, attach, restoring, narrator-idle) additionally
+//    share the same top and height - the card does not MOVE between them;
+//  - the `dialog` face is the CONTROL: a different, wider box on purpose. A
+//    run in which it matches the family is a run from an instrument that
+//    cannot see width, and its table means nothing.
+//
+// Structure copied from `window-host-modal-alignment-browser.mjs` (vite +
+// headless Chrome over CDP).
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { createServer as createTcpServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const FACES = [
+  "runtime",
+  "attach",
+  "restoring",
+  "narrator-idle",
+  "narrator-lane",
+  "narrator-slow",
+  "narrator-failed",
+  "narrator-no-host",
+  "narrator-plan",
+  "narrator-update",
+  "gate-provisioning-error",
+  "gate-removed",
+  "dialog",
+];
+/** The faces that must not MOVE relative to one another (same top + height). */
+const WAIT_FACES = new Set(["runtime", "attach", "restoring", "narrator-idle"]);
+
+const args = process.argv.slice(2);
+const outFlag = args.indexOf("--out");
+const dark = args.includes("--dark");
+const viewportFlag = args.indexOf("--viewport");
+const [viewportWidth, viewportHeight] =
+  viewportFlag === -1
+    ? [1200, 900]
+    : args[viewportFlag + 1].split("x").map((n) => Number(n));
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const fixtureUrlPath = "/src/__tests__/browser/host-boot-family-gallery.html";
+const chromePath = await findChrome();
+const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-gallery-"));
+const outDir =
+  outFlag === -1
+    ? await mkdtemp(path.join(tmpdir(), "traycer-boot-gallery-"))
+    : path.resolve(args[outFlag + 1]);
+await mkdir(outDir, { recursive: true });
+const vitePort = await freePort();
+let devtoolsPort = await freePort();
+while (devtoolsPort === vitePort) devtoolsPort = await freePort();
+let chrome;
+let client;
+let viteProcess;
+
+try {
+  const requireFromHere = createRequire(import.meta.url);
+  const viteManifestPath = requireFromHere.resolve("vite/package.json");
+  const viteManifest = requireFromHere(viteManifestPath);
+  const viteEntry = path.resolve(
+    path.dirname(viteManifestPath),
+    viteManifest.bin.vite,
+  );
+  viteProcess = spawn(
+    "node",
+    [
+      viteEntry,
+      "--config",
+      path.join(projectRoot, "vitest.config.ts"),
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(vitePort),
+      "--strictPort",
+    ],
+    { cwd: projectRoot, stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let viteError = "";
+  viteProcess.stderr.setEncoding("utf8");
+  viteProcess.stderr.on("data", (chunk) => {
+    viteError += chunk;
+  });
+  const baseUrl = `http://127.0.0.1:${vitePort}${fixtureUrlPath}`;
+  await waitForHttp(baseUrl, viteProcess, () => viteError, "Vite");
+
+  chrome = spawn(
+    chromePath,
+    [
+      "--headless=new",
+      "--disable-background-networking",
+      "--disable-component-update",
+      "--disable-default-apps",
+      "--disable-extensions",
+      "--disable-features=Translate",
+      "--disable-sync",
+      "--no-default-browser-check",
+      "--no-first-run",
+      "--no-sandbox",
+      `--remote-debugging-port=${devtoolsPort}`,
+      `--user-data-dir=${profilePath}`,
+      "about:blank",
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let chromeError = "";
+  chrome.stderr.setEncoding("utf8");
+  chrome.stderr.on("data", (chunk) => {
+    chromeError += chunk;
+  });
+  await waitForHttp(
+    `http://127.0.0.1:${devtoolsPort}/json/version`,
+    chrome,
+    () => chromeError,
+    "Chrome DevTools",
+  );
+  const targetResponse = await fetch(
+    `http://127.0.0.1:${devtoolsPort}/json/new?about:blank`,
+    { method: "PUT" },
+  );
+  if (!targetResponse.ok) {
+    throw new Error(`Chrome could not open a page: ${targetResponse.status}`);
+  }
+  const target = await targetResponse.json();
+  client = await connectCdp(target.webSocketDebuggerUrl);
+  await client.send("Runtime.enable");
+  await client.send("Page.enable");
+  await client.send("Emulation.setDeviceMetricsOverride", {
+    width: viewportWidth,
+    height: viewportHeight,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+
+  const rows = [];
+  for (const theme of dark ? ["light", "dark"] : ["light"]) {
+    for (const face of FACES) {
+      const url = `${baseUrl}?face=${face}${theme === "dark" ? "&theme=dark" : ""}`;
+      await client.send("Page.navigate", { url });
+      await waitFor(
+        client,
+        `face ${face} to be painted`,
+        `Boolean(document.querySelector('[data-gallery-face="${face}"]')) &&
+         Boolean(document.querySelector('[data-testid="window-host-modal"], [data-surface="host-boot-card"]'))`,
+      );
+      // Radix animates the dialog in; the startup card fades in. A rect read
+      // mid-transform is a position the user never sees.
+      await evaluate(client, `new Promise((r) => setTimeout(r, 700))`);
+      const measured = await evaluate(
+        client,
+        `(() => {
+          const card =
+            document.querySelector('[data-testid="window-host-modal"]') ??
+            document.querySelector('[data-surface="host-boot-card"]');
+          const band = document.querySelector('[data-gallery-header-band]');
+          const r = card.getBoundingClientRect();
+          const round = (n) => Number(n.toFixed(1));
+          return {
+            sharedCard: card.getAttribute('data-surface') === 'host-boot-card',
+            left: round(r.left),
+            top: round(r.top),
+            width: round(r.width),
+            height: round(r.height),
+            centerY: round(r.top + r.height / 2),
+            bandHeight: band === null ? null : round(band.getBoundingClientRect().height),
+            // By LABEL, not by testid: the escape hatch is a user-facing
+            // promise ("Open settings" is on every card), and each surface
+            // carries it under its own testid.
+            openSettings: Array.from(document.querySelectorAll('button')).filter(
+              (b) => b.textContent.trim() === 'Open settings',
+            ).length,
+            showDetails: document.querySelectorAll('[data-testid="local-host-loading-toggle-details"]').length,
+            text: card.innerText.replace(/\\s+/g, ' ').trim().slice(0, 90),
+          };
+        })()`,
+      );
+      const shot = await client.send("Page.captureScreenshot", {
+        format: "png",
+      });
+      const file = path.join(
+        outDir,
+        `${face}${theme === "dark" ? ".dark" : ""}.png`,
+      );
+      await writeFile(file, Buffer.from(shot.data, "base64"));
+      rows.push({ face, theme, ...measured, file });
+    }
+  }
+
+  // The report. Printed as a table, then judged.
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log(
+    `\nviewport ${viewportWidth}x${viewportHeight}, out ${outDir}\n` +
+      [
+        pad("face", 26),
+        pad("theme", 6),
+        pad("shared", 7),
+        pad("left", 7),
+        pad("top", 7),
+        pad("width", 7),
+        pad("height", 7),
+        pad("cY", 7),
+        pad("settings", 9),
+        pad("details", 8),
+        "text",
+      ].join(" "),
+  );
+  for (const row of rows) {
+    console.log(
+      [
+        pad(row.face, 26),
+        pad(row.theme, 6),
+        pad(row.sharedCard ? "yes" : "NO", 7),
+        pad(row.left, 7),
+        pad(row.top, 7),
+        pad(row.width, 7),
+        pad(row.height, 7),
+        pad(row.centerY, 7),
+        pad(row.openSettings, 9),
+        pad(row.showDetails, 8),
+        row.text,
+      ].join(" "),
+    );
+  }
+
+  const family = rows.filter((row) => row.face !== "dialog");
+  const control = rows.filter((row) => row.face === "dialog");
+  const widths = new Set(family.map((row) => row.width));
+  const lefts = new Set(family.map((row) => row.left));
+  const controlSeesWidth = control.every((row) => !widths.has(row.width));
+  const waits = family.filter((row) => WAIT_FACES.has(row.face));
+  const waitBoxes = new Set(
+    waits.map((row) => `${row.theme}:${row.top}:${row.height}`),
+  );
+  const waitBoxesPerTheme = dark ? 2 : 1;
+  const everyFamilyShared = family.every((row) => row.sharedCard);
+  const everyFamilyHasSettings = family.every((row) => row.openSettings >= 1);
+  const findings = [];
+  if (!controlSeesWidth) {
+    findings.push(
+      "CONTROL FAILED: the dialog measures the same width as the family - the instrument cannot see width; ignore this table.",
+    );
+  }
+  if (widths.size !== 1) {
+    findings.push(`family widths differ: ${[...widths].join(", ")}`);
+  }
+  if (lefts.size !== 1) {
+    findings.push(`family left edges differ: ${[...lefts].join(", ")}`);
+  }
+  if (waitBoxes.size !== waitBoxesPerTheme) {
+    findings.push(
+      `wait faces do not share one box (top:height): ${[...waitBoxes].join(", ")}`,
+    );
+  }
+  if (!everyFamilyShared) {
+    findings.push(
+      `not drawn through HostBootCard: ${family
+        .filter((row) => !row.sharedCard)
+        .map((row) => row.face)
+        .join(", ")}`,
+    );
+  }
+  if (!everyFamilyHasSettings) {
+    findings.push(
+      `Open settings missing on: ${family
+        .filter((row) => row.openSettings === 0)
+        .map((row) => row.face)
+        .join(", ")}`,
+    );
+  }
+  console.log("");
+  if (findings.length === 0) {
+    console.log(
+      `OK: ${family.length} family faces share one card (width ${[...widths][0]}, left ${[...lefts][0]}); ${waits.length} wait faces share one box; control differs (${control.map((r) => r.width).join("/")}).`,
+    );
+  } else {
+    for (const finding of findings) console.log(`FINDING: ${finding}`);
+    process.exitCode = 1;
+  }
+} finally {
+  client?.close();
+  chrome?.kill("SIGKILL");
+  viteProcess?.kill("SIGKILL");
+  await delay(300);
+  try {
+    await rm(profilePath, { recursive: true, force: true });
+  } catch {
+    // A leftover temp profile is not a measurement result.
+  }
+}
+
+async function findChrome() {
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("No Chrome/Chromium binary found");
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port =
+        typeof address === "object" && address !== null ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url, child, readError, label) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`${label} exited early: ${readError()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // not up yet
+    }
+    await delay(150);
+  }
+  throw new Error(`${label} did not become reachable: ${readError()}`);
+}
+
+function connectCdp(url) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    const pending = new Map();
+    let nextId = 0;
+    const connectTimer = setTimeout(
+      () => reject(new Error("CDP connect timed out")),
+      15_000,
+    );
+    socket.addEventListener("error", (event) =>
+      reject(new Error(String(event))),
+    );
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (typeof message.id !== "number") return;
+      const request = pending.get(message.id);
+      if (request === undefined) return;
+      pending.delete(message.id);
+      if (message.error === undefined) request.resolve(message.result);
+      else request.reject(new Error(message.error.message));
+    });
+    socket.addEventListener("open", () => {
+      clearTimeout(connectTimer);
+      resolve({
+        send(method, params = {}) {
+          return new Promise((requestResolve, requestReject) => {
+            const id = ++nextId;
+            pending.set(id, { resolve: requestResolve, reject: requestReject });
+            socket.send(JSON.stringify({ id, method, params }));
+          });
+        },
+        close() {
+          socket.close();
+        },
+      });
+    });
+  });
+}
+
+async function evaluate(client, expression) {
+  const response = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (response.exceptionDetails !== undefined) {
+    throw new Error(
+      response.exceptionDetails.exception?.description ??
+        response.exceptionDetails.text ??
+        "Browser evaluation failed",
+    );
+  }
+  return response.result.value;
+}
+
+async function waitFor(client, label, expression) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (await evaluate(client, expression)) return;
+    await delay(50);
+  }
+  const pageState = await evaluate(
+    client,
+    `({ text: document.body.innerText, html: document.body.innerHTML.slice(0, 3000) })`,
+  );
+  throw new Error(
+    `Timed out waiting for ${label}:\n${JSON.stringify(pageState, null, 2)}`,
+  );
+}

--- a/clients/gui-app/scripts/window-host-modal-alignment-browser.mjs
+++ b/clients/gui-app/scripts/window-host-modal-alignment-browser.mjs
@@ -196,7 +196,6 @@ try {
       description: edge(byTestId('window-host-modal-description')),
       spinner: edge(byTestId('local-host-loading-spinner')),
       heading: edge(heading),
-      progressDetail: edge(byTestId('local-host-loading-progress-detail')),
       progressBar: edge(byTestId('local-host-download-progress')),
       toggle: edge(byTestId('local-host-loading-toggle-details')),
       // The LABEL, not the button box. The disclosure's column stretches its
@@ -233,7 +232,6 @@ try {
         type('dialogTitle', byTestId('window-host-modal-title')),
         type('dialogDescription', byTestId('window-host-modal-description')),
         type('stage', heading),
-        type('laneDetail', byTestId('local-host-loading-progress-detail')),
         type('toggleLabel', (() => {
           const el = byTestId('local-host-loading-toggle-details');
           return el === null ? null : el.querySelector('span');
@@ -314,7 +312,7 @@ try {
   // screen with a real box, so an "edges agree" verdict cannot be two nulls.
   //
   // NAMED FOR ITS ARM, deliberately. This member set is the cold-start body's -
-  // spinner, stage, lane detail, progress bar - so this check REQUIRES that arm
+  // spinner, stage, progress bar - so this check REQUIRES that arm
   // and would fail rather than measure if pointed at the ∅ body, which renders
   // the attempt panel and the disclosure and nothing else. That makes the whole
   // script a cold-start instrument, and the name has to say so: an arm-agnostic
@@ -325,7 +323,6 @@ try {
     description: closed.description,
     spinner: closed.spinner,
     heading: closed.heading,
-    progressDetail: closed.progressDetail,
     progressBar: closed.progressBar,
     toggleLabel: closed.toggleLabel,
   };

--- a/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.html
+++ b/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Host boot family - gallery</title>
+    <style>
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./host-boot-family-gallery.tsx"></script>
+  </body>
+</html>

--- a/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.tsx
+++ b/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.tsx
@@ -30,10 +30,7 @@ import {
 } from "@/components/local-host-loading";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import {
-  buildHostProgressView,
-  HOST_PROGRESS_IDLE_HEADING,
-} from "@/lib/host/host-progress-copy";
+import { buildHostProgressView } from "@/lib/host/host-progress-copy";
 import { cn } from "@/lib/utils";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import "@/index.css";
@@ -361,7 +358,6 @@ function Face(): ReactElement {
           <div className="flex flex-1 items-center justify-center p-6">
             <HostBootSurface
               testId="host-gate-attach-pending"
-              message={HOST_PROGRESS_IDLE_HEADING}
               onConfigureShell={noop}
               onOpenSettings={noop}
             />

--- a/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.tsx
+++ b/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.tsx
@@ -1,0 +1,430 @@
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MockRunnerHost,
+  MockTraycerCli,
+} from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { HostRuntimeBootFallback } from "@/components/host/host-runtime-boot-fallback";
+import {
+  BootOpenSettingsButton,
+  HostBootSurface,
+} from "@/components/host/host-boot-surface";
+import { LocalBootstrapAttempts } from "@/components/host/local-bootstrap-attempts";
+import { APP_HEADER_HEIGHT_CLASS } from "@/components/layout/header/app-header-height";
+import {
+  WindowHostModal,
+  WindowHostStartupCard,
+  type WindowHostModalProps,
+} from "@/components/layout/dialogs/window-host-modal";
+import { SurfaceReadinessFallback } from "@/components/layout/host-readiness-controller";
+import {
+  HostReadinessControllerContext,
+  type DefaultHostReadinessPresentation,
+  type GateDrawnReadiness,
+} from "@/components/layout/host-readiness-controller-context";
+import {
+  BootstrapLogDisclosure,
+  LocalHostBodyShell,
+  LocalHostLoadingContent,
+} from "@/components/local-host-loading";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  buildHostProgressView,
+  HOST_PROGRESS_IDLE_HEADING,
+} from "@/lib/host/host-progress-copy";
+import { cn } from "@/lib/utils";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import "@/index.css";
+
+/**
+ * THE BOOT-FAMILY GALLERY: every face a launch can show, one per page load,
+ * selected by `?face=<name>` (and `?theme=dark` for the dark variant).
+ *
+ * WHY IT EXISTS. This family has been "unified" three times, and each time the
+ * report was visual - "it looks very weird, non aligned", "a modal with only
+ * the Open settings button". jsdom cannot see any of that: it has no layout
+ * engine, so a card that is 64px wider than its neighbour, or 20px lower, or
+ * empty but for one link, is invisible to every unit test in the tree. The
+ * only instrument that sees the defect is a rendered screenshot, and this
+ * fixture is what `scripts/host-boot-family-gallery-browser.mjs` renders to
+ * take them - and to read the card's box on each face, so "one geometry" is a
+ * measured claim rather than a described one.
+ *
+ * NOT wired into CI. It is a manual instrument for the person changing this
+ * family: run the driver, look at the images, read the table. Wiring an
+ * unrun screenshot lane into CI is a new gate with a false-pass default and
+ * nobody watching it.
+ *
+ * WHAT IS REAL AND WHAT IS A STAND-IN, stated because a gallery that measures
+ * its own scaffolding proves nothing:
+ *  - Every CARD is the production component with production props:
+ *    `HostRuntimeBootFallback`, `HostBootSurface`, `WindowHostStartupCard`,
+ *    `SurfaceReadinessFallback`, `WindowHostModal`, and the bodies
+ *    `buildBootBody` composes for the narrator (`LocalHostLoadingContent`,
+ *    `LocalBootstrapAttempts` + `BootstrapLogDisclosure`).
+ *  - The header BAND is a stand-in (`FrameHeaderBand`). The real `AppHeader`
+ *    needs the app's provider stack; the band only has to occupy the header's
+ *    exact height (`APP_HEADER_HEIGHT_CLASS`) so the box under it is the box
+ *    the real frame has. The gate frame's column and `p-6` slot are copied
+ *    from `DefaultHostReadyGate` / `AttachPendingCard` for the same reason.
+ *
+ * The `dialog` face is the gallery's own CONTROL: it is the one member drawn
+ * at a different width on purpose (a dialog over a live app), so a report in
+ * which every face measures the same width - dialog included - is a report
+ * from an instrument that cannot see width.
+ */
+const FACES = [
+  "runtime",
+  "attach",
+  "restoring",
+  "narrator-idle",
+  "narrator-lane",
+  "narrator-slow",
+  "narrator-failed",
+  "narrator-no-host",
+  "narrator-plan",
+  "narrator-update",
+  "gate-provisioning-error",
+  "gate-removed",
+  "dialog",
+] as const;
+export type GalleryFace = (typeof FACES)[number];
+
+const params = new URLSearchParams(location.search);
+const requestedFace = params.get("face");
+const face: GalleryFace = FACES.includes(requestedFace as GalleryFace)
+  ? (requestedFace as GalleryFace)
+  : "narrator-idle";
+if (params.get("theme") === "dark") {
+  document.documentElement.classList.add("dark");
+}
+// The narrator's failed faces and the gate's provisioning-error card offer
+// `Report issue`, which gates on this store. Production sets it from the
+// desktop shell; here it is set so the row renders the way a user sees it.
+useDesktopDialogStore.getState().setReportIssueAvailable(true);
+
+const BOOTSTRAP_TAIL = [
+  "[host] resolving release channel stable",
+  "[host] downloading traycer-host 1.2.3",
+  "[host] verifying signature",
+].join("\n");
+
+function buildRunnerHost(): MockRunnerHost {
+  const traycerCli = new MockTraycerCli();
+  traycerCli.hostStatusSnapshot = {
+    running: false,
+    pidMetadata: null,
+    bootstrapMarkers: [
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        phase: "starting",
+        fields: { shell: "/bin/zsh", args: "-i -l -c traycer" },
+      },
+      {
+        timestamp: "2026-01-01T00:00:03.000Z",
+        phase: "crashed",
+        fields: { code: "1" },
+      },
+    ],
+    bootstrapLogPath: "/Users/me/.traycer/bootstrap.log",
+    bootstrapLogTail: BOOTSTRAP_TAIL,
+  };
+  return new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli,
+  });
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const noop = (): void => undefined;
+
+const LANE_PROGRESS = buildHostProgressView({
+  kind: "ensure",
+  startedAt: "2026-01-01T00:00:00.000Z",
+  progress: {
+    stage: "download",
+    percent: 42,
+    bytes: 104_857_600,
+    totalBytes: 250_609_664,
+    workUnits: null,
+    message: "downloading host 1.2.3",
+  },
+});
+
+const PRESENTATION: DefaultHostReadinessPresentation = {
+  targetKind: "local",
+  localBootIntent: true,
+  localHostState: "unavailable",
+  stage: "loading",
+  progress: null,
+  lastProgress: null,
+  provisioningError: null,
+  provisioning: false,
+  removed: false,
+  hostBusy: false,
+  canManageHost: true,
+  retryProvisioning: noop,
+  forceProvisioning: noop,
+  reinstall: noop,
+  configureShell: noop,
+  refreshDirectory: noop,
+  openSettings: noop,
+  compatibility: {
+    status: "compatible",
+    degraded: false,
+    unreachable: false,
+    hostStatus: null,
+  },
+};
+
+/** The stand-in for `AppHeader variant="host-loading"`: its height and nothing else. */
+function FrameHeaderBand(): React.ReactElement {
+  return (
+    <div
+      data-gallery-header-band
+      className={cn(
+        "relative z-20 flex shrink-0 items-center border-b border-border/90 bg-canvas px-3 text-ui-xs text-muted-foreground",
+        APP_HEADER_HEIGHT_CLASS,
+      )}
+    >
+      Traycer
+    </div>
+  );
+}
+
+/** The gate frame (`DefaultHostReadyGate`): header band over a `min-h-svh` column. */
+function GateFrame(props: {
+  readonly children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex min-h-svh w-full flex-col bg-background text-foreground">
+      <FrameHeaderBand />
+      {props.children}
+    </div>
+  );
+}
+
+/** The failed-attempt body, exactly as `buildBootBody`'s settled arm composes it. */
+function settledBody(): React.ReactNode {
+  return (
+    <LocalHostBodyShell>
+      <LocalBootstrapAttempts />
+      <BootstrapLogDisclosure onConfigureShell={noop} trailing={null} />
+    </LocalHostBodyShell>
+  );
+}
+
+/** The healthy body, exactly as `buildBootBody`'s loading arm composes it. */
+function loadingBody(
+  progress: WindowHostModalProps["progress"],
+  settingsOnly: boolean,
+): React.ReactNode {
+  return (
+    <LocalHostLoadingContent
+      progress={progress}
+      onConfigureShell={noop}
+      footerTrailing={
+        settingsOnly ? <BootOpenSettingsButton onOpenSettings={noop} /> : null
+      }
+    />
+  );
+}
+
+const HEALTHY: WindowHostModalProps = {
+  cause: "cold-start",
+  variant: { kind: "offline" },
+  progress: null,
+  bootBody: loadingBody(null, true),
+  onRetry: null,
+  retryPending: false,
+  onUpdateHost: null,
+  onOpenSettings: noop,
+  showReportIssue: false,
+  settingsEmphasis: "link",
+  settingsOnly: true,
+};
+
+function narratorProps(which: GalleryFace): WindowHostModalProps {
+  switch (which) {
+    case "narrator-lane":
+      return {
+        ...HEALTHY,
+        progress: LANE_PROGRESS,
+        bootBody: loadingBody(LANE_PROGRESS, true),
+      };
+    case "narrator-slow":
+      return {
+        ...HEALTHY,
+        progress: LANE_PROGRESS,
+        bootBody: loadingBody(LANE_PROGRESS, false),
+        onRetry: noop,
+        settingsEmphasis: "button",
+        settingsOnly: false,
+      };
+    case "narrator-failed":
+      return {
+        ...HEALTHY,
+        bootBody: settledBody(),
+        onRetry: noop,
+        showReportIssue: true,
+        settingsEmphasis: "button",
+        settingsOnly: false,
+      };
+    case "narrator-no-host":
+    case "dialog":
+      return {
+        ...HEALTHY,
+        cause: "no-usable-host",
+        bootBody: settledBody(),
+        onRetry: noop,
+        showReportIssue: true,
+        settingsEmphasis: "button",
+        settingsOnly: false,
+      };
+    case "narrator-plan":
+      return {
+        ...HEALTHY,
+        cause: "no-usable-host",
+        variant: { kind: "plan-restricted" },
+        bootBody: null,
+        showReportIssue: true,
+        settingsEmphasis: "button",
+        settingsOnly: false,
+      };
+    case "narrator-update":
+      return {
+        ...HEALTHY,
+        cause: "no-usable-host",
+        variant: {
+          kind: "update-host",
+          hostId: "local-host",
+          isTargetHost: true,
+          detail: {
+            code: "HOST_PROTOCOL_TOO_OLD",
+            hostVersion: "1.1.4",
+            minSupportedVersion: "1.2.0",
+          },
+        },
+        bootBody: null,
+        onUpdateHost: noop,
+        showReportIssue: true,
+        settingsEmphasis: "button",
+        settingsOnly: false,
+      };
+    default:
+      return HEALTHY;
+  }
+}
+
+function gateReadiness(which: GalleryFace): GateDrawnReadiness {
+  if (which === "gate-removed") return { kind: "removed-host" };
+  if (which === "restoring") return { kind: "restoring-request-context" };
+  return { kind: "provisioning-error" };
+}
+
+function gatePresentation(
+  which: GalleryFace,
+): DefaultHostReadinessPresentation {
+  if (which === "gate-provisioning-error") {
+    return {
+      ...PRESENTATION,
+      provisioningError: new Error(
+        "traycer host ensure exited with code 1 (see bootstrap.log)",
+      ),
+    };
+  }
+  if (which === "gate-removed") return { ...PRESENTATION, removed: true };
+  return PRESENTATION;
+}
+
+function Face(): React.ReactElement {
+  switch (face) {
+    case "runtime":
+      return (
+        <HostRuntimeBootFallback
+          onConfigureShell={noop}
+          onOpenSettings={noop}
+        />
+      );
+    case "attach":
+      return (
+        <GateFrame>
+          {/* `AttachPendingCard`'s slot, verbatim. */}
+          <div className="flex flex-1 items-center justify-center p-6">
+            <HostBootSurface
+              testId="host-gate-attach-pending"
+              message={HOST_PROGRESS_IDLE_HEADING}
+              onConfigureShell={noop}
+              onOpenSettings={noop}
+            />
+          </div>
+        </GateFrame>
+      );
+    case "restoring":
+    case "gate-provisioning-error":
+    case "gate-removed":
+      return (
+        <HostReadinessControllerContext.Provider
+          value={{
+            readinessFor: () => gateReadiness(face),
+            defaultHostPresentation: gatePresentation(face),
+            hasBeenDefaultHostReady: false,
+          }}
+        >
+          <GateFrame>
+            <SurfaceReadinessFallback readiness={gateReadiness(face)} />
+          </GateFrame>
+        </HostReadinessControllerContext.Provider>
+      );
+    case "dialog":
+      return (
+        <>
+          <div className="flex min-h-svh w-full flex-col bg-background text-foreground">
+            <FrameHeaderBand />
+            <div className="flex-1 p-6 text-ui-sm text-muted-foreground">
+              (a mounted app sits behind the dialog)
+            </div>
+          </div>
+          <WindowHostModal {...narratorProps(face)} />
+        </>
+      );
+    default:
+      // The narrator's startup card floats in a fixed layer over the gate
+      // frame, whose own attach cover has yielded (`attached === true`).
+      return (
+        <>
+          <GateFrame>
+            <div className="flex flex-1 items-center justify-center p-6" />
+          </GateFrame>
+          <WindowHostStartupCard {...narratorProps(face)} />
+        </>
+      );
+  }
+}
+
+export function HostBootFamilyGalleryFixture(): React.ReactElement {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={buildRunnerHost()}>
+        <TooltipProvider>
+          <div data-gallery-face={face}>
+            <Face />
+          </div>
+        </TooltipProvider>
+      </RunnerHostProvider>
+    </QueryClientProvider>
+  );
+}
+
+const container = document.querySelector("#root");
+if (container === null) throw new Error("gallery root missing");
+createRoot(container).render(<HostBootFamilyGalleryFixture />);

--- a/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.tsx
+++ b/clients/gui-app/src/__tests__/browser/host-boot-family-gallery.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement, ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -187,7 +188,7 @@ const PRESENTATION: DefaultHostReadinessPresentation = {
 };
 
 /** The stand-in for `AppHeader variant="host-loading"`: its height and nothing else. */
-function FrameHeaderBand(): React.ReactElement {
+function FrameHeaderBand(): ReactElement {
   return (
     <div
       data-gallery-header-band
@@ -202,9 +203,7 @@ function FrameHeaderBand(): React.ReactElement {
 }
 
 /** The gate frame (`DefaultHostReadyGate`): header band over a `min-h-svh` column. */
-function GateFrame(props: {
-  readonly children: React.ReactNode;
-}): React.ReactElement {
+function GateFrame(props: { readonly children: ReactNode }): ReactElement {
   return (
     <div className="flex min-h-svh w-full flex-col bg-background text-foreground">
       <FrameHeaderBand />
@@ -214,7 +213,7 @@ function GateFrame(props: {
 }
 
 /** The failed-attempt body, exactly as `buildBootBody`'s settled arm composes it. */
-function settledBody(): React.ReactNode {
+function settledBody(): ReactNode {
   return (
     <LocalHostBodyShell>
       <LocalBootstrapAttempts />
@@ -227,7 +226,7 @@ function settledBody(): React.ReactNode {
 function loadingBody(
   progress: WindowHostModalProps["progress"],
   settingsOnly: boolean,
-): React.ReactNode {
+): ReactNode {
   return (
     <LocalHostLoadingContent
       progress={progress}
@@ -346,7 +345,7 @@ function gatePresentation(
   return PRESENTATION;
 }
 
-function Face(): React.ReactElement {
+function Face(): ReactElement {
   switch (face) {
     case "runtime":
       return (
@@ -411,7 +410,7 @@ function Face(): React.ReactElement {
   }
 }
 
-export function HostBootFamilyGalleryFixture(): React.ReactElement {
+export function HostBootFamilyGalleryFixture(): ReactElement {
   return (
     <QueryClientProvider client={queryClient}>
       <RunnerHostProvider runnerHost={buildRunnerHost()}>

--- a/clients/gui-app/src/__tests__/browser/window-host-modal-alignment.tsx
+++ b/clients/gui-app/src/__tests__/browser/window-host-modal-alignment.tsx
@@ -180,7 +180,7 @@ export function WindowHostModalAlignmentFixture(): React.ReactElement {
             // The REAL body, composed exactly as `buildLocalBootstrapBody`
             // composes it for this arm. A hand-rolled stand-in would be a
             // measurement of the fixture.
-            localBootstrapBody={
+            bootBody={
               <LocalHostLoadingContent
                 progress={progress}
                 onConfigureShell={() => undefined}

--- a/clients/gui-app/src/__tests__/browser/window-host-modal-alignment.tsx
+++ b/clients/gui-app/src/__tests__/browser/window-host-modal-alignment.tsx
@@ -143,8 +143,10 @@ const queryClient = new QueryClient({
 
 export function WindowHostModalAlignmentFixture(): React.ReactElement {
   // Built through the real shared copy table rather than hand-assembled, so the
-  // body renders the same detail line and progress bar a live download does -
-  // they are members of the alignment set being measured.
+  // body renders the same heading and progress bar a live download does - they
+  // are members of the alignment set being measured. (The table's detail line
+  // and byte count are supplied and deliberately NOT drawn by this body; see
+  // `HostProgress`.)
   const progress = buildHostProgressView({
     kind: "ensure",
     startedAt: "2026-01-01T00:00:00.000Z",
@@ -177,8 +179,8 @@ export function WindowHostModalAlignmentFixture(): React.ReactElement {
             cause="cold-start"
             variant={{ kind: "offline" }}
             progress={progress}
-            // The REAL body, composed exactly as `buildLocalBootstrapBody`
-            // composes it for this arm. A hand-rolled stand-in would be a
+            // The REAL body, composed exactly as `buildBootBody` composes it
+            // for this arm. A hand-rolled stand-in would be a
             // measurement of the fixture.
             bootBody={
               <LocalHostLoadingContent

--- a/clients/gui-app/src/__tests__/local-bootstrap-alignment-lint.test.ts
+++ b/clients/gui-app/src/__tests__/local-bootstrap-alignment-lint.test.ts
@@ -44,10 +44,10 @@ const SRC_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
  * The files whose alignment `LocalHostBodyShell` owns.
  *
  * Listed explicitly rather than globbed. The gate's own fallback card
- * (`host-readiness-controller.tsx`) is DELIBERATELY centred - it is the
- * `max-w-md` host-boot splash shape, which predates this work and must not
- * drift - so a glob over the host surfaces would flag a correct file and the
- * guard would be waived into uselessness on its first run.
+ * (`host-readiness-controller.tsx`) is drawn through the shared `HostBootCard`
+ * and composes this family's body by import; its own lines carry no
+ * alignment of their own to guard, so a glob over the host surfaces would only
+ * widen the list without adding a claim.
  */
 const BODY_FAMILY: readonly string[] = [
   "components/local-host-loading.tsx",

--- a/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
@@ -161,12 +161,13 @@ describe("<LocalHostLoadingContent />", () => {
     ).not.toBeNull();
   });
 
-  it("renders host download progress with percentage and byte count", () => {
+  it("renders host download progress as the heading and a percentage - never the byte count, never the lane's own message", () => {
     const container = mountLoadingContent(
       buildHost(),
-      // Built through the REAL shared table, not a hand-written view:
-      // the copy and the units are what this asserts, and a
-      // hand-assembled view would supply the very thing under test.
+      // Built through the REAL shared table, not a hand-written view: the
+      // table still produces the transfer label and the detail line (Settings
+      // ▸ Host reads them), so this proves the SURFACE withholds them rather
+      // than a fixture that never supplied them.
       buildHostProgressView({
         kind: "ensure",
         startedAt: LANE_STARTED_AT,
@@ -182,11 +183,39 @@ describe("<LocalHostLoadingContent />", () => {
     );
 
     expect(container.textContent).toContain("Downloading Traycer Host…");
-    expect(container.textContent).toContain("downloading host 1.2.3");
-    expect(container.textContent).toContain("100 MB of 239 MB");
     expect(container.textContent).toContain("42%");
     const progress = screen.getByRole("progressbar");
     expect(progress.getAttribute("aria-valuenow")).toBe("42");
+    // NO BYTES on a launch card. "100 MB of 239 MB" on a card that is on
+    // screen the moment the app opens read as "Traycer began downloading
+    // something because I launched it" - reported as alarming. The figure is
+    // still in the view (positive control below); this surface does not draw
+    // it.
+    expect(container.textContent).not.toContain("MB");
+    expect(container.textContent).not.toContain("100 MB of 239 MB");
+    // NO LANE-DETAIL LINE. "downloading host 1.2.3" is the lane's log line;
+    // the heading already names the phase in the user's words, and a second
+    // line appearing under it was one of the shapes in "3-4 different modals".
+    expect(container.textContent).not.toContain("downloading host 1.2.3");
+    expect(
+      screen.queryByTestId("local-host-loading-progress-detail"),
+    ).toBeNull();
+    // Positive control: the table DID produce both, so the absences above are
+    // the surface's doing.
+    const view = buildHostProgressView({
+      kind: "ensure",
+      startedAt: LANE_STARTED_AT,
+      progress: {
+        stage: "download",
+        percent: 42,
+        bytes: 104_857_600,
+        totalBytes: 250_609_664,
+        workUnits: null,
+        message: "downloading host 1.2.3",
+      },
+    });
+    expect(view?.transferLabel).toBe("100 MB of 239 MB");
+    expect(view?.detail).toBe("downloading host 1.2.3");
   });
 
   it("says the setup event ONCE - the bar carries position, never a second phrasing of the heading", () => {
@@ -217,9 +246,8 @@ describe("<LocalHostLoadingContent />", () => {
     );
 
     expect(container.textContent).toContain("Setting up Traycer Host…");
-    // The lane's own message and its position both survive - what goes is the
-    // restatement.
-    expect(container.textContent).toContain("extracting host runtime");
+    // The position survives - what goes is the restatement (and the lane's own
+    // log line, which is not this surface's to draw; see the download test).
     expect(container.textContent).toContain("80%");
     expect(container.textContent).not.toContain("Setting up…");
     expect(container.textContent).not.toContain("Downloading…");
@@ -230,25 +258,33 @@ describe("<LocalHostLoadingContent />", () => {
     expect(container.textContent.match(/Setting up/g)?.length ?? 0).toBe(1);
   });
 
-  it("draws NO bar when no lane is running, and an indeterminate one when a lane reports no percentage", () => {
-    // THE BOUNDARY on the indeterminate contract, and the inverse of the lie it
-    // replaced. The bar means "this stage is running"; with no lane running there
-    // is nothing to claim, and a bar on the idle heading would assert activity
-    // where there is none.
+  it("draws an indeterminate bar when no lane is running, and when a lane reports no percentage", () => {
+    // THE CONTRACT: no measured position => indeterminate, and the bar is on
+    // EVERY wait face. This REVERSES an earlier pin here ("draws NO bar when no
+    // lane is running"), which read the bar as a claim that a lane runs. It is
+    // not: an indeterminate `progressbar` means "busy, position unknown", which
+    // is exactly what a start that has not reported yet is - and a bar that
+    // appeared only once a lane reported was a mid-wait height change on a
+    // centred card. Reported after a real install as "3-4 different modals …
+    // the UI feels jumpy when the modal size keeps changing", the ruling
+    // changed. The height it holds is measured in the browser gallery
+    // (`scripts/host-boot-family-gallery-browser.mjs`); jsdom cannot see it.
     //
-    // `progress: null` is exactly that state - `useHostProvisioningProgress`
+    // `progress: null` is exactly the no-lane state - `useHostProvisioningProgress`
     // returns null when no lane is running, and the body falls back to
     // HOST_PROGRESS_IDLE_HEADING.
     mountLoadingContent(buildHost(), null);
-    expect(screen.queryByRole("progressbar")).toBeNull();
-    expect(screen.queryByTestId("local-host-download-progress")).toBeNull();
+    const idleBar = screen.getByTestId("local-host-download-progress");
+    expect(idleBar.dataset.indeterminate).toBe("true");
+    expect(
+      screen.getByRole("progressbar").getAttribute("aria-valuenow"),
+    ).toBeNull();
+    expect(idleBar.textContent).not.toContain("%");
 
     cleanup();
 
-    // A RUNNING lane with no percentage: the bar appears, marked indeterminate,
-    // with no percentage figure beside it. The height it holds is what stops the
-    // card jumping at a stage transition - measured in the browser harness, since
-    // jsdom has no layout engine and cannot see it.
+    // A RUNNING lane with no percentage: the same bar, still indeterminate,
+    // with no percentage figure beside it.
     mountLoadingContent(
       buildHost(),
       buildHostProgressView({

--- a/clients/gui-app/src/components/centered-card.tsx
+++ b/clients/gui-app/src/components/centered-card.tsx
@@ -2,40 +2,79 @@ import type { ReactNode } from "react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import type { AgentSpinnerVariant } from "@/components/ui/agent-spinner-variant";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+/**
+ * Marker every card of this family carries (`data-surface`), so a test can
+ * prove a surface is drawn THROUGH this component rather than merely
+ * resembling it. The family's whole guarantee is that its members share one
+ * geometry by construction; a class-list comparison would pin the current
+ * spelling of that geometry, this pins the construction. Its own attribute
+ * rather than `data-slot`, which is the primitive's (`card`) and is what its
+ * styling keys on.
+ */
+export const HOST_BOOT_CARD_SURFACE = "host-boot-card";
 
 /**
  * THE ONE SHAPE every pre-app host surface wears.
  *
- * A launch crosses three of them in sequence - the runtime-binding fallback
- * ("Starting Traycer…"), the gate's attach cover, and the window narrator's
- * startup card - and they are necessarily different React trees: the first
- * mounts above `HostRuntimeProvider`, the second inside the gate frame, the
- * third beside it. Nothing can make them one component.
+ * A launch crosses several of them in sequence - the runtime-binding fallback
+ * ("Starting Traycer…"), the gate's attach cover, the window narrator's
+ * startup card, and on a bad day one of the gate's own terminal cards - and
+ * they are necessarily different React trees: the first mounts above
+ * `HostRuntimeProvider`, the next inside the gate frame, the narrator's beside
+ * it. Nothing can make them one component.
  *
  * What CAN be shared is their geometry, and it has to be, because the user
- * does not see three components - they see one card that changes shape twice
- * mid-launch. Reported exactly that way: "the UX design gap between them, it
- * looks very weird, non aligned". Before this, the sequence went `max-w-sm`
- * centred with a small muted spinner, then `max-w-md` left-aligned with a
- * large foreground spinner floating on its own line.
+ * does not see several components - they see one card that changes shape
+ * mid-launch. Reported exactly that way, twice: "the UX design gap between
+ * them, it looks very weird, non aligned", and later "a modal with only the
+ * Open settings button and nothing else". Before this, the sequence went
+ * `max-w-sm` centred with a small muted spinner, then `max-w-md` left-aligned
+ * with a large foreground spinner floating on its own line - and the
+ * narrator's card was `max-w-md` again while the two before it were `sm`.
  *
  * One width, one alignment, one spinner treatment: later phases then ADD
- * content (a progress bar, a details toggle, actions) into a box that does not
- * move, which reads as one surface filling in rather than three modals taking
- * turns.
+ * content (a progress bar, a details toggle, actions, a title when something
+ * has actually failed) into a box that does not move, which reads as one
+ * surface filling in rather than several modals taking turns.
+ *
+ * `pointer-events-auto` is unconditional and inert everywhere but one place:
+ * the narrator's startup layer is `pointer-events-none` so toasts and the gate
+ * frame's header stay clickable through it, and this card is what re-enables
+ * itself inside that layer. Stating it here rather than at that one call site
+ * keeps the card a self-contained thing to drop into any layer.
  */
 export function HostBootCard(props: {
   readonly children: ReactNode;
   readonly testId: string | null;
+  /**
+   * Extra `data-*` markers for the card element (a narration's variant and
+   * cause, for tests and for a screenshot's provenance). `{}` when none.
+   */
+  readonly dataset: Readonly<Record<`data-${string}`, string>>;
+  /**
+   * Caps the card at the viewport and scrolls it inside, for a card drawn in a
+   * FIXED layer that cannot grow the page. A card in the gate frame or the
+   * runtime fallback sits in a `min-h-svh` column that scrolls as a whole, so
+   * it passes `false`; the narrator's startup layer passes `true`, because a
+   * failed face with the bootstrap log open can outgrow a small window.
+   */
+  readonly viewportCapped: boolean;
 }): ReactNode {
-  const cardProps =
+  const testIdProps =
     props.testId === null ? {} : { "data-testid": props.testId };
   return (
     <Card
-      {...cardProps}
+      {...props.dataset}
+      {...testIdProps}
+      data-surface={HOST_BOOT_CARD_SURFACE}
       role="status"
       aria-live="polite"
-      className="w-full max-w-sm shadow-sm"
+      className={cn(
+        "pointer-events-auto w-full max-w-sm shadow-sm",
+        props.viewportCapped ? "max-h-[85svh] overflow-y-auto" : null,
+      )}
     >
       {/* CENTRED, and narrow. Ruled by the user against rendered screenshots,
           twice: the released card centred its content and "the centered one
@@ -47,9 +86,9 @@ export function HostBootCard(props: {
           `local-host-loading.tsx`. That decision was correct for what it was
           deciding - a DIALOG whose own left-aligned title and description sat
           above the body, where a centred body fought the heading above it. The
-          healthy boot card has no title and no description now, so there is
-          nothing left for the body to align WITH, and the winning argument for
-          left-alignment went with it. */}
+          boot card is not a dialog: when a face of it does carry a title (a
+          settled failure), the title centres with everything else, the way an
+          alert card reads. */}
       <CardContent className="flex flex-col items-center gap-4 py-6 text-center">
         {props.children}
       </CardContent>
@@ -89,36 +128,6 @@ export function HostBootHeadline(props: {
       >
         {props.message}
       </p>
-    </div>
-  );
-}
-
-export interface CenteredCardProps {
-  readonly message: string;
-  readonly spinnerVariant: AgentSpinnerVariant | null;
-  readonly testId: string | null;
-}
-
-/**
- * Full-viewport centered boot card, for the surfaces that own the whole window
- * (the host-runtime fallback, which renders before any app chrome exists).
- *
- * The viewport wrapper is the ONLY thing this adds over {@link HostBootCard} -
- * surfaces that sit inside the gate frame supply their own centering, because
- * that frame already carries the header and a second `min-h-svh` inside it
- * would push the card below the fold.
- */
-export function CenteredCard(props: CenteredCardProps): ReactNode {
-  return (
-    <div className="flex min-h-svh w-full items-center justify-center bg-background p-6 text-foreground">
-      <HostBootCard testId={props.testId}>
-        <HostBootHeadline
-          message={props.message}
-          spinnerVariant={props.spinnerVariant}
-          spinnerTestId="centered-card-agent-spinner"
-          messageTestId={null}
-        />
-      </HostBootCard>
     </div>
   );
 }

--- a/clients/gui-app/src/components/centered-card.tsx
+++ b/clients/gui-app/src/components/centered-card.tsx
@@ -34,9 +34,11 @@ export const HOST_BOOT_CARD_SURFACE = "host-boot-card";
  * with a large foreground spinner floating on its own line - and the
  * narrator's card was `max-w-md` again while the two before it were `sm`.
  *
- * One width, one alignment, one spinner treatment: later phases then ADD
- * content (a progress bar, a details toggle, actions, a title when something
- * has actually failed) into a box that does not move, which reads as one
+ * One width, one alignment, one spinner treatment - and one BODY for every
+ * healthy wait (`LocalHostLoadingContent`: headline, bar, footer, whether or
+ * not a lane has spoken yet), so across a healthy launch only the sentence
+ * and the bar's fill change inside a box that does not move. Only a settled
+ * failure ADDS to it (a title, diagnostics, actions), which reads as one
  * surface filling in rather than several modals taking turns.
  *
  * `pointer-events-auto` is unconditional and inert everywhere but one place:
@@ -54,11 +56,22 @@ export function HostBootCard(props: {
    */
   readonly dataset: Readonly<Record<`data-${string}`, string>>;
   /**
-   * Caps the card at the viewport and scrolls it inside, for a card drawn in a
-   * FIXED layer that cannot grow the page. A card in the gate frame or the
-   * runtime fallback sits in a `min-h-svh` column that scrolls as a whole, so
-   * it passes `false`; the narrator's startup layer passes `true`, because a
-   * failed face with the bootstrap log open can outgrow a small window.
+   * Caps the card at ITS LAYER's height and scrolls it inside, for a card
+   * drawn in a FIXED layer that cannot grow the page. A card in the gate frame
+   * or the runtime fallback sits in a `min-h-svh` column that scrolls as a
+   * whole, so it passes `false`; the narrator's startup layer passes `true`,
+   * because a failed face with the bootstrap log open can outgrow a small
+   * window.
+   *
+   * `max-h-full`, against the layer - NOT a viewport unit. The layer starts
+   * below the app header, so it is shorter than the viewport, and a cap
+   * written in `svh` can exceed the space that actually exists: at the
+   * supported 300% zoom on the 600px minimum window the CSS viewport is
+   * ~200px, the layer ~160px, and an `85svh` card of 170px centred in it
+   * overlapped the header and the window's bottom edge with its scrollable
+   * controls clipped. A percentage of the layer's own content box cannot.
+   * (Resolvable because the layer is a definite-height FLEX container - see
+   * `WindowHostStartupCard` for why the layer is flex and not grid.)
    */
   readonly viewportCapped: boolean;
 }): ReactNode {
@@ -73,7 +86,7 @@ export function HostBootCard(props: {
       aria-live="polite"
       className={cn(
         "pointer-events-auto w-full max-w-sm shadow-sm",
-        props.viewportCapped ? "max-h-[85svh] overflow-y-auto" : null,
+        props.viewportCapped ? "max-h-full overflow-y-auto" : null,
       )}
     >
       {/* CENTRED, and narrow. Ruled by the user against rendered screenshots,

--- a/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
+++ b/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MockRunnerHost,
+  MockTraycerCli,
+} from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type { TraycerHostStatusSnapshot } from "@traycer-clients/shared/platform/runner-host";
+import { LocalBootstrapAttempts } from "@/components/host/local-bootstrap-attempts";
+import { runnerQueryKeys } from "@/lib/query-keys";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+
+/**
+ * The snapshot the HEALTHY card's `Show details` disclosure read seconds before
+ * the failure: the attempt is mid-spawn, no terminal marker yet. Within the
+ * 30-second `staleTime`, so an ordinary mount would reuse it.
+ */
+const BEFORE_FAILURE: TraycerHostStatusSnapshot = {
+  running: false,
+  pidMetadata: null,
+  bootstrapMarkers: [
+    {
+      timestamp: "2026-01-01T00:00:00.000Z",
+      phase: "starting",
+      fields: { shell: "/bin/zsh", args: "-i -l -c traycer" },
+    },
+  ],
+  bootstrapLogPath: "/Users/me/.traycer/bootstrap.log",
+  bootstrapLogTail: "",
+};
+
+/** What the CLI reports NOW: the same attempt, and how it ended. */
+const AFTER_FAILURE: TraycerHostStatusSnapshot = {
+  ...BEFORE_FAILURE,
+  bootstrapMarkers: [
+    ...BEFORE_FAILURE.bootstrapMarkers,
+    {
+      timestamp: "2026-01-01T00:00:03.000Z",
+      phase: "crashed",
+      fields: { code: "1" },
+    },
+  ],
+};
+
+function mount(traycerCli: MockTraycerCli, queryClient: QueryClient) {
+  const runnerHost = new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli,
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={runnerHost}>
+        <LocalBootstrapAttempts />
+      </RunnerHostProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("<LocalBootstrapAttempts />", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reads the host status FRESH on mount and never draws the cached snapshot, even while that snapshot is within staleTime", async () => {
+    // THE RACE THIS PINS. The failure card mounts this panel the moment the
+    // install fails, and the healthy card before it read the SAME query for its
+    // `Show details` tail. That read is seconds old - "fresh" by the 30-second
+    // rule - and describes the attempt before it ended: no terminal marker, so
+    // no panel, or on a retry the PREVIOUS attempt's ending. Only
+    // `convergeReady`'s success invalidates the key, so nothing else refreshes
+    // it in time. The panel therefore refetches on mount regardless of
+    // freshness, and shows nothing until that fetch lands.
+    const traycerCli = new MockTraycerCli();
+    traycerCli.hostStatusSnapshot = AFTER_FAILURE;
+    const hostStatus = vi.spyOn(traycerCli, "hostStatus");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    // The disclosure's read, as the cache holds it: JUST written, so it is as
+    // fresh as a snapshot can be.
+    queryClient.setQueryData(
+      runnerQueryKeys.traycerHostStatus(traycerCli),
+      BEFORE_FAILURE,
+    );
+
+    mount(traycerCli, queryClient);
+
+    // Not the cached snapshot. Asserted synchronously, before any fetch could
+    // resolve: a panel drawn here would be drawn from `BEFORE_FAILURE`, which
+    // has no outcome - and would show whatever an older attempt had ended
+    // with, on a card that is reporting this one.
+    expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
+
+    // The fresh read lands and the panel describes the attempt that just
+    // failed.
+    const panel = await screen.findByTestId("local-host-bootstrap-details");
+    expect(panel.textContent).toContain("Host crashed with code 1");
+    expect(
+      screen.getByTestId("local-host-bootstrap-log-path").textContent,
+    ).toBe("/Users/me/.traycer/bootstrap.log");
+    // And it WAS a read of the CLI, not a cache hit - the positive control for
+    // the whole test. Without `refetchOnMount: "always"` a fresh cache entry
+    // is never re-read and this stays at zero.
+    expect(hostStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("draws the fetched attempt once, then holds it without polling", async () => {
+    // A single read, not a poll: the user is reading a crash report and the CLI
+    // is not re-run underneath them. `refetchInterval` is off for this reader;
+    // the recovery actions are what invalidate the key.
+    const traycerCli = new MockTraycerCli();
+    traycerCli.hostStatusSnapshot = AFTER_FAILURE;
+    const hostStatus = vi.spyOn(traycerCli, "hostStatus");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    mount(traycerCli, queryClient);
+    await screen.findByTestId("local-host-bootstrap-details");
+    // Settle any follow-up the observer might schedule; there must be none.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => {
+      expect(hostStatus).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
+++ b/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
@@ -109,6 +109,49 @@ describe("<LocalBootstrapAttempts />", () => {
     expect(hostStatus).toHaveBeenCalledTimes(1);
   });
 
+  it("draws NOTHING when the forced refetch rejects, rather than the cached snapshot it kept", async () => {
+    // THE OTHER HALF of the guard above, and the reason it is two conditions.
+    // `isFetchedAfterMount` is `dataUpdateCount > initial || errorUpdateCount >
+    // initial` (query-core's `queryObserver`), so a REJECTED refetch flips it
+    // true - and React Query deliberately keeps serving the cached data on a
+    // refetch error. Fetched-after-mount plus pre-failure data is exactly the
+    // state this component must refuse, and a guard written on
+    // `isFetchedAfterMount` alone renders it.
+    const traycerCli = new MockTraycerCli();
+    const hostStatus = vi
+      .spyOn(traycerCli, "hostStatus")
+      .mockRejectedValue(new Error("traycer host status exited with code 1"));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      runnerQueryKeys.traycerHostStatus(traycerCli),
+      BEFORE_FAILURE,
+    );
+
+    mount(traycerCli, queryClient);
+
+    // The refetch is attempted and fails...
+    await waitFor(() => {
+      expect(hostStatus).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryState(runnerQueryKeys.traycerHostStatus(traycerCli))
+          ?.status,
+      ).toBe("error");
+    });
+    // ...the cached snapshot survives in the cache (which is the premise, not
+    // an incidental)...
+    expect(
+      queryClient.getQueryData(runnerQueryKeys.traycerHostStatus(traycerCli)),
+    ).toEqual(BEFORE_FAILURE);
+    // ...and nothing is drawn from it. The card around this still carries its
+    // heading, the error, Retry and the log path.
+    expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
+    expect(screen.queryByTestId("local-host-bootstrap-log-path")).toBeNull();
+  });
+
   it("draws the fetched attempt once, then holds it without polling", async () => {
     // A single read, not a poll: the user is reading a crash report and the CLI
     // is not re-run underneath them. `refetchInterval` is off for this reader;

--- a/clients/gui-app/src/components/host/host-boot-surface.tsx
+++ b/clients/gui-app/src/components/host/host-boot-surface.tsx
@@ -1,19 +1,30 @@
 import type { ReactNode } from "react";
-import { HostBootCard, HostBootHeadline } from "@/components/centered-card";
-import { BootstrapLogDisclosure } from "@/components/local-host-loading";
+import { HostBootCard } from "@/components/centered-card";
+import { LocalHostLoadingContent } from "@/components/local-host-loading";
 
 /**
- * The WHOLE boot card - headline, details disclosure and `Open settings` -
- * for the two phases that precede the window narrator.
+ * The WHOLE boot card - headline, progress bar, details disclosure and
+ * `Open settings` - for the phases that precede the window narrator.
+ *
+ * It is the narrator's own healthy body (`LocalHostLoadingContent`) with no
+ * lane, drawn in the shared card. Not "the same headline and controls" - the
+ * SAME BODY, bar included, so the card the runtime fallback draws before the
+ * router exists is, to the pixel, the card the narrator draws once a lane is
+ * reporting: same box, same rows, and the only things that change across a
+ * healthy launch are the sentence and the bar's fill. There is deliberately
+ * no `message` prop: every wait face says the body's idle heading
+ * (`HOST_PROGRESS_IDLE_HEADING`) until a lane says something new, and a prop
+ * would be a way for one phase to say it differently.
  *
  * WHY THE CONTROLS ARE HERE AND NOT ONLY ON THE LAST CARD. A launch crosses
  * three surfaces, and only the last one used to carry `Show details` and
  * `Open settings`; the first two were bare. So the card visibly GREW controls
  * partway through a wait, which reads as a different dialog replacing the
  * first rather than one surface progressing - the "why do we have these 2
- * modals" report. Same controls in the same places at every phase means the
- * only thing that changes across a launch is the sentence and, once a lane
- * reports, a progress bar.
+ * modals" report. The bar followed the same rule one review later: it used
+ * to appear only once a lane reported, and a fresh install showed "3-4
+ * different modals … a modal shows some progress bar in the middle … the UI
+ * feels jumpy when the modal size keeps changing".
  *
  * Both controls are genuinely LIVE here, which is why they are rendered rather
  * than stubbed disabled:
@@ -30,22 +41,16 @@ import { BootstrapLogDisclosure } from "@/components/local-host-loading";
  *    hatch this family must never lose.
  */
 export function HostBootSurface(props: {
-  readonly message: string;
   readonly testId: string | null;
   readonly onConfigureShell: () => void;
   readonly onOpenSettings: () => void;
 }): ReactNode {
   return (
     <HostBootCard testId={props.testId} dataset={{}} viewportCapped={false}>
-      <HostBootHeadline
-        message={props.message}
-        spinnerVariant="sparkle"
-        spinnerTestId="host-boot-spinner"
-        messageTestId="host-boot-message"
-      />
-      <BootstrapLogDisclosure
+      <LocalHostLoadingContent
+        progress={null}
         onConfigureShell={props.onConfigureShell}
-        trailing={
+        footerTrailing={
           <BootOpenSettingsButton onOpenSettings={props.onOpenSettings} />
         }
       />

--- a/clients/gui-app/src/components/host/host-boot-surface.tsx
+++ b/clients/gui-app/src/components/host/host-boot-surface.tsx
@@ -36,7 +36,7 @@ export function HostBootSurface(props: {
   readonly onOpenSettings: () => void;
 }): ReactNode {
   return (
-    <HostBootCard testId={props.testId}>
+    <HostBootCard testId={props.testId} dataset={{}} viewportCapped={false}>
       <HostBootHeadline
         message={props.message}
         spinnerVariant="sparkle"

--- a/clients/gui-app/src/components/host/host-runtime-boot-fallback.tsx
+++ b/clients/gui-app/src/components/host/host-runtime-boot-fallback.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { HostBootSurface } from "@/components/host/host-boot-surface";
 import { APP_HEADER_HEIGHT_CLASS } from "@/components/layout/header/app-header-height";
-import { HOST_PROGRESS_IDLE_HEADING } from "@/lib/host/host-progress-copy";
 import { cn } from "@/lib/utils";
 
 /**
@@ -9,9 +8,9 @@ import { cn } from "@/lib/utils";
  * draws before the runtime binding exists, i.e. before any app chrome.
  *
  * Deliberately the same component as the two after it - same card, same
- * sentence, same controls (`HostBootSurface`). Giving each phase its own shape
- * and its own phrasing is what made one continuous wait look like a sequence
- * of unrelated modals.
+ * sentence, same bar, same controls (`HostBootSurface`). Giving each phase its
+ * own shape and its own phrasing is what made one continuous wait look like a
+ * sequence of unrelated modals.
  *
  * It owns the whole window, so it RESERVES the header's slot instead of
  * centring against the full viewport. The two surfaces after it sit under the
@@ -33,7 +32,6 @@ export function HostRuntimeBootFallback(props: {
       <div className="flex flex-1 items-center justify-center p-6">
         <HostBootSurface
           testId={null}
-          message={HOST_PROGRESS_IDLE_HEADING}
           onConfigureShell={props.onConfigureShell}
           onOpenSettings={props.onOpenSettings}
         />

--- a/clients/gui-app/src/components/host/host-runtime-boot-fallback.tsx
+++ b/clients/gui-app/src/components/host/host-runtime-boot-fallback.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { HostBootSurface } from "@/components/host/host-boot-surface";
+import { APP_HEADER_HEIGHT_CLASS } from "@/components/layout/header/app-header-height";
+import { HOST_PROGRESS_IDLE_HEADING } from "@/lib/host/host-progress-copy";
+import { cn } from "@/lib/utils";
+
+/**
+ * THE FIRST of a launch's three boot surfaces: what `HostRuntimeProvider`
+ * draws before the runtime binding exists, i.e. before any app chrome.
+ *
+ * Deliberately the same component as the two after it - same card, same
+ * sentence, same controls (`HostBootSurface`). Giving each phase its own shape
+ * and its own phrasing is what made one continuous wait look like a sequence
+ * of unrelated modals.
+ *
+ * It owns the whole window, so it RESERVES the header's slot instead of
+ * centring against the full viewport. The two surfaces after it sit under the
+ * gate frame's header, and a card that centres once against the viewport and
+ * then against the area under a 40px header moves 20px at the hand-off. Same
+ * column, same empty band on top, same `p-6` box: the header later paints INTO
+ * the band, and the card does not move.
+ */
+export function HostRuntimeBootFallback(props: {
+  readonly onConfigureShell: () => void;
+  readonly onOpenSettings: () => void;
+}): ReactNode {
+  return (
+    <div
+      className="flex min-h-svh w-full flex-col bg-background text-foreground"
+      data-testid="host-runtime-boot-fallback"
+    >
+      <div aria-hidden className={cn("shrink-0", APP_HEADER_HEIGHT_CLASS)} />
+      <div className="flex flex-1 items-center justify-center p-6">
+        <HostBootSurface
+          testId={null}
+          message={HOST_PROGRESS_IDLE_HEADING}
+          onConfigureShell={props.onConfigureShell}
+          onOpenSettings={props.onOpenSettings}
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
+++ b/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
@@ -34,7 +34,18 @@ export function LocalBootstrapAttempts(): ReactNode {
     pollIntervalMs: null,
     onMount: "always",
   });
-  if (!status.isFetchedAfterMount || status.data === undefined) return null;
+  // BOTH halves, and the second one is not redundant. `isFetchedAfterMount` is
+  // `dataUpdateCount > initial || errorUpdateCount > initial` (query-core's
+  // `queryObserver`), so a forced refetch that REJECTS flips it true - while
+  // React Query keeps serving the cached snapshot, which on a refetch error is
+  // by design. That pair is precisely the state this component exists to
+  // refuse: fetched-after-mount, and the data is still the pre-failure one.
+  // `isSuccess` is what says the fetch this mount forced actually landed.
+  //
+  // A read we could not take is narrated as nothing, not as an older attempt:
+  // the card around this still has its heading, the error, Retry and the log
+  // path, so the user is not left without the affordance that matters.
+  if (!status.isFetchedAfterMount || !status.isSuccess) return null;
   const summary = summariseBootstrapAttempts(status.data.bootstrapMarkers);
   if (summary === null) return null;
   return (

--- a/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
+++ b/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+import { BootstrapAttemptDetails } from "@/components/host/bootstrap-attempt-details";
+import { summariseBootstrapAttempts } from "@/components/host/bootstrap-attempt-summary";
+import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-traycer-host-status-query";
+
+/**
+ * What the last bootstrap attempt tried, and where the full log lives - the
+ * settled-failure diagnostics of THIS machine's host, read once and drawn.
+ *
+ * A single read, not a poll: while a user is staring at a failure card there
+ * is nothing to gain from re-running the CLI underneath them, and the recovery
+ * actions invalidate this query when they fire.
+ *
+ * Shared by the two surfaces that can be on screen for a failed local start -
+ * the window narrator's settled arm and the gate's `provisioning-error` card.
+ * It lived inside the narrator's host, and the gate's card, which WINS over
+ * the narrator on exactly that state (see `gateCardReadiness`), had no attempt
+ * panel and no log path at all - so the one launch that most needed the
+ * bootstrap.log path was the one that did not get it.
+ */
+export function LocalBootstrapAttempts(): ReactNode {
+  const status = useRunnerTraycerHostStatusQuery({ pollIntervalMs: null });
+  if (status.data === undefined) return null;
+  const summary = summariseBootstrapAttempts(status.data.bootstrapMarkers);
+  if (summary === null) return null;
+  return (
+    <BootstrapAttemptDetails
+      summary={summary}
+      bootstrapLogPath={status.data.bootstrapLogPath}
+    />
+  );
+}

--- a/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
+++ b/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
@@ -11,6 +11,17 @@ import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-trayc
  * is nothing to gain from re-running the CLI underneath them, and the recovery
  * actions invalidate this query when they fire.
  *
+ * A single FRESH read, though - never the cached snapshot. This panel mounts
+ * ON the failure, and the same query was read seconds earlier by the
+ * `Show details` disclosure of the healthy card that preceded it; that
+ * snapshot is within the 30-second `staleTime`, so an ordinary mount would
+ * reuse it and describe the attempt BEFORE the one that just failed - or no
+ * attempt at all. Only `convergeReady`'s SUCCESS invalidates the key. So the
+ * mount refetches unconditionally (`onMount: "always"`) and the panel waits
+ * for that fetch (`isFetchedAfterMount`) rather than drawing the stale one
+ * for the beat it takes - a wrong attempt panel that corrects itself is still
+ * a wrong attempt panel on a crash report.
+ *
  * Shared by the two surfaces that can be on screen for a failed local start -
  * the window narrator's settled arm and the gate's `provisioning-error` card.
  * It lived inside the narrator's host, and the gate's card, which WINS over
@@ -19,8 +30,11 @@ import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-trayc
  * bootstrap.log path was the one that did not get it.
  */
 export function LocalBootstrapAttempts(): ReactNode {
-  const status = useRunnerTraycerHostStatusQuery({ pollIntervalMs: null });
-  if (status.data === undefined) return null;
+  const status = useRunnerTraycerHostStatusQuery({
+    pollIntervalMs: null,
+    onMount: "always",
+  });
+  if (!status.isFetchedAfterMount || status.data === undefined) return null;
   const summary = summariseBootstrapAttempts(status.data.bootstrapMarkers);
   if (summary === null) return null;
   return (

--- a/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
@@ -52,6 +52,13 @@ const hostStatus = vi.hoisted(() => ({
         readonly bootstrapLogTail: string;
       }
     | undefined,
+  // A result that HAS BEEN FETCHED since the reader mounted. The attempt panel
+  // (`LocalBootstrapAttempts`) refuses the cached snapshot and waits for a fresh
+  // read, so a mock that only carried `data` would hide the panel from every
+  // test here. That fresh-read behaviour is exercised against the real hook in
+  // `local-bootstrap-attempts.test.tsx`; this seam is only about what the
+  // surfaces do with a snapshot once they have one.
+  isFetchedAfterMount: true,
 }));
 
 vi.mock("@/hooks/runner/use-runner-traycer-host-status-query", () => ({
@@ -621,13 +628,15 @@ describe("<HostReadyGate />", () => {
     expect(screen.queryByText("Starting Traycer…")).toBeNull();
   });
 
-  it("draws restoring-request-context as the shared boot surface: idle heading, spinner, Show details and Open settings", () => {
+  it("draws restoring-request-context as the shared boot surface: idle heading, spinner, indeterminate bar, Show details and Open settings", () => {
     // A WAIT, not a terminal, and it can sit between the attach cover and the
     // narrator's card on any launch. It used to be a bare "Restoring
     // authenticated session…" line with no spinner and no controls - a fourth
     // card shape in a launch that must have one. Now it is the same card, the
-    // same idle sentence and the same footer pair as the surfaces on either
-    // side of it, so the hand-off is invisible.
+    // same idle sentence, the same bar and the same footer pair as the
+    // surfaces on either side of it, so the hand-off is invisible. The
+    // testids are the boot BODY's own (`local-host-loading-*`): the surface
+    // is that body with no lane, not a look-alike.
     renderGateWithCli(
       { kind: "restoring-request-context" },
       PRESENTATION,
@@ -638,10 +647,13 @@ describe("<HostReadyGate />", () => {
       "host-ready-gate-restoring-request-context",
     );
     expect(card.getAttribute("data-surface")).toBe(HOST_BOOT_CARD_SURFACE);
-    expect(screen.getByTestId("host-boot-spinner")).toBeTruthy();
-    expect(screen.getByTestId("host-boot-message").textContent).toBe(
+    expect(screen.getByTestId("local-host-loading-spinner")).toBeTruthy();
+    expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
       "Starting Traycer…",
     );
+    expect(
+      screen.getByTestId("local-host-download-progress").dataset.indeterminate,
+    ).toBe("true");
     expect(screen.queryByText("Restoring authenticated session…")).toBeNull();
     expect(
       screen.getByTestId("local-host-loading-toggle-details"),

--- a/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
@@ -52,17 +52,24 @@ const hostStatus = vi.hoisted(() => ({
         readonly bootstrapLogTail: string;
       }
     | undefined,
-  // A result that HAS BEEN FETCHED since the reader mounted. The attempt panel
-  // (`LocalBootstrapAttempts`) refuses the cached snapshot and waits for a fresh
-  // read, so a mock that only carried `data` would hide the panel from every
-  // test here. That fresh-read behaviour is exercised against the real hook in
-  // `local-bootstrap-attempts.test.tsx`; this seam is only about what the
-  // surfaces do with a snapshot once they have one.
-  isFetchedAfterMount: true,
 }));
 
+// The reader flags are DERIVED from `data`, never set beside it. The attempt
+// panel (`LocalBootstrapAttempts`) refuses a cached snapshot and refuses the
+// one a failed refetch retained, so it reads `isFetchedAfterMount` and
+// `isSuccess` as well - and a seam that let a fixture assert `isSuccess` while
+// `data` was `undefined` would be a state the real hook cannot produce, which
+// is how a mock ends up testing itself. `success` means "there is a snapshot"
+// here exactly as it does there. The fresh-read behaviour itself is exercised
+// against the real hook in `local-bootstrap-attempts.test.tsx`; this seam is
+// only about what the surfaces do with a snapshot once they legitimately have
+// one.
 vi.mock("@/hooks/runner/use-runner-traycer-host-status-query", () => ({
-  useRunnerTraycerHostStatusQuery: () => hostStatus,
+  useRunnerTraycerHostStatusQuery: () => ({
+    data: hostStatus.data,
+    isFetchedAfterMount: hostStatus.data !== undefined,
+    isSuccess: hostStatus.data !== undefined,
+  }),
 }));
 
 vi.mock("@tanstack/react-router", () => ({

--- a/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
@@ -8,7 +8,11 @@ import {
   type RenderResult,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import {
+  MockRunnerHost,
+  MockTraycerCli,
+} from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type { ITraycerCli } from "@traycer-clients/shared/platform/runner-host";
 import type { HostLeaseSnapshot } from "@traycer-clients/shared/host-selection/selection-authority-contract";
 import type { SelectionKernelSnapshot } from "@traycer-clients/shared/host-selection/selection-evidence-kernel";
 import {
@@ -22,6 +26,7 @@ import {
 // `HostReadyGate` to `return props.children` would restore the regression with
 // every test still green.
 import { HostReadyGate } from "@/components/layout/host-ready-gate";
+import { HOST_BOOT_CARD_SURFACE } from "@/components/centered-card";
 import { WindowHostModalHost } from "@/components/layout/dialogs/window-host-modal-host";
 import { appLogger } from "@/lib/logger";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
@@ -119,6 +124,20 @@ function renderGate(
   readiness: SurfaceReadiness,
   presentation: DefaultHostReadinessPresentation,
 ): GateHarness {
+  return renderGateWithCli(readiness, presentation, undefined);
+}
+
+/**
+ * `renderGate` with the shell's CLI stated. The default harness models a shell
+ * with NO CLI, where the bootstrap-log disclosure structurally cannot render
+ * (see `BootstrapLogDisclosure`) - so a fixture that asserts `Show details`
+ * PRESENT has to pass a real one, or it is asserting against nothing.
+ */
+function renderGateWithCli(
+  readiness: SurfaceReadiness,
+  presentation: DefaultHostReadinessPresentation,
+  traycerCli: ITraycerCli | null | undefined,
+): GateHarness {
   const runnerHost = new MockRunnerHost({
     signInUrl: "https://auth.traycer.invalid/sign-in",
     authnBaseUrl: "http://localhost:5005",
@@ -126,7 +145,7 @@ function renderGate(
     hosts: [],
     workspaceFolderPickerPaths: undefined,
     hasLocalHost: undefined,
-    traycerCli: undefined,
+    traycerCli,
   });
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -546,6 +565,112 @@ describe("<HostReadyGate />", () => {
       screen.getByRole<HTMLButtonElement>("button", { name: "Open settings" })
         .disabled,
     ).toBe(false);
+  });
+
+  it("gives the provisioning-error card the failed attempt's diagnostics: the heading, the attempt panel with the bootstrap.log path, and Show details", () => {
+    // This card WINS over the window narrator on the state it describes (see
+    // `gateCardReadiness`), so the narrator's settled arm - the one place the
+    // attempt panel and the log path lived - was unreachable on exactly the
+    // launch that most needed them. A first launch whose install failed got
+    // "boom" and a Retry, and no path to take the failure anywhere.
+    hostStatus.data = {
+      bootstrapMarkers: [
+        {
+          timestamp: "t0",
+          phase: "starting",
+          fields: { shell: "/bin/zsh", args: "-i -l -c traycer" },
+        },
+        { timestamp: "t1", phase: "crashed", fields: { code: "1" } },
+      ],
+      bootstrapLogPath: "/Users/me/.traycer/bootstrap.log",
+      bootstrapLogTail: "",
+    };
+    renderGateWithCli(
+      { kind: "provisioning-error" },
+      { ...PRESENTATION, provisioningError: new Error("boom") },
+      // A real CLI: the disclosure self-hides without one, so its PRESENCE can
+      // only be proved on the positive shell.
+      new MockTraycerCli(),
+    );
+
+    // Existence first, so the assertions below cannot be satisfied by a card
+    // that failed to render at all.
+    const card = screen.getByTestId("host-ready-gate-provisioning-error");
+    expect(card).toBeTruthy();
+    // The same heading the narrator's settled cold-start face draws.
+    expect(
+      screen.getByRole("heading", { name: "Traycer Host didn't start" }),
+    ).toBeTruthy();
+    expect(screen.getByText("boom")).toBeTruthy();
+    // The attempt panel, with the log path IN THE OPEN (not behind the toggle).
+    expect(screen.getByTestId("local-host-bootstrap-details")).toBeTruthy();
+    expect(
+      screen.getByTestId("local-host-bootstrap-log-path").textContent,
+    ).toBe("/Users/me/.traycer/bootstrap.log");
+    // The disclosure, and NOT a second `Open settings` inside it: this card
+    // has a real action row that already carries the escape hatch.
+    expect(
+      screen.getByTestId("local-host-loading-toggle-details"),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("host-boot-open-settings")).toBeNull();
+    expect(
+      screen.getAllByRole("button", { name: "Open settings" }),
+    ).toHaveLength(1);
+    // Nothing is starting: no spinner, no boot headline.
+    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
+    expect(screen.queryByText("Starting Traycer…")).toBeNull();
+  });
+
+  it("draws restoring-request-context as the shared boot surface: idle heading, spinner, Show details and Open settings", () => {
+    // A WAIT, not a terminal, and it can sit between the attach cover and the
+    // narrator's card on any launch. It used to be a bare "Restoring
+    // authenticated session…" line with no spinner and no controls - a fourth
+    // card shape in a launch that must have one. Now it is the same card, the
+    // same idle sentence and the same footer pair as the surfaces on either
+    // side of it, so the hand-off is invisible.
+    renderGateWithCli(
+      { kind: "restoring-request-context" },
+      PRESENTATION,
+      new MockTraycerCli(),
+    );
+
+    const card = screen.getByTestId(
+      "host-ready-gate-restoring-request-context",
+    );
+    expect(card.getAttribute("data-surface")).toBe(HOST_BOOT_CARD_SURFACE);
+    expect(screen.getByTestId("host-boot-spinner")).toBeTruthy();
+    expect(screen.getByTestId("host-boot-message").textContent).toBe(
+      "Starting Traycer…",
+    );
+    expect(screen.queryByText("Restoring authenticated session…")).toBeNull();
+    expect(
+      screen.getByTestId("local-host-loading-toggle-details"),
+    ).toBeTruthy();
+    expect(screen.getByTestId("host-boot-open-settings")).toBeTruthy();
+    // Still the gate's block: the app is not mounted behind it.
+    expect(screen.queryByRole("main")).toBeNull();
+  });
+
+  it("draws every gate-owned terminal through the shared boot card, so a launch that ends badly does not change shape to say so", () => {
+    // The family's guarantee is one geometry by construction; this pins the
+    // construction (the card's marker) rather than a class list, which would
+    // pin the current spelling of the geometry instead of the sharing.
+    for (const [readiness, presentation] of [
+      [
+        { kind: "provisioning-error" },
+        { ...PRESENTATION, provisioningError: new Error("boom") },
+      ],
+      [{ kind: "removed-host" }, { ...PRESENTATION, removed: true }],
+      [{ kind: "mobile-no-host" }, PRESENTATION],
+    ] as const) {
+      renderGate(readiness, presentation);
+      const frame = screen.getByTestId(`host-ready-gate-${readiness.kind}`);
+      expect(
+        frame.querySelector(`[data-surface="${HOST_BOOT_CARD_SURFACE}"]`),
+        readiness.kind,
+      ).not.toBeNull();
+      cleanup();
+    }
   });
 
   it("defers the zero-dialable default-host card to the window modal too - no gate-drawn card, no tab wording", () => {

--- a/clients/gui-app/src/components/layout/__tests__/host-switch-keeps-app-mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-switch-keeps-app-mounted.test.tsx
@@ -52,7 +52,10 @@ vi.mock("@/components/layout/header/app-header", () => ({
 
 // A shell with no CLI: the query is disabled and the local-bootstrap
 // diagnostics correctly stay hidden.
-const hostStatus = vi.hoisted(() => ({ data: undefined }));
+const hostStatus = vi.hoisted(() => ({
+  data: undefined,
+  isFetchedAfterMount: true,
+}));
 
 vi.mock("@/hooks/runner/use-runner-traycer-host-status-query", () => ({
   useRunnerTraycerHostStatusQuery: () => hostStatus,

--- a/clients/gui-app/src/components/layout/__tests__/host-switch-keeps-app-mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-switch-keeps-app-mounted.test.tsx
@@ -52,13 +52,21 @@ vi.mock("@/components/layout/header/app-header", () => ({
 
 // A shell with no CLI: the query is disabled and the local-bootstrap
 // diagnostics correctly stay hidden.
-const hostStatus = vi.hoisted(() => ({
-  data: undefined,
-  isFetchedAfterMount: true,
-}));
+const hostStatus = vi.hoisted(() => ({ data: undefined }));
 
+// This suite never supplies a snapshot, so all three fields are the no-read
+// state and are written as such - `data !== undefined` would be a comparison
+// the type already decides (and ESLint says so). The reader flags exist
+// because `LocalBootstrapAttempts` refuses a cached snapshot and refuses the
+// one a failed refetch retained; see the note in
+// `default-host-ready-gate.test.tsx`. The local-bootstrap diagnostics
+// correctly stay hidden here either way.
 vi.mock("@/hooks/runner/use-runner-traycer-host-status-query", () => ({
-  useRunnerTraycerHostStatusQuery: () => hostStatus,
+  useRunnerTraycerHostStatusQuery: () => ({
+    data: hostStatus.data,
+    isFetchedAfterMount: false,
+    isSuccess: false,
+  }),
 }));
 
 const PRESENTATION: DefaultHostReadinessPresentation = {

--- a/clients/gui-app/src/components/layout/__tests__/local-boot-intent.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/local-boot-intent.test.tsx
@@ -376,8 +376,7 @@ describe("local-boot intent", () => {
     );
 
     // The surface settles on the non-local wait: the window narrator comes up
-    // with NO local bootstrap body (no spinner, no local-host-loading
-    // content) - the positive proof this reached its non-local settled state.
+    // - the positive proof this reached its non-local settled state.
     //
     // EITHER presentation counts as the anchor. This stack mounts the real
     // gate, so which form the narrator takes depends on whether the gate is
@@ -390,11 +389,21 @@ describe("local-boot intent", () => {
           screen.queryByTestId("window-host-startup-card"),
       ).toBeTruthy();
     });
-    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
-    // …and it must never claim this machine's host is starting, nor offer any
-    // action against it.
-    expect(screen.queryByText("Starting Traycer…")).toBeNull();
-    expect(screen.queryByTestId("local-host-retry")).toBeNull();
+    // WHAT THIS FENCE IS ABOUT, and what it is not. It is about ARMING: the
+    // local lifecycle's two calls below belong to a machine the user is not
+    // pointed at, and neither may run. It is NOT about the card. An earlier
+    // version of this fixture also pinned the card as bodiless for a remote
+    // target - no spinner, no "Starting Traycer…" - and that pin was the
+    // reported launch: the narrator's card rendering as nothing but the
+    // `Open settings` link for exactly this selection, while the two boot
+    // surfaces before it (which cannot know the target) drew the full card.
+    // The card is drawn now, whatever the target: the same idle heading the
+    // surfaces before it use, which names no machine.
+    // What the card must still NOT do is offer a host-management action
+    // against this machine: nothing has failed and nothing is slow, so there
+    // is no Retry of any kind on it.
+    expect(screen.queryByTestId("window-host-modal-retry")).toBeNull();
+    expect(screen.queryByTestId("local-host-provisioning-retry")).toBeNull();
     // The two calls the blocker was about: both belong to a machine the user
     // is not pointed at, and neither may run.
     expect(spy.convergeReadyCalls()).toBe(0);

--- a/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
@@ -9,6 +9,7 @@ import type { ITraycerCli } from "@traycer-clients/shared/platform/runner-host";
 import type { HostLeaseSnapshot } from "@traycer-clients/shared/host-selection/selection-authority-contract";
 import type { SelectionKernelSnapshot } from "@traycer-clients/shared/host-selection/selection-evidence-kernel";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { HOST_BOOT_CARD_SURFACE } from "@/components/centered-card";
 import { WindowHostModalHost } from "@/components/layout/dialogs/window-host-modal-host";
 import {
   HostReadinessControllerContext,
@@ -353,16 +354,87 @@ describe("<WindowHostModalHost />", () => {
     expect(screen.queryByTestId("local-host-bootstrap-log-path")).toBeNull();
   });
 
-  it("cold-start on a REMOTE target keeps the settings escape hatch: no local body to host it inline, so the action row draws it", async () => {
-    // The one arm of the family that could lose `Open settings`. Blocking cold
-    // start, target REMOTE (activated in Settings, lease still connecting),
-    // nothing failed, local host fine so the slow stage never promotes: no
-    // Retry, no Update host, and `settled.failed` false. That made
-    // `settingsOnly` true - which suppresses the action row and delegates the
-    // link to the body - while `buildLocalBootstrapBody` returns null for any
-    // non-local lifecycle. An empty card over a blocked app, with the header
-    // nav disabled: a lockout. `settingsOnly` now also asks whether the body
-    // EXISTS to host the link.
+  it("cold-start on a REMOTE target draws the SAME boot body as a local one: headline, spinner, inline Open settings, no action row", async () => {
+    // THE REPORTED LAUNCH. A fresh install on an account that has remote hosts
+    // derives a remote as effective until the local host registers (the
+    // engine's third arm: no preference, no local row, first usable remote), so
+    // for that whole window the target is REMOTE, its lease is `connecting`,
+    // nothing has failed and nothing is slow. This arm used to withhold the
+    // boot body for any non-local target and let the action row carry the
+    // settings link on its own - which rendered as a card containing nothing
+    // but "Open settings". Now the body is drawn whatever the target's kind:
+    // same headline, same footer pair, same card as the two boot surfaces
+    // before it.
+    applySnapshot({
+      attached: true,
+      effectiveHostId: REMOTE_HOST_ID,
+      targetHostId: REMOTE_HOST_ID,
+      leases: [
+        lease({ hostId: REMOTE_HOST_ID, status: "connecting", dead: null }),
+      ],
+    });
+
+    renderHostWithGate(
+      {
+        ...EMPTY_PRESENTATION,
+        targetKind: "remote",
+        localBootIntent: false,
+      },
+      false,
+      new MockTraycerCli(),
+      GATE_BLOCKING,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("window-host-startup-card")).toBeTruthy();
+    });
+    const card = screen.getByTestId("window-host-startup-card");
+    expect(card.getAttribute("data-cause")).toBe("cold-start");
+    // Drawn THROUGH the shared boot card, not merely resembling it.
+    expect(card.getAttribute("data-surface")).toBe(HOST_BOOT_CARD_SURFACE);
+
+    // The boot body: spinner + the family's idle heading (no lane is running,
+    // and no machine has been named that a lane could describe).
+    expect(screen.getByTestId("local-host-loading-spinner")).toBeTruthy();
+    expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
+      "Starting Traycer…",
+    );
+    // The footer pair, exactly as the two surfaces before this one draw it:
+    // `Show details` with `Open settings` INLINE beside it ...
+    expect(
+      screen.getByTestId("local-host-loading-toggle-details"),
+    ).toBeTruthy();
+    expect(screen.getByTestId("host-boot-open-settings").textContent).toContain(
+      "Open settings",
+    );
+    // ... and NO action row of the card's own: nothing failed, nothing to
+    // retry, so an equal-weight row would be the "something is wrong, pick
+    // one" signal on a start that is fine.
+    expect(screen.queryByTestId("window-host-modal-open-settings")).toBeNull();
+    expect(screen.queryByTestId("window-host-modal-retry")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+    // And no title/description: the headline is the one line.
+    expect(screen.queryByTestId("window-host-startup-card-title")).toBeNull();
+    expect(
+      screen.queryByTestId("window-host-startup-card-description"),
+    ).toBeNull();
+  });
+
+  it("cold-start on a REMOTE target while this machine's lane runs: the lane heading in the boot headline and the bar, never the boxed lane line", async () => {
+    // The second shape of the same launch: the desktop's reconciler is
+    // installing the local host underneath while the derived target is still
+    // the remote. The lane is real and it is this machine's, so the boot body
+    // narrates it the way every other phase would - headline + progress bar -
+    // instead of the bordered `LaneProgressLine` strip that titled faces use
+    // under their own description. That strip under NO title was the
+    // "weird-looking Setting up Traycer" card.
+    controllerStatus.data = {
+      mutation: {
+        kind: "ensure",
+        progress: null,
+        startedAt: "2026-01-01T00:00:00.000Z",
+      },
+    };
     applySnapshot({
       attached: true,
       effectiveHostId: REMOTE_HOST_ID,
@@ -386,17 +458,50 @@ describe("<WindowHostModalHost />", () => {
     await waitFor(() => {
       expect(screen.getByTestId("window-host-startup-card")).toBeTruthy();
     });
+    expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
+      "Setting up Traycer Host…",
+    );
+    expect(screen.getByTestId("local-host-download-progress")).toBeTruthy();
+    expect(screen.queryByTestId("window-host-modal-progress")).toBeNull();
+    // Still the healthy footer, still no action row.
+    expect(screen.getByTestId("host-boot-open-settings")).toBeTruthy();
+    expect(screen.queryByTestId("window-host-modal-open-settings")).toBeNull();
+  });
+
+  it("∅ on a REMOTE-only fleet keeps this machine's diagnostics OFF the card: the settled arm is the one place the target still gates", async () => {
+    // The counterweight to the two fixtures above. The healthy body lost its
+    // target gate; the SETTLED body did not, and must not - an attempt panel
+    // about a local install under "No host is available" on a fleet this
+    // machine is not part of blames the wrong computer. Title + description +
+    // actions are that arm's whole story.
+    hostStatus.data = BOOTSTRAP_MARKERS;
+    applySnapshot({
+      attached: true,
+      effectiveHostId: null,
+      targetHostId: REMOTE_HOST_ID,
+      leases: [deadLease(REMOTE_HOST_ID, { reason: "offline" })],
+    });
+
+    renderHost(
+      {
+        ...EMPTY_PRESENTATION,
+        targetKind: "remote",
+        localBootIntent: false,
+      },
+      false,
+      new MockTraycerCli(),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("window-host-modal")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
+    expect(screen.queryByTestId("local-host-bootstrap-log-path")).toBeNull();
+    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
     expect(
-      screen.getByTestId("window-host-startup-card").getAttribute("data-cause"),
-    ).toBe("cold-start");
-    // No local body on a remote target ...
-    expect(screen.queryByTestId("host-boot-open-settings")).toBeNull();
-    // ... so the action row is what carries the escape hatch.
-    const openSettings = screen.getByTestId("window-host-modal-open-settings");
-    expect(openSettings.textContent).toContain("Open settings");
-    // Still a healthy start: nothing failed, nothing to retry.
-    expect(screen.queryByTestId("window-host-modal-retry")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+      screen.queryByTestId("local-host-loading-toggle-details"),
+    ).toBeNull();
+    expect(screen.getByTestId("window-host-modal-open-settings")).toBeTruthy();
   });
 
   it("cold-start, healthy (stage: loading, no provisioningError): Retry, Report issue absent; Open settings present as a link; spinner shown; no attempt summary", async () => {
@@ -944,7 +1049,7 @@ describe("<WindowHostModalHost />", () => {
       // The defect class: both bodies were fragments, so their children became
       // direct children of the dialog's own column and each one carried its own
       // alignment or none. Asserted per arm because the two arms are built by
-      // different branches of `buildLocalBootstrapBody` - fixing one and
+      // different branches of `buildBootBody` - fixing one and
       // leaving the other is exactly how they drift.
       hostStatus.data = BOOTSTRAP_MARKERS;
       applySnapshot({

--- a/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
@@ -33,6 +33,13 @@ const hostStatus = vi.hoisted(() => ({
         readonly bootstrapLogTail: string;
       }
     | undefined,
+  // A result that HAS BEEN FETCHED since the reader mounted. The attempt panel
+  // (`LocalBootstrapAttempts`) refuses the cached snapshot and waits for a fresh
+  // read, so a mock that only carried `data` would hide the panel from every
+  // test here. That fresh-read behaviour is exercised against the real hook in
+  // `local-bootstrap-attempts.test.tsx`; this seam is only about what the
+  // surfaces do with a snapshot once they have one.
+  isFetchedAfterMount: true,
 }));
 
 vi.mock("@/hooks/runner/use-runner-traycer-host-status-query", () => ({

--- a/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
@@ -33,17 +33,24 @@ const hostStatus = vi.hoisted(() => ({
         readonly bootstrapLogTail: string;
       }
     | undefined,
-  // A result that HAS BEEN FETCHED since the reader mounted. The attempt panel
-  // (`LocalBootstrapAttempts`) refuses the cached snapshot and waits for a fresh
-  // read, so a mock that only carried `data` would hide the panel from every
-  // test here. That fresh-read behaviour is exercised against the real hook in
-  // `local-bootstrap-attempts.test.tsx`; this seam is only about what the
-  // surfaces do with a snapshot once they have one.
-  isFetchedAfterMount: true,
 }));
 
+// The reader flags are DERIVED from `data`, never set beside it. The attempt
+// panel (`LocalBootstrapAttempts`) refuses a cached snapshot and refuses the
+// one a failed refetch retained, so it reads `isFetchedAfterMount` and
+// `isSuccess` as well - and a seam that let a fixture assert `isSuccess` while
+// `data` was `undefined` would be a state the real hook cannot produce, which
+// is how a mock ends up testing itself. `success` means "there is a snapshot"
+// here exactly as it does there. The fresh-read behaviour itself is exercised
+// against the real hook in `local-bootstrap-attempts.test.tsx`; this seam is
+// only about what the surfaces do with a snapshot once they legitimately have
+// one.
 vi.mock("@/hooks/runner/use-runner-traycer-host-status-query", () => ({
-  useRunnerTraycerHostStatusQuery: () => hostStatus,
+  useRunnerTraycerHostStatusQuery: () => ({
+    data: hostStatus.data,
+    isFetchedAfterMount: hostStatus.data !== undefined,
+    isSuccess: hostStatus.data !== undefined,
+  }),
 }));
 
 /**

--- a/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal.test.tsx
@@ -209,7 +209,7 @@ describe("<WindowHostModal />", () => {
     expect(screen.queryByTestId("window-host-modal-update-host")).toBeNull();
   });
 
-  it("renders heading/percent/transfer in window-host-modal-progress when progress is set and bootBody is null", () => {
+  it("renders heading and percent - never the byte count or the lane's message - in window-host-modal-progress when progress is set and bootBody is null", () => {
     renderModal(
       baseProps({
         variant: { kind: "offline" },
@@ -217,6 +217,7 @@ describe("<WindowHostModal />", () => {
           heading: "Setting up Traycer Host…",
           percent: 42,
           transferLabel: "1.0 MB of 2.0 MB",
+          detail: "extracting host archive into /Users/me/.traycer/staging",
         }),
         bootBody: null,
       }),
@@ -224,7 +225,10 @@ describe("<WindowHostModal />", () => {
     const progressBlock = screen.getByTestId("window-host-modal-progress");
     expect(progressBlock.textContent).toContain("Setting up Traycer Host…");
     expect(progressBlock.textContent).toContain("42%");
-    expect(progressBlock.textContent).toContain("1.0 MB of 2.0 MB");
+    // The view carries both (supplied above); the launch card draws neither -
+    // same rule as the boot body's bar, see `HostProgress`.
+    expect(progressBlock.textContent).not.toContain("MB");
+    expect(progressBlock.textContent).not.toContain("extracting host archive");
   });
 
   it("the bootstrap body wins over progress when both are supplied", () => {

--- a/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal.test.tsx
@@ -31,7 +31,7 @@ function baseProps(
     cause: "no-usable-host",
     variant: { kind: "offline" },
     progress: null,
-    localBootstrapBody: null,
+    bootBody: null,
     onRetry: null,
     retryPending: false,
     onUpdateHost: null,
@@ -209,7 +209,7 @@ describe("<WindowHostModal />", () => {
     expect(screen.queryByTestId("window-host-modal-update-host")).toBeNull();
   });
 
-  it("renders heading/percent/transfer in window-host-modal-progress when progress is set and localBootstrapBody is null", () => {
+  it("renders heading/percent/transfer in window-host-modal-progress when progress is set and bootBody is null", () => {
     renderModal(
       baseProps({
         variant: { kind: "offline" },
@@ -218,7 +218,7 @@ describe("<WindowHostModal />", () => {
           percent: 42,
           transferLabel: "1.0 MB of 2.0 MB",
         }),
-        localBootstrapBody: null,
+        bootBody: null,
       }),
     );
     const progressBlock = screen.getByTestId("window-host-modal-progress");
@@ -232,7 +232,7 @@ describe("<WindowHostModal />", () => {
       baseProps({
         variant: { kind: "offline" },
         progress: buildProgress({}),
-        localBootstrapBody: <div data-testid="local-bootstrap-body">boot</div>,
+        bootBody: <div data-testid="local-bootstrap-body">boot</div>,
       }),
     );
     expect(screen.getByTestId("local-bootstrap-body")).toBeTruthy();

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
@@ -11,8 +11,7 @@ import {
   useHostReadinessController,
   type DefaultHostReadinessPresentation,
 } from "@/components/layout/host-readiness-controller-context";
-import { BootstrapAttemptDetails } from "@/components/host/bootstrap-attempt-details";
-import { summariseBootstrapAttempts } from "@/components/host/bootstrap-attempt-summary";
+import { LocalBootstrapAttempts } from "@/components/host/local-bootstrap-attempts";
 import {
   BootstrapLogDisclosure,
   LocalHostBodyShell,
@@ -20,7 +19,6 @@ import {
 } from "@/components/local-host-loading";
 import { BootOpenSettingsButton } from "@/components/host/host-boot-surface";
 import { useHostProvisioningProgress } from "@/hooks/host/use-host-provisioning-progress";
-import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-traycer-host-status-query";
 import { useWindowNarration } from "@/hooks/host/use-window-narration";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { getClientAppVersion } from "@/lib/app-version";
@@ -218,29 +216,25 @@ function NarratingWindowHostModal(props: {
   // then draws no action row of its own). Two derivations of this would let a
   // card render the settings link in both places or in neither.
   //
-  // "In neither" is exactly what happened when this did not ask whether the
-  // body EXISTS: `buildLocalBootstrapBody` returns null for anything but a
-  // local `offline` lifecycle, so a blocking cold start whose target is a
-  // REMOTE host (activated in Settings, lease still `connecting`; no Retry,
-  // no update, nothing failed) hid the action row for a body that was not
-  // there - an empty card, and the settings escape hatch this file calls a
-  // lockout if lost was the thing lost. The body can host the link only under
-  // the same two conditions it renders under, so the gate states them.
-  const bodyCanHostSettings =
-    localLifecycle && narration.variant.kind === "offline";
+  // It is true exactly on the healthy blocking start - `offline`, nothing to
+  // retry, nothing to update, nothing failed - and that is also exactly when
+  // `buildBootBody` draws the boot body, so the link always has its footer row
+  // to sit on. This gate used to ask a fourth question, "is the target this
+  // machine", because the body was withheld for any other target; the answer
+  // was a card that drew nothing but the `Open settings` link. The body no
+  // longer depends on the target (see `buildBootBody`), so neither does this.
   const settingsOnly =
-    !blocking ||
-    retry.onRetry !== null ||
-    updateHost !== null ||
-    !bodyCanHostSettings
-      ? false
-      : !settled.failed;
+    blocking &&
+    narration.variant.kind === "offline" &&
+    retry.onRetry === null &&
+    updateHost === null &&
+    !settled.failed;
   const narrationProps: WindowHostModalProps = {
     cause: narration.cause,
     variant: narration.variant,
     progress,
     settingsOnly,
-    localBootstrapBody: buildLocalBootstrapBody({
+    bootBody: buildBootBody({
       variant: narration.variant,
       presentation,
       localLifecycle,
@@ -392,27 +386,47 @@ function resolveUpdateHost(
 }
 
 /**
- * The rich local-bootstrap body, or null when this wait is not about this
- * machine.
+ * The boot body, or null when this state has none.
  *
- * Only the `offline` variant gets it: a plan gate and a version mismatch are
+ * Only the `offline` variant gets one: a plan gate and a version mismatch are
  * both about a host that is up and answering, so a bootstrap log and a
  * "Configure shell…" button would be diagnostics for a failure that did not
  * happen.
  *
- * `LocalHostLoadingContent` has ONE face now, and this is why. It used to take
- * a `stage` and grow a second one on `"slow"`: its own Retry, and the
+ * TWO ARMS, gated on different things, and the difference is the point:
+ *
+ *  - A start that has NOT settled gets the loading body WHATEVER the target's
+ *    kind. It is the shared boot headline (the lane's F19 heading when this
+ *    machine's controller is doing something, the idle "Starting Traycer…"
+ *    when it is not), the current stage's bar, and the Show details / Open
+ *    settings footer - the same card the two boot surfaces before it drew.
+ *    This arm used to be withheld unless the target was this machine, on the
+ *    argument that the bootstrap log describes this computer. But the two
+ *    surfaces before it offer that same disclosure without knowing the target
+ *    at all, and on a desktop this machine's lane IS what is running under a
+ *    remote-target start (the launch reconciler installs the local host
+ *    regardless). What withholding it actually produced was the reported
+ *    launch: a fresh install on an account with remote hosts derives a remote
+ *    as effective until the local host registers, and for that whole window
+ *    the card was either empty but for the `Open settings` link or the boxed
+ *    lane line - a third shape, in a launch that must have one.
+ *
+ *  - A start that HAS settled in failure gets this machine's diagnostics
+ *    (the attempt panel and the log disclosure) only when the failure is this
+ *    machine's. On a fleet this machine is not part of, the title and the
+ *    description are the whole story; a crash report about a local install
+ *    under "No host is available" blames the wrong computer.
+ *
+ * `LocalHostLoadingContent` has ONE face, and this is why. It used to take a
+ * `stage` and grow a second one on `"slow"`: its own Retry, and the
  * failed-attempt diagnostics. The Retry was a second place for this modal to
  * state an action it already states in one row, and the diagnostics belong on
- * the arm below where they are TRUE, not under a healthy spinner - so this
- * call site passed `"loading"` unconditionally, and once P3.2 deleted the
- * gate's fallbacks it was the only caller left. P3.4 deleted the branch it
- * had already stopped reaching. That the bootstrap.log path survives all of
- * this is the whole point - it is the one thing that lets a user take a stuck
- * startup somewhere else, and it has been orphaned by a surface move once
- * already.
+ * the settled arm where they are TRUE, not under a healthy spinner. That the
+ * bootstrap.log path survives all of this is the whole point - it is the one
+ * thing that lets a user take a stuck startup somewhere else, and it has been
+ * orphaned by a surface move once already.
  */
-function buildLocalBootstrapBody(args: {
+function buildBootBody(args: {
   readonly variant: WindowNarrationVariant;
   readonly presentation: DefaultHostReadinessPresentation;
   readonly localLifecycle: boolean;
@@ -428,14 +442,13 @@ function buildLocalBootstrapBody(args: {
   readonly settingsOnly: boolean;
 }): ReactNode | null {
   if (args.variant.kind !== "offline") return null;
-  if (!args.localLifecycle) return null;
   // NOTHING IS STARTING, so nothing may claim to be. The spinner and the stage
   // line are gated on the settled FAILURE rather than placed beside it:
   // `LocalHostLoadingContent`'s stage line falls back to
-  // `HOST_PROGRESS_IDLE_HEADING` - "Starting local Traycer Host…" - exactly when
-  // no lane is running, which is precisely this state. A live spinner over a
-  // crash report tells a user to wait for a start that is not happening, and
-  // they report a hang instead of a crash.
+  // `HOST_PROGRESS_IDLE_HEADING` exactly when no lane is running, which is
+  // precisely this state. A live spinner over a crash report tells a user to
+  // wait for a start that is not happening, and they report a hang instead of
+  // a crash.
   //
   // GATED ON THE FAILURE, NOT THE CAUSE - and it was the cause until a review
   // caught it. `cause === "no-usable-host"` covers only the arm where nothing can
@@ -444,24 +457,17 @@ function buildLocalBootstrapBody(args: {
   // issue) still reached the loading body and drew a live spinner claiming a
   // start. That is the user's original complaint inverted: they objected to
   // recovery actions on a start with no error, and this was a modal that HAD
-  // errored still insisting it was starting. The reachable route is a registered
-  // local host - so `effectiveHostId` is non-null and the cause stays
-  // `cold-start` - whose bootstrap failed on first launch.
+  // errored still insisting it was starting.
   //
   // One rule, two arms: ∅ is settled-by-definition (nothing can serve this
   // window IS the failure), and cold-start settles when the install reports one.
-  // The ∅ arm is now a case of the rule rather than a special arm beside it.
-  //
-  // The log disclosure still renders: it is the one affordance that lets
-  // someone take a stuck startup somewhere else, and it is TRUE on both.
-  // The attempt panel comes first because it is what explains the state; the
-  // toggle is a footnote to it.
-  //
-  // Wrapped in the same shell as the loading body, not a fragment: a body
-  // returned as a fragment hands its children straight to the dialog's own
-  // column, where each one carries its own alignment or none. One contract, both
-  // arms - otherwise the two bodies drift apart the moment either is touched.
   if (args.settledFailure) {
+    if (!args.localLifecycle) return null;
+    // The attempt panel comes first because it is what explains the state; the
+    // toggle is a footnote to it. Wrapped in the same shell as the loading
+    // body, not a fragment: a body returned as a fragment hands its children
+    // straight to the dialog's own column, where each one carries its own
+    // alignment or none. One contract, both arms.
     return (
       <LocalHostBodyShell>
         <LocalBootstrapAttempts />
@@ -491,26 +497,6 @@ function buildLocalBootstrapBody(args: {
         ) : null
       }
       onConfigureShell={args.presentation.configureShell}
-    />
-  );
-}
-
-/**
- * What the last bootstrap attempt tried, and where the full log lives.
- *
- * A single read, not a poll: while a user is staring at a failure card there
- * is nothing to gain from re-running the CLI underneath them, and the recovery
- * actions invalidate this query when they fire.
- */
-function LocalBootstrapAttempts(): ReactNode {
-  const status = useRunnerTraycerHostStatusQuery({ pollIntervalMs: null });
-  if (status.data === undefined) return null;
-  const summary = summariseBootstrapAttempts(status.data.bootstrapMarkers);
-  if (summary === null) return null;
-  return (
-    <BootstrapAttemptDetails
-      summary={summary}
-      bootstrapLogPath={status.data.bootstrapLogPath}
     />
   );
 }

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
@@ -401,15 +401,28 @@ function resolveUpdateHost(
  *    when it is not), the current stage's bar, and the Show details / Open
  *    settings footer - the same card the two boot surfaces before it drew.
  *    This arm used to be withheld unless the target was this machine, on the
- *    argument that the bootstrap log describes this computer. But the two
- *    surfaces before it offer that same disclosure without knowing the target
- *    at all, and on a desktop this machine's lane IS what is running under a
- *    remote-target start (the launch reconciler installs the local host
- *    regardless). What withholding it actually produced was the reported
- *    launch: a fresh install on an account with remote hosts derives a remote
- *    as effective until the local host registers, and for that whole window
- *    the card was either empty but for the `Open settings` link or the boxed
- *    lane line - a third shape, in a launch that must have one.
+ *    argument that the bootstrap log describes this computer. It does - and
+ *    that is TRUE information under a remote-target start too: on a desktop
+ *    the main process starts this machine's host whichever host is effective
+ *    (`armFirstInstallOnSignIn` and `runLaunchHostConvergeReconcile` in
+ *    `clients/desktop/src/electron-main/startup/host-launch-converge.ts`
+ *    consult sign-in and removal, never the selection), so the tail behind
+ *    `Show details` is the log of a start that is happening right now on
+ *    this computer, not a stale one. The two surfaces before this card offer
+ *    that same disclosure without knowing the target at all - they mount
+ *    before it is known - and gating only this phase on it re-creates the
+ *    mid-launch shape change this family exists to remove. The disclosure's
+ *    one gate is the one every phase can see: the shell has a CLI
+ *    (`BootstrapLogDisclosure` self-hides on `traycerCli === null`). What
+ *    the target DOES gate is what it should: no local action ARMS for a
+ *    remote target (`local-boot-intent.test.tsx` pins `convergeReady` /
+ *    `removalState` at zero with this body drawn), and the settled
+ *    diagnostics below stay target-gated. What withholding the body actually
+ *    produced was the reported launch: a fresh install on an account with
+ *    remote hosts derives a remote as effective until the local host
+ *    registers, and for that whole window the card was either empty but for
+ *    the `Open settings` link or the boxed lane line - a third shape, in a
+ *    launch that must have one.
  *
  *  - A start that HAS settled in failure gets this machine's diagnostics
  *    (the attempt panel and the log disclosure) only when the failure is this

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
@@ -180,7 +180,13 @@ export function WindowHostModal(props: WindowHostModalProps): ReactNode {
  * centred against the full viewport while they centred under the header - so
  * the card widened by 64px and jumped 20px the moment the narrator took over.
  * The layer now starts BELOW the header (`BELOW_APP_HEADER_TOP_CLASS`) so its
- * `p-6` box is the gate frame's box.
+ * `p-6` box is the gate frame's box - and it is a FLEX row like that box, not
+ * a grid, for the same reason and one more: `HostBootCard`'s
+ * `viewportCapped` is a percentage `max-height`, and a percentage resolves
+ * against a flex container's definite height where an auto grid track grows
+ * with its content and would let the cap resolve against the very height it
+ * is meant to bound. Same centring, and a card that can actually be capped by
+ * the layer it sits in.
  *
  * Structural differences from the dialog, all deliberate:
  *
@@ -219,7 +225,7 @@ export function WindowHostStartupCard(props: WindowHostModalProps): ReactNode {
   return (
     <div
       className={cn(
-        "pointer-events-none fixed inset-x-0 bottom-0 z-50 grid place-items-center p-6",
+        "pointer-events-none fixed inset-x-0 bottom-0 z-50 flex items-center justify-center p-6",
         BELOW_APP_HEADER_TOP_CLASS,
       )}
       data-testid="window-host-startup-card-layer"
@@ -383,6 +389,12 @@ function WindowHostModalBody(props: {
  * instead was the "weird-looking Setting up Traycer" report - a bordered
  * strip with a truncated heading and a percentage where every other phase of
  * the launch draws the headline, the bar and the details footer.
+ *
+ * Heading and percentage ONLY - the same two things the boot body's bar says.
+ * The lane's byte count and its own message line (`transferLabel`, `detail`)
+ * are Settings ▸ Host's: on a launch card a "100 MB of 239 MB" reads as a
+ * download the app started because it was opened, and the detail is a log
+ * line with a path in it. See `HostProgress` in `local-host-loading.tsx`.
  */
 function LaneProgressLine(props: {
   readonly progress: HostProgressView;
@@ -390,32 +402,20 @@ function LaneProgressLine(props: {
   const { progress } = props;
   return (
     <div
-      className="flex flex-col gap-2 rounded-md border border-border/60 bg-foreground/8 px-3 py-2"
+      className="flex items-center gap-2 rounded-md border border-border/60 bg-foreground/8 px-3 py-2"
       data-testid="window-host-modal-progress"
     >
-      <div className="flex items-center gap-2">
-        <AgentSpinningDots
-          className="size-3 shrink-0"
-          testId={undefined}
-          variant={undefined}
-        />
-        <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
-          {progress.heading}
-        </span>
-        {progress.percent === null ? null : (
-          <span className="shrink-0 font-mono text-code-xs tabular-nums text-muted-foreground">
-            {progress.percent}%
-          </span>
-        )}
-      </div>
-      {progress.transferLabel === null ? null : (
-        <span className="text-ui-xs text-muted-foreground">
-          {progress.transferLabel}
-        </span>
-      )}
-      {progress.detail === null ? null : (
-        <span className="truncate text-ui-xs text-muted-foreground">
-          {progress.detail}
+      <AgentSpinningDots
+        className="size-3 shrink-0"
+        testId={undefined}
+        variant={undefined}
+      />
+      <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
+        {progress.heading}
+      </span>
+      {progress.percent === null ? null : (
+        <span className="shrink-0 font-mono text-code-xs tabular-nums text-muted-foreground">
+          {progress.percent}%
         </span>
       )}
     </div>

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
@@ -2,7 +2,8 @@ import { type ReactNode } from "react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { HostBootCard } from "@/components/centered-card";
+import { BELOW_APP_HEADER_TOP_CLASS } from "@/components/layout/header/app-header-height";
 import { PlanRestrictedUpgradeAction } from "@/components/settings/host-scope/plan-restricted-upgrade-action";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { getClientAppVersion } from "@/lib/app-version";
@@ -55,15 +56,20 @@ export interface WindowHostModalProps {
   readonly variant: WindowNarrationVariant;
   readonly progress: HostProgressView | null;
   /**
-   * The rich local-bootstrap body (live progress, Show details / bootstrap.log,
-   * "Configure shell…"), or `null` when this wait is not about this machine.
+   * The boot body - the shared boot headline with this machine's lane
+   * progress and the Show details / bootstrap.log disclosure while a start is
+   * in progress, or the failed attempt's diagnostics once it has settled - or
+   * `null` when this state has no body of that kind to draw.
    *
-   * Passed in rather than rendered here because it is only ever CORRECT for a
-   * local boot: offering to inspect this machine's bootstrap log while the
-   * fleet's only hosts are remote describes the wrong computer, which is the
-   * misattribution the readiness controller's loading arm already documents.
+   * Passed in rather than rendered here because the decision is the host's:
+   * every healthy start gets the body, WHATEVER the target's kind (see
+   * `buildBootBody`), while the settled diagnostics are drawn only when the
+   * failure is this machine's. Offering to inspect this machine's failed
+   * install while the fleet's only hosts are remote describes the wrong
+   * computer, and that arm keeps the title and description as its whole
+   * story.
    */
-  readonly localBootstrapBody: ReactNode | null;
+  readonly bootBody: ReactNode | null;
   readonly onRetry: (() => void) | null;
   readonly retryPending: boolean;
   /**
@@ -96,7 +102,7 @@ export interface WindowHostModalProps {
   readonly settingsEmphasis: "button" | "link";
   /**
    * Whether `Open settings` is the ONLY action this state offers, in which
-   * case the body already carries it inline on the footer row beside
+   * case the boot body already carries it inline on the footer row beside
    * `Show details` and the startup card draws no action row of its own.
    *
    * Decided above like every other action question - see the module doc. The
@@ -152,7 +158,7 @@ export function WindowHostModal(props: WindowHostModalProps): ReactNode {
           <WindowHostModalBody
             variant={props.variant}
             progress={props.progress}
-            localBootstrapBody={props.localBootstrapBody}
+            bootBody={props.bootBody}
           />
           <NarrationActions {...props} copy={copy} align="end" />
         </DialogPrimitive.Content>
@@ -166,20 +172,34 @@ export function WindowHostModal(props: WindowHostModalProps): ReactNode {
  * versions drew a host boot - a centered card in the gate's frame, not a
  * dialog.
  *
+ * It is drawn THROUGH `HostBootCard`, the same component as the two boot
+ * surfaces before it, and that is the whole point of it: a launch hands off
+ * from the runtime fallback to the gate's attach cover to this card, and the
+ * user sees ONE card the whole way only if all three are literally the same
+ * geometry. This one used to be `max-w-md` while the others were `sm`, and it
+ * centred against the full viewport while they centred under the header - so
+ * the card widened by 64px and jumped 20px the moment the narrator took over.
+ * The layer now starts BELOW the header (`BELOW_APP_HEADER_TOP_CLASS`) so its
+ * `p-6` box is the gate frame's box.
+ *
  * Structural differences from the dialog, all deliberate:
  *
- *  - NO overlay and NO pointer trap. The wrapper is `pointer-events-none`
- *    with only the card re-enabling itself, so toasts (the update toast
- *    above all - a pending update is MOST actionable when the host is being
- *    set up) and the gate frame's own header stay clickable.
+ *  - NO overlay and NO pointer trap. The layer is `pointer-events-none` with
+ *    only the card re-enabling itself, so toasts (the update toast above all
+ *    - a pending update is MOST actionable when the host is being set up)
+ *    and the gate frame's own header stay clickable.
  *  - The cold-start face has NO title and NO description while the start is
  *    healthy. "Setting up Traycer" over "Setting up Traycer Host…" over
  *    "Setting up…" was one event announced three times by three layers; the
- *    lane's own F19 heading inside the body is the one line, exactly as the
- *    released card had it.
+ *    boot body's own headline is the one line, exactly as the released card
+ *    had it. And that body is ALWAYS there on a healthy start - a card whose
+ *    body was withheld for a remote target rendered as nothing but the
+ *    `Open settings` link, which is the "modal with only the Open settings
+ *    button" report.
  *  - Recovery actions are withheld until they mean something: on a healthy
- *    start the row carries ONLY the quiet `Open settings` link, with Retry
- *    and Report issue gated above exactly as the released card gated them.
+ *    start the body's footer carries ONLY the quiet `Open settings` beside
+ *    `Show details`, with Retry and Report issue gated above exactly as the
+ *    released card gated them.
  *
  * ⚠ `Open settings` IS NOT OMITTED, however quiet the start looks, and the
  * temptation to drop it for a cleaner card is a LOCKOUT. This surface renders
@@ -198,48 +218,49 @@ export function WindowHostStartupCard(props: WindowHostModalProps): ReactNode {
   const bareColdStart = props.cause === "cold-start" && !props.showReportIssue;
   return (
     <div
-      className="pointer-events-none fixed inset-0 z-50 grid place-items-center p-6"
+      className={cn(
+        "pointer-events-none fixed inset-x-0 bottom-0 z-50 grid place-items-center p-6",
+        BELOW_APP_HEADER_TOP_CLASS,
+      )}
       data-testid="window-host-startup-card-layer"
     >
-      <Card
-        role="status"
-        aria-live="polite"
-        data-testid="window-host-startup-card"
-        data-variant={props.variant.kind}
-        data-cause={props.cause}
-        className="pointer-events-auto max-h-[85svh] w-full max-w-md overflow-y-auto shadow-sm"
+      <HostBootCard
+        testId="window-host-startup-card"
+        dataset={{
+          "data-variant": props.variant.kind,
+          "data-cause": props.cause,
+        }}
+        viewportCapped
       >
-        <CardContent className="flex flex-col gap-4 py-6">
-          {bareColdStart ? null : (
-            <>
-              <h2
-                data-testid="window-host-startup-card-title"
-                className="font-heading text-lg leading-none font-medium"
+        {bareColdStart ? null : (
+          <div className="flex flex-col gap-2">
+            <h2
+              data-testid="window-host-startup-card-title"
+              className="font-heading text-lg leading-none font-medium"
+            >
+              {props.cause === "cold-start"
+                ? "Traycer Host didn't start"
+                : copy.title}
+            </h2>
+            {props.cause === "cold-start" ? null : (
+              <p
+                className="text-ui-sm text-muted-foreground"
+                data-testid="window-host-startup-card-description"
               >
-                {props.cause === "cold-start"
-                  ? "Traycer Host didn't start"
-                  : copy.title}
-              </h2>
-              {props.cause === "cold-start" ? null : (
-                <p
-                  className="text-ui-sm text-muted-foreground"
-                  data-testid="window-host-startup-card-description"
-                >
-                  {copy.description}
-                </p>
-              )}
-            </>
-          )}
-          <WindowHostModalBody
-            variant={props.variant}
-            progress={props.progress}
-            localBootstrapBody={props.localBootstrapBody}
-          />
-          {props.settingsOnly ? null : (
-            <NarrationActions {...props} copy={copy} align="center" />
-          )}
-        </CardContent>
-      </Card>
+                {copy.description}
+              </p>
+            )}
+          </div>
+        )}
+        <WindowHostModalBody
+          variant={props.variant}
+          progress={props.progress}
+          bootBody={props.bootBody}
+        />
+        {props.settingsOnly ? null : (
+          <NarrationActions {...props} copy={copy} align="center" />
+        )}
+      </HostBootCard>
     </div>
   );
 }
@@ -339,23 +360,29 @@ function NarrationActions(
 function WindowHostModalBody(props: {
   readonly variant: WindowNarrationVariant;
   readonly progress: HostProgressView | null;
-  readonly localBootstrapBody: ReactNode | null;
+  readonly bootBody: ReactNode | null;
 }): ReactNode {
   if (props.variant.kind === "update-host") {
     return <IncompatibleDetail variant={props.variant} />;
   }
-  if (props.localBootstrapBody !== null) return props.localBootstrapBody;
+  if (props.bootBody !== null) return props.bootBody;
   if (props.progress === null) return null;
   return <LaneProgressLine progress={props.progress} />;
 }
 
 /**
- * The lane's own words, for the case where the rich local body is not the
- * right thing to draw but the controller is demonstrably doing something.
+ * The lane's own words, for a TITLED face that has no boot body but whose
+ * controller is demonstrably doing something: the plan-restricted arm, or a
+ * settled ∅ on a fleet this machine is not part of, while this machine's lane
+ * still runs underneath.
  *
  * "Traycer can't reach any host" beside a silent screen reads as a dead end
  * even while an install is streaming underneath; this is the line that says
- * the difference.
+ * the difference. It is NEVER the healthy startup card's body: that face has
+ * the full boot body (`buildBootBody`), and drawing this boxed line there
+ * instead was the "weird-looking Setting up Traycer" report - a bordered
+ * strip with a truncated heading and a percentage where every other phase of
+ * the launch draws the headline, the bar and the details footer.
  */
 function LaneProgressLine(props: {
   readonly progress: HostProgressView;
@@ -412,8 +439,10 @@ function IncompatibleDetail(props: {
   return (
     <div
       // align-ok: a labelled version list inside its own fill - the labels
-      // line up only if the block keeps one left edge.
-      className="flex flex-col gap-1 rounded-md bg-foreground/8 px-3 py-2 text-left text-ui-xs text-muted-foreground"
+      // line up only if the block keeps one left edge. `w-full` so the block
+      // spans the card like the attempt panel does on the settled faces,
+      // rather than shrink-wrapping in the centred column.
+      className="flex w-full flex-col gap-1 rounded-md bg-foreground/8 px-3 py-2 text-left text-ui-xs text-muted-foreground"
       data-testid="window-host-modal-incompatible-detail"
     >
       {detail.hostVersion === null ? null : (

--- a/clients/gui-app/src/components/layout/header/app-header-height.ts
+++ b/clients/gui-app/src/components/layout/header/app-header-height.ts
@@ -1,0 +1,18 @@
+/**
+ * The app header's height, and the offset that puts a layer directly below it.
+ *
+ * A LEAF module on purpose: the pre-app boot surfaces need this number and
+ * they mount in trees that cannot import the header itself (the runtime
+ * fallback draws before the router exists; the window narrator's startup layer
+ * mounts at the app root and its suites do not carry the header's provider
+ * stack). Two of them use it to reserve the header's slot so the boot card
+ * centres in the SAME box before, during and after the header is on screen -
+ * a launch crosses three boot surfaces, and a card that centred once against
+ * the whole viewport and once against the area under a 40px header moved 20px
+ * at each hand-off.
+ *
+ * The two literals MUST agree; they are separate because Tailwind resolves
+ * class names statically and `top-` and `h-` cannot share one token.
+ */
+export const APP_HEADER_HEIGHT_CLASS = "h-10";
+export const BELOW_APP_HEADER_TOP_CLASS = "top-10";

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -8,6 +8,7 @@ import { WindowsMenuBar } from "@/components/layout/header/windows-menu-bar";
 import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
 import { ResourceMonitorPopover } from "@/components/resources/resource-monitor-popover";
 import { SignInButton } from "@/components/layout/header/sign-in-button";
+import { APP_HEADER_HEIGHT_CLASS } from "@/components/layout/header/app-header-height";
 import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/stores/auth/auth-store";
@@ -75,7 +76,10 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
       data-testid="app-header"
       data-variant={variant}
       className={cn(
-        "relative z-20 flex h-10 shrink-0 items-center bg-canvas text-canvas-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-['']",
+        // The height is a shared token: the boot surfaces reserve this exact
+        // slot so their card does not move when the header appears under it.
+        APP_HEADER_HEIGHT_CLASS,
+        "relative z-20 flex shrink-0 items-center bg-canvas text-canvas-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-['']",
         framelessDesktop
           ? cn(
               "pl-3 pr-3",

--- a/clients/gui-app/src/components/layout/host-readiness-controller.tsx
+++ b/clients/gui-app/src/components/layout/host-readiness-controller.tsx
@@ -19,7 +19,6 @@ import {
   BootstrapLogDisclosure,
   LocalHostBodyShell,
 } from "@/components/local-host-loading";
-import { HOST_PROGRESS_IDLE_HEADING } from "@/lib/host/host-progress-copy";
 import { hostFailureReportIssueAction } from "@/components/layout/host-failure-report";
 import { compatibilityPresentation } from "@/components/layout/host-compatibility-presentation";
 import {
@@ -450,7 +449,6 @@ export function SurfaceReadinessFallback(props: {
       <div className="flex flex-1 items-center justify-center p-6">
         <HostBootSurface
           testId="host-ready-gate-restoring-request-context"
-          message={HOST_PROGRESS_IDLE_HEADING}
           onConfigureShell={presentation.configureShell}
           onOpenSettings={presentation.openSettings}
         />
@@ -590,7 +588,6 @@ function AttachPendingCard(props: {
           is what made the sequence read as unrelated modals. */}
       <HostBootSurface
         testId="host-gate-attach-pending"
-        message={HOST_PROGRESS_IDLE_HEADING}
         onConfigureShell={props.presentation.configureShell}
         onOpenSettings={props.presentation.openSettings}
       />

--- a/clients/gui-app/src/components/layout/host-readiness-controller.tsx
+++ b/clients/gui-app/src/components/layout/host-readiness-controller.tsx
@@ -10,10 +10,15 @@ import { useRouterState } from "@tanstack/react-router";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import type { HostLeaseSnapshot } from "@traycer-clients/shared/host-selection/selection-authority-contract";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { AppHeader } from "@/components/layout/header/app-header";
+import { HostBootCard } from "@/components/centered-card";
 import { HostBootSurface } from "@/components/host/host-boot-surface";
+import { LocalBootstrapAttempts } from "@/components/host/local-bootstrap-attempts";
+import {
+  BootstrapLogDisclosure,
+  LocalHostBodyShell,
+} from "@/components/local-host-loading";
 import { HOST_PROGRESS_IDLE_HEADING } from "@/lib/host/host-progress-copy";
 import { hostFailureReportIssueAction } from "@/components/layout/host-failure-report";
 import { compatibilityPresentation } from "@/components/layout/host-compatibility-presentation";
@@ -420,15 +425,41 @@ export function HostScopeReady(props: {
  * claims. That is what makes the deletions below provable rather than argued -
  * add a kind to the narrator without removing its case here and this file stops
  * compiling, instead of quietly reviving a second narrator.
+ *
+ * Exported for ONE reader outside this file: the boot-family screenshot gallery
+ * (`__tests__/browser/host-boot-family-gallery.tsx`), which renders every face
+ * of the launch side by side to prove they are one card. Production mounts it
+ * only through `DefaultHostReadyGate`.
  */
-function SurfaceReadinessFallback(props: {
+export function SurfaceReadinessFallback(props: {
   readonly readiness: GateDrawnReadiness;
 }): ReactNode {
   const controller = useHostReadinessController();
   const presentation = controller.defaultHostPresentation;
+  // The auth-restore wait is a WAIT, not a terminal, and it can sit between
+  // the attach cover and the narrator's card on any launch. It therefore wears
+  // the shared boot surface - same card, same idle sentence, same Show details
+  // / Open settings footer - rather than a bare "Restoring authenticated
+  // session…" line with no spinner and no controls, which read as a fourth,
+  // unrelated card taking a turn in the middle of one launch. The sentence is
+  // the family's idle heading on purpose: while nothing lane-specific is
+  // known every phase says the same thing, and "Traycer is starting" is what
+  // restoring the session is a step of.
+  if (props.readiness.kind === "restoring-request-context") {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <HostBootSurface
+          testId="host-ready-gate-restoring-request-context"
+          message={HOST_PROGRESS_IDLE_HEADING}
+          onConfigureShell={presentation.configureShell}
+          onOpenSettings={presentation.openSettings}
+        />
+      </div>
+    );
+  }
   // No install-progress read here any more. Every kind that HAD progress to
   // show (`loading-host`, `provisioning-host`, the slow-host card) belongs to
-  // the window narrator now; the four kinds left are terminals with nothing
+  // the window narrator now; the kinds left are terminals with nothing
   // streaming behind them.
   return (
     <FallbackFrame
@@ -568,10 +599,15 @@ function AttachPendingCard(props: {
 }
 
 /**
- * The full-screen host-boot card, drawn (max-w-md, shadow-sm, gap-4/py-6) the
- * way the standalone host-boot splash drew it before the gate took over - that
- * view predates the split work and must not drift. The splash component itself
- * was deleted in P3.4; this frame is where its shape lives now.
+ * The gate's own full-screen card, drawn through the SHARED boot card.
+ *
+ * It used to carry its own `max-w-md` card, which was the released splash's
+ * shape before the gate took over. That predated the boot-card family; once
+ * the family existed, this was the one member with a different width, so a
+ * launch that ended on a terminal (a failed install, a removed host) widened
+ * its card by 64px at the very moment it had bad news. Same card, same
+ * centring, same spinner rules; this frame adds only the message, the
+ * optional detail line, a body slot and the action row.
  *
  * It took a `variant` until P3.2: `slot` was the bounded in-surface form, drawn
  * without a card because it sat inside a tab's frame. P2.2 deleted the per-pane
@@ -586,58 +622,58 @@ function FallbackFrame(props: {
 }): ReactNode {
   const hasActionsRow =
     props.fallback.actions.length > 0 || props.fallback.footer !== null;
-  const content = (
-    <>
-      {props.fallback.message === null ? null : (
-        <p data-testid={props.messageTestId} className="text-muted-foreground">
-          {props.fallback.message}
-        </p>
-      )}
-      {props.fallback.detail === null ? null : (
-        <p className="text-ui-xs text-muted-foreground">
-          {props.fallback.detail}
-        </p>
-      )}
-      {props.fallback.body}
-      {hasActionsRow ? (
-        <div className="flex flex-wrap justify-center gap-2">
-          {props.fallback.actions.map((action) => (
-            <Button
-              key={action.testId}
-              type="button"
-              size="sm"
-              variant={action.variant}
-              disabled={action.disabled}
-              onClick={action.onClick}
-              data-testid={action.testId}
-            >
-              <span className="inline-flex items-center gap-1.5">
-                <span>{action.label}</span>
-                {action.pending ? (
-                  <AgentSpinningDots
-                    className={undefined}
-                    testId={`${action.testId}-spinner`}
-                    variant={undefined}
-                  />
-                ) : null}
-              </span>
-            </Button>
-          ))}
-          {props.fallback.footer}
-        </div>
-      ) : null}
-    </>
-  );
   return (
     <div
       className="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background p-6 text-foreground"
       data-testid={props.testId}
     >
-      <Card className="w-full max-w-md shadow-sm">
-        <CardContent className="flex flex-col items-center gap-4 py-6 text-center text-ui-sm">
-          {content}
-        </CardContent>
-      </Card>
+      <HostBootCard testId={null} dataset={{}} viewportCapped={false}>
+        {props.fallback.title === null ? null : (
+          // The same heading treatment as the narrator's titled faces
+          // (`WindowHostStartupCard`): a settled failure gets a title, and the
+          // two cards that can say "this machine's host didn't start" say it
+          // in the same type on the same card.
+          <h2 className="font-heading text-lg leading-none font-medium">
+            {props.fallback.title}
+          </h2>
+        )}
+        {props.fallback.message === null ? null : (
+          <p
+            data-testid={props.messageTestId}
+            className="text-ui-sm text-muted-foreground"
+          >
+            {props.fallback.message}
+          </p>
+        )}
+        {props.fallback.body}
+        {hasActionsRow ? (
+          <div className="flex flex-wrap justify-center gap-2">
+            {props.fallback.actions.map((action) => (
+              <Button
+                key={action.testId}
+                type="button"
+                size="sm"
+                variant={action.variant}
+                disabled={action.disabled}
+                onClick={action.onClick}
+                data-testid={action.testId}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <span>{action.label}</span>
+                  {action.pending ? (
+                    <AgentSpinningDots
+                      className={undefined}
+                      testId={`${action.testId}-spinner`}
+                      variant={undefined}
+                    />
+                  ) : null}
+                </span>
+              </Button>
+            ))}
+            {props.fallback.footer}
+          </div>
+        ) : null}
+      </HostBootCard>
     </div>
   );
 }
@@ -658,9 +694,10 @@ interface ReadinessFallbackAction {
 }
 
 interface ReadinessFallback {
+  /** The heading of a SETTLED state, or null for a card that is only a line. */
+  readonly title: string | null;
   readonly message: string | null;
-  readonly detail: string | null;
-  /** Rich slot content rendered between the message/detail text and the actions row. */
+  /** Rich slot content rendered between the message and the actions row. */
   readonly body: ReactNode | null;
   /** Rich content rendered alongside the action buttons, in the same row. */
   readonly footer: ReactNode | null;
@@ -668,7 +705,19 @@ interface ReadinessFallback {
 }
 
 /**
- * Four kinds, and the type says so.
+ * The gate-drawn kinds that are TERMINALS - a card with a message and actions
+ * rather than a wait. `restoring-request-context` is a wait and draws the boot
+ * surface instead (see `SurfaceReadinessFallback`), so it is carved out here
+ * at the type level: the switch below is total over what is left, and a new
+ * gate-drawn kind has to say which of the two it is.
+ */
+type GateTerminalReadiness = Exclude<
+  GateDrawnReadiness,
+  { readonly kind: "restoring-request-context" }
+>;
+
+/**
+ * Three kinds, and the type says so.
  *
  * `loading-host`, `provisioning-host` and `unavailable-host` are absent because
  * `GateDrawnReadiness` excludes them - the window narrator speaks for all three.
@@ -679,23 +728,15 @@ interface ReadinessFallback {
  * reachability was a predicate rather than a type.
  */
 function fallbackContent(
-  readiness: GateDrawnReadiness,
+  readiness: GateTerminalReadiness,
   presentation: DefaultHostReadinessPresentation,
 ): ReadinessFallback {
   switch (readiness.kind) {
-    case "restoring-request-context":
-      return {
-        message: "Restoring authenticated session…",
-        detail: null,
-        body: null,
-        footer: null,
-        actions: [],
-      };
     case "mobile-no-host":
       return {
+        title: null,
         message:
           "No host connected. Connect a host from this device to get started.",
-        detail: null,
         body: null,
         footer: null,
         actions: [],
@@ -704,11 +745,11 @@ function fallbackContent(
       return provisioningErrorFallback(presentation);
     case "removed-host":
       return {
-        message: "Traycer was removed",
+        title: "Traycer was removed",
         // The original card named the actual next step. "Reinstall to start
         // the host again" answered a question the user was not asking: they
         // removed it on purpose and need to know how to finish.
-        detail:
+        message:
           "You removed Traycer's background components from this device, so the host won't start. Your agents and history are preserved. To finish, quit Traycer and drag it from Applications to the Trash.",
         body: null,
         footer: null,
@@ -731,6 +772,20 @@ function fallbackContent(
             pending: false,
             onClick: presentation.reinstall,
           },
+          // The family's escape hatch, on this card too. Removing this
+          // machine's background components does not remove the account's
+          // OTHER hosts, and Settings ▸ Host is where one of those gets
+          // activated - a user who removed local Traycer on purpose may well
+          // be doing so to work from a remote machine. Same rule as every
+          // other card in the launch: never a terminal with no way to Settings.
+          {
+            label: "Open settings",
+            testId: "local-host-removed-open-settings",
+            variant: "outline",
+            disabled: false,
+            pending: false,
+            onClick: presentation.openSettings,
+          },
         ],
       };
   }
@@ -740,11 +795,31 @@ function provisioningErrorFallback(
   presentation: DefaultHostReadinessPresentation,
 ): ReadinessFallback {
   return {
+    // The same heading the narrator's settled cold-start face uses: both cards
+    // say "this machine's host didn't start", and they say it identically.
+    title: "Traycer Host didn't start",
     message:
       presentation.provisioningError?.message ??
       "Could not start Traycer Host.",
-    detail: null,
-    body: null,
+    // THE DIAGNOSTICS, and this card had none. It is drawn when this machine's
+    // install just failed, and it WINS over the window narrator on that state
+    // (`gateCardReadiness`) - which meant the narrator's settled arm, the one
+    // place the attempt panel and the bootstrap.log path lived, was unreachable
+    // for exactly the launch that most needed them. A user staring at "Could
+    // not start Traycer Host." with Retry and nothing else has no path to take
+    // the failure anywhere. Same body as the narrator's settled arm, by
+    // composition rather than by copy: the attempt panel first (it explains
+    // the state), then the log disclosure with NO trailing peer, because this
+    // card has a real action row that already carries `Open settings`.
+    body: (
+      <LocalHostBodyShell>
+        <LocalBootstrapAttempts />
+        <BootstrapLogDisclosure
+          onConfigureShell={presentation.configureShell}
+          trailing={null}
+        />
+      </LocalHostBodyShell>
+    ),
     footer: hostFailureReportIssueAction({
       title: "Could not start Traycer Host",
       message: "Traycer Host could not start.",

--- a/clients/gui-app/src/components/local-host-loading.tsx
+++ b/clients/gui-app/src/components/local-host-loading.tsx
@@ -307,11 +307,16 @@ function HostProgress(props: HostProgressProps) {
           the bar and fall back to the stage's short label ("Setting up…"),
           which merely repeated the heading two lines up in fewer words - the
           third of the three "Setting up"s - and later carried the byte count
-          (see above). The row keeps its height either way (`min-h-4` is
-          `text-ui-xs`'s line height) so a percentage appearing at the
-          download stage does not bounce the centred card, and `tabular-nums`
-          keeps "9%" -> "10%" from shifting as it counts. */}
-      <div className="flex min-h-4 items-center justify-center text-ui-xs text-muted-foreground tabular-nums">
+          (see above). The row keeps its height either way so a percentage
+          appearing at the download stage does not bounce the centred card,
+          and `tabular-nums` keeps "9%" -> "10%" from shifting as it counts.
+
+          `min-h-[1lh]`, not a fixed `min-h-4`: the reserved slot is exactly
+          one line OF THIS ROW, so it follows `text-ui-xs`'s line height
+          instead of restating today's value of it in `rem` - the two agree
+          now and a token change is where they would stop. The unit is
+          already used across the composer surfaces. */}
+      <div className="flex min-h-[1lh] items-center justify-center text-ui-xs text-muted-foreground tabular-nums">
         {indeterminate ? null : <span>{props.percent}%</span>}
       </div>
     </div>

--- a/clients/gui-app/src/components/local-host-loading.tsx
+++ b/clients/gui-app/src/components/local-host-loading.tsx
@@ -60,6 +60,7 @@ export function BootstrapLogDisclosure(
   // toggles closed-then-open quickly.
   const status = useRunnerTraycerHostStatusQuery({
     pollIntervalMs: showDetails ? BOOTSTRAP_TAIL_POLL_MS : null,
+    onMount: "when-stale",
   });
   // No CLI, no bootstrap log - but a neighbour control still has to render, or
   // the footer disappears entirely on shells that never had a log to offer.
@@ -146,10 +147,10 @@ export interface LocalHostLoadingContentProps {
 }
 
 /**
- * The host-boot body: spinner, progress heading/detail, the download progress
- * bar, and the bootstrap-log disclosure (with the "Configure shell…"
- * shortcut). Deliberately has no outer chrome (no `min-h-svh` wrapper, no
- * `<AppHeader>`, no `<Card>`) so its caller provides its own bounded layout.
+ * The host-boot body: spinner + heading, the progress bar, and the
+ * bootstrap-log disclosure (with the "Configure shell…" shortcut).
+ * Deliberately has no outer chrome (no `min-h-svh` wrapper, no `<AppHeader>`,
+ * no `<Card>`) so its caller provides its own bounded layout.
  *
  * ONE PURPOSE, since P3.4: this describes a start that is still in progress,
  * and nothing else. It used to take a `stage` and grow a second face on
@@ -159,6 +160,25 @@ export interface LocalHostLoadingContentProps {
  * actions in one row of its own, drawing the attempt diagnostics beside this
  * body on the arm where they are true. A body with no branch cannot disagree
  * with the surface it sits in about what is happening.
+ *
+ * ONE HEIGHT, whatever the lane has said. Every member of this body is drawn
+ * on every call - `progress: null` (no lane yet) draws the idle heading over
+ * an indeterminate bar, a reporting lane draws its heading over a filling
+ * bar - so the same body serves the two boot surfaces BEFORE the narrator
+ * (`HostBootSurface`) and the narrator's healthy face itself, and the card is
+ * one box from the first frame of a launch until a lane finishes. It used to
+ * add the bar (and a lane-detail line) only once a lane reported, which made
+ * the card grow mid-wait; on a centred card that moves both edges, and it was
+ * reported after a real install as "3-4 different modals … the UI feels jumpy
+ * when the modal size keeps changing".
+ *
+ * NO LANE-DETAIL LINE. `HostProgressView.detail` is the lane's own message -
+ * "extracting host archive into ~/.traycer/…/staging", "atomically replacing
+ * install directory" - a log line with a path in it, not a sentence for a
+ * launch card, and its arrival was one of the shapes in that report. The
+ * heading (`hostProgressHeading`) already names the phase in the user's
+ * words; the detail stays in the shared table for Settings ▸ Host, where a
+ * user has gone looking for it.
  */
 export function LocalHostLoadingContent(
   props: LocalHostLoadingContentProps,
@@ -185,7 +205,14 @@ export function LocalHostLoadingContent(
         spinnerTestId="local-host-loading-spinner"
         messageTestId="local-host-loading-stage"
       />
-      <ProgressLines view={progressView} />
+      {/* THE CONTRACT, not a special case: no measured position => indeterminate.
+          That covers a lane that reports no percentage (`verify`, `swap`,
+          `service-start`, anything added later) AND the wait before any lane
+          has spoken - both are "busy, position unknown", which is exactly what
+          an indeterminate `progressbar` means. The block is the CURRENT
+          stage's, not "the download's": it stopped being that the moment the
+          carry-forward was scoped to one stage. */}
+      <HostProgress percent={progressView?.percent ?? null} />
       <BootstrapLogDisclosure
         onConfigureShell={props.onConfigureShell}
         trailing={props.footerTrailing}
@@ -194,56 +221,31 @@ export function LocalHostLoadingContent(
   );
 }
 
-/**
- * The lane's detail line and its progress bar, both of which only exist when
- * the lane has said something. Split out of the body so the body's branch
- * count stays about its own layout rather than about the view's optionality.
- */
-function ProgressLines(props: {
-  readonly view: HostProgressView | null;
-}): ReactNode {
-  const { view } = props;
-  if (view === null) return null;
-  return (
-    <>
-      {view.detail === null ? null : (
-        <p
-          data-testid="local-host-loading-progress-detail"
-          className="text-ui-sm text-muted-foreground"
-        >
-          {view.detail}
-        </p>
-      )}
-      {/* THE CONTRACT, not a special case: a lane is RUNNING and reports no
-          percentage => indeterminate. Reaching here at all means a lane is
-          running - `useHostProvisioningProgress` returns `null` when none is,
-          which the guard above already handled - so the only question left is
-          whether it has a number.
-
-          Written as the contract rather than as an extract-shaped patch, so it
-          covers `verify`, `swap`, `service-start` and anything added later for
-          free. The block also stopped being "the download's progress" the moment
-          the carry-forward was scoped to one stage; it is the CURRENT stage's. */}
-      <HostProgress percent={view.percent} transferLabel={view.transferLabel} />
-    </>
-  );
-}
-
 interface HostProgressProps {
-  /** `null` for a running stage with no measured position - see the contract above. */
+  /** `null` while nothing has a measured position - see the contract above. */
   readonly percent: number | null;
-  readonly transferLabel: string | null;
 }
 
 /**
- * The current stage's progress: determinate when it reports a percentage,
- * indeterminate when it is merely running.
+ * The boot card's ONE progress bar: determinate when the running stage
+ * reports a percentage, indeterminate otherwise - and present on EVERY wait
+ * face, the idle "Starting Traycer…" included.
  *
  * WHY IT RENDERS AT ALL WITHOUT A NUMBER. Before this, the block was gated on
  * `percent !== null`, so at a stage transition the whole thing unmounted and the
  * card lost 48px - and because the modal is centred with `-translate-y-1/2`, both
  * of its edges moved 24px and the whole dialog jumped mid-install. Measured, on
- * the one surface this epic exists to fix. Holding the space is the point.
+ * the one surface this epic exists to fix. Holding the space is the point - and
+ * it now holds it from the first frame of the launch (see
+ * `LocalHostLoadingContent`), because a bar that appeared when the lane began
+ * reporting was the same jump one phase earlier.
+ *
+ * NO BYTES. This row used to carry "100 MB of 239 MB" beside the percentage.
+ * On a card that is on screen the moment the app opens, a byte count reads as
+ * "Traycer began downloading something because I launched it" - reported as
+ * alarming - where a percentage reads as the same start progressing. The
+ * transfer figures stay in the shared table (`HostProgressView.transferLabel`)
+ * for Settings ▸ Host, where a user has gone looking for them.
  *
  * ⚠ AND IT MUST NOT HIDE A STALL. It cannot: stall detection is entirely the
  * staged wait's (`LOCAL_HOST_SLOW_START_THRESHOLD_MS` and
@@ -258,19 +260,12 @@ function HostProgress(props: HostProgressProps) {
     <div
       data-testid="local-host-download-progress"
       data-indeterminate={indeterminate ? "true" : "false"}
-      className="flex w-full flex-col gap-2"
+      // `items-center`: the figure below the track centres, like everything
+      // else on this card (heading above, footer below). A right-aligned
+      // figure with nothing on its left - which is what dropping the byte
+      // count left behind - hung off the track's end like an orphan.
+      className="flex w-full flex-col items-center gap-2"
     >
-      {/* Bytes and percent ONLY. This slot used to fall back to the stage's
-          short label ("Setting up…"), which merely repeated the heading two
-          lines up in fewer words - the third of the three "Setting up"s. The
-          row keeps its height either way so a transfer label appearing at the
-          download stage does not bounce the centered card. */}
-      <div className="flex min-h-4 items-center justify-between text-ui-xs text-muted-foreground">
-        <span>{props.transferLabel ?? ""}</span>
-        {indeterminate ? null : (
-          <span className="font-medium text-foreground">{props.percent}%</span>
-        )}
-      </div>
       <div
         role="progressbar"
         aria-valuemin={0}
@@ -279,7 +274,13 @@ function HostProgress(props: HostProgressProps) {
         // a `progressbar` with no `aria-valuenow` is announced as busy with an
         // unknown position, rather than as a specific amount done.
         aria-valuenow={props.percent ?? undefined}
-        className="h-2 w-full overflow-hidden rounded-full bg-foreground/8"
+        // Thin, fully rounded, and CLIPPED: `overflow-hidden` is what keeps
+        // the sweeping segment (which travels from -100% to +340% of its own
+        // width) inside the track's rounded ends, and the track is `w-full`
+        // of the body column, so it can never run past the card's padding.
+        // The track's fill is an alpha of the foreground, which survives
+        // every preset theme on a raised surface (see AGENTS.md).
+        className="h-1.5 w-full overflow-hidden rounded-full bg-foreground/8"
       >
         {indeterminate ? (
           // A SWEEPING SEGMENT, not a pulsing full-width fill: a full bar reads as
@@ -301,6 +302,17 @@ function HostProgress(props: HostProgressProps) {
             style={{ width: `${String(props.percent)}%` }}
           />
         )}
+      </div>
+      {/* The percentage ONLY, under the track. This slot used to sit above
+          the bar and fall back to the stage's short label ("Setting up…"),
+          which merely repeated the heading two lines up in fewer words - the
+          third of the three "Setting up"s - and later carried the byte count
+          (see above). The row keeps its height either way (`min-h-4` is
+          `text-ui-xs`'s line height) so a percentage appearing at the
+          download stage does not bounce the centred card, and `tabular-nums`
+          keeps "9%" -> "10%" from shifting as it counts. */}
+      <div className="flex min-h-4 items-center justify-center text-ui-xs text-muted-foreground tabular-nums">
+        {indeterminate ? null : <span>{props.percent}%</span>}
       </div>
     </div>
   );

--- a/clients/gui-app/src/hooks/runner/use-runner-traycer-host-status-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-traycer-host-status-query.ts
@@ -19,11 +19,29 @@ export interface UseRunnerTraycerHostStatusQueryOptions {
    * host is starting up.
    */
   readonly pollIntervalMs: number | null;
+  /**
+   * What a MOUNT does with a snapshot already in the cache.
+   *
+   *  - `"when-stale"`: the ordinary rule - reuse it while it is within
+   *    `staleTime`, refetch otherwise. For a reader that shows the LIVE tail
+   *    (`BootstrapLogDisclosure`), whose poll refreshes it anyway.
+   *  - `"always"`: refetch on mount regardless, and let the caller gate on
+   *    `isFetchedAfterMount` so it never presents the cached one. For a
+   *    reader that describes a state transition that HAPPENED JUST NOW -
+   *    the failed-attempt panel (`LocalBootstrapAttempts`) mounts on the
+   *    failure, but the disclosure beside it read this same query while the
+   *    start was still healthy, and a snapshot from 20 seconds ago is
+   *    "fresh" by the 30-second rule while describing the attempt BEFORE
+   *    the one that just failed - or none. Only `convergeReady`'s SUCCESS
+   *    invalidates this key, so nothing else would refresh it in time.
+   */
+  readonly onMount: "when-stale" | "always";
 }
 
 function traycerHostStatusQueryOptions(
   traycerCli: ITraycerCli | null,
   pollIntervalMs: number | null,
+  onMount: "when-stale" | "always",
 ) {
   return queryOptions<TraycerHostStatusSnapshot>({
     queryKey:
@@ -43,6 +61,7 @@ function traycerHostStatusQueryOptions(
     // explicit invalidate.
     staleTime: pollIntervalMs !== null ? 0 : 30_000,
     refetchInterval: pollIntervalMs ?? false,
+    refetchOnMount: onMount === "always" ? "always" : true,
   });
 }
 
@@ -50,10 +69,13 @@ function traycerHostStatusQueryOptions(
  * Reads `traycer host status` through the runner-host CLI bridge. Host-
  * independent: works whether the host is up, starting, or wedged.
  * Consumers:
- *   - `LocalHostLoadingContent` - polls only while its details disclosure is
- *     open, so the live bootstrap.log tail stays fresh while a user watches.
- *   - `LocalBootstrapAttempts` in the window narrator - a single read: the
- *     renderer stops driving updates while the user reads the diagnostics.
+ *   - `BootstrapLogDisclosure` (every boot card's `Show details`) - polls only
+ *     while the disclosure is open, so the live bootstrap.log tail stays
+ *     fresh while a user watches.
+ *   - `LocalBootstrapAttempts` (the narrator's settled arm and the gate's
+ *     `provisioning-error` card) - a single FRESH read on mount, then no
+ *     polling: the renderer stops driving updates while the user reads the
+ *     diagnostics. See `onMount`.
  *
  * Disabled on shells without a CLI (mobile, web) - `traycerCli === null`.
  */
@@ -62,6 +84,10 @@ export function useRunnerTraycerHostStatusQuery(
 ): UseQueryResult<TraycerHostStatusSnapshot> {
   const runnerHost = useRunnerHost();
   return useQuery(
-    traycerHostStatusQueryOptions(runnerHost.traycerCli, opts.pollIntervalMs),
+    traycerHostStatusQueryOptions(
+      runnerHost.traycerCli,
+      opts.pollIntervalMs,
+      opts.onMount,
+    ),
   );
 }

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -5,8 +5,7 @@ import { HostControllerStatusListener } from "@/components/layout/bridges/host-c
 import { RunnerHostBridges } from "@/components/layout/bridges/runner-host-bridges";
 import { WorktreeDeleteProgressToastBridge } from "@/components/layout/bridges/worktree-delete-progress-toast-bridge";
 import { ReportIssueDialogHost } from "@/components/layout/dialogs/report-issue-dialog-host";
-import { HostBootSurface } from "@/components/host/host-boot-surface";
-import { HOST_PROGRESS_IDLE_HEADING } from "@/lib/host/host-progress-copy";
+import { HostRuntimeBootFallback } from "@/components/host/host-runtime-boot-fallback";
 import { RootErrorBoundary } from "@/components/errors/root-error-boundary";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -131,24 +130,15 @@ export function TraycerApp(props: TraycerAppProps): ReactNode {
   const openSettings = useCallback(() => {
     void router.navigate({ to: "/settings/host" });
   }, [router]);
-  // THE FIRST of a launch's three boot surfaces, and deliberately the same
-  // component as the others - same card, same sentence, same controls. Giving
-  // each phase its own shape and its own phrasing is what made one continuous
-  // wait look like a sequence of unrelated modals.
-  //
-  // Rendered inside a full-viewport centering wrapper because this one owns
-  // the whole window: it draws before any app chrome exists, where the later
-  // two sit inside the gate frame that already carries the header.
+  // THE FIRST of a launch's three boot surfaces - see
+  // `HostRuntimeBootFallback` for why it is the same card as the other two and
+  // why it reserves the header's slot.
   const hostRuntimeFallback = useMemo(
     () => (
-      <div className="flex min-h-svh w-full items-center justify-center bg-background p-6 text-foreground">
-        <HostBootSurface
-          testId={null}
-          message={HOST_PROGRESS_IDLE_HEADING}
-          onConfigureShell={configureShell}
-          onOpenSettings={openSettings}
-        />
-      </div>
+      <HostRuntimeBootFallback
+        onConfigureShell={configureShell}
+        onOpenSettings={openSettings}
+      />
     ),
     [configureShell, openSettings],
   );

--- a/clients/traycer-cli/src/runner/__tests__/output.test.ts
+++ b/clients/traycer-cli/src/runner/__tests__/output.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createOutput,
   type Output,
@@ -18,6 +18,15 @@ import { noopLogger } from "../../logger";
 // with a newline and the next byte tick starts a NEW bar - one frozen,
 // stacked bar per attempt. The contract: one bar per download, redrawn in
 // place; a heartbeat is a status update on that bar, never its finalizer.
+
+/**
+ * The rail's cell count, mirrored from `../output`. Not exported from there:
+ * the module's public surface is `createOutput`, and a test that reached in
+ * for the constant would be asserting the renderer's arithmetic against
+ * itself. Stated here so a width change reddens these cases rather than
+ * silently re-deriving with them.
+ */
+const PROGRESS_BAR_WIDTH = 24;
 
 function makeRuntime(): RuntimeContext {
   return {
@@ -98,11 +107,54 @@ function captureStderr(isTty: boolean): StderrCapture {
   };
 }
 
+interface StdoutCapture {
+  readonly lines: () => string[];
+  readonly restore: () => void;
+}
+
+/** JSON-mode events go to STDOUT; this is the seam for reading them back. */
+function captureJsonStdout(): StdoutCapture {
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  return {
+    lines: () =>
+      spy.mock.calls
+        .map((call) => {
+          const chunk = call[0];
+          return typeof chunk === "string"
+            ? chunk
+            : Buffer.from(chunk).toString("utf8");
+        })
+        .join("")
+        .split("\n")
+        .filter((line) => line.length > 0),
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+}
+
 let capture: StderrCapture | null = null;
+
+// COLOUR IS ENV-DEPENDENT, so it is pinned rather than inherited. The rail's
+// unfilled half is dimmed on a colour-capable TTY, and a developer (or a CI
+// runner) with `NO_COLOR` set would otherwise be reading a different string
+// from these assertions than the next person. Every case below states which
+// of the two it is exercising; `NO_COLOR` is the default because the plain
+// rail is the one whose GEOMETRY these tests are about.
+const originalNoColor = process.env.NO_COLOR;
+
+beforeEach(() => {
+  process.env.NO_COLOR = "1";
+});
 
 afterEach(() => {
   capture?.restore();
   capture = null;
+  if (originalNoColor === undefined) {
+    delete process.env.NO_COLOR;
+  } else {
+    process.env.NO_COLOR = originalNoColor;
+  }
 });
 
 describe("createOutput human-mode TTY progress bar", () => {
@@ -127,7 +179,10 @@ describe("createOutput human-mode TTY progress bar", () => {
     // the last real transfer numbers - not as a bare stage line.
     expect(writes[1]).toContain("fetching host archive (attempt 1)");
     expect(writes[1]).toContain("0%");
-    expect(writes[1]).toContain("[");
+    // The RAIL, not `[`: that used to be this line and it never tested
+    // anything - every frame starts with the `\x1b[2K` clear, so a bar drawn
+    // with no brackets at all satisfied it.
+    expect(writes[1]).toContain("─".repeat(PROGRESS_BAR_WIDTH));
     expect(writes[2]).toContain("downloading host 1.5.0");
     expect(writes[2]).toContain("61%");
   });
@@ -206,6 +261,123 @@ describe("createOutput human-mode TTY progress bar", () => {
       "downloading host 1.5.0\n",
       "fetching host archive (attempt 1)\n",
     ]);
+  });
+});
+
+describe("createOutput progress bar rendering", () => {
+  /** The rail's cells, with the frame's clear/label/percent stripped off. */
+  function railOf(frame: string): string {
+    const match = /([━╸─]+)/.exec(frame);
+    return match === null ? "" : match[1];
+  }
+
+  it("never prints a byte count, however many bytes the tick carries", () => {
+    // THE RULE, and the reason for it: this bar is on screen while someone
+    // waits for Traycer to start, and "(5.2 MB / 10.0 MB)" there reads as
+    // "it started downloading something because I ran a command" - reported
+    // as alarming on the GUI's equivalent card, and fixed the same way in
+    // both. The tick still CARRIES the figures (asserted below), so this is
+    // the renderer withholding them, not a fixture that never supplied them.
+    capture = captureStderr(true);
+    const output = createOutput(makeRuntime());
+    const tick = downloadTick(
+      "downloading host 1.5.0",
+      52,
+      5_452_595,
+      10_485_760,
+    );
+    expect(tick.bytes).toBe(5_452_595);
+    expect(tick.totalBytes).toBe(10_485_760);
+    output.progress(tick);
+
+    const frame = capture.writes()[0] ?? "";
+    expect(frame).toContain("52%");
+    expect(frame).not.toContain("MB");
+    expect(frame).not.toContain("KB");
+    expect(frame).not.toContain("GB");
+    expect(frame).not.toMatch(/\d+(\.\d+)?\s*[KMGT]?B/);
+    // And the bytes are still on the wire for Desktop, which reads the JSON
+    // stream rather than this rail.
+    const jsonCapture = captureJsonStdout();
+    try {
+      createOutput({ ...makeRuntime(), json: true }).progress(tick);
+      const event = JSON.parse(jsonCapture.lines()[0] ?? "{}") as ProgressEvent;
+      expect(event.bytes).toBe(5_452_595);
+      expect(event.totalBytes).toBe(10_485_760);
+    } finally {
+      jsonCapture.restore();
+    }
+  });
+
+  it("holds the rail at a fixed cell count so the percentage column never moves", () => {
+    // A bar whose width tracked its fill would shuffle the number sideways on
+    // every frame - the terminal equivalent of the card that changed height
+    // mid-wait. Checked across the whole range, including the two ends.
+    capture = captureStderr(true);
+    const output = createOutput(makeRuntime());
+    for (const percent of [0, 1, 2, 17, 42, 61, 99, 100]) {
+      output.progress(
+        downloadTick("downloading host 1.5.0", percent, percent, 100),
+      );
+    }
+
+    const rails = capture.writes().map(railOf);
+    expect(rails).toHaveLength(8);
+    for (const rail of rails) {
+      expect([...rail]).toHaveLength(PROGRESS_BAR_WIDTH);
+    }
+    // The percentage sits at the same column in every frame.
+    const columns = new Set(capture.writes().map((w) => w.indexOf("%")));
+    expect(columns.size).toBe(1);
+  });
+
+  it("fills by FLOOR with a half-cell leading edge, so it neither overstates a start nor completes early", () => {
+    // `Math.round` on whole cells drew a full cell from 2.1% and a full rail
+    // from ~98%; the half-cell edge is what buys the resolution back without
+    // either lie. One cell is 100/24 = 4.1666…%, so 61% is 14.6 cells.
+    capture = captureStderr(true);
+    const output = createOutput(makeRuntime());
+    for (const percent of [0, 2, 3, 61, 99, 100]) {
+      output.progress(
+        downloadTick("downloading host 1.5.0", percent, percent, 100),
+      );
+    }
+    const rails = capture.writes().map(railOf);
+
+    // 0% and 2% (0.48 cells) are empty; 3% (0.72) shows the half edge. So the
+    // smallest visible advance is ~2.1%, not ~4.2%.
+    expect(rails[0]).toBe("─".repeat(PROGRESS_BAR_WIDTH));
+    expect(rails[1]).toBe("─".repeat(PROGRESS_BAR_WIDTH));
+    expect(rails[2]).toBe(`╸${"─".repeat(PROGRESS_BAR_WIDTH - 1)}`);
+    // 61% -> 14.6 cells: 14 full, one half, 9 empty.
+    expect(rails[3]).toBe(`${"━".repeat(14)}╸${"─".repeat(9)}`);
+    // 99% -> 23.76 cells: NOT a full rail. Only 100% is.
+    expect(rails[4]).toBe(`${"━".repeat(23)}╸`);
+    expect(rails[5]).toBe("━".repeat(PROGRESS_BAR_WIDTH));
+  });
+
+  it("dims the unfilled rail on a colour-capable TTY and prints it bare under NO_COLOR", () => {
+    // The two halves differ by line WEIGHT first, so the bar still reads
+    // without colour - which is the whole point of dimming only the empty
+    // run. A completed rail closes no sequence it never opened.
+    delete process.env.NO_COLOR;
+    capture = captureStderr(true);
+    const coloured = createOutput(makeRuntime());
+    coloured.progress(downloadTick("downloading host 1.5.0", 52, 52, 100));
+    coloured.progress(downloadTick("downloading host 1.5.0", 100, 100, 100));
+    const colouredWrites = capture.writes();
+    expect(colouredWrites[0]).toContain(`\x1b[2m${"─".repeat(12)}\x1b[0m`);
+    // Nothing dimmed once the rail is full - no stray empty escape pair.
+    expect(colouredWrites[1]).not.toContain("\x1b[2m");
+    capture.restore();
+
+    process.env.NO_COLOR = "1";
+    capture = captureStderr(true);
+    const plain = createOutput(makeRuntime());
+    plain.progress(downloadTick("downloading host 1.5.0", 52, 52, 100));
+    const plainFrame = capture.writes()[0] ?? "";
+    expect(plainFrame).not.toContain("\x1b[2m");
+    expect(plainFrame).toContain(`${"━".repeat(12)}${"─".repeat(12)}`);
   });
 });
 

--- a/clients/traycer-cli/src/runner/__tests__/output.test.ts
+++ b/clients/traycer-cli/src/runner/__tests__/output.test.ts
@@ -315,20 +315,40 @@ describe("createOutput progress bar rendering", () => {
     // mid-wait. Checked across the whole range, including the two ends.
     capture = captureStderr(true);
     const output = createOutput(makeRuntime());
-    for (const percent of [0, 1, 2, 17, 42, 61, 99, 100]) {
+    // FRACTIONS INCLUDED. `ProgressInfo.percent` is a `number`, and every
+    // producer in this repo happening to `Math.round` its byte ratio is each
+    // caller remembering rather than a property of this sink - "2.5%" is five
+    // characters and would move the column the rail exists to hold still.
+    for (const percent of [0, 1, 2, 2.5, 17, 42, 61, 99.6, 100]) {
       output.progress(
         downloadTick("downloading host 1.5.0", percent, percent, 100),
       );
     }
 
     const rails = capture.writes().map(railOf);
-    expect(rails).toHaveLength(8);
+    expect(rails).toHaveLength(9);
     for (const rail of rails) {
       expect([...rail]).toHaveLength(PROGRESS_BAR_WIDTH);
     }
     // The percentage sits at the same column in every frame.
     const columns = new Set(capture.writes().map((w) => w.indexOf("%")));
     expect(columns.size).toBe(1);
+    // Floored, not rounded: 99.6 reads as 99 beside a rail that is
+    // deliberately not full, rather than as a 100% that disagrees with it.
+    expect(capture.writes()[3]).toContain("  2%");
+    expect(capture.writes()[7]).toContain(" 99%");
+    expect(capture.writes()[7]).not.toContain("100%");
+    expect(rails[7]).not.toBe("━".repeat(PROGRESS_BAR_WIDTH));
+  });
+
+  it("floors the percentage on the non-TTY line too, where there is no rail to hold a column", () => {
+    // The other half of the same defect: a CI log reading
+    // "downloading host 1.5.0 52.34000000000001%".
+    capture = captureStderr(false);
+    const output = createOutput(makeRuntime());
+    output.progress(downloadTick("downloading host 1.5.0", 52.34, 52, 100));
+
+    expect(capture.writes()).toEqual(["downloading host 1.5.0 52%\n"]);
   });
 
   it("fills by FLOOR with a half-cell leading edge, so it neither overstates a start nor completes early", () => {

--- a/clients/traycer-cli/src/runner/output.ts
+++ b/clients/traycer-cli/src/runner/output.ts
@@ -171,6 +171,23 @@ const ARCHIVE_HEARTBEAT_STAGE_PREFIX = "registry-archive-";
 function isArchiveHeartbeatStage(stage: string): boolean {
   return stage.startsWith(ARCHIVE_HEARTBEAT_STAGE_PREFIX);
 }
+/**
+ * The integer a human reads, from a position that need not be one.
+ *
+ * `ProgressInfo.percent` is a `number`: every producer in this repo happens to
+ * `Math.round` its byte ratio, but that is each caller remembering, not a
+ * property of the sink - and the rail's whole promise is that its figure
+ * occupies a fixed three-column slot ("2.5%" is five characters and moves it).
+ * Normalising HERE makes the promise the renderer's own.
+ *
+ * FLOOR, matching the rail's own fill: `Math.round(99.6)` would print 100%
+ * beside a rail that is deliberately not full (see the half-cell rule), and a
+ * label disagreeing with the bar it labels is worse than a rounded digit.
+ */
+function displayPercent(percent: number): string {
+  return String(Math.floor(percent));
+}
+
 function renderProgressBar(
   info: ProgressInfo,
   dim: (s: string) => string,
@@ -193,7 +210,7 @@ function renderProgressBar(
   // The number column is padded so a rail does not shuffle sideways as the
   // figure grows a digit, and it trails the rail (rather than leading it) so
   // the eye tracks one moving edge.
-  return `${label}${bar}  ${String(percent).padStart(3)}%`;
+  return `${label}${bar}  ${displayPercent(percent).padStart(3)}%`;
 }
 
 export function createOutput(runtime: RuntimeContext): Output {
@@ -302,7 +319,12 @@ export function createOutput(runtime: RuntimeContext): Output {
         if (decile === lastNonTtyDecile) return;
         lastNonTtyDecile = decile;
         if (info.message !== null) {
-          writeStderrLine(`${info.message} ${info.percent}%`);
+          // Same normalisation as the rail's: a CI log line reading
+          // "downloading host 1.5.0 52.34000000000001%" is the other half of
+          // the same defect.
+          writeStderrLine(
+            `${info.message} ${displayPercent(Math.max(0, Math.min(100, info.percent)))}%`,
+          );
         }
         return;
       }

--- a/clients/traycer-cli/src/runner/output.ts
+++ b/clients/traycer-cli/src/runner/output.ts
@@ -127,22 +127,34 @@ function writeStderrLine(line: string): void {
   writeStderr(`${line}\n`);
 }
 
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let value = n / 1024;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  return `${value.toFixed(1)} ${units[unit]}`;
-}
-
 // Renders a single-line progress bar for a percent-bearing tick, e.g.
-//   downloading host 1.5.0 [████████░░░░░░░░] 52% (5.2 MB / 10.0 MB)
+//   downloading host 1.5.0  ━━━━━━━━━━━━╹───────────   52%
 // The caller rewrites this in place with a carriage return on a TTY.
+//
+// A THIN RAIL, and NO BYTE COUNT. Both are the same decision the GUI's boot
+// card made: this bar is on screen while a user waits for Traycer to start,
+// and "(5.2 MB / 10.0 MB)" there reads as "it began downloading something
+// because I ran a command" - reported as alarming. The percentage says the
+// same thing about the wait without naming a size. The byte figures stay on
+// the wire (`ProgressEvent.bytes` / `totalBytes`, consumed by Desktop) and in
+// the diagnostics that describe a FAILED transfer, where a size is the point.
+//
+// The rail replaces `[████░░░░]`: box-drawing weights rather than block shading, so
+// the filled and empty halves differ by line weight instead of by fill
+// density, and no brackets are needed to delimit something that already
+// reads as one rail. Same Unicode neighbourhood as the blocks it replaces
+// (U+2500 vs U+2580), so it asks nothing new of a terminal font.
 const PROGRESS_BAR_WIDTH = 24;
+
+// The leading edge, drawn when the fill lands past the middle of a cell:
+// U+2578, the LEFT half of a heavy rail, so it continues the filled run and
+// stops halfway rather than sitting beside it as a separate mark. It halves
+// the rail's step - one cell of 24 is worth ~4.2%, this makes the smallest
+// visible advance ~2.1% - which is what keeps a slow transfer looking like it
+// is moving at all.
+const PROGRESS_BAR_FILLED = "━";
+const PROGRESS_BAR_HALF = "╸";
+const PROGRESS_BAR_EMPTY = "─";
 
 // Percent-less liveness heartbeats for the archive transfer. The registry
 // client publishes these as `registry-archive-<phase>` ticks (phases:
@@ -159,16 +171,29 @@ const ARCHIVE_HEARTBEAT_STAGE_PREFIX = "registry-archive-";
 function isArchiveHeartbeatStage(stage: string): boolean {
   return stage.startsWith(ARCHIVE_HEARTBEAT_STAGE_PREFIX);
 }
-function renderProgressBar(info: ProgressInfo): string {
+function renderProgressBar(
+  info: ProgressInfo,
+  dim: (s: string) => string,
+): string {
   const percent = Math.max(0, Math.min(100, info.percent ?? 0));
-  const filled = Math.round((percent / 100) * PROGRESS_BAR_WIDTH);
-  const bar = `${"█".repeat(filled)}${"░".repeat(PROGRESS_BAR_WIDTH - filled)}`;
-  const bytes =
-    info.bytes !== null && info.totalBytes !== null && info.totalBytes > 0
-      ? ` (${formatBytes(info.bytes)} / ${formatBytes(info.totalBytes)})`
-      : "";
-  const label = info.message !== null ? `${info.message} ` : "";
-  return `${label}[${bar}] ${String(percent).padStart(3)}%${bytes}`;
+  // FLOOR plus a half cell, never `Math.round` on the whole cell: rounding
+  // draws a full cell for anything past its midpoint, so a bar reads as 4%
+  // done at 2% and - at the other end - as complete two cells before it is.
+  const exact = (percent / 100) * PROGRESS_BAR_WIDTH;
+  const full = Math.floor(exact);
+  const half = exact - full >= 0.5 && full < PROGRESS_BAR_WIDTH;
+  const empty = PROGRESS_BAR_WIDTH - full - (half ? 1 : 0);
+  // The rail is ALWAYS `PROGRESS_BAR_WIDTH` cells, so the percentage after it
+  // never moves. `dim` is skipped on an empty run rather than wrapping "" -
+  // a completed bar should not end in a stray pair of escape codes.
+  const bar = `${PROGRESS_BAR_FILLED.repeat(full)}${half ? PROGRESS_BAR_HALF : ""}${
+    empty === 0 ? "" : dim(PROGRESS_BAR_EMPTY.repeat(empty))
+  }`;
+  const label = info.message !== null ? `${info.message}  ` : "";
+  // The number column is padded so a rail does not shuffle sideways as the
+  // figure grows a digit, and it trails the rail (rather than leading it) so
+  // the eye tracks one moving edge.
+  return `${label}${bar}  ${String(percent).padStart(3)}%`;
 }
 
 export function createOutput(runtime: RuntimeContext): Output {
@@ -235,6 +260,16 @@ export function createOutput(runtime: RuntimeContext): Output {
   // tracks whether an in-place bar is currently on screen so the next
   // discrete line (or human text) terminates it with a newline first.
   const isTty = process.stderr.isTTY === true;
+  // Dim on the rail's UNFILLED half only, so the two halves differ by weight
+  // AND by intensity on a terminal that has colour, and by weight alone on
+  // one that does not. Resolved once here, on the same gate `host-status`
+  // uses (`NO_COLOR` plus a TTY) - read from `stderr`, which is where this
+  // bar is written. The non-TTY path never renders a rail at all.
+  const useColor = isTty && process.env.NO_COLOR === undefined;
+  // `\x1b[0m` to close, matching `host-status`'s colorizer: nothing else on
+  // this line is styled, so a full reset is the safer of the two closers.
+  const dim = (text: string): string =>
+    useColor ? `\x1b[2m${text}\x1b[0m` : text;
   let progressOpen = false;
   // The last percent-bearing tick rendered as the open TTY bar. An archive
   // liveness heartbeat borrows these numbers so its in-place redraw holds
@@ -256,7 +291,7 @@ export function createOutput(runtime: RuntimeContext): Output {
         if (isTty) {
           // `\r` returns to column 0; `\x1b[2K` clears the line so a shorter
           // render can't leave stale characters from a longer previous one.
-          writeStderr(`\r\x1b[2K${renderProgressBar(info)}`);
+          writeStderr(`\r\x1b[2K${renderProgressBar(info, dim)}`);
           progressOpen = true;
           openBarInfo = info;
           return;
@@ -285,14 +320,17 @@ export function createOutput(runtime: RuntimeContext): Output {
         isArchiveHeartbeatStage(info.stage)
       ) {
         writeStderr(
-          `\r\x1b[2K${renderProgressBar({
-            stage: info.stage,
-            message: info.message ?? openBarInfo.message,
-            percent: openBarInfo.percent,
-            bytes: openBarInfo.bytes,
-            totalBytes: openBarInfo.totalBytes,
-            workUnits: null,
-          })}`,
+          `\r\x1b[2K${renderProgressBar(
+            {
+              stage: info.stage,
+              message: info.message ?? openBarInfo.message,
+              percent: openBarInfo.percent,
+              bytes: openBarInfo.bytes,
+              totalBytes: openBarInfo.totalBytes,
+              workUnits: null,
+            },
+            dim,
+          )}`,
         );
         return;
       }


### PR DESCRIPTION
## What

A fresh staging install after the host-lifecycle PRs showed two things on launch: a card containing **only the `Open settings` link**, and a "weird-looking Setting up Traycer" card that was not the unified `Starting Traycer…` / Show details / Open settings one.

Both are one arm. A fresh install on an account that has remote hosts derives a **remote** host as effective until the local host registers (`deriveDesiredEffective`'s third arm — no preference, no local row, first usable remote; `connecting` counts as usable). The window narrator's startup card withheld its boot body for any non-local target, so during that window it drew either nothing but the `Open settings` link (no lane running) or a boxed `LaneProgressLine` strip (lane running). Two geometry drifts sat under it: the narrator card was `max-w-md` while the two boot surfaces before it were `max-w-sm`, and it centred against the full viewport while they centred under the 40px header — a 64px widen and a 20px jump at the hand-off.

## Audit of the desktop launch path (all fixed in this pass)

| # | Surface | Was | Now |
|---|---|---|---|
| 1 | `HostRuntimeProvider` fallback | Unified card, viewport-centred | Reserves the header slot so it centres in the same box as 2–3 (`HostRuntimeBootFallback`) |
| 2 | Gate attach cover | Unified card | Unchanged |
| 3 | Gate `restoring-request-context` | Bare "Restoring authenticated session…", no spinner/controls, `max-w-md` | The unified boot surface (idle heading, Show details, Open settings) |
| 4 | Narrator startup card, healthy local target | Unified body but `max-w-md`, viewport-centred | Drawn through `HostBootCard`; layer starts below the header |
| 5 | Narrator startup card, healthy **remote/unknown target** | Only `Open settings`, or a boxed lane strip | **Same boot body as a local target** (`buildBootBody` no longer gates the healthy arm on target kind) |
| 6 | Narrator titled faces (∅ pre-latch, plan, update, failed) | Left title in a centred card | Centred on the shared card; version block full-width |
| 7 | Gate `provisioning-error` | Message + Retry/Open settings/Report — no attempt panel, no bootstrap.log path, no Show details (this card wins over the narrator, so the narrator's rich failed arm was unreachable) | Heading + attempt panel + log path + Show details + actions (`LocalBootstrapAttempts` shared) |
| 8 | Gate `removed-host` | Own card, Quit/Reinstall | Shared card + `Open settings` |
| 9 | Post-latch ∅ dialog | Radix dialog | Unchanged (a dialog over a live app; different geometry on purpose) |

What is still target-gated: the **settled** diagnostics (attempt panel) — a local crash report under "No host is available" on a remote-only fleet would blame the wrong computer.

## Instrument

`clients/gui-app/scripts/host-boot-family-gallery-browser.mjs` renders every face (`src/__tests__/browser/host-boot-family-gallery.tsx`), screenshots each, and measures the card's box. Manual, not CI. On this branch: 12 faces × 2 themes share width 384 / left 408; the four wait faces (runtime, attach, restoring, narrator-idle) share one box exactly (top 389 / height 162); the dialog control differs (512), so the instrument sees width. Also green at 800×600.

## Tests

- `window-host-modal-host.test.tsx`: the remote-target fixture flips from "no body, action row carries the link" to the unified body; + lane-running arm; + the settled remote-only counterweight.
- `default-host-ready-gate.test.tsx`: `provisioning-error` diagnostics; `restoring-request-context` boot surface; every gate terminal drawn through the shared card.
- `local-boot-intent.test.tsx`: the remote fixture keeps its load-bearing invariant (nothing local armed, no Retry) and drops the pins on the bare card it was defending.
- Mutation probes: re-gating the healthy body on target kind reds 2 arms; removing the provisioning-error body reds 1; reverting restoring-request-context reds 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
