### PR TITLE
fix(gui-app): surface the reason a create failed, and close its ghost tab

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-create-rejection.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-create-rejection.test.tsx
@@ -1,0 +1,423 @@
+import { useRef, useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import type { ComposerBodyProps } from "@/components/home/composer/composer-body";
+import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
+import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
+import { SurfacePresentationBoundary } from "@/components/layout/surface-presentation-boundary";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { createComposerPickerStore } from "@/components/chat/composer/picker/composer-picker-store";
+import {
+  selectInitialChatHandoff,
+  useInitialChatHandoffStore,
+  type InitialChatHandoff,
+} from "@/stores/epics/initial-chat-handoff-store";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { NewConversationModalBody } from "../new-conversation-modal";
+import { NewConversationTransientContext } from "../new-conversation-transient-context";
+
+/**
+ * The in-Epic new-agent modal's CREATE-REJECTED path.
+ *
+ * Staging finding, 2026-08-19: a "New worktree" whose branch name already
+ * existed made the host hard-fail `epic.createChat` (409, the `git worktree
+ * add` reason on the message). The eager-opened "Untitled agent" tab then sat
+ * there - "Loading this agent from <host>…", then, once the 15s tile budget
+ * elapsed, "That host hasn't answered." The host HAD answered; it refused.
+ *
+ * The mechanism that takes such a tab down already existed - a `failed` handoff
+ * is terminal, which releases `pendingCreateArtifactIds` and lets the record
+ * sweep close the tile - but the modal marked the failure from `mutate`'s
+ * per-call `onError`, and TanStack Query v5 drops those once the observer has
+ * no listeners. This modal closes itself SYNCHRONOUSLY on submit, so that
+ * callback could never run: the handoff stayed non-terminal until the 60s
+ * orphan deadline, which is a backstop written for a host that says nothing.
+ *
+ * So the assertions here are about the handoff reaching `failed` DESPITE the
+ * unmount. The harness reproduces the unmount exactly as the real dialog does
+ * it (`props.open ? <Body/> : null`), because a harness that keeps the body
+ * mounted passes either way and proves nothing.
+ */
+
+const DIRTY_CONTENT: JsonContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "dirty" }] }],
+};
+
+const EPIC_ID = "epic-1";
+const HOST_ID = "host-a";
+
+/** What the host answers when `git worktree add` refused the branch name. */
+function worktreeCreateRejection(): HostRpcError {
+  return new HostRpcError({
+    code: "RPC_ERROR",
+    message:
+      "git worktree add failed for traycer/tidy-badger: " +
+      "fatal: a branch named 'traycer/tidy-badger' already exists",
+    requestId: "req-1",
+    method: "epic.createChat",
+    fatalDetails: null,
+  });
+}
+
+const testState = vi.hoisted(() => ({
+  /** Resolved per test - a rejection, or a deferred one for the race case. */
+  createChat:
+    vi.fn<(request: { readonly chatId: string }) => Promise<unknown>>(),
+  /** Every request the modal sent, so a test can name the chat it submitted. */
+  createRequests: [] as Array<{ readonly chatId: string }>,
+  bodySubmit: null as (() => void) | null,
+  installEditor: null as (() => void) | null,
+}));
+
+vi.mock("@/components/home/composer/composer-body", async () => {
+  const React = await import("react");
+  return {
+    ComposerBody: (props: ComposerBodyProps) => {
+      testState.bodySubmit = props.onSubmit;
+      testState.installEditor = () => {
+        props.editorRef.current = editorHandle();
+      };
+      return React.createElement("div", null, props.topBanner);
+    },
+  };
+});
+
+function editorHandle(): ComposerPromptEditorHandle {
+  const editorIncarnation = createComposerEditorIncarnation();
+  return {
+    isReady: () => true,
+    getEditorIncarnation: () => editorIncarnation,
+    hasFocus: () => false,
+    focus: () => undefined,
+    focusAtEnd: () => undefined,
+    getJSON: () => DIRTY_CONTENT,
+    isEmpty: () => false,
+    clear: () => undefined,
+    setContent: () => undefined,
+    syncContent: () => undefined,
+    insertImageAttachments: () => undefined,
+    insertMentionAttachment: () => false,
+    beginPathInsertion: () => null,
+    rewriteImageAttachmentHashById: () => false,
+    removeImageAttachmentById: () => undefined,
+    insertDictatedText: () => undefined,
+    dismissActiveSuggestion: () => false,
+  };
+}
+
+const PLACEMENT_TARGET = {
+  resolvedHostId: HOST_ID,
+  client: { getActiveHostId: () => HOST_ID },
+  hostLabel: "Studio Mac",
+  isPinned: false,
+  namedHostDead: false,
+};
+
+vi.mock("@/hooks/host/use-composer-placement", () => ({
+  useEpicConversationPlacement: () => ({
+    pin: {
+      selection: null,
+      honoredSelection: null,
+      setSelection: () => undefined,
+      resolvedHostId: PLACEMENT_TARGET.resolvedHostId,
+      isPinned: false,
+      latchOnFirstUse: () => undefined,
+    },
+    target: PLACEMENT_TARGET,
+    submitTarget: PLACEMENT_TARGET,
+    hostLabelFor: () => PLACEMENT_TARGET.hostLabel,
+    followsEffective: true,
+  }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-session-host-id", () => ({
+  useEpicSessionHostId: () => HOST_ID,
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicCreateChatForHostClient: () => ({
+    isPending: false,
+    mutateAsync: (request: { readonly chatId: string }) => {
+      testState.createRequests.push(request);
+      return testState.createChat(request);
+    },
+  }),
+}));
+
+vi.mock("@/hooks/agent/use-create-tui-agent", () => ({
+  useCreateTuiAgentForClient: () => ({
+    isPending: false,
+    create: () => Promise.resolve(null),
+  }),
+}));
+
+vi.mock("@/components/home/hooks/use-composer-toolbar-store", async () => {
+  const { createStore } = await import("zustand/vanilla");
+  const store = createStore(() => ({
+    selection: { harnessId: "claude", modelSlug: "sonnet", profileId: null },
+    selectedModel: null,
+    permission: "supervised",
+    reasoning: "medium",
+    serviceTier: "",
+    agentMode: "regular",
+    catalog: { harnesses: [] },
+  }));
+  return { useComposerToolbarStore: () => store };
+});
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicPermissionRole: () => "owner",
+  useEpicConnectionStatus: () => "open",
+  useEpicNodeOwnerKind: () => "chat",
+  useEpicNodeWorkspaceFolders: () => [],
+}));
+
+const stubHostClient = {
+  getActiveHostId: () => HOST_ID,
+  getRequestContext: () => null,
+  getRequestContextUserId: () => null,
+};
+vi.mock("@/lib/host", () => ({ useHostClient: () => stubHostClient }));
+vi.mock("@/lib/host/runtime", () => ({ useHostClient: () => stubHostClient }));
+
+vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
+  useHostDirectoryList: () => ({ data: [] }),
+}));
+vi.mock("@/hooks/worktree/use-latest-conversation-workspace-seed", () => ({
+  useLatestConversationWorkspaceSeed: () => null,
+  latestCreatedConversationOwner: () => null,
+}));
+vi.mock("@/hooks/worktree/use-owner-workspace-inheritance-seed", () => ({
+  useOwnerWorkspaceInheritanceSeed: () => ({ seed: null }),
+}));
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: () => ({
+    chats: { byId: {}, allIds: [] },
+    tuiAgents: { byId: {}, allIds: [] },
+  }),
+}));
+vi.mock("@/providers/use-runner-host", () => ({
+  useRunnerHost: () => ({
+    fileDrops: {
+      resolveDroppedFilePaths: () => Promise.resolve([]),
+      copyDroppedFilePaths: (paths: readonly string[]) =>
+        Promise.resolve(paths),
+    },
+  }),
+}));
+vi.mock("@/hooks/composer/use-composer-paste", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/composer/use-composer-paste")
+  >("@/hooks/composer/use-composer-paste");
+  return {
+    ...actual,
+    useComposerPaste: () => ({
+      onPaste: vi.fn(),
+      onDrop: vi.fn(),
+      onDragOver: vi.fn(),
+      onDragEnter: vi.fn(),
+      onDragLeave: vi.fn(),
+      attachImageFiles: vi.fn(),
+      isDraggingFiles: false,
+      dragOverlayVariant: null,
+      isIngestingImages: false,
+      isResolvingFilePaths: false,
+    }),
+  };
+});
+vi.mock("@/hooks/workspace/use-resolved-workspace-folders-query", () => ({
+  useResolvedWorkspaceFolders: () => ({ folders: [], isLoading: false }),
+}));
+vi.mock("@/lib/composer/workspace-composer-availability", () => ({
+  deriveFolderlessAllowedWorkspaceAvailability: () => ({ disabledHint: null }),
+  workspaceComposerCanStart: () => true,
+}));
+vi.mock("@/components/chat/composer/picker/use-composer-picker-items", () => ({
+  useComposerPickerItems: () => undefined,
+}));
+vi.mock("@/hooks/providers/use-provider-pack-gate", () => ({
+  useProviderPackGate: () => ({ blocked: false, hint: null, preparing: null }),
+  useProviderPackGateForClient: () => ({
+    blocked: false,
+    hint: null,
+    preparing: null,
+  }),
+}));
+vi.mock("@/hooks/composer/use-composer-dictation", () => ({
+  useComposerDictation: () => ({
+    dictationControl: null,
+    dictationPreparing: null,
+  }),
+}));
+vi.mock("@/hooks/composer/use-workspace-mention-roots", () => ({
+  mentionRootsFromWorktreeIntent: () => [],
+  useWorkspaceMentionRoots: () => [],
+}));
+vi.mock(
+  "@/components/home/host-workspace-selector/host-workspace-selector",
+  () => ({ ActiveHostWorkspaceControls: () => null }),
+);
+vi.mock("@/lib/attachments/use-attachment-blob-src", () => ({
+  useEpicImageFetcher: () => vi.fn(),
+  useEpicAttachmentBytesPresence: () => null,
+}));
+vi.mock("@/stores/epics/canvas/store", () => ({
+  useEpicCanvasStore: {
+    getState: () => ({
+      markChatTitlePending: vi.fn(),
+      clearChatTitlePending: vi.fn(),
+    }),
+  },
+}));
+
+/**
+ * The real dialog renders its body behind `props.open`, so submitting UNMOUNTS
+ * the component that owns the create mutation. That is the whole point of this
+ * suite, so the harness reproduces it rather than keeping the body alive.
+ */
+function Harness() {
+  const [open, setOpen] = useState(true);
+  const [transient] = useState(() => ({
+    pickerStore: createComposerPickerStore(),
+  }));
+  const dismissPickerRef = useRef<(() => boolean) | null>(null);
+  return (
+    <SurfacePresentationBoundary visible focused>
+      <Dialog open>
+        <DialogContent>
+          {open ? (
+            <NewConversationTransientContext.Provider value={transient}>
+              <NewConversationModalBody
+                epicId={EPIC_ID}
+                tabId="tab-1"
+                placement={ACTIVE_TILE_PLACEMENT}
+                parentId={null}
+                hostId={null}
+                dismissPickerRef={dismissPickerRef}
+                onSubmitted={() => setOpen(false)}
+              />
+            </NewConversationTransientContext.Provider>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </SurfacePresentationBoundary>
+  );
+}
+
+/**
+ * The handoff for this epic, read by SCOPE - the modal mints its own chat id,
+ * so the test cannot name it up front. `userId` is `null` because no profile is
+ * signed in here, which is exactly what `initialChatHandoffKey` uses.
+ */
+function handoff(): InitialChatHandoff | null {
+  return selectInitialChatHandoff(useInitialChatHandoffStore.getState(), {
+    hostId: HOST_ID,
+    userId: null,
+    epicId: EPIC_ID,
+  });
+}
+
+function renderModal(): void {
+  render(<Harness />);
+  act(() => {
+    testState.installEditor?.();
+  });
+}
+
+/**
+ * Submit, then drain the microtasks the create's promise chain settles on.
+ * `.then` and `.catch` are separate links, so an already-rejected `mutateAsync`
+ * still needs more than one turn to reach the failure arm.
+ */
+async function submitAndSettle(): Promise<void> {
+  await act(async () => {
+    testState.bodySubmit?.();
+    await flushMicrotasks();
+  });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let turn = 0; turn < 4; turn += 1) {
+    await Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  useNewConversationModalStore.getState().resetForTests();
+  useNewConversationModalStore.getState().setContent(EPIC_ID, DIRTY_CONTENT);
+  useNewConversationModalStore.getState().setComposerMode(EPIC_ID, "chat");
+  useInitialChatHandoffStore.getState().resetForTests();
+  testState.createRequests.length = 0;
+  testState.createChat.mockReset();
+  testState.createChat.mockRejectedValue(worktreeCreateRejection());
+});
+
+afterEach(() => {
+  cleanup();
+  testState.bodySubmit = null;
+  testState.installEditor = null;
+  useNewConversationModalStore.getState().resetForTests();
+  useInitialChatHandoffStore.getState().resetForTests();
+});
+
+describe("new-conversation modal: a rejected create leaves no live pending tab", () => {
+  it("registers a live handoff at submit - the eager tab's licence to exist", async () => {
+    renderModal();
+    // Pinned so the failure assertion below cannot pass vacuously: if nothing
+    // were ever registered, "not pending" would be true for the wrong reason.
+    testState.createChat.mockReturnValue(new Promise(() => undefined));
+    await submitAndSettle();
+
+    expect(handoff()?.status).toBe("pending");
+  });
+
+  it("marks the handoff failed when the host rejects the create, after the modal has closed", async () => {
+    renderModal();
+    await submitAndSettle();
+
+    // The modal is gone - the create's own observer has no listeners left.
+    expect(testState.createRequests).toHaveLength(1);
+    const settled = handoff();
+    expect(settled?.status).toBe("failed");
+    expect(settled?.failureReason).toBe("Couldn't create the agent.");
+  });
+
+  it("fails only the handoff that was actually rejected, never a later create's", async () => {
+    // The handoff key is {user, epic}, so a second create in this epic REPLACES
+    // the entry. Now that the rejection arm actually runs, an unguarded
+    // `markFailed` would close the second agent's tab when the first one's
+    // rejection landed - which is why the modal uses `markFailedByAction`.
+    let rejectFirst: (error: HostRpcError) => void = () => undefined;
+    testState.createChat.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectFirst = reject;
+      }),
+    );
+    testState.createChat.mockReturnValue(new Promise(() => undefined));
+
+    renderModal();
+    await submitAndSettle();
+    const first = handoff();
+
+    // A second submit, still in flight, replaces the scope's handoff.
+    cleanup();
+    useNewConversationModalStore.getState().setContent(EPIC_ID, DIRTY_CONTENT);
+    renderModal();
+    await submitAndSettle();
+    const second = handoff();
+    expect(second?.chatId).not.toBe(first?.chatId);
+
+    await act(async () => {
+      rejectFirst(worktreeCreateRejection());
+      await flushMicrotasks();
+    });
+
+    expect(handoff()?.chatId).toBe(second?.chatId);
+    expect(handoff()?.status).toBe("pending");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-create-rejection.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-create-rejection.test.tsx
@@ -17,6 +17,7 @@ import {
   type InitialChatHandoff,
 } from "@/stores/epics/initial-chat-handoff-store";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { useAuthStore } from "@/stores/auth/auth-store";
 import { NewConversationModalBody } from "../new-conversation-modal";
 import { NewConversationTransientContext } from "../new-conversation-transient-context";
 
@@ -50,6 +51,14 @@ const DIRTY_CONTENT: JsonContent = {
 
 const EPIC_ID = "epic-1";
 const HOST_ID = "host-a";
+/**
+ * Signed in for every case here, deliberately. `userId` is half the handoff
+ * key, and it is also what decides whether the request carries an
+ * `initialMessage` at all - which is the only way a host can answer
+ * `initialTurnStarted: true`. A signed-out harness would let the success case
+ * assert a response the system cannot actually produce.
+ */
+const USER_ID = "user-1";
 
 /** What the host answers when `git worktree add` refused the branch name. */
 function worktreeCreateRejection(): HostRpcError {
@@ -311,13 +320,14 @@ function Harness() {
 
 /**
  * The handoff for this epic, read by SCOPE - the modal mints its own chat id,
- * so the test cannot name it up front. `userId` is `null` because no profile is
- * signed in here, which is exactly what `initialChatHandoffKey` uses.
+ * so the test cannot name it up front. `initialChatHandoffKey` is
+ * {user, epic}, and the host segment is data on the record rather than part of
+ * the key.
  */
 function handoff(): InitialChatHandoff | null {
   return selectInitialChatHandoff(useInitialChatHandoffStore.getState(), {
     hostId: HOST_ID,
-    userId: null,
+    userId: USER_ID,
     epicId: EPIC_ID,
   });
 }
@@ -348,6 +358,9 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 beforeEach(() => {
+  useAuthStore.setState({
+    profile: { userId: USER_ID, userName: "Tester", email: "t@example.com" },
+  });
   useNewConversationModalStore.getState().resetForTests();
   useNewConversationModalStore.getState().setContent(EPIC_ID, DIRTY_CONTENT);
   useNewConversationModalStore.getState().setComposerMode(EPIC_ID, "chat");
@@ -359,6 +372,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useAuthStore.setState({ profile: null });
   testState.bodySubmit = null;
   testState.installEditor = null;
   useNewConversationModalStore.getState().resetForTests();
@@ -385,6 +399,30 @@ describe("new-conversation modal: a rejected create leaves no live pending tab",
     const settled = handoff();
     expect(settled?.status).toBe("failed");
     expect(settled?.failureReason).toBe("Couldn't create the agent.");
+  });
+
+  // Review #1297 finding 3, the symmetric case. `markInitialTurnStarted` was
+  // dead for the SAME observer-unmount reason as the failure arm: the host has
+  // already kicked the provider turn from `initialMessage`, and this is what
+  // tells the handoff driver not to send it again. A regression leaves the
+  // handoff short of `sending` and costs a redundant round trip.
+  it("marks the initial turn started when the create resolves after the modal has closed", async () => {
+    testState.createChat.mockResolvedValue({ initialTurnStarted: true });
+    renderModal();
+    await submitAndSettle();
+
+    expect(testState.createRequests).toHaveLength(1);
+    expect(handoff()?.status).toBe("sending");
+  });
+
+  // The other side of that arm: the host did NOT start the turn, so the driver
+  // still owes the send and the handoff must not jump ahead of it.
+  it("leaves the handoff pending when the host did not start the initial turn", async () => {
+    testState.createChat.mockResolvedValue({ initialTurnStarted: false });
+    renderModal();
+    await submitAndSettle();
+
+    expect(handoff()?.status).toBe("pending");
   });
 
   it("fails only the handoff that was actually rejected, never a later create's", async () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
@@ -86,7 +86,11 @@ function placementHolder(): { current: PlacementTargetShape } {
 }
 
 const testState = vi.hoisted(() => ({
-  createChat: vi.fn<(request: { readonly hostId: string }) => void>(),
+  createChat: vi.fn<
+    (request: { readonly hostId: string }) => Promise<{
+      readonly initialTurnStarted: boolean;
+    }>
+  >(() => Promise.resolve({ initialTurnStarted: false })),
   createTerminalAgent: vi.fn(() => Promise.resolve(null)),
   onSubmitted: vi.fn(),
   bodySubmit: null as (() => void) | null,
@@ -196,7 +200,10 @@ vi.mock("@/hooks/epic/use-epic-session-host-id", () => ({
 vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
   useEpicCreateChatForHostClient: () => ({
     isPending: false,
-    mutate: testState.createChat,
+    // `mutateAsync`, matching the modal: it closes itself on submit, so its
+    // completion handling rides a promise chain rather than the per-call
+    // callbacks TanStack drops with the observer.
+    mutateAsync: testState.createChat,
   }),
 }));
 
@@ -333,7 +340,7 @@ vi.mock("@/stores/epics/initial-chat-handoff-store", () => ({
     getState: () => ({
       register: vi.fn(),
       markInitialTurnStarted: vi.fn(),
-      markFailed: vi.fn(),
+      markFailedByAction: vi.fn(),
     }),
   },
 }));
@@ -414,6 +421,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   testState.createChat.mockClear();
+  testState.createChat.mockResolvedValue({ initialTurnStarted: false });
   testState.createTerminalAgent.mockClear();
   testState.onSubmitted.mockClear();
   testState.bodySubmit = null;
@@ -431,7 +439,6 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     expect(testState.createChat).toHaveBeenCalledTimes(1);
     expect(testState.createChat).toHaveBeenCalledWith(
       expect.objectContaining({ hostId: "host-a" }),
-      expect.anything(),
     );
   });
 
@@ -456,7 +463,6 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     expect(testState.createChat).toHaveBeenCalledTimes(1);
     expect(testState.createChat).toHaveBeenCalledWith(
       expect.objectContaining({ hostId: "host-effective" }),
-      expect.anything(),
     );
   });
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx
@@ -30,7 +30,7 @@ const DIRTY_CONTENT: JsonContent = {
 };
 
 const testState = vi.hoisted(() => ({
-  createChat: vi.fn(),
+  createChat: vi.fn(() => Promise.resolve({ initialTurnStarted: false })),
   bodySubmit: null as (() => void) | null,
   installEditor: null as (() => void) | null,
   ingesting: false,
@@ -215,7 +215,8 @@ vi.mock("@/lib/composer/workspace-composer-availability", () => ({
 vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
   useEpicCreateChatForHostClient: () => ({
     isPending: false,
-    mutate: testState.createChat,
+    // `mutateAsync`, matching the modal - see `new-conversation-placement`.
+    mutateAsync: testState.createChat,
   }),
 }));
 
@@ -270,7 +271,7 @@ vi.mock("@/stores/epics/initial-chat-handoff-store", () => ({
     getState: () => ({
       register: vi.fn(),
       markInitialTurnStarted: vi.fn(),
-      markFailed: vi.fn(),
+      markFailedByAction: vi.fn(),
     }),
   },
 }));

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -892,8 +892,26 @@ export function NewConversationModalBody(props: {
     if (initialMessage !== null) {
       useEpicCanvasStore.getState().markChatTitlePending(chatId, "");
     }
-    createChat.mutate(
-      {
+    // `mutateAsync` + a promise chain, NOT `mutate`'s per-call callbacks, for
+    // the reason `use-epic-route-synchronization.ts` records for the sidebar's
+    // delete: TanStack Query v5 gates `mutateOptions` on the observer still
+    // having listeners, and `cleanupAfterSubmit()` below closes this modal
+    // SYNCHRONOUSLY - the dialog renders its body behind `props.open`, so the
+    // component holding this mutation is gone before any answer arrives. Both
+    // callbacks were therefore dead code, and the failure one is what took the
+    // eager-opened tab back down: without `markFailed` the handoff stayed
+    // non-terminal, `pendingCreateArtifactIds` kept the tile exempt from the
+    // record sweep, and a create the host had DEFINITIVELY rejected left an
+    // "Untitled agent" tab that spun for 15s and then told the user "that host
+    // hasn't answered" - about a host that had answered, with a refusal. Only
+    // `useInitialChatHandoff`'s 60s orphan deadline eventually cleared it, a
+    // backstop written for a host that says NOTHING.
+    //
+    // The landing composer already submits this way (`use-landing-composer-
+    // actions.ts`), and for the same reason: a surface that closes itself on
+    // submit cannot own its own completion through the observer.
+    void createChat
+      .mutateAsync({
         epicId,
         // The host the modal resolved its own client for, checked non-null
         // just above - the machine the user picked, not the app-wide active
@@ -906,29 +924,36 @@ export function NewConversationModalBody(props: {
         workspaceMode,
         worktreeIntent,
         initialMessage,
-      },
-      {
-        onSuccess: (response) => {
-          if (response.initialTurnStarted === true) {
-            useInitialChatHandoffStore
-              .getState()
-              .markInitialTurnStarted(
-                { hostId: activeHostId, userId, epicId },
-                chatId,
-              );
-          }
-        },
-        onError: () => {
-          useEpicCanvasStore.getState().clearChatTitlePending(chatId);
+      })
+      .then((response) => {
+        if (response.initialTurnStarted === true) {
           useInitialChatHandoffStore
             .getState()
-            .markFailed(
+            .markInitialTurnStarted(
               { hostId: activeHostId, userId, epicId },
-              "Couldn't create the agent.",
+              chatId,
             );
-        },
-      },
-    );
+        }
+      })
+      .catch(() => {
+        useEpicCanvasStore.getState().clearChatTitlePending(chatId);
+        // `markFailedByAction`, not `markFailed`: the handoff key is
+        // {user, epic} only, so a SECOND create in this epic replaces the
+        // entry while the first is still in flight - and now that this arm
+        // actually runs, an unguarded `markFailed` would close the second
+        // agent's tab when the first one's rejection landed. The by-action
+        // variant fails only the handoff still carrying these exact ids.
+        useInitialChatHandoffStore
+          .getState()
+          .markFailedByAction(
+            { hostId: activeHostId, userId, epicId },
+            chatId,
+            clientActionId,
+            "Couldn't create the agent.",
+          );
+      });
+    // The toast (with the host's reason) is the shared create hook's, which
+    // is mutation-level and so survives this close.
     cleanupAfterSubmit();
   }, [
     canSubmit,

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-chat-error-policy.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-chat-error-policy.test.ts
@@ -65,15 +65,27 @@ import type { CreateChatMutationInput } from "@/hooks/epic/use-epic-chat-mutatio
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { RpcErrorCode } from "@traycer/protocol/framework/index";
 
-function makeError(code: RpcErrorCode): HostRpcError {
+function makeError(code: RpcErrorCode, message: string): HostRpcError {
   return new HostRpcError({
     code,
-    message: "test",
+    message,
     requestId: "test",
     method: "epic.createChat",
     fatalDetails: null,
   });
 }
+
+/**
+ * Verbatim shape of what the host puts on the wire when the requested worktree
+ * could not be made: `WorktreeCreateFailedError` joins each failed entry's own
+ * `git worktree add` stderr, and `dispatchRpc` answers 409 `RPC_ERROR` with
+ * that string as the message - no dedicated wire code, by design. The reason
+ * exists NOWHERE else the user can reach, which is why this arm forwards it.
+ */
+const WORKTREE_CREATE_FAILED_MESSAGE =
+  "git worktree add failed for traycer/tidy-badger at " +
+  "/Users/x/.traycer/worktrees/repo-tidy-badger: " +
+  "fatal: a branch named 'traycer/tidy-badger' already exists";
 
 function makeWrapper(): ({ children }: { children: ReactNode }) => ReactNode {
   const queryClient = new QueryClient({
@@ -117,7 +129,7 @@ const VARIABLES: CreateChatMutationInput = {
   },
 };
 
-describe("useEpicCreateChatForHostClient inline fork refusal", () => {
+describe("useEpicCreateChatForHostClient error policy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     for (const method of Object.keys(capturedMutations)) {
@@ -129,7 +141,10 @@ describe("useEpicCreateChatForHostClient inline fork refusal", () => {
     renderHook(() => useEpicCreateChatForHostClient(null), {
       wrapper: makeWrapper(),
     });
-    getCreateOnError()(makeError("E_FORK_BOUNDARY_NOT_PUBLISHED"), VARIABLES);
+    getCreateOnError()(
+      makeError("E_FORK_BOUNDARY_NOT_PUBLISHED", "test"),
+      VARIABLES,
+    );
     expect(toast.error).not.toHaveBeenCalled();
     expect(clearPendingChatCreation).toHaveBeenCalledWith("e", "c");
   });
@@ -138,7 +153,38 @@ describe("useEpicCreateChatForHostClient inline fork refusal", () => {
     renderHook(() => useEpicCreateChatForHostClient(null), {
       wrapper: makeWrapper(),
     });
-    getCreateOnError()(makeError("RPC_ERROR"), VARIABLES);
-    expect(toast.error).toHaveBeenCalledWith("Couldn't create agent.");
+    getCreateOnError()(makeError("RPC_ERROR", "test"), VARIABLES);
+    expect(toast.error).toHaveBeenCalledWith("Couldn't create agent. test");
+  });
+
+  // The staging finding: the 409 carried "…a branch named 'traycer/tidy-badger'
+  // already exists" and the user was shown "Couldn't create agent." alone, with
+  // the reason reachable only by opening host.log.
+  it("names the worktree failure the host reported, not just 'Couldn't create agent.'", () => {
+    renderHook(() => useEpicCreateChatForHostClient(null), {
+      wrapper: makeWrapper(),
+    });
+    getCreateOnError()(
+      makeError("RPC_ERROR", WORKTREE_CREATE_FAILED_MESSAGE),
+      VARIABLES,
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      `Couldn't create agent. ${WORKTREE_CREATE_FAILED_MESSAGE}`,
+    );
+  });
+
+  // The other half of forwarding detail: an error the toast mapper already has
+  // written-for-a-person copy for must NOT gain a raw host suffix.
+  it("leaves a mapped code's copy alone rather than appending the raw message", () => {
+    renderHook(() => useEpicCreateChatForHostClient(null), {
+      wrapper: makeWrapper(),
+    });
+    getCreateOnError()(
+      makeError("E_HOST_UNSUPPORTED", "epic.createChat@12.0 not supported"),
+      VARIABLES,
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "This needs a newer Traycer host. Update the host to continue.",
+    );
   });
 });

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-chat-error-policy.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-chat-error-policy.test.ts
@@ -113,6 +113,10 @@ function getCreateOnError(): (
   ).onError;
 }
 
+/**
+ * The MANUAL fork dialog's request: a precise boundary the user picked. Nobody
+ * retries it, so every refusal it earns is terminal and must be reported.
+ */
 const VARIABLES: CreateChatMutationInput = {
   hostId: "host-test",
   epicId: "e",
@@ -127,6 +131,33 @@ const VARIABLES: CreateChatMutationInput = {
     interviewBlockId: null,
     carriedInterviews: null,
   },
+};
+
+/**
+ * The CLONE-on-host-switch request. `boundary: "latest"` has exactly one
+ * producer in this app (`cloneChatOnHostSwitch`), and that producer is standing
+ * by to narrate the history downgrade and retry without `forkSource`.
+ */
+const CLONE_VARIABLES: CreateChatMutationInput = {
+  hostId: "host-test",
+  epicId: "e",
+  chatId: "c",
+  parentId: null,
+  title: "t",
+  forkSource: {
+    boundary: "latest",
+    sourceChatId: "source-chat",
+    sourceOwnerUserId: null,
+  },
+};
+
+/** A plain create - the new-agent modal's shape, no fork at all. */
+const PLAIN_VARIABLES: CreateChatMutationInput = {
+  hostId: "host-test",
+  epicId: "e",
+  chatId: "c",
+  parentId: null,
+  title: "t",
 };
 
 describe("useEpicCreateChatForHostClient error policy", () => {
@@ -185,6 +216,70 @@ describe("useEpicCreateChatForHostClient error policy", () => {
     );
     expect(toast.error).toHaveBeenCalledWith(
       "This needs a newer Traycer host. Update the host to continue.",
+    );
+  });
+
+  // Review #1297 finding 1. The clone flow recovers from both of these - it
+  // narrates the downgrade and retries without `forkSource` - so a toast here
+  // describes an attempt, not an outcome, and the detail policy above makes it
+  // read as a specific terminal failure moments before the clone succeeds.
+  it.each([
+    ["E_FORK_CHECKPOINT_UNAVAILABLE" as const, "no assistant checkpoint yet"],
+    ["DOWNGRADE_UNSUPPORTED" as const, "epic.createChat@1.1 unavailable"],
+  ])(
+    "stays silent on %s for the clone's latest-boundary fork - the flow retries",
+    (code, message) => {
+      renderHook(() => useEpicCreateChatForHostClient(null), {
+        wrapper: makeWrapper(),
+      });
+      getCreateOnError()(makeError(code, message), CLONE_VARIABLES);
+      expect(toast.error).not.toHaveBeenCalled();
+      // Still released: no record will arrive for an attempt that failed, and
+      // the retry creates under its own id.
+      expect(clearPendingChatCreation).toHaveBeenCalledWith("e", "c");
+    },
+  );
+
+  // The guard that keeps the suppression from swallowing a real failure. Same
+  // code, precise boundary: the manual fork dialog has no retry behind it.
+  it("still toasts E_FORK_CHECKPOINT_UNAVAILABLE for a precise-boundary fork", () => {
+    renderHook(() => useEpicCreateChatForHostClient(null), {
+      wrapper: makeWrapper(),
+    });
+    getCreateOnError()(
+      makeError("E_FORK_CHECKPOINT_UNAVAILABLE", "no assistant checkpoint yet"),
+      VARIABLES,
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't create agent. no assistant checkpoint yet",
+    );
+  });
+
+  // And the suppression is scoped to the codes the flow retries on, not to the
+  // clone request as a whole - a worktree failure on a clone is terminal.
+  it("still toasts a non-recoverable failure on the clone's own request", () => {
+    renderHook(() => useEpicCreateChatForHostClient(null), {
+      wrapper: makeWrapper(),
+    });
+    getCreateOnError()(
+      makeError("RPC_ERROR", WORKTREE_CREATE_FAILED_MESSAGE),
+      CLONE_VARIABLES,
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      `Couldn't create agent. ${WORKTREE_CREATE_FAILED_MESSAGE}`,
+    );
+  });
+
+  it("toasts a checkpoint refusal that arrives with no fork source at all", () => {
+    renderHook(() => useEpicCreateChatForHostClient(null), {
+      wrapper: makeWrapper(),
+    });
+    getCreateOnError()(
+      makeError("E_FORK_CHECKPOINT_UNAVAILABLE", "no assistant checkpoint yet"),
+      PLAIN_VARIABLES,
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't create agent. no assistant checkpoint yet",
     );
   });
 });

--- a/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
@@ -27,7 +27,10 @@ import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import { hostQueryKeys, epicMutationKeys } from "@/lib/query-keys";
-import { toastFromHostError } from "@/lib/host-error-toast";
+import {
+  toastFromHostError,
+  toastFromHostErrorWithDetail,
+} from "@/lib/host-error-toast";
 import { invalidateEpicChatRecords } from "@/hooks/chats/use-epic-chat-records";
 import { invalidateChatRunSettings } from "@/hooks/chats/use-chat-run-settings-query";
 import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
@@ -209,7 +212,21 @@ export function useEpicCreateChatForHostClient(
       onError: (error, variables) => {
         releaseCreatedChat(variables);
         if (isInlineForkRefusal(error)) return;
-        toastFromHostError(error, "Couldn't create agent.");
+        // WITH DETAIL, unlike its sibling mutations. A create is refused for
+        // reasons that live entirely in the host's message and nowhere else:
+        // the worktree the user asked for could not be made (`git worktree
+        // add` failed - a branch name that already exists, a dirty source, a
+        // path that is not a repo). The host answers `RPC_ERROR` with that
+        // reason as free text and deliberately mints no wire code for it
+        // (`WORKTREE_CREATE_FAILED` is a chat-stream reject code only), so the
+        // bare fallback is the whole of what the user gets - "Couldn't create
+        // agent.", with the actual cause reachable only by opening host.log.
+        //
+        // `toastFromHostErrorWithDetail` appends the host text ONLY when no
+        // mapped copy claimed the error, so every branch above
+        // (`E_HOST_UNSUPPORTED`, `WORKTREE_BUSY`, the transport arm) keeps its
+        // written-for-a-person sentence and never gains a raw suffix.
+        toastFromHostErrorWithDetail(error, "Couldn't create agent.");
       },
     },
   });

--- a/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
@@ -38,6 +38,7 @@ import {
   beginPendingChatCreation,
   clearPendingChatCreation,
 } from "@/lib/chats/pending-chat-creations";
+import { isRecoverableLatestForkRefusal } from "@/lib/chats/recoverable-fork-refusal";
 import { evictChatTabPersistenceForChat } from "@/stores/chats/chat-tab-persistence-eviction";
 import { useAuthStore } from "@/stores/auth/auth-store";
 
@@ -212,6 +213,14 @@ export function useEpicCreateChatForHostClient(
       onError: (error, variables) => {
         releaseCreatedChat(variables);
         if (isInlineForkRefusal(error)) return;
+        // A step inside an operation that recovers from it, not the end of
+        // one: the clone-on-host-switch flow narrates the history downgrade
+        // itself and retries without `forkSource`, so a toast here describes
+        // an ATTEMPT moments before the clone succeeds. Keyed on the request's
+        // `boundary: "latest"` as well as the code, so the manual fork
+        // dialog's precise-boundary refusal - genuinely terminal, nobody
+        // retrying - is still reported.
+        if (isRecoverableLatestForkRefusal(error, variables)) return;
         // WITH DETAIL, unlike its sibling mutations. A create is refused for
         // reasons that live entirely in the host's message and nowhere else:
         // the worktree the user asked for could not be made (`git worktree

--- a/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
+++ b/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
@@ -276,4 +276,63 @@ describe("toastFromHostError", () => {
       "Couldn't start terminal agent session. No connected OpenCode providers.",
     );
   });
+
+  // Review #1297 finding 2: host detail is unbounded by construction. The
+  // producer that motivated forwarding it - `worktreeCreateFailed` - joins one
+  // line per failed workspace, each an absolute path plus raw git stderr, so
+  // appended verbatim it is an arbitrarily tall toast.
+  describe("bounds free-form host detail", () => {
+    it("keeps a realistic single-line worktree reason intact", () => {
+      // The failure this whole change set exists for. Cutting it would drop
+      // the clause that says WHY, which is the entire value of forwarding it.
+      const reason =
+        "git worktree add failed for traycer/tidy-badger at " +
+        "/Users/tgill/.traycer/worktrees/traycerai__traycer-internal/" +
+        "repo-tidy-badger: fatal: a branch named 'traycer/tidy-badger' " +
+        "already exists";
+      toastFromHostErrorWithDetail(
+        makeError("RPC_ERROR", reason),
+        "Couldn't create agent.",
+      );
+      expect(toast.error).toHaveBeenCalledWith(
+        `Couldn't create agent. ${reason}`,
+      );
+    });
+
+    it("shows the first failure and COUNTS the rest for a multi-entry failure", () => {
+      toastFromHostErrorWithDetail(
+        makeError(
+          "RPC_ERROR",
+          ["first failed: fatal: a", "second failed: fatal: b", ""].join("\n"),
+        ),
+        "Couldn't create agent.",
+      );
+      // The count, not a silent first-line take: dropping the other folders
+      // without saying so is the quiet omission this change set removes. The
+      // trailing blank line must not be counted as a third entry.
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't create agent. first failed: fatal: a (+1 more)",
+      );
+    });
+
+    it("truncates a single line that is a diagnostic dump rather than a sentence", () => {
+      toastFromHostErrorWithDetail(
+        makeError("RPC_ERROR", "x".repeat(400)),
+        "Couldn't create agent.",
+      );
+      // Pinned exactly rather than "is shorter than the input": the cut has to
+      // be at the documented cap and it has to SAY it was cut.
+      expect(toast.error).toHaveBeenCalledWith(
+        `Couldn't create agent. ${"x".repeat(240)}…`,
+      );
+    });
+
+    it("falls back to the plain copy when the detail is only whitespace", () => {
+      toastFromHostErrorWithDetail(
+        makeError("RPC_ERROR", "\n  \n"),
+        "Couldn't create agent.",
+      );
+      expect(toast.error).toHaveBeenCalledWith("Couldn't create agent.");
+    });
+  });
 });

--- a/clients/gui-app/src/lib/chats/recoverable-fork-refusal.ts
+++ b/clients/gui-app/src/lib/chats/recoverable-fork-refusal.ts
@@ -1,0 +1,68 @@
+import {
+  classifyHostRequestFailure,
+  type HostRpcError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { CreateChatRequestV11 } from "@traycer/protocol/host/epic/unary-schemas";
+
+/**
+ * The two client-visible ways a LATEST-checkpoint fork request can fail
+ * without ending the operation that sent it.
+ *
+ * `"no-checkpoint"` names the SOURCE - it has no assistant turn yet, so there
+ * is no checkpoint to fork through, and the host refuses with a typed
+ * `E_FORK_CHECKPOINT_UNAVAILABLE` rather than failing the whole create.
+ * `"host-too-old"` names the TARGET - `epic.createChat@1.1`'s
+ * `boundary: "latest"` variant carries no `assistantMessageId`, so the
+ * transport's same-major minor downgrade cannot re-parse the request against a
+ * `@1.0` host's schema and rejects it client-side as `DOWNGRADE_UNSUPPORTED`,
+ * before a frame is sent.
+ *
+ * Both mean the same thing to the caller - "this attempt cannot carry history"
+ * - and get the same recovery: retry once without `forkSource`.
+ */
+export type RecoverableForkFailure = "no-checkpoint" | "host-too-old";
+
+export function classifyRecoverableForkFailure(
+  error: HostRpcError,
+): RecoverableForkFailure | null {
+  if (error.code === "E_FORK_CHECKPOINT_UNAVAILABLE") return "no-checkpoint";
+  if (classifyHostRequestFailure(error).kind === "downgrade-unsupported") {
+    return "host-too-old";
+  }
+  return null;
+}
+
+/**
+ * Whether this create failure is a step INSIDE an operation that recovers from
+ * it, rather than the end of one - the question the shared `epic.createChat`
+ * error toast has to answer before it says anything.
+ *
+ * `cloneChatOnHostSwitch` is the only producer of `boundary: "latest"` in this
+ * app, and it treats exactly {@link classifyRecoverableForkFailure}'s two arms
+ * as recoverable: it narrates the history downgrade itself
+ * (`onHistoryUnavailable`) and retries without `forkSource`, so the clone still
+ * lands. A toast from the shared handler is therefore describing an attempt,
+ * not an outcome - and since `epic.createChat`'s toast now forwards the host's
+ * own text, it reads as a specific, terminal failure moments before the
+ * operation succeeds. That is the opposite of what the detail was added for.
+ *
+ * Keyed on the REQUEST as well as the error, which is what keeps this from
+ * silencing a real failure: the manual fork dialog names a precise
+ * `boundary: "assistantMessage"`, has no retry, and reaches
+ * `E_FORK_CHECKPOINT_UNAVAILABLE` as a genuinely terminal refusal that must
+ * still be reported. Only the variant whose sender is standing by to retry is
+ * suppressed.
+ *
+ * This predicate and the clone flow's own recovery branch read the SAME
+ * classifier deliberately. They are one decision expressed at two seams, and
+ * the failure mode of duplicating it is silent: a clone flow that stopped
+ * recovering from one arm would leave this suppression swallowing a failure
+ * nobody reports.
+ */
+export function isRecoverableLatestForkRefusal(
+  error: HostRpcError,
+  request: CreateChatRequestV11,
+): boolean {
+  if (request.forkSource?.boundary !== "latest") return false;
+  return classifyRecoverableForkFailure(error) !== null;
+}

--- a/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
+++ b/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
@@ -1,9 +1,7 @@
 import type { IHostDirectoryService } from "@traycer-clients/shared/host-client/host-runtime";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import {
-  classifyHostRequestFailure,
-  type HostRpcError,
-} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { classifyRecoverableForkFailure } from "@/lib/chats/recoverable-fork-refusal";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import { buildTransientHostClient } from "@/hooks/host/use-host-client-for";
@@ -19,20 +17,12 @@ import { resolveClonedChatSettings } from "@/lib/commands/actions/resolve-cloned
 import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
-/**
- * Which of the two client-visible ways a latest-checkpoint fork request can
- * fail this flow recovers from, if any - see the module doc below for what
- * each one means and why both retry identically.
- */
-function classifyRecoverableForkFailure(
-  error: HostRpcError,
-): "no-checkpoint" | "host-too-old" | null {
-  if (error.code === "E_FORK_CHECKPOINT_UNAVAILABLE") return "no-checkpoint";
-  if (classifyHostRequestFailure(error).kind === "downgrade-unsupported") {
-    return "host-too-old";
-  }
-  return null;
-}
+// `classifyRecoverableForkFailure` - which of the two client-visible ways a
+// latest-checkpoint fork request can fail this flow recovers from, if any -
+// lives in `lib/chats/recoverable-fork-refusal.ts` rather than here, so the
+// shared `epic.createChat` error toast can stay silent on exactly the failures
+// this flow retries on. Two seams, one classifier, deliberately: see that
+// module for why duplicating it fails silently.
 
 /**
  * Clone-not-migrate flow for switching a chat tab's bound host: chat tabs

--- a/clients/gui-app/src/lib/host-error-toast.ts
+++ b/clients/gui-app/src/lib/host-error-toast.ts
@@ -176,9 +176,55 @@ function hostErrorToastMessageWithDetail(
 ) {
   const message = hostErrorToastMessage(error, fallback);
   if (message !== fallback) return message;
-  const detail = error.message.trim();
+  const detail = summarizeHostErrorDetail(error.message);
   if (detail.length === 0 || detail === fallback) return fallback;
   return `${fallback} ${detail}`;
+}
+
+/**
+ * How much of one host detail line a toast will show before cutting it.
+ *
+ * Sized from the failure this exists for: a `git worktree add` refusal names
+ * one branch, one absolute path and the git reason - around 190 characters
+ * for a realistic worktree under a nested repo - and cutting THAT is what a
+ * cap must not do, since the last clause ("a branch named 'x' already exists")
+ * is the whole point. Anything materially longer is a diagnostic dump, not a
+ * sentence, and the ellipsis is the honest thing to show for it.
+ */
+const HOST_ERROR_DETAIL_MAX_CHARS = 240;
+
+/**
+ * Bound a free-form host message down to something a toast can be.
+ *
+ * Host detail is UNBOUNDED by construction, and the producer this helper's
+ * `epic.createChat` caller targets is the clearest case: `worktreeCreateFailed`
+ * joins ONE line per failed workspace, each carrying an absolute path plus raw
+ * git stderr. Appended verbatim that is an arbitrarily tall toast full of local
+ * paths and command diagnostics.
+ *
+ * So: the first non-empty line, character-capped, and an explicit count of what
+ * was dropped. The count is not decoration - taking the first line silently
+ * would hide that two other folders also failed, which is exactly the kind of
+ * quiet omission this whole change set exists to remove. Blank lines are
+ * dropped before counting so a trailing newline never claims a phantom entry.
+ *
+ * No details/expand affordance deliberately: the first line names the first
+ * failing folder AND its reason, which is what someone acts on, and a
+ * disclosure widget is a surface to design rather than a bound to enforce.
+ */
+function summarizeHostErrorDetail(raw: string): string {
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return "";
+  const head = truncateWithEllipsis(lines[0], HOST_ERROR_DETAIL_MAX_CHARS);
+  return lines.length === 1 ? head : `${head} (+${lines.length - 1} more)`;
+}
+
+function truncateWithEllipsis(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars).trimEnd()}…`;
 }
 
 function isLastOwnerRevokeError(message: string): boolean {


### PR DESCRIPTION
Fixes two GUI defects on the chat-creation failure path, found in today's
staging regression pass. One flow, one handler family.

**Repro (staging, verified live):** new-agent modal → workspace selector →
"New worktree" → give it a branch name that already exists → submit. The host
correctly hard-fails `epic.createChat` (internal #5073) with 409 `RPC_ERROR`
carrying `git worktree add failed for traycer/tidy-badger …: fatal: a branch
named 'traycer/tidy-badger' already exists`.

### 1. The reason never reached the user

The GUI showed only "Couldn't create agent." — the cause was reachable only by
opening `host.log`. Worktree-creation failure deliberately mints no wire code
(`WORKTREE_CREATE_FAILED` is a chat-stream reject code only), so the message
text is the *only* place that reason exists.

`useEpicCreateChatForHostClient` now toasts through
`toastFromHostErrorWithDetail`, which appends the host's text **only** when no
mapped copy claimed the error — so `E_HOST_UNSUPPORTED`, `WORKTREE_BUSY` and
the transport arm keep their written-for-a-person sentences and never gain a
raw suffix. No protocol change.

### 2. The rejected create left a ghost tab

The eager-opened "Untitled agent" tab lingered: "Loading this agent from
`<host>`…", then, once the 15s tile budget elapsed, "This agent hasn't loaded
from `<host>` yet. That host hasn't answered." The host *had* answered — it
refused.

The mechanism to take that tab down already existed: a `failed` handoff is
terminal, which releases `pendingCreateArtifactIds` and lets
`useEpicRouteSynchronization`'s record sweep close the tile. But the modal
marked the failure from `mutate`'s per-call `onError`, and TanStack Query v5
gates `mutateOptions` on the observer still having listeners. This modal
renders its body behind `props.open` and closes itself **synchronously** in
`cleanupAfterSubmit()`, so both per-call callbacks were dead code. Only
`useInitialChatHandoff`'s 60s orphan deadline — a backstop written for a host
that says *nothing* — eventually cleared it.

The submit now uses `mutateAsync` + a promise chain, which survives the
unmount. `use-landing-composer-actions.ts` already submits this way, for the
same reason. The `onSuccess` leg (`markInitialTurnStarted`, the turn-overlap
shortcut) was dead for the same reason and moves with it.

The failure arm uses `markFailedByAction` rather than `markFailed`: the handoff
key is `{user, epic}`, so a second create in the epic *replaces* the entry —
and now that this arm actually runs, an unguarded `markFailed` would close the
second agent's tab when the first one's rejection landed.

### Tests

- `use-epic-create-chat-error-policy.test.ts` (renamed from
  `…-inline-fork-refusal.test.ts`, its fork cases intact): the toast forwards a
  verbatim worktree-failure message, and a mapped code's copy is left alone.
- `new-conversation-create-rejection.test.tsx`: the harness reproduces the real
  dialog's unmount-on-submit. A rejected create marks the handoff `failed`
  after the modal has closed, and fails **only** the handoff it was rejected
  for.

Each assertion was ablation-verified — removing the fix turns exactly the
matching test red, including the `markFailedByAction` → `markFailed`
substitution.

`bun run compile` (all 5 projects), `bun run lint` (`--max-warnings 0`) and
prettier are clean; 1428 tests pass across the epic-canvas sidebar, chat,
host-workspace-selector, landing-composer and host-error-toast suites.
