### PR TITLE
fix(gui-app): open the minimap hover at the row it says is current

### DIFF
--- a/clients/gui-app/src/components/minimap/__tests__/minimap-list-card.test.tsx
+++ b/clients/gui-app/src/components/minimap/__tests__/minimap-list-card.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MinimapListCard,
+  type MinimapListEntry,
+} from "@/components/minimap/minimap-list-card";
+
+/**
+ * jsdom has no layout, so the card's geometry is faked here: rows are a fixed
+ * height in DOM order, and the scroller reports a viewport shorter than its
+ * content. The fake is installed on the LAYOUT properties only (`offsetTop` /
+ * `offsetHeight` / `clientHeight` / `scrollHeight`) and leaves
+ * `getBoundingClientRect()` at jsdom's all-zero default — measuring through
+ * rects is the defect this suite pins, because the card mounts inside its own
+ * `zoom-in-95` entry animation, where a scaled rect reads every distance short.
+ */
+const ROW_HEIGHT = 28;
+const VIEW_HEIGHT = 160;
+const ITEM_COUNT = 20;
+const CONTENT_HEIGHT = ROW_HEIGHT * ITEM_COUNT;
+const MAX_SCROLL = CONTENT_HEIGHT - VIEW_HEIGHT;
+
+const ITEMS: ReadonlyArray<MinimapListEntry> = Array.from(
+  { length: ITEM_COUNT },
+  (_unused, index) => ({
+    key: `item-${index}`,
+    label: `Message ${index}`,
+    level: 1,
+  }),
+);
+
+const scrollTops = new WeakMap<HTMLElement, number>();
+const patched: Array<{
+  readonly target: object;
+  readonly name: string;
+  readonly original: PropertyDescriptor | undefined;
+}> = [];
+
+function isRow(element: HTMLElement): boolean {
+  return element.hasAttribute("data-minimap-list-row");
+}
+
+function isScroller(element: HTMLElement): boolean {
+  return (
+    element.parentElement !== null &&
+    element.parentElement.hasAttribute("data-minimap-list-card") &&
+    element.querySelector("[data-minimap-list-row]") !== null
+  );
+}
+
+function rowIndex(element: HTMLElement): number {
+  const siblings = element.parentElement?.children;
+  if (siblings === undefined) return 0;
+  return Array.prototype.indexOf.call(siblings, element);
+}
+
+function patch(name: string, descriptor: PropertyDescriptor): void {
+  const target = Object.getOwnPropertyDescriptor(HTMLElement.prototype, name)
+    ? HTMLElement.prototype
+    : Element.prototype;
+  patched.push({
+    target,
+    name,
+    original: Object.getOwnPropertyDescriptor(target, name),
+  });
+  Object.defineProperty(target, name, { configurable: true, ...descriptor });
+}
+
+function installLayoutFake(): void {
+  patch("scrollTop", {
+    get(this: HTMLElement) {
+      return scrollTops.get(this) ?? 0;
+    },
+    set(this: HTMLElement, value: number) {
+      scrollTops.set(this, value);
+    },
+  });
+  patch("offsetTop", {
+    get(this: HTMLElement) {
+      return isRow(this) ? rowIndex(this) * ROW_HEIGHT : 0;
+    },
+  });
+  patch("offsetHeight", {
+    get(this: HTMLElement) {
+      return isRow(this) ? ROW_HEIGHT : 0;
+    },
+  });
+  patch("clientHeight", {
+    get(this: HTMLElement) {
+      return isScroller(this) ? VIEW_HEIGHT : 0;
+    },
+  });
+  patch("scrollHeight", {
+    get(this: HTMLElement) {
+      return isScroller(this) ? CONTENT_HEIGHT : 0;
+    },
+  });
+}
+
+function restoreLayoutFake(): void {
+  for (const entry of patched.reverse()) {
+    if (entry.original === undefined) {
+      Reflect.deleteProperty(entry.target, entry.name);
+    } else {
+      Object.defineProperty(entry.target, entry.name, entry.original);
+    }
+  }
+  patched.length = 0;
+}
+
+function renderCard(currentIndex: number): HTMLElement {
+  const view = render(
+    <MinimapListCard
+      currentIndex={currentIndex}
+      cursorIndex={currentIndex}
+      items={ITEMS}
+      onCursorIndexChange={() => undefined}
+      onSelect={() => undefined}
+      side="right"
+      title="Messages"
+    />,
+  );
+  const row = view.container.querySelector<HTMLElement>(
+    "[data-minimap-list-row]",
+  );
+  const scroller = row?.parentElement?.parentElement ?? null;
+  if (scroller === null || !isScroller(scroller)) {
+    throw new Error("minimap list scroller not found");
+  }
+  return scroller;
+}
+
+describe("MinimapListCard reveal on open", () => {
+  beforeEach(installLayoutFake);
+
+  afterEach(() => {
+    cleanup();
+    restoreLayoutFake();
+  });
+
+  it("opens at the very end when the last row is current", () => {
+    expect(renderCard(ITEM_COUNT - 1).scrollTop).toBe(MAX_SCROLL);
+  });
+
+  it("opens at the top when the first row is current", () => {
+    expect(renderCard(0).scrollTop).toBe(0);
+  });
+
+  it("opens with a mid-list row revealed at the bottom edge", () => {
+    expect(renderCard(9).scrollTop).toBe(10 * ROW_HEIGHT - VIEW_HEIGHT);
+  });
+
+  it("leaves an already-visible row alone", () => {
+    expect(renderCard(2).scrollTop).toBe(0);
+  });
+});

