### PR TITLE
feat(history): filter tasks by the hosts that own their chats

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel-phase-activation.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel-phase-activation.test.tsx
@@ -171,6 +171,7 @@ function phaseHistoryItem(): HistoryItem {
     updatedBucket: "today",
     linkedRepos: [],
     linkedWorkspaces: [],
+    chatHostIds: null,
     pullRequestNumbers: [],
     worktreeBranches: [],
     worktreePaths: [],

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -269,6 +269,7 @@ function historyItem(overrides: Partial<HistoryItem>): HistoryItem {
     updatedBucket: "today",
     linkedRepos: [],
     linkedWorkspaces: [],
+    chatHostIds: null,
     pullRequestNumbers: [],
     worktreeBranches: [],
     worktreePaths: [],

--- a/clients/gui-app/src/components/epics/epics-filter-popover.tsx
+++ b/clients/gui-app/src/components/epics/epics-filter-popover.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/popover";
 import { MatchModeToggle } from "@/components/home/toolbar/match-mode-toggle";
 import type {
+  HistoryMatchMode,
   HistoryOwnershipScope,
   HistoryWorkspaceRef,
 } from "@/components/home/data/home-page.data";
@@ -14,6 +15,8 @@ import {
   dedupSortWorkspaces,
   workspaceKey,
 } from "@/components/home/data/home-page.data";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query";
 import { EpicsFilterTrigger } from "@/components/epics/epics-filter-trigger";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import type { HistoryFacets } from "@/hooks/home/use-history-query";
@@ -30,6 +33,18 @@ interface EpicsFilterPopoverProps {
   readonly search: HistorySearchState;
   readonly onSearchChange: (patch: HistorySearchPatch) => void;
   readonly facets: HistoryFacets | undefined;
+  /**
+   * `false` when the serving host negotiated `epic.listTasks` below @1.3 and
+   * would silently discard a host filter. The section still renders any
+   * ALREADY-selected host so a deep link can be undone, but offers no new
+   * ones - an affordance that cannot do what it says is worse than none.
+   */
+  readonly chatHostFilterSupported: boolean;
+}
+
+interface ChatHostOption {
+  readonly hostId: string;
+  readonly label: string;
 }
 
 const OWNERSHIP_OPTIONS: ReadonlyArray<{
@@ -44,7 +59,8 @@ export function EpicsFilterPopover(props: EpicsFilterPopoverProps): ReactNode {
   const activeCount =
     props.search.ownershipScopes.length +
     props.search.repos.length +
-    props.search.workspaces.length;
+    props.search.workspaces.length +
+    props.search.chatHosts.length;
   const ownershipCounts = new Map(
     props.facets?.ownershipScopes.map((facet) => [facet.value, facet.count]) ??
       [],
@@ -136,6 +152,13 @@ export function EpicsFilterPopover(props: EpicsFilterPopoverProps): ReactNode {
             ))
           )}
         </FilterSection>
+        <ChatHostFilterSection
+          facets={props.facets}
+          selected={props.search.chatHosts}
+          matchMode={props.search.chatHostMode}
+          supported={props.chatHostFilterSupported}
+          onSearchChange={props.onSearchChange}
+        />
         <FilterSection
           label="Workspaces"
           trailing={
@@ -185,6 +208,85 @@ export function EpicsFilterPopover(props: EpicsFilterPopoverProps): ReactNode {
         </FilterSection>
       </PopoverContent>
     </Popover>
+  );
+}
+
+function ChatHostFilterSection(props: {
+  readonly facets: HistoryFacets | undefined;
+  readonly selected: ReadonlyArray<string>;
+  readonly matchMode: HistoryMatchMode;
+  readonly supported: boolean;
+  readonly onSearchChange: (patch: HistorySearchPatch) => void;
+}): ReactNode {
+  const hostDirectory = useHostDirectoryList();
+  const counts = new Map(
+    props.facets?.chatHosts?.map((facet) => [facet.hostId, facet.count]) ?? [],
+  );
+  // A host the peer cannot filter by is not offered, so an unsupported peer
+  // contributes no options and only an already-selected host survives - see
+  // `buildChatHostOptions`.
+  const options = buildChatHostOptions(
+    props.supported
+      ? (props.facets?.chatHosts?.map((facet) => facet.hostId) ?? [])
+      : [],
+    props.selected,
+    hostDirectory.data ?? [],
+  );
+  return (
+    <FilterSection
+      label="Hosts"
+      trailing={
+        props.selected.length > 1 ? (
+          <MatchModeToggle
+            value={props.matchMode}
+            selectedLabel="hosts"
+            onChange={(chatHostMode) => {
+              props.onSearchChange({ chatHostMode });
+            }}
+          />
+        ) : null
+      }
+    >
+      <ChatHostFilterOptions
+        options={options}
+        counts={counts}
+        selected={props.selected}
+        supported={props.supported}
+        onSearchChange={props.onSearchChange}
+      />
+    </FilterSection>
+  );
+}
+
+function ChatHostFilterOptions(props: {
+  readonly options: ReadonlyArray<ChatHostOption>;
+  readonly counts: ReadonlyMap<string, number>;
+  readonly selected: ReadonlyArray<string>;
+  readonly supported: boolean;
+  readonly onSearchChange: (patch: HistorySearchPatch) => void;
+}): ReactNode {
+  if (props.options.length > 0) {
+    return props.options.map((option) => (
+      <FilterOption
+        key={option.hostId}
+        label={option.label}
+        truncateLabelFromStart={false}
+        count={props.counts.get(option.hostId)}
+        checked={props.selected.includes(option.hostId)}
+        onToggle={() => {
+          props.onSearchChange({
+            chatHosts: withToggledValue(props.selected, option.hostId),
+          });
+        }}
+      />
+    ));
+  }
+  return (
+    <p className="px-1 py-1.5 text-ui-xs text-muted-foreground">
+      {props.supported
+        ? "No hosts yet"
+        : "This host is too old to filter by host"}
+    </p>
   );
 }
 
@@ -273,6 +375,41 @@ function withToggledWorkspace(
   return values.some((current) => workspaceKey(current) === valueKey)
     ? values.filter((current) => workspaceKey(current) !== valueKey)
     : [...values, value];
+}
+
+/**
+ * The host rows, ordered by display name.
+ *
+ * The facet is the source of WHICH hosts to offer - only hosts that actually
+ * own chats in the caller's tasks - and the directory supplies the name. The
+ * two sets deliberately do not have to agree: a host the directory no longer
+ * knows (deregistered, or another machine of the user's that this one has
+ * never seen) still owns chats in past tasks, so it stays selectable under its
+ * raw id rather than vanishing from a filter that would still match rows.
+ *
+ * Selected ids are unioned in for the same reason a repo/workspace selection
+ * is: a filter narrow enough to zero out its own facet must still render its
+ * checkbox, or it cannot be unchecked.
+ */
+function buildChatHostOptions(
+  facetHostIds: ReadonlyArray<string>,
+  selectedHostIds: ReadonlyArray<string>,
+  directory: ReadonlyArray<HostDirectoryEntry>,
+): ReadonlyArray<ChatHostOption> {
+  const labelsByHostId = new Map(
+    directory.map((entry) => [entry.hostId, entry.label]),
+  );
+  const hostIds = new Set([...facetHostIds, ...selectedHostIds]);
+  return Array.from(hostIds)
+    .map((hostId) => ({
+      hostId,
+      label: labelsByHostId.get(hostId) ?? hostId,
+    }))
+    .sort(
+      (left, right) =>
+        left.label.localeCompare(right.label) ||
+        left.hostId.localeCompare(right.hostId),
+    );
 }
 
 function countWorkspacePaths(

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -988,7 +988,7 @@ function describeDeleteTitle(
 function EpicsListChatHostFilterUnsupported(): ReactNode {
   return (
     <div
-      className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
+      className="flex flex-col items-center justify-center gap-2 py-[min(4rem,12vh)] text-center text-ui-sm text-muted-foreground"
       data-testid="epics-list-chat-host-filter-unsupported"
     >
       <p className="font-medium text-foreground">

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -80,6 +80,7 @@ import {
   DEFAULT_SORT,
 } from "@/components/home/data/home-page.data";
 import { EpicsFilterPopover } from "@/components/epics/epics-filter-popover";
+import { useChatHostFilterSupport } from "@/hooks/home/use-chat-host-filter-support";
 import { EpicsSortMenu } from "@/components/epics/epics-sort-menu";
 import { useHistoryListKeyboardNav } from "@/components/epics/use-history-list-keyboard-nav";
 import { NotificationIndicatorIcon } from "@/components/notifications/notification-indicator-icon";
@@ -88,6 +89,7 @@ import { NotificationIndicatorsProvider } from "@/components/notifications/notif
 import {
   useHistoryQuery,
   type HistoryFacets,
+  type HistoryFetchResult,
 } from "@/hooks/home/use-history-query";
 import { useEpicActivityStatus } from "@/hooks/epic/use-epic-activity-status";
 import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
@@ -311,6 +313,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     chatIds: [],
     enabled: indicatorEpicIds.length > 0,
   });
+  const { chatHostFilterSupported, chatHostFilterUnsupported } =
+    useChatHostFilterGate(hostId, data);
   const availableRepos = data?.availableRepos ?? EMPTY_REPOS;
   const availableWorkspaces = data?.availableWorkspaces ?? EMPTY_WORKSPACES;
   const facets = data?.facets;
@@ -602,6 +606,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
           search={search}
           onSearchChange={updateSearch}
           facets={facets}
+          chatHostFilterSupported={chatHostFilterSupported}
           refresh={{ isFetching, hostId, onRefetch: refetch }}
         />
         <NotificationIndicatorsProvider indicators={notificationIndicators}>
@@ -611,6 +616,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
               isPending={isPending}
               isFetching={isFetching}
               hasActiveFilters={hasActiveFilters}
+              chatHostFilterUnsupported={chatHostFilterUnsupported}
               items={items}
               onRetry={handleRetry}
               selectionMode={selectionMode}
@@ -666,10 +672,33 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
   );
 }
 
+/**
+ * The two chat-host gate answers the panel needs, kept together because they
+ * are two faces of one decision: whether to OFFER the filter, and whether the
+ * rows in hand were withheld because it could not be applied.
+ *
+ * "unknown" (no handshake yet) stays OFFERABLE. The manifest fills in on the
+ * first RPC to the host, and hiding the section until then would make it
+ * flicker in on every cold open. A filter actually issued against a host that
+ * turns out to be too old is caught by the fail-closed arm in
+ * `useHistoryQuery`, which withholds rows rather than showing them unfiltered.
+ */
+function useChatHostFilterGate(
+  hostId: string | null,
+  data: HistoryFetchResult | undefined,
+): { chatHostFilterSupported: boolean; chatHostFilterUnsupported: boolean } {
+  const support = useChatHostFilterSupport(hostId);
+  return {
+    chatHostFilterSupported: support !== "unsupported",
+    chatHostFilterUnsupported: data?.chatHostFilterUnsupported ?? false,
+  };
+}
+
 function hasActiveHistoryFilters(search: HistorySearchState): boolean {
   return (
     search.repos.length > 0 ||
     search.workspaces.length > 0 ||
+    search.chatHosts.length > 0 ||
     search.ownershipScopes.length > 0 ||
     (search.sortExplicit && search.sort !== DEFAULT_SORT) ||
     search.query.trim().length > 0
@@ -797,6 +826,7 @@ interface PanelChromeBarProps {
   readonly search: HistorySearchState;
   readonly onSearchChange: (patch: HistorySearchPatch) => void;
   readonly facets: HistoryFacets | undefined;
+  readonly chatHostFilterSupported: boolean;
   readonly refresh: PanelRefreshControls;
 }
 
@@ -892,6 +922,7 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
               search={props.search}
               onSearchChange={props.onSearchChange}
               facets={props.facets}
+              chatHostFilterSupported={props.chatHostFilterSupported}
             />
             {props.showSelection ? (
               <Button
@@ -948,11 +979,35 @@ function describeDeleteTitle(
   return `Delete "${matchTitle}"?`;
 }
 
+/**
+ * Shown when a host filter is active but the serving peer cannot apply it, so
+ * the rows were withheld. Deliberately NOT an empty-history message: the
+ * account's tasks exist, this client just declined to show a list it could not
+ * honestly call filtered.
+ */
+function EpicsListChatHostFilterUnsupported(): ReactNode {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
+      data-testid="epics-list-chat-host-filter-unsupported"
+    >
+      <p className="font-medium text-foreground">
+        Can&apos;t filter by host here
+      </p>
+      <p className="max-w-full">
+        This host is running a version that doesn&apos;t support the host
+        filter. Update it, or clear the host filter to see your tasks.
+      </p>
+    </div>
+  );
+}
+
 interface EpicsListBodyProps {
   readonly error: Error | null;
   readonly isPending: boolean;
   readonly isFetching: boolean;
   readonly hasActiveFilters: boolean;
+  readonly chatHostFilterUnsupported: boolean;
   readonly items: ReadonlyArray<HistoryItem>;
   readonly onRetry: () => void;
   readonly selectionMode: boolean;
@@ -986,6 +1041,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     isPending,
     isFetching,
     hasActiveFilters,
+    chatHostFilterUnsupported,
     items,
     onRetry,
     selectionMode,
@@ -1014,6 +1070,11 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
   }
   if (isPending) {
     return <EpicsListLoading />;
+  }
+  // Ahead of every other empty state: the rows were WITHHELD, not absent, and
+  // "No tasks yet" would be an outright false statement about the account.
+  if (chatHostFilterUnsupported) {
+    return <EpicsListChatHostFilterUnsupported />;
   }
   if (items.length === 0 && !hasActiveFilters) {
     return (

--- a/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
@@ -28,6 +28,7 @@ function makeItem(
     updatedLabel: overrides.updatedLabel ?? "x",
     updatedBucket: overrides.updatedBucket ?? "today",
     linkedRepos: overrides.linkedRepos ?? [],
+    chatHostIds: overrides.chatHostIds ?? null,
     linkedWorkspaces: overrides.linkedWorkspaces ?? [],
     pullRequestNumbers: overrides.pullRequestNumbers ?? [],
     worktreeBranches: overrides.worktreeBranches ?? [],
@@ -60,6 +61,8 @@ describe("home-page history helpers", () => {
         repoMatchMode: "any",
         workspaces: [],
         workspaceMatchMode: "any",
+        chatHosts: [],
+        chatHostMatchMode: "any",
         ownershipScopes: [],
       }),
     ).toHaveLength(2);
@@ -70,6 +73,8 @@ describe("home-page history helpers", () => {
         repoMatchMode: "all",
         workspaces: [],
         workspaceMatchMode: "any",
+        chatHosts: [],
+        chatHostMatchMode: "any",
         ownershipScopes: [],
       }),
     ).toHaveLength(1);
@@ -351,6 +356,58 @@ describe("home-page history helpers", () => {
       updatedBucket: "today",
       linkedRepos: ["traycerai/gui-app"],
       isPinned: false,
+    });
+  });
+
+  describe("chat-host filter", () => {
+    const hostItems: ReadonlyArray<HistoryItem> = [
+      makeItem({ id: "a", title: "A", chatHostIds: ["host-1"] }),
+      makeItem({ id: "b", title: "B", chatHostIds: ["host-1", "host-2"] }),
+      makeItem({ id: "c", title: "C", chatHostIds: [] }),
+      // No `chatHostIds` at all - served by a peer too old to report them.
+      makeItem({ id: "d", title: "D", chatHostIds: null }),
+    ];
+
+    function filterByHosts(
+      chatHosts: ReadonlyArray<string>,
+      chatHostMatchMode: "any" | "all",
+    ): ReadonlyArray<string> {
+      return filterHistoryItems(hostItems, {
+        repoNames: [],
+        repoMatchMode: "any",
+        workspaces: [],
+        workspaceMatchMode: "any",
+        chatHosts,
+        chatHostMatchMode,
+        ownershipScopes: [],
+      }).map((item) => item.id);
+    }
+
+    it("matches any selected host and excludes a row with none of them", () => {
+      // "c" reports an empty set, which is a truthful negative - it is
+      // excluded, unlike "d", which cannot answer at all.
+      expect(filterByHosts(["host-2"], "any")).toEqual(["b", "d"]);
+    });
+
+    it("requires every selected host under `all`", () => {
+      // "a" has host-1 only, so `all` drops it where `any` keeps it.
+      expect(filterByHosts(["host-1", "host-2"], "any")).toEqual([
+        "a",
+        "b",
+        "d",
+      ]);
+      expect(filterByHosts(["host-1", "host-2"], "all")).toEqual(["b", "d"]);
+    });
+
+    it("keeps a row that cannot report its hosts rather than inventing a negative", () => {
+      // Dropping "d" would empty the list against an older peer, which reads
+      // identically to "you have no tasks on that host". The version gate
+      // prevents this case; abstaining is the residual safety choice.
+      expect(filterByHosts(["host-9"], "any")).toEqual(["d"]);
+    });
+
+    it("is inert when no host is selected", () => {
+      expect(filterByHosts([], "any")).toEqual(["a", "b", "c", "d"]);
     });
   });
 });

--- a/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
@@ -384,26 +384,24 @@ describe("home-page history helpers", () => {
     }
 
     it("matches any selected host and excludes a row with none of them", () => {
-      // "c" reports an empty set, which is a truthful negative - it is
-      // excluded, unlike "d", which cannot answer at all.
-      expect(filterByHosts(["host-2"], "any")).toEqual(["b", "d"]);
+      // "c" reports an empty set - a truthful negative. "d" cannot answer, and
+      // is excluded too: nothing has checked it against the filter.
+      expect(filterByHosts(["host-2"], "any")).toEqual(["b"]);
     });
 
     it("requires every selected host under `all`", () => {
       // "a" has host-1 only, so `all` drops it where `any` keeps it.
-      expect(filterByHosts(["host-1", "host-2"], "any")).toEqual([
-        "a",
-        "b",
-        "d",
-      ]);
-      expect(filterByHosts(["host-1", "host-2"], "all")).toEqual(["b", "d"]);
+      expect(filterByHosts(["host-1", "host-2"], "any")).toEqual(["a", "b"]);
+      expect(filterByHosts(["host-1", "host-2"], "all")).toEqual(["b"]);
     });
 
-    it("keeps a row that cannot report its hosts rather than inventing a negative", () => {
-      // Dropping "d" would empty the list against an older peer, which reads
-      // identically to "you have no tasks on that host". The version gate
-      // prevents this case; abstaining is the residual safety choice.
-      expect(filterByHosts(["host-9"], "any")).toEqual(["d"]);
+    it("excludes a row that cannot report its hosts", () => {
+      // "d" reaches this predicate only from a source the server never
+      // filtered - an id-fetched worktree/PR match, or a cached row mid
+      // request. Keeping it would render an unfiltered row as a filtered one.
+      // A peer too old to report the field never gets this far: the version
+      // gate withholds the whole list with an explicit explanation.
+      expect(filterByHosts(["host-9"], "any")).toEqual([]);
     });
 
     it("is inert when no host is selected", () => {

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -43,6 +43,16 @@ export interface HistoryItem {
   updatedBucket: HistoryRecencyBucket;
   linkedRepos: ReadonlyArray<string>;
   linkedWorkspaces: ReadonlyArray<HistoryWorkspaceRef>;
+  /**
+   * Hosts owning chats in this task that the signed-in user may see, or
+   * `null` when the serving peer predates the field.
+   *
+   * `null` is not `[]`. An empty array truthfully says "no visible chats on
+   * any host", which a host filter may act on by excluding the row; `null`
+   * says the row cannot answer, and the predicate must abstain rather than
+   * invent a negative.
+   */
+  chatHostIds: ReadonlyArray<string> | null;
   pullRequestNumbers: ReadonlyArray<string>;
   worktreeBranches: ReadonlyArray<string>;
   worktreePaths: ReadonlyArray<string>;
@@ -56,6 +66,8 @@ export interface HistoryFilters {
   repoMatchMode: HistoryMatchMode;
   workspaces: ReadonlyArray<HistoryWorkspaceRef>;
   workspaceMatchMode: HistoryMatchMode;
+  chatHosts: ReadonlyArray<string>;
+  chatHostMatchMode: HistoryMatchMode;
   ownershipScopes: ReadonlyArray<HistoryOwnershipScope>;
 }
 
@@ -156,6 +168,7 @@ function buildHistoryItem(args: {
     updatedBucket: toHistoryRecencyBucket(light.updatedAt, nowMs),
     linkedRepos: readTaskRepos(task),
     linkedWorkspaces: readTaskWorkspaces(task),
+    chatHostIds: task.chatHostIds ?? null,
     pullRequestNumbers: [],
     worktreeBranches: [],
     worktreePaths: [],
@@ -350,6 +363,35 @@ function matchesRepoFilter(
   return repoNames.some((repoName) => item.linkedRepos.includes(repoName));
 }
 
+/**
+ * Whether a row satisfies the chat-host filter.
+ *
+ * A row whose `chatHostIds` is `null` came from a peer that cannot report the
+ * field, so it is KEPT rather than excluded: the alternative silently empties
+ * the list against an older host, which looks identical to "you have no tasks
+ * there". The version gate is what stops that case from arising; this is the
+ * residual safety choice if it ever does.
+ */
+function matchesChatHostFilter(
+  item: HistoryItem,
+  chatHosts: ReadonlyArray<string>,
+  chatHostMatchMode: HistoryMatchMode,
+): boolean {
+  if (chatHosts.length === 0) {
+    return true;
+  }
+  if (item.chatHostIds === null) {
+    return true;
+  }
+
+  const itemHostIds = new Set(item.chatHostIds);
+  if (chatHostMatchMode === "all") {
+    return chatHosts.every((hostId) => itemHostIds.has(hostId));
+  }
+
+  return chatHosts.some((hostId) => itemHostIds.has(hostId));
+}
+
 function matchesWorkspaceFilter(
   item: HistoryItem,
   workspaces: ReadonlyArray<HistoryWorkspaceRef>,
@@ -383,6 +425,11 @@ export function filterHistoryItems(
       return false;
     }
     if (!matchesRepoFilter(item, filters.repoNames, filters.repoMatchMode)) {
+      return false;
+    }
+    if (
+      !matchesChatHostFilter(item, filters.chatHosts, filters.chatHostMatchMode)
+    ) {
       return false;
     }
     return matchesWorkspaceFilter(

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -44,13 +44,12 @@ export interface HistoryItem {
   linkedRepos: ReadonlyArray<string>;
   linkedWorkspaces: ReadonlyArray<HistoryWorkspaceRef>;
   /**
-   * Hosts owning chats in this task that the signed-in user may see, or
-   * `null` when the serving peer predates the field.
+   * Hosts owning the signed-in user's OWN chats in this task, or `null` when
+   * the serving peer predates the field.
    *
-   * `null` is not `[]`. An empty array truthfully says "no visible chats on
-   * any host", which a host filter may act on by excluding the row; `null`
-   * says the row cannot answer, and the predicate must abstain rather than
-   * invent a negative.
+   * `null` is not `[]`. An empty array truthfully says "none of my chats live
+   * on any host", which a host filter acts on by excluding the row; `null`
+   * says the row cannot answer at all.
    */
   chatHostIds: ReadonlyArray<string> | null;
   pullRequestNumbers: ReadonlyArray<string>;
@@ -366,11 +365,22 @@ function matchesRepoFilter(
 /**
  * Whether a row satisfies the chat-host filter.
  *
- * A row whose `chatHostIds` is `null` came from a peer that cannot report the
- * field, so it is KEPT rather than excluded: the alternative silently empties
- * the list against an older host, which looks identical to "you have no tasks
- * there". The version gate is what stops that case from arising; this is the
- * residual safety choice if it ever does.
+ * A row whose `chatHostIds` is `null` is EXCLUDED while a host is selected,
+ * because nothing about that row has been checked against the filter. This
+ * predicate runs on rows from three sources and only one of them is
+ * pre-filtered by the server: settled `epic.listTasks` pages. The other two -
+ * tasks fetched by id for a branch/worktree/PR match, and cached rows still
+ * showing while a new request is in flight - never passed through it, so
+ * keeping an unverifiable row there renders an unfiltered result as a
+ * filtered one.
+ *
+ * Abstaining was the earlier choice, on the reasoning that excluding would
+ * silently empty the list against an older peer. That case cannot reach here:
+ * a peer too old to report the field is caught by the version gate in
+ * `useHistoryQuery`, which withholds every row behind an explicit
+ * "can't filter by host here" state. A settled row from a peer that CAN report
+ * always carries the field - `[]` at minimum. So the only rows this exclusion
+ * can reach are the unverified ones, which is exactly the intent.
  */
 function matchesChatHostFilter(
   item: HistoryItem,
@@ -381,7 +391,7 @@ function matchesChatHostFilter(
     return true;
   }
   if (item.chatHostIds === null) {
-    return true;
+    return false;
   }
 
   const itemHostIds = new Set(item.chatHostIds);

--- a/clients/gui-app/src/components/layout/tabs/__tests__/split-slot-chooser-t9-round4.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/split-slot-chooser-t9-round4.test.tsx
@@ -11,6 +11,7 @@ const chooserHistoryItem = vi.hoisted<HistoryItem>(() => ({
   updatedBucket: "today",
   linkedRepos: [],
   linkedWorkspaces: [],
+  chatHostIds: null,
   pullRequestNumbers: [],
   worktreeBranches: [],
   worktreePaths: [],

--- a/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
@@ -246,6 +246,15 @@ function taskProjectionMatchesRequest(
   if (!matchesRepoFilter(projection.repoLabels, filters)) {
     return false;
   }
+  // A host filter cannot be evaluated from a create projection: the response
+  // carries no `chatHostIds`, and the epic has no chats to own a host yet.
+  // Refuse the optimistic insert rather than guess - inserting would place an
+  // UNVERIFIED row into a host-filtered list, which is the one thing this
+  // filter's fail-closed design exists to prevent. The row appears on the next
+  // fetch, once the server can answer for it.
+  if (filters.chatHostIds !== undefined && filters.chatHostIds.length > 0) {
+    return false;
+  }
   return matchesWorkspaceFilter(projection.workspaces, filters);
 }
 
@@ -270,7 +279,14 @@ function mergeProjectionIntoFacets(
   ) {
     return facets;
   }
-  return { repos, workspaces, ownershipScopes };
+  // `chatHosts` is CARRIED, never rebuilt. Dropping it makes the history gate
+  // read the response as one from a server that cannot filter by host, which
+  // withholds every row behind "Can't filter by host here" - and these entries
+  // never refetch on their own (`staleTime`/`gcTime` at Infinity), so a single
+  // create would strand the list there. It is carried UNCHANGED because a
+  // brand-new epic has no published chats yet, so it contributes to no host's
+  // count; the next real fetch is what introduces one.
+  return { repos, workspaces, ownershipScopes, chatHosts: facets.chatHosts };
 }
 
 function incrementRepoFacets(

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -59,8 +59,14 @@ vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
       currentUserId: "user-1",
       tasks,
       query: {
+        // Facets ride along even on the query branch: the real server computes
+        // them for every FIRST page regardless of filters, and this query
+        // never carries a cursor. Dropping them here would fake the
+        // old-cloud-tier signal the host filter fails closed on.
         data:
-          query.length === 0 ? testState.response : { tasks, hasMore: false },
+          query.length === 0
+            ? testState.response
+            : { tasks, hasMore: false, facets: testState.response.facets },
         isPending: false,
         isFetching: testState.isFetching,
         isPlaceholderData: testState.isPlaceholderData,
@@ -530,6 +536,23 @@ describe("useHistoryQuery", () => {
           ownershipScopes: [],
         },
       };
+      render(<HistoryQueryHarness search={hostSearch} />);
+
+      expect(screen.getByTestId("chat-host-unsupported").textContent).toBe(
+        "true",
+      );
+      expect(
+        screen.getByRole("status", { name: "History titles" }).textContent,
+      ).toBe("");
+    });
+
+    it("withholds rows when the response carries no facets object at all", () => {
+      // This query never carries a cursor - "Show more" pages append through a
+      // separate mutation and store - so its response is always a first page.
+      // A first page with no facets is a server that never computed them, not
+      // a later page that legitimately omits them.
+      testState.chatHostSupport = "supported";
+      testState.response = { tasks: testState.tasks, hasMore: false };
       render(<HistoryQueryHarness search={hostSearch} />);
 
       expect(screen.getByTestId("chat-host-unsupported").textContent).toBe(

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -33,6 +33,7 @@ const testState = vi.hoisted(() => {
     activityError: null as Error | null,
     taskContexts: new Map<string, ListTaskLight>(),
     taskContextsError: null as Error | null,
+    chatHostSupport: "supported",
     refetch: vi.fn(),
     fetchNextPage: vi.fn(),
   };
@@ -94,6 +95,10 @@ vi.mock("@/hooks/worktree/use-task-worktree-metadata-query", () => ({
   }),
 }));
 
+vi.mock("@/hooks/home/use-chat-host-filter-support", () => ({
+  useChatHostFilterSupport: () => testState.chatHostSupport,
+}));
+
 vi.mock("@/hooks/epic/use-epic-get-task-contexts-query", () => ({
   useEpicGetTaskContexts: (taskIds: readonly string[]) => ({
     tasksById: new Map(
@@ -127,6 +132,7 @@ describe("useHistoryQuery", () => {
     testState.activityError = null;
     testState.taskContexts = new Map();
     testState.taskContextsError = null;
+    testState.chatHostSupport = "supported";
     testState.refetch.mockReset();
     testState.fetchNextPage.mockReset();
   });
@@ -486,6 +492,140 @@ describe("useHistoryQuery", () => {
       "Task contexts failed",
     );
   });
+
+  describe("chat-host filter", () => {
+    const hostSearch: HistorySearchState = {
+      ...DEFAULT_HISTORY_SEARCH,
+      chatHosts: ["host-a"],
+    };
+
+    it("withholds rows when the host negotiated a minor that drops the filter", () => {
+      // The response is well-formed and complete - that is exactly the
+      // hazard. An old host strips `chatHostIds` and answers as if no filter
+      // was asked for, so rendering these rows would present an UNFILTERED
+      // list as a filtered one, with nothing anywhere reporting a problem.
+      testState.chatHostSupport = "unsupported";
+      render(<HistoryQueryHarness search={hostSearch} />);
+
+      expect(screen.getByTestId("chat-host-unsupported").textContent).toBe(
+        "true",
+      );
+      expect(
+        screen.getByRole("status", { name: "History titles" }).textContent,
+      ).toBe("");
+    });
+
+    it("withholds rows when the first page comes back without the chat-host facet", () => {
+      // The cloud tier has no version negotiation of its own: an old server
+      // simply drops request keys it does not recognize. A first page that
+      // omits the `chatHosts` group is the only evidence of that, and it must
+      // fail closed the same way the host arm does.
+      testState.chatHostSupport = "supported";
+      testState.response = {
+        tasks: testState.tasks,
+        hasMore: false,
+        facets: {
+          repos: [],
+          workspaces: [],
+          ownershipScopes: [],
+        },
+      };
+      render(<HistoryQueryHarness search={hostSearch} />);
+
+      expect(screen.getByTestId("chat-host-unsupported").textContent).toBe(
+        "true",
+      );
+      expect(
+        screen.getByRole("status", { name: "History titles" }).textContent,
+      ).toBe("");
+    });
+
+    it("serves rows and facet counts when both tiers can apply the filter", () => {
+      testState.chatHostSupport = "supported";
+      testState.response = {
+        tasks: testState.tasks,
+        hasMore: false,
+        facets: {
+          repos: [],
+          workspaces: [],
+          ownershipScopes: [],
+          chatHosts: [{ hostId: "host-a", count: 2 }],
+        },
+      };
+      render(<HistoryQueryHarness search={hostSearch} />);
+
+      expect(screen.getByTestId("chat-host-unsupported").textContent).toBe(
+        "false",
+      );
+      expect(screen.getByTestId("chat-host-facets").textContent).toBe(
+        "host-a:2",
+      );
+      expect(
+        screen.getByRole("status", { name: "History titles" }).textContent,
+      ).toBe("Alpha workbench|Beta search flow");
+    });
+
+    it("host-filters an id-fetched worktree match instead of dropping the local search", () => {
+      // A branch name lives only in local worktree metadata, so this row can
+      // only arrive through the id-fetched union - which never passed the
+      // server's host filter. The row carries its own visible chat hosts, so
+      // the filter is re-applied here rather than the whole local arm being
+      // switched off (which would make branch search silently return nothing
+      // whenever a host was selected).
+      const onHost = taskLight("epic-local", "Local only", "traycer/gui-app");
+      testState.taskContexts = new Map([
+        ["epic-local", { ...onHost, chatHostIds: ["host-a"] }],
+      ]);
+      testState.worktreeIndex = [
+        {
+          ...worktreeWithPullRequest(1),
+          worktreePath: "/w/histogram",
+          branch: "feature/histogram",
+          owners: [
+            {
+              epicId: "epic-local",
+              ownerKind: "chat",
+              ownerId: "chat-local",
+              updatedAt: 1,
+            },
+          ],
+        },
+      ];
+      testState.response = {
+        tasks: [],
+        hasMore: false,
+        facets: {
+          repos: [],
+          workspaces: [],
+          ownershipScopes: [],
+          chatHosts: [{ hostId: "host-a", count: 1 }],
+        },
+      };
+
+      const { rerender } = render(
+        <HistoryQueryHarness
+          search={{ ...hostSearch, query: "feature/histogram" }}
+        />,
+      );
+      expect(
+        screen.getByRole("status", { name: "History titles" }).textContent,
+      ).toBe("Local only");
+
+      // The same search against a host the row does NOT have drops it.
+      rerender(
+        <HistoryQueryHarness
+          search={{
+            ...hostSearch,
+            chatHosts: ["host-z"],
+            query: "feature/histogram",
+          }}
+        />,
+      );
+      expect(
+        screen.getByRole("status", { name: "History titles" }).textContent,
+      ).toBe("");
+    });
+  });
 });
 
 function HistoryQueryHarness(props: {
@@ -513,6 +653,14 @@ function HistoryQueryHarness(props: {
               `${facet.workspace.hostId}:${facet.workspace.workspacePath}:${facet.count}`,
           )
           .join("|") ?? ""}
+      </div>
+      <div data-testid="chat-host-unsupported">
+        {String(result.data?.chatHostFilterUnsupported ?? false)}
+      </div>
+      <div data-testid="chat-host-facets">
+        {result.data?.facets.chatHosts
+          ?.map((facet) => `${facet.hostId}:${facet.count}`)
+          .join("|") ?? "none"}
       </div>
       <div data-testid="ownership-facets">
         {result.data?.facets.ownershipScopes

--- a/clients/gui-app/src/hooks/home/use-chat-host-filter-support.ts
+++ b/clients/gui-app/src/hooks/home/use-chat-host-filter-support.ts
@@ -1,0 +1,30 @@
+import { useHostMethodSchemaVersion } from "@/hooks/host/use-host-supports-method";
+
+/**
+ * Whether this host can evaluate the history page's chat-host filter.
+ *
+ * - `supported` - the host negotiated `epic.listTasks` at @1.3 or later.
+ * - `unsupported` - it negotiated an older minor, which SILENTLY STRIPS
+ *   `chatHostIds` from the request. That is the entire reason this gate
+ *   exists: the response comes back well-formed and complete, so an
+ *   unfiltered list would render as a filtered one with no error anywhere.
+ * - `unknown` - no handshake with this host has completed yet.
+ *
+ * `epic.listTasks` is a RELEASED-FLOOR method, so `useHostSupportsMethod` is
+ * the wrong question - every host advertises it. Only the negotiated MINOR
+ * distinguishes a host that will honor the filter from one that will discard
+ * it.
+ */
+export type ChatHostFilterSupport = "supported" | "unsupported" | "unknown";
+
+/** The `epic.listTasks` minor that introduced `chatHostIds`. */
+const CHAT_HOST_FILTER_MINOR = 3;
+
+export function useChatHostFilterSupport(
+  hostId: string | null,
+): ChatHostFilterSupport {
+  const version = useHostMethodSchemaVersion(hostId, "epic.listTasks");
+  if (version === null) return "unknown";
+  if (version.major !== 1) return "unsupported";
+  return version.minor >= CHAT_HOST_FILTER_MINOR ? "supported" : "unsupported";
+}

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -17,6 +17,7 @@ import {
   withHistoryItemWorktreeMetadata,
 } from "@/components/home/data/home-page.data";
 import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
+import { useChatHostFilterSupport } from "@/hooks/home/use-chat-host-filter-support";
 import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
 import { useEpicGetTaskContexts } from "@/hooks/epic/use-epic-get-task-contexts-query";
 import {
@@ -123,6 +124,8 @@ export function useHistoryQuery(
     isFetchingNextPage,
   } = useCloudEpicTasksQuery(request, { enabled: true });
   const tasksQueryRefetch = tasksQuery.refetch;
+  const chatHostFilterActive = params.search.chatHosts.length > 0;
+  const hostChatHostSupport = useChatHostFilterSupport(hostId);
   const isQueryDebouncing = debouncedQuery !== trimmedQuery;
   const shouldProjectLocally =
     isQueryDebouncing || tasksQuery.isFetching || tasksQuery.isPlaceholderData;
@@ -196,6 +199,31 @@ export function useHistoryQuery(
       facets.workspaces.length > 0
         ? facets.workspaces.map((workspace) => workspace.workspace)
         : collectHistoryWorkspaces(allItems);
+    // Fail closed on BOTH skew directions. The host arm is the negotiated
+    // minor; the cloud arm is a first page that came back without the
+    // `chatHosts` group at all, which is how an old cloud tier - it has no
+    // version negotiation, it simply drops request keys it does not know -
+    // reveals that it never applied the filter. In either case the rows in
+    // hand are UNFILTERED, and showing them under an active host filter is
+    // the exact failure this whole gate exists to prevent. Withhold them and
+    // let the panel say why.
+    const chatHostFilterUnsupported =
+      chatHostFilterActive &&
+      (hostChatHostSupport === "unsupported" ||
+        (canUseServerFacets &&
+          tasksQuery.data.facets !== undefined &&
+          facets.chatHosts === null));
+    if (chatHostFilterUnsupported) {
+      return {
+        items: [],
+        availableRepos: EMPTY_REPOS,
+        availableWorkspaces: EMPTY_WORKSPACE_REFS,
+        totalCount: 0,
+        facets: EMPTY_FACETS,
+        worktreesByEpicId,
+        chatHostFilterUnsupported: true,
+      };
+    }
     return {
       items,
       availableRepos:
@@ -206,10 +234,13 @@ export function useHistoryQuery(
       totalCount: items.length,
       facets,
       worktreesByEpicId,
+      chatHostFilterUnsupported: false,
     };
   }, [
     allItems,
+    chatHostFilterActive,
     contextExtrasCount,
+    hostChatHostSupport,
     debouncedQuery,
     isQueryDebouncing,
     params.search,
@@ -246,6 +277,9 @@ export function useHistoryQuery(
   };
 }
 
+const EMPTY_REPOS: ReadonlyArray<string> = [];
+const EMPTY_WORKSPACE_REFS: ReadonlyArray<HistoryWorkspaceRef> = [];
+
 export interface HistoryFetchResult {
   items: ReadonlyArray<HistoryItem>;
   availableRepos: ReadonlyArray<string>;
@@ -253,12 +287,25 @@ export interface HistoryFetchResult {
   totalCount: number;
   facets: HistoryFacets;
   worktreesByEpicId: ReadonlyMap<string, readonly WorktreeHostEntryV12[]>;
+  /**
+   * The chat-host filter is active but the serving peer cannot apply it, so
+   * `items` is deliberately EMPTY rather than unfiltered. Render an
+   * explanation, never an empty-history message.
+   */
+  chatHostFilterUnsupported: boolean;
 }
 
 export interface HistoryFacets {
   readonly repos: ReadonlyArray<HistoryRepoFacet>;
   readonly workspaces: ReadonlyArray<HistoryWorkspaceFacet>;
+  /** `null` when the peer did not report the group at all. */
+  readonly chatHosts: ReadonlyArray<HistoryChatHostFacet> | null;
   readonly ownershipScopes: ReadonlyArray<HistoryOwnershipFacet>;
+}
+
+export interface HistoryChatHostFacet {
+  readonly hostId: string;
+  readonly count: number;
 }
 
 export interface HistoryRepoFacet {
@@ -279,6 +326,7 @@ export interface HistoryOwnershipFacet {
 const EMPTY_FACETS: HistoryFacets = {
   repos: [],
   workspaces: [],
+  chatHosts: null,
   ownershipScopes: [],
 };
 
@@ -295,6 +343,12 @@ function mapHistoryFacets(
       workspace: facet.workspaceIdentifier,
       count: facet.count,
     })),
+    // Absence is preserved as `null` rather than flattened to `[]`. It is the
+    // only signal that the CLOUD tier (which has no version negotiation of its
+    // own - an old server's body schema just drops unknown request keys)
+    // could not evaluate the filter, and `[]` would read as a truthful
+    // "no host owns any chat".
+    chatHosts: facets.chatHosts ?? null,
     ownershipScopes: facets.ownershipScopes,
   };
 }
@@ -335,6 +389,12 @@ function filterHistoryItemsLocally(
     repoMatchMode: search.repoMode,
     workspaces: search.workspaces,
     workspaceMatchMode: search.workspaceMode,
+    // Rows carry their caller-visible chat hosts, so the host filter is
+    // re-applied locally: to id-fetched worktree/PR matches, which never went
+    // through the server's filter, and to cached rows while a request for a
+    // newly-toggled host is still in flight.
+    chatHosts: search.chatHosts,
+    chatHostMatchMode: search.chatHostMode,
     ownershipScopes: search.ownershipScopes,
   });
 }

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -207,12 +207,15 @@ export function useHistoryQuery(
     // hand are UNFILTERED, and showing them under an active host filter is
     // the exact failure this whole gate exists to prevent. Withhold them and
     // let the panel say why.
+    //
+    // A MISSING `facets` object counts too, and deliberately has no exemption:
+    // this query never carries a cursor ("Show more" pages append through a
+    // separate mutation and store), so its response is always a first page,
+    // and a first page without facets is a server that never computed them.
     const chatHostFilterUnsupported =
       chatHostFilterActive &&
       (hostChatHostSupport === "unsupported" ||
-        (canUseServerFacets &&
-          tasksQuery.data.facets !== undefined &&
-          facets.chatHosts === null));
+        (canUseServerFacets && facets.chatHosts === null));
     if (chatHostFilterUnsupported) {
       return {
         items: [],

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -392,7 +392,7 @@ function filterHistoryItemsLocally(
     repoMatchMode: search.repoMode,
     workspaces: search.workspaces,
     workspaceMatchMode: search.workspaceMode,
-    // Rows carry their caller-visible chat hosts, so the host filter is
+    // Rows carry the caller's own chat hosts, so the host filter is
     // re-applied locally: to id-fetched worktree/PR matches, which never went
     // through the server's filter, and to cached rows while a request for a
     // newly-toggled host is still in flight.

--- a/clients/gui-app/src/lib/__tests__/history-search.test.ts
+++ b/clients/gui-app/src/lib/__tests__/history-search.test.ts
@@ -100,6 +100,18 @@ describe("history search params", () => {
     ).toBeUndefined();
   });
 
+  it("collapses whitespace variants of one chat-host id to a single entry", () => {
+    // Deduping raw values first would let `" host-a "` and `"host-a"` both
+    // survive and then trim into the same id, serializing it twice.
+    const parsed = parseHistorySearch({
+      historyChatHosts: ["host-a", " host-a ", "host-a  "],
+    });
+    expect(parsed.chatHosts).toEqual(["host-a"]);
+    expect(historySearchToParams(parsed).historyChatHosts).toEqual(["host-a"]);
+    // One id, so no match mode belongs in the URL either.
+    expect(historySearchToParams(parsed).historyChatHostMode).toBeUndefined();
+  });
+
   it("drops blank chat-host ids and clears the params", () => {
     expect(
       parseHistorySearch({ historyChatHosts: ["", "  ", "host-a"] }).chatHosts,

--- a/clients/gui-app/src/lib/__tests__/history-search.test.ts
+++ b/clients/gui-app/src/lib/__tests__/history-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_HISTORY_SEARCH,
   clearHistorySearchParams,
   historySearchToParams,
   parseHistorySearch,
@@ -26,6 +27,8 @@ describe("history search params", () => {
       repoMode: "all",
       workspaces: [{ hostId: "host-1", workspacePath: "/Users/me/gui-app" }],
       workspaceMode: "all",
+      chatHosts: [],
+      chatHostMode: "any",
       ownershipScopes: ["shared"],
       sort: "relevance",
       sortExplicit: false,
@@ -67,5 +70,46 @@ describe("history search params", () => {
         historySort: "relevance",
       }),
     ).toEqual({ focusedAt: 1 });
+  });
+  it("round-trips chat-host selections through the URL, dropping a default mode", () => {
+    const parsed = parseHistorySearch({
+      historyChatHosts: ["host-b", "host-a"],
+      historyChatHostMode: "all",
+    });
+    // Sorted on parse so two URLs naming the same hosts in different orders
+    // produce the same state - and therefore the same query key.
+    expect(parsed.chatHosts).toEqual(["host-a", "host-b"]);
+    expect(parsed.chatHostMode).toBe("all");
+    expect(historySearchToParams(parsed)).toMatchObject({
+      historyChatHosts: ["host-a", "host-b"],
+      historyChatHostMode: "all",
+    });
+
+    // A single host cannot have a match mode worth serializing, and "any" is
+    // the default - neither belongs in the URL.
+    const single = patchHistorySearch(DEFAULT_HISTORY_SEARCH, {
+      chatHosts: ["host-a"],
+      chatHostMode: "all",
+    });
+    expect(historySearchToParams(single).historyChatHostMode).toBeUndefined();
+    const defaulted = patchHistorySearch(DEFAULT_HISTORY_SEARCH, {
+      chatHosts: ["host-a", "host-b"],
+    });
+    expect(
+      historySearchToParams(defaulted).historyChatHostMode,
+    ).toBeUndefined();
+  });
+
+  it("drops blank chat-host ids and clears the params", () => {
+    expect(
+      parseHistorySearch({ historyChatHosts: ["", "  ", "host-a"] }).chatHosts,
+    ).toEqual(["host-a"]);
+    expect(
+      clearHistorySearchParams({
+        historyChatHosts: ["host-a"],
+        historyChatHostMode: "all",
+        keep: 1,
+      }),
+    ).toEqual({ keep: 1 });
   });
 });

--- a/clients/gui-app/src/lib/cloud-epic-tasks-query/__tests__/cache.test.ts
+++ b/clients/gui-app/src/lib/cloud-epic-tasks-query/__tests__/cache.test.ts
@@ -100,6 +100,53 @@ describe("removeDeletedEpicsFromCloudTaskCaches", () => {
       queryClient.getQueryData<ListTasksResponse>(otherUserKey)?.tasks,
     ).toHaveLength(1);
   });
+
+  it("keeps the chat-host facet group when deleting, decrementing its counts", () => {
+    // The group's PRESENCE is a sentinel: `useHistoryQuery` reads a missing
+    // `chatHosts` as proof the server never applied the host filter and
+    // withholds every row. Rebuilding facets without it would strand a
+    // host-filtered list in "can't filter by host here" - permanently, since
+    // these entries never refetch on their own.
+    const queryClient = new QueryClient();
+    const key = cloudEpicTasksQueryKey(
+      "host-a",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData<ListTasksResponse>(key, {
+      tasks: [
+        {
+          ...taskLight("epic-a", "Alpha", "traycer/gui-app", "user-1"),
+          chatHostIds: ["host-a", "host-b"],
+        },
+        {
+          ...taskLight("epic-b", "Beta", "traycer/server", "user-1"),
+          chatHostIds: ["host-b"],
+        },
+      ],
+      hasMore: false,
+      facets: {
+        repos: [],
+        workspaces: [],
+        ownershipScopes: [{ value: "mine", count: 2 }],
+        chatHosts: [
+          { hostId: "host-a", count: 1 },
+          { hostId: "host-b", count: 2 },
+        ],
+      },
+    });
+
+    removeDeletedEpicsFromCloudTaskCaches(
+      queryClient,
+      { hostId: null, userId: "user-1" },
+      ["epic-a"],
+    );
+
+    // host-a lost its only task and drops out; host-b keeps the survivor.
+    expect(
+      queryClient.getQueryData<ListTasksResponse>(key)?.facets?.chatHosts,
+    ).toEqual([{ hostId: "host-b", count: 1 }]);
+  });
 });
 
 describe("readEpicTitlesFromCloudTaskCaches", () => {

--- a/clients/gui-app/src/lib/cloud-epic-tasks-query/cache.ts
+++ b/clients/gui-app/src/lib/cloud-epic-tasks-query/cache.ts
@@ -361,7 +361,7 @@ function updateEpicTitleInListTaskLight(
 
 function removeTasksFromFacets(
   facets: ListTasksFacets,
-  tasks: ReadonlyArray<TaskLight>,
+  tasks: ReadonlyArray<ListTaskLight>,
   userId: string,
 ): ListTasksFacets {
   return {
@@ -374,7 +374,42 @@ function removeTasksFromFacets(
       facets.ownershipScopes,
       ownershipScopesFromTasks(tasks, userId),
     ),
+    // Rebuilding this object DROPS `chatHosts` unless it is carried, and its
+    // absence is not cosmetic: the history gate reads a missing group as proof
+    // that the server never applied the host filter and withholds every row
+    // (`use-history-query`). A local delete would then present as "this host
+    // is too old to filter by host" - permanently, since these entries are
+    // cached with `staleTime`/`gcTime` at Infinity and never refetch on their
+    // own. Any future facet group must be carried here for the same reason.
+    chatHosts: decrementChatHostFacets(facets.chatHosts, tasks),
   };
+}
+
+/**
+ * Decrements per-host task counts for the removed rows, and drops a host whose
+ * last task just went.
+ *
+ * A row with no `chatHostIds` (an older peer that cannot report them) is
+ * skipped rather than treated as contributing to no host: its counts stay
+ * high until the next fetch, which is a stale number rather than a wrong
+ * shape. Losing the GROUP entirely is the failure that matters.
+ */
+function decrementChatHostFacets(
+  current: ListTasksFacets["chatHosts"],
+  removed: ReadonlyArray<ListTaskLight>,
+): ListTasksFacets["chatHosts"] {
+  if (current === undefined) return undefined;
+  const removedCounts = new Map<string, number>();
+  for (const task of removed) {
+    for (const hostId of new Set(task.chatHostIds ?? [])) {
+      removedCounts.set(hostId, (removedCounts.get(hostId) ?? 0) + 1);
+    }
+  }
+  if (removedCounts.size === 0) return current;
+  return current.flatMap((facet) => {
+    const count = facet.count - (removedCounts.get(facet.hostId) ?? 0);
+    return count > 0 ? [{ hostId: facet.hostId, count }] : [];
+  });
 }
 
 function reposFromTasks(

--- a/clients/gui-app/src/lib/cloud-epic-tasks-query/query.ts
+++ b/clients/gui-app/src/lib/cloud-epic-tasks-query/query.ts
@@ -119,6 +119,12 @@ export function listCloudTasksRequestForHistorySearch(
     filters.workspaceIdentifiers = [...dedupSortWorkspaces(search.workspaces)];
     filters.workspaceMatchMode = search.workspaceMode;
   }
+  if (search.chatHosts.length > 0) {
+    filters.chatHostIds = Array.from(new Set(search.chatHosts)).sort(
+      (left, right) => left.localeCompare(right),
+    );
+    filters.chatHostMatchMode = search.chatHostMode;
+  }
   if (search.ownershipScopes.length > 0) {
     filters.ownershipScopes = sortOwnershipScopes(search.ownershipScopes);
   }

--- a/clients/gui-app/src/lib/history-search.ts
+++ b/clients/gui-app/src/lib/history-search.ts
@@ -226,12 +226,17 @@ function normalizeRepos(
 function normalizeChatHosts(
   value: string | string[] | undefined,
 ): ReadonlyArray<string> {
-  return normalizeArray(value)
-    .flatMap((hostId) => {
-      const trimmed = hostId.trim();
-      return trimmed.length > 0 ? [trimmed] : [];
-    })
-    .sort((left, right) => left.localeCompare(right));
+  // Dedupe AFTER trimming. `normalizeArray` dedupes raw values, so
+  // `"host-a"` and `" host-a "` survive it as two entries and then trim into
+  // the same id - which would serialize the same host twice into the URL and
+  // double its contribution to the active-filter count.
+  const hostIds = normalizeArray(value).flatMap((hostId) => {
+    const trimmed = hostId.trim();
+    return trimmed.length > 0 ? [trimmed] : [];
+  });
+  return Array.from(new Set(hostIds)).sort((left, right) =>
+    left.localeCompare(right),
+  );
 }
 
 function normalizeWorkspaces(

--- a/clients/gui-app/src/lib/history-search.ts
+++ b/clients/gui-app/src/lib/history-search.ts
@@ -25,6 +25,8 @@ export const historySearchParamsSchema = z.object({
   historyRepoMode: historyMatchModeSchema.optional(),
   historyWorkspaces: z.union([z.string(), z.array(z.string())]).optional(),
   historyWorkspaceMode: historyMatchModeSchema.optional(),
+  historyChatHosts: z.union([z.string(), z.array(z.string())]).optional(),
+  historyChatHostMode: historyMatchModeSchema.optional(),
   historyOwnership: z
     .union([historyOwnershipSchema, z.array(historyOwnershipSchema)])
     .optional(),
@@ -37,6 +39,14 @@ export interface HistorySearchState {
   readonly repoMode: HistoryMatchMode;
   readonly workspaces: ReadonlyArray<HistoryWorkspaceRef>;
   readonly workspaceMode: HistoryMatchMode;
+  /**
+   * Hosts that own chats in the task (`chats.owner_host_id`), NOT the hosts
+   * named by `workspaces` - a workspace is bound at create, a chat host is
+   * where the work actually happens. Raw host ids; display names are resolved
+   * against the host directory at render time.
+   */
+  readonly chatHosts: ReadonlyArray<string>;
+  readonly chatHostMode: HistoryMatchMode;
   readonly ownershipScopes: ReadonlyArray<HistoryOwnershipScope>;
   readonly sort: HistorySortOption;
   readonly sortExplicit: boolean;
@@ -50,6 +60,8 @@ export type HistorySearchPatch = Partial<
     | "repoMode"
     | "workspaces"
     | "workspaceMode"
+    | "chatHosts"
+    | "chatHostMode"
     | "ownershipScopes"
     | "sort"
   >
@@ -63,6 +75,8 @@ export const DEFAULT_HISTORY_SEARCH: HistorySearchState = {
   repoMode: "any",
   workspaces: [],
   workspaceMode: "any",
+  chatHosts: [],
+  chatHostMode: "any",
   ownershipScopes: [],
   sort: "recent",
   sortExplicit: false,
@@ -82,6 +96,9 @@ export function parseHistorySearch(
     workspaces: normalizeWorkspaces(parsed.data.historyWorkspaces),
     workspaceMode:
       parsed.data.historyWorkspaceMode ?? DEFAULT_HISTORY_SEARCH.workspaceMode,
+    chatHosts: normalizeChatHosts(parsed.data.historyChatHosts),
+    chatHostMode:
+      parsed.data.historyChatHostMode ?? DEFAULT_HISTORY_SEARCH.chatHostMode,
     ownershipScopes: normalizeArray(parsed.data.historyOwnership),
     sort:
       parsed.data.historySort ??
@@ -104,6 +121,8 @@ export function patchHistorySearch(
     repoMode: patch.repoMode ?? current.repoMode,
     workspaces: patch.workspaces ?? current.workspaces,
     workspaceMode: patch.workspaceMode ?? current.workspaceMode,
+    chatHosts: patch.chatHosts ?? current.chatHosts,
+    chatHostMode: patch.chatHostMode ?? current.chatHostMode,
     ownershipScopes: patch.ownershipScopes ?? current.ownershipScopes,
     sort,
     sortExplicit,
@@ -130,6 +149,12 @@ export function historySearchToParams(
       state.workspaceMode !== DEFAULT_HISTORY_SEARCH.workspaceMode
         ? state.workspaceMode
         : undefined,
+    historyChatHosts: state.chatHosts.length > 0 ? state.chatHosts : undefined,
+    historyChatHostMode:
+      state.chatHosts.length > 1 &&
+      state.chatHostMode !== DEFAULT_HISTORY_SEARCH.chatHostMode
+        ? state.chatHostMode
+        : undefined,
     historyOwnership:
       state.ownershipScopes.length > 0 ? state.ownershipScopes : undefined,
     historySort:
@@ -146,6 +171,8 @@ export type HistorySearchParamKey =
   | "historyRepoMode"
   | "historyWorkspaces"
   | "historyWorkspaceMode"
+  | "historyChatHosts"
+  | "historyChatHostMode"
   | "historyOwnership"
   | "historySort";
 
@@ -165,6 +192,8 @@ export function clearHistorySearchParams<
     historyRepoMode: _historyRepoMode,
     historyWorkspaces: _historyWorkspaces,
     historyWorkspaceMode: _historyWorkspaceMode,
+    historyChatHosts: _historyChatHosts,
+    historyChatHostMode: _historyChatHostMode,
     historyOwnership: _historyOwnership,
     historySort: _historySort,
     ...rest
@@ -189,6 +218,17 @@ function normalizeRepos(
   return normalizeArray(value)
     .flatMap((repo) => {
       const trimmed = repo.trim();
+      return trimmed.length > 0 ? [trimmed] : [];
+    })
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeChatHosts(
+  value: string | string[] | undefined,
+): ReadonlyArray<string> {
+  return normalizeArray(value)
+    .flatMap((hostId) => {
+      const trimmed = hostId.trim();
       return trimmed.length > 0 ? [trimmed] : [];
     })
     .sort((left, right) => left.localeCompare(right));

--- a/protocol/src/host/epic/__tests__/epic-get-task-contexts-schema.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-get-task-contexts-schema.test.ts
@@ -5,6 +5,7 @@ import {
   GET_TASK_CONTEXTS_MAX_IDS,
   getTaskContextsRequestSchema,
   getTaskContextsResponseSchema,
+  getTaskContextsResponseSchemaPre12,
   getTaskContextsResponseSchemaV10,
   type ListTaskLight,
   listTaskLightSchema,
@@ -45,12 +46,15 @@ describe("epic.getTaskContexts", () => {
     hostRpcRegistry["epic.getTaskContexts"][1].versions[0].contract;
   const v11Contract =
     hostRpcRegistry["epic.getTaskContexts"][1].versions[1].contract;
+  const v12Contract =
+    hostRpcRegistry["epic.getTaskContexts"][1].versions[2].contract;
 
   it("keeps v1.0 frozen and registers the v1.1 explicit-resolution minor", () => {
     expect(v10Contract.schemaVersion).toEqual({ major: 1, minor: 0 });
     expect(v11Contract.method).toBe("epic.getTaskContexts");
     expect(v11Contract.schemaVersion).toEqual({ major: 1, minor: 1 });
-    expect(hostRpcRegistry["epic.getTaskContexts"][1].latestMinor).toBe(1);
+    expect(v12Contract.schemaVersion).toEqual({ major: 1, minor: 2 });
+    expect(hostRpcRegistry["epic.getTaskContexts"][1].latestMinor).toBe(2);
     expect(hostRpcRegistry["epic.getTaskContexts"].degrade).toEqual({
       kind: "unsupported",
     });
@@ -60,7 +64,10 @@ describe("epic.getTaskContexts", () => {
     expect(v10Contract.requestSchema).toBe(getTaskContextsRequestSchema);
     expect(v10Contract.responseSchema).toBe(getTaskContextsResponseSchemaV10);
     expect(v11Contract.requestSchema).toBe(getTaskContextsRequestSchema);
-    expect(v11Contract.responseSchema).toBe(getTaskContextsResponseSchema);
+    // v1.1 stays on the pre-@1.2 row: only v1.2 carries `chatHostIds`.
+    expect(v11Contract.responseSchema).toBe(getTaskContextsResponseSchemaPre12);
+    expect(v12Contract.requestSchema).toBe(getTaskContextsRequestSchema);
+    expect(v12Contract.responseSchema).toBe(getTaskContextsResponseSchema);
   });
 
   it("round-trips a request within the id cap", () => {

--- a/protocol/src/host/epic/__tests__/epic-list-tasks-instance-identity.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-list-tasks-instance-identity.test.ts
@@ -5,6 +5,7 @@ import {
   listTasksRequestSchema,
   listTasksRequestSchemaV11,
   listTasksResponseSchema,
+  listTasksResponseSchemaPre13,
 } from "@traycer/protocol/host/epic/unary-schemas";
 
 /**
@@ -25,8 +26,11 @@ import {
  * protocol package.
  */
 describe("epic.listTasks instance identity", () => {
+  // The LATEST minor - bump alongside `latestMinor` in the registry. This
+  // test exists to catch a latest contract that drifted off the canonical
+  // instances, so it must track latest rather than a fixed minor.
   const hostContract =
-    hostRpcRegistry["epic.listTasks"][1].versions[2].contract;
+    hostRpcRegistry["epic.listTasks"][1].versions[3].contract;
 
   it("host request schema is the canonical listTasksRequestSchema instance", () => {
     expect(hostContract.requestSchema).toBe(listTasksRequestSchema);
@@ -138,5 +142,27 @@ describe("epic.listTasks instance identity", () => {
       tasks: [{ epic: null, phase: null, pinned: false }],
       hasMore: false,
     });
+  });
+  it("keeps chatHostIds on latest rows and drops it from the frozen pre-1.3 row", () => {
+    // zod STRIPS unknown keys, so a response schema that kept the pre-1.3 row
+    // would discard `chatHostIds` from every row with nothing failing - the
+    // field would just never arrive. Parse, don't typecheck, to catch that.
+    const row = {
+      epic: null,
+      phase: null,
+      pinned: false,
+      chatHostIds: ["host-a"],
+    };
+    const latest = listTasksResponseSchema.parse({
+      tasks: [row],
+      hasMore: false,
+    });
+    expect(latest.tasks[0]?.chatHostIds).toEqual(["host-a"]);
+
+    const frozen = listTasksResponseSchemaPre13.parse({
+      tasks: [row],
+      hasMore: false,
+    });
+    expect(frozen.tasks[0]).not.toHaveProperty("chatHostIds");
   });
 });

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -48,12 +48,15 @@ import {
   listEpicCollaboratorsResponseSchema,
   getTaskContextsRequestSchema,
   getTaskContextsResponseSchema,
+  getTaskContextsResponseSchemaPre12,
   getTaskContextsResponseSchemaV10,
   isFoundTaskContext,
   listTasksRequestSchema,
   listTasksRequestSchemaV11,
+  listTasksRequestSchemaPre13,
   listTasksResponseSchema,
   listTasksResponseSchemaV10,
+  listTasksResponseSchemaPre13,
   prepareArtifactImageRequestSchema,
   prepareArtifactImageResponseSchema,
   removeEpicRepoRequestSchema,
@@ -160,7 +163,7 @@ export const epicListTasksV11 = defineRpcContract({
   method: "epic.listTasks",
   schemaVersion: { major: 1, minor: 1 } as const,
   requestSchema: listTasksRequestSchemaV11,
-  responseSchema: listTasksResponseSchema,
+  responseSchema: listTasksResponseSchemaPre13,
 });
 
 export const epicListTasksUpgradeV10ToV11 = defineUpgradePath<
@@ -181,8 +184,8 @@ export const epicListTasksUpgradeV10ToV11 = defineUpgradePath<
 export const epicListTasksV12 = defineRpcContract({
   method: "epic.listTasks",
   schemaVersion: { major: 1, minor: 2 } as const,
-  requestSchema: listTasksRequestSchema,
-  responseSchema: listTasksResponseSchema,
+  requestSchema: listTasksRequestSchemaPre13,
+  responseSchema: listTasksResponseSchemaPre13,
 });
 
 export const epicListTasksUpgradeV11ToV12 = defineUpgradePath<
@@ -192,6 +195,32 @@ export const epicListTasksUpgradeV11ToV12 = defineUpgradePath<
   from: epicListTasksV11.schemaVersion,
   to: epicListTasksV12.schemaVersion,
   upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+// `epic.listTasks@1.3` adds the chat-host dimension: a `chatHostIds` filter on
+// the request and a matching `chatHosts` facet group on the response. Both are
+// optional, so a v1.2 request is already a valid latest request - but the
+// version gate is what stops a NEW client from believing an OLD host applied a
+// host filter it silently dropped, which would render an unfiltered list as a
+// filtered one.
+export const epicListTasksV13 = defineRpcContract({
+  method: "epic.listTasks",
+  schemaVersion: { major: 1, minor: 3 } as const,
+  requestSchema: listTasksRequestSchema,
+  responseSchema: listTasksResponseSchema,
+});
+
+export const epicListTasksUpgradeV12ToV13 = defineUpgradePath<
+  typeof epicListTasksV12,
+  typeof epicListTasksV13
+>({
+  from: epicListTasksV12.schemaVersion,
+  to: epicListTasksV13.schemaVersion,
+  upgradeRequest: (request) => request,
+  // A v1.2 host never counted chat hosts. `chatHosts` stays absent rather
+  // than becoming `[]`: an empty array reads as "no host has any task", and
+  // the popover would render an empty section instead of falling back.
   upgradeResponse: (response) => response,
 });
 
@@ -231,7 +260,7 @@ export const epicGetTaskContextsV11 = defineRpcContract({
   method: "epic.getTaskContexts",
   schemaVersion: { major: 1, minor: 1 } as const,
   requestSchema: getTaskContextsRequestSchema,
-  responseSchema: getTaskContextsResponseSchema,
+  responseSchema: getTaskContextsResponseSchemaPre12,
 });
 
 export const epicGetTaskContextsUpgradeV10ToV11 = defineUpgradePath<
@@ -251,6 +280,32 @@ export const epicGetTaskContextsUpgradeV10ToV11 = defineUpgradePath<
       ]),
     ),
   }),
+});
+
+// `epic.getTaskContexts@1.2` carries `chatHostIds` on the found row, matching
+// `epic.listTasks@1.3`. These rows are fetched BY ID and so never pass through
+// the list filter; without the field a client cannot tell whether an id-fetched
+// task belongs to a selected host, and has to choose between showing it
+// unfiltered or dropping it entirely. Both are wrong answers.
+export const epicGetTaskContextsV12 = defineRpcContract({
+  method: "epic.getTaskContexts",
+  schemaVersion: { major: 1, minor: 2 } as const,
+  requestSchema: getTaskContextsRequestSchema,
+  responseSchema: getTaskContextsResponseSchema,
+});
+
+export const epicGetTaskContextsUpgradeV11ToV12 = defineUpgradePath<
+  typeof epicGetTaskContextsV11,
+  typeof epicGetTaskContextsV12
+>({
+  from: epicGetTaskContextsV11.schemaVersion,
+  to: epicGetTaskContextsV12.schemaVersion,
+  upgradeRequest: (request) => request,
+  // `chatHostIds` stays ABSENT on an upgraded v1.1 row rather than becoming
+  // `[]`. An old host did not report no visible chat hosts; it reported
+  // nothing, and only absence lets the local predicate abstain instead of
+  // filtering the row out.
+  upgradeResponse: (response) => response,
 });
 
 /**
@@ -444,7 +499,6 @@ export const epicCreateChatUpgradeV10ToV11 = defineUpgradePath<
   }),
   upgradeResponse: (response) => response,
 });
-
 
 export const epicRenameChatV10 = defineRpcContract({
   method: "epic.renameChat",

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -198,9 +198,12 @@ export type TaskFiltersPre13 = z.infer<typeof taskFiltersSchemaPre13>;
  * is created there. Deliberately not the workspace association above - a
  * workspace is bound at create and never follows the work.
  *
- * Only chats the caller may see participate (their own, plus task-visible
- * ones); a collaborator's private chat must not disclose its host through a
- * filter hit or a facet count.
+ * Scoped to the caller's OWN live chats. A collaborator's host is a machine
+ * the caller cannot name - their host directory has never seen it - and
+ * surfacing which machine a teammate works on is an association nothing else
+ * in the product exposes. It also sidesteps duplicate chat ids, which the
+ * real readers resolve by an owner-precedence tiebreak that an aggregate
+ * cannot reproduce.
  */
 export const taskFiltersSchema = taskFiltersSchemaPre13.extend({
   chatHostIds: z.array(z.string()).optional(),
@@ -528,14 +531,14 @@ export const listTaskLightSchemaPre13 = taskLightSchema.extend({
 export type ListTaskLightPre13 = z.infer<typeof listTaskLightSchemaPre13>;
 
 /**
- * `chatHostIds` are the hosts owning chats in this task that the CALLER may
- * see - the same ACL the `chatHostIds` filter and the `chatHosts` facet
- * apply, evaluated per row. It is what lets a client re-apply the host filter
+ * `chatHostIds` are the hosts owning the CALLER'S OWN live chats in this task
+ * - the same scope the `chatHostIds` filter and the `chatHosts` facet apply,
+ * evaluated per row. It is what lets a client re-apply the host filter
  * locally: to cached rows while a request is in flight, and to rows it fetched
  * by id (which never passed through the server's filter at all).
  *
  * Absent, not `[]`, on a row from a peer that predates the field - the
- * distinction matters, because `[]` is a truthful "no visible chats anywhere"
+ * distinction matters, because `[]` is a truthful "none of my chats anywhere"
  * and would let a local predicate confidently filter the row OUT.
  */
 export const listTaskLightSchema = listTaskLightSchemaPre13.extend({

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -170,7 +170,13 @@ export interface TaskAssociations {
   workspaces: UserTaskWorkspace[];
 }
 
-export const taskFiltersSchema = z.object({
+// The pre-@1.3 filter shape, shared by every minor from @1.0 through @1.2 -
+// they must all resolve to the SAME schema instance, or the registry's
+// compatibility validator reads the newer field as one an older minor
+// "drops". `hostId` here is the WORKSPACE-association
+// host (it pairs with `workspacePath`), NOT the chat-host filter added in
+// @1.3 - the two dimensions answer different questions and must stay distinct.
+export const taskFiltersSchemaPre13 = z.object({
   query: z.string().optional(),
   taskType: taskTypeSchema.optional(),
   repoIdentifier: z.string().optional(),
@@ -182,6 +188,23 @@ export const taskFiltersSchema = z.object({
   workspacePath: z.string().optional(),
   hostId: z.string().optional(),
   organizationId: z.string().optional(),
+});
+export type TaskFiltersPre13 = z.infer<typeof taskFiltersSchemaPre13>;
+
+/**
+ * `chatHostIds` filters tasks by the hosts that own CHATS in them
+ * (`chats.owner_host_id`), which is what "this task is on that machine" means
+ * to a person: agents live on a host, and a task acquires a host when a chat
+ * is created there. Deliberately not the workspace association above - a
+ * workspace is bound at create and never follows the work.
+ *
+ * Only chats the caller may see participate (their own, plus task-visible
+ * ones); a collaborator's private chat must not disclose its host through a
+ * filter hit or a facet count.
+ */
+export const taskFiltersSchema = taskFiltersSchemaPre13.extend({
+  chatHostIds: z.array(z.string()).optional(),
+  chatHostMatchMode: taskRepoMatchModeSchema.optional(),
 });
 export type TaskFilters = z.infer<typeof taskFiltersSchema>;
 
@@ -499,25 +522,48 @@ export type TaskLight = z.infer<typeof taskLightSchema>;
 export const listTaskLightSchemaV10 = taskLightSchema;
 export type ListTaskLightV10 = z.infer<typeof listTaskLightSchemaV10>;
 
-export const listTaskLightSchema = taskLightSchema.extend({
+export const listTaskLightSchemaPre13 = taskLightSchema.extend({
   pinned: z.boolean().optional(),
+});
+export type ListTaskLightPre13 = z.infer<typeof listTaskLightSchemaPre13>;
+
+/**
+ * `chatHostIds` are the hosts owning chats in this task that the CALLER may
+ * see - the same ACL the `chatHostIds` filter and the `chatHosts` facet
+ * apply, evaluated per row. It is what lets a client re-apply the host filter
+ * locally: to cached rows while a request is in flight, and to rows it fetched
+ * by id (which never passed through the server's filter at all).
+ *
+ * Absent, not `[]`, on a row from a peer that predates the field - the
+ * distinction matters, because `[]` is a truthful "no visible chats anywhere"
+ * and would let a local predicate confidently filter the row OUT.
+ */
+export const listTaskLightSchema = listTaskLightSchemaPre13.extend({
+  chatHostIds: z.array(z.string()).optional(),
 });
 export type ListTaskLight = z.infer<typeof listTaskLightSchema>;
 
 export const listTasksRequestSchemaV11 = z.object({
   limit: z.number(),
   cursor: z.string().optional(),
-  filters: taskFiltersSchema.nullable(),
+  filters: taskFiltersSchemaPre13.nullable(),
   sort: listTasksSortSchemaV11.optional(),
   extensionPhaseVersion: z.string(),
   extensionEpicVersion: z.string(),
 });
-export const listTasksRequestSchema = listTasksRequestSchemaV11.extend({
+export const listTasksRequestSchemaPre13 = listTasksRequestSchemaV11.extend({
   sort: listTasksSortSchema.optional(),
+});
+export type ListTasksRequestPre13 = z.infer<typeof listTasksRequestSchemaPre13>;
+
+export const listTasksRequestSchema = listTasksRequestSchemaPre13.extend({
+  filters: taskFiltersSchema.nullable(),
 });
 export type ListTasksRequest = z.infer<typeof listTasksRequestSchema>;
 
-export const listTasksFacetsSchema = z.object({
+// The pre-@1.3 facet shape, shared by @1.0/@1.1/@1.2 - see the filter note
+// above on why every older minor must point at this one instance.
+export const listTasksFacetsSchemaPre13 = z.object({
   repos: z.array(
     z.object({
       repoIdentifier: taskRepoIdentifierSchema,
@@ -537,20 +583,47 @@ export const listTasksFacetsSchema = z.object({
     }),
   ),
 });
+export type ListTasksFacetsPre13 = z.infer<typeof listTasksFacetsSchemaPre13>;
+
+export const listTasksFacetsSchema = listTasksFacetsSchemaPre13.extend({
+  // Optional rather than required: the whole facets object is already
+  // first-page-only, and a host that upgrades ahead of the cloud tier would
+  // otherwise fail the response parse instead of degrading to "no counts".
+  chatHosts: z
+    .array(
+      z.object({
+        hostId: z.string(),
+        count: z.number(),
+      }),
+    )
+    .optional(),
+});
 export type ListTasksFacets = z.infer<typeof listTasksFacetsSchema>;
 
 export const listTasksResponseSchemaV10 = z.object({
   tasks: z.array(listTaskLightSchemaV10),
   nextCursor: z.string().optional(),
   hasMore: z.boolean(),
-  facets: listTasksFacetsSchema.optional(),
+  facets: listTasksFacetsSchemaPre13.optional(),
 });
 export type ListTasksResponseV10 = z.infer<typeof listTasksResponseSchemaV10>;
 
-export const listTasksResponseSchema = z.object({
-  tasks: z.array(listTaskLightSchema),
+export const listTasksResponseSchemaPre13 = z.object({
+  tasks: z.array(listTaskLightSchemaPre13),
   nextCursor: z.string().optional(),
   hasMore: z.boolean(),
+  facets: listTasksFacetsSchemaPre13.optional(),
+});
+export type ListTasksResponsePre13 = z.infer<
+  typeof listTasksResponseSchemaPre13
+>;
+
+// BOTH members move to their @1.3 shapes. Extending only `facets` leaves
+// `tasks` on the frozen pre-1.3 row, and since zod STRIPS unknown keys, every
+// row's `chatHostIds` would be silently discarded at response validation -
+// the field would simply never arrive, with nothing failing.
+export const listTasksResponseSchema = listTasksResponseSchemaPre13.extend({
+  tasks: z.array(listTaskLightSchema),
   facets: listTasksFacetsSchema.optional(),
 });
 export type ListTasksResponse = z.infer<typeof listTasksResponseSchema>;
@@ -604,7 +677,7 @@ export type GetTaskContextsRequest = z.infer<
 >;
 
 export const getTaskContextsResponseSchemaV10 = z.object({
-  tasks: z.record(z.string(), listTaskLightSchema.nullable()),
+  tasks: z.record(z.string(), listTaskLightSchemaPre13.nullable()),
 });
 export type GetTaskContextsResponseV10 = z.infer<
   typeof getTaskContextsResponseSchemaV10
@@ -622,6 +695,20 @@ export const taskContextUnknownReasonSchema = z.enum([
 export type TaskContextUnknownReason = z.infer<
   typeof taskContextUnknownReasonSchema
 >;
+
+export const taskContextResolutionSchemaPre12 = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("found"),
+    task: listTaskLightSchemaPre13,
+  }),
+  z.object({
+    status: z.literal("confirmed-absent"),
+  }),
+  z.object({
+    status: z.literal("unknown"),
+    reason: taskContextUnknownReasonSchema,
+  }),
+]);
 
 export const taskContextResolutionSchema = z.discriminatedUnion("status", [
   z.object({
@@ -656,6 +743,13 @@ export function isConfirmedAbsentTaskContext(
 ): result is Extract<TaskContextResolution, { status: "confirmed-absent" }> {
   return result?.status === "confirmed-absent";
 }
+
+export const getTaskContextsResponseSchemaPre12 = z.object({
+  tasks: z.record(z.string(), taskContextResolutionSchemaPre12),
+});
+export type GetTaskContextsResponsePre12 = z.infer<
+  typeof getTaskContextsResponseSchemaPre12
+>;
 
 export const getTaskContextsResponseSchema = z.object({
   tasks: z.record(z.string(), taskContextResultSchema),

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -294,7 +294,9 @@ import {
   epicFinishArtifactImageV10,
   epicGetTaskContextsV10,
   epicGetTaskContextsV11,
+  epicGetTaskContextsV12,
   epicGetTaskContextsUpgradeV10ToV11,
+  epicGetTaskContextsUpgradeV11ToV12,
   epicGrantAccessV10,
   epicChatBackupStatusV10,
   epicChatReplicaReadV10,
@@ -312,8 +314,10 @@ import {
   epicListTasksV10,
   epicListTasksV11,
   epicListTasksV12,
+  epicListTasksV13,
   epicListTasksUpgradeV10ToV11,
   epicListTasksUpgradeV11ToV12,
+  epicListTasksUpgradeV12ToV13,
   epicMentionEpicsV10,
   epicMentionReviewsV10,
   epicMentionSpecsV10,
@@ -4924,7 +4928,7 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
   },
   "epic.listTasks": {
     1: {
-      latestMinor: 2,
+      latestMinor: 3,
       versions: {
         0: {
           contract: epicListTasksV10,
@@ -4937,6 +4941,10 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         2: {
           contract: epicListTasksV12,
           upgradeFromPreviousVersion: epicListTasksUpgradeV11ToV12,
+        },
+        3: {
+          contract: epicListTasksV13,
+          upgradeFromPreviousVersion: epicListTasksUpgradeV12ToV13,
         },
       },
       downgradePathsFromLatest: {},
@@ -4975,7 +4983,7 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
     1: {
       // @1.1's new row-union values are projection-gated in host dispatch:
       // a v1.0 caller receives its released nullable rows, never a union arm.
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: epicGetTaskContextsV10,
@@ -4985,6 +4993,10 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
           contract: epicGetTaskContextsV11,
           upgradeFromPreviousVersion: epicGetTaskContextsUpgradeV10ToV11,
           responseGrowthProjectionGated: true,
+        },
+        2: {
+          contract: epicGetTaskContextsV12,
+          upgradeFromPreviousVersion: epicGetTaskContextsUpgradeV11ToV12,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
Adds a **Hosts** section to the task-history filter popover, alongside Ownership / Repositories / Workspaces. It filters by the hosts that own **your own chats** in a task (`chats.owner_host_id`) — agents live on a host, and a task acquires one when you create a chat there. Deliberately not the workspace association, which is bound at epic-create and never follows the work.

The cloud half is in `traycer-internal`.

## Scope: your own chats, not every chat you can read

The dimension is scoped to the caller's own live chats. A collaborator's host is a machine you cannot name — your host directory has never seen it, so the picker would render a raw id — and surfacing which machine a teammate works on is an association nothing else in the product exposes.

It also settles duplicate chat ids rather than working around them. Identity is `(task_id, owner_user_id, id)`, so two users can hold the same chat id in one task, and the real readers resolve exactly one (`viewerPrecedence`: your row wins, else the oldest). Aggregating over every task-visible chat would ignore that precedence and report a host for a row the canonical reader hides. Within one owner a chat id is unique by the primary key, so the ambiguity stops being reachable.

**Behaviour worth noting:** on a shared task where only a teammate has chats on host X, filtering by host X will not match it. That is the intended trade for a Hosts list containing only machines you can name.

## Protocol

`epic.listTasks@1.3` carries the `chatHostIds` filter and a `chatHosts` facet group. `epic.getTaskContexts@1.2` carries the same per-row `chatHostIds` the list rows now do.

The pre-1.3 request/response/row shapes are frozen and **shared by every older minor**. Pointing one of them at the canonical latest schema instead makes the registry validator read the new field as one an older minor *drops* — which throws at registry import, not at type-check. That is how it was caught. A second instance of the same class (a response that re-pointed `facets` but not `tasks`, silently stripping `chatHostIds` from every row) was caught only by the server's compile, so there is now a test that *parses* rather than typechecks.

## Both skew directions fail closed

Two paths would otherwise render an unfiltered list as a filtered one, and in both the response comes back well-formed — there is no error to notice:

- a host below `@1.3` parses the request through its older schema, which silently strips `chatHostIds`;
- the cloud tier has no version negotiation at all, so an old server simply drops request keys it does not recognize.

The gate is the **negotiated minor**, not method presence: `epic.listTasks` is a released-floor method, so "does this host have it" is always yes and answers the wrong question. The cloud arm is a first page that came back without the `chatHosts` group — including a response carrying no `facets` object at all, since this query never sends a cursor and its response is always a first page. Either way rows are **withheld** behind their own empty state.

## Rows carry their own chat hosts

`ListTaskLight.chatHostIds` lets the filter be re-applied client-side in the two places the server's filter never reached: **id-fetched rows** (branch / worktree-path / PR-number search only matches local worktree metadata, so those tasks bypass the list filter) and **cached rows** mid-request.

A row whose `chatHostIds` is `null` is **excluded** while a host is selected — nothing has checked it against the filter, and both untrusted sources above can produce one. `[]` is different: a truthful "none of my chats on any host". A peer too old to report the field never reaches the predicate; the version gate withholds the whole list first.

`chatHosts` is also carried through the optimistic cache patchers. Its absence is the sentinel the gate reads, so a delete or create that rebuilt the facets without it would strand the list behind "Can't filter by host here" — permanently, since those entries cache with `staleTime`/`gcTime` at `Infinity`. The create path additionally declines its optimistic insert while a host filter is active, because a create projection cannot evaluate `chatHostIds`.

## Tests

Protocol suites green. GUI coverage for the two fail-closed paths, host + branch-search, URL round-trip, `any` vs `all`, the `null`-exclusion rule, and the facet-group sentinel surviving a delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
