### PR TITLE
feat(traycer-cli): preserve the outgoing install's provider CLIs across updates

### DIFF
--- a/clients/gui-app/src/components/providers/provider-pack-readiness.ts
+++ b/clients/gui-app/src/components/providers/provider-pack-readiness.ts
@@ -54,12 +54,12 @@ export interface ProviderPackPreparing {
  * costs at worst one bounced turn on a host that has nothing, and the host's
  * typed `preparing` error is the backstop for exactly that.
  *
- * Known narrow over-openness: the D6 closure-coupled carve can make the host
- * refuse a version-mismatched PATH candidate as a NEW holder's binary even
- * though it reports `available` here. That mismatch is not on the wire yet
- * (the `advisory: row-incompatibility` field is the ticket for it), so this
- * function cannot see it. Failing open on it is the deliberate choice: the
- * alternative today is gating every provider on every host.
+ * (An earlier note here described the D6 closure-coupled carve as a narrow
+ * over-openness - a PATH candidate the host would refuse while this reports
+ * `available`. The carve was removed host-side on 2026-08-19: auto-PATH now
+ * serves closure packs like every other provider, so an `available` PATH
+ * candidate is one the host will actually spawn and the over-openness no
+ * longer exists.)
  */
 function providerHasRunnableFallback(provider: ProviderCliState): boolean {
   if (provider.availabilityPending) return true;

--- a/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
@@ -4,9 +4,10 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -110,6 +111,18 @@ describe("preserveLegacyProviders", () => {
     writeRootFile(oldResources, "providers", "PROVIDERS.json", "{}");
     writePack(newResources, "providers", "ripgrep", "14.0.0");
 
+    // Captured BEFORE the move: a same-inode comparison after is what proves
+    // this is a rename (the same bytes on disk, just re-linked), not a copy
+    // that happens to leave the source behind. `ino` is not a meaningful
+    // identity on win32 (NTFS via Node reports it inconsistently across
+    // rename), so that half of the assertion is skipped there.
+    const originalIno =
+      platform() === "win32"
+        ? null
+        : statSync(
+            join(oldResources, "providers", "codex", PLATFORM_ARCH, "codex"),
+          ).ino;
+
     await preserveLegacyProviders(oldInstall, newInstall, noopLogger);
 
     expect(
@@ -138,6 +151,13 @@ describe("preserveLegacyProviders", () => {
 
     // The move is a rename, not a copy - the old pack dir is gone afterward.
     expect(existsSync(join(oldResources, "providers", "codex"))).toBe(false);
+
+    if (originalIno !== null) {
+      const movedIno = statSync(
+        join(newResources, "legacy-providers", "codex", PLATFORM_ARCH, "codex"),
+      ).ino;
+      expect(movedIno).toBe(originalIno);
+    }
   });
 
   it("chains a carryover forward: packs the old install itself inherited (its own legacy-providers) ride along too", async () => {
@@ -219,6 +239,51 @@ describe("preserveLegacyProviders", () => {
     expect(
       existsSync(
         join(newResources, "legacy-providers", "codex", PLATFORM_ARCH),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns with the pack's name and keeps moving the rest when one pack's move fails", async () => {
+    const oldInstall = join(sandboxRoot, "old-install");
+    const newInstall = join(sandboxRoot, "new-install");
+    const oldResources = wrappedResources(oldInstall);
+    const newResources = wrappedResources(newInstall);
+
+    writePack(oldResources, "providers", "codex", "1.2.3");
+    writePack(oldResources, "providers", "opencode", "0.9.0");
+    writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+    // Pre-seed the destination slot a "codex" move would land in with a FILE,
+    // not a directory: `rename()` of a directory onto an existing
+    // non-directory path fails (ENOTDIR/EISDIR depending on platform), which
+    // is the one failure this best-effort loop must survive without
+    // aborting the packs after it.
+    const dest = join(newResources, "legacy-providers");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "codex"), "not a directory");
+
+    const { logger, warnings } = capturingLogger();
+    await expect(
+      preserveLegacyProviders(oldInstall, newInstall, logger),
+    ).resolves.toBeUndefined();
+
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]?.message).toBe(
+      "Host install carryover could not move a provider pack",
+    );
+    expect(warnings[0]?.fields.pack).toBe("codex");
+
+    // codex's move failed - its source dir is untouched, and the collided
+    // destination slot is still the plain file it was.
+    expect(
+      existsSync(join(oldResources, "providers", "codex", PLATFORM_ARCH)),
+    ).toBe(true);
+    expect(existsSync(join(dest, "codex", PLATFORM_ARCH))).toBe(false);
+
+    // opencode has no collision and moves fine despite codex's failure.
+    expect(
+      existsSync(
+        join(newResources, "legacy-providers", "opencode", PLATFORM_ARCH),
       ),
     ).toBe(true);
   });

--- a/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
@@ -1,0 +1,225 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { noopLogger } from "../../logger";
+import type { ILogger, LogFields } from "../../logger";
+import { preserveLegacyProviders } from "../legacy-providers";
+
+/**
+ * `preserveLegacyProviders` - the OSS half of the slim-release carryover
+ * contract with `traycer-host/src/domain/providers/legacy-provider-carryover.ts`
+ * in the internal repo. tmpdir-based, real filesystem: the point of the
+ * function is what actually lands on disk after the swap.
+ */
+
+let sandboxRoot: string;
+
+beforeEach(() => {
+  sandboxRoot = mkdtempSync(join(tmpdir(), "legacy-providers-"));
+});
+
+afterEach(() => {
+  rmSync(sandboxRoot, { recursive: true, force: true });
+});
+
+const PLATFORM_ARCH = "darwin-arm64";
+
+// The nested `host-runtime/resources/...` shape a release archive extracts
+// into - `resolveResourcesDir`'s "one level down" branch.
+function wrappedResources(installDir: string): string {
+  return join(installDir, "host-runtime", "resources");
+}
+
+// The flat `resources/...` shape - `resolveResourcesDir`'s direct-hit branch.
+function topLevelResources(installDir: string): string {
+  return join(installDir, "resources");
+}
+
+function writePack(
+  resourcesDir: string,
+  bundleDirname: "providers" | "legacy-providers",
+  pack: string,
+  version: string,
+): void {
+  const packDir = join(resourcesDir, bundleDirname, pack, PLATFORM_ARCH);
+  mkdirSync(packDir, { recursive: true });
+  writeFileSync(join(packDir, "version.json"), JSON.stringify({ version }));
+  writeFileSync(join(packDir, pack), "binary-bytes");
+}
+
+function writeRootFile(
+  resourcesDir: string,
+  bundleDirname: "providers" | "legacy-providers",
+  name: string,
+  content: string,
+): void {
+  const dir = join(resourcesDir, bundleDirname);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), content);
+}
+
+function readCarriedVersion(resourcesDir: string, pack: string): unknown {
+  return JSON.parse(
+    readFileSync(
+      join(
+        resourcesDir,
+        "legacy-providers",
+        pack,
+        PLATFORM_ARCH,
+        "version.json",
+      ),
+      "utf8",
+    ),
+  );
+}
+
+function capturingLogger(): {
+  readonly logger: ILogger;
+  readonly warnings: readonly { message: string; fields: LogFields }[];
+} {
+  const warnings: { message: string; fields: LogFields }[] = [];
+  const logger: ILogger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: (message, fields) => {
+      warnings.push({ message, fields });
+    },
+    error: () => undefined,
+  };
+  return { logger, warnings };
+}
+
+describe("preserveLegacyProviders", () => {
+  it("carries a pack the new install does not bundle, skips one it does, and leaves root metadata files behind", async () => {
+    const oldInstall = join(sandboxRoot, "old-install");
+    const newInstall = join(sandboxRoot, "new-install");
+    const oldResources = wrappedResources(oldInstall);
+    const newResources = wrappedResources(newInstall);
+
+    writePack(oldResources, "providers", "codex", "1.2.3");
+    writePack(oldResources, "providers", "ripgrep", "13.0.0");
+    writeRootFile(oldResources, "providers", "PROVIDERS.json", "{}");
+    writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+    await preserveLegacyProviders(oldInstall, newInstall, noopLogger);
+
+    expect(
+      existsSync(
+        join(newResources, "legacy-providers", "codex", PLATFORM_ARCH),
+      ),
+    ).toBe(true);
+    expect(readCarriedVersion(newResources, "codex")).toEqual({
+      version: "1.2.3",
+    });
+    expect(
+      existsSync(
+        join(newResources, "legacy-providers", "codex", PLATFORM_ARCH, "codex"),
+      ),
+    ).toBe(true);
+
+    // ripgrep is bundled by the new install itself - never carried.
+    expect(existsSync(join(newResources, "legacy-providers", "ripgrep"))).toBe(
+      false,
+    );
+
+    // Root-level metadata dies with the old install; only per-pack dirs move.
+    expect(
+      existsSync(join(newResources, "legacy-providers", "PROVIDERS.json")),
+    ).toBe(false);
+
+    // The move is a rename, not a copy - the old pack dir is gone afterward.
+    expect(existsSync(join(oldResources, "providers", "codex"))).toBe(false);
+  });
+
+  it("chains a carryover forward: packs the old install itself inherited (its own legacy-providers) ride along too", async () => {
+    const oldInstall = join(sandboxRoot, "old-install");
+    const newInstall = join(sandboxRoot, "new-install");
+    const oldResources = wrappedResources(oldInstall);
+    const newResources = wrappedResources(newInstall);
+
+    writePack(oldResources, "providers", "ripgrep", "13.0.0");
+    writePack(oldResources, "legacy-providers", "codex", "1.2.3");
+    writePack(oldResources, "legacy-providers", "opencode", "0.9.0");
+    writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+    await preserveLegacyProviders(oldInstall, newInstall, noopLogger);
+
+    expect(
+      existsSync(
+        join(newResources, "legacy-providers", "codex", PLATFORM_ARCH),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(newResources, "legacy-providers", "opencode", PLATFORM_ARCH),
+      ),
+    ).toBe(true);
+    expect(existsSync(join(newResources, "legacy-providers", "ripgrep"))).toBe(
+      false,
+    );
+  });
+
+  it("on a collision, the outgoing install's OWN bundle wins over the carryover it inherited", async () => {
+    const oldInstall = join(sandboxRoot, "old-install");
+    const newInstall = join(sandboxRoot, "new-install");
+    const oldResources = wrappedResources(oldInstall);
+    const newResources = wrappedResources(newInstall);
+
+    // Both trees carry a "codex" pack; `providers` is the outgoing install's
+    // own bundle and must be the one that survives the merge.
+    writePack(oldResources, "providers", "codex", "newer");
+    writePack(oldResources, "legacy-providers", "codex", "older");
+    // The new install needs SOME resources dir for `resolveResourcesDir` to
+    // find - an unrelated pack, so this stays a pure collision test on codex.
+    writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+    await preserveLegacyProviders(oldInstall, newInstall, noopLogger);
+
+    expect(readCarriedVersion(newResources, "codex")).toEqual({
+      version: "newer",
+    });
+  });
+
+  it("is a no-op that never throws when the old install has no resources dir at all", async () => {
+    const oldInstall = join(sandboxRoot, "old-install-bare");
+    const newInstall = join(sandboxRoot, "new-install");
+    mkdirSync(oldInstall, { recursive: true });
+    const newResources = wrappedResources(newInstall);
+    writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+    const { logger, warnings } = capturingLogger();
+    await expect(
+      preserveLegacyProviders(oldInstall, newInstall, logger),
+    ).resolves.toBeUndefined();
+
+    expect(warnings).toEqual([]);
+    expect(existsSync(join(newResources, "legacy-providers"))).toBe(false);
+  });
+
+  it("resolves a top-level resources/ dir too, not only one nested under host-runtime/", async () => {
+    const oldInstall = join(sandboxRoot, "old-install");
+    const newInstall = join(sandboxRoot, "new-install");
+    const oldResources = topLevelResources(oldInstall);
+    const newResources = topLevelResources(newInstall);
+
+    writePack(oldResources, "providers", "codex", "1.2.3");
+    writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+    await preserveLegacyProviders(oldInstall, newInstall, noopLogger);
+
+    expect(
+      existsSync(
+        join(newResources, "legacy-providers", "codex", PLATFORM_ARCH),
+      ),
+    ).toBe(true);
+  });
+});

--- a/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
@@ -342,4 +342,54 @@ describe("preserveLegacyProviders", () => {
       }
     },
   );
+
+  it.skipIf(platform() === "win32" || runsAsRoot)(
+    "warns 'could not enumerate an install dir' when the OLD INSTALL DIR itself cannot be listed, and resolves without throwing",
+    async () => {
+      const oldInstall = join(sandboxRoot, "old-install-locked");
+      const newInstall = join(sandboxRoot, "new-install");
+      // A real nested layout first, so this models an install that GENUINELY
+      // has packs - not an empty stub - before locking the dir down.
+      writePack(wrappedResources(oldInstall), "providers", "codex", "1.2.3");
+      const newResources = wrappedResources(newInstall);
+      writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+      // EACCES on the install dir itself: neither `stat` on a path inside
+      // it (the direct "<install>/resources" probe) nor `readdir` on it
+      // directly can succeed - both fail EACCES, not ENOENT/ENOTDIR, so
+      // BOTH must be warned rather than silently swallowed.
+      chmodSync(oldInstall, 0o000);
+
+      const { logger, warnings } = capturingLogger();
+      try {
+        await expect(
+          preserveLegacyProviders(oldInstall, newInstall, logger),
+        ).resolves.toBeUndefined();
+
+        expect(warnings.length).toBe(2);
+
+        const enumerateWarning = warnings.find(
+          (w) =>
+            w.message ===
+            "Host install carryover could not enumerate an install dir",
+        );
+        expect(enumerateWarning).toBeDefined();
+        expect(enumerateWarning?.fields.installDir).toBe(oldInstall);
+
+        // The direct "<install>/resources" stat probe fails through the
+        // same unreadable parent - also EACCES, also warned.
+        const statWarning = warnings.find(
+          (w) => w.message === "Host install carryover could not stat a path",
+        );
+        expect(statWarning).toBeDefined();
+
+        // Nothing from the unreachable old install was carried.
+        expect(existsSync(join(newResources, "legacy-providers"))).toBe(false);
+      } finally {
+        // Restore permissions so afterEach's rmSync(sandboxRoot) can
+        // actually enumerate and delete it.
+        chmodSync(oldInstall, 0o755);
+      }
+    },
+  );
 });

