### PR TITLE
fix(gui-app,shared): keep a pinned panel recoverable when its host cannot answer

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-body-live.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-body-live.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -19,6 +20,10 @@ import type {
 import type { HostRpcRegistry } from "@/lib/host";
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import {
+  HostRpcError,
+  HostTransportFailureError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 import {
   useWsStreamClient,
   type StreamRuntimeBinding,
@@ -100,10 +105,38 @@ const observedSubscriptionClients: Array<IHostStreamClient<HostStreamRpcRegistry
 // place a host that cannot answer shows up. `bindingsError` drives that arm;
 // the default stays a resolved, non-empty read so every other test is
 // unaffected.
+//
+// The error's CLASS is load-bearing, not decoration: only
+// `HostTransportFailureError` means the host never answered, and the panel
+// picks a different screen for anything else. Seeding a bare `Error` here
+// would silently exercise the answered-refusal arm while reading like an
+// offline host.
 const bindingsState = vi.hoisted(() => ({
-  error: null as Error | null,
+  error: null as HostRpcError | null,
   refetch: vi.fn<() => Promise<unknown>>(),
 }));
+
+/** The host never answered - a dial/handshake failure, not a refusal. */
+function transportFailure(message: string): HostTransportFailureError {
+  return new HostTransportFailureError({
+    code: "RPC_ERROR",
+    message,
+    requestId: "req-test",
+    method: "worktree.listBindingsForEpic",
+    fatalDetails: null,
+  });
+}
+
+/** The host answered, and the answer was a refusal. */
+function answeredRefusal(message: string): HostRpcError {
+  return new HostRpcError({
+    code: "RPC_ERROR",
+    message,
+    requestId: "req-test",
+    method: "worktree.listBindingsForEpic",
+    fatalDetails: null,
+  });
+}
 
 function bindingsResult() {
   return {
@@ -1195,7 +1228,7 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
           { hostId: "host-2", status: "connecting", dead: null },
         ],
       });
-      bindingsState.error = new Error("host unreachable");
+      bindingsState.error = transportFailure("host unreachable");
       renderPanel(rootSelected);
     }
 
@@ -1258,7 +1291,7 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
         .getState()
         .setSelection(gitDiffPanelSurfaceKey(TAB_ID), "host-1");
       pinTestState.activeHostId = "host-1";
-      bindingsState.error = new Error("host unreachable");
+      bindingsState.error = transportFailure("host unreachable");
 
       renderPanel(rootSelected);
 
@@ -1266,6 +1299,122 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
       expect(
         screen.queryByTestId("git-host-unreachable-use-active"),
       ).toBeNull();
+    });
+
+    it("does not offer 'Use active host' once the pin has been DEPOSED", () => {
+      // The pin still names host-2, but the authority has declared it dead, so
+      // the panel has already auto-followed to host-1 and it is host-1's read
+      // that failed. Reading the raw preference here would offer to switch to
+      // the machine the panel is already on - clearing a sticky pin, moving
+      // nothing, and leaving the same error on screen.
+      useSurfaceHostSelectionStore
+        .getState()
+        .setSelection(gitDiffPanelSurfaceKey(TAB_ID), "host-2");
+      pinTestState.activeHostId = "host-1";
+      pinTestState.directory = [
+        { hostId: "host-1", label: "Host One" },
+        { hostId: "host-2", label: "Host Two" },
+      ];
+      useSelectionAuthorityStore.setState({
+        attached: true,
+        effectiveHostId: "host-1",
+        leases: [
+          { hostId: "host-1", status: "ready", dead: null },
+          { hostId: "host-2", status: "dead", dead: { reason: "offline" } },
+        ],
+      });
+      bindingsState.error = transportFailure("host unreachable");
+
+      renderPanel(rootSelected);
+
+      expect(screen.getByTestId("git-host-unreachable")).toBeDefined();
+      // Deposed: the panel resolves to host-1, which is also what unpinning
+      // would land on.
+      expect(pinTestState.lastClientHostId).toBe("host-1");
+      expect(
+        screen.queryByTestId("git-host-unreachable-use-active"),
+      ).toBeNull();
+    });
+
+    it("keeps Retry pending until the re-dial actually settles", async () => {
+      // `useRefreshSpinner` holds the spinner for a 350ms MINIMUM regardless of
+      // the promise, so "spinner visible right after the click" is true whether
+      // or not the retry tracks the read - asserting only that measures
+      // nothing. The discriminating question is what happens PAST that window
+      // with the read still in flight: tracked, the button is still disabled;
+      // fire-and-forget, it re-enabled at 350ms and a second click can stack
+      // another dial on the first.
+      const settles: Array<() => void> = [];
+      bindingsState.refetch.mockImplementation(
+        () =>
+          new Promise<unknown>((resolve) => {
+            settles.push(() => resolve(undefined));
+          }),
+      );
+      vi.useFakeTimers();
+      try {
+        renderPinnedToUnreachableHost();
+        fireEvent.click(screen.getByTestId("git-host-unreachable-retry"));
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        const retryDisabled = (): boolean =>
+          screen
+            .getByTestId("git-host-unreachable-retry")
+            .hasAttribute("disabled");
+        expect(retryDisabled()).toBe(true);
+
+        // Well past the minimum-visible window; the refetch has NOT resolved.
+        await act(async () => {
+          vi.advanceTimersByTime(2_000);
+          await Promise.resolve();
+        });
+        expect(retryDisabled()).toBe(true);
+        expect(bindingsState.refetch).toHaveBeenCalledTimes(1);
+
+        // Now let the read finish, and the affordance comes back.
+        await act(async () => {
+          for (const settle of settles) settle();
+          await Promise.resolve();
+          vi.advanceTimersByTime(1_000);
+          await Promise.resolve();
+        });
+        expect(retryDisabled()).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("surfaces the host's own reason when it ANSWERED with a refusal", () => {
+      // Not a reachability failure: the machine replied. Saying "can't reach"
+      // here would repeat, one layer up, the defect this panel was fixed for -
+      // asserting a remedy the user cannot act on while hiding the one fact
+      // that could point at a cause.
+      bindingsState.error = answeredRefusal(
+        "worktree.listBindingsForEpic: not authorized",
+      );
+
+      renderPanel(rootSelected);
+
+      expect(screen.getByTestId("git-bindings-unreadable")).toBeDefined();
+      expect(
+        screen.getByTestId("git-bindings-unreadable-message").textContent,
+      ).toBe("worktree.listBindingsForEpic: not authorized");
+      expect(screen.queryByTestId("git-host-unreachable")).toBeNull();
+      expect(screen.queryByText("No git workspaces available")).toBeNull();
+    });
+
+    it("keeps the host picker reachable on an answered refusal too", () => {
+      bindingsState.error = answeredRefusal("internal error");
+
+      renderPanel(rootSelected);
+
+      const trigger = screen.getByTestId("git-diff-repo-switcher-trigger");
+      fireEvent.click(trigger);
+      expect(
+        screen.getByTestId("mock-worktree-picker-host-section"),
+      ).toBeDefined();
     });
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-body-live.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-body-live.test.tsx
@@ -96,17 +96,27 @@ vi.mock("@/hooks/host/use-surface-host-stream-binding", async () => {
 const observedSubscriptionClients: Array<IHostStreamClient<HostStreamRpcRegistry> | null> =
   [];
 
+// The bindings read is the panel's ONE host call, so it is also the only
+// place a host that cannot answer shows up. `bindingsError` drives that arm;
+// the default stays a resolved, non-empty read so every other test is
+// unaffected.
+const bindingsState = vi.hoisted(() => ({
+  error: null as Error | null,
+  refetch: vi.fn<() => Promise<unknown>>(),
+}));
+
+function bindingsResult() {
+  return {
+    data: bindingsState.error === null ? { rows: testState.rows } : undefined,
+    error: bindingsState.error,
+    isPending: false,
+    refetch: bindingsState.refetch,
+  };
+}
+
 vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
-  useWorktreeListBindingsForEpic: () => ({
-    data: { rows: testState.rows },
-    error: null,
-    isPending: false,
-  }),
-  useWorktreeListBindingsForEpicForClient: () => ({
-    data: { rows: testState.rows },
-    error: null,
-    isPending: false,
-  }),
+  useWorktreeListBindingsForEpic: () => bindingsResult(),
+  useWorktreeListBindingsForEpicForClient: () => bindingsResult(),
 }));
 
 interface PinTestReachability {
@@ -119,7 +129,7 @@ interface PinTestState {
   activeHostId: string | null;
   lastClientHostId: string | null;
   reachability: PinTestReachability;
-  directory: Array<{ readonly hostId: string }>;
+  directory: Array<{ readonly hostId: string; readonly label: string }>;
 }
 
 const pinTestState = vi.hoisted((): PinTestState => ({
@@ -130,7 +140,7 @@ const pinTestState = vi.hoisted((): PinTestState => ({
     hostLabel: "Host One",
     unavailability: null,
   },
-  directory: [{ hostId: "host-1" }],
+  directory: [{ hostId: "host-1", label: "Host One" }],
 }));
 
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({
@@ -160,6 +170,15 @@ vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
     pinTestState.lastClientHostId = hostId;
     return null;
   },
+  // The panel resolves the host's DISPLAY NAME through the same module, for
+  // the unreachable state's "Can't reach <host>" line. Mocking the module
+  // replaces all of it, so this member has to exist here or the panel throws
+  // on a hook that is undefined - a failure that would read as a render bug.
+  useHostDirectoryEntryForHostId: (hostId: string | null) =>
+    hostId === null
+      ? null
+      : (pinTestState.directory.find((entry) => entry.hostId === hostId) ??
+        null),
 }));
 
 vi.mock("@/hooks/git/use-git-prefetch-worktree-status", () => ({
@@ -465,6 +484,9 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
       ],
     ]);
     testState.capabilities = new Map();
+    bindingsState.error = null;
+    bindingsState.refetch.mockReset();
+    bindingsState.refetch.mockResolvedValue(undefined);
     window.localStorage.clear();
     useGitPanelStore.setState({ stateByEpicId: {} });
     useSurfaceHostSelectionStore.getState().resetForTests();
@@ -476,7 +498,7 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
       hostLabel: "Host One",
       unavailability: null,
     };
-    pinTestState.directory = [{ hostId: "host-1" }];
+    pinTestState.directory = [{ hostId: "host-1", label: "Host One" }];
   });
 
   afterEach(() => {
@@ -862,7 +884,11 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
     expect(screen.getByTestId("git-roots-unavailable")).toBeDefined();
     expect(screen.queryByText("No git workspaces available")).toBeNull();
     expect(screen.queryByTestId("diff-loading-skeleton")).toBeNull();
-    expect(screen.queryByTestId("git-diff-repo-switcher-trigger")).toBeNull();
+    // The picker SURVIVES the degrade. It used to be asserted absent here,
+    // which codified the dead end: every degraded state is reached by a host
+    // or workspace choice, and hiding the switcher removed the only control
+    // that could make a different one.
+    expect(screen.getByTestId("git-diff-repo-switcher-trigger")).toBeDefined();
     expect(screen.queryByText("No changes")).toBeNull();
   });
 
@@ -889,7 +915,11 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
     // default-pick settles to null and the panel must surface an explicit state.
     expect(screen.getByTestId("git-roots-unavailable")).toBeDefined();
     expect(screen.queryByTestId("diff-loading-skeleton")).toBeNull();
