### PR TITLE
fix(gui-app): strip the managed-CLI version popover to its list

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-model.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-model.test.ts
@@ -483,6 +483,50 @@ describe("labels and helpers", () => {
     }
   });
 
+  it("speaks a blocking certification on the CURRENT row, whose chip slot `Current` owns", () => {
+    // `versionRowChip` hands `Current` the chip unconditionally, so a current
+    // version that is later withdrawn has nowhere else to say so. Non-current
+    // blocked rows wear the certification AS their chip and must not get a
+    // second copy here.
+    for (const certification of [
+      "yanked",
+      "below-security-floor",
+      "host-ineligible",
+    ] as const) {
+      const current = version({
+        version: "1.0.0",
+        current: true,
+        certification,
+        installState: { status: "installed" },
+      });
+      expect(versionRowChip(current)?.label).toBe("Current");
+      expect(versionTroubleLine(current)).toBe(
+        certificationMetaLine(certification),
+      );
+
+      const sibling = version({
+        version: "0.9.0",
+        current: false,
+        certification,
+        installState: { status: "installed" },
+      });
+      expect(versionRowChip(sibling)?.tone).toBe("blocked");
+      expect(versionTroubleLine(sibling)).toBeNull();
+    }
+    // `uncertified` is NOT blocking (D8): a current copy the channel stopped
+    // listing stays usable and must stay quiet.
+    expect(
+      versionTroubleLine(
+        version({
+          version: "1.0.0",
+          current: true,
+          certification: "uncertified",
+          installState: { status: "installed" },
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it("finds the recommended version from managed state", () => {
     expect(
       findRecommendedVersion(

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-model.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-model.test.ts
@@ -7,11 +7,9 @@ import {
   certificationBadgeLabel,
   certificationMetaLine,
   comparePackVersionsDescending,
-  composeVersionRowMeta,
-  installErrorReasonLabel,
   findRecommendedVersion,
-  formatPackSizeBytes,
   formatSharedWithProvidersLine,
+  installErrorReasonLabel,
   installPackVersionRefusalMessage,
   removeResultUserMessage,
   unusableReasonLabel,
@@ -21,7 +19,10 @@ import {
   versionDownloadEligibility,
   versionErrorIsRetryable,
   versionInstallFetchLabel,
+  versionRowChip,
+  versionShowsDeleteAction,
   versionShowsInstallFetchAction,
+  versionTroubleLine,
   versionUseEligibility,
 } from "@/components/settings/panels/provider-pack-version-manager-model";
 
@@ -424,39 +425,6 @@ describe("labels and helpers", () => {
     );
   });
 
-  it("composes uncertified + unverified without claiming still usable", () => {
-    const meta = composeVersionRowMeta({
-      installState: { status: "unusable", reason: "unverified" },
-      certification: "uncertified",
-      sizeLabel: "40 MB",
-      recommended: false,
-    });
-    expect(meta.toLowerCase()).toMatch(/not necessarily damaged/);
-    expect(meta.toLowerCase()).toMatch(/no longer published|remains on disk/);
-    expect(meta.toLowerCase()).not.toMatch(/still usable/);
-  });
-
-  it("never renders the operator-facing wire message on a failed install", () => {
-    // `message` is documented as the UNDERLYING detail and can carry raw
-    // filesystem/network text. The row must speak from the typed reason, which
-    // is also the only field that says whether retrying helps.
-    const raw = "ENOSPC: no space left on device, write '/var/tmp/pack.part'";
-    const meta = composeVersionRowMeta({
-      installState: {
-        status: "error",
-        reason: "disk-full",
-        message: raw,
-        retryAtMs: null,
-      },
-      certification: "eligible",
-      sizeLabel: "40 MB",
-      recommended: false,
-    });
-    expect(meta).not.toContain(raw);
-    expect(meta).not.toContain("ENOSPC");
-    expect(meta).toContain(installErrorReasonLabel("disk-full"));
-  });
-
   it("gives every install-error reason its own sentence", () => {
     // Totality matters more than the wording: a reason with no case would be a
     // compile error, but two reasons collapsing onto one sentence would not,
@@ -475,6 +443,44 @@ describe("labels and helpers", () => {
     expect(new Set(sentences).size).toBe(reasons.length);
     for (const sentence of sentences)
       expect(sentence.length).toBeGreaterThan(0);
+  });
+
+  it("speaks a broken row's trouble from the typed reason, never the wire message", () => {
+    // `message` is documented as the UNDERLYING operator-facing detail and can
+    // carry raw filesystem or network text. This assertion used to live on
+    // `composeVersionRowMeta`, which the hover card's removal deleted; the
+    // invariant outlived the function, so it moves here.
+    const raw = "ENOSPC: no space left on device, write '/var/tmp/pack.part'";
+    const line = versionTroubleLine(
+      version({
+        version: "1.0.0",
+        installState: {
+          status: "error",
+          reason: "disk-full",
+          message: raw,
+          retryAtMs: null,
+        },
+      }),
+    );
+    expect(line).not.toBeNull();
+    expect(line).not.toContain(raw);
+    expect(line).not.toContain("ENOSPC");
+    expect(line).toBe(installErrorReasonLabel("disk-full"));
+  });
+
+  it("gives a healthy row no trouble line at all", () => {
+    // The redesign's whole premise: a row that is fine is a number, a chip and
+    // its controls. If this ever returns a string for `installed` or `absent`,
+    // every healthy row grows a second line and the list is a wall again.
+    for (const state of [
+      { status: "installed" },
+      { status: "absent" },
+      { status: "downloading", percent: 42 },
+    ] as const) {
+      expect(
+        versionTroubleLine(version({ version: "1.0.0", installState: state })),
+      ).toBeNull();
+    }
   });
 
   it("finds the recommended version from managed state", () => {
@@ -582,9 +588,76 @@ describe("labels and helpers", () => {
     }
   });
 
-  it("formats pack sizes and preserves null for yank tombstones", () => {
-    expect(formatPackSizeBytes(null)).toBeNull();
-    expect(formatPackSizeBytes(512)).toBe("512 B");
-    expect(formatPackSizeBytes(40_000_000)).toMatch(/MB/);
+  it("gives an unpublished version a chip that outranks Recommended", () => {
+    // The signal this chip carries is "deleting this is permanent", because an
+    // unpublished version cannot be fetched again. A version can be BOTH
+    // unpublished and recommended, and of the two only one of them changes
+    // what pressing delete costs - so the warning has to win. This ordering
+    // is the whole reason the chip exists; before it, the state lived only in
+    // a hover card, and deleting the card would have taken it with it.
+    const chip = versionRowChip(
+      version({
+        version: "1.0.0",
+        recommended: true,
+        certification: "uncertified",
+        installState: { status: "installed" },
+      }),
+    );
+    expect(chip).toEqual({ label: "Unpublished", tone: "unpublished" });
+  });
+
+  it("still lets Current outrank an unpublished chip", () => {
+    // Not an oversight that the warning loses here: delete is refused for the
+    // current version outright, so there is no reversibility question to warn
+    // about on this row.
+    const chip = versionRowChip(
+      version({
+        version: "1.0.0",
+        current: true,
+        certification: "uncertified",
+        installState: { status: "installed" },
+      }),
+    );
+    expect(chip).toEqual({ label: "Current", tone: "current" });
+  });
+
+  it("shows a Delete control for anything with bytes on disk, and only that", () => {
+    // `versionShowsDeleteAction` is what lets a BLOCKED delete still render as
+    // a disabled button carrying its reason. The quarantine case is the one
+    // that regressed before: the panel hardcoded a `current`-only disabled arm,
+    // so a quarantined row rendered no control and never showed the sentence
+    // `versionDeleteEligibility` computes for it.
+    const onDisk = [
+      version({ version: "1.0.0", installState: { status: "installed" } }),
+      version({
+        version: "1.1.0",
+        installState: { status: "unusable", reason: "quarantined" },
+      }),
+      version({
+        version: "1.2.0",
+        current: true,
+        installState: { status: "installed" },
+      }),
+    ];
+    for (const row of onDisk) expect(versionShowsDeleteAction(row)).toBe(true);
+
+    const notOnDisk = [
+      version({ version: "2.0.0", installState: { status: "absent" } }),
+      version({
+        version: "2.1.0",
+        installState: { status: "downloading", percent: 42 },
+      }),
+      version({
+        version: "2.2.0",
+        installState: {
+          status: "error",
+          reason: "network",
+          message: "timeout",
+          retryAtMs: null,
+        },
+      }),
+    ];
+    for (const row of notOnDisk)
+      expect(versionShowsDeleteAction(row)).toBe(false);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-panel.test.tsx
@@ -870,6 +870,65 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
     });
   });
 
+  it("disarms a delete when the settings scope follows to another host carrying the same version", async () => {
+    // The panel is mounted unkeyed under a scope whose host can auto-follow
+    // while the popover is open. If the arming were a bare version string it
+    // would survive the move, and the new host's identical row would mount
+    // already armed — one press from deleting on a machine nothing was armed
+    // on. Same pack, same version, different host: must NOT be armed.
+    const user = userEvent.setup();
+    const rows = [
+      version({ version: "1.5.0", installState: { status: "installed" } }),
+    ];
+    const view = render(
+      <ProviderPackVersionManagerPanel
+        hostId="host-1"
+        packId="opencode"
+        packDisplayName="opencode CLI"
+        managedVersions={managed(rows, null)}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: rowActionName("Delete", "1.5.0") }),
+    );
+    expect(screen.getByTestId("version-delete-confirm-1.5.0")).toBeTruthy();
+
+    view.rerender(
+      <ProviderPackVersionManagerPanel
+        hostId="host-2"
+        packId="opencode"
+        packDisplayName="opencode CLI"
+        managedVersions={managed(rows, null)}
+      />,
+    );
+
+    expect(screen.queryByTestId("version-delete-confirm-1.5.0")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: rowActionName("Delete", "1.5.0") }),
+    ).toBeTruthy();
+    expect(mocks.removeMutate).not.toHaveBeenCalled();
+  });
+
+  it("says why the CURRENT version is blocked, since its chip slot is taken by Current", () => {
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({
+          version: "1.5.0",
+          current: true,
+          certification: "yanked",
+          installState: { status: "installed" },
+        }),
+      ],
+      managedOverrides: null,
+    });
+
+    expect(screen.getByText("Current")).toBeTruthy();
+    const trouble = screen.getByTestId("version-row-trouble");
+    expect(trouble.textContent).toContain("Withdrawn");
+  });
+
   it("disarms an armed delete when another row's action runs", async () => {
     const user = userEvent.setup();
     renderPanel({

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-panel.test.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@traycer/protocol/host/provider-schemas";
 import { ProviderPackVersionManagerPanel } from "@/components/settings/panels/provider-pack-version-manager-panel";
 import { PROVIDER_PACK_VERSION_MANAGER_CAPABILITY_METHODS } from "@/components/settings/panels/provider-pack-version-manager-capability";
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 
 type UsePackVersionVariables = {
   readonly packId: string;
@@ -83,6 +84,33 @@ type InstallMutateOptions = {
   readonly onError?: (error: unknown) => void;
 };
 
+type RemovePackVersionVariables = {
+  readonly packId: string;
+  readonly version: string;
+};
+
+type RemovePackVersionRefusalCode =
+  "is-current" | "holder-reserved" | "quarantine-reserved" | "deferred-locked";
+
+type RemoveMutateOptions = {
+  readonly onSuccess?: (response: {
+    readonly result:
+      | { readonly ok: true }
+      | {
+          readonly ok: false;
+          readonly code: RemovePackVersionRefusalCode;
+          readonly detail: string | null;
+        };
+  }) => void;
+  readonly onSettled?: () => void;
+  readonly onError?: (error: unknown) => void;
+};
+
+type SetPackPolicyVariables = {
+  readonly packId: string;
+  readonly autoDownload: boolean;
+};
+
 const mocks = vi.hoisted(() => {
   const supportByHostId = new Map<string, boolean | null>();
   let lastSupportArgs: HostMethodSupportArgs | null = null;
@@ -96,12 +124,18 @@ const mocks = vi.hoisted(() => {
           options: InstallMutateOptions,
         ) => void
       >(),
-    removeMutate: vi.fn(),
+    removeMutate:
+      vi.fn<
+        (
+          variables: RemovePackVersionVariables,
+          options: RemoveMutateOptions,
+        ) => void
+      >(),
     useMutate:
       vi.fn<
         (variables: UsePackVersionVariables, options: UseMutateOptions) => void
       >(),
-    setPolicyMutate: vi.fn(),
+    setPolicyMutate: vi.fn<(variables: SetPackPolicyVariables) => void>(),
     /**
      * Per-host capability map. The gate must consult the *passed* hostId, not an
      * ambient default — regressions would re-introduce scoped-host bugs.
@@ -227,22 +261,9 @@ function renderPanel(options: {
   );
 }
 
-/**
- * The row's details, as a screen reader gets them.
- *
- * THROWS rather than `?? ""`: an absent aria-label is the exact regression
- * these assertions exist to catch (Radix keeps hover-card content out of the
- * a11y tree, so the label is the only form a screen reader ever sees), and a
- * fallback would turn that into a passing test against an empty string.
- */
-function detailsLabel(version: string): string {
-  const label = screen
-    .getByTestId(`version-details-trigger-${version}`)
-    .getAttribute("aria-label");
-  if (label === null) {
-    throw new Error(`version ${version} rendered no details aria-label`);
-  }
-  return label;
+/** Row action buttons are icon-only; their accessible name carries the version. */
+function rowActionName(label: string, version: string): string {
+  return `${label} ${version}`;
 }
 
 describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
@@ -298,7 +319,11 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       screen.getByTestId("provider-pack-version-manager-unsupported"),
     ).toBeTruthy();
     expect(screen.queryByTestId("provider-pack-version-manager")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: rowActionName("Download", "1.0.0"),
+      }),
+    ).toBeNull();
 
     cleanup();
     mocks.lastSupportArgs = null;
@@ -330,7 +355,11 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       screen.queryByTestId("provider-pack-version-manager-unsupported"),
     ).toBeNull();
     expect(screen.queryByTestId("provider-pack-version-manager")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: rowActionName("Download", "1.0.0"),
+      }),
+    ).toBeNull();
   });
 
   it("shows unsupported copy when the host completed handshake without the methods", () => {
@@ -348,9 +377,17 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
     ).toBeNull();
     expect(screen.queryByTestId("provider-pack-version-manager")).toBeNull();
     // Capability gate: no offered-then-failed action buttons.
-    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Use" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: rowActionName("Download", "1.0.0"),
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: rowActionName("Use", "1.0.0") }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: rowActionName("Delete", "1.0.0") }),
+    ).toBeNull();
   });
 
   it("renders indeterminate progress for downloading with null percent, not error copy", () => {
@@ -369,21 +406,28 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
     expect(screen.queryByTestId("download-progress-determinate")).toBeNull();
     expect(screen.queryByTestId("condemned-no-retry")).toBeNull();
     expect(screen.queryByTestId("version-row-notice")).toBeNull();
+    // The row's action column is icon-only now; "in progress" is carried by
+    // the disabled "Downloading <version>" button, not by row text.
+    const downloadingButton = screen.getByRole("button", {
+      name: "Downloading 1.4.0",
+    });
+    expect(downloadingButton.hasAttribute("disabled")).toBe(true);
     // Row meta should describe progress, not a permanent/destructive failure.
     // textContent is typed non-null on HTMLElement; assert the real string.
     const row = screen.getByTestId("provider-pack-version-row-1.4.0");
-    expect(row.textContent).toMatch(/Downloading/i);
     expect(row.textContent).not.toMatch(
       /failed permanently|Install failed permanently/i,
     );
-    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: rowActionName("Retry", "1.4.0") }),
+    ).toBeNull();
   });
 
