### PR TITLE
fix(desktop,gui-app,shared): make the local host's lifecycle target-independent and self-healing

### DIFF
--- a/clients/desktop/src/electron-main/selection/__tests__/desktop-selection-ports.test.ts
+++ b/clients/desktop/src/electron-main/selection/__tests__/desktop-selection-ports.test.ts
@@ -1652,21 +1652,29 @@ describe("createDesktopLocalHostEnsurePort", () => {
     });
   });
 
-  it("maps a busy outcome to {ok: true} - a host with work in progress is a running host", async () => {
+  it("does NOT treat a busy refusal as proof of life - E_HOST_BUSY is a fail-safe", async () => {
     const controller = new FakeHostController();
     const port = createDesktopLocalHostEnsurePort(controller);
-    // The converge wanted to swap bytes and declined to disrupt live work.
-    // The engine asked "is the local host running?", and it is. Resolving
-    // `deferred` here instead paced a retry that re-spawned the CLI every
-    // hold for as long as the host stayed busy, once the ensure stopped being
-    // gated on the local host being the window's target (nothing dials a
-    // non-target local host, so nothing else could end never-dialed).
+    // The tempting reading is "a host that is up with active work", and an
+    // earlier revision of this port resolved `{ok: true}` on it to spare a
+    // non-target local host one CLI spawn per pacing hold. `assertHostNotBusy`
+    // says otherwise in its own words: it raises `E_HOST_BUSY` when a live
+    // PID's idle state CANNOT BE DETERMINED - `/activity` timed out, refused,
+    // answered malformed, or 404'd - exactly as it does when the host reports
+    // real work. A WEDGED host is the first case, so `{ok: true}` handed
+    // `onHostProvedAlive` a host that cannot serve: refusal evidence cleared,
+    // lease usable, failover free to choose it, and each later ensure clearing
+    // the refusals its failed dials had just rebuilt.
     controller.outcome = {
       kind: "busy",
       continuation: "retry-with-force",
       message: "busy",
     };
-    await expect(port.ensureReady()).resolves.toEqual({ ok: true });
+    await expect(port.ensureReady()).resolves.toEqual({
+      ok: false,
+      reason: "busy",
+      deferred: true,
+    });
   });
 
   it("maps failed/deferred outcomes to {ok: false, reason: <kind>}, with only failed non-deferred", async () => {

--- a/clients/desktop/src/electron-main/selection/__tests__/desktop-selection-ports.test.ts
+++ b/clients/desktop/src/electron-main/selection/__tests__/desktop-selection-ports.test.ts
@@ -1630,22 +1630,26 @@ describe("createDesktopLocalHostEnsurePort", () => {
     await expect(port.ensureReady()).resolves.toEqual({ ok: true });
   });
 
-  it("maps busy/failed/deferred outcomes to {ok: false, reason: <kind>}, with only failed non-deferred", async () => {
+  it("maps a busy outcome to {ok: true} - a host with work in progress is a running host", async () => {
     const controller = new FakeHostController();
     const port = createDesktopLocalHostEnsurePort(controller);
-
-    // `busy` is a host UP with active work - the converge declined to
-    // disrupt it. Proof of life must not become a dead lease, so it defers.
+    // The converge wanted to swap bytes and declined to disrupt live work.
+    // The engine asked "is the local host running?", and it is. Resolving
+    // `deferred` here instead paced a retry that re-spawned the CLI every
+    // hold for as long as the host stayed busy, once the ensure stopped being
+    // gated on the local host being the window's target (nothing dials a
+    // non-target local host, so nothing else could end never-dialed).
     controller.outcome = {
       kind: "busy",
       continuation: "retry-with-force",
       message: "busy",
     };
-    await expect(port.ensureReady()).resolves.toEqual({
-      ok: false,
-      reason: "busy",
-      deferred: true,
-    });
+    await expect(port.ensureReady()).resolves.toEqual({ ok: true });
+  });
+
+  it("maps failed/deferred outcomes to {ok: false, reason: <kind>}, with only failed non-deferred", async () => {
+    const controller = new FakeHostController();
+    const port = createDesktopLocalHostEnsurePort(controller);
 
     // `failed` actually ran and concluded - the one arm allowed to arm the
     // engine's dead-lease cooldown.

--- a/clients/desktop/src/electron-main/selection/__tests__/desktop-selection-ports.test.ts
+++ b/clients/desktop/src/electron-main/selection/__tests__/desktop-selection-ports.test.ts
@@ -1630,6 +1630,28 @@ describe("createDesktopLocalHostEnsurePort", () => {
     await expect(port.ensureReady()).resolves.toEqual({ ok: true });
   });
 
+  it("refuses to call a REMOVED host alive, even though its converge answers ok", async () => {
+    const controller = new FakeHostController();
+    const port = createDesktopLocalHostEnsurePort(controller);
+    // The exact short-circuit `HostController.convergeReady` returns while the
+    // removal sentinel stands: `ok`, because nothing failed - and `running:
+    // false`, because by consent nothing ran either. The engine reads a bare
+    // `ok` as FIRSTHAND proof of life (`onHostProvedAlive` clears the refusal
+    // streak and makes the lease usable), so mapping this one to `{ok: true}`
+    // handed failover a host that is not installed, and re-cleared that streak
+    // every pacing hold. Now it is a plain failure - and NOT deferred, because
+    // nothing here changes on its own until the user reinstalls.
+    controller.outcome = {
+      kind: "ok",
+      value: { running: false, version: null },
+    };
+    await expect(port.ensureReady()).resolves.toEqual({
+      ok: false,
+      reason: "removed-by-user",
+      deferred: false,
+    });
+  });
+
   it("maps a busy outcome to {ok: true} - a host with work in progress is a running host", async () => {
     const controller = new FakeHostController();
     const port = createDesktopLocalHostEnsurePort(controller);

--- a/clients/desktop/src/electron-main/selection/desktop-selection-ports.ts
+++ b/clients/desktop/src/electron-main/selection/desktop-selection-ports.ts
@@ -692,7 +692,29 @@ export function createDesktopLocalHostEnsurePort(
   return {
     ensureReady: async () => {
       const outcome = await hostController.convergeReady(false);
-      if (outcome.kind === "ok") return { ok: true };
+      if (outcome.kind === "ok") {
+        // `ok` ALONE IS NOT PROOF OF LIFE, and the engine reads this answer as
+        // exactly that (`onHostProvedAlive`: it clears the refusal streak and
+        // makes the lease usable). `HostController.convergeReady`
+        // short-circuits `ok {running:false}` while the removal sentinel
+        // stands - it starts nothing, by consent - so collapsing every `ok`
+        // credited a host the user had removed with being alive. Harmless
+        // while the ensure only fired for a WANTED local host; since it fires
+        // whichever host is effective, a machine whose fleet still names its
+        // removed local host (enrollment or a lingering `pid.json` outlives
+        // the uninstall, and the fleet snapshot outlives both until it
+        // refreshes) would hand failover a host that is not installed, and
+        // every 30s the same no-op ensure would clear the refusal streak that
+        // failing to dial it had just built.
+        //
+        // `running: false` reaches here from that short-circuit alone - every
+        // other `ok` path returns a version it just proved reachable - so the
+        // honest mapping is a plain failure: not deferred (nothing is going to
+        // change on its own), and paced by the engine's cooldown, whose retry
+        // costs one sentinel read until the user reinstalls.
+        if (outcome.value.running) return { ok: true };
+        return { ok: false, reason: "removed-by-user", deferred: false };
+      }
       // `busy` is a HOST that is up with active work: the converge wanted to
       // swap its bytes and declined to disrupt it. For the engine that IS the
       // answer it asked for - "is the local host running?" - so it resolves

--- a/clients/desktop/src/electron-main/selection/desktop-selection-ports.ts
+++ b/clients/desktop/src/electron-main/selection/desktop-selection-ports.ts
@@ -715,26 +715,35 @@ export function createDesktopLocalHostEnsurePort(
         if (outcome.value.running) return { ok: true };
         return { ok: false, reason: "removed-by-user", deferred: false };
       }
-      // `busy` is a HOST that is up with active work: the converge wanted to
-      // swap its bytes and declined to disrupt it. For the engine that IS the
-      // answer it asked for - "is the local host running?" - so it resolves
-      // `ok`, which is what lets proof of life create the evidence record that
-      // ends never-dialed. It used to resolve `deferred` (paced retry, lease
-      // left alone), which was harmless while the ensure only fired for a
-      // WANTED local host: a window pointed at it dialed it and ended
-      // never-dialed on its own. The ensure now fires whichever host is
-      // effective, and a local host nothing dials would otherwise draw one
-      // converge - a CLI spawn - every pacing hold for as long as it stayed
-      // busy. The pending swap is not this port's business: the launch
-      // reconciler and the idle-apply monitors own updates.
-      if (outcome.kind === "busy") return { ok: true };
-      // `deferred` says nothing dead-worthy about the host, and the engine
-      // must not turn it into a dead lease: it is the controller's word for
-      // "the lane or its CLI lock was busy, nothing ran".
+      // NEITHER SURVIVING OUTCOME IS PROOF OF LIFE, and `busy` is the one that
+      // looks like it. It reads as "a host that is up with active work", and
+      // an earlier revision of this port resolved it `ok` on that reading, to
+      // spare a non-target local host one CLI spawn per pacing hold. The
+      // reading is wrong: `E_HOST_BUSY` is a FAIL-SAFE. `assertHostNotBusy`
+      // raises it when a live PID's idle state CANNOT BE DETERMINED - the
+      // `/activity` probe timed out, refused the connection, answered
+      // malformed, or 404'd from a pre-feature host - as much as when the host
+      // answers "I am working". A WEDGED host is exactly the first case, so
+      // crediting it handed `onHostProvedAlive` a host that cannot serve:
+      // refusal evidence cleared, the lease usable, failover free to pick it,
+      // and every following ensure clearing the refusals the failed dials had
+      // just rebuilt.
+      //
+      // So `busy` rejoins `deferred`: the lease is left alone and the request
+      // is paced, which is the honest answer to "nothing here was
+      // established". `failed` keeps its own answer - it ran and concluded, so
+      // it stays the one arm allowed to arm the engine's dead-lease cooldown.
+      // The cost is the spawn that reading was meant to avoid, once per hold
+      // while a host stays busy - accepted, because it is bounded, it ends by
+      // itself when real work finishes (the next converge answers `ok` with a
+      // version it proved), and no amount of it can select a host that is not
+      // serving. Only reachability independently confirmed could restore the
+      // shortcut, and this port has no such evidence - the engine's own dial
+      // is what has it.
       return {
         ok: false,
         reason: outcome.kind,
-        deferred: outcome.kind === "deferred",
+        deferred: outcome.kind === "deferred" || outcome.kind === "busy",
       };
     },
   };

--- a/clients/desktop/src/electron-main/selection/desktop-selection-ports.ts
+++ b/clients/desktop/src/electron-main/selection/desktop-selection-ports.ts
@@ -682,9 +682,9 @@ export class DesktopLocalHostOutageSignal implements LocalHostOutageSignal {
  * provisioning controller.
  *
  * P1.1 composes it and NEVER calls it: the caller is P1.3's derivation, which
- * requests `ensure` when it wants the local host and that host is down, and
- * surfaces the outcome as the local lease's own status. Wiring it now means
- * P1.3 adds a call site, not a port.
+ * requests `ensure` whenever the local host is down (target-independent by
+ * decision, 2026-08-19), and surfaces the outcome as the local lease's own
+ * status. Wiring it now means P1.3 adds a call site, not a port.
  */
 export function createDesktopLocalHostEnsurePort(
   hostController: IpcHostController,
@@ -693,15 +693,26 @@ export function createDesktopLocalHostEnsurePort(
     ensureReady: async () => {
       const outcome = await hostController.convergeReady(false);
       if (outcome.kind === "ok") return { ok: true };
-      // Two non-ok outcomes say nothing dead-worthy about the host, and the
-      // engine must not turn either into a dead lease: `deferred` is the
-      // controller's word for "the lane or its CLI lock was busy, nothing
-      // ran", and `busy` is a HOST that is up with active work - the converge
-      // declined to disrupt it, which is proof of life, not death.
+      // `busy` is a HOST that is up with active work: the converge wanted to
+      // swap its bytes and declined to disrupt it. For the engine that IS the
+      // answer it asked for - "is the local host running?" - so it resolves
+      // `ok`, which is what lets proof of life create the evidence record that
+      // ends never-dialed. It used to resolve `deferred` (paced retry, lease
+      // left alone), which was harmless while the ensure only fired for a
+      // WANTED local host: a window pointed at it dialed it and ended
+      // never-dialed on its own. The ensure now fires whichever host is
+      // effective, and a local host nothing dials would otherwise draw one
+      // converge - a CLI spawn - every pacing hold for as long as it stayed
+      // busy. The pending swap is not this port's business: the launch
+      // reconciler and the idle-apply monitors own updates.
+      if (outcome.kind === "busy") return { ok: true };
+      // `deferred` says nothing dead-worthy about the host, and the engine
+      // must not turn it into a dead lease: it is the controller's word for
+      // "the lane or its CLI lock was busy, nothing ran".
       return {
         ok: false,
         reason: outcome.kind,
-        deferred: outcome.kind === "deferred" || outcome.kind === "busy",
+        deferred: outcome.kind === "deferred",
       };
     },
   };

--- a/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
@@ -53,9 +53,10 @@ vi.mock("../../ipc/host-management-ipc", () => ({
 // Imported after the mocks above so the module under test picks them up.
 const {
   runLaunchHostConvergeReconcile,
-  armFirstInstallOnSignIn,
+  armLocalHostBootOnSignIn,
   refreshHostRegistryIfNotRemoved,
   applyHostUpdateMenuState,
+  LOCAL_HOST_BOOT_RETRY_LADDER_MS,
 } = await import("../host-launch-converge");
 const { __setDesktopStartupTestHooks, runDesktopStartup } =
   await import("../desktop-startup");
@@ -686,17 +687,29 @@ describe("runLaunchHostConvergeReconcile (fixup B1 + B2)", () => {
   });
 });
 
-describe("armFirstInstallOnSignIn", () => {
+describe("armLocalHostBootOnSignIn", () => {
   const neverInstalled = (removedByUser: boolean): HostControllerStatus => ({
     ...fakeStatus(false, "unavailable", removedByUser),
     installedVersion: null,
   });
 
-  it("re-arms after an attempt that THREW, instead of retiring the only first-install actor", async () => {
+  afterEach(() => {
+    // Several tests below arm real ladder timers via `vi.useFakeTimers()`;
+    // leaving fake timers active would leak into whatever test runs next in
+    // this file.
+    vi.useRealTimers();
+  });
+
+  it("re-arms after an attempt that THREW, and retries on the ladder rather than a sign-in edge", async () => {
     // `settled` used to be set before the async work started, and the detached
     // promise had no catch: one transient IPC failure retired first-install for
     // the whole process, leaving a signed-in user in the unavailable-host flow
-    // until a manual retry or a relaunch.
+    // until a manual retry or a relaunch. The retry now comes from the LADDER
+    // TIMER a throw schedules (when still signed in), not from waiting on
+    // another sign-in edge - so this also proves a same-state sign-in change
+    // (e.g. a token refresh) does not bypass the ladder while a timer is
+    // already pending.
+    vi.useFakeTimers();
     const controller = fakeHostController(
       neverInstalled(false),
       {
@@ -718,30 +731,36 @@ describe("armFirstInstallOnSignIn", () => {
     };
     const gate = fakeSignedInGate(true);
 
-    armFirstInstallOnSignIn(throwsFirstTime, gate);
+    armLocalHostBootOnSignIn(throwsFirstTime, gate);
+    await vi.advanceTimersByTimeAsync(0);
 
-    await vi.waitFor(() => {
-      expect(statusCalls).toBe(1);
-    });
+    expect(statusCalls).toBe(1);
     expect(controller.convergeReadyCalls).toEqual([]);
     // The subscription is what the failure re-arms against, so it must still
     // be there - the immediate-attempt path used to skip subscribing entirely.
     expect(gate.listenerCount()).toBe(1);
 
+    // A same-state "signed in" edge must not bypass the ladder while a retry
+    // timer is already pending.
     gate.signIn();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(statusCalls).toBe(1);
 
-    await vi.waitFor(() => {
-      expect(controller.convergeReadyCalls).toEqual([false]);
-    });
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0]);
+    expect(controller.convergeReadyCalls).toEqual([false]);
     // And the retry that succeeded settles it: no third attempt.
     expect(gate.listenerCount()).toBe(0);
   });
 
-  it("stays armed after a RESOLVED non-ok outcome, and retries on the next sign-in edge", async () => {
-    // Deliberately NOT a throw. The throw path was fixed in `2e05de85` and its
-    // test sits directly above; this is the surviving half - `busy`,
-    // `deferred` and `failed` are ordinary resolved values, so they never
-    // reach the catch, and `outcome.kind` was logged without being read.
+  it("stays armed after a RESOLVED non-ok outcome, and retries on the ladder without a sign-in edge", async () => {
+    // Deliberately NOT a throw. The throw path is the test directly above;
+    // this is the surviving half - `busy`, `deferred` and `failed` are
+    // ordinary resolved values, so they never reach the catch, and
+    // `outcome.kind` was logged without being read. Before the ladder this
+    // arm only retried on the NEXT SIGN-IN EDGE, which for a user who stays
+    // signed in never comes - the local host used to come up again without
+    // anyone signing in again, and the user has ruled it must keep doing so.
+    // This test drives the whole ladder with NO sign-in edge at all.
     //
     // `convergeReady` is OVERRIDDEN rather than configured, because
     // `fakeHostController` hardcodes it to `ok` - its second parameter is
@@ -749,6 +768,7 @@ describe("armFirstInstallOnSignIn", () => {
     // there drives the SUCCESS path while looking like a failure fixture, and
     // an earlier version of this test did exactly that and passed for the
     // wrong reason.
+    vi.useFakeTimers();
     const base = fakeHostController(
       neverInstalled(false),
       {
@@ -778,11 +798,9 @@ describe("armFirstInstallOnSignIn", () => {
     };
     const gate = fakeSignedInGate(true);
 
-    armFirstInstallOnSignIn(failsConverge, gate);
-
-    await vi.waitFor(() => {
-      expect(convergeCalls).toEqual([false]);
-    });
+    armLocalHostBootOnSignIn(failsConverge, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(convergeCalls).toEqual([false]);
 
     // Premise, positively: the convergence really ran and really came back
     // non-ok, and nothing is installed. Without this the assertions below are
@@ -791,23 +809,32 @@ describe("armFirstInstallOnSignIn", () => {
     expect(await failsConverge.getStatus()).toMatchObject({
       installedVersion: null,
     });
-
-    // Fixed: the arm survives, so the sign-in edge it retries from is still
-    // subscribed...
     expect(gate.listenerCount()).toBe(1);
 
-    // ...and that edge produces a REAL second attempt which, this time
-    // succeeding, settles the arm. Asserting only the listener count would
-    // pass on a build that kept the subscription and never acted on it - the
-    // point is the retry, not the bookkeeping.
+    // Nothing happens until rung 0 actually elapses - no sign-in edge fires
+    // anywhere in this test.
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0] - 1);
+    expect(convergeCalls).toEqual([false]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(convergeCalls).toEqual([false, false]);
+
+    // Rung 1 is longer than rung 0 - the ladder actually backs off between
+    // failures rather than retrying at a flat interval.
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[1] - 1);
+    expect(convergeCalls).toEqual([false, false]);
+
+    // ...and that third attempt, this time succeeding, settles the arm.
+    // Asserting only the listener count would pass on a build that kept the
+    // subscription and never acted on it - the point is the retry, not the
+    // bookkeeping.
     outcomeKind = "ok";
-    gate.signIn();
-    await vi.waitFor(() => {
-      expect(convergeCalls).toEqual([false, false]);
-    });
-    await vi.waitFor(() => {
-      expect(gate.listenerCount()).toBe(0);
-    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(convergeCalls).toEqual([false, false, false]);
+    expect(gate.listenerCount()).toBe(0);
+
+    // Settled arms never re-arm, no matter how long the process keeps running.
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[3] * 2);
+    expect(convergeCalls).toEqual([false, false, false]);
   });
 
   it("installs once for a signed-in user on a machine that has never had a host", async () => {
@@ -820,7 +847,7 @@ describe("armFirstInstallOnSignIn", () => {
       { kind: "ok", value: { activated: true } },
     );
 
-    armFirstInstallOnSignIn(controller, fakeSignedInGate(true));
+    armLocalHostBootOnSignIn(controller, fakeSignedInGate(true));
 
     await vi.waitFor(() => {
       expect(controller.convergeReadyCalls).toEqual([false]);
@@ -841,7 +868,7 @@ describe("armFirstInstallOnSignIn", () => {
     );
     const gate = fakeSignedInGate(false);
 
-    armFirstInstallOnSignIn(controller, gate);
+    armLocalHostBootOnSignIn(controller, gate);
     await Promise.resolve();
 
     // Installing a background service is consent-bearing: the retired renderer
@@ -863,7 +890,7 @@ describe("armFirstInstallOnSignIn", () => {
       { kind: "ok", value: { activated: true } },
     );
     const gate = fakeSignedInGate(false);
-    armFirstInstallOnSignIn(controller, gate);
+    armLocalHostBootOnSignIn(controller, gate);
 
     gate.signIn();
 
@@ -911,7 +938,7 @@ describe("armFirstInstallOnSignIn", () => {
       },
     };
 
-    armFirstInstallOnSignIn(signsOutMidStatus, gate);
+    armLocalHostBootOnSignIn(signsOutMidStatus, gate);
 
     await vi.waitFor(() => {
       expect(statusCalls).toBe(1);
@@ -949,7 +976,7 @@ describe("armFirstInstallOnSignIn", () => {
       { kind: "ok", value: { activated: true } },
     );
 
-    armFirstInstallOnSignIn(controller, fakeSignedInGate(true));
+    armLocalHostBootOnSignIn(controller, fakeSignedInGate(true));
     await vi.waitFor(() => {
       expect(controller.getStatusCalls).toBeGreaterThan(0);
     });
@@ -960,7 +987,12 @@ describe("armFirstInstallOnSignIn", () => {
     expect(controller.convergeReadyCalls).toEqual([]);
   });
 
-  it("does nothing when a host is already installed - that debt is the reconciler's", async () => {
+  it("does nothing when a host is already RUNNING - activation debt is the reconciler's", async () => {
+    // Fixture is `activated` (a live runtime), so this still describes a
+    // one-shot no-op for THIS actor. What changed is the neighbour case: an
+    // INSTALLED host that is NOT running is no longer the reconciler's alone
+    // to catch - see "boots an INSTALLED host that is not running at launch"
+    // below, which is this actor's now too.
     const controller = fakeHostController(
       fakeStatus(false, "activated", false),
       {
@@ -970,12 +1002,292 @@ describe("armFirstInstallOnSignIn", () => {
       { kind: "ok", value: { activated: true } },
     );
 
-    armFirstInstallOnSignIn(controller, fakeSignedInGate(true));
+    armLocalHostBootOnSignIn(controller, fakeSignedInGate(true));
     await vi.waitFor(() => {
       expect(controller.getStatusCalls).toBeGreaterThan(0);
     });
 
     expect(controller.convergeReadyCalls).toEqual([]);
+  });
+
+  it("boots an INSTALLED host that is not running at launch, and leaves a running one alone", async () => {
+    // The widened contract: the owed condition is "no host RUNNING"
+    // (`activation === "unavailable"`), not "nothing installed"
+    // (`installedVersion === null`). An installed host with no running
+    // service is owed a boot from THIS actor now - not only from the
+    // one-shot reconciler, which can miss it entirely (see the regression
+    // test right below this one) - and a host that answers with any other
+    // activation value is already running and must settle without ever
+    // calling `convergeReady`.
+    const downController = fakeHostController(
+      fakeStatus(false, "unavailable", false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const downGate = fakeSignedInGate(true);
+
+    armLocalHostBootOnSignIn(downController, downGate);
+
+    await vi.waitFor(() => {
+      expect(downController.convergeReadyCalls).toEqual([false]);
+    });
+    expect(downGate.listenerCount()).toBe(0);
+
+    const runningController = fakeHostController(
+      fakeStatus(false, "activated", false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const runningGate = fakeSignedInGate(true);
+
+    armLocalHostBootOnSignIn(runningController, runningGate);
+
+    await vi.waitFor(() => {
+      expect(runningController.getStatusCalls).toBeGreaterThan(0);
+    });
+    expect(runningController.convergeReadyCalls).toEqual([]);
+    // Settling because a host is running IS the point - assert it directly
+    // rather than only the absence of a converge call, which would pass just
+    // as happily against an arm that got stuck.
+    await vi.waitFor(() => {
+      expect(runningGate.listenerCount()).toBe(0);
+    });
+  });
+
+  it("a half-completed first install (bytes landed, service never started) is still owed a boot", async () => {
+    // THE regression this widening exists to prevent: before it, `settle()`
+    // fired the moment `installedVersion !== null`, so an install whose bytes
+    // landed but whose service never registered looked "done" to this actor
+    // on its very first status read - a half-completed first install left the
+    // machine hostless with nothing retrying. The status read below models
+    // exactly that machine: `neverInstalled` on the FIRST read, then
+    // `installed but unavailable` on every read after - and the arm must ask
+    // `convergeReady` a second time rather than treat the now-installed bytes
+    // as a settled outcome.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    let getStatusCalls = 0;
+    let convergeOutcome: MutationOutcome<ConvergeReadyOk> = {
+      kind: "failed",
+      message: "installer could not write to the prefix",
+    };
+    const convergeReadyCalls: boolean[] = [];
+    const controller: IpcHostController = {
+      ...base,
+      getStatus: () => {
+        getStatusCalls += 1;
+        return Promise.resolve(
+          getStatusCalls === 1
+            ? neverInstalled(false)
+            : fakeStatus(false, "unavailable", false),
+        );
+      },
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return Promise.resolve(convergeOutcome);
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(convergeReadyCalls).toEqual([false]);
+    expect(gate.listenerCount()).toBe(1);
+
+    convergeOutcome = {
+      kind: "ok",
+      value: { running: true, version: "1.4.0" },
+    };
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0]);
+    // The second read now carries a real `installedVersion` - and the arm did
+    // NOT settle on that; it asked `convergeReady` again.
+    expect(convergeReadyCalls).toEqual([false, false]);
+    expect(gate.listenerCount()).toBe(0);
+  });
+
+  it("a `busy` outcome is a running host and settles the arm", async () => {
+    // `busy` is the CLI's HOST_BUSY: only a LIVE host declines a byte swap, so
+    // this is a running host by the same reading the selection authority's
+    // ensure port makes elsewhere - not a resolved failure that earns a
+    // retry.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const convergeReadyCalls: boolean[] = [];
+    const controller: IpcHostController = {
+      ...base,
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return Promise.resolve({
+          kind: "busy" as const,
+          continuation: "retry-with-force" as const,
+          message: "host is mid-mutation",
+        });
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(convergeReadyCalls).toEqual([false]);
+    expect(gate.listenerCount()).toBe(0);
+
+    // No timer was ever scheduled - a settled arm has nothing left to fire.
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0]);
+    expect(convergeReadyCalls).toEqual([false]);
+  });
+
+  it("a `deferred` outcome (CLI lock held elsewhere) earns the next rung, not a sign-in wait", async () => {
+    // `deferred` is an ordinary resolved outcome, same as `failed` above - it
+    // never reaches the catch, and it clears on its own once the other
+    // Traycer process releases the CLI lock, so it earns a ladder retry
+    // exactly like `failed` rather than falling back to the pre-ladder
+    // "wait for a sign-in edge" behaviour.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    let outcomeKind: MutationOutcome<ConvergeReadyOk>["kind"] = "deferred";
+    const convergeReadyCalls: boolean[] = [];
+    const controller: IpcHostController = {
+      ...base,
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return Promise.resolve(
+          outcomeKind === "ok"
+            ? {
+                kind: "ok" as const,
+                value: { running: true, version: "1.4.0" },
+              }
+            : {
+                kind: "deferred" as const,
+                message: "another Traycer process holds the CLI lock",
+              },
+        );
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(convergeReadyCalls).toEqual([false]);
+    expect(gate.listenerCount()).toBe(1);
+
+    outcomeKind = "ok";
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0]);
+    expect(convergeReadyCalls).toEqual([false, false]);
+    expect(gate.listenerCount()).toBe(0);
+  });
+
+  it("CONSENT: a sign-out mid-ladder cancels the pending retry, and the next sign-in starts the ladder over", async () => {
+    // The other half of consent-as-precondition: a sign-out must stop a
+    // pending retry from firing into an account that just left, and the
+    // ladder itself must not carry over - a real re-login gets the same
+    // rung-0 pace a fresh sign-in would, never the tail end of the previous
+    // attempt's backoff.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const convergeReadyCalls: boolean[] = [];
+    const controller: IpcHostController = {
+      ...base,
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return Promise.resolve({
+          kind: "failed" as const,
+          message: "installer could not write to the prefix",
+        });
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(convergeReadyCalls).toEqual([false]);
+
+    gate.signOut();
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[3] * 2);
+    // No attempt fires while signed out, however long the process runs.
+    expect(convergeReadyCalls).toEqual([false]);
+
+    gate.signIn();
+    await vi.advanceTimersByTimeAsync(0);
+    // A real re-login attempts immediately - there is no timer left pending
+    // to gate it.
+    expect(convergeReadyCalls).toEqual([false, false]);
+
+    // The ladder reset: the NEXT retry lands after rung 0, not rung 1.
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0] - 1);
+    expect(convergeReadyCalls).toEqual([false, false]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(convergeReadyCalls).toEqual([false, false, false]);
+  });
+
+  it("the disposer clears a pending retry", async () => {
+    // The returned disposer is the one thing standing between an armed retry
+    // ladder and a leaked timer once main no longer wants this actor running.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const convergeReadyCalls: boolean[] = [];
+    const controller: IpcHostController = {
+      ...base,
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return Promise.resolve({
+          kind: "failed" as const,
+          message: "installer could not write to the prefix",
+        });
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    const dispose = armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(convergeReadyCalls).toEqual([false]);
+
+    dispose();
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[3] * 2);
+
+    expect(convergeReadyCalls).toEqual([false]);
+    expect(gate.listenerCount()).toBe(0);
   });
 });
 

--- a/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
@@ -1289,6 +1289,69 @@ describe("armLocalHostBootOnSignIn", () => {
     expect(convergeReadyCalls).toEqual([false]);
     expect(gate.listenerCount()).toBe(0);
   });
+
+  it("the disposer fences an attempt that is already in flight", async () => {
+    // `dispose()` used to clear the timer and the subscription without
+    // setting `settled` - so an attempt already in flight when it ran had its
+    // CONTINUATION land after disposal and walk straight into
+    // `scheduleRetry()`, arming a fresh timer for an actor main just tore
+    // down: a disposed actor that keeps provisioning. `dispose()` now sets
+    // `settled = true` before anything else, so that continuation's
+    // `scheduleRetry()` sees it and returns without arming.
+    //
+    // The disposal below lands INSIDE the in-flight window deterministically,
+    // not as a race the scheduler might win: `convergeReady` returns a
+    // promise this test holds the resolver for, so `dispose()` runs from the
+    // test body itself while that promise is PROVABLY still pending - only
+    // after it returns do we resolve `convergeReady` and let the
+    // continuation run.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const convergeReadyCalls: boolean[] = [];
+    let resolveConverge: (
+      outcome: MutationOutcome<ConvergeReadyOk>,
+    ) => void = () => undefined;
+    const controller: IpcHostController = {
+      ...base,
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return new Promise<MutationOutcome<ConvergeReadyOk>>((resolve) => {
+          resolveConverge = resolve;
+        });
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    const dispose = armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    // Premise: the attempt is really in flight, parked on the unresolved
+    // `convergeReady` promise - not merely about to start one.
+    expect(convergeReadyCalls).toEqual([false]);
+    expect(gate.listenerCount()).toBe(1);
+
+    dispose();
+    expect(gate.listenerCount()).toBe(0);
+
+    // The in-flight promise now resolves - straight onto the disposed actor.
+    resolveConverge({
+      kind: "failed",
+      message: "installer could not write to the prefix",
+    });
+    // WITHOUT the fix (`settled` left false by `dispose()`), this advance
+    // would let the resolved continuation's `scheduleRetry()` arm rung 0 and
+    // then fire it, producing a SECOND `convergeReady` call below.
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[3] * 2);
+
+    expect(convergeReadyCalls).toEqual([false]);
+    expect(gate.listenerCount()).toBe(0);
+  });
 });
 
 describe("applyHostUpdateMenuState", () => {

--- a/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
@@ -1290,6 +1290,67 @@ describe("armLocalHostBootOnSignIn", () => {
     expect(gate.listenerCount()).toBe(0);
   });
 
+  it("the disposer stops an attempt BEFORE it can start provisioning", async () => {
+    // The sibling test above proves a disposed actor cannot re-ARM. This one
+    // proves it cannot START: teardown landing inside the `getStatus()` round
+    // trip left the continuation free to walk on to `convergeReady`, spawning
+    // a CLI `host ensure` against a controller the app was tearing down.
+    // Recording terminal in `dispose()` alone did not cover that - the guard
+    // has to be read again AFTER the await, which is what this asserts.
+    //
+    // Deterministic, not a scheduler race: `getStatus` parks on a promise this
+    // test holds the resolver for, so `dispose()` runs from the test body
+    // while the attempt is provably inside that await.
+    vi.useFakeTimers();
+    const base = fakeHostController(
+      neverInstalled(false),
+      {
+        kind: "ok",
+        value: { appliedVersion: "1.4.1", runningActivated: true },
+      },
+      { kind: "ok", value: { activated: true } },
+    );
+    const convergeReadyCalls: boolean[] = [];
+    let statusCalls = 0;
+    let releaseStatus: (status: HostControllerStatus) => void = () => undefined;
+    const controller: IpcHostController = {
+      ...base,
+      getStatus: () => {
+        statusCalls += 1;
+        return new Promise<HostControllerStatus>((resolve) => {
+          releaseStatus = resolve;
+        });
+      },
+      convergeReady: (force: boolean) => {
+        convergeReadyCalls.push(force);
+        return Promise.resolve({
+          kind: "ok" as const,
+          value: { running: true, version: "1.4.0" },
+        });
+      },
+    };
+    const gate = fakeSignedInGate(true);
+
+    const dispose = armLocalHostBootOnSignIn(controller, gate);
+    await vi.advanceTimersByTimeAsync(0);
+    // Premise: the attempt is parked inside the status round trip, and has
+    // not yet decided anything.
+    expect(statusCalls).toBe(1);
+    expect(convergeReadyCalls).toEqual([]);
+
+    dispose();
+    // The account is STILL SIGNED IN, so nothing else in the continuation
+    // would turn it back: without the post-await guard the status below
+    // (never installed, `activation: "unavailable"`) sends it straight into
+    // `convergeReady`.
+    expect(gate.isSignedIn()).toBe(true);
+    releaseStatus(neverInstalled(false));
+    await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[3] * 2);
+
+    expect(convergeReadyCalls).toEqual([]);
+    expect(gate.listenerCount()).toBe(0);
+  });
+
   it("the disposer fences an attempt that is already in flight", async () => {
     // `dispose()` used to clear the timer and the subscription without
     // setting `settled` - so an attempt already in flight when it ran had its

--- a/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
@@ -1118,11 +1118,16 @@ describe("armLocalHostBootOnSignIn", () => {
     expect(gate.listenerCount()).toBe(0);
   });
 
-  it("a `busy` outcome is a running host and settles the arm", async () => {
-    // `busy` is the CLI's HOST_BUSY: only a LIVE host declines a byte swap, so
-    // this is a running host by the same reading the selection authority's
-    // ensure port makes elsewhere - not a resolved failure that earns a
-    // retry.
+  it("a `busy` outcome earns the next rung - it is a fail-safe, not a running host", async () => {
+    // The tempting reading is "only a LIVE host declines a byte swap", and an
+    // earlier revision of this actor settled on it. `assertHostNotBusy` raises
+    // `E_HOST_BUSY` whenever a live PID's idle state cannot be DETERMINED -
+    // `/activity` timed out, refused, answered malformed, or 404'd - which is
+    // what a WEDGED host looks like. Settling there retired this process's
+    // only retry ladder for a host that may never serve, and the authority
+    // cannot always cover it: it can only ensure a host the fleet can NAME,
+    // and an unusable enrollment record makes `readLastKnownLocalHostId`
+    // answer null outright.
     vi.useFakeTimers();
     const base = fakeHostController(
       neverInstalled(false),
@@ -1150,11 +1155,14 @@ describe("armLocalHostBootOnSignIn", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(convergeReadyCalls).toEqual([false]);
-    expect(gate.listenerCount()).toBe(0);
+    // STILL ARMED: the ladder is what a wedged host needs, so the
+    // subscription is not released here.
+    expect(gate.listenerCount()).toBe(1);
 
-    // No timer was ever scheduled - a settled arm has nothing left to fire.
+    // And the rung really fires - asserting the listener count alone would
+    // pass against an arm that kept its subscription and never acted.
     await vi.advanceTimersByTimeAsync(LOCAL_HOST_BOOT_RETRY_LADDER_MS[0]);
-    expect(convergeReadyCalls).toEqual([false]);
+    expect(convergeReadyCalls).toEqual([false, false]);
   });
 
   it("a `deferred` outcome (CLI lock held elsewhere) earns the next rung, not a sign-in wait", async () => {

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -939,7 +939,12 @@ function runDeferredBackground(state: BootState, services: AppServices): void {
 // caller is `runDesktopStartup`, and it invokes the real reconciliation that
 // determines whether a launch is allowed to apply, activate, or do nothing.
 export function runDeferred<
-  TState,
+  // Constrained to what the teardown registration below needs, and no more:
+  // the generic exists so a test can hand this a light state object, and
+  // `BootState` satisfies this shape structurally.
+  TState extends {
+    readonly bridge: { readonly disposeFns: Array<() => void> } | null;
+  },
   TServices extends {
     readonly hostController: IpcHostController;
     readonly menu: HostUpdateMenuSurface;
@@ -957,7 +962,20 @@ export function runDeferred<
   // and keeps retrying until it is (see `armLocalHostBootOnSignIn`). Arming is
   // synchronous and cheap - it either acts now or waits for the sign-in that
   // the pre-retirement renderer gate also waited for.
-  armLocalHostBootOnSignIn(services.hostController, services.signedIn);
+  //
+  // Its disposer is registered on the bridge's teardown list because the arm
+  // now owns a RETRY TIMER as well as the sign-in subscription, and a settled
+  // arm is not the only way this process ends: a shutdown while the ladder is
+  // still climbing would otherwise leave a live auth-session listener behind.
+  // The timers are `unref`ed and so can never hold the process open; this is
+  // about not leaving a subscription running through teardown. `bridge` is
+  // installed by the window phase, well before this handoff - a null here
+  // (a test plan that never built one) simply keeps today's behaviour.
+  const disposeLocalHostBoot = armLocalHostBootOnSignIn(
+    services.hostController,
+    services.signedIn,
+  );
+  state.bridge?.disposeFns.push(disposeLocalHostBoot);
   void timed("deferred", "host-launch-converge", () =>
     runLaunchHostConvergeReconcile(services.hostController, services.menu),
   );

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -42,7 +42,7 @@ import { applyQuitDecision } from "./quit-decision";
 import { RunnerIpcBridge } from "../ipc/register-runner-ipc";
 import {
   applyHostUpdateMenuState,
-  armFirstInstallOnSignIn,
+  armLocalHostBootOnSignIn,
   refreshHostRegistryIfNotRemoved,
   runLaunchHostConvergeReconcile,
   signedInGateFromAuthSession,
@@ -255,7 +255,7 @@ interface AppServices {
   readonly menu: MenuController;
   readonly windowRegistry: WindowRegistry;
   readonly zoomController: WindowZoomController;
-  /** Consent gate for the first install; see `armFirstInstallOnSignIn`. */
+  /** Consent gate for booting the local host; see `armLocalHostBootOnSignIn`. */
   readonly signedIn: SignedInGate;
 }
 
@@ -952,11 +952,12 @@ export function runDeferred<
 ): void {
   runBackground(state, services);
   // Two DIFFERENT actions, deliberately not merged. The reconciler settles the
-  // debt of a host that exists; the first install creates one that never has,
-  // and only for a signed-in user (see `armFirstInstallOnSignIn`). Arming is
+  // debt of a host that exists, once; the boot actor gets a host RUNNING -
+  // installing one that never existed if need be - only for a signed-in user,
+  // and keeps retrying until it is (see `armLocalHostBootOnSignIn`). Arming is
   // synchronous and cheap - it either acts now or waits for the sign-in that
   // the pre-retirement renderer gate also waited for.
-  armFirstInstallOnSignIn(services.hostController, services.signedIn);
+  armLocalHostBootOnSignIn(services.hostController, services.signedIn);
   void timed("deferred", "host-launch-converge", () =>
     runLaunchHostConvergeReconcile(services.hostController, services.menu),
   );

--- a/clients/desktop/src/electron-main/startup/host-launch-converge.ts
+++ b/clients/desktop/src/electron-main/startup/host-launch-converge.ts
@@ -217,9 +217,9 @@ export const LOCAL_HOST_BOOT_RETRY_LADDER_MS: readonly number[] = [
  * must not have it reinstalled underneath them.
  *
  * Returns a disposer for the subscription and any pending retry. Settles -
- * disposes itself - once a host is running (its own `convergeReady` came back
- * `ok`, or a status read shows a live runtime, or the host answered `busy`,
- * which only a live host does) or the user has removed Traycer.
+ * disposes itself - only once a host is RUNNING (its own `convergeReady` came
+ * back `ok`, or a status read shows a live runtime) or the user has removed
+ * Traycer. Notably NOT on `busy`: see the outcome branch below.
  */
 export function armLocalHostBootOnSignIn(
   hostController: IpcHostController,
@@ -338,22 +338,32 @@ export function armLocalHostBootOnSignIn(
           return;
         }
         const outcome = await hostController.convergeReady(false);
-        if (outcome.kind === "ok" || outcome.kind === "busy") {
-          // `busy` is the CLI's HOST_BUSY: a live host with active work
-          // declined a byte swap. That is a running host, which is all this
-          // actor wants - the same reading the authority's ensure port makes.
+        if (outcome.kind === "ok") {
           settle();
           log.info("[host-controller] local host boot complete", {
             kind: outcome.kind,
           });
           return;
         }
-        // A RESOLVED non-ok is not a running host. `deferred` (CLI lock held
-        // by another Traycer process), `failed`, `installed-not-converged`
-        // and `stage-fingerprint-mismatch` are ordinary return values, so
-        // they never reach the catch below - and every one of them can clear
-        // on its own, so every one of them earns the next rung. `inFlight`
-        // clears in `finally`, so nothing blocks that retry.
+        // A RESOLVED non-ok is not a running host, and `busy` is the one that
+        // argues otherwise. It reads as "a live host with active work declined
+        // a byte swap" - but `E_HOST_BUSY` is a FAIL-SAFE, raised by
+        // `assertHostNotBusy` whenever a live PID's idle state cannot be
+        // determined at all (`/activity` timed out, refused, answered
+        // malformed, or 404'd), which is exactly what a WEDGED host looks
+        // like. Settling on it retired this process's only retry ladder for a
+        // host that may never serve, and nothing downstream necessarily
+        // covers that: the authority can only ensure a host the fleet can
+        // NAME, and `readLastKnownLocalHostId` answers null outright for an
+        // UNUSABLE enrollment record - it deliberately does not fall back to
+        // `pid.json` there - so the wedge would wait for a relaunch.
+        //
+        // `deferred` (CLI lock held by another Traycer process), `failed`,
+        // `installed-not-converged` and `stage-fingerprint-mismatch` are
+        // ordinary return values too, so none of them reach the catch below -
+        // and every one of them, `busy` included, can clear on its own, so
+        // every one earns the next rung. `inFlight` clears in `finally`, so
+        // nothing blocks that retry.
         log.warn("[host-controller] local host boot did not complete", {
           kind: outcome.kind,
         });

--- a/clients/desktop/src/electron-main/startup/host-launch-converge.ts
+++ b/clients/desktop/src/electron-main/startup/host-launch-converge.ts
@@ -19,7 +19,7 @@ import type { IpcHostController } from "../ipc/runner-ipc-bridge";
 /**
  * Whether an account is signed in, and a way to hear when that changes.
  *
- * Narrow on purpose: {@link armFirstInstallOnSignIn} needs consent, not
+ * Narrow on purpose: {@link armLocalHostBootOnSignIn} needs consent, not
  * identity. Main already has this fact - the selection authority's
  * `DesktopAuthorityIdentitySource` is built from the same `authSession` - and
  * declaring the shape here keeps this module from importing the authority to
@@ -125,6 +125,262 @@ export async function refreshHostRegistryIfNotRemoved(
   applyHostUpdateMenuState(menu, status);
 }
 
+/**
+ * Backoff between attempts of {@link armLocalHostBootOnSignIn} after one that
+ * did not end with a running host. Rung 0 matches the selection authority's
+ * `LOCAL_ENSURE_RETRY_COOLDOWN_MS`, so the two process actors that can drive
+ * `convergeReady` for this machine pace their first retry the same way; the
+ * ladder then backs off to a five-minute ceiling and stays there - the retry
+ * never stops on its own, because the released desktop's local host was
+ * always brought up eventually and the user has ruled that this must not
+ * regress. Every attempt is one `host ensure` invocation: for a host whose
+ * install keeps failing that is a bounded, mostly-idle process every five
+ * minutes, and for a host that is only waiting on the user (macOS "Allow in
+ * the Background") the same register cycle the Retry button used to run.
+ */
+export const LOCAL_HOST_BOOT_RETRY_LADDER_MS: readonly number[] = [
+  30_000, 60_000, 120_000, 300_000,
+];
+
+/**
+ * BOOTING THIS MACHINE'S HOST, and the actor that owns it: install when there
+ * has never been one, start when there is one and it is not running, and keep
+ * trying - on {@link LOCAL_HOST_BOOT_RETRY_LADDER_MS} - until a host is
+ * running. Signed-in gated (below).
+ *
+ * Deliberately a SIBLING of {@link runLaunchHostConvergeReconcile} rather than
+ * an arm inside it. That reconciler's contract is "settle the debt of a host
+ * that EXISTS, once, in priority order" - its update, activation and recovery
+ * arms are all structurally unable to first-install, by their own predicates:
+ * `deriveUpdateReady` returns false outright when `installedVersion` is null,
+ * nothing is running so activation reads `"unavailable"` rather than
+ * pending/unknown, and `isUnavailableInstalledHost` requires an installed
+ * version by definition. Two tests pin that contract, and it stays true. This
+ * actor's contract is different in both halves: it does not care WHY there is
+ * no running host, and it is not one-shot. Where the two overlap - an
+ * installed host that is down at launch - both ask `convergeReady(false)`, and
+ * the controller coalesces identical in-flight intents onto one job, so the
+ * overlap costs nothing and the reconciler keeps its unavailable-first
+ * ordering against the release download.
+ *
+ * ## Why main performs it at all
+ *
+ * The RENDERER used to: a once-per-mount `convergeReady` in the local-host
+ * gate (deleted in P3.4), with a manual Retry. Redesign P1.3 retired that -
+ * correctly, because two process actors for one host is what made the ∅
+ * definition undecidable - and moved boot-time provisioning intent to the
+ * selection authority. But the authority asks through `LocalHostEnsurePort`
+ * keyed on a hostId it reads from the fleet, and the fleet reads the local id
+ * from the enrollment and pid-metadata files. Until this machine's host has
+ * RUN at least once those files do not exist, the id is null, and
+ * `requestLocalEnsureIfDown` returns on its second line. The authority cannot
+ * ask for a host that has never existed, so the intent had moved to an actor
+ * unable to exercise it in the one case where boot-time provisioning IS the
+ * point: a first launch sat on "Starting local Traycer Host…" with nothing
+ * starting.
+ *
+ * The split, stated once: getting a host RUNNING for the first time in a
+ * process lifetime here, with retry; steady-state ensure of a host the fleet
+ * can name (one that has run) in the authority - whichever host a window is
+ * pointed at, since 2026-08-19 (the local lifecycle is target-independent;
+ * only its narration is target-scoped). D14/C5's "one sanctioned process
+ * action" is untouched - that constraint scopes the AUTHORITY, which still
+ * performs exactly one.
+ *
+ * ## Why it retries on a timer, not only on a sign-in edge
+ *
+ * A first attempt can fail for reasons that clear on their own - the CLI lock
+ * held by another Traycer process (`deferred`), a download that lost the
+ * network, a service that took longer than the readiness budget, an IPC round
+ * trip that threw - and until 2026-08-19 the only thing that tried again was
+ * the next SIGN-IN edge, which for a user who stays signed in is never. The
+ * ruling that fixed this: the local host is brought up automatically, and it
+ * used to come up without anyone signing in again, so it must keep doing so.
+ * Hence the ladder. A settled arm never re-arms; a mid-session death after a
+ * successful boot is the authority's, since by then the fleet knows the id.
+ *
+ * ## Consent is the precondition, and it is not decoration
+ *
+ * Installing a background service on someone's machine is consent-bearing, and
+ * the retired renderer path was SIGN-IN GATED - `computeGateEligibility`
+ * passes through for a signed-out user, so the host was only ever installed
+ * for someone signed in and looking at a card that said so. Restoring the
+ * behaviour without that gate would not be restoring it; it would be the same
+ * action under a materially weaker precondition. Hence the wait: signed out at
+ * launch means nothing happens until an account actually signs in, which is
+ * also the pre-retirement TIMING, since the gate only mounted after sign-in. A
+ * sign-out cancels a pending retry the same way, and the next sign-in starts
+ * the ladder over from rung 0.
+ *
+ * `removedByUser` is the other half of consent and is checked at the moment of
+ * acting: a user who removed the host has `installedVersion === null` too, and
+ * must not have it reinstalled underneath them.
+ *
+ * Returns a disposer for the subscription and any pending retry. Settles -
+ * disposes itself - once a host is running (its own `convergeReady` came back
+ * `ok`, or a status read shows a live runtime, or the host answered `busy`,
+ * which only a live host does) or the user has removed Traycer.
+ */
+export function armLocalHostBootOnSignIn(
+  hostController: IpcHostController,
+  identity: SignedInGate,
+): () => void {
+  let settled = false;
+  let unsubscribe: (() => void) | null = null;
+  let retryTimer: NodeJS.Timeout | null = null;
+  let retryRung = 0;
+
+  const clearRetry = (): void => {
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const dispose = (): void => {
+    clearRetry();
+    if (unsubscribe !== null) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  };
+
+  const settle = (): void => {
+    settled = true;
+    dispose();
+  };
+
+  const scheduleRetry = (): void => {
+    // Consent is re-read for the TIMER, not only for the action: an outcome
+    // that lands alongside a sign-out (the falling edge reached the
+    // subscription while the converge was in flight) must not leave a retry
+    // ticking for an account that left. The sign-in edge is that account's
+    // retry, and it starts a fresh ladder.
+    if (settled || retryTimer !== null || !identity.isSignedIn()) return;
+    const delayMs =
+      LOCAL_HOST_BOOT_RETRY_LADDER_MS[
+        Math.min(retryRung, LOCAL_HOST_BOOT_RETRY_LADDER_MS.length - 1)
+      ];
+    retryRung += 1;
+    const timer = setTimeout(() => {
+      retryTimer = null;
+      attempt();
+    }, delayMs);
+    // The retry ladder must never be what keeps the main process alive.
+    timer.unref();
+    retryTimer = timer;
+    log.info("[host-controller] local host boot retry scheduled", { delayMs });
+  };
+
+  let inFlight = false;
+  const attempt = (): void => {
+    if (settled || inFlight) return;
+    inFlight = true;
+    void (async () => {
+      try {
+        const status = await hostController.getStatus();
+        if (status.removedByUser) {
+          log.info(
+            "[host-controller] local host boot skipped for removed host",
+          );
+          settle();
+          return;
+        }
+        if (status.activation !== "unavailable") {
+          // `unavailable` is the one activation state that means NO runtime is
+          // running (`deriveActivationState`); every other value is a live
+          // host - activated, or carrying activation debt that is the
+          // reconciler's to settle, never this actor's. Something brought it
+          // up between arming and now (a previous launch that finished late,
+          // the reconciler's recovery arm, a user at the terminal), or the
+          // retry that just fired is looking at its predecessor's success.
+          // Nothing owed. Note this is NOT `installedVersion !== null`: a host
+          // whose bytes landed but whose service never started is still owed
+          // a boot, and settling on the bytes was how a half-completed first
+          // install left a machine hostless with nothing retrying.
+          settle();
+          return;
+        }
+        if (!identity.isSignedIn()) {
+          // RE-READ AT THE MOMENT OF ACTING, because the precondition is
+          // consent and `getStatus()` above is a round trip. A sign-out
+          // landing inside that await reaches the subscription as
+          // `onChanged(false)`, which cancels any pending retry but cannot
+          // reach into this continuation - so without this line it installs
+          // a background service for an account that just left.
+          // `removedByUser` is checked one step above for the same reason:
+          // both halves of consent are read here, not at arming time.
+          //
+          // Left ARMED with NO retry scheduled: the next sign-in edge attempts
+          // again, which is exactly the timing a signed-out launch already
+          // has. A timer here would only fire into this same branch.
+          log.info("[host-controller] local host boot deferred to a sign-in");
+          return;
+        }
+        const outcome = await hostController.convergeReady(false);
+        if (outcome.kind === "ok" || outcome.kind === "busy") {
+          // `busy` is the CLI's HOST_BUSY: a live host with active work
+          // declined a byte swap. That is a running host, which is all this
+          // actor wants - the same reading the authority's ensure port makes.
+          settle();
+          log.info("[host-controller] local host boot complete", {
+            kind: outcome.kind,
+          });
+          return;
+        }
+        // A RESOLVED non-ok is not a running host. `deferred` (CLI lock held
+        // by another Traycer process), `failed`, `installed-not-converged`
+        // and `stage-fingerprint-mismatch` are ordinary return values, so
+        // they never reach the catch below - and every one of them can clear
+        // on its own, so every one of them earns the next rung. `inFlight`
+        // clears in `finally`, so nothing blocks that retry.
+        log.warn("[host-controller] local host boot did not complete", {
+          kind: outcome.kind,
+        });
+        scheduleRetry();
+      } catch (error: unknown) {
+        // A THROW is not an outcome. `settled` used to be set before this work
+        // began and the rejection had nowhere to land, so one transient IPC
+        // failure retired the only automatic boot actor for the whole
+        // process: the signed-in user stayed in the unavailable-host flow until
+        // a manual retry or a relaunch. Only a running host or a removed one
+        // settles the arm; a failure schedules the next rung.
+        log.warn("[host-controller] local host boot attempt failed", {
+          error: String(error),
+        });
+        scheduleRetry();
+      } finally {
+        inFlight = false;
+      }
+    })();
+  };
+
+  // Subscribed even when already signed in. The subscription is what a
+  // signed-out launch (and a sign-out mid-ladder) re-arms AGAINST; a
+  // successful or terminal attempt disposes it from inside.
+  unsubscribe = identity.onChanged((signedIn) => {
+    if (!signedIn) {
+      // Consent withdrawn: nothing may fire until it is given again, and when
+      // it is, the account gets a fresh ladder rather than the tail of the
+      // previous one.
+      clearRetry();
+      retryRung = 0;
+      return;
+    }
+    // A rising edge attempts at once - UNLESS a retry is already scheduled.
+    // The auth session emits `change` for every token refresh too, and each
+    // of those reaches here as `signedIn: true` while still signed in; letting
+    // them attempt would replace the ladder's pacing with the token's. A real
+    // re-login always arrives with no timer pending, because the sign-out
+    // before it cleared the one there was.
+    if (retryTimer === null) attempt();
+  });
+  if (identity.isSignedIn()) {
+    attempt();
+  }
+  return dispose;
+}
+
 // Launch-time boot reconcile (Fixup B1 + B2): converges any pre-existing
 // activation debt AND applies an eligible staged update, in the correct
 // priority order. `applyStaged`'s own no-op fast path is broader than
@@ -137,163 +393,6 @@ export async function refreshHostRegistryIfNotRemoved(
 // fakes, through the same path `runDeferred` calls - per the ticket, B1/B2
 // must be proven through the production startup wiring, not by calling
 // controller methods directly.
-/**
- * THE FIRST INSTALL, and the actor that performs it.
- *
- * Deliberately a SIBLING of {@link runLaunchHostConvergeReconcile} rather than
- * an arm inside it. That reconciler's contract is "settle the debt of a host
- * that EXISTS" - its update, activation and recovery arms are all structurally
- * unable to first-install, by their own predicates: `deriveUpdateReady`
- * returns false outright when `installedVersion` is null, nothing is running so
- * activation reads `"unavailable"` rather than pending/unknown, and
- * `isUnavailableInstalledHost` requires an installed version by definition.
- * Two tests pin that contract, and it stays true; first install is a different
- * action with a different precondition, so it gets its own entry point.
- *
- * ## Why main performs it at all
- *
- * The RENDERER used to: a once-per-mount `convergeReady` in the local-host
- * gate (deleted in P3.4). Redesign P1.3 retired that - correctly, because two
- * process actors for one host is what made the ∅ definition undecidable - and
- * moved boot-time provisioning intent to the selection authority. But the
- * authority asks through `LocalHostEnsurePort` keyed on a hostId it reads from
- * the fleet, and the fleet reads the local id from the enrollment and
- * pid-metadata files. On a first-ever start those files do not exist, the id is
- * null, and `requestLocalEnsureIfWanted` returns on its second line. The
- * authority cannot ask for a host that has never existed, so the intent had
- * moved to an actor unable to exercise it in the one case where boot-time
- * provisioning IS the point: a first launch sat on "Starting local Traycer
- * Host…" with nothing starting.
- *
- * The split, stated once: launch-time FIRST INSTALL here; selection-time
- * ensure of an existing-but-down host in the authority. D14/C5's "one
- * sanctioned process action" is untouched - that constraint scopes the
- * AUTHORITY, which still performs exactly one.
- *
- * ## Consent is the precondition, and it is not decoration
- *
- * Installing a background service on someone's machine is consent-bearing, and
- * the retired renderer path was SIGN-IN GATED - `computeGateEligibility`
- * passes through for a signed-out user, so the host was only ever installed
- * for someone signed in and looking at a card that said so. Restoring the
- * behaviour without that gate would not be restoring it; it would be the same
- * action under a materially weaker precondition. Hence the wait: signed out at
- * launch means nothing happens until an account actually signs in, which is
- * also the pre-retirement TIMING, since the gate only mounted after sign-in.
- *
- * `removedByUser` is the other half of consent and is checked at the moment of
- * acting: a user who removed the host has `installedVersion === null` too, and
- * must not have it reinstalled underneath them.
- *
- * Returns a disposer for the subscription. One-shot: the first attempt wins,
- * whether it installs or declines.
- */
-export function armFirstInstallOnSignIn(
-  hostController: IpcHostController,
-  identity: SignedInGate,
-): () => void {
-  let settled = false;
-  let unsubscribe: (() => void) | null = null;
-
-  const dispose = (): void => {
-    if (unsubscribe !== null) {
-      unsubscribe();
-      unsubscribe = null;
-    }
-  };
-
-  let inFlight = false;
-  const attempt = (): void => {
-    if (settled || inFlight) return;
-    inFlight = true;
-    void (async () => {
-      try {
-        const status = await hostController.getStatus();
-        if (status.removedByUser) {
-          log.info("[host-controller] first install skipped for removed host");
-          settled = true;
-          dispose();
-          return;
-        }
-        if (status.installedVersion !== null) {
-          // Something installed it between arming and now - a concurrent
-          // recovery arm, or a previous launch that finished late. Nothing
-          // owed.
-          settled = true;
-          dispose();
-          return;
-        }
-        if (!identity.isSignedIn()) {
-          // RE-READ AT THE MOMENT OF ACTING, because the precondition is
-          // consent and `getStatus()` above is a round trip. A sign-out
-          // landing inside that await reaches the subscription as
-          // `onChanged(false)`, which this arm ignores by design - it only
-          // acts on the rising edge - so without this line the continuation
-          // installs a background service for an account that just left.
-          // `removedByUser` is checked one step above for the same reason:
-          // both halves of consent are read here, not at arming time.
-          //
-          // Left ARMED, like every other non-terminal outcome below: the next
-          // sign-in edge attempts again, which is exactly the timing a signed
-          // -out launch already has.
-          log.info("[host-controller] first install deferred to a sign-in");
-          return;
-        }
-        const outcome = await hostController.convergeReady(false);
-        if (outcome.kind !== "ok") {
-          // A RESOLVED non-ok is not an install. `busy`, `deferred` and
-          // `failed` are ordinary return values, so they never reach the catch
-          // below - the throw fix left this half open, and `outcome.kind` was
-          // logged without ever being read. Settling here retired the only
-          // automatic first-install actor for the process and disposed the
-          // sign-in edge it would have retried from, while logging "complete"
-          // about a machine that still has no host.
-          //
-          // Left ARMED deliberately, matching the throw arm: the next sign-in
-          // edge attempts again. `inFlight` clears in `finally`, so nothing
-          // blocks that retry.
-          log.warn("[host-controller] first install did not complete", {
-            kind: outcome.kind,
-          });
-          return;
-        }
-        settled = true;
-        dispose();
-        log.info("[host-controller] first install complete", {
-          kind: outcome.kind,
-        });
-      } catch (error: unknown) {
-        // A THROW is not an outcome. `settled` used to be set before this work
-        // began and the rejection had nowhere to land, so one transient IPC
-        // failure retired the only automatic first-install actor for the whole
-        // process: the signed-in user stayed in the unavailable-host flow until
-        // a manual retry or a relaunch. Only a terminal STATUS or a completed
-        // convergence settles the arm; a failure leaves it armed, so the next
-        // sign-in edge tries again.
-        log.warn("[host-controller] first install attempt failed", {
-          error: String(error),
-        });
-      } finally {
-        inFlight = false;
-      }
-    })();
-  };
-
-  // Subscribed even when already signed in, which the immediate-attempt path
-  // used to skip. The subscription is what a contained failure re-arms
-  // AGAINST: without it, a first attempt that threw at launch had no later
-  // edge to retry from at all. A successful or terminal attempt disposes it
-  // from inside, so the one-shot contract is unchanged for every path that
-  // actually reaches an outcome.
-  unsubscribe = identity.onChanged((signedIn) => {
-    if (signedIn) attempt();
-  });
-  if (identity.isSignedIn()) {
-    attempt();
-  }
-  return dispose;
-}
-
 export async function runLaunchHostConvergeReconcile(
   hostController: IpcHostController,
   menu: HostUpdateMenuSurface,
@@ -317,13 +416,16 @@ export async function runLaunchHostConvergeReconcile(
   // host; `isUnavailableInstalledHost` is what keeps it from ever being the
   // thing that performs the first install.
   //
-  // FIRST INSTALL IS NOT MISSING - it lives in `armFirstInstallOnSignIn`
-  // above, sign-in gated, and it is deliberately NOT an arm of this
-  // reconciler. If you arrived here tracing "nothing installs a first-ever
-  // host", that is the sibling to read; the two pinned tests below
-  // ("does not provision a host that was never installed", "does not turn a
-  // failed apply into a first install") are still true and still describe
-  // THIS function.
+  // FIRST INSTALL IS NOT MISSING - it lives in `armLocalHostBootOnSignIn`
+  // above, sign-in gated and retrying, and it is deliberately NOT an arm of
+  // this reconciler. If you arrived here tracing "nothing installs a
+  // first-ever host" or "the launch converge failed once and nothing tried
+  // again", that is the sibling to read; the two pinned tests below ("does
+  // not provision a host that was never installed", "does not turn a failed
+  // apply into a first install") are still true and still describe THIS
+  // function - a one-shot reconcile. When both this arm and that actor find
+  // an installed host down at launch, both ask `convergeReady(false)` and the
+  // controller coalesces the two onto one job.
   const recovery =
     !initialStatus.updateReady && isUnavailableInstalledHost(initialStatus)
       ? await hostController.convergeReady(false)

--- a/clients/desktop/src/electron-main/startup/host-launch-converge.ts
+++ b/clients/desktop/src/electron-main/startup/host-launch-converge.ts
@@ -238,6 +238,15 @@ export function armLocalHostBootOnSignIn(
   };
 
   const dispose = (): void => {
+    // TERMINAL, and that has to be recorded BEFORE the resources go, because
+    // an attempt can be in flight right now. Clearing the timer and the
+    // subscription alone leaves `settled` false, so the continuation of an
+    // `getStatus()`/`convergeReady()` that resolves after disposal walks into
+    // `scheduleRetry()` and arms a fresh timer - a disposed actor that goes on
+    // provisioning. Reachable in production since the disposer is registered
+    // on the bridge's teardown list: a quit that lands mid-ladder is exactly
+    // this race.
+    settled = true;
     clearRetry();
     if (unsubscribe !== null) {
       unsubscribe();
@@ -245,8 +254,10 @@ export function armLocalHostBootOnSignIn(
     }
   };
 
+  // Reaching a terminal outcome and being torn down are now the SAME
+  // operation. The name is kept because the call sites below mean "this actor
+  // is done", not "someone asked it to stop".
   const settle = (): void => {
-    settled = true;
     dispose();
   };
 

--- a/clients/desktop/src/electron-main/startup/host-launch-converge.ts
+++ b/clients/desktop/src/electron-main/startup/host-launch-converge.ts
@@ -290,6 +290,15 @@ export function armLocalHostBootOnSignIn(
     void (async () => {
       try {
         const status = await hostController.getStatus();
+        // DISPOSAL RE-READ, and it belongs here for the same reason the
+        // consent re-read below does: the decision to act was taken before a
+        // round trip, and teardown can land inside it. Recording terminal in
+        // `dispose()` stops this continuation from arming another RETRY, but
+        // by itself it would let this one still reach `convergeReady` and
+        // enqueue a provisioning mutation - a CLI `host ensure` starting
+        // against a controller the app is tearing down. The check has to be
+        // before the mutation, not only after it.
+        if (settled) return;
         if (status.removedByUser) {
           log.info(
             "[host-controller] local host boot skipped for removed host",

--- a/clients/gui-app/src/components/host/host-provisioning-controller.tsx
+++ b/clients/gui-app/src/components/host/host-provisioning-controller.tsx
@@ -450,11 +450,13 @@ function useHostProvisioning(args: {
   // it reads from the fleet, and the fleet reads the local id from the
   // enrollment / pid-metadata files - so on a machine that has never had a
   // host the id is null and the authority structurally cannot ask. It owns
-  // SELECTION-TIME ensure: derivation wants the local host and that host
-  // exists but is down. The FIRST INSTALL belongs to the desktop's launch
-  // reconciler (`electron-main/startup/host-launch-converge.ts`), which is the
-  // launch-time process actor and gates on the removal sentinel. Retiring this
-  // effect without that arm left nobody installing a first-ever host.
+  // the STEADY-STATE ensure: the local host exists but is down, whichever host
+  // the window is pointed at. The FIRST BOOT belongs to the desktop's launch
+  // module (`armLocalHostBootOnSignIn` in
+  // `electron-main/startup/host-launch-converge.ts`), which is the launch-time
+  // process actor: sign-in and removal-sentinel gated, and retrying on a
+  // backoff ladder until a host runs. Retiring this effect without that arm
+  // left nobody installing a first-ever host.
   void attemptedRef;
 
   // Direct removal-sentinel check, independent of the retired one-shot

--- a/clients/gui-app/src/components/layout/__tests__/local-boot-intent.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/local-boot-intent.test.tsx
@@ -436,13 +436,14 @@ describe("local-boot intent", () => {
     // asserting otherwise would be pinning the defect the retirement removed.
     //
     // First install did not disappear with it: it is
-    // `armFirstInstallOnSignIn` in the desktop's launch reconciler
-    // (`electron-main/startup/host-launch-converge.ts`), sign-in gated and
-    // removal-sentinel gated, and it is proven THERE - in the process that
-    // actually performs it - by that module's own suite. This chain does not
-    // mount main, so a renderer test asserting a main-process action could
-    // only ever be theatre. What is genuinely this layer's to promise is that
-    // it does not act, and does not lie about the host while it waits.
+    // `armLocalHostBootOnSignIn` in the desktop's launch reconciler
+    // (`electron-main/startup/host-launch-converge.ts`), sign-in gated,
+    // removal-sentinel gated and retrying, and it is proven THERE - in the
+    // process that actually performs it - by that module's own suite. This
+    // chain does not mount main, so a renderer test asserting a main-process
+    // action could only ever be theatre. What is genuinely this layer's to
+    // promise is that it does not act, and does not lie about the host while
+    // it waits.
     const spy = buildManagementSpy();
 
     mountRealChain(spy.management, false);

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
@@ -404,7 +404,7 @@ function resolveUpdateHost(
  *    argument that the bootstrap log describes this computer. It does - and
  *    that is TRUE information under a remote-target start too: on a desktop
  *    the main process starts this machine's host whichever host is effective
- *    (`armFirstInstallOnSignIn` and `runLaunchHostConvergeReconcile` in
+ *    (`armLocalHostBootOnSignIn` and `runLaunchHostConvergeReconcile` in
  *    `clients/desktop/src/electron-main/startup/host-launch-converge.ts`
  *    consult sign-in and removal, never the selection), so the tail behind
  *    `Show details` is the log of a start that is happening right now on

--- a/clients/gui-app/src/components/settings/host-scope/__tests__/host-health.test.ts
+++ b/clients/gui-app/src/components/settings/host-scope/__tests__/host-health.test.ts
@@ -6,13 +6,13 @@ import type {
 import { deriveHostHealth } from "@/components/settings/host-scope/host-health";
 
 /**
- * `stopped` and `not-installed` are the only two health states a person can
- * ACT on — Start, or Install — and for a long time nothing could produce
- * them: `useHostScope` passed `undefined` for the installed record, so
- * `deriveStatus` could only answer `running` or nothing, and a stopped local
- * host fell through to its registry connectivity and read "Offline · last
- * seen 3h ago". True about the cloud's answer, useless to someone whose host
- * is sitting right there with a Start button one click away.
+ * `stopped` and `not-installed` are the two health states that name what this
+ * machine's own host is doing about itself — being restarted, or being
+ * installed — and for a long time nothing could produce them: `useHostScope`
+ * passed `undefined` for the installed record, so `deriveStatus` could only
+ * answer `running` or nothing, and a stopped local host fell through to its
+ * registry connectivity and read "Offline · last seen 3h ago". True about the
+ * cloud's answer, useless to someone whose host is sitting right there.
  *
  * Nothing covered `deriveHostHealth` at all, which is how that shipped.
  */

--- a/clients/gui-app/src/components/settings/host-scope/use-host-options.ts
+++ b/clients/gui-app/src/components/settings/host-scope/use-host-options.ts
@@ -161,11 +161,12 @@ export function useHostOptions(): HostOptions {
   }, [directory, binding]);
 
   // The installed record is what separates "stopped" from "not installed" — the
-  // two local states a person can actually act on. Without it `deriveStatus`
-  // can only answer `running` or `undefined`, and a stopped local host falls
-  // through to its registry lease and reads "Offline · last seen 3h ago": true
-  // of the lease, useless to someone whose host is sitting there stopped with a
-  // Start button one click away.
+  // two local states worth telling apart (one is being restarted for the user,
+  // the other installed; a removed one gets Reinstall). Without it
+  // `deriveStatus` can only answer `running` or `undefined`, and a stopped
+  // local host falls through to its registry lease and reads "Offline · last
+  // seen 3h ago": true of the lease, useless to someone whose host is sitting
+  // right there on this machine.
   //
   // Same query key as the Host panel's, so the two share one request rather
   // than doubling it, and `enabled` keeps shells without the CLI bridge on the

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
@@ -1,0 +1,216 @@
+// `LocalHostDownActions` is the header cluster `HostOverviewPanel` renders
+// for THIS machine's own host when it is unreachable and the shell has a CLI
+// bridge. There is no Start verb (decision 2026-08-19): the local host's
+// lifecycle is automatic and target-independent, so all that remains is a
+// "Run doctor" button (disabled while this machine's lifecycle lane is busy)
+// and, only after the user has removed Traycer, a "Reinstall Traycer" escape
+// hatch that clears the removal sentinel and converges.
+
+// Same boundary as the sibling Overview suites: mock `useHostScope` and
+// `@/lib/host`'s `useHostBinding` rather than standing up a host runtime.
+const scopeOverrides = vi.hoisted((): { current: Record<string, unknown> } => ({
+  current: {},
+}));
+vi.mock("@/components/settings/host-scope/use-host-scope", async () => {
+  const { hostScopeFixture } =
+    await import("@/components/settings/host-scope/host-scope-fixture");
+  return {
+    useHostScope: () => hostScopeFixture(scopeOverrides.current),
+  };
+});
+
+const hostBindingMock = vi.hoisted(
+  (): { current: { readonly hostClient: unknown } | null } => ({
+    current: null,
+  }),
+);
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return { ...actual, useHostBinding: () => hostBindingMock.current };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { resetNegotiatedManifests } from "@traycer-clients/shared/host-transport/negotiated-manifest-registry";
+import type {
+  ConvergeReadyOk,
+  IHostManagement,
+  IRunnerHost,
+  MutationOutcome,
+} from "@traycer-clients/shared/platform/runner-host";
+import { hostScopeOptionFixture } from "@/components/settings/host-scope/host-scope-fixture";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { HostSettingsPanel } from "@/components/settings/panels/host-settings-panel";
+import { buildOverviewManagement } from "@/components/settings/panels/__tests__/host-overview-test-support";
+
+afterEach(() => {
+  cleanup();
+  resetNegotiatedManifests();
+  scopeOverrides.current = {};
+  hostBindingMock.current = null;
+});
+
+/**
+ * Renders `HostSettingsPanel` scoped to THIS machine's own host, affirmatively
+ * down: `status: "unreachable"`, a local-machine host fixture with no live
+ * client, and a CLI bridge (`hostManagement`) so `LocalHostDownActions` is the
+ * header cluster that mounts. `localHost: null` on the mock runner host mirrors
+ * the down process — no live snapshot to answer with.
+ */
+function renderLocalDown(options: {
+  readonly settingUp: boolean;
+  readonly management: IHostManagement;
+  readonly name: string;
+}): void {
+  const hostId = "host-local-down";
+  scopeOverrides.current = {
+    host: hostScopeOptionFixture({
+      hostId,
+      name: options.name,
+      isLocalMachine: true,
+      connectable: false,
+      settingUp: options.settingUp,
+    }),
+    hostId,
+    status: "unreachable",
+    client: null,
+  };
+  hostBindingMock.current = null;
+
+  const runnerHost: IRunnerHost = new MockRunnerHost({
+    signInUrl: "https://example.invalid/signin",
+    authnBaseUrl: "https://example.invalid",
+    // No live snapshot — this machine's host is down, which is the whole
+    // scenario under test.
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+    hostManagement: options.management,
+  });
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={runnerHost}>
+        <HostSettingsPanel />
+      </RunnerHostProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Overview — this machine's own host, down (LocalHostDownActions)", () => {
+  it("a down local host offers Run doctor and no Start verb", async () => {
+    const management = buildOverviewManagement({
+      getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
+    });
+    renderLocalDown({ settingUp: false, management, name: "This Mac" });
+
+    const doctorButton = await screen.findByTestId(
+      "host-overview-recovery-doctor",
+    );
+    expect(doctorButton.hasAttribute("disabled")).toBe(false);
+    expect(screen.queryByTestId("host-overview-start-local")).toBeNull();
+    expect(screen.queryByTestId("host-overview-reinstall-local")).toBeNull();
+    // No Start verb anywhere on the page — not merely absent under its old
+    // test id.
+    expect(screen.queryByText("Start host")).toBeNull();
+  });
+
+  it("Run doctor is locked while this machine's lifecycle lane is busy", async () => {
+    const management = buildOverviewManagement({
+      getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
+    });
+    renderLocalDown({ settingUp: true, management, name: "This Mac" });
+
+    const doctorButton = await screen.findByTestId(
+      "host-overview-recovery-doctor",
+    );
+    expect(doctorButton.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("a removed host gets Reinstall Traycer, which clears the sentinel and converges", async () => {
+    // Captures the ORDER the two bridge calls actually land in, not merely
+    // that both happened — `reinstall()` chains `convergeReady` off
+    // `clearRemoval`'s resolution, and that is the behaviour worth pinning.
+    const callOrder: string[] = [];
+    const clearRemoval = vi.fn((): Promise<void> =>
+      Promise.resolve().then(() => {
+        callOrder.push("clearRemoval");
+      }),
+    );
+    const convergeReady = vi.fn(
+      (force: boolean): Promise<MutationOutcome<ConvergeReadyOk>> => {
+        void force;
+        callOrder.push("convergeReady");
+        return Promise.resolve({
+          kind: "ok",
+          value: { running: true, version: "1.5.0" },
+        });
+      },
+    );
+    const management = buildOverviewManagement({
+      getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: true })),
+      clearRemoval,
+      convergeReady,
+    });
+    renderLocalDown({ settingUp: false, management, name: "This Mac" });
+
+    // The removal read is async (the sentinel query starts disabled-shaped
+    // and resolves after mount), so the button only appears once it settles.
+    const reinstallButton = await screen.findByTestId(
+      "host-overview-reinstall-local",
+    );
+    fireEvent.click(reinstallButton);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Reinstalling Traycer on This Mac…",
+      );
+    });
+
+    expect(clearRemoval).toHaveBeenCalledTimes(1);
+    expect(convergeReady).toHaveBeenCalledWith(false);
+    expect(callOrder).toEqual(["clearRemoval", "convergeReady"]);
+  });
+
+  it("a NOT-removed down host gets no Reinstall", async () => {
+    const getRemovalState = vi.fn(() =>
+      Promise.resolve({ removedByUser: false }),
+    );
+    const management = buildOverviewManagement({ getRemovalState });
+    renderLocalDown({ settingUp: false, management, name: "This Mac" });
+
+    await screen.findByTestId("host-overview-recovery-doctor");
+    // Let the removal-state query actually settle before trusting the
+    // absence below — otherwise a still-pending query would pass this
+    // assertion for the wrong reason.
+    await waitFor(() => {
+      expect(getRemovalState).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("host-overview-reinstall-local")).toBeNull();
+    });
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
@@ -213,4 +213,80 @@ describe("Overview — this machine's own host, down (LocalHostDownActions)", ()
       expect(screen.queryByTestId("host-overview-reinstall-local")).toBeNull();
     });
   });
+
+  it("a reinstall whose converge fails keeps the verb, because the sentinel is already cleared", async () => {
+    // `useRunnerReinstallTraycer` clears the removal sentinel FIRST and only
+    // THEN converges (`use-runner-reinstall-traycer-mutation.ts`). A converge
+    // that RESOLVES non-ok is turned into a REJECTION by the mutation itself
+    // (`throw new Error(outcome.message)`), but the sentinel clear already
+    // landed - and `onSettled` refetches the removal-state query regardless
+    // of the mutation's outcome. Before the fix, `removalRepairable` gated on
+    // `removed` alone, so that refetch (now `removedByUser: false`) dropped
+    // the only affordance a machine with no host had left. The cluster now
+    // also renders on `reinstall.isError`, so the verb survives its own
+    // failure.
+    //
+    // The fixture models the real persisted sentinel across that refetch: the
+    // FIRST `getRemovalState` read (the down state that shows the button in
+    // the first place) says `removedByUser: true`; every read after
+    // (`clearRemoval` having actually run) says `false`.
+    // No initial implementation: what call 1 vs. call 2+ answer is owned
+    // entirely by the two lines below, not by a constructor default that
+    // would be shadowed by them anyway.
+    const getRemovalState =
+      vi.fn<() => Promise<{ readonly removedByUser: boolean }>>();
+    getRemovalState.mockResolvedValueOnce({ removedByUser: true });
+    getRemovalState.mockResolvedValue({ removedByUser: false });
+    const clearRemoval = vi.fn((): Promise<void> => Promise.resolve());
+    const convergeReady = vi.fn(
+      (force: boolean): Promise<MutationOutcome<ConvergeReadyOk>> => {
+        void force;
+        return Promise.resolve({
+          kind: "failed",
+          message: "installer could not write to the prefix",
+        });
+      },
+    );
+    const management = buildOverviewManagement({
+      getRemovalState,
+      clearRemoval,
+      convergeReady,
+    });
+    renderLocalDown({ settingUp: false, management, name: "This Mac" });
+
+    const reinstallButton = await screen.findByRole("button", {
+      name: "Reinstall Traycer",
+    });
+    fireEvent.click(reinstallButton);
+
+    // Premise: the converge really ran and really came back non-ok - which is
+    // what turns the mutation into a rejection and raises the error toast
+    // below, rather than the success path the earlier test in this file
+    // pins.
+    await waitFor(() => {
+      expect(convergeReady).toHaveBeenCalledWith(false);
+    });
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't reinstall Traycer on This Mac.",
+        expect.objectContaining({
+          description: "installer could not write to the prefix",
+        }),
+      );
+    });
+
+    // The refetch actually happened - not merely that the button never left,
+    // which would pass just as happily against a query that stayed disabled
+    // and never re-read the sentinel at all.
+    await waitFor(() => {
+      expect(getRemovalState.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    await waitFor(() => {
+      const stillThere = screen.getByRole<HTMLButtonElement>("button", {
+        name: "Reinstall Traycer",
+      });
+      expect(stillThere.disabled).toBe(false);
+    });
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
@@ -127,10 +127,10 @@ describe("Overview — this machine's own host, down (LocalHostDownActions)", ()
     });
     renderLocalDown({ settingUp: false, management, name: "This Mac" });
 
-    const doctorButton = await screen.findByTestId(
-      "host-overview-recovery-doctor",
-    );
-    expect(doctorButton.hasAttribute("disabled")).toBe(false);
+    const doctorButton = await screen.findByRole<HTMLButtonElement>("button", {
+      name: "Run doctor",
+    });
+    expect(doctorButton.disabled).toBe(false);
     expect(screen.queryByTestId("host-overview-start-local")).toBeNull();
     expect(screen.queryByTestId("host-overview-reinstall-local")).toBeNull();
     // No Start verb anywhere on the page — not merely absent under its old
@@ -144,10 +144,10 @@ describe("Overview — this machine's own host, down (LocalHostDownActions)", ()
     });
     renderLocalDown({ settingUp: true, management, name: "This Mac" });
 
-    const doctorButton = await screen.findByTestId(
-      "host-overview-recovery-doctor",
-    );
-    expect(doctorButton.hasAttribute("disabled")).toBe(true);
+    const doctorButton = await screen.findByRole<HTMLButtonElement>("button", {
+      name: "Run doctor",
+    });
+    expect(doctorButton.disabled).toBe(true);
   });
 
   it("a removed host gets Reinstall Traycer, which clears the sentinel and converges", async () => {
@@ -179,9 +179,9 @@ describe("Overview — this machine's own host, down (LocalHostDownActions)", ()
 
     // The removal read is async (the sentinel query starts disabled-shaped
     // and resolves after mount), so the button only appears once it settles.
-    const reinstallButton = await screen.findByTestId(
-      "host-overview-reinstall-local",
-    );
+    const reinstallButton = await screen.findByRole("button", {
+      name: "Reinstall Traycer",
+    });
     fireEvent.click(reinstallButton);
 
     await waitFor(() => {
@@ -202,7 +202,7 @@ describe("Overview — this machine's own host, down (LocalHostDownActions)", ()
     const management = buildOverviewManagement({ getRemovalState });
     renderLocalDown({ settingUp: false, management, name: "This Mac" });
 
-    await screen.findByTestId("host-overview-recovery-doctor");
+    await screen.findByRole("button", { name: "Run doctor" });
     // Let the removal-state query actually settle before trusting the
     // absence below — otherwise a still-pending query would pass this
     // assertion for the wrong reason.

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-down.test.tsx
@@ -39,6 +39,7 @@ vi.mock("sonner", () => ({
 }));
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -287,6 +288,111 @@ describe("Overview — this machine's own host, down (LocalHostDownActions)", ()
         name: "Reinstall Traycer",
       });
       expect(stillThere.disabled).toBe(false);
+    });
+  });
+
+  it("a second reinstall attempt keeps the button mounted while it is in flight", async () => {
+    // `removalRepairable` used to read `removed || reinstall.isError` alone.
+    // The FIRST attempt never exposes the missing `isPending` term: `removed`
+    // stays true until the removal-state refetch lands, so the button
+    // survives on that alone regardless of `isError`. It takes a SECOND click
+    // to expose the hole - by then the refetch has landed (`removed: false`),
+    // and starting a new attempt resets `reinstall.isError` back to false the
+    // instant it goes pending. With `isPending` missing from the disjunction,
+    // every term is false and the whole cluster - the Button, its testid, its
+    // own inline spinner - unmounts for the length of the retry. The fix
+    // (`host-overview-panel.tsx`'s `removalRepairable`) adds
+    // `reinstall.isPending` back into the disjunction; without it, the
+    // `getByRole` lookup below the second click finds no button at all.
+    const getRemovalState =
+      vi.fn<() => Promise<{ readonly removedByUser: boolean }>>();
+    getRemovalState.mockResolvedValueOnce({ removedByUser: true });
+    getRemovalState.mockResolvedValue({ removedByUser: false });
+    const clearRemoval = vi.fn((): Promise<void> => Promise.resolve());
+
+    // The SECOND convergeReady call is parked on this gate so the test can
+    // assert the retry is provably still in flight before letting it finish -
+    // the same manually-released-promise idiom
+    // `host-overview-mutations.test.tsx` uses for its arm-time-capture suite.
+    // The first call resolves immediately to a failure, exactly like the
+    // sibling test above.
+    let releaseSecondConverge: (() => void) | null = null;
+    const secondConvergeGate = new Promise<void>((resolve) => {
+      releaseSecondConverge = resolve;
+    });
+    let convergeCalls = 0;
+    const convergeReady = vi.fn(
+      async (force: boolean): Promise<MutationOutcome<ConvergeReadyOk>> => {
+        void force;
+        convergeCalls += 1;
+        if (convergeCalls === 1) {
+          return {
+            kind: "failed",
+            message: "installer could not write to the prefix",
+          };
+        }
+        await secondConvergeGate;
+        return { kind: "ok", value: { running: true, version: "1.5.0" } };
+      },
+    );
+    const management = buildOverviewManagement({
+      getRemovalState,
+      clearRemoval,
+      convergeReady,
+    });
+    renderLocalDown({ settingUp: false, management, name: "This Mac" });
+
+    const reinstallButton = await screen.findByRole("button", {
+      name: "Reinstall Traycer",
+    });
+    fireEvent.click(reinstallButton);
+
+    // Let the first attempt fully settle, including its refetch - `removed`
+    // really is false now, not merely "hasn't answered yet".
+    await waitFor(() => {
+      expect(convergeReady).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(getRemovalState.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't reinstall Traycer on This Mac.",
+        expect.objectContaining({
+          description: "installer could not write to the prefix",
+        }),
+      );
+    });
+
+    const retryButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Reinstall Traycer",
+    });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(convergeReady).toHaveBeenCalledTimes(2);
+    });
+    // The retry is provably still in flight - parked on the gate above, not
+    // merely fast enough to have already finished - and the button must
+    // still be in the DOM, disabled by `busy` (which includes
+    // `reinstall.isPending`).
+    await waitFor(() => {
+      const stillMounted = screen.getByRole<HTMLButtonElement>("button", {
+        name: "Reinstall Traycer",
+      });
+      expect(stillMounted.disabled).toBe(true);
+    });
+
+    // Let the retry finish so no unhandled rejection is left dangling past
+    // the end of the test.
+    await act(async () => {
+      releaseSecondConverge?.();
+      await secondConvergeGate;
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Reinstalling Traycer on This Mac…",
+      );
     });
   });
 });

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -1033,7 +1033,14 @@ function LocalHostDownActions(props: {
   // main's boot actor settled at launch on the sentinel it saw then. Keeping
   // the button on `isError` makes the retry the user's to take now; the next
   // launch sees a cleared sentinel and boots on the ladder without them.
-  const removalRepairable = removed || reinstall.isError;
+  //
+  // `isPending` is in here for the RETRY, and its absence was a real hole: a
+  // second click flips the mutation error -> pending, so with the sentinel
+  // already cleared BOTH other terms go false and the button unmounted for
+  // the length of the attempt - taking its own spinner with it. The first
+  // attempt never showed that, because `removed` is still true until the
+  // sentinel refetch lands, which is why it needs its own test.
+  const removalRepairable = removed || reinstall.isError || reinstall.isPending;
   const busy = props.settingUp || reinstall.isPending;
   return (
     <div className="flex shrink-0 items-center gap-1.5">

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -43,6 +43,8 @@ import {
 import { persistedDraftFromIdentity } from "@/components/settings/panels/host-settings-panel-model";
 import { LocalPackageManagerUpgradeHint } from "@/components/settings/panels/host-settings-package-manager-upgrade-hint";
 import { useRunnerConvergeReady } from "@/hooks/runner/use-runner-converge-ready-mutation";
+import { useRunnerHostRemovalStateQuery } from "@/hooks/runner/use-runner-host-removal-state-query";
+import { useRunnerReinstallTraycer } from "@/hooks/runner/use-runner-reinstall-traycer-mutation";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import {
@@ -175,16 +177,17 @@ export function HostOverviewPanel(props: {
   // fires against the ambient host and caches the answer under this page's key,
   // however well a gate hides the result.
   const usable = isHostScopeUsable(scope.status) && client !== null;
-  // THIS machine's host, affirmatively down, with the bridge right here to
-  // revive it. The one state where the RPC-only rule would strand a user: the
-  // page can describe the host from the registry but nothing on it could
-  // start the process back up. `unreachable` only — while `connecting` the
-  // route may still resolve, and offering Start against a host that is about
-  // to answer would race the very process it spawns. This is what remains of
-  // the recovery console's Start/doctor half (its uninstall half lives on the
-  // empty-account path); the app-level gate draws no recovery card of its own
-  // any more, so Settings cannot delegate this state upstream.
-  const localRecovery =
+  // THIS machine's host, affirmatively down, with the bridge right here.
+  // `unreachable` only — while `connecting` the route may still resolve. What
+  // this state gets is NOT a Start verb: this machine's host is brought back
+  // automatically whichever host the window is pointed at (the desktop's
+  // launch reconciler and retrying boot actor, the selection authority's
+  // ensure, the health monitor's crash respawn, the OS service manager), so a
+  // button here was a second actor for the same process and read as "the app
+  // forgot to start my host". It gets the bridge doctor, and — in the one
+  // state the automation deliberately leaves alone, the user having removed
+  // Traycer from this computer — the consent-reversing Reinstall.
+  const localDown =
     scope.status === "unreachable" &&
     (host?.isLocalMachine ?? false) &&
     props.hasLocalBridge;
@@ -620,14 +623,15 @@ export function HostOverviewPanel(props: {
   // already says the host cannot be reached — and "disabled" would wrongly
   // imply a capability verdict rather than a connectivity one. What survives
   // an outage is the account-backed half below: the update policy, which
-  // needs no route at all. The ONE exception is this computer's own stopped
-  // host, whose revival verbs run over the CLI bridge and need no route by
-  // construction.
+  // needs no route at all. The ONE exception is this computer's own down
+  // host, whose doctor (and, after a removal, Reinstall) run over the CLI
+  // bridge and need no route by construction.
   let headerActions: ReactNode = null;
-  if (localRecovery) {
+  if (localDown) {
     headerActions = (
-      <LocalHostRecoveryActions
+      <LocalHostDownActions
         hostName={displayName}
+        settingUp={host.settingUp}
         onOpenDoctor={() => setDoctorOpen(true)}
       />
     );
@@ -910,7 +914,7 @@ export function HostOverviewPanel(props: {
           // report this machine's bridge produces IS about the machine the
           // page names — the misattribution the rpc-only rule guards against
           // cannot happen when the subject is this computer.
-          localRecovery
+          localDown
             ? { kind: "bridge" }
             : {
                 kind: "rpc",
@@ -942,8 +946,9 @@ export function HostOverviewPanel(props: {
  *
  * The lane is `convergeReady({ force: true })` — the SAME mutation and the same
  * `runnerMutationKeys.hostConvergeReady()` key the window modal's "Update host"
- * drives through `forceProvisioning`, and the same one `LocalHostRecoveryActions`
- * below uses with `force: false`. So a click here is narrated by the existing
+ * drives through `forceProvisioning`, and the same one `LocalHostDownActions`
+ * below drives (with `force: false`) for a Reinstall. So a click here is
+ * narrated by the existing
  * actor-agnostic progress lane ("Applying the host update…") with no second
  * observer and no new key; nothing about this surface needed a mechanism of its
  * own, which is why it does not have one.
@@ -984,59 +989,80 @@ export function HostUpdateRequiredSlot(props: {
 /**
  * The header cluster for this computer's host when it is affirmatively DOWN.
  *
- * Two verbs, both bridge-backed and so both honest without a route: Start
- * (`convergeReady` — install + register + start, the same intent the post-auth
- * gate uses) and the bridge doctor. Success needs no explicit refresh here:
- * the host coming up flips the scope status through its ordinary reactivity
- * and the live cluster replaces this one.
+ * NO START VERB, by decision (2026-08-19). The local host's lifecycle is
+ * automatic and independent of which host a window is pointed at: launch
+ * converge and the retrying boot actor (main), the selection authority's
+ * ensure, the health monitor's crash respawn, and the OS service manager
+ * between them bring this machine's host back. A Start button here was a
+ * second process actor for the same host and read as "the app forgot to start
+ * my host" - which is exactly how it was reported. Two things remain, both
+ * bridge-backed and so both honest without a route:
+ *
+ *  - REINSTALL, only when the user removed Traycer from this computer. That is
+ *    the one down state the automation deliberately leaves alone (consent),
+ *    and the danger-zone dialog promises "you can reinstall anytime from
+ *    Settings" - this is where. It clears the removal sentinel and converges;
+ *    `convergeReady` under the sentinel short-circuits `ok {running:false}`
+ *    without installing, which is why the old Start button was a silent no-op
+ *    in precisely this state (`useRunnerReinstallTraycer` does both steps).
+ *  - the bridge doctor, which diagnoses without a route. Disabled while this
+ *    machine's lifecycle lane is busy (`settingUp`, actor-agnostic): a CLI
+ *    inspecting an installation the converge is mid-rewrite reports (and
+ *    offers to fix) states that are simply "not done yet".
+ *
+ * Success needs no explicit refresh here: the host coming up flips the scope
+ * status through its ordinary reactivity and the live cluster replaces this
+ * one.
  */
-function LocalHostRecoveryActions(props: {
+function LocalHostDownActions(props: {
   readonly hostName: string;
+  readonly settingUp: boolean;
   readonly onOpenDoctor: () => void;
 }): ReactNode {
-  const convergeReady = useRunnerConvergeReady();
+  const management = useRunnerHostOrNull()?.hostManagement ?? null;
+  const removal = useRunnerHostRemovalStateQuery({
+    enabled: management !== null,
+  });
+  const reinstall = useRunnerReinstallTraycer();
+  const removed = removal.data?.removedByUser === true;
+  const busy = props.settingUp || reinstall.isPending;
   return (
     <div className="flex shrink-0 items-center gap-1.5">
-      <Button
-        type="button"
-        variant="default"
-        size="sm"
-        disabled={convergeReady.isPending}
-        data-testid="host-overview-start-local"
-        onClick={() => {
-          convergeReady.mutate(
-            { force: false },
-            {
+      {removed ? (
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          disabled={busy}
+          data-testid="host-overview-reinstall-local"
+          onClick={() => {
+            reinstall.mutate(undefined, {
               onSuccess: () => {
-                toast.success(`Starting ${props.hostName}…`);
+                toast.success(`Reinstalling Traycer on ${props.hostName}…`);
               },
               onError: (error) =>
                 toastFromRunnerError(
                   error,
-                  `Couldn't start ${props.hostName}.`,
+                  `Couldn't reinstall Traycer on ${props.hostName}.`,
                 ),
-            },
-          );
-        }}
-      >
-        {convergeReady.isPending ? (
-          <AgentSpinningDots
-            className="mr-2 size-3"
-            testId={undefined}
-            variant={undefined}
-          />
-        ) : null}
-        Start host
-      </Button>
+            });
+          }}
+        >
+          {reinstall.isPending ? (
+            <AgentSpinningDots
+              className="mr-2 size-3"
+              testId={undefined}
+              variant={undefined}
+            />
+          ) : null}
+          Reinstall Traycer
+        </Button>
+      ) : null}
       <Button
         type="button"
         variant="outline"
         size="sm"
-        // Same overlap rule as the live host's page-wide gate: opening the
-        // sheet mounts a doctor card that dispatches immediately, and a CLI
-        // inspecting the installation converge is mid-rewrite would report
-        // (and offer to fix) states that are simply "not done yet".
-        disabled={convergeReady.isPending}
+        disabled={busy}
         data-testid="host-overview-recovery-doctor"
         onClick={props.onOpenDoctor}
       >

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -1025,10 +1025,19 @@ function LocalHostDownActions(props: {
   });
   const reinstall = useRunnerReinstallTraycer();
   const removed = removal.data?.removedByUser === true;
+  // The verb SURVIVES ITS OWN FAILURE. `reinstall` clears the removal
+  // sentinel first and converges second, so a converge that comes back
+  // `failed`/`deferred` leaves the sentinel already cleared - `removed` flips
+  // to false, and this cluster would drop the only affordance for a machine
+  // that still has no host. Nothing else picks it up in this session either:
+  // main's boot actor settled at launch on the sentinel it saw then. Keeping
+  // the button on `isError` makes the retry the user's to take now; the next
+  // launch sees a cleared sentinel and boots on the ladder without them.
+  const removalRepairable = removed || reinstall.isError;
   const busy = props.settingUp || reinstall.isPending;
   return (
     <div className="flex shrink-0 items-center gap-1.5">
-      {removed ? (
+      {removalRepairable ? (
         <Button
           type="button"
           variant="default"

--- a/clients/gui-app/src/components/settings/settings-sidebar.tsx
+++ b/clients/gui-app/src/components/settings/settings-sidebar.tsx
@@ -135,14 +135,20 @@ function SettingsSidebarHostPicker(props: {
         onRetryLists={scope.retryLists}
       />
       {/* Said at rest, not on discovery: sections describing a host that is
-          NOT the one this window runs on is the single most confusing state
-          this surface can be in, so it never waits to be noticed. */}
+          NOT the app's active one is the single most confusing state this
+          surface can be in, so it never waits to be noticed.
+
+          "Active host", not "this window runs on": `activeHost` is the
+          app-wide EFFECTIVE host, and after a failover or an explicit pick
+          that can be a machine across the room - a developer on their laptop
+          read "this window runs on <their iMac>" as a claim about the
+          computer in front of them. */}
       {scope.host === null || scope.isViewingActive ? null : (
         <p
           className="px-1 text-[0.6875rem] leading-snug text-muted-foreground/80"
           data-testid="settings-host-viewing-note"
         >
-          Viewing — this window runs on{" "}
+          Viewing — the active host is{" "}
           {scope.activeHost?.name ?? "another host"}.
         </p>
       )}

--- a/clients/gui-app/src/hooks/runner/__tests__/use-runner-reinstall-traycer-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/runner/__tests__/use-runner-reinstall-traycer-mutation.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  MockRunnerHost,
+  MockTraycerCli,
+} from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type {
+  ConvergeReadyOk,
+  IHostManagement,
+  IRunnerHost,
+  ITraycerCli,
+  MutationOutcome,
+} from "@traycer-clients/shared/platform/runner-host";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { RunnerHostContext } from "@/providers/runner-host-context";
+import { runnerQueryKeys } from "@/lib/query-keys";
+import { buildOverviewManagement } from "@/components/settings/panels/__tests__/host-overview-test-support";
+import { useRunnerReinstallTraycer } from "../use-runner-reinstall-traycer-mutation";
+
+/**
+ * `useRunnerReinstallTraycer` at the HOOK level, because the invalidations it
+ * owes are not observable from the Overview panel: the only query mounted
+ * there on `hostInstalledRecord` is the empty-account recovery zone, whose
+ * `enabled` requires `scope.host === null` - the exact opposite of the
+ * down-local scenario the Reinstall verb renders in, and `traycerCli` is
+ * `undefined` in those fixtures besides. A UI-level assertion on either key
+ * would pass no matter what this hook did, so it is made here against the
+ * cache itself.
+ */
+function createManagement(
+  outcome: MutationOutcome<ConvergeReadyOk>,
+): IHostManagement {
+  return buildOverviewManagement({
+    getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: true })),
+    clearRemoval: vi.fn(() => Promise.resolve()),
+    convergeReady: vi.fn(() => Promise.resolve(outcome)),
+  });
+}
+
+function createWrapper(options: {
+  readonly management: IHostManagement;
+  readonly traycerCli: ITraycerCli;
+  readonly queryClient: QueryClient;
+}): (props: { readonly children: ReactNode }) => ReactNode {
+  const host: IRunnerHost = new MockRunnerHost({
+    signInUrl: "https://auth.traycer.test/sign-in",
+    authnBaseUrl: "https://auth.traycer.test",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: options.traycerCli,
+    hostManagement: options.management,
+  });
+  return function ReinstallWrapper(props: { readonly children: ReactNode }) {
+    return (
+      <QueryClientProvider client={options.queryClient}>
+        <RunnerHostContext.Provider value={host}>
+          {props.children}
+        </RunnerHostContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useRunnerReinstallTraycer", () => {
+  it("refreshes install state after a converge that FAILED with the bytes already committed", async () => {
+    // `installed-not-converged` says in as many words that the install
+    // committed and only the post-commit service invariant failed. The
+    // mutation still rejects, so while these invalidations lived in
+    // `onSuccess` they never ran for it, and Settings went on reporting "Not
+    // installed" for a machine whose bytes had landed.
+    //
+    // Without the move to `onSettled`, the two assertions after the removal
+    // one below fail: the sentinel key would be the ONLY entry dropped.
+    const management = createManagement({
+      kind: "installed-not-converged",
+      message: "the service did not come up after the swap",
+    });
+    const traycerCli: ITraycerCli = new MockTraycerCli();
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(useRunnerReinstallTraycer, {
+      wrapper: createWrapper({ management, traycerCli, queryClient }),
+    });
+
+    await expect(result.current.mutateAsync()).rejects.toThrow(
+      "the service did not come up after the swap",
+    );
+
+    // The sentinel read: already `onSettled` before this change, asserted
+    // here as the POSITIVE CONTROL. If the mutation had not run its settle
+    // handler at all, this would fail too - which is what separates "the fix
+    // works" from "nothing invalidated anything".
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: runnerQueryKeys.hostRemovalState(management),
+      });
+    });
+    // Keyed on the management/CLI INSTANCE, so these assert the exact cache
+    // entries a landed install changes - not merely that something was
+    // invalidated some number of times.
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: runnerQueryKeys.hostInstalledRecord(management),
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),
+    });
+  });
+});

--- a/clients/gui-app/src/hooks/runner/__tests__/use-runner-reinstall-traycer-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/runner/__tests__/use-runner-reinstall-traycer-mutation.test.tsx
@@ -65,6 +65,62 @@ function createWrapper(options: {
 }
 
 describe("useRunnerReinstallTraycer", () => {
+  it("rejects a BUSY converge - nothing was reinstalled, and busy is a fail-safe", async () => {
+    // `busy` is the CLI declining to swap the bytes of a live host, so the
+    // reinstall did not happen - and `E_HOST_BUSY` is raised as a FAIL-SAFE
+    // whenever a live PID's idle state cannot be determined at all, so it is
+    // not even evidence the host serves. A leftover process from the removal
+    // is exactly that case. Resolving it ran the success toast and, with the
+    // sentinel now cleared, left `isError` false - which is what takes the
+    // Reinstall verb off the page for a computer that still has no host.
+    const management = createManagement({
+      kind: "busy",
+      continuation: "retry-with-force",
+      message: "The running host has work in progress",
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const { result } = renderHook(useRunnerReinstallTraycer, {
+      wrapper: createWrapper({
+        management,
+        traycerCli: new MockTraycerCli(),
+        queryClient,
+      }),
+    });
+
+    await expect(result.current.mutateAsync()).rejects.toThrow(
+      "The running host has work in progress",
+    );
+  });
+
+  it("rejects an ok converge that started NO host - the sentinel clear did not take", async () => {
+    // `ok` with `running: false` is `HostController.convergeReady`'s removal
+    // -sentinel short-circuit, which after `clearRemoval` means the clear did
+    // not land: the converge did nothing, under consent that was supposed to
+    // have been revoked. Same shape as the `busy` case above and the ensure
+    // port's, and the same rule - an `ok`-ish outcome is not an answer to the
+    // question this verb asked.
+    const management = createManagement({
+      kind: "ok",
+      value: { running: false, version: null },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const { result } = renderHook(useRunnerReinstallTraycer, {
+      wrapper: createWrapper({
+        management,
+        traycerCli: new MockTraycerCli(),
+        queryClient,
+      }),
+    });
+
+    await expect(result.current.mutateAsync()).rejects.toThrow(
+      "no host started on this computer",
+    );
+  });
+
   it("refreshes install state after a converge that FAILED with the bytes already committed", async () => {
     // `installed-not-converged` says in as many words that the install
     // committed and only the post-commit service invariant failed. The

--- a/clients/gui-app/src/hooks/runner/use-runner-reinstall-traycer-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-reinstall-traycer-mutation.ts
@@ -1,0 +1,74 @@
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import type {
+  ConvergeReadyOk,
+  MutationOutcome,
+} from "@traycer-clients/shared/platform/runner-host";
+import { useRunnerHost } from "@/providers/use-runner-host";
+import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
+
+/**
+ * Reinstall this computer's host after the user removed Traycer from it
+ * (Settings ▸ Danger zone). The one consent-reversing verb the automatic
+ * local lifecycle deliberately does not perform on its own.
+ *
+ * Two steps, one mutation, in this order: clear the removed-by-user sentinel,
+ * THEN converge. `HostController.convergeReady` short-circuits `ok
+ * {running:false}` while the sentinel stands - it never installs - so a
+ * converge alone here is a silent no-op, which is exactly what the Overview's
+ * old "Start host" button was in this state.
+ *
+ * Same settle mapping as `useRunnerConvergeReady`: `ok`/`busy` resolve, every
+ * other outcome rejects with its message so the caller's `onError` toast says
+ * why. Same cache invalidations too, plus the removal-state read the sentinel
+ * clear just changed.
+ */
+export function useRunnerReinstallTraycer(): UseMutationResult<
+  MutationOutcome<ConvergeReadyOk>,
+  Error,
+  void
+> {
+  const runnerHost = useRunnerHost();
+  const queryClient = useQueryClient();
+  const { hostManagement, traycerCli } = runnerHost;
+  return useMutation<MutationOutcome<ConvergeReadyOk>>({
+    mutationKey: runnerMutationKeys.reinstallTraycer(),
+    mutationFn: async () => {
+      if (hostManagement === null) {
+        throw new Error("Host provisioning is not available on this platform.");
+      }
+      await hostManagement.clearRemoval();
+      const outcome = await hostManagement.convergeReady(false);
+      if (outcome.kind === "ok" || outcome.kind === "busy") {
+        return outcome;
+      }
+      throw new Error(outcome.message);
+    },
+    onSettled: () => {
+      // Settled, not success: the sentinel clear can have landed even when the
+      // converge that followed it failed, and a removal-state read that still
+      // says "removed" would keep offering Reinstall for a host that is now
+      // merely not installed.
+      if (hostManagement !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: runnerQueryKeys.hostRemovalState(hostManagement),
+        });
+      }
+    },
+    onSuccess: () => {
+      if (traycerCli !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),
+        });
+      }
+      if (hostManagement !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: runnerQueryKeys.hostInstalledRecord(hostManagement),
+        });
+      }
+    },
+  });
+}

--- a/clients/gui-app/src/hooks/runner/use-runner-reinstall-traycer-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-reinstall-traycer-mutation.ts
@@ -23,8 +23,10 @@ import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
  *
  * Same settle mapping as `useRunnerConvergeReady`: `ok`/`busy` resolve, every
  * other outcome rejects with its message so the caller's `onError` toast says
- * why. Same cache invalidations too, plus the removal-state read the sentinel
- * clear just changed.
+ * why. It invalidates the same two reads that hook does, plus the removal
+ * state the sentinel clear just changed - but from `onSettled` rather than
+ * `onSuccess`, because a rejected converge can still have moved all three
+ * (see the comment on that handler).
  */
 export function useRunnerReinstallTraycer(): UseMutationResult<
   MutationOutcome<ConvergeReadyOk>,
@@ -47,26 +49,29 @@ export function useRunnerReinstallTraycer(): UseMutationResult<
       }
       throw new Error(outcome.message);
     },
+    // SETTLED, NOT SUCCESS - for all three reads, because every one of them
+    // can have been changed by an attempt that ends up rejecting:
+    //
+    //  - the sentinel clear lands first and survives a failed converge, so a
+    //    removal-state read that still says "removed" would keep offering
+    //    Reinstall for a host that is now merely not installed;
+    //  - `installed-not-converged` says in as many words that the BYTES
+    //    COMMITTED and only the post-commit service invariant failed, and
+    //    `failed` can follow a service cycle that already wrote its record.
+    //    Refreshing those two only on success left Settings reporting "Not
+    //    installed" for a machine whose install had landed.
     onSettled: () => {
-      // Settled, not success: the sentinel clear can have landed even when the
-      // converge that followed it failed, and a removal-state read that still
-      // says "removed" would keep offering Reinstall for a host that is now
-      // merely not installed.
       if (hostManagement !== null) {
         void queryClient.invalidateQueries({
           queryKey: runnerQueryKeys.hostRemovalState(hostManagement),
         });
+        void queryClient.invalidateQueries({
+          queryKey: runnerQueryKeys.hostInstalledRecord(hostManagement),
+        });
       }
-    },
-    onSuccess: () => {
       if (traycerCli !== null) {
         void queryClient.invalidateQueries({
           queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),
-        });
-      }
-      if (hostManagement !== null) {
-        void queryClient.invalidateQueries({
-          queryKey: runnerQueryKeys.hostInstalledRecord(hostManagement),
         });
       }
     },

--- a/clients/gui-app/src/hooks/runner/use-runner-reinstall-traycer-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-reinstall-traycer-mutation.ts
@@ -21,12 +21,14 @@ import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
  * converge alone here is a silent no-op, which is exactly what the Overview's
  * old "Start host" button was in this state.
  *
- * Same settle mapping as `useRunnerConvergeReady`: `ok`/`busy` resolve, every
- * other outcome rejects with its message so the caller's `onError` toast says
- * why. It invalidates the same two reads that hook does, plus the removal
- * state the sentinel clear just changed - but from `onSettled` rather than
- * `onSuccess`, because a rejected converge can still have moved all three
- * (see the comment on that handler).
+ * A STRICTER settle mapping than `useRunnerConvergeReady`: only a converge
+ * that reports a RUNNING host resolves, and every other outcome rejects with
+ * a message so the caller's `onError` toast says why (see the comment in the
+ * mutation body - the two near-misses are what make this verb disappear from
+ * a machine that still has no host). It invalidates the same two reads that
+ * hook does, plus the removal state the sentinel clear just changed - but from
+ * `onSettled` rather than `onSuccess`, because a rejected converge can still
+ * have moved all three (see the comment on that handler).
  */
 export function useRunnerReinstallTraycer(): UseMutationResult<
   MutationOutcome<ConvergeReadyOk>,
@@ -44,8 +46,32 @@ export function useRunnerReinstallTraycer(): UseMutationResult<
       }
       await hostManagement.clearRemoval();
       const outcome = await hostManagement.convergeReady(false);
-      if (outcome.kind === "ok" || outcome.kind === "busy") {
+      // SUCCESS IS "A HOST IS RUNNING ON THIS COMPUTER", and nothing weaker.
+      // Two outcomes look like success and are not, and both matter more here
+      // than anywhere else, because the success toast plus a cleared sentinel
+      // is what takes the Reinstall verb off the page:
+      //
+      //  - `busy` did NOT reinstall anything. It is the CLI refusing to swap
+      //    the bytes of a live host - and `E_HOST_BUSY` is a FAIL-SAFE, raised
+      //    when a live PID's idle state cannot be determined at all (see
+      //    `assertHostNotBusy`), so it is not even evidence the host serves.
+      //    A leftover process from the removal is exactly that case.
+      //  - `ok` with `running: false` is the removal sentinel still standing,
+      //    which after `clearRemoval` means the clear did not take. The
+      //    converge did nothing, by consent that was supposed to be revoked.
+      //
+      // Both reject, so `onError` says why and `isError` keeps the verb on the
+      // page for another try. This is a DELIBERATE divergence from
+      // `useRunnerConvergeReady`, which resolves `busy` - it asks "is the host
+      // up?", where a busy answer is informative; this asks "did the reinstall
+      // happen?", where it is not.
+      if (outcome.kind === "ok" && outcome.value.running) {
         return outcome;
+      }
+      if (outcome.kind === "ok") {
+        throw new Error(
+          "Traycer was reinstalled, but no host started on this computer. Run doctor to see why.",
+        );
       }
       throw new Error(outcome.message);
     },

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -3222,7 +3222,10 @@ describe("SelectionAuthorityEngineImpl - P1.3 failover scenarios", () => {
     authority.dispose();
   });
 
-  it("A6: healthy remote preferred does not ensure local; killing it requests ensure once", async () => {
+  it("A6: a healthy remote preferred still ensures a DOWN local host (target-independent lifecycle), and stays on the remote while it boots", async () => {
+    // Decision 2026-08-19: the local host's lifecycle does not depend on which
+    // host a window is pointed at. This test used to pin the opposite ("does
+    // not ensure local; killing the remote requests ensure once").
     const clock = createFakeAuthorityClock(0);
     const ensure = createDeferredEnsure();
     const authority = createTestAuthority({
@@ -3241,14 +3244,30 @@ describe("SelectionAuthorityEngineImpl - P1.3 failover scenarios", () => {
     expect(engine.snapshot().preferredHostId).toBe("P");
     expect(engine.snapshot().effectiveHostId).toBe("P");
 
-    killHostWithRefusals(engine, "A", incarnation, "L");
-    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("dead");
-    expect(engine.snapshot().effectiveHostId).toBe("P");
-    expect(ensure.calls.count).toBe(0);
-
-    killHostWithRefusals(engine, "A", incarnation, "P");
+    // Cold boot: L is never-dialed, so the ensure fires at once - exactly as
+    // it would with L preferred - and the window keeps serving P meanwhile.
     expect(ensure.calls.count).toBe(1);
     expect(findLease(engine.snapshot().leases, "L")?.status).toBe("connecting");
+    expect(engine.snapshot().effectiveHostId).toBe("P");
+
+    // The converge answers: proof of life for L. Nothing moves - P is the
+    // preferred host and it is serving.
+    await ensure.resolve(true);
+    expect(engine.snapshot().effectiveHostId).toBe("P");
+    expect(ensure.calls.count).toBe(1);
+
+    // L dies later (something pinned to it dialed it and was refused). The
+    // engine brings it back although P is healthy and effective: down means
+    // ensure, whichever host is the target.
+    killHostWithRefusals(engine, "A", incarnation, "L");
+    expect(ensure.calls.count).toBe(2);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("connecting");
+    expect(engine.snapshot().effectiveHostId).toBe("P");
+
+    // And when P dies too, L - already booting - is the fallback, with no
+    // second request stacked on the one in flight.
+    killHostWithRefusals(engine, "A", incarnation, "P");
+    expect(ensure.calls.count).toBe(2);
     expect(engine.snapshot().effectiveHostId).toBe("L");
 
     authority.dispose();
@@ -3296,18 +3315,106 @@ describe("SelectionAuthorityEngineImpl - P1.3 failover scenarios", () => {
     expect(engine.snapshot().effectiveHostId).toBe("L");
 
     // 4. Now L - the INCUMBENT the hold is protecting - dies too, the same
-    // three-refusal recipe used against P in step 2.
+    // three-refusal recipe used against P in step 2. The engine's ensure fires
+    // in that same pass (down means bring it back, whichever host is the
+    // target), so the PUBLISHED lease is the in-flight arm's `connecting`,
+    // not `dead` - L is being started, not written off.
     killHostWithRefusals(engine, "A", incarnation, "L");
-    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("dead");
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("connecting");
 
     // 5. The engine must not keep serving a host it has itself called dead
-    // for the remaining ~17s of the 20s window (clock is at 3_000ms, well
-    // inside RETURN_TO_TARGET_STABILITY_MS). Under the old code - the
-    // bypass arm asks only about the destination, never the origin - this
-    // read L until t=20_000.
+    // (and is now merely booting) for the remaining ~17s of the 20s window
+    // (clock is at 3_000ms, well inside RETURN_TO_TARGET_STABILITY_MS). Under
+    // the old code - the bypass arm asks only about the destination, never
+    // the origin - this read L until t=20_000; and an incumbent held usable
+    // only by the engine's own in-flight ensure is no more able to serve than
+    // a dead one, so that hold does not keep the window either.
     expect(engine.snapshot().effectiveHostId).toBe("P");
     expect(lastSelectionChange(authority.events).cause).toBe("recovery");
 
+    authority.dispose();
+  });
+
+  it("returns to a revived target at once when the incumbent is a local host held usable only by the engine's own in-flight ensure", async () => {
+    // The consequence of the incumbent rule stated for the decided lifecycle:
+    // a booting local host is a CANDIDATE (∅ never shows for it) but not
+    // something to keep serving a window from once the target can. Before,
+    // the return window would sit on it for up to 20s.
+    const clock = createFakeAuthorityClock(0);
+    const ensure = createDeferredEnsure();
+    const authority = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: "L",
+        hosts: [fleetHost("L", "local"), fleetHost("P", "remote")],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+      localHostEnsure: ensure.port,
+    });
+    const { engine } = authority;
+    const incarnation = attachReporter(engine, "A");
+    // The cold-boot ensure for the never-dialed L is in flight from attach.
+    expect(ensure.calls.count).toBe(1);
+
+    // 1. Activate P -> effective P.
+    expect(await engine.activate("A", incarnation, "P")).toEqual({ ok: true });
+    expect(engine.snapshot().effectiveHostId).toBe("P");
+
+    // 2. Kill P -> failover to L, whose only claim to usability is the ensure
+    // still in flight (no dial, no session).
+    killHostWithRefusals(engine, "A", incarnation, "P");
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("connecting");
+
+    // 3. P proves alive. No 20s hold on a host that is not serving anyone:
+    // the window goes home now.
+    engine.ingestEvidence(
+      "A",
+      incarnation,
+      dialOutcome("P", "revive", "success", clock.now()),
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("P");
+    expect(lastSelectionChange(authority.events).cause).toBe("recovery");
+
+    // 4. And a live session on L is what WOULD have kept the window - the
+    // in-flight arm reads `ready` for it, which is service. Prove the guard
+    // is about service, not about the token: with a session, the same revive
+    // is damped for the full window.
+    const authority2 = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: "L",
+        hosts: [fleetHost("L", "local"), fleetHost("P", "remote")],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+      localHostEnsure: createDeferredEnsure().port,
+    });
+    const incarnation2 = attachReporter(authority2.engine, "A");
+    expect(await authority2.engine.activate("A", incarnation2, "P")).toEqual({
+      ok: true,
+    });
+    killHostWithRefusals(authority2.engine, "A", incarnation2, "P");
+    expect(authority2.engine.snapshot().effectiveHostId).toBe("L");
+    authority2.engine.ingestEvidence(
+      "A",
+      incarnation2,
+      sessionEvidence("L", "s-local", "established", clock.now()),
+    );
+    expect(findLease(authority2.engine.snapshot().leases, "L")?.status).toBe(
+      "ready",
+    );
+    authority2.engine.ingestEvidence(
+      "A",
+      incarnation2,
+      dialOutcome("P", "revive", "success", clock.now()),
+    );
+    expect(authority2.engine.snapshot().effectiveHostId).toBe("L");
+    clock.advance(RETURN_TO_TARGET_STABILITY_MS);
+    expect(authority2.engine.snapshot().effectiveHostId).toBe("P");
+
+    authority2.dispose();
     authority.dispose();
   });
 });
@@ -4023,7 +4130,7 @@ describe("SelectionAuthorityEngineImpl - local proof-of-life clears the ensure c
 // completion lands into a fleet whose local host is B. The fix compares
 // `token.hostId` to the CURRENT `this.fleet.localHostId` and discards a
 // mismatch - clearing the token too, which is a second, separately
-// assertable defect: while it stood, `requestLocalEnsureIfWanted` refused to
+// assertable defect: while it stood, `requestLocalEnsureIfDown` refused to
 // start anything, so B could not ask for its own ensure until A's ceiling
 // lapsed.
 
@@ -4226,7 +4333,7 @@ describe("SelectionAuthorityEngineImpl - a dead host reaches `dead` (B1/C6)", ()
    * predicate never fires, and the lease falls through to `connecting` -
    * which is usable. No failover, no empty state, no error.
    */
-  it("a host whose session dies with no further dial evidence still leaves `connecting`", () => {
+  it("a host whose session dies with no further dial evidence still leaves `connecting`", async () => {
     const clock = createFakeAuthorityClock(0);
     const authority = createTestAuthority({
       initialFleet: {
@@ -4241,6 +4348,13 @@ describe("SelectionAuthorityEngineImpl - a dead host reaches `dead` (B1/C6)", ()
     });
     const { engine } = authority;
     const incarnation = attachReporter(engine, "A");
+    // The cold-boot ensure for L fires at attach whichever host is preferred
+    // (target-independent lifecycle). Let the ready port answer it: this test
+    // jumps the clock 30 minutes below, past the in-flight ceiling, and an
+    // ensure that was never given its microtask would lapse into the failed
+    // cooldown and read L dead at exactly the moment the fallback needs it.
+    await Promise.resolve();
+    await Promise.resolve();
 
     engine.ingestEvidence(
       "A",

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -3381,6 +3381,14 @@ describe("SelectionAuthorityEngineImpl - P1.3 failover scenarios", () => {
     // in-flight arm reads `ready` for it, which is service. Prove the guard
     // is about service, not about the token: with a session, the same revive
     // is damped for the full window.
+    //
+    // The first authority is disposed HERE, not at the end: the control below
+    // shares this `clock`, so an engine left armed would also take timer
+    // callbacks from the `advance` that drives the control's return window.
+    // Nothing above is asserted again, so those callbacks could not change a
+    // verdict - but a second engine reacting to the first one's deadlines is
+    // not a fixture anyone should have to reason about.
+    authority.dispose();
     const authority2 = createTestAuthority({
       initialFleet: {
         identityGeneration: 0,
@@ -3415,7 +3423,6 @@ describe("SelectionAuthorityEngineImpl - P1.3 failover scenarios", () => {
     expect(authority2.engine.snapshot().effectiveHostId).toBe("P");
 
     authority2.dispose();
-    authority.dispose();
   });
 });
 

--- a/clients/shared/host-selection/selection-authority-contract.ts
+++ b/clients/shared/host-selection/selection-authority-contract.ts
@@ -1117,8 +1117,10 @@ export interface AuthorityIdentitySource {
 
 /**
  * The engine's one sanctioned process action (C5/D14): request local-host
- * provisioning when derivation wants the local host and it is down. Progress
- * surfaces as the local lease's status; this port carries no state.
+ * provisioning whenever the local host is down - whichever host a window is
+ * pointed at (the local lifecycle is target-independent by decision,
+ * 2026-08-19). Progress surfaces as the local lease's status; this port
+ * carries no state.
  *
  * `deferred` distinguishes "the lifecycle lane was busy, nothing ran" (a CLI
  * lock another actor held, a drained queue slot) from a provisioning attempt

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -1884,6 +1884,18 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    *    authority itself called dead for the remaining seventeen - the
    *    enumeration above asks only about the destination, and this is the one
    *    question about the origin.
+   *  - An incumbent held usable ONLY by the engine's own in-flight ensure: NO
+   *    window either. The in-flight arm reports the local host `connecting`
+   *    so that ∅ never shows for a host the engine is starting FOR the user -
+   *    a claim about candidacy, not about service. Since the ensure fires for
+   *    a down local host whichever host is the target (2026-08-19), the arm
+   *    now also fires for a dead INCUMBENT: the window failed over onto the
+   *    local host, the target came back, and then the local host died - the
+   *    same pass that publishes it dead starts booting it and would otherwise
+   *    hand the return window a `connecting` incumbent that cannot serve
+   *    anyone for the remaining seventeen seconds. A live session is the one
+   *    thing that makes an in-flight ensure's host genuinely serving (the
+   *    lease arm says so too), so it is the one thing that keeps the window.
    *
    * Explicit writes bypass all of it. Activate is valid from any state (M5)
    * and must land immediately - a user who picks a host in Settings and waits
@@ -1909,7 +1921,8 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       effectiveHostId === null ||
       effectiveHostId === targetHostId ||
       desired === null ||
-      !this.isUsable(effectiveHostId, leases)
+      !this.isUsable(effectiveHostId, leases) ||
+      this.isHeldOnlyByOwnEnsure(effectiveHostId)
     ) {
       this.pendingDampingDeadline = null;
       return desired;
@@ -1980,6 +1993,21 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
   ): boolean {
     const lease = leases.find((entry) => entry.hostId === hostId);
     return lease !== undefined && isUsableForSelection(lease);
+  }
+
+  /**
+   * Whether this host reads usable ONLY because the engine's own ensure for it
+   * is in flight - the in-flight arm of `deriveLease`, minus its live-session
+   * exception. Read by the damping's incumbent check: such a host is a
+   * candidate (so ∅ never shows while it boots) but not something to keep
+   * SERVING a window from against a target that can.
+   */
+  private isHeldOnlyByOwnEnsure(hostId: string): boolean {
+    return (
+      this.localEnsureToken !== null &&
+      this.localEnsureToken.hostId === hostId &&
+      !this.hasLiveSession(hostId)
+    );
   }
 
   /**
@@ -2106,31 +2134,38 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    * "local first" candidate systematically absent at exactly the moment
    * failover needed it. Nothing in the app would boot a deselected local host,
    * so ∅ was reachable with a perfectly working machine sitting idle. The
-   * engine may now ask for it, and only for it: the registry still never
-   * drives processes, and the rejected alternative (keeping the local host
-   * booted whenever signed in) would charge every deliberate remote user for
-   * an idle host.
+   * engine may ask for it, and only it may: the registry still never drives
+   * processes.
    *
-   * Requested only when derivation genuinely WANTS the local host - it is the
-   * target, or the target cannot serve so local is the next candidate. A
-   * healthy preferred remote leaves the local host alone: that want-local
-   * conjunct is the whole of the narrow rule, and it is what keeps a
-   * deliberate-remote user from paying for an idle local boot.
+   * INDEPENDENT OF THE TARGET, by decision (2026-08-19). This landed with a
+   * narrower rule - request only when derivation WANTED the local host (it was
+   * the target, or the target could not serve), so a healthy preferred remote
+   * left the local host alone and a deliberate-remote user never paid for an
+   * idle local boot. That rule was reversed: the local host's lifecycle is the
+   * same whichever host a window is pointed at - down means bring it back, as
+   * the released desktop always did for the machine it runs on - and only the
+   * NARRATION is target-scoped (a window serving a remote says nothing about
+   * a local boot). So there is no want-local conjunct here any more. What
+   * survives of the C5 argument is where the action lives: this engine, once,
+   * paced by the same cooldowns whichever host is effective.
    *
-   * WANTED + NOT-KNOWN-USABLE, where not-known-usable is `dead` OR
-   * NEVER-DIALED. The dead-only reading was too narrow in exactly one case and
-   * it was the commonest one: a cold boot has no evidence at all, so the local
-   * lease reads `connecting` - which is *usable* - and the engine would refrain
-   * until three confirmed refusals accumulated against a socket that does not
-   * exist yet. Never-dialed is not "up"; and since the ensure is what makes the
-   * socket dialable in the first place, waiting for dial evidence to justify it
-   * is circular. A host that HAS been dialed is excluded either way: mid-streak
-   * it is still connecting, and once it reaches `dead` the first arm takes it.
+   * DOWN means `dead` OR NEVER-DIALED. The dead-only reading was too narrow in
+   * exactly one case and it was the commonest one: a cold boot has no evidence
+   * at all, so the local lease reads `connecting` - which is *usable* - and the
+   * engine would refrain until three confirmed refusals accumulated against a
+   * socket that does not exist yet. Never-dialed is not "up"; and since the
+   * ensure is what makes the socket dialable in the first place, waiting for
+   * dial evidence to justify it is circular. A host that HAS been dialed is
+   * excluded either way: mid-streak it is still connecting, and once it reaches
+   * `dead` the first arm takes it. A never-dialed local host that is up (a
+   * remote is serving the window, nothing has reason to dial it) draws exactly
+   * ONE ensure: the converge answers `ok`, that is proof of life, and proof of
+   * life creates the evidence record that ends never-dialed.
    *
    * Returns whether a request was started, because the caller must re-derive:
    * the request itself changes the local lease.
    */
-  private requestLocalEnsureIfWanted(
+  private requestLocalEnsureIfDown(
     leases: readonly HostLeaseSnapshot[],
     now: number,
   ): boolean {
@@ -2178,10 +2213,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       return false;
     }
 
-    const targetHostId = this.preferredHostId ?? localHostId;
-    if (targetHostId !== localHostId && this.isUsable(targetHostId, leases)) {
-      return false;
-    }
+    // Deliberately NO "is the target serving?" gate here - see the doc above.
     const cooldownUntil = this.localEnsureFailedUntil;
     if (cooldownUntil !== null && now < cooldownUntil) return false;
     const retryHoldUntil = this.localEnsureRetryHoldUntil;
@@ -2266,7 +2298,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       // been applied - a guard one step downstream of the damage.
       //
       // Clearing the token is part of the fix, not bookkeeping: while it
-      // stands, `requestLocalEnsureIfWanted` refuses to start anything, so B
+      // stands, `requestLocalEnsureIfDown` refuses to start anything, so B
       // could not ask for its own ensure until A's ceiling lapsed. No
       // cooldown is armed - the failure describes a host this engine is no
       // longer pointed at - and the commit re-derives so B may ask at once.
@@ -2407,7 +2439,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       // ours. That stamp is provably always false: an ensure is minted from
       // exactly two arms, and both guarantee a false signal at mint - the
       // never-dialed arm is guarded on it explicitly (see
-      // `requestLocalEnsureIfWanted`), and `dead` is unreachable while
+      // `requestLocalEnsureIfDown`), and `dead` is unreachable while
       // `inExpectedOutage` is true because THIS ORDER puts the outage arm
       // above every dead arm. The one residue - a ceiling-lapsed outage whose
       // start is still recorded - has `inExpectedOutage` answering false
@@ -2446,7 +2478,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       // the cooldown would otherwise render an answering host `dead`.
       //
       // Arm order alone was never sufficient, in two places it cannot reach:
-      // `requestLocalEnsureIfWanted` reads the cooldown DIRECTLY, under no arm
+      // `requestLocalEnsureIfDown` reads the cooldown DIRECTLY, under no arm
       // ordering at all (it is separately declined under a live session, by
       // the never-dialed conjunct), and the masking lapses the moment the
       // session drops, resurfacing a cooldown whose premise the host has since
@@ -2674,14 +2706,13 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // still be reporting `connecting` into the leases computed below (B2).
     this.expireLocalEnsureIfLapsed(now);
     // TWO PASSES, because the two answers depend on each other: the ensure
-    // decision needs the leases to know whether the local host is down and
-    // whether the target can serve, and the leases then need to reflect that a
-    // request is in flight. Deriving twice is cheap (a map over the fleet) and
+    // decision needs the leases to know whether the local host is down, and
+    // the leases then need to reflect that a request is in flight. Deriving twice is cheap (a map over the fleet) and
     // keeps both answers from the same instant; the alternative - deciding
     // ensure from raw evidence - would duplicate the arm order that IS the
     // evidence hierarchy.
     const initialLeases = this.deriveLeases(now);
-    const leases = this.requestLocalEnsureIfWanted(initialLeases, now)
+    const leases = this.requestLocalEnsureIfDown(initialLeases, now)
       ? this.deriveLeases(now)
       : initialLeases;
     this.trackUsability(leases, now);


### PR DESCRIPTION
A developer on a MacBook whose app was bound to a remote host (their iMac) found Settings ▸ Host ▸ Overview offering a **Start host** button for a "Not installed" local row, next to a window card saying the host was unavailable. Two rulings came out of that report; this PR implements both.

## 1. The local lifecycle is independent of which host is active

The selection authority's ensure was gated *"only when the local host is wanted"* (the redesign's C5): a user with a healthy preferred remote never paid for an idle local boot. That rule is reversed — `requestLocalEnsureIfWanted` → **`requestLocalEnsureIfDown`**, so a dead or never-dialed local host is ensured whichever host a window is pointed at, paced by the same 30 s cooldown and retry hold.

Only the **narration** stays target-scoped: the window narrator still speaks for the window's own host, so a background local ensure while a remote serves is silent.

Two companion rules were needed for that to be correct:

| Rule | Why |
| --- | --- |
| `applyDamping` bypasses the return-to-target window for an incumbent held usable **only** by the engine's own in-flight ensure (`isHeldOnlyByOwnEnsure`) | Otherwise "window failed over onto L, P came back, L dies" hands the 20 s window a `connecting` host that serves nobody. A test caught this. |
| the desktop ensure port maps `busy` → `{ok: true}` | A host with work in progress **is** running. Otherwise a never-dialed non-target local host with a pending byte swap draws a CLI converge every 30 s forever — nothing dials a non-target host, so nothing else can end never-dialed. |

## 2. A failed boot retries on its own, without a re-sign-in

`armFirstInstallOnSignIn` → **`armLocalHostBootOnSignIn`**, with both halves of its contract widened:

- **Owed while no host is RUNNING** (`activation === "unavailable"`), not while no bytes are installed. A half-completed first install — bytes landed, service never started — is still owed a boot instead of reading as done on the first status read.
- **Retries on `LOCAL_HOST_BOOT_RETRY_LADDER_MS`** (30 s → 60 s → 2 min → 5 min cap) after any outcome that did not leave a host running: `deferred` (CLI lock held by another Traycer process), `failed`, `installed-not-converged`, a fingerprint mismatch, or a throw. Previously the only thing that tried again was the next sign-in **edge**, which for a user who stays signed in never comes.
- Settles on `ok`/`busy`, on a status read showing a live runtime, or on the removal sentinel.

Consent is unchanged and still read at the moment of acting: signed out means nothing happens until an account signs in; a sign-out cancels a pending retry and resets the ladder; a host the user removed is never reinstalled. A same-state `signedIn: true` change (a token refresh) does not bypass the ladder's pacing. Rung 0 matches the authority's `LOCAL_ENSURE_RETRY_COOLDOWN_MS`, and where both actors find an installed host down at launch the controller coalesces the two `ensure:false` intents onto one job.

## 3. No Start verb

Overview's down-local cluster loses **Start host** — it was a second process actor for a host the app already brings back, and under `removedByUser` it was a silent no-op (`convergeReady` short-circuits under the sentinel). What remains:

- **Run doctor**, disabled while this machine's lifecycle lane is busy.
- **Reinstall Traycer**, only in the one state the automation deliberately leaves alone: it clears the sentinel, then converges (new `useRunnerReinstallTraycer`).

The sidebar's *"Viewing — this window runs on X"* named the app-wide **active host**, not the physical machine; it now reads *"the active host is X"*.

## Verification

- `bun run compile` green (5 projects); eslint + prettier clean on every changed file.
- `clients/shared` full suite **76 files / 1273 tests**; selection-authority engine **101/101** (A6 inverted for the target-independent ensure, a new pin for the incumbent rule with both halves, the corpse test made async so the cold-boot ensure settles).
- desktop selection-ports **33/33**; desktop `host-launch-converge` **43/43** — the boot-actor block reworked with fake timers to prove the retry lands *without* a sign-in edge, at the right rung boundaries, that a half-install is still owed, `busy`/`deferred` handling, that a sign-out cancels and resets the ladder, and that the disposer clears a pending timer.
- gui-app settings/host suites 13 files / 109, plus a new 4-case `host-overview-local-down.test.tsx`.

## Known residual

A deliberate `traycer host stop` of a **non-active** local host mid-session is not fought: nothing dials it, so no evidence reaches the engine, and the health monitor treats pid.json-gone as a deliberate stop — same as released builds. The doctor sheet's own fix action for a `host-start` issue is still labelled "Start host" (a repair inside a diagnostic flow), left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)