### PR TITLE
fix(gui-app): keycaps on a filled button, and one selected cmdk row at a time

### DIFF
--- a/clients/gui-app/__tests__/contrast.ts
+++ b/clients/gui-app/__tests__/contrast.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 /**
  * WCAG contrast-ratio calculator for `oklch(...)`/hex color strings, plus a
  * snapshot of `src/index.css`'s per-preset surface tokens. Lets tests assert
@@ -8,7 +9,20 @@
  * with it by hand - accent-only presets (rose/blue/violet/green/orange/pink)
  * are omitted because they inherit the default `:root`/`.dark`
  * background/canvas/popover unchanged.
+ *
+ * `resolveThemeTokens` at the bottom is the successor to that hand-sync: it
+ * parses `src/index.css` and cascades the theme blocks itself, and its preset
+ * set is pinned to the app's own `THEME_PRESETS` registry so a preset added to
+ * one and not the other fails loudly. Prefer it for new tests. It resolves
+ * every custom property `index.css` declares, but only OPAQUE colors are
+ * measurable - read them through `themeToken`, which rejects the rest by name
+ * (see its docstring).
  */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { THEME_PRESETS } from "@/lib/theme-presets";
 
 export interface ThemeSurfaces {
   readonly background: string;
@@ -304,4 +318,316 @@ export function compositeOverBackground(
   const [fgR, fgG, fgB] = parseColorToLinearSrgb(foreground);
   const [bgR, bgG, bgB] = parseColorToLinearSrgb(background);
   return `#${mixChannel(fgR, bgR)}${mixChannel(fgG, bgG)}${mixChannel(fgB, bgB)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Theme resolution straight out of `src/index.css`
+// ---------------------------------------------------------------------------
+
+/**
+ * Which of the two palettes is on `<html>`. Named after `theme-applier`'s
+ * `ResolvedTheme` rather than reusing `ThemeMode`, which the settings store
+ * already exports as the THREE-member `"system" | "light" | "dark"`.
+ */
+export type ResolvedThemeMode = "light" | "dark";
+
+interface ThemeBlock {
+  readonly selectors: ReadonlyArray<string>;
+  readonly declarations: ReadonlyMap<string, string>;
+}
+
+/** `:root`, `.dark`, `[data-theme="x"]`, `.dark[data-theme="x"]` - nothing else. */
+const THEME_SELECTOR =
+  /^(?::root|\.dark(?:\[data-theme="[^"]+"\])?|\[data-theme="[^"]+"\])$/;
+
+const THEMED_SELECTOR = /\[data-theme="([^"]+)"\]/;
+
+const CUSTOM_PROPERTY = /^\s*(--[a-z0-9-]+)\s*:\s*([\s\S]+?)\s*$/i;
+
+/** The only color shapes the math below can consume. Shared with `themeToken`. */
+const MEASURABLE_COLOR =
+  /^(?:#[0-9a-f]{6}|oklch\([\d.]+\s+[\d.]+\s+[\d.]+\))$/i;
+
+let cachedThemeBlocks: ReadonlyArray<ThemeBlock> | null = null;
+
+/**
+ * Every rule in `index.css` whose selector list is made only of theme
+ * selectors, with the at-rules enclosing it.
+ *
+ * Brace-depth tracked rather than pattern-matched. The distinction matters
+ * because a pattern that merely fails to match a block DROPS it, and every
+ * sweep built on this asserts an empty failure list - so a dropped preset
+ * makes those tests strictly easier to pass. It is also why this is hand-rolled
+ * instead of reaching for postcss: `postcss` is not a declared dependency of
+ * the OSS repo (only of the internal monorepo this happens to be nested in),
+ * so importing it here passes locally and fails in `traycer`'s own CI.
+ */
+function parseThemeRules(css: string): ReadonlyArray<{
+  readonly selectors: ReadonlyArray<string>;
+  readonly body: string;
+  readonly atRules: ReadonlyArray<string>;
+}> {
+  const rules: Array<{
+    selectors: ReadonlyArray<string>;
+    body: string;
+    atRules: ReadonlyArray<string>;
+  }> = [];
+  const openAtRules: string[] = [];
+  let pending = "";
+  let index = 0;
+  while (index < css.length) {
+    const character = css[index];
+    if (character === "{") {
+      const prelude = pending.trim();
+      const close = matchingBrace(css, index);
+      if (prelude.startsWith("@")) {
+        openAtRules.push(prelude.split(/\s+/)[0].slice(1));
+        pending = "";
+        index += 1;
+        continue;
+      }
+      const selectors = prelude.split(",").map((selector) => selector.trim());
+      if (selectors.every((selector) => THEME_SELECTOR.test(selector))) {
+        rules.push({
+          selectors,
+          body: css.slice(index + 1, close),
+          atRules: [...openAtRules],
+        });
+      }
+      pending = "";
+      index = close + 1;
+      continue;
+    }
+    if (character === "}") {
+      openAtRules.pop();
+      pending = "";
+      index += 1;
+      continue;
+    }
+    pending += character;
+    index += 1;
+  }
+  return rules;
+}
+
+/** Index of the `}` closing the `{` at `open`, or the end of the input. */
+function matchingBrace(css: string, open: number): number {
+  let depth = 0;
+  for (let index = open; index < css.length; index += 1) {
+    if (css[index] === "{") depth += 1;
+    else if (css[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return css.length;
+}
+
+function themeBlocks(): ReadonlyArray<ThemeBlock> {
+  if (cachedThemeBlocks !== null) return cachedThemeBlocks;
+  // Resolved off `process.cwd()` - vitest runs from the project root here. NOT
+  // `import.meta.url`: Vite rewrites that to a non-file URL for this module
+  // when the importing test lives under `src/**`. A `?raw` import is not an
+  // option either - vitest does not process CSS, so it yields "".
+  const stylesheet = join(process.cwd(), "src", "index.css");
+  // Comments can hold braces and stray selector text; drop them before any
+  // structural scanning.
+  const css = readFileSync(stylesheet, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  const blocks: ThemeBlock[] = [];
+  for (const rule of parseThemeRules(css)) {
+    const declarations = new Map<string, string>();
+    for (const declaration of splitDeclarations(rule.body)) {
+      const parsed = CUSTOM_PROPERTY.exec(declaration);
+      if (parsed !== null) declarations.set(parsed[1], parsed[2]);
+    }
+    if (declarations.size === 0) continue;
+    // Neither cascade layers nor media/support conditions are modelled by the
+    // specificity+order ranking below, so a palette token inside one is
+    // refused rather than ranked wrongly. `@layer base`'s `:root` holds only
+    // `--traycer-code-*`, which nothing here measures, so it is skipped
+    // silently - it is a theme block by selector, not by content.
+    if (rule.atRules.length > 0) {
+      const measurable = [...declarations].filter(([, value]) =>
+        MEASURABLE_COLOR.test(value),
+      );
+      if (measurable.length > 0) {
+        throw new Error(
+          `Palette tokens inside @${rule.atRules.join(" > @")} are not modelled here ` +
+            `(${rule.selectors.join(", ")} in ${stylesheet}): ` +
+            measurable.map(([name]) => name).join(", "),
+        );
+      }
+      continue;
+    }
+    blocks.push({ selectors: rule.selectors, declarations });
+  }
+  assertPaletteCoverage(blocks, stylesheet);
+  cachedThemeBlocks = blocks;
+  return blocks;
+}
+
+/** Splits a rule body on `;` at depth 0, so a `;` inside `url(...)` is safe. */
+function splitDeclarations(body: string): ReadonlyArray<string> {
+  const out: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const character of body) {
+    if (character === "(") depth += 1;
+    else if (character === ")") depth -= 1;
+    if (character === ";" && depth === 0) {
+      out.push(current);
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  out.push(current);
+  return out;
+}
+
+/**
+ * The completeness guard. A scanner that silently sees FEWER presets than exist
+ * makes every sweep pass more easily, so the derived set is checked against the
+ * app's own registry - the one the theme picker offers and `theme-applier`
+ * writes to `data-theme`. `THEME_PRESETS` calls the unthemed palette
+ * `"neutral"`; this module calls it `"default"`, since it has no `data-theme`
+ * block of its own. A dropped `:root`/`.dark` block is caught separately, by
+ * `themeToken` throwing on the tokens that would go missing.
+ */
+function assertPaletteCoverage(
+  blocks: ReadonlyArray<ThemeBlock>,
+  stylesheet: string,
+): void {
+  const parsed = new Set<string>();
+  for (const block of blocks) {
+    for (const selector of block.selectors) {
+      const themed = THEMED_SELECTOR.exec(selector);
+      if (themed !== null) parsed.add(themed[1]);
+    }
+  }
+  const expected: ReadonlyArray<string> = THEME_PRESETS.map(
+    (preset) => preset.id,
+  ).filter((id) => id !== "neutral");
+  const missing = expected.filter((id) => !parsed.has(id));
+  const unexpected = [...parsed].filter((id) => !expected.includes(id));
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `Theme presets in ${stylesheet} do not match THEME_PRESETS. ` +
+        `Missing from the stylesheet: [${missing.join(", ")}]. ` +
+        `Not in the registry: [${unexpected.join(", ")}].`,
+    );
+  }
+}
+
+/** Class-column specificity: these selectors are flat lists of simple parts. */
+function selectorSpecificity(selector: string): number {
+  return (selector.match(/:root|\.dark|\[data-theme="[^"]+"\]/g) ?? []).length;
+}
+
+function selectorApplies(
+  selector: string,
+  theme: string,
+  mode: ResolvedThemeMode,
+): boolean {
+  // Structural, not `includes(".dark")`: a `:root:not(.dark)` would read as
+  // dark-only under a substring test, i.e. exactly backwards.
+  if (selector.startsWith(".dark") && mode !== "dark") return false;
+  const themed = THEMED_SELECTOR.exec(selector);
+  if (themed === null) return true;
+  return themed[1] === theme;
+}
+
+/**
+ * The custom properties in effect on `<html>` for a given preset and mode,
+ * cascaded by specificity then source order, later writes winning. `theme` is
+ * `"default"` for the unthemed `:root`/`.dark` palette, or a `data-theme`
+ * value. Every block reaching this point is unlayered and unconditional -
+ * `themeBlocks` refuses a palette token declared inside an at-rule rather than
+ * rank it by a model that ignores layer origin and media conditions.
+ */
+export function resolveThemeTokens(
+  theme: string,
+  mode: ResolvedThemeMode,
+): ReadonlyMap<string, string> {
+  const applicable = themeBlocks().flatMap((block, order) => {
+    const hits = block.selectors.filter((selector) =>
+      selectorApplies(selector, theme, mode),
+    );
+    if (hits.length === 0) return [];
+    return [
+      {
+        specificity: Math.max(...hits.map(selectorSpecificity)),
+        order,
+        declarations: block.declarations,
+      },
+    ];
+  });
+  applicable.sort((a, b) => a.specificity - b.specificity || a.order - b.order);
+  const resolved = new Map<string, string>();
+  for (const entry of applicable) {
+    for (const [name, value] of entry.declarations) resolved.set(name, value);
+  }
+  return resolved;
+}
+
+/**
+ * Reads a token that must exist AND must be an opaque color the math here can
+ * consume. Both halves matter: the resolver returns raw declaration text, so
+ * plenty of real tokens are alpha-carrying oklch (`--border`, `--input`),
+ * `var()` indirection (`--app-background`), or not colors at all (`--radius`,
+ * the font stacks). Failing here names the token; failing inside
+ * `parseColorToLinearSrgb` does not - which is why both gates share
+ * `MEASURABLE_COLOR` rather than keeping two patterns that can drift.
+ */
+export function themeToken(
+  tokens: ReadonlyMap<string, string>,
+  name: string,
+): string {
+  const value = tokens.get(name);
+  if (value === undefined) throw new Error(`Theme token ${name} is undefined`);
+  if (!MEASURABLE_COLOR.test(value)) {
+    throw new Error(
+      `Theme token ${name} is not an opaque color this module can measure: ${value}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * `"default"` plus every `data-theme` value `index.css` defines. Derived, and
+ * `assertPaletteCoverage` pins it to the app's own registry, so a preset added
+ * to both is swept by existing tests without touching this file - and one
+ * added to only one of them fails loudly.
+ */
+export function themePresets(): ReadonlyArray<string> {
+  const presets = new Set<string>(["default"]);
+  for (const block of themeBlocks()) {
+    for (const selector of block.selectors) {
+      const themed = THEMED_SELECTOR.exec(selector);
+      if (themed !== null) presets.add(themed[1]);
+    }
+  }
+  return [...presets];
+}
+
+/**
+ * A full-palette preset repaints the surfaces; an accent-only one
+ * (rose/blue/violet/green/orange/pink) overrides `--primary` and friends on
+ * top of the default light/dark palette.
+ *
+ * Decided on the RESOLVED `--background` for the mode asked about, not on
+ * which block happens to declare one: a preset that repaints surfaces in light
+ * only shares the default `--background` in dark, and inspecting blocks would
+ * call it full-palette in both (a bare `[data-theme="x"]` selector applies in
+ * either mode).
+ */
+export function isFullPalettePreset(
+  theme: string,
+  mode: ResolvedThemeMode,
+): boolean {
+  if (theme === "default") return true;
+  return (
+    resolveThemeTokens(theme, mode).get("--background") !==
+    resolveThemeTokens("default", mode).get("--background")
+  );
 }

--- a/clients/gui-app/src/__tests__/data-selected-value-form-lint.test.ts
+++ b/clients/gui-app/src/__tests__/data-selected-value-form-lint.test.ts
@@ -1,0 +1,106 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `data-selected` must always be matched by VALUE, never by presence.
+ *
+ * cmdk sets the attribute on every item it renders (`"data-selected":
+ * !!selected`, which React stringifies to `"false"` rather than omitting it),
+ * while Tailwind compiles the shorter bare `data-selected:` variant to
+ * `[data-selected]` - an attribute-PRESENCE selector. Every row in a cmdk list
+ * therefore matched, and "selected" styling applied to all of them at once.
+ *
+ * It read as a theme rather than as a bug because the variant drives all four
+ * of a row's channels together - fill, border, shadow and icon tint - so
+ * nothing looked half-applied; there was simply no unselected state to compare
+ * against. It shipped that way in the command palette, the worktree folder
+ * list, the theme-preset picker and the prompt stash simultaneously.
+ *
+ * The other `data-*` attributes in this codebase are written as
+ * `data-x={cond ? "true" : undefined}`, where presence and truth coincide and
+ * the bare form is correct - so this guard is deliberately scoped to
+ * `data-selected` rather than banning bare `data-*` variants in general.
+ *
+ * `components/ui/__tests__/command-selected-state.test.tsx` is the other half:
+ * this file keeps the bare form out of the tree, that one checks the compiled
+ * rules actually discriminate a selected row from an unselected one.
+ */
+const SRC_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * A Tailwind variant keyed on bare `data-selected`, in either the plain or the
+ * `group-`/`peer-` scoped form. The negative lookbehind keeps this off the
+ * attribute WRITE (`data-selected="true"`) and off the already-correct value
+ * form (`data-[selected=true]:`), both of which contain the same letters.
+ */
+const BARE_VARIANT = /(?:group-|peer-)?data-selected(?:\/[a-z0-9-]+)?:/;
+
+function collectSourceFiles(dir: string): readonly string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue;
+      found.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (entry.endsWith(".tsx") || entry.endsWith(".ts")) found.push(full);
+  }
+  return found;
+}
+
+/** Prose explaining the rule is not markup - this file's own docstring included. */
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("{/*")
+  );
+}
+
+describe("data-selected variants", () => {
+  it("are matched by value, never by attribute presence", () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, index) => {
+        if (isCommentLine(line)) return;
+        if (!BARE_VARIANT.test(line)) return;
+        offenders.push(
+          `${path.relative(SRC_DIR, file)}:${index + 1} - use data-[selected=true]: instead`,
+        );
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("recognises the bare form it is meant to reject", () => {
+    // Positive control: a guard whose matcher silently stopped matching would
+    // report an empty offender list forever, which is indistinguishable from
+    // a clean tree.
+    expect(BARE_VARIANT.test('className="data-selected:bg-primary/12"')).toBe(
+      true,
+    );
+    expect(
+      BARE_VARIANT.test('className="group-data-selected/command-item:hidden"'),
+    ).toBe(true);
+    expect(BARE_VARIANT.test('data-selected="true"')).toBe(false);
+    expect(
+      BARE_VARIANT.test('data-selected={selected ? "true" : undefined}'),
+    ).toBe(false);
+    expect(
+      BARE_VARIANT.test('className="data-[selected=true]:bg-primary/12"'),
+    ).toBe(false);
+    expect(
+      BARE_VARIANT.test(
+        'className="group-data-[selected=true]/command-item:hidden"',
+      ),
+    ).toBe(false);
+  });
+});

--- a/clients/gui-app/src/components/chat/composer/__tests__/prompt-stash-control.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/prompt-stash-control.test.tsx
@@ -238,8 +238,8 @@ describe("PromptStashControl", () => {
     expect(popover?.className).toContain("p-0");
     expect(row?.className).toContain("min-h-9");
     expect(row?.className).toContain("py-1.5");
-    expect(row?.className).toContain("data-selected:border-primary/35");
-    expect(row?.className).toContain("data-selected:shadow-sm");
+    expect(row?.className).toContain("data-[selected=true]:border-primary/35");
+    expect(row?.className).toContain("data-[selected=true]:shadow-sm");
   });
 
   it("visibly tracks the active row as pointer selection changes", async () => {

--- a/clients/gui-app/src/components/chat/composer/prompt-stash-control.tsx
+++ b/clients/gui-app/src/components/chat/composer/prompt-stash-control.tsx
@@ -467,7 +467,7 @@ function PromptStashRowMetadata(props: { readonly children: ReactNode }) {
   return (
     <div
       data-slot="prompt-stash-row-metadata"
-      className="pointer-events-none col-start-2 row-start-1 flex h-6 w-full items-center justify-end gap-1 text-[11px] leading-none text-muted-foreground transition-opacity group-hover/stash:opacity-0 group-focus-within/stash:opacity-0 group-data-selected/stash:opacity-0"
+      className="pointer-events-none col-start-2 row-start-1 flex h-6 w-full items-center justify-end gap-1 text-[11px] leading-none text-muted-foreground transition-opacity group-hover/stash:opacity-0 group-focus-within/stash:opacity-0 group-data-[selected=true]/stash:opacity-0"
     >
       {props.children}
     </div>
@@ -478,7 +478,7 @@ function PromptStashRowActions(props: { readonly children: ReactNode }) {
   return (
     <div
       data-slot="prompt-stash-row-actions"
-      className="pointer-events-none col-start-2 row-start-1 flex h-6 w-full items-center justify-end opacity-0 transition-opacity duration-150 group-hover/stash:opacity-100 group-focus-within/stash:opacity-100 group-data-selected/stash:opacity-100"
+      className="pointer-events-none col-start-2 row-start-1 flex h-6 w-full items-center justify-end opacity-0 transition-opacity duration-150 group-hover/stash:opacity-100 group-focus-within/stash:opacity-100 group-data-[selected=true]/stash:opacity-100"
     >
       {props.children}
     </div>

--- a/clients/gui-app/src/components/command-palette/__tests__/command-palette.test.tsx
+++ b/clients/gui-app/src/components/command-palette/__tests__/command-palette.test.tsx
@@ -115,7 +115,9 @@ describe("<CommandPalette />", () => {
 
     const firstRows = getVisibleCommandRows(document.body);
     expect(firstRows.length).toBeGreaterThan(1);
-    expect(firstRows[0].className).toContain("data-selected:bg-primary/12");
+    expect(firstRows[0].className).toContain(
+      "data-[selected=true]:bg-primary/12",
+    );
     await waitFor(() => {
       expect(firstRows[0].getAttribute("data-selected")).toBe("true");
     });

--- a/clients/gui-app/src/components/command-palette/palette-item-row.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-item-row.tsx
@@ -12,7 +12,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import { cn } from "@/lib/utils";
 
 const ROW_CLASSNAME =
-  "group/command-item relative flex cursor-default items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 text-ui-sm outline-hidden select-none transition-[background-color,border-color,box-shadow,color] duration-150 in-data-[slot=dialog-content]:rounded-lg hover:bg-foreground/5 hover:text-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:border-primary/35 data-selected:bg-primary/12 data-selected:text-foreground data-selected:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-primary";
+  "group/command-item relative flex cursor-default items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 text-ui-sm outline-hidden select-none transition-[background-color,border-color,box-shadow,color] duration-150 in-data-[slot=dialog-content]:rounded-lg hover:bg-foreground/5 hover:text-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:border-primary/35 data-[selected=true]:bg-primary/12 data-[selected=true]:text-foreground data-[selected=true]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[selected=true]:*:[svg]:text-primary";
 
 export function PaletteItemRow({
   className,

--- a/clients/gui-app/src/components/command-palette/pin-toggle.tsx
+++ b/clients/gui-app/src/components/command-palette/pin-toggle.tsx
@@ -39,10 +39,10 @@ export function PinToggle(props: PinToggleProps) {
         onToggle();
       }}
       className={cn(
-        "size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground group-data-selected/command-item:text-primary",
+        "size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground group-data-[selected=true]/command-item:text-primary",
         pinned
           ? "inline-flex text-foreground"
-          : "hidden group-hover/command-item:inline-flex group-data-selected/command-item:inline-flex",
+          : "hidden group-hover/command-item:inline-flex group-data-[selected=true]/command-item:inline-flex",
       )}
     >
       {pinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}

--- a/clients/gui-app/src/components/settings/controls/theme-preset-picker.tsx
+++ b/clients/gui-app/src/components/settings/controls/theme-preset-picker.tsx
@@ -117,7 +117,7 @@ export function ThemePresetPicker(props: ThemePresetPickerProps) {
                   onChange(preset.id);
                   setOpen(false);
                 }}
-                className="gap-2.5 rounded-md py-1.5 data-selected:border-transparent data-selected:bg-accent data-selected:text-foreground data-selected:shadow-none data-[checked=true]:text-primary"
+                className="gap-2.5 rounded-md py-1.5 data-[selected=true]:border-transparent data-[selected=true]:bg-accent data-[selected=true]:text-foreground data-[selected=true]:shadow-none data-[checked=true]:text-primary"
               >
                 <PresetSwatch preset={preset} />
                 <span className="min-w-0 flex-1 truncate">{preset.label}</span>

--- a/clients/gui-app/src/components/ui/__tests__/command-selected-state.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/command-selected-state.test.tsx
@@ -1,0 +1,136 @@
+/// <reference types="node" />
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { cleanup, render } from "@testing-library/react";
+import { compile } from "tailwindcss";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  Command,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command";
+
+/**
+ * The selected-state utilities every cmdk row in the app relies on. All four
+ * of a row's channels - fill, border, shadow and icon tint - are driven by
+ * this one variant, which is why getting it wrong looked like a theme rather
+ * than a bug.
+ */
+const SELECTED_UTILITIES = [
+  "data-[selected=true]:bg-primary/12",
+  "data-[selected=true]:border-primary/35",
+  "data-[selected=true]:shadow-sm",
+  "data-[selected=true]:text-foreground",
+  "data-[selected=true]:*:[svg]:text-primary",
+  "group-data-[selected=true]/command-item:text-foreground",
+] as const;
+
+/**
+ * The selectors Tailwind ACTUALLY emits, rather than ones the test invents.
+ * The whole defect this file guards was a mismatch between the class an author
+ * wrote and the selector Tailwind produced from it, so reconstructing the
+ * selector here would reproduce the blind spot instead of closing it.
+ */
+async function emittedSelectors(
+  candidates: ReadonlyArray<string>,
+): Promise<ReadonlyMap<string, string>> {
+  const entry = createRequire(join(process.cwd(), "package.json")).resolve(
+    "tailwindcss/index.css",
+  );
+  // The app's own palette tokens, declared inline rather than by compiling
+  // `src/index.css` (which pulls in `@plugin` and a nested `@import`). Only the
+  // SELECTORS matter here - a `bg-primary` that cannot resolve its color emits
+  // no rule at all, which would read as "the variant does not apply" - so
+  // stand-in values are sufficient and keep the fixture independent of a
+  // palette edit.
+  const source = [
+    '@import "tailwindcss";',
+    "@theme { --color-primary: #7c3aed; --color-foreground: #111111; }",
+  ].join("\n");
+  const compiler = await compile(source, {
+    base: process.cwd(),
+    loadStylesheet: async () => ({
+      path: entry,
+      base: dirname(entry),
+      content: await readFile(entry, "utf8"),
+    }),
+  });
+  const css = compiler.build([...candidates]);
+  const rules = css
+    .split("\n")
+    .flatMap((line) => {
+      const rule = /^\s*(\S.*?)\s*\{\s*$/.exec(line);
+      return rule === null ? [] : [rule[1]];
+    })
+    .filter((rule) => !rule.startsWith("@"));
+  const selectors = new Map<string, string>();
+  for (const candidate of candidates) {
+    const escaped = candidate.replace(
+      /[^a-zA-Z0-9_-]/g,
+      (character) => `\\${character}`,
+    );
+    const hit = rules.find((rule) => rule.includes(`.${escaped}`));
+    if (hit !== undefined) selectors.set(candidate, hit);
+  }
+  return selectors;
+}
+
+function renderRows(): ReadonlyArray<Element> {
+  const { container } = render(
+    <Command>
+      <CommandList>
+        <CommandItem value="alpha">
+          Alpha
+          <CommandShortcut>A</CommandShortcut>
+        </CommandItem>
+        <CommandItem value="beta">
+          Beta
+          <CommandShortcut>B</CommandShortcut>
+        </CommandItem>
+      </CommandList>
+    </Command>,
+  );
+  return [...container.querySelectorAll('[data-slot="command-item"]')];
+}
+
+describe("cmdk selected-state styling", () => {
+  let emitted: ReadonlyMap<string, string> = new Map();
+
+  beforeAll(async () => {
+    emitted = await emittedSelectors(SELECTED_UTILITIES);
+  });
+
+  afterEach(cleanup);
+
+  it("marks unselected rows with the attribute rather than omitting it", () => {
+    // The premise of the whole file. cmdk renders `"data-selected": !!selected`
+    // and React stringifies `false`, so the attribute is PRESENT on every row -
+    // which is what makes a presence-matching selector useless here. If cmdk
+    // ever starts omitting it, the bare form would become correct and this
+    // guard should be revisited rather than worked around.
+    const rows = renderRows();
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute("data-selected")).toBe("true");
+    expect(rows[1].getAttribute("data-selected")).toBe("false");
+    expect(rows[1].matches("[data-selected]")).toBe(true);
+  });
+
+  it("applies each selected-state rule to the selected row only", () => {
+    const rows = renderRows();
+    const [selected, unselected] = rows;
+    for (const candidate of SELECTED_UTILITIES) {
+      const selector = emitted.get(candidate);
+      expect(selector, candidate).toBeTypeOf("string");
+      // `:not(*)` never matches, so a candidate that compiled to nothing fails
+      // here instead of silently reporting "does not apply" for both rows.
+      const rule = selector ?? ":not(*)";
+      const matchIn = (row: Element): boolean =>
+        row.matches(rule) || row.querySelector(rule) !== null;
+      expect(matchIn(selected), `selected / ${candidate}`).toBe(true);
+      expect(matchIn(unselected), `unselected / ${candidate}`).toBe(false);
+    }
+  });
+});

--- a/clients/gui-app/src/components/ui/__tests__/command-selected-state.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/command-selected-state.test.tsx
@@ -52,13 +52,30 @@ async function emittedSelectors(
   ].join("\n");
   const compiler = await compile(source, {
     base: process.cwd(),
-    loadStylesheet: async () => ({
-      path: entry,
-      base: dirname(entry),
-      content: await readFile(entry, "utf8"),
-    }),
+    loadStylesheet: async (id: string, base: string) => {
+      // Called exactly once, for the `@import` above: 4.3.3's `index.css`
+      // INLINES its theme/base/utilities layers rather than `@import`ing the
+      // sibling `theme.css` / `preflight.css` / `utilities.css` of those names.
+      // Refuse any other id by name - a version that splits the entry again
+      // should fail here saying which import went unresolved, rather than
+      // further down as "the utility compiled to nothing".
+      if (id !== "tailwindcss") {
+        throw new Error(`Unexpected stylesheet import ${id} from ${base}`);
+      }
+      return {
+        path: entry,
+        base: dirname(entry),
+        content: await readFile(entry, "utf8"),
+      };
+    },
   });
   const css = compiler.build([...candidates]);
+  // Tailwind emits ONE FLAT selector per candidate - the condition is appended
+  // to the class itself (`.data-\[selected\=true\]\:bg-primary\/12[data-selected="true"]`,
+  // `:is(.…[data-selected="true"] > *):is(svg)`), never a nested `&` rule - so
+  // the line carrying the escaped class IS the whole discriminating selector.
+  // The only nesting in the output is the `@supports (color: color-mix(…))`
+  // fallback inside a declaration block, which is what the `@` filter drops.
   const rules = css
     .split("\n")
     .flatMap((line) => {

--- a/clients/gui-app/src/components/ui/__tests__/kbd.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/kbd.test.tsx
@@ -94,14 +94,31 @@ async function emittedSelectors(
   );
   const compiler = await compile('@import "tailwindcss";', {
     base: process.cwd(),
-    loadStylesheet: async () => ({
-      path: entry,
-      base: dirname(entry),
-      content: await readFile(entry, "utf8"),
-    }),
+    loadStylesheet: async (id: string, base: string) => {
+      // Called exactly once, for the `@import` above: 4.3.3's `index.css`
+      // INLINES its theme/base/utilities layers rather than `@import`ing the
+      // sibling `theme.css` / `preflight.css` / `utilities.css` of those names.
+      // Refuse any other id by name - a version that splits the entry again
+      // should fail here saying which import went unresolved, rather than
+      // further down as "the utility compiled to nothing".
+      if (id !== "tailwindcss") {
+        throw new Error(`Unexpected stylesheet import ${id} from ${base}`);
+      }
+      return {
+        path: entry,
+        base: dirname(entry),
+        content: await readFile(entry, "utf8"),
+      };
+    },
   });
   const css = compiler.build([...candidates]);
   const selectors = new Map<string, string>();
+  // Tailwind emits ONE FLAT selector per candidate - the ancestor condition is
+  // a prefix on the same line (`:where(:is([data-slot=button]:is(…))) .in-\[…\]`),
+  // never a nested `&` rule - so the line carrying the escaped class IS the
+  // whole discriminating selector. The only nesting in the output is the
+  // `@supports (color: color-mix(…))` fallback inside a declaration block,
+  // which is what the `@` filter drops.
   const rules = css
     .split("\n")
     .flatMap((line) => {

--- a/clients/gui-app/src/components/ui/__tests__/kbd.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/kbd.test.tsx
@@ -1,0 +1,271 @@
+/// <reference types="node" />
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { cleanup, render } from "@testing-library/react";
+import { compile } from "tailwindcss";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
+import {
+  contrastRatio,
+  isFullPalettePreset,
+  resolveThemeTokens,
+  themePresets,
+  themeToken,
+  type ResolvedThemeMode,
+} from "../../../../__tests__/contrast";
+
+type ButtonVariant =
+  "default" | "secondary" | "destructive" | "outline" | "ghost" | "link";
+
+// The three utilities `Kbd` must ship for a button that paints an opaque fill.
+// Spelled out rather than scraped off the element: the source assertion below
+// pins these EXACT strings as literals present in `kbd.tsx`, which is the half
+// a scraping test could never check - hoisting them into a shared const and
+// interpolating would leave the class attribute intact on every keycap while
+// Tailwind's content scan emitted no rule at all.
+const FILLED_SURFACE_UTILITIES = [
+  "in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:border-current",
+  "in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:bg-transparent",
+  "in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:text-current",
+] as const;
+
+interface FilledVariant {
+  readonly variant: ButtonVariant;
+  /** The opaque fill the keycap sits on. */
+  readonly fill: string;
+  /** The foreground the button's own label uses on that fill. */
+  readonly label: string;
+}
+
+/**
+ * The variants painting an opaque fill. `destructive` is deliberately absent -
+ * it paints `bg-destructive/10` over the ambient surface, so it belongs with
+ * the ambient set below.
+ */
+const FILLED_VARIANTS: ReadonlyArray<FilledVariant> = [
+  { variant: "default", fill: "--primary", label: "--primary-foreground" },
+  {
+    variant: "secondary",
+    fill: "--secondary",
+    label: "--secondary-foreground",
+  },
+];
+
+/** Variants on the ambient surface, where the quieter default is correct. */
+const AMBIENT_VARIANTS: ReadonlyArray<ButtonVariant> = [
+  "outline",
+  "ghost",
+  "link",
+  "destructive",
+];
+
+const MODES: ReadonlyArray<ResolvedThemeMode> = ["light", "dark"];
+
+/**
+ * `kbd.tsx`'s source. Tailwind's content scan is a plain-text extractor, so a
+ * candidate only produces CSS while it appears in the file verbatim - reading
+ * the source is exactly the property that matters, and needs no dependency
+ * beyond `node:fs`. (`@tailwindcss/oxide` would scan it properly, but it is
+ * not a declared dependency of the OSS repo.)
+ */
+function kbdSource(): string {
+  return readFileSync(
+    join(process.cwd(), "src", "components", "ui", "kbd.tsx"),
+    "utf8",
+  );
+}
+
+/**
+ * The selectors Tailwind ACTUALLY emits for the given candidates, read out of
+ * compiled CSS rather than reconstructed by hand. A candidate that produces no
+ * rule yields no entry, which is what lets the assertions below tell "the rule
+ * applies" apart from "nothing was generated" - jsdom loads no stylesheet, so
+ * a `matches()` against a selector the test invented cannot.
+ */
+async function emittedSelectors(
+  candidates: ReadonlyArray<string>,
+): Promise<ReadonlyMap<string, string>> {
+  const entry = createRequire(join(process.cwd(), "package.json")).resolve(
+    "tailwindcss/index.css",
+  );
+  const compiler = await compile('@import "tailwindcss";', {
+    base: process.cwd(),
+    loadStylesheet: async () => ({
+      path: entry,
+      base: dirname(entry),
+      content: await readFile(entry, "utf8"),
+    }),
+  });
+  const css = compiler.build([...candidates]);
+  const selectors = new Map<string, string>();
+  const rules = css
+    .split("\n")
+    .flatMap((line) => {
+      const rule = /^\s*(\S.*?)\s*\{\s*$/.exec(line);
+      return rule === null ? [] : [rule[1]];
+    })
+    .filter((rule) => !rule.startsWith("@"));
+  for (const candidate of candidates) {
+    // Tailwind escapes every character outside `[A-Za-z0-9_-]`.
+    const escaped = candidate.replace(
+      /[^a-zA-Z0-9_-]/g,
+      (character) => `\\${character}`,
+    );
+    const hit = rules.find((rule) => rule.includes(`.${escaped}`));
+    if (hit !== undefined) selectors.set(candidate, hit);
+  }
+  return selectors;
+}
+
+function renderKeycap(variant: ButtonVariant): Element {
+  const { container } = render(
+    <Button variant={variant}>
+      Next
+      <Kbd>↵</Kbd>
+    </Button>,
+  );
+  const keycap = container.querySelector('[data-slot="kbd"]');
+  if (keycap === null) throw new Error(`No keycap rendered for ${variant}`);
+  return keycap;
+}
+
+describe("Kbd on a button surface", () => {
+  let emitted: ReadonlyMap<string, string> = new Map();
+
+  beforeAll(async () => {
+    emitted = await emittedSelectors(FILLED_SURFACE_UTILITIES);
+  });
+
+  afterEach(cleanup);
+
+  it("ships the filled-surface utilities as literals the content scan can see", () => {
+    const source = kbdSource();
+    for (const candidate of FILLED_SURFACE_UTILITIES) {
+      expect(source.includes(candidate), candidate).toBe(true);
+    }
+  });
+
+  it("scopes every button-keyed rule it ships to the two filled variants", () => {
+    // Derived from the source rather than the constant above, so a FOURTH
+    // button-scoped rule - `destructive`, say, where `text-current` measures
+    // WORSE (nord dark 5.96 -> 2.79) - is caught even though it leaves all
+    // three constants intact and would slip past every assertion keyed on
+    // them.
+    const shipped = kbdSource().match(/in-\[\[data-slot=button\][^"`]*/g) ?? [];
+    expect(shipped.length).toBe(FILLED_SURFACE_UTILITIES.length);
+    for (const candidate of shipped) {
+      expect(FILLED_SURFACE_UTILITIES, candidate).toContain(candidate);
+    }
+  });
+
+  it("compiles each of them to a real rule", () => {
+    for (const candidate of FILLED_SURFACE_UTILITIES) {
+      expect(emitted.get(candidate), candidate).toBeTypeOf("string");
+    }
+  });
+
+  it("resolves the emitted rules inside a filled button", () => {
+    for (const { variant } of FILLED_VARIANTS) {
+      const keycap = renderKeycap(variant);
+      for (const candidate of FILLED_SURFACE_UTILITIES) {
+        const selector = emitted.get(candidate);
+        expect(selector, candidate).toBeTypeOf("string");
+        // `:not(*)` never matches, so a missing rule fails rather than
+        // throwing an unrelated selector-syntax error.
+        expect(
+          keycap.matches(selector ?? ":not(*)"),
+          `${variant} / ${selector}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("leaves the ambient calibration alone on every other variant", () => {
+    for (const variant of AMBIENT_VARIANTS) {
+      const keycap = renderKeycap(variant);
+      for (const candidate of FILLED_SURFACE_UTILITIES) {
+        const selector = emitted.get(candidate);
+        expect(selector, candidate).toBeTypeOf("string");
+        expect(
+          keycap.matches(selector ?? ":not(*)"),
+          `${variant} / ${selector}`,
+        ).toBe(false);
+      }
+      // Exact tokens, not `toContain` on the joined string: a substring check
+      // passes for `bg-foreground/80` and `text-muted-foreground/70`, i.e. for
+      // the very alpha drift that would quietly dim the ambient keycap.
+      const tokens = keycap.className.split(" ");
+      expect(tokens, variant).toContain("bg-foreground/8");
+      expect(tokens, variant).toContain("text-muted-foreground");
+    }
+  });
+
+  it("keeps both attribute anchors the rule depends on on the button itself", () => {
+    // `Button` dropping either attribute would silently un-fix every keycap
+    // while the classes sat unchanged in the markup.
+    const { container } = render(
+      <Button variant="default">
+        Next
+        <Kbd>↵</Kbd>
+      </Button>,
+    );
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("data-slot")).toBe("button");
+    expect(button?.getAttribute("data-variant")).toBe("default");
+  });
+});
+
+// Swept over every preset `src/index.css` defines, in both modes. The preset
+// set is pinned to the app's `THEME_PRESETS` registry inside `contrast.ts`, so
+// a preset the parser fails to see is a loud error rather than a smaller sweep.
+describe("Kbd contrast on a filled button, per theme", () => {
+  const presets = themePresets();
+
+  it("improves the keycap in every preset and mode by riding the button's own label color", () => {
+    const regressions: string[] = [];
+    for (const theme of presets) {
+      for (const mode of MODES) {
+        const tokens = resolveThemeTokens(theme, mode);
+        for (const { variant, fill, label } of FILLED_VARIANTS) {
+          const background = themeToken(tokens, fill);
+          const ambient = contrastRatio(
+            themeToken(tokens, "--muted-foreground"),
+            background,
+          );
+          const riding = contrastRatio(themeToken(tokens, label), background);
+          if (riding < ambient) {
+            regressions.push(
+              `${theme} ${mode} ${variant}: ${ambient.toFixed(2)} -> ${riding.toFixed(2)}`,
+            );
+          }
+        }
+      }
+    }
+    expect(regressions).toEqual([]);
+  });
+
+  it("clears 4.5:1 on a primary button in every full-palette preset", () => {
+    // Accent-only presets (rose/blue/…) are excluded on purpose: their
+    // `--primary` / `--primary-foreground` pair is what the button LABEL
+    // already renders at, so a keycap matching it inherits the preset's own
+    // choice rather than a contrast introduced here. `kbd.tsx` records where
+    // that leaves them.
+    const failures: string[] = [];
+    for (const theme of presets) {
+      for (const mode of MODES) {
+        if (!isFullPalettePreset(theme, mode)) continue;
+        const tokens = resolveThemeTokens(theme, mode);
+        const ratio = contrastRatio(
+          themeToken(tokens, "--primary-foreground"),
+          themeToken(tokens, "--primary"),
+        );
+        if (ratio < 4.5) failures.push(`${theme} ${mode}: ${ratio.toFixed(2)}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/clients/gui-app/src/components/ui/command.tsx
+++ b/clients/gui-app/src/components/ui/command.tsx
@@ -116,6 +116,19 @@ function CommandSeparator({
   );
 }
 
+/**
+ * Selected-state utilities are spelled `data-[selected=true]:`, never the
+ * shorter bare `data-selected:`. cmdk sets the attribute on EVERY item
+ * (`"data-selected": !!selected`, which React stringifies to `"false"`), and
+ * Tailwind compiles the bare form to an attribute-PRESENCE selector - so it
+ * matches every row and the "selected" styling has no unselected state to
+ * contrast with. That held for this row's fill, border, shadow and icon tint
+ * simultaneously, which is why it read as a theme rather than as a bug.
+ *
+ * `src/__tests__/data-selected-value-form-lint.test.ts` keeps the bare form
+ * out of the tree; `__tests__/command-selected-state.test.tsx` checks that the
+ * compiled rules actually discriminate.
+ */
 function CommandItem({
   className,
   children,
@@ -125,7 +138,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 text-ui-sm outline-hidden select-none transition-[background-color,border-color,box-shadow,color] duration-150 in-data-[slot=dialog-content]:rounded-lg hover:bg-foreground/5 hover:text-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:border-primary/35 data-selected:bg-primary/12 data-selected:text-foreground data-selected:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-primary",
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 text-ui-sm outline-hidden select-none transition-[background-color,border-color,box-shadow,color] duration-150 in-data-[slot=dialog-content]:rounded-lg hover:bg-foreground/5 hover:text-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:border-primary/35 data-[selected=true]:bg-primary/12 data-[selected=true]:text-foreground data-[selected=true]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[selected=true]:*:[svg]:text-primary",
         className,
       )}
       {...props}
@@ -145,12 +158,17 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        "ml-auto text-ui-xs text-muted-foreground group-data-selected/command-item:text-foreground",
+        "ml-auto text-ui-xs text-muted-foreground group-data-[selected=true]/command-item:text-foreground",
         className,
       )}
       {...props}
     >
-      <Kbd className="font-mono tabular-nums">{children}</Kbd>
+      {/* Repeated on the keycap because the span above only sets an INHERITED
+          color, and `Kbd` paints its own `text-muted-foreground` directly on
+          the element, which beats it. */}
+      <Kbd className="font-mono tabular-nums group-data-[selected=true]/command-item:text-foreground">
+        {children}
+      </Kbd>
     </span>
   );
 }

--- a/clients/gui-app/src/components/ui/kbd.tsx
+++ b/clients/gui-app/src/components/ui/kbd.tsx
@@ -6,6 +6,36 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
       data-slot="kbd"
       className={cn(
         "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-md border border-border/60 bg-foreground/8 px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:border-background/20 in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
+        // A keycap's default fill and label are calibrated for the AMBIENT
+        // surface: `bg-foreground/8` sits one step off the page/card behind
+        // it, and `--muted-foreground` is that surface's own quiet text token.
+        // A variant that paints an OPAQUE fill breaks both halves at once - a
+        // foreground alpha over `bg-primary` washes the fill instead of
+        // stepping off it, and `--muted-foreground` has no relationship to
+        // `--primary-foreground`. `--muted-foreground` on `--primary` clears
+        // 4.5:1 in NO preset, in either mode (best case 4.36 on amoled light,
+        // worst 1.01 on traycer-green light), so on a primary button the caps
+        // were unreadable everywhere, not just on the dark presets where it
+        // looks worst.
+        //
+        // Riding the button's own foreground IMPROVES every preset and mode -
+        // never worse, and at least 1.67x on `--primary` specifically (the
+        // `--secondary` minimum is only 1.002x, on everforest light). It does
+        // NOT make every preset readable: the cap lands at the action label's
+        // own contrast, so the six accent-only presets stay where their
+        // `--primary`/`--primary-foreground` pair already puts the LABEL
+        // (orange 2.73, green 2.89 - both under 3:1). That residual is the
+        // preset's, not the keycap's; `primary-action-shortcut-hint.test.tsx`
+        // pins >= 4.5:1 for the full-palette presets only, for the same reason.
+        //
+        // The line is an OPAQUE fill, NOT "the variant sets a text color".
+        // `destructive` also sets one, but paints `bg-destructive/10` - the
+        // ambient surface still shows through, so the ambient calibration is
+        // right there and `text-current` would make it WORSE (nord dark:
+        // 5.96 -> 2.79). `outline` / `ghost` / `link` are ambient too.
+        "in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:border-current",
+        "in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:bg-transparent",
+        "in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:text-current",
         className,
       )}
       {...props}

--- a/clients/gui-app/src/components/worktree/worktree-folder-list.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-folder-list.tsx
@@ -108,7 +108,7 @@ export function WorktreeFolderList(props: WorktreeFolderListProps): ReactNode {
                   }}
                   className={cn(
                     !disabled &&
-                      "cursor-pointer hover:bg-accent/60 hover:text-foreground data-selected:border-transparent data-selected:bg-accent/60 data-selected:text-foreground data-selected:shadow-none",
+                      "cursor-pointer hover:bg-accent/60 hover:text-foreground data-[selected=true]:border-transparent data-[selected=true]:bg-accent/60 data-[selected=true]:text-foreground data-[selected=true]:shadow-none",
                   )}
                 >
                   <div


### PR DESCRIPTION
## Why

Reported as "the keyboard shortcuts are not visible in the Next button" on the
interview card. Sweeping the other keycap sites for the same class of defect
turned up a second, unrelated one in the command palette.

### `Kbd` was calibrated for the ambient surface only

`bg-foreground/8` steps one notch off the page or card behind the cap, and
`--muted-foreground` is that surface's own quiet text token. Neither survives
an opaque fill: a foreground alpha over `bg-primary` washes the fill instead of
stepping off it, and `--muted-foreground` has no relationship to
`--primary-foreground`.

Measured over every preset `src/index.css` defines, in both modes:
`--muted-foreground` on `--primary` clears 4.5:1 in **no** preset — best case
4.36 (amoled light), worst 1.01 (traycer-green light). The caps were unreadable
everywhere, not only on the dark presets where it looks worst.

`PrimaryActionShortcutHint` (#1291) already patches this per-call-site by
passing `border-current bg-transparent text-current` down to `Kbd`. That fixes
the interview card, but only the sites that remember to use it, and it applies
those classes unconditionally — on a `ghost` or `outline` button they are wrong
in the other direction.

### Every cmdk row was "selected"

Selected-state utilities were spelled with the bare `data-selected:` variant,
which Tailwind compiles to an attribute-**presence** selector. cmdk renders
`"data-selected": !!selected`, which React stringifies to `"false"` rather than
omitting the attribute — so every row in every list matched.

It read as a theme rather than as a bug because the variant drives all four of a
row's channels together (fill, border, shadow, icon tint): nothing looked
half-applied, there was simply no unselected state to compare against.

## What

### `Kbd` adapts to a filled surface

Three `in-[…]` rules key on the button's own `data-slot` / `data-variant`, so
the cap rides the button's foreground on the two variants that paint an opaque
fill:

```
in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:border-current
in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:bg-transparent
in-[[data-slot=button]:is([data-variant=default],[data-variant=secondary])]:text-current
```

That improves every preset and mode — never worse, and at least 1.67x on
`--primary` (the `--secondary` minimum is 1.002x, on everforest light).

The line is **an opaque fill**, not "the variant sets a text color".
`destructive` also sets one but paints `bg-destructive/10`, so the ambient
surface still shows through, the ambient calibration is already right, and
`text-current` would make it *worse* (nord dark: 5.96 -> 2.79). It is excluded
along with `outline` / `ghost` / `link`.

This does not make every preset readable. The cap lands at the action label's
own contrast, so the six accent-only presets stay where their
`--primary`/`--primary-foreground` pair already puts the **label** (orange 2.73,
green 2.89 — both under 3:1). That residual is the preset's, not the keycap's,
and the per-theme floor test is scoped to the full-palette presets for the same
reason.

`PrimaryActionShortcutHint` is left as-is here: its classes are now redundant on
a filled button rather than wrong, and retiring them is a separate change with
its own test to update.

### `data-selected` matched by value

23 occurrences across 6 components moved to `data-[selected=true]:` (plus 3
assertions in existing tests):

| File | What matched every row |
| --- | --- |
| `command-palette/palette-item-row.tsx` | fill, border, shadow, `*:[svg]` tint |
| `ui/command.tsx` (`CommandItem`, `CommandShortcut`) | the same four, plus the shortcut brightening |
| `command-palette/pin-toggle.tsx` | pin tint **and its `inline-flex`** — the hover-reveal was permanently revealed |
| `worktree/worktree-folder-list.tsx` | fill, border, shadow |
| `settings/controls/theme-preset-picker.tsx` | fill, border, shadow |
| `chat/composer/prompt-stash-control.tsx` | the two `opacity-0`/`opacity-100` row-action swaps |

The other `data-*` attributes in this codebase are written
`data-x={cond ? "true" : undefined}`, where presence and truth coincide and the
bare form is correct — so the guard below is scoped to `data-selected` rather
than banning bare `data-*` variants in general.

`collaborator-mention-suggestion.tsx` and `worktree-branch-picker-options.tsx`
already used the value form. `pr-quote-target-picker.tsx`, `tab-group-view.tsx`
and `harness-model-picker-item.tsx` write the attribute but have no CSS consumer.

## Tests

`ui/__tests__/kbd.test.tsx` (new) — compiles the real Tailwind candidates and
reads back the **emitted** selectors, rather than reconstructing them: the
defect being guarded is a mismatch between the class an author writes and the
selector Tailwind produces, so a hand-written selector would reproduce the blind
spot. It checks the rules resolve inside a filled button and not an ambient one,
that the ambient cap keeps its exact `bg-foreground/8` / `text-muted-foreground`
tokens, that `Button` still carries both attribute anchors, and — derived from
the source, not from the constant — that no *fourth* button-scoped rule ships.
Then it sweeps contrast across every preset and mode.

`ui/__tests__/command-selected-state.test.tsx` (new) — renders two real cmdk
rows and asserts each compiled rule matches the selected one and not the
unselected one. It also pins the premise (`data-selected="false"` is present on
an unselected row), so if cmdk ever starts omitting the attribute the guard says
to revisit rather than work around.

`src/__tests__/data-selected-value-form-lint.test.ts` (new) — keeps the bare
form out of `src/**`, with a positive control on its own matcher: an
offender-list guard whose regex quietly stopped matching is indistinguishable
from a clean tree.

`__tests__/contrast.ts` — gained a resolver that reads the preset palettes out
of `src/index.css` (specificity then source order, `.dark` handled
structurally). The derived preset set is cross-checked against the app's
`THEME_PRESETS` registry, so a preset the parser cannot see is a loud error
rather than a silently smaller sweep, and a measurable palette token inside an
at-rule throws rather than being mismodelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