-  it("states a condemned install in the row's details and hides Retry", () => {
+  it("hides Retry/Download for a condemned install and states the reason inline", () => {
     // The row used to carry a `condemned-no-retry` sentence that repeated the
-    // meta line directly above it. The state is stated once now, in the
-    // details; "no retry" is carried by the ABSENCE of the button, which this
-    // still pins.
+    // meta line directly above it, then later a hover-card detail. Both are
+    // gone; the reason is now the row's own trouble line, and "no retry" is
+    // still carried by the ABSENCE of the button.
     renderPanel({
       hostId: "host-1",
       available: [
@@ -395,15 +439,23 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       managedOverrides: null,
     });
 
-    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
-    expect(detailsLabel("1.0.0")).toMatch(/permanently/i);
+    expect(
+      screen.queryByRole("button", { name: rowActionName("Retry", "1.0.0") }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: rowActionName("Download", "1.0.0"),
+      }),
+    ).toBeNull();
+    const trouble = screen.getByTestId("version-row-trouble");
+    expect(trouble.textContent).toMatch(/permanently/i);
   });
 
   it("wears ONE chip — Current outranks Recommended rather than stacking", () => {
     // Both flags are set. The row used to render both badges plus a meta line
-    // that said "pairs with this Traycer release" a third time. One chip; the
-    // rest is in the details.
+    // that said "pairs with this Traycer release" a third time; both the
+    // second badge and the meta line are gone now, with no replacement
+    // surface — a current row simply does not say "recommended" anywhere.
     renderPanel({
       hostId: "host-1",
       available: [
@@ -423,8 +475,6 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
     expect(screen.queryByTestId("version-row-chip-recommended")).toBeNull();
     const row = screen.getByTestId("provider-pack-version-row-1.2.0");
     expect(row.textContent).not.toMatch(/Recommended/u);
-    // Not lost — demoted.
-    expect(detailsLabel("1.2.0")).toMatch(/pairs with this Traycer release/iu);
   });
 
   it("offers no Download or Retry button for a non-retryable error (finding 1)", () => {
@@ -448,8 +498,14 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
     expect(row).toBeTruthy();
     // Composition: allow-list denies retry AND download eligibility denies —
     // no actionable install-fetch button under either label.
-    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: rowActionName("Download", "1.0.0"),
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: rowActionName("Retry", "1.0.0") }),
+    ).toBeNull();
   });
 
   it("shows Retry (not Download) for a retryable network error", () => {
@@ -469,8 +525,14 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       managedOverrides: null,
     });
 
-    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: rowActionName("Retry", "1.0.0") }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", {
+        name: rowActionName("Download", "1.0.0"),
+      }),
+    ).toBeNull();
   });
 
   it("clears the pin by sending version: null when Use latest automatically is clicked", async () => {
@@ -565,14 +627,17 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       managedOverrides: null,
     });
 
-    // The composed meta now lives in the row's details rather than as a line
-    // under the version. Read through the accessible name, which is the same
-    // string the hover card renders — and the only form a screen reader gets,
-    // since Radix keeps hover-card content out of the a11y tree.
-    const text = detailsLabel("1.1.0");
-    expect(text.length).toBeGreaterThan(0);
-    expect(text.toLowerCase()).toMatch(/not necessarily damaged/);
-    expect(text.toLowerCase()).not.toMatch(/still usable/);
+    // Certification and install-state are independent axes. This row wears
+    // the Unpublished chip (certification) AND states its install trouble
+    // inline (install-state) — the two must not collapse into one claim.
+    expect(screen.getByTestId("version-row-chip-unpublished").textContent).toBe(
+      "Unpublished",
+    );
+    const trouble = screen.getByTestId("version-row-trouble");
+    expect(trouble.textContent.toLowerCase()).toMatch(
+      /not necessarily damaged/,
+    );
+    expect(trouble.textContent.toLowerCase()).not.toMatch(/still usable/);
   });
 
   it("offers Use on an installed non-current version even offline with no recommended row (D1 as revised 2026-08-12)", () => {
@@ -598,7 +663,9 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       managedOverrides: null,
     });
 
-    const useButton = screen.getByRole("button", { name: "Use" });
+    const useButton = screen.getByRole("button", {
+      name: rowActionName("Use", "1.0.0"),
+    });
     expect(useButton.hasAttribute("disabled")).toBe(false);
   });
 
@@ -651,7 +718,11 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
       managedOverrides: null,
     });
 
-    await user.click(screen.getByRole("button", { name: "Download" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: rowActionName("Download", "1.5.0"),
+      }),
+    );
     const notice = screen.getByTestId("version-row-notice");
     expect(notice.textContent.toLowerCase()).toMatch(/withdrawn/);
     expect(notice.textContent.toLowerCase()).not.toMatch(/right now/);
@@ -730,12 +801,138 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
         managedOverrides: null,
       });
 
-      await user.click(screen.getByRole("button", { name: "Use" }));
+      await user.click(
+        screen.getByRole("button", { name: rowActionName("Use", "1.5.0") }),
+      );
       const notice = screen.getByTestId("version-row-notice");
       expect(notice.textContent).toMatch(expectMatch);
       expect(notice.textContent).not.toMatch(forbid);
     },
   );
