### PR TITLE
fix(gui-app): use the primary-action shortcut hint on the interview card

### DIFF
--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -140,10 +140,12 @@ function card(): HTMLElement {
   return screen.getByTestId("interview-card");
 }
 
-// The proceed (Next/Submit) action button, identified by its ⏎ shortcut hint -
-// distinct from the pager's "Next question" / "Previous question" buttons.
+// The proceed (Next/Submit) action button, distinct from the pager's
+// "Next question" / "Previous question" buttons.
 function proceedButton(): HTMLButtonElement {
-  return screen.getByRole<HTMLButtonElement>("button", { name: /↵/ });
+  return screen.getByRole<HTMLButtonElement>("button", {
+    name: /^(Next|Submit)$/,
+  });
 }
 
 describe("PendingInterviewCard keyboard navigation", () => {
@@ -151,6 +153,19 @@ describe("PendingInterviewCard keyboard navigation", () => {
     cleanup();
     useInterviewDraftStore.setState({ draftsByChat: {} });
     window.localStorage.clear();
+  });
+
+  it("keeps the Submit shortcut keycaps at the primary action contrast", () => {
+    renderCard([singleSelect("free", "Describe it", [])], vi.fn(), null);
+
+    const submit = screen.getByRole("button", { name: "Submit" });
+    const keycaps = submit.querySelectorAll('[data-slot="kbd"]');
+    expect(keycaps).toHaveLength(2);
+    for (const keycap of keycaps) {
+      expect(keycap.className).toContain("border-current");
+      expect(keycap.className).toContain("bg-transparent");
+      expect(keycap.className).toContain("text-current");
+    }
   });
 
   it("restores each chat's current question and answers after remount", () => {
@@ -422,9 +437,7 @@ describe("PendingInterviewCard keyboard navigation", () => {
     expect(
       screen.getByRole<HTMLButtonElement>("button", { name: /Skip/ }).disabled,
     ).toBe(true);
-    expect(
-      screen.getByRole<HTMLButtonElement>("button", { name: /↵/ }).disabled,
-    ).toBe(true);
+    expect(proceedButton().disabled).toBe(true);
     expect(
       screen.getByRole<HTMLButtonElement>("button", {
         name: "Previous question",

--- a/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
@@ -7,8 +7,8 @@ import type {
   InterviewQuestion,
 } from "@traycer/protocol/persistence/epic/schemas";
 import { Button } from "@/components/ui/button";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
-import { modLabel } from "@/lib/keybindings/platform";
+import { Kbd } from "@/components/ui/kbd";
+import { PrimaryActionShortcutHint } from "@/components/ui/primary-action-shortcut-hint";
 import { InterviewForkActions } from "@/components/chat/segments/interview-fork-actions";
 import { QuestionPage } from "./question-page";
 import { QUESTION_TRANSITION, useInterviewCard } from "./use-interview-card";
@@ -167,10 +167,7 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
             >
               <Check className="size-3.5" aria-hidden />
               Submit
-              <KbdGroup>
-                <Kbd>{modLabel()}</Kbd>
-                <Kbd>↵</Kbd>
-              </KbdGroup>
+              <PrimaryActionShortcutHint />
             </Button>
           ) : (
             <Button
@@ -181,10 +178,7 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
               onClick={goNext}
             >
               Next
-              <KbdGroup>
-                <Kbd>{modLabel()}</Kbd>
-                <Kbd>↵</Kbd>
-              </KbdGroup>
+              <PrimaryActionShortcutHint />
             </Button>
           )}
         </div>


### PR DESCRIPTION
Reuses PrimaryActionShortcutHint for pending-interview Next/Submit actions so shortcut keycaps inherit primary-button contrast. Adds regression coverage for Submit keycaps.