--- a/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -33,6 +34,11 @@ afterEach(() => {
 });
 
 const PLATFORM_ARCH = "darwin-arm64";
+
+// Root ignores directory permission bits, so the EACCES-enumerate case below
+// would read the chmod-0o000 dir cleanly and assert nothing.
+const runsAsRoot =
+  typeof process.getuid === "function" && process.getuid() === 0;
 
 // The nested `host-runtime/resources/...` shape a release archive extracts
 // into - `resolveResourcesDir`'s "one level down" branch.
@@ -221,6 +227,8 @@ describe("preserveLegacyProviders", () => {
       preserveLegacyProviders(oldInstall, newInstall, logger),
     ).resolves.toBeUndefined();
 
+    // A genuinely absent source (ENOENT) is `isExpectedAbsence` territory -
+    // silent, not warned. This already pins that: zero warn calls.
     expect(warnings).toEqual([]);
     expect(existsSync(join(newResources, "legacy-providers"))).toBe(false);
   });
@@ -287,4 +295,51 @@ describe("preserveLegacyProviders", () => {
       ),
     ).toBe(true);
   });
+
+  it.skipIf(platform() === "win32" || runsAsRoot)(
+    "warns with the source path (not silently skipping) when a source dir exists but cannot be enumerated, and still processes the OTHER source",
+    async () => {
+      const oldInstall = join(sandboxRoot, "old-install");
+      const newInstall = join(sandboxRoot, "new-install");
+      const oldResources = wrappedResources(oldInstall);
+      const newResources = wrappedResources(newInstall);
+
+      const oldProvidersDir = join(oldResources, "providers");
+      mkdirSync(oldProvidersDir, { recursive: true });
+      // Seed the OTHER source ("legacy-providers") so this proves it is
+      // still processed despite "providers" being unreadable.
+      writePack(oldResources, "legacy-providers", "opencode", "0.9.0");
+      writePack(newResources, "providers", "ripgrep", "14.0.0");
+
+      // EACCES, not ENOENT/ENOTDIR: the dir genuinely exists but this
+      // process cannot list it - the one case `isExpectedAbsence` must NOT
+      // swallow silently.
+      chmodSync(oldProvidersDir, 0o000);
+
+      const { logger, warnings } = capturingLogger();
+      try {
+        await expect(
+          preserveLegacyProviders(oldInstall, newInstall, logger),
+        ).resolves.toBeUndefined();
+
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]?.message).toBe(
+          "Host install carryover could not enumerate a provider source",
+        );
+        expect(warnings[0]?.fields.source).toBe(oldProvidersDir);
+
+        // The other source is still processed despite the first one's
+        // enumeration failure - one bad source must not abort the loop.
+        expect(
+          existsSync(
+            join(newResources, "legacy-providers", "opencode", PLATFORM_ARCH),
+          ),
+        ).toBe(true);
+      } finally {
+        // Restore permissions so afterEach's rmSync(sandboxRoot) can actually
+        // enumerate and delete it.
+        chmodSync(oldProvidersDir, 0o755);
+      }
+    },
+  );
 });

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -25,6 +25,7 @@ import { createCliLogger, errorFromUnknown, type ILogger } from "../logger";
 import { createOwnedTempDir } from "../store/owned-temp";
 import { hostHomeDir, hostInstallDir, ensureHostHomeDir } from "../store/paths";
 import { extractHostSource, resolveHostExecutable } from "./extract";