+
+  it("arms delete on the first click and only removes on the confirming click", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({ version: "1.5.0", installState: { status: "installed" } }),
+      ],
+      managedOverrides: null,
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: rowActionName("Delete", "1.5.0") }),
+    );
+
+    expect(mocks.removeMutate).not.toHaveBeenCalled();
+    const confirm = screen.getByTestId("version-delete-confirm-1.5.0");
+    expect(confirm).toBeTruthy();
+
+    await user.click(confirm);
+
+    expect(mocks.removeMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.removeMutate.mock.calls[0]?.[0]).toEqual({
+      packId: "opencode",
+      version: "1.5.0",
+    });
+  });
+
+  it("disarms an armed delete when another row's action runs", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({ version: "1.5.0", installState: { status: "installed" } }),
+        version({ version: "2.0.0", installState: { status: "installed" } }),
+      ],
+      managedOverrides: null,
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: rowActionName("Delete", "1.5.0") }),
+    );
+    expect(screen.getByTestId("version-delete-confirm-1.5.0")).toBeTruthy();
+
+    await user.click(
+      screen.getByRole("button", { name: rowActionName("Use", "2.0.0") }),
+    );
+
+    expect(mocks.useMutate).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("version-delete-confirm-1.5.0")).toBeNull();
+    // Back to its icon shape, not just "the confirm testid is gone".
+    expect(
+      screen.getByRole("button", { name: rowActionName("Delete", "1.5.0") }),
+    ).toBeTruthy();
+  });
+
+  it("renders a disabled delete carrying its reason for a quarantined version (regression: used to render no delete control at all)", () => {
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({
+          version: "1.3.0",
+          installState: { status: "unusable", reason: "quarantined" },
+        }),
+      ],
+      managedOverrides: null,
+    });
+
+    const blocked = screen.getByTestId("delete-disabled-blocked");
+    expect(blocked.hasAttribute("disabled")).toBe(true);
+    expect(tooltipTextNear(blocked)).toMatch(/quarantine/iu);
+  });
+
+  it("renders no delete control at all for a version with nothing on disk", () => {
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({ version: "1.6.0", installState: { status: "absent" } }),
+      ],
+      managedOverrides: null,
+    });
+
+    expect(screen.queryByTestId("delete-disabled-blocked")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: rowActionName("Delete", "1.6.0") }),
+    ).toBeNull();
+    expect(screen.queryByTestId("version-delete-confirm-1.6.0")).toBeNull();
+  });
+
+  it("renders no title and no on-disk footprint even with a non-null totalSizeBytes", () => {
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({ version: "1.0.0", installState: { status: "installed" } }),
+      ],
+      managedOverrides: { totalSizeBytes: 123_000_000 },
+    });
+
+    const panel = screen.getByTestId("provider-pack-version-manager");
+    expect(panel.textContent).not.toMatch(/· versions/u);
+    expect(panel.textContent).not.toMatch(/on disk/iu);
+  });
+
+  it("still exposes the auto-download switch and toggles the policy", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({ version: "1.0.0", installState: { status: "installed" } }),
+      ],
+      managedOverrides: { autoDownload: false },
+    });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Auto-download updates",
+    });
+    await user.click(toggle);
+
+    expect(mocks.setPolicyMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.setPolicyMutate.mock.calls[0]?.[0]).toEqual({
+      packId: "opencode",
+      autoDownload: true,
+    });
+  });
 });
 
 /**
@@ -750,29 +947,6 @@ describe("ProviderPackVersionManagerPanel: row density", () => {
   // new top-level block gets none and every render accumulates in the same
   // document - which surfaces as "Found multiple elements", not as a leak.
   afterEach(cleanup);
-
-  it("opens the details card on focus and renders the composed meta", async () => {
-    // The a11y-name assertions elsewhere would ALL still pass if the card
-    // never rendered. This is the one that proves the visible surface exists.
-    renderPanel({
-      hostId: "host-1",
-      available: [
-        version({
-          version: "1.2.0",
-          recommended: true,
-          sizeBytes: 40 * 1024 * 1024,
-          installState: { status: "installed" },
-        }),
-      ],
-      managedOverrides: null,
-    });
-
-    screen.getByTestId("version-details-trigger-1.2.0").focus();
-    const card = await screen.findByTestId("version-details-1.2.0");
-    expect(card.textContent).toMatch(/Installed/u);
-    expect(card.textContent).toMatch(/40 MB/u);
-    expect(card.textContent).toMatch(/pairs with this Traycer release/iu);
-  });
 
   it("keeps a plain published version down to its number and its button", () => {
     // Nothing to say ⇒ no chip, and no details trigger at all: an affordance
@@ -792,7 +966,12 @@ describe("ProviderPackVersionManagerPanel: row density", () => {
     });
 
     const row = screen.getByTestId("provider-pack-version-row-1.2.0");
-    expect(row.textContent).toBe("1.2.0Download");
+    expect(row.textContent).toBe("1.2.0");
+    // The row action column is icon-only now; the bare number must not read
+    // as "no button" — the download control still has to be there.
+    expect(
+      screen.getByRole("button", { name: rowActionName("Download", "1.2.0") }),
+    ).toBeTruthy();
   });
 
   it("gives a yanked row its blocking chip, outranking Recommended", () => {
@@ -816,10 +995,34 @@ describe("ProviderPackVersionManagerPanel: row density", () => {
     expect(screen.queryByTestId("version-row-chip-recommended")).toBeNull();
   });
 
-  it("demotes 'No longer published' out of the row and into the details", () => {
-    // THE REPORTED ROW. `uncertified` is informational — the copy stays
-    // installed and stays usable — and it was the loudest thing on a healthy
-    // row, stated twice: once as a badge, once inside the meta line.
+  it("gives a non-current uncertified version its Unpublished chip, outranking Recommended", () => {
+    // `uncertified` used to earn no chip at all (informational, stays
+    // installed and usable). It earns one now: it is the one state that
+    // decides whether a delete can be undone, which outranks a mere
+    // suggestion.
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({
+          version: "1.1.0",
+          recommended: true,
+          certification: "uncertified",
+          installState: { status: "installed" },
+        }),
+      ],
+      managedOverrides: null,
+    });
+
+    expect(screen.getByTestId("version-row-chip-unpublished").textContent).toBe(
+      "Unpublished",
+    );
+    expect(screen.queryByTestId("version-row-chip-recommended")).toBeNull();
+  });
+
+  it("suppresses the Unpublished chip on the current row (states Current instead)", () => {
+    // THE REPORTED ROW. On a current row the reversibility question the
+    // Unpublished chip exists to flag does not apply — delete is already
+    // disabled for the current version — so the chip goes unsaid.
     renderPanel({
       hostId: "host-1",
       available: [
@@ -834,9 +1037,10 @@ describe("ProviderPackVersionManagerPanel: row density", () => {
       managedOverrides: null,
     });
 
-    const row = screen.getByTestId("provider-pack-version-row-0.147.0");
-    expect(row.textContent).not.toMatch(/No longer published/u);
-    expect(screen.getByTestId("version-row-chip-current")).toBeTruthy();
-    expect(detailsLabel("0.147.0")).toMatch(/No longer published/u);
+    expect(screen.getByTestId("version-row-chip-current").textContent).toBe(
+      "Current",
+    );
+    expect(screen.queryByTestId("version-row-chip-unpublished")).toBeNull();
+    expect(screen.queryByTestId("version-row-chip-recommended")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-pack-version-manager-panel.test.tsx
@@ -837,6 +837,39 @@ describe("<ProviderPackVersionManagerPanel /> install-state surfaces", () => {
     });
   });
 
+  it("keeps focus on the delete control across the arming swap, named by version", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      hostId: "host-1",
+      available: [
+        version({ version: "1.5.0", installState: { status: "installed" } }),
+        version({ version: "2.0.0", installState: { status: "installed" } }),
+      ],
+      managedOverrides: null,
+    });
+
+    // Keyboard activation, because that is the path that breaks: arming
+    // unmounts the trash button, so without the mount-focus the second press
+    // lands on <body> and the two-step flow is unreachable without a mouse.
+    const trash = screen.getByRole("button", {
+      name: rowActionName("Delete", "1.5.0"),
+    });
+    trash.focus();
+    await user.keyboard("{Enter}");
+
+    const confirm = screen.getByTestId("version-delete-confirm-1.5.0");
+    expect(document.activeElement).toBe(confirm);
+    expect(confirm.getAttribute("aria-label")).toBe("Confirm delete 1.5.0");
+
+    await user.keyboard("{Enter}");
+
+    expect(mocks.removeMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.removeMutate.mock.calls[0]?.[0]).toEqual({
+      packId: "opencode",
+      version: "1.5.0",
+    });
+  });
+
   it("disarms an armed delete when another row's action runs", async () => {
     const user = userEvent.setup();
     renderPanel({

--- a/clients/gui-app/src/components/settings/panels/provider-cli-candidates-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-cli-candidates-section.tsx
@@ -1077,8 +1077,10 @@ function VersionMenuTrigger({
         // published version plus every retained install. Past the dialog's
         // collision boundary the older rows and their Use / Delete controls
         // were simply unreachable, because `overflow-hidden` clips rather than
-        // scrolls. The panel scrolls its own list, so the header and the
-        // auto-download toggle stay put.
+        // scrolls. The panel scrolls its own list, so its banners and its
+        // auto-download footer stay put. This cap is now the outer of two -
+        // the list carries its own, tighter one - and remains the binding
+        // constraint only when the banners and a long notice are all present.
         className="flex max-h-[min(70vh,32rem)] w-[min(90vw,26rem)] flex-col overflow-hidden p-0"
       >
         {data.kind === "unavailable" ? (
@@ -1361,7 +1363,24 @@ function RowStatusLine({
         ? null
         : Math.min(100, Math.max(0, Math.round(status.percent)));
     return (
-      <span className="col-span-3 col-start-2 mt-1.5 flex min-w-0 items-center gap-2 px-2.5">
+      // STACKED, not side by side. The bar and the label used to share one
+      // flex line with the bar `w-full shrink-0` - it claimed the whole line
+      // and then refused to give any of it back, so the label was squeezed
+      // into whatever remained and wrapped to four lines against the right
+      // edge, under the narrow `0.2fr` Version column it does not even belong
+      // to. Nothing about the pair wants to be horizontal: the label is a
+      // sentence with a variable-length fallback clause appended, and a
+      // sentence next to a progress track is two things fighting for the same
+      // inline axis. Column layout also drops `shrink-0`, which only existed
+      // to stop the bar collapsing in that fight.
+      <span className="col-span-3 col-start-2 mt-1.5 flex min-w-0 flex-col gap-1.5 px-2.5">
+        <span className="min-w-0 text-ui-xs text-muted-foreground">
+          {/* Own element so the visible progress label stays byte-identical to
+              the progressbar's accessible name, whether or not a fallback
+              clause follows it. */}
+          <span>{status.label}</span>
+          {status.note === null ? null : <span> · {status.note}</span>}
+        </span>
         <span
           role="progressbar"
           aria-label={status.label}