-    expect(screen.queryByTestId("git-diff-repo-switcher-trigger")).toBeNull();
+    // The picker SURVIVES the degrade. It used to be asserted absent here,
+    // which codified the dead end: every degraded state is reached by a host
+    // or workspace choice, and hiding the switcher removed the only control
+    // that could make a different one.
+    expect(screen.getByTestId("git-diff-repo-switcher-trigger")).toBeDefined();
   });
 
   it("recovers via retry once a previously unavailable root is readable again", async () => {
@@ -1129,5 +1159,113 @@ describe("<GitDiffPanelBodyLive /> workspace switcher integration", () => {
         gitDiffPanelSurfaceKey(TAB_ID)
       ],
     ).toBe("host-1");
+  });
+
+  /**
+   * The gap the arm above does NOT cover, and could not: it hands the store a
+   * lease already reading `dead`, so it proves the panel re-points when the
+   * authority has reached a verdict. It proves nothing about a host that goes
+   * offline and never earns one.
+   *
+   * That is the reported failure. Deposition needs
+   * `CONFIRMED_DEATH_REFUSAL_STREAK` transport-confirmed refusals; the panel
+   * dials once and host-scoped queries disable every automatic recovery route,
+   * so the streak stalls, the pin stays honored, and the panel sits on a host
+   * it cannot reach. Everything below is about being RECOVERABLE there -
+   * without the authority having to agree first.
+   */
+  describe("pinned host that cannot answer", () => {
+    function renderPinnedToUnreachableHost(): void {
+      useSurfaceHostSelectionStore
+        .getState()
+        .setSelection(gitDiffPanelSurfaceKey(TAB_ID), "host-2");
+      pinTestState.activeHostId = "host-1";
+      pinTestState.directory = [
+        { hostId: "host-1", label: "Host One" },
+        { hostId: "host-2", label: "Host Two" },
+      ];
+      // The lease deliberately does NOT read `dead` - that is the whole point.
+      // host-2 is quiet, not confirmed gone, which is the state the refusal
+      // streak leaves it in.
+      useSelectionAuthorityStore.setState({
+        attached: true,
+        effectiveHostId: "host-1",
+        leases: [
+          { hostId: "host-1", status: "ready", dead: null },
+          { hostId: "host-2", status: "connecting", dead: null },
+        ],
+      });
+      bindingsState.error = new Error("host unreachable");
+      renderPanel(rootSelected);
+    }
+
+    it("keeps the host picker reachable so the pin can be changed", () => {
+      renderPinnedToUnreachableHost();
+
+      // The regression in one assertion: the switcher (whose popover carries
+      // `WorktreePickerHostSection`) must outlive the failure that a host pick
+      // caused. Without it the pin is unreachable, persisted, and permanent.
+      const trigger = screen.getByTestId("git-diff-repo-switcher-trigger");
+      expect(trigger).toBeDefined();
+      fireEvent.click(trigger);
+      expect(
+        screen.getByTestId("mock-worktree-picker-host-section"),
+      ).toBeDefined();
+    });
+
+    it("names the unreachable host instead of nudging the user to add workspaces", () => {
+      renderPinnedToUnreachableHost();
+
+      expect(screen.getByTestId("git-host-unreachable")).toBeDefined();
+      expect(screen.getByText("Can't reach Host Two")).toBeDefined();
+      // "Add workspaces to the agent to get started" names a remedy on a
+      // machine that never answered, and cannot be told apart from a host that
+      // answered with nothing.
+      expect(screen.queryByText("No git workspaces available")).toBeNull();
+    });
+
+    it("re-dials on Retry, since nothing else will", () => {
+      renderPinnedToUnreachableHost();
+
+      fireEvent.click(screen.getByTestId("git-host-unreachable-retry"));
+
+      expect(bindingsState.refetch).toHaveBeenCalled();
+    });
+
+    it("clears the pin on 'Use active host' so the panel returns to effective", async () => {
+      renderPinnedToUnreachableHost();
+
+      fireEvent.click(screen.getByTestId("git-host-unreachable-use-active"));
+
+      // Unpinned, not re-pinned: the surface resolves to `effective` from here
+      // and follows it, which is the same resting state a panel that was never
+      // pinned is in.
+      await waitFor(() => {
+        expect(
+          useSurfaceHostSelectionStore.getState().selections[
+            gitDiffPanelSurfaceKey(TAB_ID)
+          ],
+        ).toBeUndefined();
+      });
+      expect(pinTestState.lastClientHostId).toBe("host-1");
+    });
+
+    it("does not offer 'Use active host' when the panel already resolves to it", () => {
+      // Pinned to the EFFECTIVE host: clearing the pin would move nothing, so
+      // the action must not be offered - a button that cannot change the
+      // outcome reads as a remedy that failed.
+      useSurfaceHostSelectionStore
+        .getState()
+        .setSelection(gitDiffPanelSurfaceKey(TAB_ID), "host-1");
+      pinTestState.activeHostId = "host-1";
+      bindingsState.error = new Error("host unreachable");
+
+      renderPanel(rootSelected);
+
+      expect(screen.getByTestId("git-host-unreachable")).toBeDefined();
+      expect(
+        screen.queryByTestId("git-host-unreachable-use-active"),
+      ).toBeNull();
+    });
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-bindings-unreadable.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-bindings-unreadable.tsx
@@ -1,0 +1,92 @@
+import { useCallback, type ReactNode } from "react";
+import { AlertCircle } from "lucide-react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+
+const GIT_BINDINGS_RETRY_TIMEOUT_MS = 10_000;
+
+/**
+ * Shown when the worktree-bindings read FAILED and the host ANSWERED - an
+ * authorization refusal, an unsupported method, an internal error on the far
+ * side. The machine is reachable; the operation is not.
+ *
+ * It is separate from {@link GitHostUnreachable} on purpose. That screen says
+ * "can't reach <host>" and offers to re-dial or move off the pin, which are the
+ * remedies for a machine that never answered and are the wrong ones here: the
+ * host is right there, and the reason it gave is the only thing that can point
+ * at a fix. Collapsing both into "can't reach" would repeat, one layer up, the
+ * exact defect this panel's empty states were fixed for - naming a remedy the
+ * user cannot act on and hiding the one fact that mattered.
+ *
+ * There is deliberately no "Use active host" here. Switching machines is not
+ * indicated by an answered failure, and the host picker in the header is
+ * reachable in this state anyway, so the affordance exists without this screen
+ * asserting it is the fix.
+ */
+export function GitBindingsUnreadable(props: {
+  /** The host's own message. The only thing here that can point at a cause. */
+  readonly message: string;
+  readonly onRetry: () => Promise<void>;
+}): ReactNode {
+  const onRetry = props.onRetry;
+  const handleRefresh = useCallback((): Promise<void> => onRetry(), [onRetry]);
+  const refresh = useRefreshSpinner({
+    onRefresh: handleRefresh,
+    externalRefreshing: false,
+    timeoutMs: GIT_BINDINGS_RETRY_TIMEOUT_MS,
+  });
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col items-center justify-center gap-3 px-4 py-8 text-center"
+      data-testid="git-bindings-unreadable"
+    >
+      <div className="flex flex-col items-center gap-2 text-muted-foreground">
+        <AlertCircle className="size-8 text-destructive/70" aria-hidden />
+        <div className="space-y-1">
+          <p className="text-ui-sm text-muted-foreground/70">
+            Couldn&apos;t load workspaces
+          </p>
+          <p
+            className="text-ui-xs text-muted-foreground/50"
+            data-testid="git-bindings-unreadable-message"
+          >
+            {props.message}
+          </p>
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap justify-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={refresh.trigger}
+          disabled={refresh.refreshing}
+          data-testid="git-bindings-unreadable-retry"
+        >
+          {refresh.refreshing ? (
+            <AgentSpinningDots
+              className="mr-1.5"
+              testId="git-bindings-unreadable-retry-spinner"
+              variant={undefined}
+            />
+          ) : null}
+          Retry
+        </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load workspaces",
+            message: props.message,
+            code: null,
+            source: "Git changes",
+          })}
+          presentation="text"
+          className={undefined}
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-host-unreachable.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-host-unreachable.tsx
@@ -1,10 +1,10 @@
 import { useCallback, type ReactNode } from "react";
-import { RotateCcw, Unplug } from "lucide-react";
+import { Unplug } from "lucide-react";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
 import { createReportIssueContext } from "@/lib/report-issue-context";
-import { cn } from "@/lib/utils";
 
 const GIT_HOST_RETRY_TIMEOUT_MS = 10_000;
 
@@ -33,7 +33,14 @@ const GIT_HOST_RETRY_TIMEOUT_MS = 10_000;
 export function GitHostUnreachable(props: {
   /** Display name of the host that did not answer. `null` while unresolved. */
   readonly hostName: string | null;
-  readonly onRetry: () => void;
+  /**
+   * Must resolve when the re-dial SETTLES. The pending state is driven off
+   * this promise, so a caller that fires and forgets re-enables the button
+   * while its own request is still in flight - which both invites a second
+   * dial on top of the first and defeats the timeout below, since there is
+   * nothing left to time out.
+   */
+  readonly onRetry: () => Promise<void>;
   /**
    * Clears this surface's pin so the panel resolves to the effective host.
    * `null` when the panel is not pinned (or is pinned to the effective host),
@@ -42,10 +49,7 @@ export function GitHostUnreachable(props: {
   readonly onUseActiveHost: (() => void) | null;
 }): ReactNode {
   const onRetry = props.onRetry;
-  const handleRefresh = useCallback((): Promise<void> => {
-    onRetry();
-    return Promise.resolve();
-  }, [onRetry]);
+  const handleRefresh = useCallback((): Promise<void> => onRetry(), [onRetry]);
   const refresh = useRefreshSpinner({
     onRefresh: handleRefresh,
     externalRefreshing: false,
@@ -81,13 +85,13 @@ export function GitHostUnreachable(props: {
           disabled={refresh.refreshing}
           data-testid="git-host-unreachable-retry"
         >
-          <RotateCcw
-            className={cn(
-              "mr-1.5 size-3.5",
-              refresh.refreshing && "animate-spin",
-            )}
-            aria-hidden
-          />
+          {refresh.refreshing ? (
+            <AgentSpinningDots
+              className="mr-1.5"
+              testId="git-host-unreachable-retry-spinner"
+              variant={undefined}
+            />
+          ) : null}
           Retry
         </Button>
         {props.onUseActiveHost === null ? null : (

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-host-unreachable.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-host-unreachable.tsx
@@ -1,0 +1,118 @@
+import { useCallback, type ReactNode } from "react";
+import { RotateCcw, Unplug } from "lucide-react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { Button } from "@/components/ui/button";
+import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { cn } from "@/lib/utils";
+
+const GIT_HOST_RETRY_TIMEOUT_MS = 10_000;
+
+/**
+ * Shown when the epic's worktree bindings could not be READ from the host this
+ * panel resolves to - overwhelmingly, a host that went offline while the panel
+ * was pinned to it.
+ *
+ * It exists because the branch that produced this screen used to render
+ * `NoGitWorktrees`, which says "Add workspaces to the agent to get started".
+ * That is the right nudge for a host that answered and has no git workspaces,
+ * and the wrong one for a host that never answered: it names a remedy on the
+ * wrong machine, and it is indistinguishable from the genuinely-empty case, so
+ * a user cannot tell "you have nothing here" from "we could not ask".
+ *
+ * Both actions are the panel's own, and NEITHER waits on the selection
+ * authority. Retry re-dials; "Use active host" clears the surface pin so the
+ * panel falls back to `effective`. That second one is the load-bearing half:
+ * the pin's designed recovery is auto-follow on lease death, which needs
+ * `CONFIRMED_DEATH_REFUSAL_STREAK` transport-confirmed refusals to land before
+ * the pin is deposed - a condition this panel can neither observe nor force,
+ * and whose failure is exactly how this screen becomes permanent. A recovery
+ * path that depends on another subsystem reaching a verdict is not a recovery
+ * path from here; an explicit unpin is.
+ */
+export function GitHostUnreachable(props: {
+  /** Display name of the host that did not answer. `null` while unresolved. */
+  readonly hostName: string | null;
+  readonly onRetry: () => void;
+  /**
+   * Clears this surface's pin so the panel resolves to the effective host.
+   * `null` when the panel is not pinned (or is pinned to the effective host),
+   * where the action would move nothing and must not be offered.
+   */
+  readonly onUseActiveHost: (() => void) | null;
+}): ReactNode {
+  const onRetry = props.onRetry;
+  const handleRefresh = useCallback((): Promise<void> => {
+    onRetry();
+    return Promise.resolve();
+  }, [onRetry]);
+  const refresh = useRefreshSpinner({
+    onRefresh: handleRefresh,
+    externalRefreshing: false,
+    timeoutMs: GIT_HOST_RETRY_TIMEOUT_MS,
+  });
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col items-center justify-center gap-3 px-4 py-8 text-center"
+      data-testid="git-host-unreachable"
+    >
+      <div className="flex flex-col items-center gap-2 text-muted-foreground">
+        <Unplug className="size-8 text-warning/70" aria-hidden />
+        <div className="space-y-1">
+          <p className="text-ui-sm text-muted-foreground/70">
+            {props.hostName === null
+              ? "Can't reach this host"
+              : `Can't reach ${props.hostName}`}
+          </p>
+          <p className="text-ui-xs text-muted-foreground/50">
+            This panel is pointed at a host that isn't responding, so its
+            workspaces couldn't be loaded. Pick another host above, or try
+            again.
+          </p>
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap justify-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={refresh.trigger}
+          disabled={refresh.refreshing}
+          data-testid="git-host-unreachable-retry"
+        >
+          <RotateCcw
+            className={cn(
+              "mr-1.5 size-3.5",
+              refresh.refreshing && "animate-spin",
+            )}
+            aria-hidden
+          />
+          Retry
+        </Button>
+        {props.onUseActiveHost === null ? null : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={props.onUseActiveHost}
+            data-testid="git-host-unreachable-use-active"
+          >
+            Use active host
+          </Button>
+        )}
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Can't reach host",
+            message:
+              "The workspaces for this agent could not be loaded from the selected host.",
+            code: null,
+            source: "Git changes",
+          })}
+          presentation="text"
+          className={undefined}
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
@@ -25,6 +25,7 @@ import {
   useSurfaceHostPin,
 } from "@/hooks/host/use-surface-host-pin";
 import { useSurfaceHostStreamBinding } from "@/hooks/host/use-surface-host-stream-binding";
+import { useHostDirectoryEntryForHostId } from "@/hooks/host/use-host-client-for-host-id";
 import { StreamRuntimeContext } from "@/lib/host/stream-runtime-context";
 import { useGitPrefetchWorktreeStatus } from "@/hooks/git/use-git-prefetch-worktree-status";
 import { useGitCapabilitiesQuery } from "@/hooks/git/use-git-capabilities-query";
@@ -54,6 +55,7 @@ import { WorkspacePickerWithOpener } from "@/components/worktree/workspace-picke
 import { WorktreePickerHostSection } from "@/components/worktree/worktree-picker-host-section";
 import { CapabilityGate } from "./capability-gate";
 import { DiffLoadingSkeleton } from "./diff-loading-skeleton";
+import { GitHostUnreachable } from "./empty-states/git-host-unreachable";
 import { GitRootsUnavailable } from "./empty-states/git-roots-unavailable";
 import { NoGitWorktrees } from "./empty-states/no-git-worktrees";
 import { GitDiffRepoSwitcher } from "./git-diff-repo-switcher";