+import { preserveLegacyProviders } from "./legacy-providers";
 import { createExtractHeartbeat } from "./extract-heartbeat";
 import { hashFileSha256 } from "./sha256";
 import {
@@ -1081,6 +1082,12 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
     });
   }
   if (targetExists) {
+    // Carry the outgoing install's bundled provider packs into the new
+    // install BEFORE the old dir is invalidated - a slim host archive ships
+    // no coding-agent CLIs, and these bytes are what keeps every provider
+    // runnable until its registry pack downloads (see legacy-providers.ts).
+    // Best-effort by its own contract; it never fails the install.
+    await preserveLegacyProviders(trash, target, logger);
     // Layered invalidation (rename-to-`.dead-*` -> sidecar-unlink ->
     // recursive-rm -> accept-and-log), not a plain `rm`: mirrors
     // `download-stage.ts`'s `replaceStagedDir`, which creates and discards

--- a/clients/traycer-cli/src/installer/legacy-providers.ts
+++ b/clients/traycer-cli/src/installer/legacy-providers.ts
@@ -40,6 +40,17 @@ async function isDirectory(path: string): Promise<boolean> {
   }
 }
 
+// The one readdir failure that means "no source here" rather than "a source
+// we could not look at": a slim old install legitimately has no providers
+// dir at all (ENOENT), or a stray file sits where the dir would be (ENOTDIR).
+function isExpectedAbsence(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
 // Locate `resources/` inside an install directory: at the top level, or one
 // level down - the same two-level strategy `resolveHostExecutable` uses for
 // the binary, since release archives wrap the runtime in `host-runtime/`.
@@ -91,7 +102,20 @@ export async function preserveLegacyProviders(
       let entries: Dirent[];
       try {
         entries = await readdir(source, { withFileTypes: true });
-      } catch {
+      } catch (cause) {
+        // Any other failure (EACCES, transient I/O) means packs that DO
+        // exist were never enumerated and will die with the old install
+        // when `invalidateAsideDir` runs - name the source and cause; the
+        // per-pack warn below cannot, because no pack was ever seen.
+        if (!isExpectedAbsence(cause)) {
+          logger.warn(
+            "Host install carryover could not enumerate a provider source",
+            {
+              source,
+              message: cause instanceof Error ? cause.message : String(cause),
+            },
+          );
+        }
         continue;
       }
       for (const entry of entries) {

--- a/clients/traycer-cli/src/installer/legacy-providers.ts
+++ b/clients/traycer-cli/src/installer/legacy-providers.ts
@@ -112,8 +112,16 @@ export async function preserveLegacyProviders(
           // that pack had before this provision existed.
           await rename(join(source, entry.name), join(dest, entry.name));
           moved += 1;
-        } catch {
+        } catch (cause) {
           skipped += 1;
+          // Name the pack and the cause: until its registry download lands,
+          // a skipped pack is a provider this user cannot run, and the
+          // summary count below cannot say which one.
+          logger.warn("Host install carryover could not move a provider pack", {
+            pack: entry.name,
+            source,
+            message: cause instanceof Error ? cause.message : String(cause),
+          });
         }
       }
     }

--- a/clients/traycer-cli/src/installer/legacy-providers.ts
+++ b/clients/traycer-cli/src/installer/legacy-providers.ts
@@ -1,0 +1,134 @@
+import type { Dirent } from "node:fs";
+import { mkdir, readdir, rename, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ILogger } from "../logger";
+
+/**
+ * TEMPORARY TRANSITION PROVISION for the host's slim-release cutover: park
+ * the OUTGOING install's bundled provider CLIs inside the NEW install before
+ * the old directory is invalidated.
+ *
+ * A slim host archive bundles no coding-agent CLIs (the host fetches
+ * registry packs at runtime), but the install being replaced carries
+ * runnable bytes - its own fat bundle, or a carryover it inherited the same
+ * way. Deleting them with the old install would strand every provider behind
+ * its first pack download. So the swap moves each pack directory from the
+ * old install's `resources/providers/` (and any `resources/legacy-providers/`
+ * it was itself carrying) into the new install's
+ * `resources/legacy-providers/`, keeping the release-tree layout so each
+ * pack's `version.json` sidecar keeps naming the version the bytes are.
+ *
+ * The host consumes this tree as its resolver's STRICTLY LAST tier and
+ * reclaims each pack once its registry copy converges - see
+ * `traycer-host/src/domain/providers/legacy-provider-carryover.ts` in the
+ * internal repo, the other half of this filesystem contract. The dir name
+ * below must match its `LEGACY_CARRYOVER_DIRNAME`.
+ *
+ * Best-effort by contract: a carryover that cannot be preserved must never
+ * fail or roll back an otherwise-good install - the fallback it provides is
+ * exactly what a failed update already lived without.
+ */
+const LEGACY_PROVIDERS_DIRNAME = "legacy-providers";
+const PROVIDERS_DIRNAME = "providers";
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// Locate `resources/` inside an install directory: at the top level, or one
+// level down - the same two-level strategy `resolveHostExecutable` uses for
+// the binary, since release archives wrap the runtime in `host-runtime/`.
+async function resolveResourcesDir(installDir: string): Promise<string | null> {
+  const direct = join(installDir, "resources");
+  if (await isDirectory(direct)) return direct;
+  let entries: Dirent[];
+  try {
+    entries = await readdir(installDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const nested = join(installDir, entry.name, "resources");
+    if (await isDirectory(nested)) return nested;
+  }
+  return null;
+}
+
+export async function preserveLegacyProviders(
+  oldInstallDir: string,
+  newInstallDir: string,
+  logger: ILogger,
+): Promise<void> {
+  try {
+    const oldResources = await resolveResourcesDir(oldInstallDir);
+    if (oldResources === null) return;
+    const newResources = await resolveResourcesDir(newInstallDir);
+    if (newResources === null) {
+      logger.warn(
+        "Host install carryover skipped: new install has no resources dir",
+        { oldInstallDir, newInstallDir },
+      );
+      return;
+    }
+    const newBundle = join(newResources, PROVIDERS_DIRNAME);
+    const dest = join(newResources, LEGACY_PROVIDERS_DIRNAME);
+    // `providers` before `legacy-providers`: on a pack both trees carry, the
+    // outgoing install's OWN bundle is the newer copy and must win over the
+    // residue it inherited from an even older install.
+    const sources = [
+      join(oldResources, PROVIDERS_DIRNAME),
+      join(oldResources, LEGACY_PROVIDERS_DIRNAME),
+    ];
+    let moved = 0;
+    let skipped = 0;
+    for (const source of sources) {
+      let entries: Dirent[];
+      try {
+        entries = await readdir(source, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        // Files at the providers root (PROVIDERS.json, README.md) are the
+        // OLD build's metadata - the version truth travels per-pack in each
+        // directory's version.json, so root files stay behind and die with
+        // the old install.
+        if (!entry.isDirectory()) continue;
+        // A pack the new install bundles itself (ripgrep) needs no carryover,
+        // and one an earlier source already placed is the newer copy.
+        if (await isDirectory(join(newBundle, entry.name))) continue;
+        if (await isDirectory(join(dest, entry.name))) continue;
+        try {
+          await mkdir(dest, { recursive: true });
+          // Same volume (both under the host home), so this is a rename, not
+          // a multi-GB copy. A pack that cannot move (a lingering handle on
+          // Windows) is skipped and dies with the old install - same outcome
+          // that pack had before this provision existed.
+          await rename(join(source, entry.name), join(dest, entry.name));
+          moved += 1;
+        } catch {
+          skipped += 1;
+        }
+      }
+    }
+    if (moved > 0 || skipped > 0) {
+      logger.info("Host install carried legacy provider packs forward", {
+        oldInstallDir,
+        moved,
+        skipped,
+      });
+    }
+  } catch (cause) {
+    logger.warn("Host install carryover failed; continuing", {
+      oldInstallDir,
+      newInstallDir,
+      message: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+}

--- a/clients/traycer-cli/src/installer/legacy-providers.ts
+++ b/clients/traycer-cli/src/installer/legacy-providers.ts
@@ -32,17 +32,14 @@ import type { ILogger } from "../logger";
 const LEGACY_PROVIDERS_DIRNAME = "legacy-providers";
 const PROVIDERS_DIRNAME = "providers";
 
-async function isDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-// The one readdir failure that means "no source here" rather than "a source
-// we could not look at": a slim old install legitimately has no providers
-// dir at all (ENOENT), or a stray file sits where the dir would be (ENOTDIR).
+// The one filesystem failure that means "nothing here" rather than "something
+// we could not look at": the path (or a parent component) does not exist
+// (ENOENT), or a stray file sits where a directory would be (ENOTDIR).
+// EVERY catch in this module routes through this split - a carryover is
+// best-effort by contract, but a pack silently lost to EACCES or a transient
+// I/O error is a provider its user cannot run, and the invalidation that
+// follows destroys the evidence, so the failure must be SAID even though it
+// is tolerated.
 function isExpectedAbsence(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -51,22 +48,49 @@ function isExpectedAbsence(error: unknown): boolean {
   );
 }
 
+async function isDirectory(path: string, logger: ILogger): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (cause) {
+    if (!isExpectedAbsence(cause)) {
+      logger.warn("Host install carryover could not stat a path", {
+        path,
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
+    return false;
+  }
+}
+
 // Locate `resources/` inside an install directory: at the top level, or one
 // level down - the same two-level strategy `resolveHostExecutable` uses for
 // the binary, since release archives wrap the runtime in `host-runtime/`.
-async function resolveResourcesDir(installDir: string): Promise<string | null> {
+async function resolveResourcesDir(
+  installDir: string,
+  logger: ILogger,
+): Promise<string | null> {
   const direct = join(installDir, "resources");
-  if (await isDirectory(direct)) return direct;
+  if (await isDirectory(direct, logger)) return direct;
   let entries: Dirent[];
   try {
     entries = await readdir(installDir, { withFileTypes: true });
-  } catch {
+  } catch (cause) {
+    // ENOENT/ENOTDIR mean "no install tree here". Anything else is an
+    // install that EXISTS but could not be searched - its packs die with
+    // the aside dir without the per-source/per-pack warns below ever seeing
+    // them, so this is the only place that can say why (Codex review P2).
+    if (!isExpectedAbsence(cause)) {
+      logger.warn("Host install carryover could not enumerate an install dir", {
+        installDir,
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
     return null;
   }
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const nested = join(installDir, entry.name, "resources");
-    if (await isDirectory(nested)) return nested;
+    if (await isDirectory(nested, logger)) return nested;
   }
   return null;
 }
@@ -77,9 +101,9 @@ export async function preserveLegacyProviders(
   logger: ILogger,
 ): Promise<void> {
   try {
-    const oldResources = await resolveResourcesDir(oldInstallDir);
+    const oldResources = await resolveResourcesDir(oldInstallDir, logger);
     if (oldResources === null) return;
-    const newResources = await resolveResourcesDir(newInstallDir);
+    const newResources = await resolveResourcesDir(newInstallDir, logger);
     if (newResources === null) {
       logger.warn(
         "Host install carryover skipped: new install has no resources dir",
@@ -126,8 +150,8 @@ export async function preserveLegacyProviders(
         if (!entry.isDirectory()) continue;
         // A pack the new install bundles itself (ripgrep) needs no carryover,
         // and one an earlier source already placed is the newer copy.
-        if (await isDirectory(join(newBundle, entry.name))) continue;
-        if (await isDirectory(join(dest, entry.name))) continue;
+        if (await isDirectory(join(newBundle, entry.name), logger)) continue;
+        if (await isDirectory(join(dest, entry.name), logger)) continue;
         try {
           await mkdir(dest, { recursive: true });
           // Same volume (both under the host home), so this is a rename, not


### PR DESCRIPTION
## Why

The v1.2.0 host archive ships **slim** — no bundled coding-agent CLIs except ripgrep; provider packs come from the provider registry at runtime. But the install that an update *replaces* carries runnable provider bytes (its own fat bundle on pre-slim installs, or a carryover it inherited the same way). Deleting them with the old install dir would leave every provider blocked behind its first pack download.

## What

`preserveLegacyProviders(oldInstallDir, newInstallDir, logger)` — called from `atomicSwap` **after** the new install is swapped in successfully and **before** `invalidateAsideDir` destroys the parked old install:

- Sources: the old install's `resources/providers`, then its `resources/legacy-providers` (so an outgoing install's own bundle wins collisions over an inherited carryover).
- Destination: the new install's `resources/legacy-providers/`, keeping the release tree's own `<pack>/<platform>-<arch>/` layout so each pack's `version.json` sidecar keeps naming the version the bytes actually are.
- Packs the new install bundles itself (ripgrep) are skipped; root metadata files (`PROVIDERS.json`, README) stay behind and die with the aside dir.
- Directory entries move with same-volume `rename` — no byte copies inside the swap window.
- Best-effort throughout: any failure logs a warning and never fails the update.

The host consults this tree as a **strictly-last** resolution tier (after the managed pack store, the ripgrep-only bundle, and auto-detected PATH copies) and reclaims each carried pack at boot once its registry cell has converged. The companion host-side change lands in the internal repo.

## Tests

`clients/traycer-cli/src/installer/__tests__/legacy-providers.test.ts` — fat→slim carry (version sidecars, ripgrep skip, root-file exclusion, rename-not-copy via inode check), chained carryover across two updates, collision preference, no-resources no-op, and top-level resources layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)