@@ -1372,7 +1391,7 @@ function RowStatusLine({
           // width, which this repo's UI rule excludes for layout surfaces - the
           // track has to shrink with a narrow settings dialog rather than hold
           // a rem figure chosen against one window size.
-          className="h-1 w-full max-w-[min(100%,30vw)] shrink-0 overflow-hidden rounded-full bg-foreground/8"
+          className="h-1 w-full max-w-[min(100%,30vw)] overflow-hidden rounded-full bg-foreground/8"
         >
           <span
             className={cn(
@@ -1383,13 +1402,6 @@ function RowStatusLine({
               percent === null ? undefined : { width: `${String(percent)}%` }
             }
           />
-        </span>
-        <span className="min-w-0 text-ui-xs text-muted-foreground">
-          {/* Own element so the visible progress label stays byte-identical to
-              the progressbar's accessible name, whether or not a fallback
-              clause follows it. */}
-          <span>{status.label}</span>
-          {status.note === null ? null : <span> · {status.note}</span>}
         </span>
       </span>
     );

--- a/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-model.ts
+++ b/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-model.ts
@@ -383,6 +383,14 @@ export function installErrorReasonLabel(
  * `quarantined` is deliberately included even though its bytes are intact: the
  * disabled Delete's tooltip says the same thing, and a tooltip is not where a
  * row should first admit it is being held.
+ *
+ * The CURRENT row is the one other place a blocking fact has nowhere to go.
+ * `versionRowChip` gives `Current` the chip slot unconditionally — the version
+ * in use has to be identifiable before anything else — so a current version
+ * that is later withdrawn, dropped below the security floor, or outgrown by
+ * this Traycer release shows `Current`, dims, and says nothing. The hover card
+ * used to carry that sentence; this line does now. Non-current blocked rows
+ * already wear the certification as their chip, so they get no second copy.
  */
 export function versionTroubleLine(
   version: ProviderPackVersion,
@@ -395,6 +403,9 @@ export function versionTroubleLine(
     // underlying operator-facing detail and can carry raw filesystem or
     // network text; it must never reach this surface.
     return installErrorReasonLabel(version.installState.reason);
+  }
+  if (version.current && isBlockingCertification(version.certification)) {
+    return certificationMetaLine(version.certification);
   }
   return null;
 }

--- a/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-model.ts
+++ b/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-model.ts
@@ -14,26 +14,6 @@ import {
 } from "@traycer/protocol/host/provider-schemas";
 import { compareHostVersions } from "@traycer-clients/shared/host-version/compare-host-versions";
 
-/**
- * Pure decision helpers for the per-pack version-manager panel.
- *
- * Kept free of React so tests can prove action availability without mounting
- * hooks, and so the panel stays a thin renderer over product rules that live
- * once.
- */
-
-/** Bytes → compact human label. Null sizes (yank tombstones) stay null. */
-export function formatPackSizeBytes(sizeBytes: number | null): string | null {
-  if (sizeBytes === null) return null;
-  if (sizeBytes < 1024) return `${String(sizeBytes)} B`;
-  const kib = sizeBytes / 1024;
-  if (kib < 1024) return `${kib.toFixed(kib < 10 ? 1 : 0)} KB`;
-  const mib = kib / 1024;
-  if (mib < 1024) return `${mib.toFixed(mib < 10 ? 1 : 0)} MB`;
-  const gib = mib / 1024;
-  return `${gib.toFixed(gib < 10 ? 1 : 0)} GB`;
-}
-
 export function providerDisplayName(providerId: ProviderId): string {
   return PROVIDER_DISPLAY_NAMES[providerId];
 }
@@ -227,22 +207,60 @@ export function versionDeleteEligibility(
 }
 
 /**
+ * Whether the row shows a Delete control at all — enabled, or disabled with a
+ * reason.
+ *
+ * The test is "does this version have bytes on disk", which is exactly when
+ * asking to delete it is a meaningful request. A row with nothing on disk gets
+ * no control: there is nothing to remove and nothing to explain. A row that HAS
+ * bytes but may not drop them — the current version, a quarantined copy — gets
+ * a disabled one carrying {@link versionDeleteEligibility}'s reason.
+ *
+ * The panel used to hardcode the `current` arm beside `del.allowed` and had no
+ * arm for anything else, so the quarantine sentence this module computes was
+ * unreachable: a quarantined row rendered no Delete and no reason, which is the
+ * one state where "why can't I remove this?" actually needs answering.
+ */
+export function versionShowsDeleteAction(
+  version: ProviderPackVersion,
+): boolean {
+  return (
+    version.installState.status === "installed" ||
+    version.installState.status === "unusable"
+  );
+}
+
+/**
  * The ONE chip a version row may wear, or none.
  *
  * The row used to stack up to three (`Recommended` + `Current` + a
  * certification badge) beside a meta line that repeated two of them, so the
  * list read as a wall of labels rather than a list of versions. One chip, by
- * priority; everything else moves to the row's hover card.
+ * priority; everything else was moved to the row's hover card, and then
+ * deleted with it.
  *
- * `uncertified` deliberately earns NO chip. "No longer published" is
- * informational - the copy stays installed and stays usable - and it was the
- * single loudest thing on a healthy row. The three certifications that
- * genuinely BLOCK do outrank `Recommended`, because a version you cannot use
- * matters more than one we suggest.
+ * `uncertified` has come BACK, quietly. It was dropped on the argument that
+ * "no longer published" is informational — the copy stays installed and stays
+ * usable — and that it was the loudest thing on an otherwise healthy row. The
+ * first half of that was wrong: it is the only state on this surface that
+ * decides whether DELETING a version can be undone, because an unpublished
+ * one cannot be fetched again. That is worth a chip on a row whose delete
+ * button is one click from armed. The second half was right, and is answered
+ * by TONE rather than by silence — `unpublished` is the one chip that renders
+ * muted (see `chipVariant`), so it reads as a footnote and not as damage.
+ *
+ * Priority is by consequence: what you are RUNNING, then what you cannot use,
+ * then what you cannot get back, then what we merely suggest. `uncertified`
+ * therefore outranks `recommended` — a version can be both, and of the two
+ * only one of them changes what happens when you press delete.
+ *
+ * On a `current` row the chip is `Current` and the unpublished state goes
+ * unsaid. That costs nothing: delete is disabled for the current version, so
+ * the reversibility the chip exists to warn about is not in question there.
  */
 export type VersionRowChip = {
   readonly label: string;
-  readonly tone: "current" | "blocked" | "recommended";
+  readonly tone: "current" | "blocked" | "unpublished" | "recommended";
 };
 
 /**
@@ -273,37 +291,15 @@ export function versionRowChip(
     const label = certificationBadgeLabel(version.certification);
     if (label !== null) return { label, tone: "blocked" };
   }
+  if (version.certification === "uncertified") {
+    // Shorter than `certificationBadgeLabel`'s "No longer published": a chip
+    // sits inline beside the version it annotates, where three words crowd the
+    // number. The longer sentence is still what the WITHDRAWN family says,
+    // because those are refusals and deserve the room.
+    return { label: "Unpublished", tone: "unpublished" };
+  }
   if (version.recommended) return { label: "Recommended", tone: "recommended" };
   return null;
-}
-
-/**
- * Everything about a version that is NOT its number, its chip, or its action.
- *
- * Lives in the row's hover card. Returned as lines rather than one string so
- * the card can space them; `composeVersionRowMeta` still owns the one-line
- * composition of install-state + size + certification, including the
- * uncertified/unverified pair that must not read as "still usable".
- */
-export function versionDetailLines(
-  version: ProviderPackVersion,
-): readonly string[] {
-  const lines: string[] = [];
-  const meta = composeVersionRowMeta({
-    installState: version.installState,
-    certification: version.certification,
-    sizeLabel: formatPackSizeBytes(version.sizeBytes),
-    recommended: version.recommended,
-  });
-  if (meta.length > 0) lines.push(meta);
-
-  // Only ever stated for a row that RENDERS a disabled Use - an installed,
-  // non-current version. Anywhere else there is no control for it to explain.
-  if (version.installState.status === "installed" && !version.current) {
-    const useElig = versionUseEligibility(version);
-    if (!useElig.allowed) lines.push(`Can't switch to it — ${useElig.reason}`);
-  }
-  return lines;
 }
 
 export function certificationBadgeLabel(
@@ -318,24 +314,6 @@ export function certificationBadgeLabel(
       return "Below security minimum";
     case "host-ineligible":
       return "Not supported on this host";
-    case "eligible":
-      return null;
-  }
-}
-
-export function certificationMetaLine(
-  certification: ProviderPackVersionCertification,
-): string | null {
-  switch (certification) {
-    case "yanked":
-      return "Withdrawn by publisher";
-    case "uncertified":
-      // Do not claim "still usable" — install-state is a separate axis (finding 7).
-      return "No longer published · remains on disk";
-    case "below-security-floor":
-      return "Below the publisher's security minimum";
-    case "host-ineligible":
-      return "This Traycer release cannot drive this version";
     case "eligible":
       return null;
   }
@@ -357,32 +335,86 @@ export function unusableReasonLabel(
   }
 }
 
-/**
- * Composed row metadata. Certification and install-state are independent wire
- * axes; this helper is the only place that concatenates them so contradictory
- * "still usable" + "could not verify" pairs cannot appear (finding 7).
- */
-export function composeVersionRowMeta(options: {
-  readonly installState: ProviderPackVersionInstallState;
-  readonly certification: ProviderPackVersionCertification;
-  readonly sizeLabel: string | null;
-  readonly recommended: boolean;
-}): string {
-  const parts: string[] = [];
-  const installPart = installStateMetaPart(options.installState);
-  if (installPart !== null) parts.push(installPart);
-  if (options.sizeLabel !== null) parts.push(options.sizeLabel);
-  if (options.recommended) {
-    parts.push("pairs with this Traycer release");
+export function installErrorReasonLabel(
+  reason: ProviderManagedInstallErrorReason,
+): string {
+  switch (reason) {
+    case "disk-full":
+      return "Not enough disk space to install";
+    case "network":
+      return "Download failed — network error";
+    case "verification":
+      return "Downloaded bytes failed verification";
+    case "live-owner-stalled":
+      return "Another process was downloading this and stalled";
+    case "unknown":
+      return "Install failed";
+    case "unrepairable":
+      return "This install cannot be repaired on this machine";
+    case "trust-unavailable":
+      return "Trust is unavailable on this host";
+    case "local-storage-mismatch":
+      return "The local copy does not match the published version";
   }
+}
 
-  const certPart = certificationMetaForCompose(
-    options.certification,
-    options.installState,
-  );
-  if (certPart !== null) parts.push(certPart);
+/**
+ * The one sentence a row owes about its OWN health, or null when it is fine.
+ *
+ * This exists because deleting the hover card deleted the only place a broken
+ * row said what was wrong with it. That was fine for the card's other content
+ * — `Installed`, the size, `pairs with this Traycer release` all restated
+ * things the row already showed — but NOT for these two states, which nothing
+ * else on the row can express:
+ *
+ *  - a `condemned` install offers no Download (correctly — it cannot be
+ *    repaired) and no Use, so without a sentence it is a version with a delete
+ *    button and no explanation of why it has nothing else;
+ *  - an `error` row offers `Retry` only when the reason is retryable, so the
+ *    non-retryable half is silent for the same reason;
+ *  - an `unverified` install offers Download instead of Use, which without a
+ *    sentence just looks like an installed version whose Use button is missing.
+ *
+ * Healthy rows return null and stay a number, a chip and their controls — the
+ * point of the redesign. Trouble is the exception that earns a line, and it
+ * earns an INLINE one rather than a hover card, because a state you have to go
+ * hunting for is a state most people never learn about.
+ *
+ * `quarantined` is deliberately included even though its bytes are intact: the
+ * disabled Delete's tooltip says the same thing, and a tooltip is not where a
+ * row should first admit it is being held.
+ */
+export function versionTroubleLine(
+  version: ProviderPackVersion,
+): string | null {
+  if (version.installState.status === "unusable") {
+    return unusableReasonLabel(version.installState.reason);
+  }
+  if (version.installState.status === "error") {
+    // The typed reason ONLY. `installState.message` is documented as the
+    // underlying operator-facing detail and can carry raw filesystem or
+    // network text; it must never reach this surface.
+    return installErrorReasonLabel(version.installState.reason);
+  }
+  return null;
+}
 
-  return parts.join(" · ");
+export function certificationMetaLine(
+  certification: ProviderPackVersionCertification,
+): string | null {
+  switch (certification) {
+    case "yanked":
+      return "Withdrawn by publisher";
+    case "uncertified":
+      // Do not claim "still usable" — install-state is a separate axis (finding 7).
+      return "No longer published · remains on disk";
+    case "below-security-floor":
+      return "Below the publisher's security minimum";
+    case "host-ineligible":
+      return "This Traycer release cannot drive this version";
+    case "eligible":
+      return null;
+  }
 }
 
 /**
@@ -517,93 +549,6 @@ export function comparePackVersionsDescending(
   return left < right ? -1 : 1;
 }
 
-// ---------------------------------------------------------------------------
-// Internals
-// ---------------------------------------------------------------------------
-
-function installStateMetaPart(
-  installState: ProviderPackVersionInstallState,
-): string | null {
-  switch (installState.status) {
-    case "installed":
-      return "Installed";
-    case "absent":
-      return "Not installed";
-    case "downloading":
-      return installState.percent === null
-        ? "Downloading…"
-        : `Downloading · ${String(Math.round(installState.percent))}%`;
-    case "unusable":
-      return unusableReasonLabel(installState.reason);
-    case "error":
-      return installErrorReasonLabel(installState.reason);
-  }
-}
-
-/**
- * User-facing copy for a failed install, derived from the TYPED reason.
- *
- * The wire `message` is deliberately not rendered. The schema documents it as
- * the underlying operator-facing detail, so it can carry raw filesystem and
- * network text; and it says nothing about the only thing the reader has to
- * decide - whether waiting, retrying, or freeing disk is what helps. The typed
- * reason carries exactly that, so the renderer owns the sentence.
- *
- * Total over the union with no `default`, so a ninth reason is a compile error
- * here rather than a raw diagnostic reaching the row.
- */
-export function installErrorReasonLabel(
-  reason: ProviderManagedInstallErrorReason,
-): string {
-  switch (reason) {
-    case "disk-full":
-      return "Not enough disk space to install";
-    case "network":
-      return "Download failed — network error";
-    case "verification":
-      return "Downloaded bytes failed verification";
-    case "live-owner-stalled":
-      return "Another process was downloading this and stalled";
-    case "unknown":
-      return "Install failed";
-    case "unrepairable":
-      return "This install cannot be repaired on this machine";
-    case "trust-unavailable":
-      return "Trust is unavailable on this host";
-    case "local-storage-mismatch":
-      return "The local copy does not match the published version";
-  }
-}
-
-function certificationMetaForCompose(
-  certification: ProviderPackVersionCertification,
-  installState: ProviderPackVersionInstallState,
-): string | null {
-  if (certification === "eligible") return null;
-
-  // Uncertified + indeterminate verification: one coherent claim — remains on
-  // disk, not proven usable, not proven damaged.
-  if (
-    certification === "uncertified" &&
-    installState.status === "unusable" &&
-    installState.reason === "unverified"
-  ) {
-    return "No longer published · remains on disk";
-  }
-
-  return certificationMetaLine(certification);
-}
-
-/**
- * Copy for the reasons the Retry allow-list deliberately excludes.
- *
- * The parameter is the protocol union, not `string`. With `string` the
- * `default` arm absorbed every typo and every future reason silently; now a
- * new non-retryable reason that needs its own sentence shows up as an
- * unhandled case at the call site rather than as generic copy in the UI. The
- * `default` stays for the reasons that are on the allow-list and therefore
- * never reach here.
- */
 function nonRetryableErrorDownloadReason(
   reason: ProviderManagedInstallErrorReason,
 ): string {

--- a/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-panel.tsx
@@ -1,4 +1,11 @@
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
+import {
+  Check,
+  Download,
+  RotateCw,
+  Trash2,
+  type LucideIcon,
+} from "lucide-react";
 import type {
   ProviderManagedVersions,
   ProviderPackVersion,
@@ -7,11 +14,6 @@ import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useProviderPackVersionManagerSupport } from "./provider-pack-version-manager-capability";
 import {
@@ -25,7 +27,6 @@ import { useProvidersUsePackVersion } from "@/hooks/providers/use-providers-use-
 import { cn } from "@/lib/utils";
 import {
   comparePackVersionsDescending,
-  formatPackSizeBytes,
   formatSharedWithProvidersLine,
   installPackVersionRefusalMessage,
   isBlockingCertification,
@@ -33,11 +34,12 @@ import {
   updateBannerDownloadEligibility,
   packVersionUseRefusalMessage,
   versionDeleteEligibility,
-  versionDetailLines,
   versionDownloadEligibility,
   versionInstallFetchLabel,
   versionRowChip,
+  versionShowsDeleteAction,
   versionShowsInstallFetchAction,
+  versionTroubleLine,
   versionUseEligibility,
   type VersionDeleteEligibility,
   type VersionDownloadEligibility,
@@ -98,8 +100,30 @@ type BannerNotice = {
 /**
  * Per-pack version manager panel (B5-T2).
  *
- * Renders the wireframe surface: header (name, sharing, footprint, auto-
- * download toggle), update-available banner, and one action row per version.
+ * Three regions, in the order a reader needs them: what is true of the pack
+ * right now (sharing, a pin, an available update), the versions themselves,
+ * and one persistent setting pinned to the bottom.
+ *
+ * The panel used to open with a titled header bar — `<pack> CLI · versions`,
+ * a footprint line, and the auto-download switch. All three were dropped:
+ *
+ * - The TITLE restated the row the popover is anchored to. It is opened from
+ *   one specific CLI's version cell, so naming that CLI again is the widest,
+ *   loudest element on the surface saying the one thing the user cannot have
+ *   forgotten. `aria-label` on the section keeps it for screen readers, which
+ *   do NOT get the anchoring for free.
+ * - The FOOTPRINT was `managedVersions.totalSizeBytes` — the whole pack cell
+ *   across every retained version — sitting directly above rows whose own
+ *   sizes are per-version. Two numbers on different axes, one labelled "on
+ *   disk" and neither summing to the other, read as an error in the smaller
+ *   one. The per-version sizes stayed (they answer "what will this cost me");
+ *   the total left, because a pack-wide figure belongs wherever pack-wide
+ *   storage is managed, not in a version picker.
+ * - The SWITCH moved to the footer. It is a durable preference, not an action
+ *   on any version, so it wants the calmest position on the surface rather
+ *   than the most prominent — and out of the header it stops competing with
+ *   the pin banner for the same corner.
+ *
  * Mutations go through the four v7.0 pack RPCs.
  *
  * Capability-gated (non-floor optional RPCs): see
@@ -139,6 +163,21 @@ export function ProviderPackVersionManagerPanel(
   // exactly the condition that makes a clear-pin refusal possible.
   const [pinNotice, setPinNotice] = useState<BannerNotice | null>(null);
   const [pendingVersion, setPendingVersion] = useState<string | null>(null);
+  // The version whose Delete is ARMED — its icon has been clicked once and is
+  // now showing a labelled "Delete?" awaiting the second click.
+  //
+  // Delete used to be a word-labelled button that fired on its only click. It
+  // is now a 28px unlabelled trash icon sitting one gap away from the other
+  // row actions, which makes a mis-click both likelier and less obviously a
+  // mistake while it is happening. Re-downloading is usually the whole cost of
+  // one, but not always: an `uncertified` version is still installed, still
+  // usable, and NOT re-downloadable, so for that row a slip is irreversible.
+  //
+  // Deliberately not a timeout — a self-disarming control is untestable
+  // without fake timers and, worse, can disarm between a user deciding and
+  // clicking. It disarms on any other action in the panel (via `clearNotice`)
+  // and on unmount, which closing the popover does.
+  const [armedDelete, setArmedDelete] = useState<string | null>(null);
 
   // Tell the mutation hooks this panel is on screen to render outcomes. While
   // it is, refusals draw inline below, anchored to what they are about; once
@@ -157,7 +196,6 @@ export function ProviderPackVersionManagerPanel(
   const sharedLine = formatSharedWithProvidersLine(
     managedVersions.sharedWithProviders,
   );
-  const totalSizeLabel = formatPackSizeBytes(managedVersions.totalSizeBytes);
   const updateAvailable = managedVersions.updateAvailable;
   const bannerDownload =
     updateAvailable === null
@@ -167,10 +205,13 @@ export function ProviderPackVersionManagerPanel(
           updateAvailable.version,
         );
 
+  // Runs at the top of every action. Disarming the delete here is what keeps
+  // an armed row from surviving the user's attention moving elsewhere.
   const clearNotice = useCallback(() => {
     setRowNotice(null);
     setBannerNotice(null);
     setPinNotice(null);
+    setArmedDelete(null);
   }, []);
 
   const onToggleAutoDownload = useCallback(
@@ -260,6 +301,16 @@ export function ProviderPackVersionManagerPanel(
     );
   }, [clearNotice, packId, useVersion]);
 
+  // First click on the trash: arm this row and clear whatever else was showing.
+  // `clearNotice` disarms, so the set has to follow it rather than precede it.
+  const onArmDelete = useCallback(
+    (version: string) => {
+      clearNotice();
+      setArmedDelete(version);
+    },
+    [clearNotice],
+  );
+
   const onDelete = useCallback(
     (version: string) => {
       clearNotice();
@@ -291,7 +342,7 @@ export function ProviderPackVersionManagerPanel(
       <div
         data-testid="provider-pack-version-manager-pending"
         data-pack-id={packId}
-        className="flex w-full max-w-2xl items-center gap-2 rounded-xl border border-border bg-card px-4 py-3 text-ui-sm text-muted-foreground"
+        className="flex w-full items-center gap-2 px-4 py-3 text-ui-sm text-muted-foreground"
         aria-busy="true"
         aria-label={`${packDisplayName} versions loading`}
       >
@@ -306,7 +357,7 @@ export function ProviderPackVersionManagerPanel(
       <div
         data-testid="provider-pack-version-manager-unsupported"
         data-pack-id={packId}
-        className="w-full max-w-2xl rounded-xl border border-border bg-card px-4 py-3 text-ui-sm text-muted-foreground sm:px-5"
+        className="w-full px-4 py-3 text-ui-sm text-muted-foreground"
         role="status"
       >
         Managing managed CLI versions requires a newer Traycer host. The
@@ -333,22 +384,27 @@ export function ProviderPackVersionManagerPanel(
       data-host-id={hostId}
       // `min-h-0` so the list below can actually scroll inside a height-capped
       // container instead of forcing this section past it.
-      className="flex w-full min-h-0 max-w-2xl flex-col overflow-hidden rounded-xl border border-border bg-card"
+      //
+      // NO frame of its own. This panel only ever mounts inside
+      // `VersionMenuTrigger`'s `PopoverContent`, which already draws the
+      // surface: `rounded-lg bg-popover ring-1 shadow-md`, with `p-0` and
+      // `overflow-hidden` so a full-bleed child clips to its corners. The
+      // `rounded-xl border border-border bg-card` this used to add put a
+      // SECOND 1px line inside the ring at a LARGER radius than the container
+      // it sat in, so the popover's own corners showed through as four slivers
+      // behind the card's — the frayed edge in the report. `bg-card` over
+      // `bg-popover` was a second, quieter mismatch of the same kind.
+      className="flex w-full min-h-0 flex-col overflow-hidden"
       aria-label={`${packDisplayName} versions`}
     >
-      <VersionManagerHeader
-        packDisplayName={packDisplayName}
+      <VersionManagerBanners
         sharedLine={sharedLine}
-        totalSizeLabel={totalSizeLabel}
-        autoDownload={managedVersions.autoDownload}
         pinnedVersion={managedVersions.pinnedVersion}
         pinNotice={pinNotice}
         clearPinPending={
           pendingVersion === CLEAR_PIN_PENDING_KEY && useVersion.isPending
         }
-        policyPending={setPolicy.isPending}
         actionsDisabled={anyPending}
-        onToggleAutoDownload={onToggleAutoDownload}
         onClearPin={onClearPin}
       />
 
@@ -366,7 +422,20 @@ export function ProviderPackVersionManagerPanel(
         />
       ) : null}
 
-      <ul className="flex w-full min-h-0 flex-col overflow-y-auto">
+      {/*
+        Capped so the list SHOWS about four rows and scrolls the rest, instead
+        of growing to whatever the popover's own `max-h` allows. Two reasons
+        the outer cap was not enough: `managedVersions.available` is every
+        published version plus every retained install, so on a mature pack the
+        popover simply became a full-height wall of near-identical rows; and
+        the footer only reads as a footer when the list visibly ends above it.
+        Viewport-derived, per the repo's fluid-sizing rule. A row is ~41px
+        (`py-1.5` around a 28px icon button, plus its 1px rule), so 10.5rem
+        lands PART-WAY THROUGH the fifth: four rows read whole and the clipped
+        one is the scroll affordance. A cap on a row boundary would look like
+        the list simply ends.
+      */}
+      <ul className="flex max-h-[min(45vh,10.5rem)] w-full min-h-0 flex-col overflow-y-auto">
         {rows.map((row) => (
           <VersionRow
             key={row.version}
@@ -376,6 +445,7 @@ export function ProviderPackVersionManagerPanel(
                 ? rowNotice
                 : null
             }
+            deleteArmed={armedDelete === row.version}
             downloadPending={
               pendingVersion === row.version && install.isPending
             }
@@ -384,72 +454,62 @@ export function ProviderPackVersionManagerPanel(
             actionsDisabled={anyPending}
             onDownload={onDownload}
             onUse={onUse}
+            onArmDelete={onArmDelete}
             onDelete={onDelete}
           />
         ))}
         {rows.length === 0 ? (
-          <li className="px-4 py-6 text-center text-ui-sm text-muted-foreground sm:px-5">
+          <li className="px-4 py-6 text-center text-ui-sm text-muted-foreground">
             No versions listed for this pack yet.
           </li>
         ) : null}
       </ul>
+
+      <VersionManagerFooter
+        autoDownload={managedVersions.autoDownload}
+        policyPending={setPolicy.isPending}
+        onToggleAutoDownload={onToggleAutoDownload}
+      />
     </section>
   );
 }
 
-function formatFootprintLine(
-  sharedLine: string | null,
-  totalSizeLabel: string | null,
-): string | null {
-  if (sharedLine !== null && totalSizeLabel !== null) {
-    return `${sharedLine} · ${totalSizeLabel} on disk`;
-  }
-  if (sharedLine !== null) return sharedLine;
-  if (totalSizeLabel !== null) return `${totalSizeLabel} on disk`;
-  return null;
-}
-
-function VersionManagerHeader(props: {
-  readonly packDisplayName: string;
+/**
+ * What is true of the PACK, above the list of versions.
+ *
+ * Everything here is conditional, and on the common pack — unshared, unpinned,
+ * up to date — the whole region renders nothing and the popover opens directly
+ * onto the versions. That is the point of it having replaced a header: a header
+ * is chrome and is always there, whereas each of these is a fact that is only
+ * sometimes worth a line.
+ *
+ * The sharing line is the one that had to survive the header's removal. It is
+ * the only warning that a pack backs several providers, which is what makes a
+ * delete here reach further than the CLI the user opened this from.
+ */
+function VersionManagerBanners(props: {
   readonly sharedLine: string | null;
-  readonly totalSizeLabel: string | null;
-  readonly autoDownload: boolean;
   readonly pinnedVersion: string | null;
   readonly pinNotice: BannerNotice | null;
   readonly clearPinPending: boolean;
-  readonly policyPending: boolean;
   readonly actionsDisabled: boolean;
-  readonly onToggleAutoDownload: (next: boolean) => void;
   readonly onClearPin: () => void;
-}): JSX.Element {
-  const footprint = formatFootprintLine(props.sharedLine, props.totalSizeLabel);
+}): JSX.Element | null {
+  const hasPin = props.pinnedVersion !== null;
+  if (props.sharedLine === null && !hasPin && props.pinNotice === null) {
+    return null;
+  }
 
   return (
-    <header className="flex w-full flex-col gap-3 border-b border-border bg-foreground/5 px-4 py-3 sm:px-5">
-      <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0 flex-1">
-          <h3 className="truncate text-ui-sm font-semibold text-foreground">
-            {props.packDisplayName}
-            <span className="font-normal text-muted-foreground">
-              {" "}
-              · versions
-            </span>
-          </h3>
-          {footprint !== null ? (
-            <p className="mt-1 text-ui-xs text-muted-foreground">{footprint}</p>
-          ) : null}
-        </div>
-        <label className="flex shrink-0 items-center gap-2 text-ui-xs text-muted-foreground">
-          <span>Auto-download updates</span>
-          <Switch
-            checked={props.autoDownload}
-            onCheckedChange={props.onToggleAutoDownload}
-            disabled={props.policyPending}
-            aria-label="Auto-download updates"
-          />
-          {props.policyPending ? <MutedAgentSpinner /> : null}
-        </label>
-      </div>
+    <div className="flex w-full shrink-0 flex-col gap-2 border-b border-border bg-foreground/5 px-4 py-2.5">
+      {props.sharedLine !== null ? (
+        <p
+          data-testid="provider-pack-shared-line"
+          className="text-ui-xs text-muted-foreground"
+        >
+          {props.sharedLine}
+        </p>
+      ) : null}
       {props.pinnedVersion !== null ? (
         <div
           data-testid="provider-pack-pinned-banner"
@@ -465,7 +525,7 @@ function VersionManagerHeader(props: {
           </p>
           <Button
             type="button"
-            size="sm"
+            size="xs"
             variant="outline"
             data-testid="provider-pack-clear-pin"
             disabled={props.actionsDisabled}
@@ -484,7 +544,35 @@ function VersionManagerHeader(props: {
           {props.pinNotice.message}
         </p>
       ) : null}
-    </header>
+    </div>
+  );
+}
+
+/**
+ * The one durable preference on this surface, pinned below the list.
+ *
+ * Outside the scrolling `<ul>` rather than `position: sticky` inside it: the
+ * list is a sibling that scrolls its own overflow, so this row is always
+ * visible by construction and never overlaps a row it is scrolling past.
+ */
+function VersionManagerFooter(props: {
+  readonly autoDownload: boolean;
+  readonly policyPending: boolean;
+  readonly onToggleAutoDownload: (next: boolean) => void;
+}): JSX.Element {
+  return (
+    <label className="flex w-full shrink-0 cursor-pointer items-center justify-between gap-3 border-t border-border bg-foreground/5 px-4 py-2.5 text-ui-xs text-muted-foreground">
+      <span>Auto-download updates</span>
+      <span className="flex shrink-0 items-center gap-2">
+        {props.policyPending ? <MutedAgentSpinner /> : null}
+        <Switch
+          checked={props.autoDownload}
+          onCheckedChange={props.onToggleAutoDownload}
+          disabled={props.policyPending}
+          aria-label="Auto-download updates"
+        />
+      </span>
+    </label>
   );
 }
 
@@ -498,9 +586,18 @@ function UpdateAvailableBanner(props: {
   readonly onDownload: (version: string) => void;
 }): JSX.Element {
   return (
+    // A full-width strip, not the inset rounded card this was. Floating a
+    // second bordered box inside a bordered popover, inset from both edges,
+    // gave the surface three nested frames before the first version; every
+    // other region here is a bordered band, so this one is too.
+    //
+    // Its Download keeps a WORD while the rows' went to icons. The rows have a
+    // repeating action column where labels are redundant by the second row —
+    // this is a one-off call to action attached to a sentence, and it is the
+    // only control on the surface that acts on a version with no row.
     <div
       data-testid="provider-pack-update-available-banner"
-      className="mx-4 mt-3 flex flex-col gap-2 rounded-lg border border-border bg-foreground/3 px-3.5 py-2.5 sm:mx-5"
+      className="flex w-full shrink-0 flex-col gap-2 border-b border-border bg-foreground/3 px-4 py-2.5"
     >
       <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-ui-sm text-foreground">
@@ -509,7 +606,7 @@ function UpdateAvailableBanner(props: {
         </p>
         <Button
           type="button"
-          size="sm"
+          size="xs"
           data-testid="provider-pack-update-download"
           disabled={!props.canDownload || props.actionsDisabled}
           onClick={() => props.onDownload(props.version)}
@@ -541,12 +638,14 @@ function UpdateAvailableBanner(props: {
 type VersionRowProps = {
   readonly row: ProviderPackVersion;
   readonly notice: RowNotice | null;
+  readonly deleteArmed: boolean;
   readonly downloadPending: boolean;
   readonly usePending: boolean;
   readonly deletePending: boolean;
   readonly actionsDisabled: boolean;
   readonly onDownload: (version: string) => void;
   readonly onUse: (version: string) => void;
+  readonly onArmDelete: (version: string) => void;
   readonly onDelete: (version: string) => void;
 };
 
@@ -558,24 +657,40 @@ type VersionRowProps = {
  * a `Use disabled: …` line, and up to three buttons. A list whose job is
  * "pick a version" was the hardest thing on the screen to read.
  *
- * What stayed inline is what a list cannot delegate: the number you scan, the
- * one state worth scanning FOR, and the control. What moved to the hover card
- * is everything you only want once you have already picked a row.
+ * That first pass moved the surplus into a hover card on the version number.
+ * The card is now gone too, because hiding redundancy is not removing it —
+ * three of its five lines restated the row. `Installed` was already told by
+ * WHICH action the row offers (`Use` means installed, `Download` means not);
+ * `pairs with this Traycer release` is the `Recommended` chip in prose; and
+ * `Can't switch to it — …` became a second copy of the disabled `Use` button's
+ * own tooltip the moment those buttons went icon-only. Size went with it: it
+ * decides one question, "what do I delete to reclaim space", and a figure you
+ * must hover each row in turn to collect is a poor way to answer it.
  *
- * Two things deliberately did NOT move to the card, because a card you have
- * to go find is the wrong home for them: live download progress, and the
+ * Only the certification survived, as a chip, because it is the one thing here
+ * that changes whether an ACTION IS REVERSIBLE — see `versionRowChip`.
+ *
+ * The card also cost more than its content. It made the version number a
+ * focusable button with a ring, so a number read as an editable field, and its
+ * content opened directly over the rows below it — a list you cannot see while
+ * inspecting a member of it.
+ *
+ * Two things were never in the card and still are not, because a surface you
+ * have to go find is the wrong home for them: live download progress, and the
  * notice returned by an action you just took.
  */
 function VersionRow(props: VersionRowProps): JSX.Element {
   const {
     row,
     notice,
+    deleteArmed,
     downloadPending,
     usePending,
     deletePending,
     actionsDisabled,
     onDownload,
     onUse,
+    onArmDelete,
     onDelete,
   } = props;
 
@@ -583,7 +698,7 @@ function VersionRow(props: VersionRowProps): JSX.Element {
   const useElig = versionUseEligibility(row);
   const del = versionDeleteEligibility(row);
   const chip = versionRowChip(row);
-  const detailLines = versionDetailLines(row);
+  const trouble = versionTroubleLine(row);
   const greyed = isBlockingCertification(row.certification);
 
   const showFetch = versionShowsInstallFetchAction(row);
@@ -594,24 +709,18 @@ function VersionRow(props: VersionRowProps): JSX.Element {
       data-testid={`provider-pack-version-row-${row.version}`}
       data-version={row.version}
       className={cn(
-        "w-full border-t border-border px-4 py-2.5 sm:px-5",
+        // `first:border-t-0` because the list no longer has a header above it
+        // to divide from — a top border on row one drew a line directly under
+        // the popover's own edge, or under a banner's, doubling it.
+        "w-full border-t border-border px-4 py-1.5 first:border-t-0",
         greyed && "opacity-70",
       )}
     >
       <div className="flex w-full items-center gap-2">
-        <VersionDetailsHoverCard version={row.version} lines={detailLines}>
-          <span className="font-mono text-ui-sm text-foreground">
-            {row.version}
-          </span>
-        </VersionDetailsHoverCard>
-        {chip === null ? null : (
-          <Badge
-            variant={chipVariant(chip.tone)}
-            data-testid={`version-row-chip-${chip.tone}`}
-          >
-            {chip.label}
-          </Badge>
-        )}
+        <span className="font-mono text-ui-sm text-foreground">
+          {row.version}
+        </span>
+        {chip === null ? null : <VersionChip chip={chip} />}
         <span className="flex-1" />
         <VersionRowActions
           row={row}
@@ -620,12 +729,14 @@ function VersionRow(props: VersionRowProps): JSX.Element {
           del={del}
           showFetch={showFetch}
           fetchLabel={fetchLabel}
+          deleteArmed={deleteArmed}
           downloadPending={downloadPending}
           usePending={usePending}
           deletePending={deletePending}
           actionsDisabled={actionsDisabled}
           onDownload={onDownload}
           onUse={onUse}
+          onArmDelete={onArmDelete}
           onDelete={onDelete}
         />
       </div>
@@ -634,77 +745,90 @@ function VersionRow(props: VersionRowProps): JSX.Element {
         <DownloadProgress percent={row.installState.percent} />
       ) : null}
 
-      {notice !== null ? (
-        <p
-          data-testid="version-row-notice"
-          className={cn(
-            "mt-1.5 text-ui-xs",
-            notice.kind === "error"
-              ? "text-destructive"
-              : "text-muted-foreground",
-          )}
-        >
-          {notice.message}
-        </p>
-      ) : null}
+      <VersionRowFootnote notice={notice} trouble={trouble} />
     </li>
   );
 }
 
-function chipVariant(
-  tone: VersionRowChip["tone"],
-): "default" | "destructive" | "secondary" {
-  if (tone === "current") return "default";
-  if (tone === "blocked") return "destructive";
-  return "secondary";
+/**
+ * At most ONE line under a row, and the action notice wins.
+ *
+ * Both answer "what is wrong here", but the notice is the fresher answer — it
+ * is the outcome of something the user just did, whereas the trouble line is
+ * the standing state they did it FROM. Stacking them shows a refusal directly
+ * above the condition that caused it, which reads as two separate problems.
+ */
+function VersionRowFootnote(props: {
+  readonly notice: RowNotice | null;
+  readonly trouble: string | null;
+}): JSX.Element | null {
+  if (props.notice !== null) {
+    return (
+      <p
+        data-testid="version-row-notice"
+        className={cn(
+          "mt-1.5 text-ui-xs",
+          props.notice.kind === "error"
+            ? "text-destructive"
+            : "text-muted-foreground",
+        )}
+      >
+        {props.notice.message}
+      </p>
+    );
+  }
+  if (props.trouble === null) return null;
+  return (
+    <p
+      data-testid="version-row-trouble"
+      className="mt-1.5 text-ui-xs text-muted-foreground"
+    >
+      {props.trouble}
+    </p>
+  );
 }
 
-/**
- * The version's details, on hover or focus of its number.
- *
- * READ-ONLY BY CONTRACT. `hover-card.tsx` documents that Radix keeps card
- * content out of the sequential tab order, so anything actionable placed here
- * would be unreachable by keyboard - which is why every control stayed in the
- * row and only sentences came here.
- *
- * The same sentences are also the trigger's accessible name: a HoverCard
- * mounts no visually-hidden a11y clone the way a Tooltip does, so without this
- * a screen reader would get the bare version number and none of its state.
- */
-function VersionDetailsHoverCard(props: {
-  readonly version: string;
-  readonly lines: readonly string[];
-  readonly children: JSX.Element;
-}): JSX.Element {
-  if (props.lines.length === 0) return props.children;
+function VersionChip(props: { readonly chip: VersionRowChip }): JSX.Element {
+  const style = chipStyle(props.chip.tone);
   return (
-    <HoverCard>
-      <HoverCardTrigger asChild>
-        <button
-          type="button"
-          data-testid={`version-details-trigger-${props.version}`}
-          aria-label={`${props.version} — ${props.lines.join(". ")}`}
-          className="cursor-default rounded-sm decoration-dotted underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-        >
-          {props.children}
-        </button>
-      </HoverCardTrigger>
-      <HoverCardContent
-        // `max-w-*` rather than a fixed `w-*`: a row whose only detail is
-        // "Not installed" gets a card that size, and the repo forbids fixed
-        // widths for layout surfaces anyway.
-        className="max-w-xs p-3"
-        data-testid={`version-details-${props.version}`}
-      >
-        <p className="font-mono text-ui-sm text-foreground">{props.version}</p>
-        {props.lines.map((line) => (
-          <p key={line} className="mt-1 text-ui-xs text-muted-foreground">
-            {line}
-          </p>
-        ))}
-      </HoverCardContent>
-    </HoverCard>
+    <Badge
+      variant={style.variant}
+      className={style.className}
+      data-testid={`version-row-chip-${props.chip.tone}`}
+    >
+      {props.chip.label}
+    </Badge>
   );
+}
+
+type ChipStyle = {
+  readonly variant: "default" | "destructive" | "outline";
+  readonly className: string | undefined;
+};
+
+/**
+ * Tone → Badge styling, loudest first.
+ *
+ * `recommended` used to be `secondary`, which is a fill this surface cannot
+ * carry: `--secondary` is identical to `--popover` in the amoled and
+ * traycer-green dark presets, so the chip was invisible on exactly the themes
+ * that collapse it — the same class of defect as the repo's `bg-muted` rule,
+ * one token over, and one the `bg-muted` lint cannot see. `outline` is safe by
+ * construction because `--border` never collapses.
+ *
+ * `unpublished` is the same outline with the text dimmed. That is deliberate:
+ * a chip warning you that deleting is permanent should be READABLE, not
+ * ALARMING — alarm belongs to `blocked`, which is a refusal.
+ */
+function chipStyle(tone: VersionRowChip["tone"]): ChipStyle {
+  if (tone === "current") return { variant: "default", className: undefined };
+  if (tone === "blocked") {
+    return { variant: "destructive", className: undefined };
+  }
+  if (tone === "unpublished") {
+    return { variant: "outline", className: "text-muted-foreground" };
+  }
+  return { variant: "outline", className: undefined };
 }
 
 function VersionRowActions(props: {
@@ -714,12 +838,14 @@ function VersionRowActions(props: {
   readonly del: VersionDeleteEligibility;
   readonly showFetch: boolean;
   readonly fetchLabel: "Download" | "Retry";
+  readonly deleteArmed: boolean;
   readonly downloadPending: boolean;
   readonly usePending: boolean;
   readonly deletePending: boolean;
   readonly actionsDisabled: boolean;
   readonly onDownload: (version: string) => void;
   readonly onUse: (version: string) => void;
+  readonly onArmDelete: (version: string) => void;
   readonly onDelete: (version: string) => void;
 }): JSX.Element {
   const {
@@ -729,27 +855,37 @@ function VersionRowActions(props: {
     del,
     showFetch,
     fetchLabel,
+    deleteArmed,
     downloadPending,
     usePending,
     deletePending,
     actionsDisabled,
     onDownload,
     onUse,
+    onArmDelete,
     onDelete,
   } = props;
 
   const downloading = row.installState.status === "downloading";
   const showUse = row.installState.status === "installed" && !row.current;
+  const showDelete = versionShowsDeleteAction(row);
   const fetchDisabled = actionsDisabled || !download.allowed;
   const useDisabled = actionsDisabled || !useElig.allowed;
   const fetchTooltip = download.allowed ? null : download.reason;
   const useTooltip = useElig.allowed ? null : useElig.reason;
 
   return (
-    <div className="flex shrink-0 flex-wrap items-center gap-2">
+    <div className="flex shrink-0 items-center gap-1">
       {downloading ? (
-        <Button type="button" size="sm" variant="outline" disabled>
-          Downloading…
+        // The button carries only "something is happening"; the progress bar
+        // below the row carries how far along. A word here duplicated the bar.
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          disabled
+          aria-label={`Downloading ${row.version}`}
+        >
           <MutedAgentSpinner />
         </Button>
       ) : null}
@@ -757,10 +893,11 @@ function VersionRowActions(props: {
       {showFetch ? (
         <ActionButton
           label={fetchLabel}
+          version={row.version}
+          icon={fetchLabel === "Retry" ? RotateCw : Download}
           disabled={fetchDisabled}
           tooltip={fetchTooltip}
           pending={downloadPending}
-          variant={fetchLabel === "Retry" ? "outline" : "default"}
           onClick={() => onDownload(row.version)}
         />
       ) : null}
@@ -768,79 +905,137 @@ function VersionRowActions(props: {
       {showUse ? (
         <ActionButton
           label="Use"
+          version={row.version}
+          icon={Check}
           disabled={useDisabled}
           tooltip={useTooltip}
           pending={usePending}
-          variant="outline"
           onClick={() => onUse(row.version)}
         />
       ) : null}
 
-      {del.allowed ? (
-        <ActionButton
-          label="Delete"
-          disabled={actionsDisabled}
-          tooltip={null}
+      {showDelete ? (
+        <DeleteAction
+          version={row.version}
+          armed={deleteArmed}
+          eligibility={del}
           pending={deletePending}
-          variant="outline"
-          destructive
-          onClick={() => onDelete(row.version)}
-        />
-      ) : null}
-
-      {row.current ? (
-        <ActionButton
-          label="Delete"
-          disabled
-          tooltip="Switch to another version first"
-          pending={false}
-          variant="outline"
-          testId="delete-disabled-current"
-          onClick={() => undefined}
+          actionsDisabled={actionsDisabled}
+          onArm={onArmDelete}
+          onConfirm={onDelete}
         />
       ) : null}
     </div>
   );
 }
 
+/**
+ * Delete, in its two shapes.
+ *
+ * Disabled it stays an icon and explains itself through the tooltip, from
+ * `versionDeleteEligibility` — one reason string, whether the block is "this is
+ * the version you are running" or "quarantine is holding these bytes". The
+ * component no longer decides which blocks exist; asking the model is what
+ * keeps a new block from silently rendering no control at all.
+ *
+ * Armed it becomes a word, which is the whole mechanism: nothing about a second
+ * click on an unchanged icon tells the user their first click registered as a
+ * request rather than as the deletion.
+ */
+function DeleteAction(props: {
+  readonly version: string;
+  readonly armed: boolean;
+  readonly eligibility: VersionDeleteEligibility;
+  readonly pending: boolean;
+  readonly actionsDisabled: boolean;
+  readonly onArm: (version: string) => void;
+  readonly onConfirm: (version: string) => void;
+}): JSX.Element {
+  if (props.armed && props.eligibility.allowed) {
+    return (
+      <Button
+        type="button"
+        size="xs"
+        variant="destructive"
+        data-testid={`version-delete-confirm-${props.version}`}
+        disabled={props.actionsDisabled}
+        onClick={() => props.onConfirm(props.version)}
+      >
+        Delete?
+        {props.pending ? <MutedAgentSpinner /> : null}
+      </Button>
+    );
+  }
+
+  return (
+    <ActionButton
+      label="Delete"
+      version={props.version}
+      icon={Trash2}
+      destructive
+      disabled={props.actionsDisabled || !props.eligibility.allowed}
+      tooltip={props.eligibility.allowed ? null : props.eligibility.reason}
+      pending={props.pending}
+      testId={props.eligibility.allowed ? undefined : "delete-disabled-blocked"}
+      onClick={() => props.onArm(props.version)}
+    />
+  );
+}
+
+/**
+ * One icon-only row control.
+ *
+ * `label` does triple duty — the accessible name (with the version appended, so
+ * the buttons of a five-row list are distinguishable), the tooltip when the
+ * control is live, and the thing a refusal replaces when it is not. A tooltip
+ * is therefore ALWAYS rendered: an icon button with nothing to hover is a
+ * guessing game, which is the standing cost of dropping the words and the
+ * reason this component has no "no tooltip" path.
+ */
 function ActionButton(props: {
   readonly label: string;
+  readonly version: string;
+  readonly icon: LucideIcon;
   readonly disabled: boolean;
   readonly tooltip: string | null;
   readonly pending: boolean;
-  readonly variant: "default" | "outline";
   readonly destructive?: boolean;
   readonly testId?: string;
   readonly onClick: () => void;
 }): JSX.Element {
+  const Icon = props.icon;
+  const accessibleName = `${props.label} ${props.version}`;
+
   const button = (
     <Button
       type="button"
-      size="sm"
-      variant={props.variant}
-      className={
-        props.destructive === true
-          ? "text-destructive hover:text-destructive"
-          : undefined
-      }
+      size="icon-sm"
+      variant="ghost"
+      className={cn(
+        props.destructive === true &&
+          "text-destructive hover:bg-destructive/10 hover:text-destructive",
+      )}
       disabled={props.disabled}
       data-testid={props.testId}
+      aria-label={accessibleName}
       onClick={props.onClick}
     >
-      {props.label}
-      {props.pending ? <MutedAgentSpinner /> : null}
+      {props.pending ? <MutedAgentSpinner /> : <Icon aria-hidden="true" />}
     </Button>
   );
 
-  if (props.tooltip === null) return button;
-
   return (
     <TooltipWrapper
-      label={props.tooltip}
+      label={props.tooltip ?? accessibleName}
       side="top"
       sideOffset={4}
       align="center"
     >
+      {/*
+        The span is load-bearing on the disabled path: `disabled` buttons emit
+        no pointer events, so a tooltip bound to the button itself never opens
+        for exactly the states whose reason the user most needs.
+      */}
       <span className="inline-flex">{button}</span>
     </TooltipWrapper>
   );

--- a/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-panel.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+} from "react";
 import {
   Check,
   Download,
@@ -953,17 +960,12 @@ function DeleteAction(props: {
 }): JSX.Element {
   if (props.armed && props.eligibility.allowed) {
     return (
-      <Button
-        type="button"
-        size="xs"
-        variant="destructive"
-        data-testid={`version-delete-confirm-${props.version}`}
+      <ArmedDeleteButton
+        version={props.version}
+        pending={props.pending}
         disabled={props.actionsDisabled}
-        onClick={() => props.onConfirm(props.version)}
-      >
-        Delete?
-        {props.pending ? <MutedAgentSpinner /> : null}
-      </Button>
+        onConfirm={props.onConfirm}
+      />
     );
   }
 
@@ -979,6 +981,50 @@ function DeleteAction(props: {
       testId={props.eligibility.allowed ? undefined : "delete-disabled-blocked"}
       onClick={() => props.onArm(props.version)}
     />
+  );
+}
+
+/**
+ * The armed half of the two-step delete, split out for the focus effect.
+ *
+ * Arming REPLACES a DOM node rather than restyling one: the trash
+ * `ActionButton` (tooltip → span → button) unmounts and this button mounts in
+ * its place. Whatever the pointer does, that drops a keyboard user's focus to
+ * `<body>`, so the second press of a two-press flow has nothing to land on and
+ * the state change is never announced — the confirmation step becomes a
+ * mouse-only affordance. Focusing on mount is what keeps the two presses on one
+ * control, and it is imperative because `jsx-a11y` forbids the `autoFocus` prop.
+ *
+ * The visible word can't carry the version the way the icon buttons' labels do
+ * ("Delete?" has to stay short), so the accessible name restates it: in a
+ * five-row list an unqualified "Delete?" names no version at all.
+ */
+function ArmedDeleteButton(props: {
+  readonly version: string;
+  readonly pending: boolean;
+  readonly disabled: boolean;
+  readonly onConfirm: (version: string) => void;
+}): JSX.Element {
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  return (
+    <Button
+      ref={confirmRef}
+      type="button"
+      size="xs"
+      variant="destructive"
+      data-testid={`version-delete-confirm-${props.version}`}
+      disabled={props.disabled}
+      aria-label={`Confirm delete ${props.version}`}
+      onClick={() => props.onConfirm(props.version)}
+    >
+      Delete?
+      {props.pending ? <MutedAgentSpinner /> : null}
+    </Button>
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-pack-version-manager-panel.tsx
@@ -105,6 +105,27 @@ type BannerNotice = {
 };
 
 /**
+ * The row whose Delete is armed — identified by WHERE it is, not just which
+ * version, so the arming cannot outlive the host and pack it was made on.
+ */
+type ArmedDelete = {
+  readonly hostId: string | null;
+  readonly packId: string;
+  readonly version: string;
+};
+
+/** The armed version, but only while the panel still shows the host and pack it was armed on. */
+function armedVersionWithin(
+  armed: ArmedDelete | null,
+  hostId: string | null,
+  packId: string,
+): string | null {
+  if (armed === null) return null;
+  if (armed.hostId !== hostId || armed.packId !== packId) return null;
+  return armed.version;
+}
+
+/**
  * Per-pack version manager panel (B5-T2).
  *
  * Three regions, in the order a reader needs them: what is true of the pack
@@ -184,7 +205,16 @@ export function ProviderPackVersionManagerPanel(
   // without fake timers and, worse, can disarm between a user deciding and
   // clicking. It disarms on any other action in the panel (via `clearNotice`)
   // and on unmount, which closing the popover does.
-  const [armedDelete, setArmedDelete] = useState<string | null>(null);
+  //
+  // Keyed by host and pack as well as version, because this panel is mounted
+  // unkeyed under a settings scope whose host can AUTO-FOLLOW to another
+  // machine while the popover is open. A bare version string would survive
+  // that move, and if the new host also carries `1.5.0` its row would mount
+  // already armed — one press from deleting something on a machine the user
+  // never armed anything on. Matching the full key makes the move disarm for
+  // free, with no effect and no remount.
+  const [armedDelete, setArmedDelete] = useState<ArmedDelete | null>(null);
+  const armedVersion = armedVersionWithin(armedDelete, hostId, packId);
 
   // Tell the mutation hooks this panel is on screen to render outcomes. While
   // it is, refusals draw inline below, anchored to what they are about; once
@@ -313,9 +343,9 @@ export function ProviderPackVersionManagerPanel(
   const onArmDelete = useCallback(
     (version: string) => {
       clearNotice();
-      setArmedDelete(version);
+      setArmedDelete({ hostId, packId, version });
     },
-    [clearNotice],
+    [clearNotice, hostId, packId],
   );
 
   const onDelete = useCallback(
@@ -452,7 +482,7 @@ export function ProviderPackVersionManagerPanel(
                 ? rowNotice
                 : null
             }
-            deleteArmed={armedDelete === row.version}
+            deleteArmed={armedVersion === row.version}
             downloadPending={
               pendingVersion === row.version && install.isPending
             }


### PR DESCRIPTION
Reported from the running app: the managed-CLI version dropdown "has a lot of redundant and weird looking information". Most of it was chrome restating context the surface already had.

## What left

| Removed | Why |
|---|---|
| **The header title** | It named the CLI whose version cell you opened the popover from, in the largest type on the surface. `aria-label` keeps it for screen readers, which don't get that anchoring for free. |
| **The `… on disk` footprint** | `totalSizeBytes` is the whole pack cell across *every* retained version, sitting directly above rows whose sizes are per-version. Two numbers on different axes, one labelled "on disk", neither summing to the other — so the smaller one read as an error. |
| **The per-version hover card** | Three of its five lines restated the row. `Installed` is told by *which* action the row offers; `pairs with this Traycer release` is the Recommended chip in prose; `Can't switch to it` became a second copy of the disabled Use tooltip once the buttons went icon-only. It also made the version number a focusable ring that read as an editable field, and opened over the rows beneath it. |

## What moved or changed shape

- **Auto-download → footer.** A durable preference, not an action on any version, so it wants the calmest position rather than the loudest.
- **The list caps at ~4 rows and scrolls**, clipping the fifth so the cut advertises itself. `available` is every published version plus every retained install, which on a mature pack was a full-height wall.
- **Row actions are icons**, with version-qualified accessible names (`Delete 2.1.232`). The words carried nothing after row one, and a screen reader used to hear *"Use, Delete, Use, Delete"* with no way to tell rows apart.
- **Delete arms before it fires**, rendering a labelled `Delete?`. A 28px unlabelled target between two others is easy to mis-hit, and for an `uncertified` version — installed, usable, **not** re-downloadable — a slip cannot be undone.
- **The update banner is a full-width strip.** Inset inside a bordered popover it was a third nested frame before the first version.

## Defects found alongside

- The panel drew `rounded-xl border bg-card` inside the popover's own `rounded-lg ring-1 bg-popover`, at a **larger** radius — the container's corners showed through behind it as slivers.
- **A quarantined version rendered no Delete and no reason.** The panel hardcoded a `current`-only disabled arm, leaving the sentence this module computes for quarantine unreachable. Visibility now asks `versionShowsDeleteAction`.
- `chipVariant` mapped `recommended` to `secondary`, and `--secondary` equals `--popover` in the amoled and traycer-green darks — an invisible chip on those themes. Same class as the repo's `bg-muted` rule, one token over, where that lint can't see it. Now `outline`, safe because `--border` never collapses.
- **The install row's label wrapped four lines deep** under the narrow Version column: the progress bar shared its flex line as `w-full shrink-0`, taking the whole line and refusing to yield any back. They stack now.
- `formatPackSizeBytes` divided by 1024 while printing `KB`/`MB`/`GB`. Deleted with the card, but it was wrong.

## What the card's removal would have cost, and didn't

- **`uncertified` earns a quiet `Unpublished` chip**, ranked above `recommended`. It's the only state here that decides whether *deleting* is reversible, and a version can be both — only one of them changes what delete costs. Suppressed on a `current` row, where delete is refused anyway.
- **`unusable` and `error` rows get one inline sentence** (`versionTroubleLine`). The card was their only explanation; without it a condemned install rendered as a row with a delete button and no reason for having nothing else. Healthy rows return `null` and stay a number, a chip and their controls.

Removing the card orphaned ~210 lines of model code — `versionDetailLines`, `composeVersionRowMeta`, `formatPackSizeBytes` and two private composition helpers — deleted with it. The raw-wire-message invariant those tests guarded (`installState.message` can carry filesystem text and must never reach the UI) moves onto `versionTroubleLine`.

## Verification

- 4 affected suites: **136 passed**, 0 failed.
- Positive control: breaking the icon buttons' naming contract turns **9 red**, restoring returns 29 green — the tests are coupled to the contract, not vacuous.
- `bun run compile` clean, verified with its own positive control (`tsc -b` is incremental, so a bare green can be empty).
- `eslint` + `prettier` clean on all 5 files; `pre-commit` nx-affected gate passed.

**Not visually verified.** jsdom has no layout engine, so the popover geometry and the install-row stacking are structural claims only — worth one look in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)