--- a/clients/gui-app/src/components/minimap/__tests__/minimap-track-geometry.test.ts
+++ b/clients/gui-app/src/components/minimap/__tests__/minimap-track-geometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   MINIMAP_TRACK_END_HIT_PADDING,
   MINIMAP_TRACK_ITEM_SPACING,
+  resolveMinimapListScrollTop,
   resolveMinimapTrackHeightStyle,
   resolveMinimapTrackTopPercent,
   resolveMinimapTrackTopStyle,
@@ -135,5 +136,72 @@ describe("equivalence with the chat rail's wrappers", () => {
         ),
       ).toBe(resolveChatTurnMinimapTopStyle(index, itemCount));
     }
+  });
+});
+
+describe("resolveMinimapListScrollTop", () => {
+  // 20 rows of 28px inside an 8px-padded scroller, showing 160px at a time.
+  const ROW_HEIGHT = 28;
+  const PADDING_TOP = 4;
+  const PADDING_BOTTOM = 8;
+  const VIEW_HEIGHT = 160;
+  const SCROLL_HEIGHT = PADDING_TOP + 20 * ROW_HEIGHT + PADDING_BOTTOM;
+  const MAX_SCROLL = SCROLL_HEIGHT - VIEW_HEIGHT;
+
+  function geometryForRow(index: number, scrollTop: number) {
+    return {
+      rowTop: PADDING_TOP + index * ROW_HEIGHT,
+      rowHeight: ROW_HEIGHT,
+      paddingTop: PADDING_TOP,
+      paddingBottom: PADDING_BOTTOM,
+      scrollTop,
+      viewHeight: VIEW_HEIGHT,
+      scrollHeight: SCROLL_HEIGHT,
+    };
+  }
+
+  it("lands at the very end when the last row is current", () => {
+    expect(resolveMinimapListScrollTop(geometryForRow(19, 0))).toBe(MAX_SCROLL);
+  });
+
+  it("lands at the very top when the first row is current", () => {
+    expect(resolveMinimapListScrollTop(geometryForRow(0, MAX_SCROLL))).toBe(0);
+  });
+
+  it("reveals a row below the fold at the bottom edge, padding included", () => {
+    expect(resolveMinimapListScrollTop(geometryForRow(9, 0))).toBe(
+      PADDING_TOP + 10 * ROW_HEIGHT + PADDING_BOTTOM - VIEW_HEIGHT,
+    );
+  });
+
+  it("leaves an already-revealed row alone", () => {
+    expect(resolveMinimapListScrollTop(geometryForRow(2, 0))).toBeNull();
+  });
+
+  it("does not scroll a list that fits", () => {
+    expect(
+      resolveMinimapListScrollTop({
+        ...geometryForRow(1, 0),
+        scrollHeight: VIEW_HEIGHT,
+      }),
+    ).toBeNull();
+  });
+
+  it("aligns a row taller than the viewport to its top", () => {
+    expect(
+      resolveMinimapListScrollTop({
+        ...geometryForRow(10, MAX_SCROLL),
+        rowHeight: VIEW_HEIGHT * 2,
+      }),
+    ).toBe(PADDING_TOP + 10 * ROW_HEIGHT - PADDING_TOP);
+  });
+
+  it("ignores non-finite geometry rather than scrolling to NaN", () => {
+    expect(
+      resolveMinimapListScrollTop({
+        ...geometryForRow(19, 0),
+        rowTop: Number.NaN,
+      }),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/minimap/minimap-list-card.tsx
+++ b/clients/gui-app/src/components/minimap/minimap-list-card.tsx
@@ -3,6 +3,7 @@ import {
   useRef,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
+import { resolveMinimapListScrollTop } from "@/components/minimap/minimap-track-geometry";
 import { cn } from "@/lib/utils";
 
 export interface MinimapListEntry {
@@ -35,16 +36,28 @@ export function MinimapListCard({
   const listRef = useRef<HTMLDivElement | null>(null);
   const rowRefs = useRef(new Map<number, HTMLButtonElement>());
 
+  // Layout boxes, never `getBoundingClientRect()`: the card measures itself on
+  // the mount that also starts its `zoom-in-95` entry animation, whose 0.95
+  // scale is already live on the first style resolution. Rect math read every
+  // distance 5% short, so a card opened at the end of a long list stopped
+  // short of the end. `offsetTop` / `clientHeight` / `scrollTop` are
+  // transform-independent; the list carries `relative` so it is the rows'
+  // offsetParent and `offsetTop` is read in its own content coordinates.
   useLayoutEffect(() => {
     const row = currentRowRef.current;
     const list = listRef.current;
     if (row === null || list === null) return;
-    const rowRect = row.getBoundingClientRect();
-    const listRect = list.getBoundingClientRect();
-    const above = rowRect.top - listRect.top;
-    const below = rowRect.bottom - listRect.bottom;
-    if (above >= 0 && below <= 0) return;
-    list.scrollTop = Math.max(0, list.scrollTop + (above < 0 ? above : below));
+    const listStyle = window.getComputedStyle(list);
+    const next = resolveMinimapListScrollTop({
+      rowTop: row.offsetTop,
+      rowHeight: row.offsetHeight,
+      paddingTop: Number.parseFloat(listStyle.paddingTop),
+      paddingBottom: Number.parseFloat(listStyle.paddingBottom),
+      scrollTop: list.scrollTop,
+      viewHeight: list.clientHeight,
+      scrollHeight: list.scrollHeight,
+    });
+    if (next !== null) list.scrollTop = next;
   }, [currentIndex]);
 
   const moveFocus = (index: number): void => {
@@ -89,7 +102,7 @@ export function MinimapListCard({
         {title}
       </div>
       <div
-        className="min-h-0 overflow-y-auto overscroll-contain p-2 pt-1"
+        className="relative min-h-0 overflow-y-auto overscroll-contain p-2 pt-1"
         ref={listRef}
       >
         <div className="flex flex-col gap-0.5">

--- a/clients/gui-app/src/components/minimap/minimap-track-geometry.ts
+++ b/clients/gui-app/src/components/minimap/minimap-track-geometry.ts
@@ -59,6 +59,72 @@ export function resolveMinimapWindow(input: {
   };
 }
 
+export interface MinimapListRevealGeometry {
+  /** Row top in scroll-content coordinates (`offsetTop` within the scroller). */
+  readonly rowTop: number;
+  readonly rowHeight: number;
+  /** The scroller's own inline padding, revealed alongside an end row. */
+  readonly paddingTop: number;
+  readonly paddingBottom: number;
+  readonly scrollTop: number;
+  /** The scroller's `clientHeight`. */
+  readonly viewHeight: number;
+  readonly scrollHeight: number;
+}
+
+function finite(value: number): number | null {
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Minimal scroll that reveals the active row, in **layout** coordinates — the
+ * caller must not feed this `getBoundingClientRect()` values. The card mounts
+ * mid `zoom-in-95` entry animation, and a scaled rect shrinks every measured
+ * distance by 5%, which left a card opened deep in a long list short of the
+ * row it was opening on.
+ *
+ * The scroller's padding counts as part of an end row, so the first row lands
+ * at 0 and the last lands at the very end of the track rather than flush
+ * against the card's edge.
+ *
+ * Returns `null` when the row is already revealed (no write).
+ */
+export function resolveMinimapListScrollTop(
+  geometry: MinimapListRevealGeometry,
+): number | null {
+  const rowTop = finite(geometry.rowTop);
+  const rowHeight = finite(geometry.rowHeight);
+  const scrollTop = finite(geometry.scrollTop);
+  const viewHeight = finite(geometry.viewHeight);
+  const scrollHeight = finite(geometry.scrollHeight);
+  if (
+    rowTop === null ||
+    rowHeight === null ||
+    scrollTop === null ||
+    viewHeight === null ||
+    scrollHeight === null
+  ) {
+    return null;
+  }
+
+  const maxScroll = Math.max(0, scrollHeight - viewHeight);
+  if (maxScroll === 0) return null;
+
+  const revealTop = rowTop - Math.max(0, finite(geometry.paddingTop) ?? 0);
+  const revealBottom =
+    rowTop + rowHeight + Math.max(0, finite(geometry.paddingBottom) ?? 0);
+
+  let next = scrollTop;
+  if (revealTop < scrollTop) {
+    next = revealTop;
+  } else if (revealBottom > scrollTop + viewHeight) {
+    next = revealBottom - viewHeight;
+  }
+
+  const clamped = Math.max(0, Math.min(next, maxScroll));
+  return clamped === scrollTop ? null : clamped;
+}
+
 export interface MinimapTrackMetrics {
   readonly itemCount: number;
   /** Gap between adjacent markers on the visible track. */


### PR DESCRIPTION
## Summary

Hovering the minimap rail opens the list card scrolled to the wrong place.
Sitting at the end of a long chat, the card opens several rows short of the
end instead of on the turn the rail is highlighting.

**Why.** The card measured itself with `getBoundingClientRect()` inside the
layout effect that runs on the mount that also starts its own `zoom-in-95`
entry animation. That animation's `from` keyframe is live on the first style
resolution — the very one the rect read forces — so every measured distance
came back scaled by 0.95, and the reveal under-scrolled by 5% of the distance
it needed. Deep in a long list that is several rows.

A second, smaller error rode along: the reveal aligned the row's bottom edge
to the scroller's bottom edge, so the container's own bottom padding stayed
out of view and the last row sat flush against the card's edge rather than at
the end of the track.

**How.** Measure in layout coordinates instead — `offsetTop` / `offsetHeight`
/ `clientHeight` / `scrollHeight` / `scrollTop`, none of which a transform can
skew — and count the scroller's padding as part of an end row, so the first
row lands at 0 and the last at the true end. The scroller carries `relative`
so it is the rows' offsetParent and `offsetTop` is read in its own content
coordinates.

The math moves into `resolveMinimapListScrollTop` in
`minimap-track-geometry.ts`, beside the rest of the shared rail geometry, and
stays DOM-free. Both rails that share this card — the chat turn rail and the
artifact heading rail — are fixed by it.

## Tests

`minimap-list-card.test.tsx` renders the real card over a faked layout and
deliberately leaves `getBoundingClientRect()` at jsdom's all-zero default, so
restoring rect measurement turns the "very end" and "mid-list" cases red
(verified by ablation: 2 failed / 2 passed, then restored to green). Seven
geometry cases in `minimap-track-geometry.test.ts` cover the ends, mid-list,
an already-visible row, a row taller than the viewport, and non-finite input.

Locally green before the commit: `bun run compile`, `eslint --max-warnings 0`,
`prettier` (unchanged), and the minimap + chat-rail + artifact-rail suites
(42 + 10 passed). The pre-commit hook's `build · compile · lint · format`
(nx affected) and DCO gates passed on commit.

Caveat worth stating for review: the diagnosis is from the code path, not a
live browser repro. The mechanism is deterministic (the entry animation's
`from` keyframe applies on the style resolution the rect read forces), and the
padding error is independent of it and fixed too.

## Related issue

None.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
