### PR TITLE
fix(gui-app): keep minimap selection visible

### DIFF
--- a/clients/gui-app/src/components/minimap/__tests__/minimap-list-card.test.tsx
+++ b/clients/gui-app/src/components/minimap/__tests__/minimap-list-card.test.tsx
@@ -1,0 +1,181 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MinimapListCard } from "@/components/minimap/minimap-list-card";
+
+/**
+ * jsdom does not lay out, and it does not apply `zoom-in-95`. Stub the opening
+ * scale onto `getBoundingClientRect` so converting that visual delta into
+ * `scrollTop` under-scrolls the current row, matching the live popover.
+ */
+const OPENING_ZOOM = 0.95;
+const VIEWPORT_HEIGHT = 200;
+const ROW_HEIGHT = 40;
+const ITEM_COUNT = 16;
+const CURRENT_INDEX = 15;
+
+function isMinimapList(node: HTMLElement): boolean {
+  return (
+    node.parentElement?.hasAttribute("data-minimap-list-card") === true &&
+    node.className.includes("overflow-y-auto")
+  );
+}
+
+function minimapListFor(node: HTMLElement): HTMLElement | null {
+  const card = node.closest("[data-minimap-list-card]");
+  if (card === null) return null;
+  const list = card.querySelector(".overflow-y-auto");
+  return list instanceof HTMLElement ? list : null;
+}
+
+function rowLayoutTop(row: HTMLElement): number {
+  const card = row.closest("[data-minimap-list-card]");
+  if (card === null) return 0;
+  const rows = card.querySelectorAll("[data-minimap-list-row]");
+  return [...rows].indexOf(row) * ROW_HEIGHT;
+}
+
+function scaledRect(layoutTop: number, layoutHeight: number): DOMRect {
+  return new DOMRect(
+    0,
+    layoutTop * OPENING_ZOOM,
+    1,
+    layoutHeight * OPENING_ZOOM,
+  );
+}
+
+function installOpeningZoomGeometry(): () => void {
+  let listScrollTop = 0;
+  const scrollTop = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollTop",
+  );
+  const clientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight",
+  );
+  const scrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollHeight",
+  );
+
+  Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (isMinimapList(this)) return listScrollTop;
+      return 0;
+    },
+    set(this: HTMLElement, value: number) {
+      if (isMinimapList(this)) {
+        listScrollTop = value;
+        return;
+      }
+      scrollTop?.set?.call(this, value);
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (isMinimapList(this)) return VIEWPORT_HEIGHT;
+      return 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (isMinimapList(this)) return ITEM_COUNT * ROW_HEIGHT;
+      return 0;
+    },
+  });
+
+  const boundingRect = vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function measure(this: HTMLElement): DOMRect {
+      if (isMinimapList(this)) {
+        return scaledRect(0, VIEWPORT_HEIGHT);
+      }
+      if (this.hasAttribute("data-minimap-list-row")) {
+        return scaledRect(rowLayoutTop(this) - listScrollTop, ROW_HEIGHT);
+      }
+      return new DOMRect();
+    });
+
+  const scrollIntoView = vi
+    .spyOn(HTMLElement.prototype, "scrollIntoView")
+    .mockImplementation(function align(this: HTMLElement): void {
+      if (!this.hasAttribute("data-minimap-list-row")) return;
+      const list = minimapListFor(this);
+      if (list === null) return;
+      const top = rowLayoutTop(this);
+      const bottom = top + ROW_HEIGHT;
+      if (top < listScrollTop) {
+        listScrollTop = top;
+        return;
+      }
+      if (bottom > listScrollTop + VIEWPORT_HEIGHT) {
+        listScrollTop = bottom - VIEWPORT_HEIGHT;
+      }
+    });
+
+  return () => {
+    boundingRect.mockRestore();
+    scrollIntoView.mockRestore();
+    restorePrototype("scrollTop", scrollTop);
+    restorePrototype("clientHeight", clientHeight);
+    restorePrototype("scrollHeight", scrollHeight);
+  };
+}
+
+function restorePrototype(
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor === undefined) {
+    Reflect.deleteProperty(HTMLElement.prototype, property);
+    return;
+  }
+  Object.defineProperty(HTMLElement.prototype, property, descriptor);
+}
+
+describe("MinimapListCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps a far-down current row inside the popover viewport while the opening zoom is applied", () => {
+    const restore = installOpeningZoomGeometry();
+    try {
+      const items = Array.from({ length: ITEM_COUNT }, (_unused, index) => ({
+        key: `item-${String(index)}`,
+        label: `Item ${String(index)}`,
+        level: 1 as const,
+      }));
+      render(
+        <MinimapListCard
+          currentIndex={CURRENT_INDEX}
+          cursorIndex={CURRENT_INDEX}
+          items={items}
+          onCursorIndexChange={vi.fn()}
+          onSelect={vi.fn()}
+          side="right"
+          title="Turns"
+        />,
+      );
+
+      const current = screen.getByRole("button", {
+        name: `Item ${String(CURRENT_INDEX)}`,
+      });
+      expect(current.getAttribute("aria-current")).toBe("location");
+      const list = minimapListFor(current);
+      if (list === null) {
+        throw new Error("missing minimap list scroller");
+      }
+
+      const top = rowLayoutTop(current);
+      const bottom = top + ROW_HEIGHT;
+      expect(top).toBeGreaterThanOrEqual(list.scrollTop);
+      expect(bottom).toBeLessThanOrEqual(list.scrollTop + list.clientHeight);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/clients/gui-app/src/components/minimap/__tests__/minimap-list-card.test.tsx
+++ b/clients/gui-app/src/components/minimap/__tests__/minimap-list-card.test.tsx
@@ -43,7 +43,7 @@ function scaledRect(layoutTop: number, layoutHeight: number): DOMRect {
   );
 }
 
-function installOpeningZoomGeometry(): () => void {
+function installOpeningZoomGeometry() {
   let listScrollTop = 0;
   const scrollTop = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
@@ -116,12 +116,15 @@ function installOpeningZoomGeometry(): () => void {
       }
     });
 
-  return () => {
-    boundingRect.mockRestore();
-    scrollIntoView.mockRestore();
-    restorePrototype("scrollTop", scrollTop);
-    restorePrototype("clientHeight", clientHeight);
-    restorePrototype("scrollHeight", scrollHeight);
+  return {
+    restore: () => {
+      boundingRect.mockRestore();
+      scrollIntoView.mockRestore();
+      restorePrototype("scrollTop", scrollTop);
+      restorePrototype("clientHeight", clientHeight);
+      restorePrototype("scrollHeight", scrollHeight);
+    },
+    scrollIntoView,
   };
 }
 
@@ -142,7 +145,7 @@ describe("MinimapListCard", () => {
   });
 
   it("keeps a far-down current row inside the popover viewport while the opening zoom is applied", () => {
-    const restore = installOpeningZoomGeometry();
+    const { restore, scrollIntoView } = installOpeningZoomGeometry();
     try {
       const items = Array.from({ length: ITEM_COUNT }, (_unused, index) => ({
         key: `item-${String(index)}`,
@@ -170,6 +173,7 @@ describe("MinimapListCard", () => {
         throw new Error("missing minimap list scroller");
       }
 
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
       const top = rowLayoutTop(current);
       const bottom = top + ROW_HEIGHT;
       expect(top).toBeGreaterThanOrEqual(list.scrollTop);

--- a/clients/gui-app/src/components/minimap/minimap-list-card.tsx
+++ b/clients/gui-app/src/components/minimap/minimap-list-card.tsx
@@ -32,19 +32,10 @@ export function MinimapListCard({
   title,
 }: MinimapListCardProps) {
   const currentRowRef = useRef<HTMLButtonElement | null>(null);
-  const listRef = useRef<HTMLDivElement | null>(null);
   const rowRefs = useRef(new Map<number, HTMLButtonElement>());
 
   useLayoutEffect(() => {
-    const row = currentRowRef.current;
-    const list = listRef.current;
-    if (row === null || list === null) return;
-    const rowRect = row.getBoundingClientRect();
-    const listRect = list.getBoundingClientRect();
-    const above = rowRect.top - listRect.top;
-    const below = rowRect.bottom - listRect.bottom;
-    if (above >= 0 && below <= 0) return;
-    list.scrollTop = Math.max(0, list.scrollTop + (above < 0 ? above : below));
+    currentRowRef.current?.scrollIntoView({ block: "nearest" });
   }, [currentIndex]);
 
   const moveFocus = (index: number): void => {
@@ -88,10 +79,7 @@ export function MinimapListCard({
       <div className="px-3 pt-3 pb-1 text-ui-xs font-medium tracking-wide text-muted-foreground/70 uppercase">
         {title}
       </div>
-      <div
-        className="min-h-0 overflow-y-auto overscroll-contain p-2 pt-1"
-        ref={listRef}
-      >
+      <div className="min-h-0 overflow-y-auto overscroll-contain p-2 pt-1">
         <div className="flex flex-col gap-0.5">
           {items.map((item, index) => {
             const current = index === currentIndex;


### PR DESCRIPTION
## Summary
- use the browser's nearest scroll alignment for the active minimap row
- add a regression test covering the opening zoom transform

## Validation
- pre-commit: passed (hygiene, affected Nx lint/format/compile/build)
- minimap regression test: passed
- targeted ESLint: passed
- scoped React Doctor: passed
- git diff --check: passed

Broader minimap/chat artifact suites were not runnable locally because existing dependencies `sonner` and `@tiptap/extension-collaboration` are missing; CI is authoritative.