### PR TITLE
fix(gui-app): treat kimi vision models as image-capable

### DIFF
--- a/clients/gui-app/src/lib/composer/__tests__/chat-run-settings.test.ts
+++ b/clients/gui-app/src/lib/composer/__tests__/chat-run-settings.test.ts
@@ -7,12 +7,21 @@ import {
   selectedModelRejectsImageAttachments,
 } from "@/lib/composer/chat-run-settings";
 import type { ModelOption } from "@/components/home/data/landing-options";
+import type { GuiHarnessId } from "@traycer/protocol/host/agent/shared";
 
 function model(metadata: Record<string, unknown>): ModelOption {
+  return modelOption(metadata, "codex", "gpt-test");
+}
+
+function modelOption(
+  metadata: Record<string, unknown>,
+  harnessId: GuiHarnessId,
+  slug: string,
+): ModelOption {
   return {
-    harnessId: "codex",
-    slug: "gpt-test",
-    label: "GPT Test",
+    harnessId,
+    slug,
+    label: "Test model",
     description: null,
     contextWindow: null,
     maxOutputTokens: null,
@@ -133,5 +142,29 @@ describe("chat run settings", () => {
     );
     expect(selectedModelRejectsImageAttachments(model({}))).toBe(true);
     expect(selectedModelRejectsImageAttachments(null)).toBe(false);
+  });
+
+  it("treats kimi vision models as image-capable", () => {
+    for (const slug of [
+      "kimi-code/k3",
+      "kimi-code/kimi-for-coding",
+      "kimi-code/kimi-for-coding-highspeed",
+    ]) {
+      expect(modelSupportsImageAttachments(modelOption({}, "kimi", slug))).toBe(
+        true,
+      );
+      expect(
+        selectedModelRejectsImageAttachments(modelOption({}, "kimi", slug)),
+      ).toBe(false);
+    }
+  });
+
+  it("still rejects non-vision kimi models", () => {
+    expect(
+      modelSupportsImageAttachments(modelOption({}, "kimi", "kimi-code/k3-256k")),
+    ).toBe(false);
+    expect(
+      modelSupportsImageAttachments(modelOption({}, "kimi", "kimi-code/k2")),
+    ).toBe(false);
   });
 });

--- a/clients/gui-app/src/lib/composer/chat-run-settings.ts
+++ b/clients/gui-app/src/lib/composer/chat-run-settings.ts
@@ -23,6 +23,18 @@ const IMAGE_INPUT_MODALITIES = new Set([
   "visual",
 ]);
 
+// The kimi harness (Kimi Code CLI) advertises image input for these models in
+// its own catalog (`provider list` → `capabilities: ["image_in", ...]`), but
+// the host's kimi adapter does not yet forward that capability into
+// `model.metadata`. Keep the GUI image-attachment gate honest so attachments
+// are not blocked on a vision-capable model. Matches the Codex/`parseCodexModel`
+// pattern of GUI-known model facts.
+const KIMI_VISION_MODEL_SLUGS = new Set([
+  "kimi-code/kimi-for-coding",
+  "kimi-code/kimi-for-coding-highspeed",
+  "kimi-code/k3",
+]);
+
 export function buildChatRunSettings(input: {
   selection: HarnessModelSelection;
   permission: PermissionMode;
@@ -87,7 +99,8 @@ export function modelSupportsImageAttachments(model: ModelOption): boolean {
     model.metadata.supportsImages === true ||
     model.metadata.supportsImageAttachments === true ||
     model.metadata.multimodal === true ||
-    model.metadata.vision === true
+    model.metadata.vision === true ||
+    (model.harnessId === "kimi" && KIMI_VISION_MODEL_SLUGS.has(model.slug))
   );
 }
 


### PR DESCRIPTION
## What

The composer's image-attachment gate (\`modelSupportsImageAttachments\`) blocks attaching images when the selected model's metadata carries no vision flag. The kimi harness (Kimi Code CLI) advertises image input for K3 / Kimi-for-coding / Kimi-for-coding-highspeed in its own catalog (\`capabilities: [image_in, video_in]\`), but the host's kimi adapter does not forward that into \`GuiAgentModelOption.metadata\`, so these vision-capable models were rejected as text-only.

## Fix

Add a GUI-known model fact for the kimi harness (mirroring the Codex \`parseCodexModel\` pattern) and check it in \`modelSupportsImageAttachments\`. K3-256k (no video_in) and other kimi models stay text-only.

## Verification

- New unit tests: kimi vision models accepted, k3-256k / unknown kimi rejected
- \`bun test clients/gui-app/src/lib/composer/__tests__/chat-run-settings.test.ts\` → 5 pass / 0 fail
- \`bun run compile\` (gui-app tsc -b) clean
- eslint clean (max-warnings 0)