@@ -324,6 +326,33 @@ export function GitDiffPanelBodyLive(
   // wrong machine's working tree while every unary read beside it was
   // correctly pinned. One swap here re-targets the whole subtree.
   //
+  // Re-dial the host this panel resolves to. Host-scoped queries deliberately
+  // disable every automatic recovery route (no retry, no polling, no
+  // focus/reconnect refetch - see `lib/host/availability-recovery.ts`), so an
+  // errored bindings read stays errored until something asks again. This is
+  // the only thing in the panel that can ask.
+  const { refetch: refetchBindings } = bindingsQuery;
+  const retryBindings = useCallback(() => {
+    void refetchBindings();
+  }, [refetchBindings]);
+
+  // Returning the surface to following by clearing the pin - the recovery the
+  // panel can perform on its own, rather than waiting on the authority to
+  // reach a death verdict it may never reach. Offered only when it would
+  // actually MOVE the panel: unpinned, or pinned to the host it would follow
+  // to anyway, it resolves to the same machine and the button would be a
+  // no-op that reads like a fix.
+  const { setSelection } = pin;
+  const canUseActiveHost =
+    pin.selection !== null &&
+    pin.followingHostId !== null &&
+    pin.followingHostId !== pin.selection;
+  const useActiveHost = useCallback(() => {
+    setSelection(null);
+  }, [setSelection]);
+
+  const resolvedHostEntry = useHostDirectoryEntryForHostId(pin.resolvedHostId);
+
   // Rendered UNCONDITIONALLY, as `ResourceMonitorPopover` is and for the same
   // reason: mounting the provider only when a pinned binding exists changes
   // the element type at this position the instant a pick resolves, and React
@@ -346,6 +375,9 @@ export function GitDiffPanelBodyLive(
         tabId: props.tabId,
         retryUnavailableRoots,
         unavailableGitRootKeys: unavailableGitRootKeys.keys,
+        retryBindings,
+        useActiveHost: canUseActiveHost ? useActiveHost : null,
+        resolvedHostName: resolvedHostEntry?.label ?? null,
       })}
     </StreamRuntimeContext.Provider>
   );
