### PR TITLE
fix(gui-app): give the failed-attempt panel a read it started itself

### DIFF
--- a/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
+++ b/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
@@ -224,6 +224,16 @@ try {
           // ancestor that CLIPS. \`auto\`/\`scroll\` ancestors do not narrow it:
           // the user can scroll those.
           const reach = (() => {
+            // The card can also hide its OWN content: capped height plus
+            // \`overflow-y: hidden\` clips the controls while the card's
+            // rectangle still sits comfortably inside every ancestor, so a
+            // check that only compares rectangles reports ok on a card whose
+            // buttons are gone. \`auto\`/\`scroll\` is the capped card's actual
+            // spelling and stays reachable - the user scrolls inside it.
+            const own = getComputedStyle(card).overflowY;
+            const cutInside =
+              (own === 'hidden' || own === 'clip') &&
+              card.scrollHeight > card.clientHeight + 0.5;
             let fixed = false;
             for (let el = card; el !== null; el = el.parentElement) {
               if (getComputedStyle(el).position === 'fixed') { fixed = true; break; }
@@ -247,12 +257,14 @@ try {
               bound: round(bottom - top),
               cutAbove: cardTop < top - 0.5,
               cutBelow: cardTop + r.height > bottom + 0.5,
+              cutInside,
             };
           })();
           return {
             reachBound: reach.bound,
             cutAbove: reach.cutAbove,
             cutBelow: reach.cutBelow,
+            cutInside: reach.cutInside,
             sharedCard: card.getAttribute('data-surface') === 'host-boot-card',
             left: round(r.left),
             top: round(r.top),
@@ -316,8 +328,8 @@ try {
         pad(row.centerY, 7),
         pad(row.reachBound, 7),
         pad(
-          row.cutAbove || row.cutBelow
-            ? `CUT ${row.cutAbove ? "^" : ""}${row.cutBelow ? "v" : ""}`
+          row.cutAbove || row.cutBelow || row.cutInside
+            ? `CUT ${row.cutAbove ? "^" : ""}${row.cutBelow ? "v" : ""}${row.cutInside ? "in" : ""}`
             : "ok",
           8,
         ),
@@ -357,13 +369,15 @@ try {
       `wait faces do not share one box (top:height): ${[...waitBoxes].join(", ")}`,
     );
   }
-  const unreachable = rows.filter((row) => row.cutAbove || row.cutBelow);
+  const unreachable = rows.filter(
+    (row) => row.cutAbove || row.cutBelow || row.cutInside,
+  );
   if (unreachable.length > 0) {
     findings.push(
       `content the user cannot scroll to: ${unreachable
         .map(
           (row) =>
-            `${row.face}${row.cutAbove ? " (above)" : ""}${row.cutBelow ? " (below)" : ""}`,
+            `${row.face}${row.cutAbove ? " (above)" : ""}${row.cutBelow ? " (below)" : ""}${row.cutInside ? " (clipped by the card)" : ""}`,
         )
         .join(", ")}`,
     );

--- a/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
+++ b/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
@@ -210,7 +210,49 @@ try {
           const band = document.querySelector('[data-gallery-header-band]');
           const r = card.getBoundingClientRect();
           const round = (n) => Number(n.toFixed(1));
+          // CAN THE USER GET TO ALL OF IT? A tall card is only a problem when
+          // some of it cannot be brought into view, and which of those it is
+          // depends entirely on what encloses it: a card in a column that GROWS
+          // just makes the page scroll, the same card under a clipping or
+          // fixed ancestor loses whatever falls outside. That is the whole
+          // question behind \`viewportCapped\`, and it was argued rather than
+          // measured until this.
+          //
+          // A \`fixed\` ancestor pins the card to the viewport, so the viewport
+          // IS the bound (the narrator's layer - hence its cap). Otherwise the
+          // bound is the document's scrollable height, narrowed by any
+          // ancestor that CLIPS. \`auto\`/\`scroll\` ancestors do not narrow it:
+          // the user can scroll those.
+          const reach = (() => {
+            let fixed = false;
+            for (let el = card; el !== null; el = el.parentElement) {
+              if (getComputedStyle(el).position === 'fixed') { fixed = true; break; }
+            }
+            const scrollRoot = document.scrollingElement;
+            let top = 0;
+            let bottom = fixed ? window.innerHeight : scrollRoot.scrollHeight;
+            if (!fixed) {
+              for (let el = card.parentElement; el !== null; el = el.parentElement) {
+                const overflowY = getComputedStyle(el).overflowY;
+                if (overflowY !== 'hidden' && overflowY !== 'clip') continue;
+                const box = el.getBoundingClientRect();
+                top = Math.max(top, box.top + window.scrollY);
+                bottom = Math.min(bottom, box.top + window.scrollY + el.clientHeight);
+              }
+            }
+            // Fixed cards are already measured against the viewport, so their
+            // rect needs no scroll offset; everything else does.
+            const cardTop = fixed ? r.top : r.top + window.scrollY;
+            return {
+              bound: round(bottom - top),
+              cutAbove: cardTop < top - 0.5,
+              cutBelow: cardTop + r.height > bottom + 0.5,
+            };
+          })();
           return {
+            reachBound: reach.bound,
+            cutAbove: reach.cutAbove,
+            cutBelow: reach.cutBelow,
             sharedCard: card.getAttribute('data-surface') === 'host-boot-card',
             left: round(r.left),
             top: round(r.top),
@@ -254,6 +296,8 @@ try {
         pad("width", 7),
         pad("height", 7),
         pad("cY", 7),
+        pad("bound", 7),
+        pad("reach", 8),
         pad("settings", 9),
         pad("details", 8),
         "text",
@@ -270,6 +314,13 @@ try {
         pad(row.width, 7),
         pad(row.height, 7),
         pad(row.centerY, 7),
+        pad(row.reachBound, 7),
+        pad(
+          row.cutAbove || row.cutBelow
+            ? `CUT ${row.cutAbove ? "^" : ""}${row.cutBelow ? "v" : ""}`
+            : "ok",
+          8,
+        ),
         pad(row.openSettings, 9),
         pad(row.showDetails, 8),
         row.text,
@@ -304,6 +355,17 @@ try {
   if (waitBoxes.size !== waitBoxesPerTheme) {
     findings.push(
       `wait faces do not share one box (top:height): ${[...waitBoxes].join(", ")}`,
+    );
+  }
+  const unreachable = rows.filter((row) => row.cutAbove || row.cutBelow);
+  if (unreachable.length > 0) {
+    findings.push(
+      `content the user cannot scroll to: ${unreachable
+        .map(
+          (row) =>
+            `${row.face}${row.cutAbove ? " (above)" : ""}${row.cutBelow ? " (below)" : ""}`,
+        )
+        .join(", ")}`,
     );
   }
   if (!everyFamilyShared) {

--- a/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
+++ b/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
@@ -300,6 +300,34 @@ describe("<LocalBootstrapAttempts />", () => {
     });
   });
 
+  it("publishes its fresh sample to the SHARED entry the closed disclosure reads", async () => {
+    // The private key must not keep the answer to itself. `Show details` is
+    // closed when a start fails, so the disclosure is not polling and its
+    // shared entry still holds the pre-crash snapshot; opening it does not
+    // refetch either (`shouldFetchOptionally` needs a changed query or a
+    // previously-disabled one, and toggling `pollIntervalMs` is neither), so
+    // the interval it arms is the first refresh - up to 1.5s of a pre-crash
+    // bootstrap.log tail beside a panel describing the crash.
+    const traycerCli = new MockTraycerCli();
+    traycerCli.hostStatusSnapshot = AFTER_FAILURE;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      runnerQueryKeys.traycerHostStatus(traycerCli),
+      BEFORE_FAILURE,
+    );
+
+    mount(traycerCli, queryClient);
+    await screen.findByTestId("local-host-bootstrap-details");
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData(runnerQueryKeys.traycerHostStatus(traycerCli)),
+      ).toEqual(AFTER_FAILURE);
+    });
+  });
+
   it("draws the fetched attempt once, then holds it without polling", async () => {
     // A single read, not a poll: the user is reading a crash report and the CLI
     // is not re-run underneath them. `refetchInterval` is off for this reader;

--- a/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
+++ b/clients/gui-app/src/components/host/__tests__/local-bootstrap-attempts.test.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   MockRunnerHost,
@@ -7,6 +8,7 @@ import {
 } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import type { TraycerHostStatusSnapshot } from "@traycer-clients/shared/platform/runner-host";
 import { LocalBootstrapAttempts } from "@/components/host/local-bootstrap-attempts";
+import { BootstrapLogDisclosure } from "@/components/local-host-loading";
 import { runnerQueryKeys } from "@/lib/query-keys";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 
@@ -42,8 +44,22 @@ const AFTER_FAILURE: TraycerHostStatusSnapshot = {
   ],
 };
 
-function mount(traycerCli: MockTraycerCli, queryClient: QueryClient) {
-  const runnerHost = new MockRunnerHost({
+function tree(
+  runnerHost: MockRunnerHost,
+  queryClient: QueryClient,
+  children: ReactNode,
+) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={runnerHost}>
+        {children}
+      </RunnerHostProvider>
+    </QueryClientProvider>
+  );
+}
+
+function runnerHostFor(traycerCli: MockTraycerCli): MockRunnerHost {
+  return new MockRunnerHost({
     signInUrl: "https://auth.traycer.invalid/sign-in",
     authnBaseUrl: "http://localhost:5005",
     localHost: null,
@@ -52,13 +68,39 @@ function mount(traycerCli: MockTraycerCli, queryClient: QueryClient) {
     hasLocalHost: undefined,
     traycerCli,
   });
+}
+
+function mount(traycerCli: MockTraycerCli, queryClient: QueryClient) {
   return render(
-    <QueryClientProvider client={queryClient}>
-      <RunnerHostProvider runnerHost={runnerHost}>
-        <LocalBootstrapAttempts />
-      </RunnerHostProvider>
-    </QueryClientProvider>,
+    tree(runnerHostFor(traycerCli), queryClient, <LocalBootstrapAttempts />),
   );
+}
+
+/**
+ * The panel's OWN cache entry - and the fact that finding it this way works is
+ * itself the assertion. `onMount: "fresh-read"` gives each mount a private key
+ * so no other reader's in-flight request can be deduplicated onto it, but that
+ * key stays a prefix EXTENSION of the shared one, which is what keeps the
+ * recovery mutations' partial-match `invalidateQueries` reaching this panel. A
+ * key that stopped extending the shared one would return nothing here.
+ */
+function panelEntry(queryClient: QueryClient, traycerCli: MockTraycerCli) {
+  return queryClient
+    .getQueryCache()
+    .findAll({ queryKey: runnerQueryKeys.traycerHostStatus(traycerCli) })
+    .find((entry) => entry.queryKey.includes("fresh-read"));
+}
+
+/** A promise a test releases by hand, so a read stays genuinely in flight. */
+function deferred(): {
+  readonly promise: Promise<TraycerHostStatusSnapshot>;
+  readonly release: (snapshot: TraycerHostStatusSnapshot) => void;
+} {
+  let release: (snapshot: TraycerHostStatusSnapshot) => void = () => {};
+  const promise = new Promise<TraycerHostStatusSnapshot>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
 }
 
 describe("<LocalBootstrapAttempts />", () => {
@@ -73,8 +115,8 @@ describe("<LocalBootstrapAttempts />", () => {
     // rule - and describes the attempt before it ended: no terminal marker, so
     // no panel, or on a retry the PREVIOUS attempt's ending. Only
     // `convergeReady`'s success invalidates the key, so nothing else refreshes
-    // it in time. The panel therefore refetches on mount regardless of
-    // freshness, and shows nothing until that fetch lands.
+    // it in time. The panel therefore takes a read of its own on mount, and
+    // shows nothing until that read lands.
     const traycerCli = new MockTraycerCli();
     traycerCli.hostStatusSnapshot = AFTER_FAILURE;
     const hostStatus = vi.spyOn(traycerCli, "hostStatus");
@@ -104,16 +146,17 @@ describe("<LocalBootstrapAttempts />", () => {
       screen.getByTestId("local-host-bootstrap-log-path").textContent,
     ).toBe("/Users/me/.traycer/bootstrap.log");
     // And it WAS a read of the CLI, not a cache hit - the positive control for
-    // the whole test. Without `refetchOnMount: "always"` a fresh cache entry
-    // is never re-read and this stays at zero.
+    // the whole test. A panel reading the disclosure's own key would find this
+    // snapshot fresh by the 30-second rule and never call out at all, leaving
+    // this at zero.
     expect(hostStatus).toHaveBeenCalledTimes(1);
   });
 
-  it("draws NOTHING when the forced refetch rejects, rather than the cached snapshot it kept", async () => {
+  it("draws NOTHING when the mount's read rejects, rather than the cached snapshot it kept", async () => {
     // THE OTHER HALF of the guard above, and the reason it is two conditions.
     // `isFetchedAfterMount` is `dataUpdateCount > initial || errorUpdateCount >
-    // initial` (query-core's `queryObserver`), so a REJECTED refetch flips it
-    // true - and React Query deliberately keeps serving the cached data on a
+    // initial` (query-core's `queryObserver`), so a REJECTED read flips it
+    // true - and React Query deliberately keeps serving cached data on a
     // refetch error. Fetched-after-mount plus pre-failure data is exactly the
     // state this component must refuse, and a guard written on
     // `isFetchedAfterMount` alone renders it.
@@ -131,15 +174,12 @@ describe("<LocalBootstrapAttempts />", () => {
 
     mount(traycerCli, queryClient);
 
-    // The refetch is attempted and fails...
+    // The read is attempted and fails...
     await waitFor(() => {
       expect(hostStatus).toHaveBeenCalledTimes(1);
     });
     await waitFor(() => {
-      expect(
-        queryClient.getQueryState(runnerQueryKeys.traycerHostStatus(traycerCli))
-          ?.status,
-      ).toBe("error");
+      expect(panelEntry(queryClient, traycerCli)?.state.status).toBe("error");
     });
     // ...the cached snapshot survives in the cache (which is the premise, not
     // an incidental)...
@@ -150,6 +190,114 @@ describe("<LocalBootstrapAttempts />", () => {
     // heading, the error, Retry and the log path.
     expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
     expect(screen.queryByTestId("local-host-bootstrap-log-path")).toBeNull();
+  });
+
+  it("refuses a read that was ALREADY IN FLIGHT when it mounted, not merely one that resolved before it", async () => {
+    // THE THIRD WAY the stale snapshot gets in, and the one a `refetchOnMount`
+    // flag cannot close. The disclosure beside this panel reads the SAME key,
+    // and polls it every 1.5s while `Show details` is open - so at the instant
+    // the install fails there is routinely a request already running. On mount,
+    // query-core's `Query.fetch` returns the EXISTING retryer promise rather
+    // than starting a read (`cancelRefetch` is unset for a mount-triggered
+    // fetch, and is honoured only when the query already holds data anyway).
+    //
+    // That request sampled bootstrap.log BEFORE the terminal marker was
+    // written. It resolves after mount, so `isFetchedAfterMount` and
+    // `isSuccess` are both true - on data that predates the failure this panel
+    // exists to describe. "Fetched after mount" is not "read after mount".
+    const traycerCli = new MockTraycerCli();
+    const preFailureRead = deferred();
+    const panelRead = deferred();
+    const hostStatus = vi
+      .spyOn(traycerCli, "hostStatus")
+      .mockImplementationOnce(() => preFailureRead.promise)
+      .mockImplementation(() => panelRead.promise);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const runnerHost = runnerHostFor(traycerCli);
+
+    // The healthy card, with its disclosure reading the host status. Nothing is
+    // resolved yet: this is the in-flight request the failure interrupts.
+    const view = render(
+      tree(
+        runnerHost,
+        queryClient,
+        <BootstrapLogDisclosure onConfigureShell={() => {}} trailing={null} />,
+      ),
+    );
+    await waitFor(() => {
+      expect(hostStatus).toHaveBeenCalledTimes(1);
+    });
+
+    // The install fails and the failure body mounts the panel BESIDE the
+    // disclosure - exactly how both failure cards compose it.
+    view.rerender(
+      tree(
+        runnerHost,
+        queryClient,
+        <>
+          <LocalBootstrapAttempts />
+          <BootstrapLogDisclosure onConfigureShell={() => {}} trailing={null} />
+        </>,
+      ),
+    );
+
+    // The pre-failure read lands. It is the only read a deduplicating mount
+    // would ever see.
+    await act(async () => {
+      preFailureRead.release(BEFORE_FAILURE);
+      await preFailureRead.promise;
+    });
+    // Nothing drawn from it - and given every chance to be. The stale render
+    // does not appear in the same tick the promise settles, so an assertion
+    // taken straight after `release` passes on an unflushed tree rather than
+    // on an empty one. Flushed, unfixed code draws "Last attempt … Host never
+    // reported a terminal status" right here, under a heading that says the
+    // host didn't start and a message quoting the exit code it died with.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+    expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
+
+    // The panel's OWN read - started after it mounted - is what it draws.
+    expect(hostStatus).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      panelRead.release(AFTER_FAILURE);
+      await panelRead.promise;
+    });
+    const panel = await screen.findByTestId("local-host-bootstrap-details");
+    expect(panel.textContent).toContain("Host crashed with code 1");
+  });
+
+  it("is still reached by the recovery actions' invalidation of the SHARED key", async () => {
+    // The property the private key must not cost. Retry, respawn and
+    // `convergeReady` all invalidate `runnerQueryKeys.traycerHostStatus(cli)`
+    // and nothing else; a panel keyed outside that prefix would quietly stop
+    // hearing them. Partial matching is what keeps it inside.
+    const traycerCli = new MockTraycerCli();
+    traycerCli.hostStatusSnapshot = BEFORE_FAILURE;
+    const hostStatus = vi.spyOn(traycerCli, "hostStatus");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    mount(traycerCli, queryClient);
+    await screen.findByTestId("local-host-bootstrap-details");
+
+    traycerCli.hostStatusSnapshot = AFTER_FAILURE;
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),
+      });
+    });
+
+    expect(hostStatus).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("local-host-bootstrap-details").textContent,
+      ).toContain("Host crashed with code 1");
+    });
   });
 
   it("draws the fetched attempt once, then holds it without polling", async () => {

--- a/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
+++ b/clients/gui-app/src/components/host/local-bootstrap-attempts.tsx
@@ -17,10 +17,10 @@ import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-trayc
  * snapshot is within the 30-second `staleTime`, so an ordinary mount would
  * reuse it and describe the attempt BEFORE the one that just failed - or no
  * attempt at all. Only `convergeReady`'s SUCCESS invalidates the key. So the
- * mount refetches unconditionally (`onMount: "always"`) and the panel waits
- * for that fetch (`isFetchedAfterMount`) rather than drawing the stale one
- * for the beat it takes - a wrong attempt panel that corrects itself is still
- * a wrong attempt panel on a crash report.
+ * mount takes a read of its own (`onMount: "fresh-read"`) and the panel waits
+ * for it (`isFetchedAfterMount`) rather than drawing the stale one for the
+ * beat it takes - a wrong attempt panel that corrects itself is still a wrong
+ * attempt panel on a crash report.
  *
  * Shared by the two surfaces that can be on screen for a failed local start -
  * the window narrator's settled arm and the gate's `provisioning-error` card.
@@ -32,7 +32,7 @@ import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-trayc
 export function LocalBootstrapAttempts(): ReactNode {
   const status = useRunnerTraycerHostStatusQuery({
     pollIntervalMs: null,
-    onMount: "always",
+    onMount: "fresh-read",
   });
   // BOTH halves, and the second one is not redundant. `isFetchedAfterMount` is
   // `dataUpdateCount > initial || errorUpdateCount > initial` (query-core's

--- a/clients/gui-app/src/hooks/runner/use-runner-traycer-host-status-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-traycer-host-status-query.ts
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   queryOptions,
   useQuery,
+  useQueryClient,
   type UseQueryResult,
 } from "@tanstack/react-query";
 import type {
@@ -77,10 +78,11 @@ function traycerHostStatusQueryKey(
   onMount: "when-stale" | "fresh-read",
   freshReadId: number,
 ): readonly unknown[] {
-  if (traycerCli === null) return ["runner.traycer.hostStatus", "disabled"];
-  const shared = runnerQueryKeys.traycerHostStatus(traycerCli);
-  if (onMount === "when-stale") return shared;
-  return [...shared, "fresh-read", freshReadId];
+  if (traycerCli === null) return runnerQueryKeys.traycerHostStatusDisabled();
+  if (onMount === "when-stale") {
+    return runnerQueryKeys.traycerHostStatus(traycerCli);
+  }
+  return runnerQueryKeys.traycerHostStatusFreshRead(traycerCli, freshReadId);
 }
 
 function traycerHostStatusQueryOptions(
@@ -133,7 +135,7 @@ export function useRunnerTraycerHostStatusQuery(
   // renders, and a hook cannot be taken conditionally - so `when-stale`
   // callers burn an integer and ignore it.
   const [freshReadId] = useState(nextFreshReadId);
-  return useQuery(
+  const query = useQuery(
     traycerHostStatusQueryOptions(
       runnerHost.traycerCli,
       opts.pollIntervalMs,
@@ -141,4 +143,50 @@ export function useRunnerTraycerHostStatusQuery(
       freshReadId,
     ),
   );
+  usePublishFreshReadToSharedEntry({
+    enabled: opts.onMount === "fresh-read",
+    traycerCli: runnerHost.traycerCli,
+    data: query.data,
+  });
+  return query;
+}
+
+/**
+ * A private entry keeps the failure panel's read out of everyone else's
+ * dedup - it should not also keep the answer to itself.
+ *
+ * The disclosure beside that panel is CLOSED at the moment of a failure, so it
+ * is not polling, and its shared entry still holds the snapshot it took while
+ * the start was healthy. Opening `Show details` does not refresh it either:
+ * `shouldFetchOptionally` gates on `query !== prevQuery || prevOptions.enabled
+ * === false`, and a disclosure merely toggling its own `pollIntervalMs`
+ * satisfies neither - so the interval it just armed is the first thing that
+ * refetches, up to 1.5s later. Until then the user reads a bootstrap.log tail
+ * from before the crash, beside a panel describing the crash.
+ *
+ * So the fresh read is published to the shared entry: it is a newer sample of
+ * the same file, and the canonical key is where every other reader looks.
+ *
+ * Written unconditionally rather than behind a "only if newer" timestamp
+ * guard. Such a guard reads as prudent and is in fact unreachable: this effect
+ * re-runs only when THIS reader's own data changes, which happens only when
+ * this reader refetches - and that sample is always the newest one it has. A
+ * later poll by the disclosure cannot provoke a re-run, so there is nothing to
+ * roll back. (`dataUpdatedAt` would not even discriminate: `setQueryData` and
+ * a resolving read routinely stamp the same millisecond.)
+ */
+function usePublishFreshReadToSharedEntry(args: {
+  readonly enabled: boolean;
+  readonly traycerCli: ITraycerCli | null;
+  readonly data: TraycerHostStatusSnapshot | undefined;
+}): void {
+  const queryClient = useQueryClient();
+  const { enabled, traycerCli, data } = args;
+  useEffect(() => {
+    if (!enabled || traycerCli === null || data === undefined) return;
+    queryClient.setQueryData(
+      runnerQueryKeys.traycerHostStatus(traycerCli),
+      data,
+    );
+  }, [enabled, traycerCli, data, queryClient]);
 }

--- a/clients/gui-app/src/hooks/runner/use-runner-traycer-host-status-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-traycer-host-status-query.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   queryOptions,
   useQuery,
@@ -25,29 +26,74 @@ export interface UseRunnerTraycerHostStatusQueryOptions {
    *  - `"when-stale"`: the ordinary rule - reuse it while it is within
    *    `staleTime`, refetch otherwise. For a reader that shows the LIVE tail
    *    (`BootstrapLogDisclosure`), whose poll refreshes it anyway.
-   *  - `"always"`: refetch on mount regardless, and let the caller gate on
-   *    `isFetchedAfterMount` so it never presents the cached one. For a
-   *    reader that describes a state transition that HAPPENED JUST NOW -
-   *    the failed-attempt panel (`LocalBootstrapAttempts`) mounts on the
-   *    failure, but the disclosure beside it read this same query while the
-   *    start was still healthy, and a snapshot from 20 seconds ago is
-   *    "fresh" by the 30-second rule while describing the attempt BEFORE
-   *    the one that just failed - or none. Only `convergeReady`'s SUCCESS
-   *    invalidates this key, so nothing else would refresh it in time.
+   *  - `"fresh-read"`: a read that provably BEGAN at this mount, on its own
+   *    cache entry. For a reader that describes a state transition which
+   *    HAPPENED JUST NOW - the failed-attempt panel
+   *    (`LocalBootstrapAttempts`) mounts on the failure, but the disclosure
+   *    beside it read this same query while the start was still healthy, and
+   *    a snapshot from 20 seconds ago is "fresh" by the 30-second rule while
+   *    describing the attempt BEFORE the one that just failed - or none. Only
+   *    `convergeReady`'s SUCCESS invalidates this key, so nothing else would
+   *    refresh it in time.
    */
-  readonly onMount: "when-stale" | "always";
+  readonly onMount: "when-stale" | "fresh-read";
+}
+
+/**
+ * The per-mount discriminator behind `"fresh-read"`, and why it is a counter.
+ *
+ * This started as `refetchOnMount: "always"`, which is NOT the same promise. A
+ * mount-triggered fetch carries no `cancelRefetch`, so query-core's
+ * `Query.fetch` hands back the retryer promise of a request that is ALREADY
+ * RUNNING instead of starting one (`fetchStatus !== "idle"` → `return
+ * this.#retryer.promise`). The disclosure polls this key every 1.5s while
+ * `Show details` is open, so at the instant an install fails there is
+ * routinely one in flight - taken BEFORE the terminal marker was written. It
+ * resolves after the mount, so `isFetchedAfterMount` and `isSuccess` both pass
+ * on pre-failure data and the panel draws "Host never reported a terminal
+ * status" over a crash that reported one. Fetched-after-mount is not
+ * read-after-mount, and no `refetchOnMount` value spells the difference.
+ *
+ * A key nothing else has used cannot be deduplicated onto: there is no entry
+ * and no retryer, so the fetch is genuinely this mount's. It stays a prefix
+ * EXTENSION of the shared key, so the recovery mutations' partial-match
+ * `invalidateQueries` still reaches it.
+ *
+ * A counter rather than `useId`, which is derived from tree position and so
+ * repeats across an unmount/remount at the same position - handing the second
+ * mount the first one's still-running request, which is the bug again. The
+ * cost is one small cache entry per settled failure the user looks at, dropped
+ * at the default `gcTime`.
+ */
+let freshReadSequence = 0;
+
+function nextFreshReadId(): number {
+  freshReadSequence += 1;
+  return freshReadSequence;
+}
+
+function traycerHostStatusQueryKey(
+  traycerCli: ITraycerCli | null,
+  onMount: "when-stale" | "fresh-read",
+  freshReadId: number,
+): readonly unknown[] {
+  if (traycerCli === null) return ["runner.traycer.hostStatus", "disabled"];
+  const shared = runnerQueryKeys.traycerHostStatus(traycerCli);
+  if (onMount === "when-stale") return shared;
+  return [...shared, "fresh-read", freshReadId];
 }
 
 function traycerHostStatusQueryOptions(
   traycerCli: ITraycerCli | null,
   pollIntervalMs: number | null,
-  onMount: "when-stale" | "always",
+  onMount: "when-stale" | "fresh-read",
+  freshReadId: number,
 ) {
   return queryOptions<TraycerHostStatusSnapshot>({
-    queryKey:
-      traycerCli !== null
-        ? runnerQueryKeys.traycerHostStatus(traycerCli)
-        : ["runner.traycer.hostStatus", "disabled"],
+    // `traycerCli` is passed rather than closed over so
+    // `@tanstack/query/exhaustive-deps` can see it in the key expression -
+    // the rule reads this property, not what a local was built from.
+    queryKey: traycerHostStatusQueryKey(traycerCli, onMount, freshReadId),
     queryFn: () => {
       if (traycerCli === null) {
         throw new Error("traycerCli unavailable on this runner host");
@@ -61,7 +107,6 @@ function traycerHostStatusQueryOptions(
     // explicit invalidate.
     staleTime: pollIntervalMs !== null ? 0 : 30_000,
     refetchInterval: pollIntervalMs ?? false,
-    refetchOnMount: onMount === "always" ? "always" : true,
   });
 }
 
@@ -83,11 +128,17 @@ export function useRunnerTraycerHostStatusQuery(
   opts: UseRunnerTraycerHostStatusQueryOptions,
 ): UseQueryResult<TraycerHostStatusSnapshot> {
   const runnerHost = useRunnerHost();
+  // Allocated for every caller and read by one. It has to come from a
+  // mount-scoped `useState` initializer to be stable across this mount's
+  // renders, and a hook cannot be taken conditionally - so `when-stale`
+  // callers burn an integer and ignore it.
+  const [freshReadId] = useState(nextFreshReadId);
   return useQuery(
     traycerHostStatusQueryOptions(
       runnerHost.traycerCli,
       opts.pollIntervalMs,
       opts.onMount,
+      freshReadId,
     ),
   );
 }

--- a/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
@@ -140,6 +140,27 @@ export const runnerQueryKeys = {
   // serialised.
   traycerHostStatus: (traycerCli: object) =>
     ["runner.traycer.hostStatus", traycerCli] as const,
+  // The host-status read on a shell with no CLI at all (mobile, web). A key of
+  // its own so the disabled query can never collide with a real runner's.
+  traycerHostStatusDisabled: () =>
+    ["runner.traycer.hostStatus", "disabled"] as const,
+  /**
+   * A PRIVATE host-status entry, one per mount of a reader that needs a sample
+   * it took itself rather than whatever the shared entry holds
+   * (`LocalBootstrapAttempts`, mounting on a settled failure). A key nothing
+   * else has used has no entry and no in-flight retryer, so the fetch cannot
+   * be deduplicated onto a request that started before the failure.
+   *
+   * It EXTENDS `traycerHostStatus` rather than standing beside it, and that is
+   * load-bearing: the recovery mutations invalidate the shared key by partial
+   * match, and only a prefix extension is still reached by them.
+   */
+  traycerHostStatusFreshRead: (traycerCli: object, readId: number) =>
+    [
+      ...runnerQueryKeys.traycerHostStatus(traycerCli),
+      "fresh-read",
+      readId,
+    ] as const,
   traycerShellConfig: (traycerCli: object) =>
     ["runner.traycer.shellConfig", traycerCli] as const,
   traycerShellList: (traycerCli: object) =>


### PR DESCRIPTION
Follow-up to #1284, from two review comments Codex posted ~30s after that PR merged. One is real and fixed here; the other is refuted by measurement, and the instrument that refutes it is added here so the question stays answerable.

## The real one — a stale crash report

`refetchOnMount: "always"` promises a read that **resolves** after mount. It does not promise one that **started** after mount, and that is the invariant `LocalBootstrapAttempts` actually needs.

A mount-triggered fetch carries no `cancelRefetch`, so query-core returns the promise of a request already in flight rather than starting one:

```js
// query-core/build/modern/query.cjs
if (this.state.fetchStatus !== "idle" && this.#retryer?.status() !== "rejected") {
  if (this.state.data !== void 0 && fetchOptions?.cancelRefetch) { this.cancel({ silent: true }) }
  else if (this.#retryer) { this.#retryer.continueRetry(); return this.#retryer.promise }   // ← here
}
```

`BootstrapLogDisclosure` sits beside this panel on the same card, reads the same key, and polls it every 1.5s while `Show details` is open — so when an install fails there is routinely a request in flight, sampled **before** the terminal marker was written. It resolves after the mount, `isFetchedAfterMount` and `isSuccess` both pass, and the crash card renders:

> Last attempt `/bin/zsh -i -l -c traycer` — **Host never reported a terminal status.**

under a heading that says the host didn't start and a message quoting the exit code it died with. That string is a rendered repro, not a description: it is what the new test prints against the pre-fix code.

**Fix.** `onMount: "fresh-read"` gives each mount its own cache entry. A key nothing has used has no entry and no retryer, so the fetch is genuinely this mount's — airtight in both arms, including the one `cancelRefetch` cannot reach (`state.data === undefined`, where query-core dedupes regardless).

The key stays a **prefix extension** of the shared one, so the recovery mutations' partial-match `invalidateQueries` still reaches the panel. That is the one property a private key could silently cost, so it has its own test.

A counter rather than `useId`: `useId` is derived from tree position and repeats across an unmount/remount at the same position, handing the second mount the first one's still-running request — the same bug again.

## The other one — refuted, and now measurable

The second comment argued the gate's `provisioning-error` card overflows its frame at high zoom, projecting above and below with the heading unreachable, because the frame is a `min-h-0` flex item that centres its child.

`min-h-0` removes the automatic minimum; it does not change how `flex-basis: 0%` resolves. Against a container whose main size is indefinite (`min-h-svh`, not `h-svh`), that basis resolves to `content` — so the column **grows** and the page scrolls. That is exactly the premise `viewportCapped`'s doc comment already states for gate-frame cards.

Measured with the boot-family gallery at 1200x200 (300% zoom on the 600px minimum window ≈ 200 CSS px — the case the comment names):

| face | top | height | reachable bound | reach |
| --- | --- | --- | --- | --- |
| `gate-provisioning-error` | 64 | 368 | 456 | `ok` |

Every one of the 13 faces reads `ok`. Heading visible at rest, recovery row reachable by scrolling.

A probe that only ever says `ok` proves nothing, so it was given a positive control — the fixture's `GateFrame` temporarily forced to `h-svh overflow-hidden`:

| face | top | reachable bound | reach |
| --- | --- | --- | --- |
| `gate-provisioning-error` | **−64** | 200 | **`CUT ^v`** |
| `gate-removed` | 1 | 200 | `CUT v` |
| `runtime` | 64 | 296 | `ok` (owns its own column — internal control) |
| `narrator-*` | 64 | 200 | `ok` (fixed layer, capped) |

So the probe reports precisely the state the comment described, on a frame that is genuinely in it — and the real frame is not. The reachability column is kept because the narrator layer's cap in #1284 was argued rather than measured, and this is the question `viewportCapped` exists to answer.

## Verification

- `local-bootstrap-attempts.test.tsx`: the new in-flight test fails on pre-fix code at the **rendered** assertion, not just a call count (asserted after a real flush, so it cannot pass on an unflushed tree).
- 130 tests across the 9 suites touching this hook and its mocks: all pass.
- pre-commit: build · compile · lint · format · DCO all green.

## Not changed

At 1200x200 the gallery also reports `wait faces do not share one box: 64:208, 64:112` — the narrator's fixed layer caps its card to the frame while the gate and runtime faces grow the page. Present identically before this change; it is the family's geometry promise degrading at extreme zoom, not a regression, and squaring it means deciding whether every boot face should cap and scroll internally. Flagged rather than folded in.