@@ -365,9 +397,84 @@ function renderGitDiffPanelBody(input: {
   readonly tabId: string;
   readonly retryUnavailableRoots: () => void;
   readonly unavailableGitRootKeys: ReadonlySet<string>;
+  readonly retryBindings: () => void;
+  readonly useActiveHost: (() => void) | null;
+  readonly resolvedHostName: string | null;
+}): ReactNode {
+  if (
+    input.selectedRepo !== null &&
+    input.selectedRootRow !== null &&
+    input.gitRows.length > 0 &&
+    !input.bindingsPending &&
+    !input.bindingsError
+  ) {
+    return (
+      <GitDiffPanelLoaded
+        epicId={input.epicId}
+        viewTabId={input.tabId}
+        rows={input.rows}
+        selected={input.selectedRepo}
+        selectedRootRow={input.selectedRootRow}
+        surfaceKey={input.surfaceKey}
+        onLatchHost={input.latchOnFirstUse}
+        client={input.client}
+      />
+    );
+  }
+
+  // EVERY degraded branch keeps the header, and that is the whole point of
+  // this shape rather than a tidier early-return chain.
+  //
+  // The host picker lives in the repo switcher's `hostSection`, which used to
+  // render only inside `GitDiffPanelLoaded`. So each of the states below -
+  // reached BY choosing a host - removed the one control that could choose a
+  // different one. Pinning to a host that could not answer produced "No git
+  // workspaces available" with no picker, no auto-follow (the pin is deposed
+  // only on a lease death that needs a refusal streak nothing here re-dials to
+  // produce) and no refetch (host queries disable every automatic recovery
+  // route), so the panel stayed there across reloads: the pin is persisted.
+  //
+  // The premise the whole pin design rests on is written down in
+  // `host-select-row-refused.ts` - "a dial that fails is recoverable where an
+  // un-pickable row is not". It only holds while the picker outlives the
+  // failure.
+  return (
+    <GitDiffPanelDegraded
+      surfaceKey={input.surfaceKey}
+      epicId={input.epicId}
+      rows={input.rows}
+      client={input.client}
+      onLatchHost={input.latchOnFirstUse}
+    >
+      {degradedGitDiffBody(input)}
+    </GitDiffPanelDegraded>
+  );
+}
+
+function degradedGitDiffBody(input: {
+  readonly bindingsPending: boolean;
+  readonly bindingsError: boolean;
+  readonly gitRows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
+  readonly rows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
+  readonly retryUnavailableRoots: () => void;
+  readonly unavailableGitRootKeys: ReadonlySet<string>;
+  readonly retryBindings: () => void;
+  readonly useActiveHost: (() => void) | null;
+  readonly resolvedHostName: string | null;
 }): ReactNode {
   if (input.bindingsPending) return <DiffLoadingSkeleton variant="panel" />;
-  if (input.bindingsError) return <NoGitWorktrees />;
+  // The host did not answer. Distinct from `NoGitWorktrees`, which tells the
+  // user to add workspaces - the wrong remedy, on the wrong machine, and
+  // indistinguishable from a host that answered with nothing.
+  if (input.bindingsError) {
+    return (
+      <GitHostUnreachable
+        hostName={input.resolvedHostName}
+        onRetry={input.retryBindings}
+        onUseActiveHost={input.useActiveHost}
+      />
+    );
+  }
   if (input.gitRows.length === 0) {
     // Rows whose git facts are still unverified placeholders (cold-resolve
     // timeout on the host, or a pre-@1.2 host) are pending, not dead: keep
@@ -379,28 +486,104 @@ function renderGitDiffPanelBody(input: {
     }
     return <NoGitWorktrees />;
   }
-  if (input.selectedRepo === null || input.selectedRootRow === null) {
-    if (allRowsKnownUnavailable(input.gitRows, input.unavailableGitRootKeys)) {
-      // Every bound root probed unavailable: an explicit, recoverable degrade -
-      // never the transient skeleton, which with zero available roots would
-      // never resolve and read as "still loading" forever.
-      return <GitRootsUnavailable onRetry={input.retryUnavailableRoots} />;
-    }
-    // Default-pick is resolving the initial selection (one commit).
-    return <DiffLoadingSkeleton variant="panel" />;
+  if (allRowsKnownUnavailable(input.gitRows, input.unavailableGitRootKeys)) {
+    // Every bound root probed unavailable: an explicit, recoverable degrade -
+    // never the transient skeleton, which with zero available roots would
+    // never resolve and read as "still loading" forever.
+    return <GitRootsUnavailable onRetry={input.retryUnavailableRoots} />;
   }
+  // Default-pick is resolving the initial selection (one commit).
+  return <DiffLoadingSkeleton variant="panel" />;
+}
+
+interface GitDiffPanelDegradedProps {
+  readonly surfaceKey: string;
+  readonly epicId: string;
+  readonly rows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly onLatchHost: () => void;
+  readonly children: ReactNode;
+}
+
+/**
+ * The panel's chrome for every state that is not fully loaded: the same
+ * workspace/host picker the loaded header carries, above whatever the degraded
+ * body is.
+ *
+ * It is a REDUCED header rather than the loaded one because the facts the
+ * loaded header renders do not exist here - there is no selected root, so no
+ * change counts, no submodule tree and no watcher status to qualify. The
+ * switcher already models exactly this: `selected: null` renders "Select
+ * workspace", and an empty `roots` renders "No workspaces found." in its list.
+ * What survives is the part that matters - the host section, and any rows the
+ * host DID return, so a pick can move the panel out of this state.
+ *
+ * `openTarget` is null throughout: with no selected workspace there is no path
+ * to open in an editor, and the opener renders inert rather than aiming at a
+ * host that just failed to answer.
+ */
+function GitDiffPanelDegraded(props: GitDiffPanelDegradedProps): ReactNode {
+  const [repoSwitcherOpen, setRepoSwitcherOpen] = useState(false);
+  const setSelectedRepo = useGitPanelStore((s) => s.setSelectedRepo);
+  const { epicId, onLatchHost } = props;
+
+  const roots: ReadonlyArray<GitDiffRepoSwitcherRootInput> = useMemo(
+    () =>
+      props.rows.map((row) => ({
+        row,
+        fileChangeCount: null,
+        moduleChangeCount: null,
+      })),
+    [props.rows],
+  );
+
+  const handleSelectRoot = useCallback(
+    (row: WorktreeBindingSelectorRowV12) => {
+      onLatchHost();
+      setSelectedRepo(epicId, {
+        hostId: row.hostId,
+        rootRunningDir: row.runningDir,
+        repoRoot: row.runningDir,
+      });
+    },
+    [epicId, onLatchHost, setSelectedRepo],
+  );
 
   return (
-    <GitDiffPanelLoaded
-      epicId={input.epicId}
-      viewTabId={input.tabId}
-      rows={input.rows}
-      selected={input.selectedRepo}
-      selectedRootRow={input.selectedRootRow}
-      surfaceKey={input.surfaceKey}
-      onLatchHost={input.latchOnFirstUse}
-      client={input.client}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border/60 px-2 pt-1.5 pb-1">
+        <div className="min-w-0 flex-1">
+          <WorkspacePickerWithOpener
+            picker={
+              <GitDiffRepoSwitcher
+                open={repoSwitcherOpen}
+                onOpenChange={setRepoSwitcherOpen}
+                roots={roots}
+                activeRootSubmodules={[]}
+                selected={null}
+                onSelectRoot={handleSelectRoot}
+                hostSection={
+                  <WorktreePickerHostSection surfaceKey={props.surfaceKey} />
+                }
+                autoFocusSearch={repoSwitcherOpen}
+                triggerClassName={undefined}
+                contentClassName={undefined}
+                triggerTestId="git-diff-repo-switcher-trigger"
+                contentTestId="git-diff-repo-switcher-popover"
+              />
+            }
+            openTarget={null}
+            hostClient={props.client}
+          />
+        </div>
+      </div>
+      {/* The bodies below are written as `h-full` blocks (they used to be the
+          panel's ONLY child). A percentage height needs a definite parent, so
+          they get a flex slot of their own rather than being dropped straight
+          into the column beside the header, where `h-full` would resolve to
+          the full panel and overflow it. */}
+      <div className="flex min-h-0 flex-1 flex-col">{props.children}</div>
+    </div>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
@@ -18,6 +18,10 @@ import type {
 } from "@traycer/protocol/host";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import {
+  HostRpcError,
+  HostTransportFailureError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 import { useWorktreeListBindingsForEpicForClient } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
 import {
   useGitDiffPanelSurfaceKey,
@@ -55,6 +59,7 @@ import { WorkspacePickerWithOpener } from "@/components/worktree/workspace-picke
 import { WorktreePickerHostSection } from "@/components/worktree/worktree-picker-host-section";
 import { CapabilityGate } from "./capability-gate";
 import { DiffLoadingSkeleton } from "./diff-loading-skeleton";
+import { GitBindingsUnreadable } from "./empty-states/git-bindings-unreadable";
 import { GitHostUnreachable } from "./empty-states/git-host-unreachable";
 import { GitRootsUnavailable } from "./empty-states/git-roots-unavailable";
 import { NoGitWorktrees } from "./empty-states/no-git-worktrees";
@@ -331,22 +336,31 @@ export function GitDiffPanelBodyLive(
   // focus/reconnect refetch - see `lib/host/availability-recovery.ts`), so an
   // errored bindings read stays errored until something asks again. This is
   // the only thing in the panel that can ask.
+  // Returns the query's own promise rather than firing and forgetting: the
+  // retry affordance keeps its pending state for exactly as long as the read
+  // is in flight, which is only true if the caller can await it.
   const { refetch: refetchBindings } = bindingsQuery;
-  const retryBindings = useCallback(() => {
-    void refetchBindings();
+  const retryBindings = useCallback(async (): Promise<void> => {
+    await refetchBindings();
   }, [refetchBindings]);
 
   // Returning the surface to following by clearing the pin - the recovery the
   // panel can perform on its own, rather than waiting on the authority to
   // reach a death verdict it may never reach. Offered only when it would
-  // actually MOVE the panel: unpinned, or pinned to the host it would follow
-  // to anyway, it resolves to the same machine and the button would be a
-  // no-op that reads like a fix.
+  // actually MOVE the panel.
+  //
+  // The comparison is against `resolvedHostId`, NOT the raw `selection`. A pin
+  // whose host the authority HAS declared dead is already deposed, so the
+  // panel is on `followingHostId` and reads through to it - and if that host's
+  // own bindings read then fails, comparing the raw preference would offer
+  // "Use active host" while the active host is precisely what already failed.
+  // Clicking would drop the sticky pin, move nothing and change no error,
+  // which is the no-op-that-reads-like-a-fix this guard exists to prevent.
   const { setSelection } = pin;
   const canUseActiveHost =
     pin.selection !== null &&
     pin.followingHostId !== null &&
-    pin.followingHostId !== pin.selection;
+    pin.resolvedHostId !== pin.followingHostId;
   const useActiveHost = useCallback(() => {
     setSelection(null);
   }, [setSelection]);
@@ -366,7 +380,7 @@ export function GitDiffPanelBodyLive(
         client,
         latchOnFirstUse: pin.latchOnFirstUse,
         bindingsPending: bindingsQuery.isPending,
-        bindingsError: bindingsQuery.error !== null,
+        bindingsFailure: classifyBindingsFailure(bindingsQuery.error),
         gitRows,
         rows,
         selectedRepo,
@@ -383,12 +397,41 @@ export function GitDiffPanelBodyLive(
   );
 }
 
+/**
+ * Why the bindings read failed, to the only resolution the panel can act on.
+ *
+ * `unreachable` is the machine not answering. Everything else is the host
+ * answering with a refusal - unauthorized, unsupported method, an internal
+ * failure on the far side - and those are NOT interchangeable: one is fixed by
+ * re-dialing or moving off the pin, the other by reading what the host said.
+ * Collapsing them would put this panel back where it started, asserting a
+ * remedy on the wrong machine.
+ */
+type BindingsFailure =
+  | { readonly kind: "unreachable" }
+  | { readonly kind: "answered"; readonly message: string };
+
+function classifyBindingsFailure(
+  error: HostRpcError | null,
+): BindingsFailure | null {
+  if (error === null) return null;
+  // `HostTransportFailureError` extends `HostRpcError`, so this order matters:
+  // it is the ONLY error that means the host did not answer.
+  if (error instanceof HostTransportFailureError)
+    return { kind: "unreachable" };
+  const message = error.message.trim();
+  return {
+    kind: "answered",
+    message: message.length > 0 ? message : "The host refused the request.",
+  };
+}
+
 function renderGitDiffPanelBody(input: {
   readonly surfaceKey: string;
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly latchOnFirstUse: () => void;
   readonly bindingsPending: boolean;
-  readonly bindingsError: boolean;
+  readonly bindingsFailure: BindingsFailure | null;
   readonly gitRows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
   readonly rows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
   readonly selectedRepo: GitPanelSelectedRepo | null;
@@ -397,7 +440,7 @@ function renderGitDiffPanelBody(input: {
   readonly tabId: string;
   readonly retryUnavailableRoots: () => void;
   readonly unavailableGitRootKeys: ReadonlySet<string>;
-  readonly retryBindings: () => void;
+  readonly retryBindings: () => Promise<void>;
   readonly useActiveHost: (() => void) | null;
   readonly resolvedHostName: string | null;
 }): ReactNode {
@@ -406,7 +449,7 @@ function renderGitDiffPanelBody(input: {
     input.selectedRootRow !== null &&
     input.gitRows.length > 0 &&
     !input.bindingsPending &&
-    !input.bindingsError
+    input.bindingsFailure === null
   ) {
     return (
       <GitDiffPanelLoaded
@@ -453,20 +496,30 @@ function renderGitDiffPanelBody(input: {
 
 function degradedGitDiffBody(input: {
   readonly bindingsPending: boolean;
-  readonly bindingsError: boolean;
+  readonly bindingsFailure: BindingsFailure | null;
   readonly gitRows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
   readonly rows: ReadonlyArray<WorktreeBindingSelectorRowV12>;
   readonly retryUnavailableRoots: () => void;
   readonly unavailableGitRootKeys: ReadonlySet<string>;
-  readonly retryBindings: () => void;
+  readonly retryBindings: () => Promise<void>;
   readonly useActiveHost: (() => void) | null;
   readonly resolvedHostName: string | null;
 }): ReactNode {
   if (input.bindingsPending) return <DiffLoadingSkeleton variant="panel" />;
-  // The host did not answer. Distinct from `NoGitWorktrees`, which tells the
-  // user to add workspaces - the wrong remedy, on the wrong machine, and
-  // indistinguishable from a host that answered with nothing.
-  if (input.bindingsError) {
+  // Both arms are distinct from `NoGitWorktrees`, which tells the user to add
+  // workspaces - the wrong remedy, on the wrong machine, and indistinguishable
+  // from a host that answered with nothing. They are also distinct from EACH
+  // OTHER, which is the finer point: "did not answer" and "answered with a
+  // refusal" have different fixes, and only the first is about reachability.
+  if (input.bindingsFailure !== null) {
+    if (input.bindingsFailure.kind === "answered") {
+      return (
+        <GitBindingsUnreadable
+          message={input.bindingsFailure.message}
+          onRetry={input.retryBindings}
+        />
+      );
+    }
     return (
       <GitHostUnreachable
         hostName={input.resolvedHostName}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
@@ -19,9 +19,9 @@ import type {
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import {
-  HostRpcError,
-  HostTransportFailureError,
-} from "@traycer-clients/shared/host-transport/host-messenger";
+  classifyBindingsFailure,
+  type BindingsFailure,
+} from "@/lib/worktree/bindings-failure";
 import { useWorktreeListBindingsForEpicForClient } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
 import {
   useGitDiffPanelSurfaceKey,
@@ -361,7 +361,7 @@ export function GitDiffPanelBodyLive(
     pin.selection !== null &&
     pin.followingHostId !== null &&
     pin.resolvedHostId !== pin.followingHostId;
-  const useActiveHost = useCallback(() => {
+  const handleUseActiveHost = useCallback(() => {
     setSelection(null);
   }, [setSelection]);
 
@@ -390,40 +390,11 @@ export function GitDiffPanelBodyLive(
         retryUnavailableRoots,
         unavailableGitRootKeys: unavailableGitRootKeys.keys,
         retryBindings,
-        useActiveHost: canUseActiveHost ? useActiveHost : null,
+        useActiveHost: canUseActiveHost ? handleUseActiveHost : null,
         resolvedHostName: resolvedHostEntry?.label ?? null,
       })}
     </StreamRuntimeContext.Provider>
   );
-}
-
-/**
- * Why the bindings read failed, to the only resolution the panel can act on.
- *
- * `unreachable` is the machine not answering. Everything else is the host
- * answering with a refusal - unauthorized, unsupported method, an internal
- * failure on the far side - and those are NOT interchangeable: one is fixed by
- * re-dialing or moving off the pin, the other by reading what the host said.
- * Collapsing them would put this panel back where it started, asserting a
- * remedy on the wrong machine.
- */
-type BindingsFailure =
-  | { readonly kind: "unreachable" }
-  | { readonly kind: "answered"; readonly message: string };
-
-function classifyBindingsFailure(
-  error: HostRpcError | null,
-): BindingsFailure | null {
-  if (error === null) return null;
-  // `HostTransportFailureError` extends `HostRpcError`, so this order matters:
-  // it is the ONLY error that means the host did not answer.
-  if (error instanceof HostTransportFailureError)
-    return { kind: "unreachable" };
-  const message = error.message.trim();
-  return {
-    kind: "answered",
-    message: message.length > 0 ? message : "The host refused the request.",
-  };
 }
 
 function renderGitDiffPanelBody(input: {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
@@ -342,28 +342,24 @@ vi.mock("@/stores/settings/settings-store", () => ({
 }));
 
 // File-tree-panel-specific dependencies.
+// Configurable so one arm can drive the ZERO-ROW read a host that cannot
+// answer produces - the state `useFileTreeWorkspaceSelection` resolves to a
+// null workspace path from, and therefore the panel's empty state.
+const fileTreeBindingsState = vi.hoisted(() => ({
+  rows: [] as Array<{
+    readonly runningDir: string;
+    readonly disabledReason: string | null;
+  }>,
+}));
+
 vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
   useWorktreeListBindingsForEpic: () => ({
-    data: {
-      rows: [
-        {
-          runningDir: "/work/repo",
-          disabledReason: null,
-        },
-      ],
-    },
+    data: { rows: fileTreeBindingsState.rows },
   }),
   // `useFileTreeWorkspaceSelection` (also reached from the P0.2 pin chain)
   // calls the host-client-parametric variant, not the app-wide one above.
   useWorktreeListBindingsForEpicForClient: () => ({
-    data: {
-      rows: [
-        {
-          runningDir: "/work/repo",
-          disabledReason: null,
-        },
-      ],
-    },
+    data: { rows: fileTreeBindingsState.rows },
   }),
 }));
 
@@ -418,12 +414,25 @@ vi.mock("@pierre/trees/react", () => ({
   }),
 }));
 
+// Rendered rather than nulled: whether this survives the panel's empty state
+// is the assertion, and a stub that renders nothing cannot make it. It still
+// renders its `picker` slot so the inner picker's presence is observable too -
+// that is the one carrying `WorktreePickerHostSection`.
 vi.mock("@/components/worktree/workspace-picker-with-opener", () => ({
-  WorkspacePickerWithOpener: () => null,
+  WorkspacePickerWithOpener: (props: { readonly picker: ReactNode }) => (
+    <div data-testid="mock-workspace-picker-with-opener">{props.picker}</div>
+  ),
 }));
 
 vi.mock("@/components/epic-canvas/sidebar/file-tree-workspace-picker", () => ({
-  FileTreeWorkspacePicker: () => null,
+  FileTreeWorkspacePicker: (props: {
+    readonly selectedPath: string | null;
+  }) => (
+    <div
+      data-testid="mock-file-tree-workspace-picker"
+      data-selected-path={props.selectedPath ?? ""}
+    />
+  ),
 }));
 
 import { EpicLeftPanelHost } from "@/components/epic-canvas/sidebar/epic-sidebar";
@@ -434,6 +443,9 @@ const EPIC_ID = "epic-1";
 describe("epic sidebar file-tree load failure report action", () => {
   beforeEach(() => {
     cleanup();
+    fileTreeBindingsState.rows = [
+      { runningDir: "/work/repo", disabledReason: null },
+    ];
   });
 
   afterEach(() => {
@@ -484,5 +496,60 @@ describe("epic sidebar file-tree load failure report action", () => {
     const context = useDesktopDialogStore.getState().reportIssueContext;
     expect(JSON.stringify(context)).not.toContain("secret-token");
     expect(JSON.stringify(context)).not.toContain("/Users/hostile/path");
+  });
+});
+
+describe("epic sidebar file-tree workspace picker persistence", () => {
+  beforeEach(() => {
+    cleanup();
+    fileTreeBindingsState.rows = [
+      { runningDir: "/work/repo", disabledReason: null },
+    ];
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderPanel(): void {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <TooltipProvider>
+          <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  it("keeps the picker when NO workspace resolves", () => {
+    // Zero rows is what a host that cannot answer resolves to, so the panel
+    // falls to "No workspace linked." The picker used to live in that
+    // conditional's OTHER arm, which meant choosing a host that could not
+    // answer removed the control that could choose a different one - and the
+    // pin is persisted, so it survived a reload. Same defect the git-diff
+    // panel had; `NewTerminalPickerBody` never had it.
+    fileTreeBindingsState.rows = [];
+
+    renderPanel();
+
+    expect(screen.getByTestId("epic-file-tree-empty")).toBeDefined();
+    expect(
+      screen.getByTestId("mock-workspace-picker-with-opener"),
+    ).toBeDefined();
+    const picker = screen.getByTestId("mock-file-tree-workspace-picker");
+    // Rendered with a NULL selection rather than being skipped - the picker
+    // already models "no workspace chosen" ("Select workspace").
+    expect(picker.getAttribute("data-selected-path")).toBe("");
+  });
+
+  it("still renders the picker once a workspace resolves", () => {
+    renderPanel();
+
+    expect(screen.queryByTestId("epic-file-tree-empty")).toBeNull();
+    expect(
+      screen
+        .getByTestId("mock-file-tree-workspace-picker")
+        .getAttribute("data-selected-path"),
+    ).toBe("/work/repo");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
@@ -10,6 +10,11 @@ import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { useFileTreeStore } from "@/stores/file-tree/file-tree-store";
+import {
+  HostRpcError,
+  HostTransportFailureError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 
 // Minimal harness for reaching the "file-tree" left panel's load-error state.
 // Mirrors the mocking approach in epic-sidebar-selection-mode.test.tsx (dnd
@@ -149,6 +154,10 @@ vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
 // pattern the sibling picker suites use.
 vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
   useHostClientForHostId: () => null,
+  // The failure state names the host it could not reach, so the panel reads
+  // the directory entry for its resolved host.
+  useHostDirectoryEntryForHostId: (hostId: string | null) =>
+    hostId === null ? undefined : { hostId, label: "Host One" },
 }));
 
 vi.mock("@/hooks/worktree/use-latest-conversation-workspace-seed", () => ({
@@ -345,22 +354,34 @@ vi.mock("@/stores/settings/settings-store", () => ({
 // Configurable so one arm can drive the ZERO-ROW read a host that cannot
 // answer produces - the state `useFileTreeWorkspaceSelection` resolves to a
 // null workspace path from, and therefore the panel's empty state.
+// `error` carries the CLASS, not just the fact of failure: only
+// `HostTransportFailureError` means the host never answered, and the panel
+// tells a different story for anything else.
 const fileTreeBindingsState = vi.hoisted(() => ({
   rows: [] as Array<{
     readonly runningDir: string;
     readonly disabledReason: string | null;
   }>,
+  error: null as HostRpcError | null,
+  refetch: vi.fn<() => Promise<unknown>>(),
 }));
 
+function fileTreeBindingsResult() {
+  return {
+    data:
+      fileTreeBindingsState.error === null
+        ? { rows: fileTreeBindingsState.rows }
+        : undefined,
+    error: fileTreeBindingsState.error,
+    refetch: fileTreeBindingsState.refetch,
+  };
+}
+
 vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
-  useWorktreeListBindingsForEpic: () => ({
-    data: { rows: fileTreeBindingsState.rows },
-  }),
+  useWorktreeListBindingsForEpic: () => fileTreeBindingsResult(),
   // `useFileTreeWorkspaceSelection` (also reached from the P0.2 pin chain)
   // calls the host-client-parametric variant, not the app-wide one above.
-  useWorktreeListBindingsForEpicForClient: () => ({
-    data: { rows: fileTreeBindingsState.rows },
-  }),
+  useWorktreeListBindingsForEpicForClient: () => fileTreeBindingsResult(),
 }));
 
 vi.mock("@/hooks/workspace/use-list-file-tree-query", () => ({
@@ -424,13 +445,19 @@ vi.mock("@/components/worktree/workspace-picker-with-opener", () => ({
   ),
 }));
 
+// `data-selected-path` distinguishes a NULL selection from an empty string:
+// collapsing both to "" would make the "renders with no workspace chosen"
+// assertion below unable to tell them apart, and "" is a path the picker could
+// in principle be handed.
 vi.mock("@/components/epic-canvas/sidebar/file-tree-workspace-picker", () => ({
   FileTreeWorkspacePicker: (props: {
     readonly selectedPath: string | null;
   }) => (
     <div
       data-testid="mock-file-tree-workspace-picker"
-      data-selected-path={props.selectedPath ?? ""}
+      data-selected-path={
+        props.selectedPath === null ? "<null>" : props.selectedPath
+      }
     />
   ),
 }));
@@ -505,6 +532,13 @@ describe("epic sidebar file-tree workspace picker persistence", () => {
     fileTreeBindingsState.rows = [
       { runningDir: "/work/repo", disabledReason: null },
     ];
+    fileTreeBindingsState.error = null;
+    fileTreeBindingsState.refetch.mockReset();
+    fileTreeBindingsState.refetch.mockResolvedValue(undefined);
+    // The selected workspace is STORE state, not fixture state, so without
+    // this the second test inherits whatever the first resolved and the order
+    // of these cases becomes load-bearing.
+    useFileTreeStore.setState({ selectedWorkspaceByEpicAndHost: {} });
   });
 
   afterEach(() => {
@@ -539,7 +573,70 @@ describe("epic sidebar file-tree workspace picker persistence", () => {
     const picker = screen.getByTestId("mock-file-tree-workspace-picker");
     // Rendered with a NULL selection rather than being skipped - the picker
     // already models "no workspace chosen" ("Select workspace").
-    expect(picker.getAttribute("data-selected-path")).toBe("");
+    expect(picker.getAttribute("data-selected-path")).toBe("<null>");
+  });
+
+  it("does not claim 'No workspace linked' when the host never ANSWERED", () => {
+    // A failed read and an answered-but-empty read both leave the selection
+    // null, so the panel used to tell one story for both. "No workspace
+    // linked." is a claim about the agent; this is a fact about the
+    // connection, and only one of them has a remedy the user can act on.
+    fileTreeBindingsState.rows = [];
+    fileTreeBindingsState.error = new HostTransportFailureError({
+      code: "RPC_ERROR",
+      message: "dial failed",
+      requestId: "req-test",
+      method: "worktree.listBindingsForEpic",
+      fatalDetails: null,
+    });
+
+    renderPanel();
+
+    expect(
+      screen.getByTestId("file-tree-workspaces-unavailable"),
+    ).toBeDefined();
+    expect(screen.queryByTestId("epic-file-tree-empty")).toBeNull();
+    // The picker still outlives it - the same invariant as the empty state.
+    expect(
+      screen.getByTestId("mock-workspace-picker-with-opener"),
+    ).toBeDefined();
+  });
+
+  it("offers a retry, because nothing else re-reads the bindings", () => {
+    fileTreeBindingsState.rows = [];
+    fileTreeBindingsState.error = new HostTransportFailureError({
+      code: "RPC_ERROR",
+      message: "dial failed",
+      requestId: "req-test",
+      method: "worktree.listBindingsForEpic",
+      fatalDetails: null,
+    });
+
+    renderPanel();
+    fireEvent.click(
+      screen.getByTestId("file-tree-workspaces-unavailable-retry"),
+    );
+
+    // Host-scoped queries disable retry, polling and focus/reconnect refetch,
+    // so without this button the panel sits there until the tab is reloaded.
+    expect(fileTreeBindingsState.refetch).toHaveBeenCalled();
+  });
+
+  it("shows the host's own reason when it ANSWERED with a refusal", () => {
+    fileTreeBindingsState.rows = [];
+    fileTreeBindingsState.error = new HostRpcError({
+      code: "RPC_ERROR",
+      message: "not authorized",
+      requestId: "req-test",
+      method: "worktree.listBindingsForEpic",
+      fatalDetails: null,
+    });
+
+    renderPanel();
+
+    expect(
+      screen.getByTestId("file-tree-workspaces-unavailable-reason").textContent,
+    ).toBe("not authorized");
   });
 
   it("still renders the picker once a workspace resolves", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -209,6 +209,12 @@ import {
   type SidebarBulkSelectionPanelId,
 } from "@/components/epic-canvas/sidebar/epic-sidebar-selection";
 import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
+import { FileTreeWorkspacesUnavailable } from "@/components/epic-canvas/sidebar/file-tree-workspaces-unavailable";
+import { useHostDirectoryEntryForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import {
+  classifyBindingsFailure,
+  type BindingsFailure,
+} from "@/lib/worktree/bindings-failure";
 import { useShallow } from "zustand/react/shallow";
 
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -228,6 +234,18 @@ interface FileTreeWorkspaceSelection {
   readonly hostId: string | null;
   readonly selectedWorkspacePath: string | null;
   readonly setSelectedWorkspacePath: (workspacePath: string) => void;
+  /**
+   * Non-null when the bindings read FAILED, as opposed to answering with no
+   * browsable roots. Both leave `selectedWorkspacePath` null, and the panel
+   * must not tell the same story about them.
+   */
+  readonly failure: BindingsFailure | null;
+  /**
+   * Re-runs the bindings read. The panel's only recovery: host-scoped queries
+   * disable retry, polling and focus/reconnect refetch, so an errored read
+   * stays errored until something asks again.
+   */
+  readonly retry: () => Promise<void>;
 }
 
 function useFileTreeWorkspaceSelection(
@@ -304,10 +322,16 @@ function useFileTreeWorkspaceSelection(
     },
     [epicId, hostId, setSelectedWorkspace],
   );
+  const { refetch: refetchWorkspaces } = workspacesQuery;
+  const retry = useCallback(async (): Promise<void> => {
+    await refetchWorkspaces();
+  }, [refetchWorkspaces]);
   return {
     hostId,
     selectedWorkspacePath,
     setSelectedWorkspacePath,
+    failure: classifyBindingsFailure(workspacesQuery.error),
+    retry,
   };
 }
 
@@ -1134,6 +1158,7 @@ function FileTreePanelBodyLive(props: LeftPanelBodyProps) {
   // dispatch on the host the workspace selection actually names, not the
   // app-wide effective host.
   const hostClient = useSurfaceHostClient(pin.resolvedHostId);
+  const resolvedHostEntry = useHostDirectoryEntryForHostId(pin.resolvedHostId);
   const handleSelectPath = (workspacePath: string): void => {
     pin.latchOnFirstUse();
     selection.setSelectedWorkspacePath(workspacePath);
@@ -1174,24 +1199,68 @@ function FileTreePanelBodyLive(props: LeftPanelBodyProps) {
           hostClient={hostClient}
         />
       </div>
-      {selection.selectedWorkspacePath === null ? (
-        <SidebarPanelEmptyState
-          icon={FolderOpen}
-          title="No workspace linked."
-          description={null}
-          testId="epic-file-tree-empty"
-        />
-      ) : (
-        <FileTreePanelBodyForWorkspace
-          key={selection.selectedWorkspacePath}
-          epicId={props.epicId}
-          tabId={props.tabId}
-          workspacePath={selection.selectedWorkspacePath}
-          hostId={pin.resolvedHostId}
-          onLatchHost={pin.latchOnFirstUse}
-        />
-      )}
+      {fileTreePanelBody({
+        epicId: props.epicId,
+        tabId: props.tabId,
+        selection,
+        resolvedHostId: pin.resolvedHostId,
+        resolvedHostName: resolvedHostEntry?.label ?? null,
+        onLatchHost: pin.latchOnFirstUse,
+      })}
     </div>
+  );
+}
+
+/**
+ * The three states below the picker, in the order their conditions must be
+ * asked - which is not the order they were written in.
+ *
+ * A FAILED bindings read is checked first, because it also leaves
+ * `selectedWorkspacePath` null and would otherwise fall through to "No
+ * workspace linked." That sentence is a claim about the agent ("you have not
+ * linked one"), and here the truth is a fact about the connection ("we could
+ * not ask") - the same wrong-remedy conflation the git-diff panel's empty
+ * state had. It is also the only branch that offers a way out: host-scoped
+ * queries disable every automatic recovery route, so nothing re-reads on its
+ * own.
+ */
+function fileTreePanelBody(input: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly selection: FileTreeWorkspaceSelection;
+  readonly resolvedHostId: string | null;
+  readonly resolvedHostName: string | null;
+  readonly onLatchHost: () => void;
+}): ReactNode {
+  const { selection } = input;
+  if (selection.failure !== null) {
+    return (
+      <FileTreeWorkspacesUnavailable
+        failure={selection.failure}
+        hostName={input.resolvedHostName}
+        onRetry={selection.retry}
+      />
+    );
+  }
+  if (selection.selectedWorkspacePath === null) {
+    return (
+      <SidebarPanelEmptyState
+        icon={FolderOpen}
+        title="No workspace linked."
+        description={null}
+        testId="epic-file-tree-empty"
+      />
+    );
+  }
+  return (
+    <FileTreePanelBodyForWorkspace
+      key={selection.selectedWorkspacePath}
+      epicId={input.epicId}
+      tabId={input.tabId}
+      workspacePath={selection.selectedWorkspacePath}
+      hostId={input.resolvedHostId}
+      onLatchHost={input.onLatchHost}
+    />
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -1138,8 +1138,42 @@ function FileTreePanelBodyLive(props: LeftPanelBodyProps) {
     pin.latchOnFirstUse();
     selection.setSelectedWorkspacePath(workspacePath);
   };
+  // The picker is OUTSIDE the selection branch, and that is load-bearing
+  // rather than cosmetic: its popover carries `WorktreePickerHostSection`, so
+  // while it lived in the `else` arm the empty state removed the only control
+  // that could change the host - and pinning this panel to a host that cannot
+  // answer resolves NO workspace roots, which lands exactly there. The pin is
+  // persisted, so that was a dead end that survived reloads. The git-diff
+  // panel had the identical shape; `NewTerminalPickerBody` never did, and it
+  // is the model here - host section first, unconditionally, whatever the body
+  // below it turns out to be.
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 px-2 pb-1.5 pt-0.5">
+        <WorkspacePickerWithOpener
+          picker={
+            <FileTreeWorkspacePicker
+              epicId={props.epicId}
+              hostId={selection.hostId}
+              selectedPath={selection.selectedWorkspacePath}
+              onSelectPath={handleSelectPath}
+              surfaceKey={surfaceKey}
+            />
+          }
+          // Nothing to open while no workspace is selected; the opener renders
+          // inert rather than aiming at the host that just failed to answer.
+          openTarget={
+            selection.hostId !== null &&
+            selection.selectedWorkspacePath !== null
+              ? {
+                  workspacePath: selection.selectedWorkspacePath,
+                  hostId: selection.hostId,
+                }
+              : null
+          }
+          hostClient={hostClient}
+        />
+      </div>
       {selection.selectedWorkspacePath === null ? (
         <SidebarPanelEmptyState
           icon={FolderOpen}
@@ -1148,38 +1182,14 @@ function FileTreePanelBodyLive(props: LeftPanelBodyProps) {
           testId="epic-file-tree-empty"
         />
       ) : (
-        <>
-          <div className="shrink-0 px-2 pb-1.5 pt-0.5">
-            <WorkspacePickerWithOpener
-              picker={
-                <FileTreeWorkspacePicker
-                  epicId={props.epicId}
-                  hostId={selection.hostId}
-                  selectedPath={selection.selectedWorkspacePath}
-                  onSelectPath={handleSelectPath}
-                  surfaceKey={surfaceKey}
-                />
-              }
-              openTarget={
-                selection.hostId !== null
-                  ? {
-                      workspacePath: selection.selectedWorkspacePath,
-                      hostId: selection.hostId,
-                    }
-                  : null
-              }
-              hostClient={hostClient}
-            />
-          </div>
-          <FileTreePanelBodyForWorkspace
-            key={selection.selectedWorkspacePath}
-            epicId={props.epicId}
-            tabId={props.tabId}
-            workspacePath={selection.selectedWorkspacePath}
-            hostId={pin.resolvedHostId}
-            onLatchHost={pin.latchOnFirstUse}
-          />
-        </>
+        <FileTreePanelBodyForWorkspace
+          key={selection.selectedWorkspacePath}
+          epicId={props.epicId}
+          tabId={props.tabId}
+          workspacePath={selection.selectedWorkspacePath}
+          hostId={pin.resolvedHostId}
+          onLatchHost={pin.latchOnFirstUse}
+        />
       )}
     </div>
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/file-tree-workspaces-unavailable.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/file-tree-workspaces-unavailable.tsx
@@ -1,0 +1,93 @@
+import { useCallback, type ReactNode } from "react";
+import { AlertCircle, Unplug } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import type { BindingsFailure } from "@/lib/worktree/bindings-failure";
+
+const FILE_TREE_RETRY_TIMEOUT_MS = 10_000;
+
+/**
+ * Shown when the file-tree panel's worktree-bindings read FAILED, in place of
+ * the "No workspace linked." empty state.
+ *
+ * That empty state is right for a host that answered and has nothing bound,
+ * and wrong for one that could not be asked: it reads as a fact about the
+ * agent ("you have not linked a workspace") when the truth is a fact about the
+ * connection, and it offers no way back. This panel resolves no workspace
+ * roots from a host that cannot answer, so a pinned host going offline landed
+ * there - and host-scoped queries disable every automatic recovery route, so
+ * nothing re-dialed on its own.
+ *
+ * It mirrors the git-diff panel's pair of failure states rather than sharing
+ * them, because the copy and the test ids belong to this panel; what the two
+ * DO share is {@link BindingsFailure}, so they can never disagree about which
+ * failure a given error is.
+ */
+export function FileTreeWorkspacesUnavailable(props: {
+  readonly failure: BindingsFailure;
+  /** Display name of the host that did not answer. `null` while unresolved. */
+  readonly hostName: string | null;
+  /** Must resolve when the re-read SETTLES, or the spinner lies. */
+  readonly onRetry: () => Promise<void>;
+}): ReactNode {
+  const onRetry = props.onRetry;
+  const handleRefresh = useCallback((): Promise<void> => onRetry(), [onRetry]);
+  const refresh = useRefreshSpinner({
+    onRefresh: handleRefresh,
+    externalRefreshing: false,
+    timeoutMs: FILE_TREE_RETRY_TIMEOUT_MS,
+  });
+  const unreachable = props.failure.kind === "unreachable";
+  const Icon = unreachable ? Unplug : AlertCircle;
+  const unreachableTitle =
+    props.hostName === null
+      ? "Can't reach this host"
+      : `Can't reach ${props.hostName}`;
+  const title = unreachable ? unreachableTitle : "Couldn't load workspaces";
+  const reason =
+    props.failure.kind === "answered"
+      ? props.failure.message
+      : "This panel is pointed at a host that isn't responding. Pick another host above, or try again.";
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-1 flex-col items-center justify-center gap-2 px-4 py-8 text-center text-muted-foreground"
+      data-testid="file-tree-workspaces-unavailable"
+    >
+      <Icon
+        className={
+          unreachable ? "size-8 text-warning/70" : "size-8 text-destructive/70"
+        }
+        aria-hidden
+      />
+      <div className="space-y-1">
+        <p className="text-ui-sm text-muted-foreground/60">{title}</p>
+        <p
+          className="text-ui-xs text-muted-foreground/50"
+          data-testid="file-tree-workspaces-unavailable-reason"
+        >
+          {reason}
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-2"
+        onClick={refresh.trigger}
+        disabled={refresh.refreshing}
+        data-testid="file-tree-workspaces-unavailable-retry"
+      >
+        {refresh.refreshing ? (
+          <AgentSpinningDots
+            className="mr-1.5"
+            testId="file-tree-workspaces-unavailable-retry-spinner"
+            variant={undefined}
+          />
+        ) : null}
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/clients/gui-app/src/hooks/host/use-surface-host-pin.ts
+++ b/clients/gui-app/src/hooks/host/use-surface-host-pin.ts
@@ -41,6 +41,20 @@ export interface SurfaceHostPin {
    * never be silent about which machine it is about to create on.
    */
   readonly resolvedHostId: string | null;
+  /**
+   * Where this surface would resolve with NO pin - its default tier if it has
+   * one, else `effective`. In other words, what clearing the pin would move it
+   * to.
+   *
+   * It is here rather than read at the call site because the app-wide host
+   * reads are fenced out of Epic-session surfaces by lint, and correctly so: a
+   * panel that re-derived `effective` itself would be a second decider on the
+   * question this hook already answers. A surface offering "return to
+   * following" needs to know whether that would MOVE anything - a remedy that
+   * resolves to the same machine is a button that cannot work - and this is
+   * that answer, computed on the same three tiers `resolvedHostId` is.
+   */
+  readonly followingHostId: string | null;
   readonly isPinned: boolean;
   readonly latchOnFirstUse: () => void;
 }
@@ -167,6 +181,7 @@ function useSurfaceHostPinResolved(
     honoredSelection,
     setSelection,
     resolvedHostId,
+    followingHostId: honoredDefaultHostId ?? effectiveHostId,
     isPinned: selection !== null,
     latchOnFirstUse,
     resolvedFrom,

--- a/clients/gui-app/src/hooks/host/use-surface-host-pin.ts
+++ b/clients/gui-app/src/hooks/host/use-surface-host-pin.ts
@@ -148,9 +148,14 @@ function useSurfaceHostPinResolved(
     defaultHostId !== null && !isSurfacePinDeposed(defaultHostId, fleet)
       ? defaultHostId
       : null;
+  // ONE local, deliberately: `resolvedHostId` falls back to this exact value,
+  // and consumers compare the two to ask "would unpinning move me?"
+  // (`resolvedHostId !== followingHostId`). That question is only answerable
+  // while both are the same expression, so they must not be able to drift.
+  const followingHostId = honoredDefaultHostId ?? effectiveHostId;
   const resolvedHostId = resolvedSurfaceHostId(
     selection,
-    honoredDefaultHostId ?? effectiveHostId,
+    followingHostId,
     fleet,
   );
   const resolvedFrom = resolvedTier(honoredSelection, honoredDefaultHostId);
@@ -181,7 +186,7 @@ function useSurfaceHostPinResolved(
     honoredSelection,
     setSelection,
     resolvedHostId,
-    followingHostId: honoredDefaultHostId ?? effectiveHostId,
+    followingHostId,
     isPinned: selection !== null,
     latchOnFirstUse,
     resolvedFrom,

--- a/clients/gui-app/src/lib/worktree/bindings-failure.ts
+++ b/clients/gui-app/src/lib/worktree/bindings-failure.ts
@@ -1,0 +1,40 @@
+import {
+  HostRpcError,
+  HostTransportFailureError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+
+/**
+ * Why a worktree-bindings read failed, reduced to the only distinction a
+ * surface can act on.
+ *
+ * `unreachable` is the machine not answering. Everything else is the host
+ * answering with a refusal - unauthorized, unsupported method, an internal
+ * failure on the far side - and the two are NOT interchangeable: one is fixed
+ * by re-dialing or moving off a pin, the other only by reading what the host
+ * said. Presenting an answered refusal as an offline machine names a remedy on
+ * the wrong box and hides the one fact that could point at a cause, which is
+ * the defect the panels' empty states were rewritten to stop making.
+ *
+ * It lives here rather than in either panel because BOTH the git-diff panel
+ * and the file-tree panel read the same bindings call, and two surfaces that
+ * disagreed about what "unreachable" means would show a user two different
+ * stories about one host.
+ */
+export type BindingsFailure =
+  | { readonly kind: "unreachable" }
+  | { readonly kind: "answered"; readonly message: string };
+
+export function classifyBindingsFailure(
+  error: HostRpcError | null,
+): BindingsFailure | null {
+  if (error === null) return null;
+  // `HostTransportFailureError` extends `HostRpcError`, so this order matters:
+  // it is the ONLY error that means the host did not answer.
+  if (error instanceof HostTransportFailureError)
+    return { kind: "unreachable" };
+  const message = error.message.trim();
+  return {
+    kind: "answered",
+    message: message.length > 0 ? message : "The host refused the request.",
+  };
+}

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -5006,6 +5006,76 @@ describe("selection authority dial-evidence instrumentation", () => {
     authority.dispose();
   });
 
+  it("warns ONCE per stall episode, not once per dial past the threshold", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // The test above stops exactly AT the threshold, so it cannot tell "fire
+    // at the crossing" from "fire at or above it". This one runs well past it:
+    // a prolonged outage is when this warn fires and also when dials are most
+    // frequent, so warning on every subsequent report would bury the
+    // transition under its own repetitions, in the logs of the very incident
+    // it exists to mark.
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      sessionEvidence("H", "s1", "established", 0),
+    );
+    const dials = CONFIRMED_DEATH_REFUSAL_STREAK * 4;
+    for (let i = 0; i < dials; i += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialRefusal("H", `attempt-${i}`, null, i),
+      );
+    }
+
+    expect(stallWarnings(log.records)).toHaveLength(1);
+    // Every report is still individually recorded - the `debug` channel keeps
+    // the full history, so quieting the warn costs no evidence.
+    expect(dialLogs(log.records)).toHaveLength(dials);
+
+    authority.dispose();
+  });
+
+  it("warns again after a host recovers and stalls a SECOND time", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // Latching on the host forever would be the wrong cure for the flood: a
+    // machine that recovers and then strands a surface again is a new
+    // incident, and the second one is exactly as worth reporting as the first.
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      sessionEvidence("H", "s1", "established", 0),
+    );
+    let seq = 0;
+    for (let episode = 0; episode < 2; episode += 1) {
+      for (let i = 0; i < CONFIRMED_DEATH_REFUSAL_STREAK; i += 1) {
+        seq += 1;
+        engine.ingestEvidence(
+          "A",
+          incarnationId,
+          dialRefusal("H", `attempt-${seq}`, null, seq),
+        );
+      }
+      seq += 1;
+      // Proof of life clears the stall.
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialOutcome("H", `attempt-${seq}`, "success", seq),
+      );
+    }
+
+    expect(stallWarnings(log.records)).toHaveLength(2);
+
+    authority.dispose();
+  });
+
   it("stays silent on a healthy host - the stall resets on any real evidence", () => {
     const log = createRecordingAuthorityLog();
     const { authority, incarnationId } = attachedAuthority(log);

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -5039,6 +5039,127 @@ describe("selection authority dial-evidence instrumentation", () => {
     authority.dispose();
   });
 
+  it("names the crossing ONCE - later refusals stay ordinary `counted`", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    const dials = CONFIRMED_DEATH_REFUSAL_STREAK + 3;
+    for (let i = 0; i < dials; i += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialRefusal("H", `attempt-${i}`, null, i),
+      );
+    }
+
+    // The lease DECISION stays `>=` - the host is dead and stays dead - but
+    // the label marks the single report that crossed. `>=` here would report a
+    // long outage as an unbroken run of deaths.
+    const dispositions = dialLogs(log.records).map(
+      (record) => record.detail.disposition,
+    );
+    expect(
+      dispositions.filter((d) => d === "counted-reached-death"),
+    ).toHaveLength(1);
+    expect(dispositions[CONFIRMED_DEATH_REFUSAL_STREAK - 1]).toBe(
+      "counted-reached-death",
+    );
+    expect(dispositions[CONFIRMED_DEATH_REFUSAL_STREAK]).toBe("counted");
+    expect(findLease(engine.snapshot().leases, "H")?.status).toBe("dead");
+
+    authority.dispose();
+  });
+
+  it("keeps NO stall state for a host outside the fleet", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // Evidence for an unknown host is dropped, so there is no lease to strand
+    // a surface on and nothing to warn about. Accumulating here would grow one
+    // entry per distinct id between fleet snapshots, and an entry recreated
+    // after a prune would be inherited by a durable id that later re-registers.
+    for (let i = 0; i < CONFIRMED_DEATH_REFUSAL_STREAK * 3; i += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialRefusal(`GONE-${i}`, `attempt-${i}`, null, i),
+      );
+    }
+    // Same id repeatedly, which is the case a per-host counter would catch.
+    for (let i = 0; i < CONFIRMED_DEATH_REFUSAL_STREAK * 3; i += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialRefusal("GONE", `gone-${i}`, null, 100 + i),
+      );
+    }
+
+    expect(stallWarnings(log.records)).toHaveLength(0);
+
+    authority.dispose();
+  });
+
+  it("does not count a REPLAYED success as a stalled failure", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // A duplicate is classified before its outcome is ever read, so a success
+    // arriving twice looks exactly like a refusal that went nowhere. Warning
+    // "dial failures are not advancing" on a run of successes would point the
+    // reader at the opposite of what happened.
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialOutcome("H", "same", "success", 0),
+    );
+    for (let i = 0; i < CONFIRMED_DEATH_REFUSAL_STREAK * 2; i += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialOutcome("H", "same", "success", 1 + i),
+      );
+    }
+
+    expect(stallWarnings(log.records)).toHaveLength(0);
+
+    authority.dispose();
+  });
+
+  it("clears the stall on proof of life that is not a dial - a session", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // `onHostProvedAlive` is the funnel for every kind of proof, not just a
+    // dial success. Without clearing there, inert reports from BEFORE a
+    // recovery combine with one after it and warn about an episode that ended.
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialOutcome("H", "a1", "indeterminate", 0),
+    );
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialOutcome("H", "a2", "indeterminate", 1),
+    );
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      sessionEvidence("H", "s1", "established", 2),
+    );
+    // With the session live every later refusal is suppressed, so this is the
+    // first report after the recovery and must not complete the old episode.
+    engine.ingestEvidence("A", incarnationId, dialRefusal("H", "a3", null, 3));
+
+    expect(stallWarnings(log.records)).toHaveLength(0);
+
+    authority.dispose();
+  });
+
   it("warns again after a host recovers and stalls a SECOND time", () => {
     const log = createRecordingAuthorityLog();
     const { authority, incarnationId } = attachedAuthority(log);

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -36,11 +36,14 @@ import {
 } from "../in-process-selection-authority";
 import {
   createFakeAuthorityClock,
+  createRecordingAuthorityLog,
   createTestAuthority,
   fleetHost,
   findLease,
   recordEngineEvents,
+  type RecordedAuthorityLog,
   type RecordedEngineEvent,
+  type RecordingAuthorityLog,
 } from "./selection-authority-harness";
 
 // ---------------------------------------------------------------- builders
@@ -4839,6 +4842,219 @@ describe("SelectionAuthorityEngineImpl - compat anchor must displace, not merely
       compatIncompatible("H", "s1", INCOMPAT_DETAIL),
     );
     expect(findLease(engine.snapshot().leases, "H")?.status).not.toBe("dead");
+
+    authority.dispose();
+  });
+});
+
+/**
+ * The dial-evidence path's instrumentation.
+ *
+ * These exist because "a pinned host stopped answering and its lease never
+ * reached `dead`" was not diagnosable from a production log. Six of
+ * `ingestDial`'s seven exits were indistinguishable from outside - two logged
+ * at `debug` (which the renderer drops in production, where the level defaults
+ * to `info`) and four logged nothing - so a refusal that was dropped,
+ * deduplicated or classified inert left exactly the same trace as a dial that
+ * never happened. Those two have opposite fixes, so the instrument's whole job
+ * is telling them apart.
+ *
+ * Every disposition gets its own arm deliberately: an instrument asserted only
+ * on its happy path is the one that reports "nothing found" when the truth is
+ * "nothing ran".
+ */
+describe("selection authority dial-evidence instrumentation", () => {
+  function dialLogs(records: ReadonlyArray<RecordedAuthorityLog>) {
+    return records.filter(
+      (record) => record.message === "[selection-authority] dial evidence",
+    );
+  }
+
+  function stallWarnings(records: ReadonlyArray<RecordedAuthorityLog>) {
+    return records.filter((record) => record.level === "warn");
+  }
+
+  function attachedAuthority(log: RecordingAuthorityLog) {
+    const clock = createFakeAuthorityClock(0);
+    const authority = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: null,
+        hosts: [fleetHost("H", "remote")],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+      log,
+    });
+    const seq = authority.engine.allocateAttachSeq("A");
+    const attach = authority.engine.attach("A", attachRequest(seq, []));
+    if (!attach.ok) throw new Error("expected attach to succeed");
+    return { authority, incarnationId: attach.incarnationId };
+  }
+
+  it("reports a disposition for EVERY dial exit, including the silent ones", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // 1. counted
+    engine.ingestEvidence("A", incarnationId, dialRefusal("H", "a1", null, 0));
+    // 2. dropped-duplicate-attempt (same attempt id)
+    engine.ingestEvidence("A", incarnationId, dialRefusal("H", "a1", null, 1));
+    // 3. inert-indeterminate
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialOutcome("H", "a2", "indeterminate", 2),
+    );
+    // 4. cleared-by-success
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialOutcome("H", "a3", "success", 3),
+    );
+    // 5. suppressed-live-session
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      sessionEvidence("H", "s1", "established", 4),
+    );
+    engine.ingestEvidence("A", incarnationId, dialRefusal("H", "a4", null, 5));
+    // 6. dropped-outside-fleet
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialRefusal("GONE", "a5", null, 6),
+    );
+
+    expect(
+      dialLogs(log.records).map((record) => record.detail.disposition),
+    ).toEqual([
+      "counted",
+      "dropped-duplicate-attempt",
+      "inert-indeterminate",
+      "cleared-by-success",
+      "suppressed-live-session",
+      "dropped-outside-fleet",
+    ]);
+
+    authority.dispose();
+  });
+
+  it("names the death crossing distinctly from an ordinary counted refusal", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+
+    for (let i = 0; i < CONFIRMED_DEATH_REFUSAL_STREAK; i += 1) {
+      authority.engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialRefusal("H", `attempt-${i}`, null, i),
+      );
+    }
+
+    const dispositions = dialLogs(log.records).map(
+      (record) => record.detail.disposition,
+    );
+    // Only the crossing is distinguished; everything before it is progress.
+    expect(dispositions[dispositions.length - 1]).toBe("counted-reached-death");
+    expect(dispositions.slice(0, -1).every((d) => d === "counted")).toBe(true);
+    // The streak is reported as it stands AFTER the decision, so a reader can
+    // see it advance rather than having to count the lines.
+    expect(
+      dialLogs(log.records).map((record) => record.detail.refusalStreak),
+    ).toEqual(
+      Array.from({ length: CONFIRMED_DEATH_REFUSAL_STREAK }, (_, i) => i + 1),
+    );
+    expect(findLease(authority.engine.snapshot().leases, "H")?.status).toBe(
+      "dead",
+    );
+
+    authority.dispose();
+  });
+
+  it("warns once dial failures stop advancing the streak - the reported pathology", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // A live session suppresses every refusal (invariant 5), so the host fails
+    // repeatedly while its lease can never move. This is the shape that
+    // strands a pinned surface, and it is silent in production today.
+    engine.ingestEvidence(
+      "A",
+      incarnationId,
+      sessionEvidence("H", "s1", "established", 0),
+    );
+    for (let i = 0; i < CONFIRMED_DEATH_REFUSAL_STREAK; i += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialRefusal("H", `attempt-${i}`, null, i),
+      );
+    }
+
+    const warnings = stallWarnings(log.records);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].detail).toMatchObject({
+      hostId: "H",
+      disposition: "suppressed-live-session",
+      consecutiveNonCounting: CONFIRMED_DEATH_REFUSAL_STREAK,
+      refusalStreak: 0,
+    });
+
+    authority.dispose();
+  });
+
+  it("stays silent on a healthy host - the stall resets on any real evidence", () => {
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+    const { engine } = authority;
+
+    // Two non-counting reports, then proof of life, repeatedly. A warn here
+    // would fire on every ordinary reconnect and the signal would be worthless.
+    for (let round = 0; round < 4; round += 1) {
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialOutcome("H", `ind-${round}-a`, "indeterminate", round),
+      );
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialOutcome("H", `ind-${round}-b`, "indeterminate", round),
+      );
+      engine.ingestEvidence(
+        "A",
+        incarnationId,
+        dialOutcome("H", `ok-${round}`, "success", round),
+      );
+    }
+
+    expect(stallWarnings(log.records)).toHaveLength(0);
+
+    authority.dispose();
+  });
+
+  it("does not materialise an evidence record for a host whose dial was dropped", () => {
+    // The instrument reads the streak WITHOUT `hostEvidence()`, because the
+    // evidence map's emptiness is load-bearing ("never dialed" gates the
+    // launch-time ensure). A diagnostic that created records here would change
+    // which hosts get provisioned - observable as a lease that stops being
+    // `connecting` for a host nothing legitimately dialed.
+    const log = createRecordingAuthorityLog();
+    const { authority, incarnationId } = attachedAuthority(log);
+
+    authority.engine.ingestEvidence(
+      "A",
+      incarnationId,
+      dialOutcome("H", "a1", "indeterminate", 0),
+    );
+
+    expect(findLease(authority.engine.snapshot().leases, "H")?.status).toBe(
+      "connecting",
+    );
+    expect(dialLogs(log.records)[0].detail.refusalStreak).toBe(0);
 
     authority.dispose();
   });

--- a/clients/shared/host-selection/__tests__/selection-authority-harness.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-harness.ts
@@ -19,6 +19,7 @@ import {
   silentAuthorityLog,
   SelectionAuthorityEngineImpl,
   type AuthorityClock,
+  type AuthorityLog,
   type PreferredHostStore,
 } from "../selection-authority-engine";
 import {
@@ -160,6 +161,8 @@ export function createTestAuthority(input: {
   readonly localHostEnsure?: LocalHostEnsurePort;
   readonly preferredStore?: PreferredHostStore;
   readonly seedPreferred?: string | null;
+  /** Defaults to the silent log; pass a recorder to assert on diagnostics. */
+  readonly log?: AuthorityLog;
 }): TestAuthority {
   const fleet = new InMemoryHostFleetSource({
     revision: 0,
@@ -184,7 +187,7 @@ export function createTestAuthority(input: {
     preferredStore,
     clock: input.clock,
     newIncarnationId: createIncrementingIncarnationIds(),
-    log: silentAuthorityLog,
+    log: input.log ?? silentAuthorityLog,
   });
   const { events, subscriptions } = recordEngineEvents(engine);
   return {
@@ -197,6 +200,37 @@ export function createTestAuthority(input: {
     dispose: () => {
       for (const subscription of subscriptions) subscription.dispose();
       engine.dispose();
+    },
+  };
+}
+
+/** One captured {@link AuthorityLog} call. */
+export interface RecordedAuthorityLog {
+  readonly level: "debug" | "warn";
+  readonly message: string;
+  readonly detail: Record<string, unknown>;
+}
+
+/**
+ * An {@link AuthorityLog} that keeps what it was told.
+ *
+ * The engine's dial-evidence instrumentation is only worth having if it is
+ * exhaustive, and "exhaustive" is a claim about lines that DO get emitted -
+ * which the silent log cannot see. Tests assert against this.
+ */
+export interface RecordingAuthorityLog extends AuthorityLog {
+  readonly records: RecordedAuthorityLog[];
+}
+
+export function createRecordingAuthorityLog(): RecordingAuthorityLog {
+  const records: RecordedAuthorityLog[] = [];
+  return {
+    records,
+    debug: (message, detail) => {
+      records.push({ level: "debug", message, detail });
+    },
+    warn: (message, detail) => {
+      records.push({ level: "warn", message, detail });
     },
   };
 }

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -1383,6 +1383,13 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     evidence.refusalStreak = 0;
     evidence.lastCountedRefusalDetail = null;
     evidence.restartEpisodeEndsAt = null;
+    // The dial-stall counter retires with the streak, and HERE rather than
+    // only on a dial success, because this is the single funnel every kind of
+    // proof already passes through. A session appearing, an announcement or a
+    // successful ensure all mean the authority learned something; leaving the
+    // counter set would let inert reports from before the recovery combine
+    // with one after it to warn about an episode that had already ended.
+    this.dialStalls.delete(hostId);
     // Proof of life is proof of life: it retires the corpse deadline for the
     // same reason it clears the streak. This is the ONLY producer that needs
     // to know about the deadline, because every kind of proof already funnels
@@ -1439,7 +1446,12 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       report.outcome === "confirmed-refusal" ? report.refusalDetail : null;
     this.recordDialDisposition(
       report,
-      evidence.refusalStreak >= CONFIRMED_DEATH_REFUSAL_STREAK
+      // Equality, not `>=`: this names the ONE report that crossed, which is
+      // what a reader is looking for. The lease decision itself stays `>=` -
+      // a host at or above the threshold IS dead, and it stays dead - but a
+      // label that re-announced the crossing on every later refusal would
+      // report a prolonged outage as an endless series of deaths.
+      evidence.refusalStreak === CONFIRMED_DEATH_REFUSAL_STREAK
         ? "counted-reached-death"
         : "counted",
     );
@@ -1496,12 +1508,26 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       refusalStreak: streakAfter,
       deathThreshold: CONFIRMED_DEATH_REFUSAL_STREAK,
     });
+    // Evidence for a host outside the fleet is DROPPED, so there is no stall
+    // to track: this host has no lease to strand a surface on. Creating an
+    // entry here would also grow the map once per distinct unknown id between
+    // fleet snapshots, and - worse - survive a prune, because an in-flight
+    // report landing after `pruneEvidenceOutsideFleet` recreates the entry,
+    // and the NEXT prune sees a durable id that has since re-registered and
+    // keeps it. The re-registered host would then inherit a stall it never
+    // earned and warn early.
+    if (disposition === "dropped-outside-fleet") {
+      this.dialStalls.delete(hostId);
+      return;
+    }
     // A success is proof of life and a counted refusal is progress toward a
     // verdict; either way the authority learned something, so the stall ends.
-    if (
-      disposition === "cleared-by-success" ||
-      dispositionCounts(disposition)
-    ) {
+    //
+    // Keyed off the report's OUTCOME rather than the disposition alone, because
+    // a success that arrives twice is classified `dropped-duplicate-attempt`
+    // before its outcome is ever examined. Counting that as a stalled failure
+    // would let a replayed SUCCESS raise "dial failures are not advancing".
+    if (report.outcome === "success" || dispositionCounts(disposition)) {
       this.dialStalls.delete(hostId);
       return;
     }

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -1473,6 +1473,13 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    * healthy fleet by construction - a success or a counted refusal both reset
    * it - and it fires exactly when a host is failing while its lease cannot
    * move, which is the state that strands a pinned surface.
+   *
+   * It fires ONCE per stall episode, at the crossing. The alternative - warn
+   * while the counter sits at or above the threshold - turns the longest
+   * outages into the loudest ones and buries the transition under its own
+   * repetitions; the counter still climbs, and the `debug` line still carries
+   * every individual report. A later success or counted refusal clears the
+   * stall, so a host that recovers and stalls again warns again.
    */
   private recordDialDisposition(
     report: Extract<SelectionEvidenceReport, { kind: "dial" }>,
@@ -1500,7 +1507,12 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     }
     const stalled = (this.dialStalls.get(hostId) ?? 0) + 1;
     this.dialStalls.set(hostId, stalled);
-    if (stalled < CONFIRMED_DEATH_REFUSAL_STREAK) return;
+    // Exactly at the crossing, not `>=`. A prolonged outage is precisely when
+    // this fires, and it is also when dials are most frequent, so a `>=` here
+    // would warn on EVERY subsequent report and bury the transition it exists
+    // to mark. The counter keeps climbing either way; the `debug` line above
+    // carries each individual report for anyone reading the whole history.
+    if (stalled !== CONFIRMED_DEATH_REFUSAL_STREAK) return;
     this.options.log.warn(
       "[selection-authority] dial failures are not advancing the death streak",
       {

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -308,6 +308,44 @@ export const silentAuthorityLog: AuthorityLog = {
 };
 
 /**
+ * What the authority DID with one dial report - the complete, closed set of
+ * exits from {@link SelectionAuthorityEngineImpl.ingestDial}.
+ *
+ * It exists because "the refusal streak never reached the threshold" was not
+ * answerable from a production log. Six of these seven exits used to be
+ * indistinguishable from outside: two logged at `debug` (which the renderer
+ * drops in production, where the default level is `info`) and four logged
+ * nothing at all. A report that advances no counter and leaves no trace is
+ * the same observation as a report that never arrived, and those two have
+ * opposite fixes - one is a classification bug in the transport, the other is
+ * a missing dial.
+ *
+ * Exhaustive by construction: `ingestDial` funnels EVERY exit through
+ * {@link SelectionAuthorityEngineImpl.recordDialDisposition}, so a new arm
+ * added without a disposition fails to compile rather than going dark.
+ */
+export type DialDisposition =
+  /** Streak advanced. The only disposition that can ever reach death. */
+  | "counted"
+  /** Streak advanced AND crossed {@link CONFIRMED_DEATH_REFUSAL_STREAK}. */
+  | "counted-reached-death"
+  /** A dial succeeded: proof of life, streak reset to zero. */
+  | "cleared-by-success"
+  /** `indeterminate` - inert by contract, advances nothing. */
+  | "inert-indeterminate"
+  /** A live session for this host outranks the failure (invariant 5). */
+  | "suppressed-live-session"
+  /** The host is not in the answered fleet. */
+  | "dropped-outside-fleet"
+  /** This (incarnation, attemptId) was already ingested. */
+  | "dropped-duplicate-attempt";
+
+/** Whether a disposition moved the host closer to a death verdict. */
+function dispositionCounts(disposition: DialDisposition): boolean {
+  return disposition === "counted" || disposition === "counted-reached-death";
+}
+
+/**
  * Incarnation ids identify a client instance to the engine that minted them;
  * they never cross a trust boundary and are never persisted, so a process
  * -local counter is sufficient and keeps tests deterministic.
@@ -684,6 +722,22 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
 
   private readonly reporters = new Map<string, ReporterRecord>();
   private readonly evidence = new Map<string, HostEvidence>();
+  /**
+   * Per host, consecutive dial reports that taught the authority NOTHING - a
+   * drop, a dedup, an inert `indeterminate`, or a live-session suppression.
+   * Reset by any success or counted refusal.
+   *
+   * PURELY DIAGNOSTIC, and deliberately its own map rather than a field on
+   * {@link HostEvidence}: that map's emptiness for a host is read as
+   * "never dialed" ({@link SelectionAuthorityEngineImpl.isLocalNeverDialed}),
+   * so hanging a counter off it would materialise records for hosts whose
+   * evidence was DROPPED and silently change which hosts the launch-time
+   * ensure considers. It shares `evidence`'s lifecycle exactly - pruned in
+   * {@link SelectionAuthorityEngineImpl.pruneEvidenceOutsideFleet}, cleared in
+   * the identity transition - so it can neither leak nor outlive the fleet it
+   * describes.
+   */
+  private readonly dialStalls = new Map<string, number>();
   /**
    * The next observation ordinal to hand out. The ordinals themselves live on
    * the ATTACHMENT that observed them (see {@link AttachmentRecord}); this
@@ -1351,31 +1405,114 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     report: Extract<SelectionEvidenceReport, { kind: "dial" }>,
   ): void {
     const hostId = report.hostId;
-    if (this.dropsAsOutsideFleet(hostId, report.kind)) return;
+    if (this.dropsAsOutsideFleet(hostId, report.kind)) {
+      this.recordDialDisposition(report, "dropped-outside-fleet");
+      return;
+    }
     const key = attemptKey(attachment.incarnationId, report.attemptId);
-    if (attachment.seenAttemptIds.has(key)) return;
+    if (attachment.seenAttemptIds.has(key)) {
+      this.recordDialDisposition(report, "dropped-duplicate-attempt");
+      return;
+    }
     attachment.seenAttemptIds.add(key);
     if (report.outcome === "success") {
       this.onHostProvedAlive(hostId);
+      this.recordDialDisposition(report, "cleared-by-success");
       return;
     }
     // `indeterminate` is inert by contract: a liveness-read failure or an
     // attempt abandoned for unrelated reasons is not evidence about the host.
-    if (report.outcome === "indeterminate") return;
+    if (report.outcome === "indeterminate") {
+      this.recordDialDisposition(report, "inert-indeterminate");
+      return;
+    }
     if (this.hasLiveSession(hostId)) {
       // Recorded for diagnostics, never accumulated: a live session anywhere
       // in the app outranks every other evidence class (invariant 5). The
       // streak resumes only once the session set for this host empties.
-      this.options.log.debug(
-        "[selection-authority] dial failure suppressed by live session",
-        { hostId, outcome: report.outcome },
-      );
+      this.recordDialDisposition(report, "suppressed-live-session");
       return;
     }
     const evidence = this.hostEvidence(hostId);
     evidence.refusalStreak += 1;
     evidence.lastCountedRefusalDetail =
       report.outcome === "confirmed-refusal" ? report.refusalDetail : null;
+    this.recordDialDisposition(
+      report,
+      evidence.refusalStreak >= CONFIRMED_DEATH_REFUSAL_STREAK
+        ? "counted-reached-death"
+        : "counted",
+    );
+  }
+
+  /**
+   * The single exit every dial report leaves by, and the whole instrumentation
+   * of this path.
+   *
+   * ONE REPORT IN, ONE LINE OUT. The question this answers is "a host stopped
+   * answering and never reached `dead` - where did its refusals go?", and that
+   * was previously unanswerable: a dropped, deduplicated or inert report was
+   * byte-identical, in the log, to a report that was never sent. Distinguishing
+   * "the transport classified it as `indeterminate`" from "nothing dialed the
+   * host at all" is the difference between a transport bug and a missing
+   * subscriber, and no amount of reading the code settles which one a given
+   * install hit.
+   *
+   * `streakAfter` is read WITHOUT creating an evidence record
+   * (`this.evidence.get`, never `hostEvidence`): the map's emptiness for a host
+   * is load-bearing state - {@link SelectionAuthorityEngineImpl.isLocalNeverDialed}
+   * reads `!this.evidence.has(hostId)` to gate the launch-time ensure - so
+   * instrumentation that materialised a record here would change which hosts
+   * get provisioned. A diagnostic that alters the thing it measures is worse
+   * than no diagnostic.
+   *
+   * LEVELS. Every report logs at `debug`, which is the complete picture when
+   * someone reproduces with the level raised. The `warn` is reserved for the
+   * pathology itself: {@link CONFIRMED_DEATH_REFUSAL_STREAK} consecutive
+   * FAILED dials that the authority learned nothing from. That is silent on a
+   * healthy fleet by construction - a success or a counted refusal both reset
+   * it - and it fires exactly when a host is failing while its lease cannot
+   * move, which is the state that strands a pinned surface.
+   */
+  private recordDialDisposition(
+    report: Extract<SelectionEvidenceReport, { kind: "dial" }>,
+    disposition: DialDisposition,
+  ): void {
+    const hostId = report.hostId;
+    const streakAfter = this.evidence.get(hostId)?.refusalStreak ?? 0;
+    this.options.log.debug("[selection-authority] dial evidence", {
+      hostId,
+      disposition,
+      outcome: report.outcome,
+      transportKind: report.transportKind,
+      attemptId: report.attemptId,
+      refusalStreak: streakAfter,
+      deathThreshold: CONFIRMED_DEATH_REFUSAL_STREAK,
+    });
+    // A success is proof of life and a counted refusal is progress toward a
+    // verdict; either way the authority learned something, so the stall ends.
+    if (
+      disposition === "cleared-by-success" ||
+      dispositionCounts(disposition)
+    ) {
+      this.dialStalls.delete(hostId);
+      return;
+    }
+    const stalled = (this.dialStalls.get(hostId) ?? 0) + 1;
+    this.dialStalls.set(hostId, stalled);
+    if (stalled < CONFIRMED_DEATH_REFUSAL_STREAK) return;
+    this.options.log.warn(
+      "[selection-authority] dial failures are not advancing the death streak",
+      {
+        hostId,
+        disposition,
+        outcome: report.outcome,
+        transportKind: report.transportKind,
+        consecutiveNonCounting: stalled,
+        refusalStreak: streakAfter,
+        deathThreshold: CONFIRMED_DEATH_REFUSAL_STREAK,
+      },
+    );
   }
 
   private ingestSession(
@@ -1594,6 +1731,9 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     for (const hostId of Array.from(this.seenTombstoneIds.keys())) {
       if (!present.has(hostId)) this.seenTombstoneIds.delete(hostId);
     }
+    for (const hostId of Array.from(this.dialStalls.keys())) {
+      if (!present.has(hostId)) this.dialStalls.delete(hostId);
+    }
   }
 
   /**
@@ -1694,6 +1834,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     }
     this.evidence.clear();
     this.seenTombstoneIds.clear();
+    this.dialStalls.clear();
     this.nextSessionOrdinal = 0;
     // The local expected-outage hold is PORT STATE, not evidence: the
     // HostController mutation lane does not stop being in flight because the


### PR DESCRIPTION
## Summary

Pinning the git-diff panel to an **offline** host was an unrecoverable dead end. The panel showed *"No git workspaces available / Add workspaces to the agent to get started"* — with no picker to choose a different host. The pin is persisted per tab, so it survived reloads. The file-tree panel had the identical defect.

Two independent causes, both required.

### 1. The escape hatch lived inside the branch that stops rendering

The host picker is not a panel-level control — it is the `hostSection` slot of the workspace picker's popover, and that popover rendered **only** in each panel's fully-loaded branch. So every degraded state, reached *by* choosing a host, removed the only control that could choose a different one.

| Panel | Picker's old home | Reachable when degraded? |
| --- | --- | --- |
| Git diff | `hostSection` of `GitDiffRepoSwitcher`, inside `GitDiffPanelLoaded` | no — 4 early returns bypassed it |
| File tree | the `selectedWorkspacePath !== null` arm | no — an unreachable host resolves no roots |
| New terminal | rendered first, unconditionally | **yes** — never had the defect |

`NewTerminalPickerBody` was already correct; both panels now follow that shape.

This violates the premise the pin design rests on, written down in `host-select-row-refused.ts`: *"a failed liveness read is not a fact about the host, and a dial that fails is recoverable where an un-pickable row is not."* That holds only while the picker outlives the failure.

### 2. There was no host-failure state at all

The designed recovery is silent auto-follow: a pinned host that dies is deposed and the surface falls back to `effective`. That bet is conditional, and the condition did not hold:

- `isSurfacePinDeposed` requires `lease.status === "dead"`.
- Death requires `CONFIRMED_DEATH_REFUSAL_STREAK` **consecutive** transport-confirmed refusals.
- The panel dials **once**. Host-scoped queries deliberately disable every automatic recovery route (`availability-recovery.ts`: *"transport retries already ran, no polling, no focus/reconnect refetch"*). The only escape is `notifyHostAvailabilityRecovered`, fed by a live stream **to that host** — which by definition does not exist for an offline one.

So the streak stalls, the pin is never deposed, and `bindingsError` fell through to `NoGitWorktrees` — naming a remedy ("add workspaces") on the **wrong machine**, and indistinguishable from a host that answered with nothing.

## What changed

Recoverability is now independent of the authority reaching a verdict. That is the design point: a remedy that waits on another subsystem to agree is not a remedy from inside a panel.

- **The picker renders in every state** of both panels. `GitDiffPanelDegraded` wraps the degraded bodies in the same header chrome; the file-tree header is hoisted out of its selection branch.
- **`GitHostUnreachable`** replaces the misleading empty state on a bindings error. It names the host, and offers **Retry** (nothing else will re-dial) and **Use active host**, which clears the pin. The latter is offered only when unpinning would actually move the surface.
- **`SurfaceHostPin.followingHostId`** lets a surface ask *"would unpinning move me?"* without re-deriving the app-wide host, which lint correctly fences out of Epic-session surfaces.

Offline rows stay **selectable**, deliberately. Blocking them would not fix this — a host can go offline *after* it is pinned, landing in the same state — and would break the relay-fuse recovery dial, which is why `connectable` means "has a dialable route" rather than "is online".

### Why no test caught it

The one test covering auto-follow **hand-seeds the verdict**:

```ts
leases: [{ hostId: "host-1", status: "dead", dead: { reason: "offline" } }]
```

It proves the panel re-points *when handed a dead lease*, and nothing about whether a host going offline ever **produces** one. Two assertions that codified the dead end (picker absent while degraded) are flipped, and the new tests drive the failure through the bindings query instead.

## Instrumenting the stall

Why the streak never reaches death is a **separate, unresolved bug** whose blast radius is every pinned surface. It was undiagnosable: of `ingestDial`'s seven exits, two logged at `debug` and four logged nothing — and the renderer's level is `info` in production, so **none of them emitted anything** in a real install. A refusal that was dropped, deduplicated or classified inert left exactly the trace of a dial that never happened, and those have opposite fixes.

| Exit | Advances streak? | Logged before |
| --- | --- | --- |
| `dropped-outside-fleet` | no | `debug` (invisible in prod) |
| `dropped-duplicate-attempt` | no | nothing |
| `cleared-by-success` | resets to 0 | nothing |
| `inert-indeterminate` | no | nothing |
| `suppressed-live-session` | no | `debug` (invisible in prod) |
| `counted` | yes | nothing |
| `counted-reached-death` | yes, crosses | nothing |

Every exit now funnels through one `recordDialDisposition`, so one report in produces one line out and no exit can go dark. `DialDisposition` is a closed union, so a new arm added without one fails to compile. Each line carries `hostId`, `disposition`, `outcome`, `transportKind`, `attemptId`, the resulting `refusalStreak` and the threshold.

Levels are chosen so the signal survives production: per-report lines are `debug`, and a `warn` fires only on the pathology itself — `CONFIRMED_DEATH_REFUSAL_STREAK` consecutive failed dials the authority learned nothing from. Any success or counted refusal resets that counter, so it is **silent on a healthy fleet by construction**.

That counter lives in its own `dialStalls` map rather than on `HostEvidence`, because the evidence map's emptiness for a host is load-bearing — `isLocalNeverDialed` reads `!this.evidence.has(hostId)` to gate the launch-time ensure. Hanging a counter off it would have materialised records for hosts whose evidence was dropped and silently changed which hosts get provisioned. A diagnostic that alters what it measures is worse than none, and there is a test pinning that.

**Known blind spot, left deliberately:** `TransportEvidenceRelay` drops every report when no kernel is bound (`this.target?.reportDialRefusal(...)`) and has no logger. The window is narrow by construction (`acquireRendererSelectionKernel` binds before `start()`), so it is not worth churning the relay's constructor and every test that builds one. If the dispositions above account for every dial in a captured repro, that is where the missing ones went.

## Audit of the other pinned surfaces

All five `SurfaceKind` members were checked for the same shape, plus the two transient surfaces that share the composer's pin.

| Surface | Picker placement | Verdict |
| --- | --- | --- |
| git-diff panel | was inside the loaded branch | **fixed** |
| file-tree panel | was inside the selection branch | **fixed** |
| new-terminal picker | unconditional, rendered first | clean |
| landing composer | unconditional in both layouts | clean |
| new-conversation modal | mounts on `props.open` alone | clean |
| add-node dropdown | unconditional | clean |
| terminal-agent fork dialog | unconditional, deliberately inert | clean by design |

The structural reason the panels were vulnerable and the composers are not is worth stating, because it predicts where this class recurs: **a panel's entire body IS a host query result, so a failed query leaves it nothing to render but a full-surface empty state — and the picker was inside the part that got replaced. A composer's body is an editor, which does not depend on the host query at all.** The rule to hold going forward: a host failure may disable *actions*, but must never replace the surface that owns the host control.

## Not fixed here

`HostOnlySelect` takes `entries={directoryEntries}` from `useHostDirectoryList()`, while the stacked layout reads merged `useHostOptions` — which documents itself as *"THE answer… Every host picker in the app reads this and nothing else"*. So the landing composer's resting picker and its stacked one answer "what hosts do I have" from different lists: a host the account owns but this client cannot dial is listed-and-inert in `stacked`, and simply **absent** from the resting one. Not a dead end (other hosts stay pickable, and `hostSelectOptions` synthesizes a row for a missing `activeHostId`), so it is an honesty defect rather than a trap — filed, not fixed.

## Related issue

None public — reported from a staging session.

## Verification

- `bun run compile` — clean, all 5 projects
- `bun run lint` (`--max-warnings 0`) and prettier — clean, via pre-commit
- **154** tests in `clients/shared/host-selection` (149 pre-existing unchanged + 5 new), **44** across the two changed gui-app suites
- Three mutation probes — git-diff picker render, file-tree picker render, and a removed `recordDialDisposition` call — each killed exactly the intended tests and were reverted. The disposition probe is what caught a fixture whose `identityGeneration` mismatch had been silently measuring nothing.

## Checklist

- [x] Pre-commit static checks pass
- [ ] Separate CI test checks pass — pending this PR's run
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
