### PR TITLE
feat(gui-app): show recent folders in live chats

### DIFF
--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -295,7 +295,7 @@ describe.each(["chat", "terminal-agent"] as const)(
       renderBoundSurface(kind, true);
 
       // Open the folder-rows popover from the collapsed summary.
-      fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+      fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
       const rows = await screen.findAllByTestId("folder-row");
       expect(rows).toHaveLength(2);
 
@@ -303,14 +303,16 @@ describe.each(["chat", "terminal-agent"] as const)(
       expect(screen.getByTestId("folder-primary-pin")).toBeTruthy();
       // ...and the collapsed chip agreed with it (isPrimary, not items[0]).
       expect(
-        screen.getByTestId("workspace-summary-trigger").textContent,
+        screen.getByRole("button", { name: /^beta/ }).textContent,
       ).toContain("beta");
 
       // No atomic set-primary RPC exists for a live binding - the action
       // must be absent on EVERY row of a bound surface.
       expect(screen.queryByTestId("folder-make-primary")).toBeNull();
       // The other row actions are still there (the rows are editable).
-      expect(screen.getAllByTestId("folder-remove").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByRole("button", { name: /^(?:Move|Remove) / }).length,
+      ).toBeGreaterThan(0);
     });
   },
 );
@@ -328,14 +330,14 @@ it("explains why a terminal agent's host selector is locked", async () => {
 
 it("shows Recent folders in a live chat picker but not a terminal-agent binding", async () => {
   renderBoundSurface("chat", true);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
   expect(
     await screen.findByRole("button", { name: "Recent folders, 1" }),
   ).toBeTruthy();
 
   cleanup();
   renderBoundSurface("terminal-agent", true);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
   expect(
     screen.queryByRole("button", { name: "Recent folders, 1" }),
   ).toBeNull();
@@ -343,7 +345,7 @@ it("shows Recent folders in a live chat picker but not a terminal-agent binding"
 
 it("keeps Recent unavailable until a chat binding snapshot resolves", () => {
   renderBoundSurface("chat", false);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
 
   expect(
     screen.queryByRole("button", { name: "Recent folders, 1" }),
@@ -353,7 +355,7 @@ it("keeps Recent unavailable until a chat binding snapshot resolves", () => {
 it("adds a Recent folder through the chat owner binding", async () => {
   mutationMocks.addBindingFolder.mockResolvedValue({});
   renderBoundSurface("chat", true);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
   fireEvent.click(
     await screen.findByRole("button", { name: "Recent folders, 1" }),
   );
@@ -373,8 +375,14 @@ it("adds a Recent folder through the chat owner binding", async () => {
 
 it("removes a chat folder only after moving it to Recent succeeds", async () => {
   renderBoundSurface("chat", true);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
-  fireEvent.click((await screen.findAllByTestId("folder-remove"))[0]);
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  fireEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: /^(?:Move|Remove) alpha(?: to Recent)?$/,
+      })
+    )[0],
+  );
 
   await waitFor(() => {
     expect(recentMocks.recordRecentAsync).toHaveBeenCalledWith({
@@ -389,8 +397,14 @@ it("removes a chat folder only after moving it to Recent succeeds", async () => 
   recentMocks.recordRecentAsync.mockRejectedValueOnce(new Error("nope"));
   mutationMocks.removeBindingFolder.mockClear();
   renderBoundSurface("chat", true);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
-  fireEvent.click((await screen.findAllByTestId("folder-remove"))[0]);
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  fireEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: /^(?:Move|Remove) alpha(?: to Recent)?$/,
+      })
+    )[0],
+  );
 
   await waitFor(() => {
     expect(recentMocks.recordRecentAsync).toHaveBeenCalledWith({
@@ -429,7 +443,7 @@ it("refuses terminal Update when metadata regresses to unresolved", async () => 
   });
 
   renderBoundSurface("terminal-agent", true);
-  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
   const update = await screen.findByRole("button", { name: "Update" });
   fireEvent.click(update);
 

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanup,
   fireEvent,
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type {
   WorktreeBinding,
   WorktreeBindingEntry,
@@ -34,19 +35,16 @@ const mutationMocks = vi.hoisted(() => ({
   removeBindingFolder: vi.fn(),
 }));
 const recentMocks = vi.hoisted(() => ({
-  add: vi.fn(),
-  forget: vi.fn(() => Promise.resolve(true)),
-  locate: vi.fn(() => Promise.resolve(true)),
-  moveToRecent: vi.fn(() => Promise.resolve(true)),
+  prepareRecent: vi.fn(),
+  recordRecentAsync: vi.fn(),
 }));
 
-interface RecentHookArgs {
-  readonly disabled: boolean;
-  readonly activatePreparedFolders: (
-    folders: ReadonlyArray<PreparedWorkspaceFolder>,
-    hostId: string,
-  ) => Promise<ReadonlyArray<string>>;
-}
+const RECENT_FOLDER: PreparedWorkspaceFolder = {
+  workspacePath: "/repo/recent",
+  workspaceName: "recent",
+  repoIdentifier: null,
+  repoUrl: null,
+};
 
 vi.mock("@/lib/host", () => ({
   useHostBinding: () => null,
@@ -81,8 +79,6 @@ vi.mock("@/hooks/worktree/use-worktree-list-by-workspace-paths-query", () => ({
     isLoading: false,
   }),
 }));
-// Its sibling above is mocked, so the real hook's `useQueryClient` would be
-// the only thing in this file demanding a provider it deliberately has none of.
 vi.mock("@/hooks/worktree/use-worktree-workspaces-refresh", () => ({
   useWorktreeWorkspacesRefresh: () => ({
     refresh: () => Promise.resolve(),
@@ -129,43 +125,24 @@ vi.mock(
   () => ({
     useWorkspaceRecordRecentWorkspace: () => ({
       mutate: mutationMocks.recordRecent,
+      mutateAsync: recentMocks.recordRecentAsync,
     }),
   }),
 );
-vi.mock("../use-recent-workspaces", () => ({
-  useRecentWorkspaces: (args: RecentHookArgs) => ({
-    supported: !args.disabled,
-    entries: args.disabled
-      ? []
-      : [
-          {
-            path: "/repo/recent",
-            lastOpenedAt: "2026-08-20T00:00:00.000Z",
-          },
-        ],
-    pendingPath: null,
-    movingPath: null,
-    failedPaths: new Set<string>(),
-    announcement: "",
-    moveToRecent: recentMocks.moveToRecent,
-    add: async (path: string) => {
-      recentMocks.add(path);
-      const activated = await args.activatePreparedFolders(
-        [
-          {
-            workspacePath: path,
-            workspaceName: "recent",
-            repoIdentifier: null,
-            repoUrl: null,
-          },
-        ],
-        "host-test",
-      );
-      return activated.length > 0;
+vi.mock("@/hooks/workspace/use-workspace-list-recent-workspaces-query", () => ({
+  useWorkspaceListRecentWorkspaces: () => ({
+    data: {
+      recentWorkspaces: [
+        {
+          path: RECENT_FOLDER.workspacePath,
+          lastOpenedAt: "2026-08-20T00:00:00.000Z",
+        },
+      ],
     },
-    locate: recentMocks.locate,
-    forget: recentMocks.forget,
   }),
+}));
+vi.mock("@/hooks/host/use-host-negotiated-method-version", () => ({
+  useHostNegotiatedMethodVersion: () => ({ major: 1, minor: 2 }),
 }));
 vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
   // Host-parametric clone create (redesign P1.2, D6): the panel now runs the
@@ -184,7 +161,7 @@ vi.mock("@/hooks/workspace/use-resolved-workspace-folders-query", () => ({
 }));
 vi.mock("@/hooks/workspace/use-workspace-folder-actions", () => ({
   useWorkspaceFolderActionsForClient: () => ({
-    pickAndPrepareFolders: vi.fn(),
+    pickAndPrepareFolders: vi.fn(() => Promise.resolve(null)),
     isPreparing: false,
   }),
   preparedWorkspaceFolderToWorkspaceFolderInfo: (value: unknown) => value,
@@ -194,6 +171,11 @@ vi.mock("@/hooks/host/use-host-queries", () => ({
 }));
 vi.mock("@/hooks/host/use-host-query", () => ({
   useHostQuery: () => ({ data: undefined, isLoading: false }),
+  useHostMutation: () => ({
+    mutate: vi.fn(),
+    mutateAsync: recentMocks.prepareRecent,
+    isPending: false,
+  }),
 }));
 vi.mock("@/components/settings/host-scope/use-host-options", async () => {
   const { hostOptionsFixture, hostScopeOptionFixture } =
@@ -258,29 +240,42 @@ const BINDING: WorktreeBinding = {
   ],
 };
 
-function renderBoundSurface(kind: "chat" | "terminal-agent"): void {
+function renderBoundSurface(
+  kind: "chat" | "terminal-agent",
+  bindingResolved: boolean,
+): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
   render(
-    <TooltipProvider>
-      <HostWorkspaceSelector
-        disabled={false}
-        surface={{
-          kind,
-          hostId: "host-test",
-          epicId: "epic-1",
-          tabId: "tab-1",
-          ownerId: "owner-1",
-          binding: BINDING,
-          isOwnerActive: false,
-          hasActiveTurn: false,
-          missingWorktreePaths: [],
-          bindingResolved: true,
-          onBindingCommitted: null,
-          onForkOnHost: null,
-        }}
-      />
-    </TooltipProvider>,
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <HostWorkspaceSelector
+          disabled={false}
+          surface={{
+            kind,
+            hostId: "host-test",
+            epicId: "epic-1",
+            tabId: "tab-1",
+            ownerId: "owner-1",
+            binding: BINDING,
+            isOwnerActive: false,
+            hasActiveTurn: false,
+            missingWorktreePaths: [],
+            bindingResolved,
+            onBindingCommitted: null,
+            onForkOnHost: null,
+          }}
+        />
+      </TooltipProvider>
+    </QueryClientProvider>,
   );
 }
+
+beforeEach(() => {
+  recentMocks.prepareRecent.mockResolvedValue({ folders: [RECENT_FOLDER] });
+  recentMocks.recordRecentAsync.mockResolvedValue({});
+});
 
 afterEach(() => {
   cleanup();
@@ -288,11 +283,8 @@ afterEach(() => {
   mutationMocks.createWorktree.mockReset();
   mutationMocks.recordRecent.mockReset();
   mutationMocks.removeBindingFolder.mockReset();
-  recentMocks.add.mockReset();
-  recentMocks.forget.mockClear();
-  recentMocks.locate.mockClear();
-  recentMocks.moveToRecent.mockReset();
-  recentMocks.moveToRecent.mockResolvedValue(true);
+  recentMocks.prepareRecent.mockReset();
+  recentMocks.recordRecentAsync.mockReset();
   useWorktreeIntentStagingStore.getState().resetForTests();
 });
 
@@ -300,7 +292,7 @@ describe.each(["chat", "terminal-agent"] as const)(
   "InEpicSurface (%s owner)",
   (kind) => {
     it("renders the primary pin read-only and offers NO Set-as-primary action on any bound row", async () => {
-      renderBoundSurface(kind);
+      renderBoundSurface(kind, true);
 
       // Open the folder-rows popover from the collapsed summary.
       fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
@@ -324,7 +316,7 @@ describe.each(["chat", "terminal-agent"] as const)(
 );
 
 it("explains why a terminal agent's host selector is locked", async () => {
-  renderBoundSurface("terminal-agent");
+  renderBoundSurface("terminal-agent", true);
 
   const switcher = screen.getByTestId("composer-host-trigger");
   expect(switcher instanceof HTMLButtonElement && switcher.disabled).toBe(true);
@@ -335,15 +327,24 @@ it("explains why a terminal agent's host selector is locked", async () => {
 });
 
 it("shows Recent folders in a live chat picker but not a terminal-agent binding", async () => {
-  renderBoundSurface("chat");
+  renderBoundSurface("chat", true);
   fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
   expect(
     await screen.findByRole("button", { name: "Recent folders, 1" }),
   ).toBeTruthy();
 
   cleanup();
-  renderBoundSurface("terminal-agent");
+  renderBoundSurface("terminal-agent", true);
   fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  expect(
+    screen.queryByRole("button", { name: "Recent folders, 1" }),
+  ).toBeNull();
+});
+
+it("keeps Recent unavailable until a chat binding snapshot resolves", () => {
+  renderBoundSurface("chat", false);
+  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+
   expect(
     screen.queryByRole("button", { name: "Recent folders, 1" }),
   ).toBeNull();
@@ -351,7 +352,7 @@ it("shows Recent folders in a live chat picker but not a terminal-agent binding"
 
 it("adds a Recent folder through the chat owner binding", async () => {
   mutationMocks.addBindingFolder.mockResolvedValue({});
-  renderBoundSurface("chat");
+  renderBoundSurface("chat", true);
   fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
   fireEvent.click(
     await screen.findByRole("button", { name: "Recent folders, 1" }),
@@ -371,24 +372,32 @@ it("adds a Recent folder through the chat owner binding", async () => {
 });
 
 it("removes a chat folder only after moving it to Recent succeeds", async () => {
-  renderBoundSurface("chat");
+  renderBoundSurface("chat", true);
   fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
   fireEvent.click((await screen.findAllByTestId("folder-remove"))[0]);
 
   await waitFor(() => {
-    expect(recentMocks.moveToRecent).toHaveBeenCalledWith("/repo/alpha");
+    expect(recentMocks.recordRecentAsync).toHaveBeenCalledWith({
+      path: "/repo/alpha",
+      bumpRecency: false,
+      failureFeedback: "move_warning",
+    });
     expect(mutationMocks.removeBindingFolder).toHaveBeenCalledTimes(1);
   });
 
   cleanup();
-  recentMocks.moveToRecent.mockResolvedValue(false);
+  recentMocks.recordRecentAsync.mockRejectedValueOnce(new Error("nope"));
   mutationMocks.removeBindingFolder.mockClear();
-  renderBoundSurface("chat");
+  renderBoundSurface("chat", true);
   fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
   fireEvent.click((await screen.findAllByTestId("folder-remove"))[0]);
 
   await waitFor(() => {
-    expect(recentMocks.moveToRecent).toHaveBeenCalledWith("/repo/alpha");
+    expect(recentMocks.recordRecentAsync).toHaveBeenCalledWith({
+      path: "/repo/alpha",
+      bumpRecency: false,
+      failureFeedback: "move_warning",
+    });
   });
   expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
 });
@@ -419,7 +428,7 @@ it("refuses terminal Update when metadata regresses to unresolved", async () => 
     ],
   });
 
-  renderBoundSurface("terminal-agent");
+  renderBoundSurface("terminal-agent", true);
   fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
   const update = await screen.findByRole("button", { name: "Update" });
   fireEvent.click(update);

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type {
   WorktreeBinding,
   WorktreeBindingEntry,
 } from "@traycer/protocol/host/worktree-schemas";
+import type { PreparedWorkspaceFolder } from "@traycer/protocol/host/epic/unary-schemas";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   useWorktreeIntentStagingStore,
@@ -20,7 +27,26 @@ const FAKE_CLIENT = {
   getRequestContextUserId: () => "user-test",
   onChange: () => () => undefined,
 };
-const mutationMocks = vi.hoisted(() => ({ createWorktree: vi.fn() }));
+const mutationMocks = vi.hoisted(() => ({
+  addBindingFolder: vi.fn(),
+  createWorktree: vi.fn(),
+  recordRecent: vi.fn(),
+  removeBindingFolder: vi.fn(),
+}));
+const recentMocks = vi.hoisted(() => ({
+  add: vi.fn(),
+  forget: vi.fn(() => Promise.resolve(true)),
+  locate: vi.fn(() => Promise.resolve(true)),
+  moveToRecent: vi.fn(() => Promise.resolve(true)),
+}));
+
+interface RecentHookArgs {
+  readonly disabled: boolean;
+  readonly activatePreparedFolders: (
+    folders: ReadonlyArray<PreparedWorkspaceFolder>,
+    hostId: string,
+  ) => Promise<ReadonlyArray<string>>;
+}
 
 vi.mock("@/lib/host", () => ({
   useHostBinding: () => null,
@@ -86,7 +112,7 @@ vi.mock(
   "@/hooks/workspace/use-workspace-binding-remove-entry-mutation",
   () => ({
     useWorkspaceBindingRemoveEntryForClient: () => ({
-      mutate: vi.fn(),
+      mutate: mutationMocks.removeBindingFolder,
       isPending: false,
     }),
     usePendingRemoveBindingEntryPaths: () => new Set<string>(),
@@ -94,8 +120,51 @@ vi.mock(
 );
 vi.mock("@/hooks/workspace/use-workspace-binding-add-folder-mutation", () => ({
   useWorkspaceBindingAddFolderForClient: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: mutationMocks.addBindingFolder,
     isPending: false,
+  }),
+}));
+vi.mock(
+  "@/hooks/workspace/use-workspace-record-recent-workspace-mutation",
+  () => ({
+    useWorkspaceRecordRecentWorkspace: () => ({
+      mutate: mutationMocks.recordRecent,
+    }),
+  }),
+);
+vi.mock("../use-recent-workspaces", () => ({
+  useRecentWorkspaces: (args: RecentHookArgs) => ({
+    supported: !args.disabled,
+    entries: args.disabled
+      ? []
+      : [
+          {
+            path: "/repo/recent",
+            lastOpenedAt: "2026-08-20T00:00:00.000Z",
+          },
+        ],
+    pendingPath: null,
+    movingPath: null,
+    failedPaths: new Set<string>(),
+    announcement: "",
+    moveToRecent: recentMocks.moveToRecent,
+    add: async (path: string) => {
+      recentMocks.add(path);
+      const activated = await args.activatePreparedFolders(
+        [
+          {
+            workspacePath: path,
+            workspaceName: "recent",
+            repoIdentifier: null,
+            repoUrl: null,
+          },
+        ],
+        "host-test",
+      );
+      return activated.length > 0;
+    },
+    locate: recentMocks.locate,
+    forget: recentMocks.forget,
   }),
 }));
 vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
@@ -215,7 +284,15 @@ function renderBoundSurface(kind: "chat" | "terminal-agent"): void {
 
 afterEach(() => {
   cleanup();
+  mutationMocks.addBindingFolder.mockReset();
   mutationMocks.createWorktree.mockReset();
+  mutationMocks.recordRecent.mockReset();
+  mutationMocks.removeBindingFolder.mockReset();
+  recentMocks.add.mockReset();
+  recentMocks.forget.mockClear();
+  recentMocks.locate.mockClear();
+  recentMocks.moveToRecent.mockReset();
+  recentMocks.moveToRecent.mockResolvedValue(true);
   useWorktreeIntentStagingStore.getState().resetForTests();
 });
 
@@ -255,6 +332,65 @@ it("explains why a terminal agent's host selector is locked", async () => {
   expect((await screen.findByRole("tooltip")).textContent).toContain(
     "Terminal host is fixed",
   );
+});
+
+it("shows Recent folders in a live chat picker but not a terminal-agent binding", async () => {
+  renderBoundSurface("chat");
+  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  expect(
+    await screen.findByRole("button", { name: "Recent folders, 1" }),
+  ).toBeTruthy();
+
+  cleanup();
+  renderBoundSurface("terminal-agent");
+  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  expect(
+    screen.queryByRole("button", { name: "Recent folders, 1" }),
+  ).toBeNull();
+});
+
+it("adds a Recent folder through the chat owner binding", async () => {
+  mutationMocks.addBindingFolder.mockResolvedValue({});
+  renderBoundSurface("chat");
+  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Recent folders, 1" }),
+  );
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Add recent to context" }),
+  );
+
+  await waitFor(() => {
+    expect(mutationMocks.addBindingFolder).toHaveBeenCalledWith({
+      epicId: "epic-1",
+      ownerId: "owner-1",
+      ownerKind: "chat",
+      workspacePath: "/repo/recent",
+    });
+  });
+});
+
+it("removes a chat folder only after moving it to Recent succeeds", async () => {
+  renderBoundSurface("chat");
+  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click((await screen.findAllByTestId("folder-remove"))[0]);
+
+  await waitFor(() => {
+    expect(recentMocks.moveToRecent).toHaveBeenCalledWith("/repo/alpha");
+    expect(mutationMocks.removeBindingFolder).toHaveBeenCalledTimes(1);
+  });
+
+  cleanup();
+  recentMocks.moveToRecent.mockResolvedValue(false);
+  mutationMocks.removeBindingFolder.mockClear();
+  renderBoundSurface("chat");
+  fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
+  fireEvent.click((await screen.findAllByTestId("folder-remove"))[0]);
+
+  await waitFor(() => {
+    expect(recentMocks.moveToRecent).toHaveBeenCalledWith("/repo/alpha");
+  });
+  expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
 });
 
 it("refuses terminal Update when metadata regresses to unresolved", async () => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -20,6 +20,7 @@ import {
   unavailableHostOption,
 } from "@/components/settings/host-scope/host-scope-model";
 import { activeRunNoticeFor } from "./active-run-notice";
+import type { PreparedWorkspaceFolder } from "@traycer/protocol/host/epic/unary-schemas";
 import type {
   RepoBranchPrefixState,
   WorktreeBinding,
@@ -56,7 +57,11 @@ import { useWorkspaceBindingAddFolderForClient } from "@/hooks/workspace/use-wor
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
 import { useResolvedWorkspaceFolders } from "@/hooks/workspace/use-resolved-workspace-folders-query";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
-import { useWorkspaceFolderActionsForClient } from "@/hooks/workspace/use-workspace-folder-actions";
+import {
+  preparedWorkspaceFolderToWorkspaceFolderInfo,
+  useWorkspaceFolderActionsForClient,
+} from "@/hooks/workspace/use-workspace-folder-actions";
+import { useWorkspaceRecordRecentWorkspace } from "@/hooks/workspace/use-workspace-record-recent-workspace-mutation";
 import type { LandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
 import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
 import { locateReplaceBoundFolder } from "./locate-replace-bound-folder";
@@ -679,10 +684,25 @@ function HomeWorkspaceRows(props: {
     activeHostClient,
     workspaceSource,
   );
+  const activatePreparedRecentFolders = useCallback(
+    (
+      folders: ReadonlyArray<PreparedWorkspaceFolder>,
+      hostId: string,
+    ): Promise<ReadonlyArray<string>> => {
+      workspaceSource.addResolvedFolders(
+        folders.map((folder) =>
+          preparedWorkspaceFolderToWorkspaceFolderInfo(folder, hostId),
+        ),
+      );
+      return Promise.resolve(folders.map((folder) => folder.workspacePath));
+    },
+    [workspaceSource],
+  );
   const recentWorkspaces = useRecentWorkspaces({
     client: activeHostClient,
     hostId: props.activeHostId,
-    workspaceSource,
+    activePaths: workspaceSource.folders,
+    activatePreparedFolders: activatePreparedRecentFolders,
     disabled: props.disabled,
     surface: stagingKey.surface,
   });
@@ -1932,6 +1952,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const addFolderMutation = useWorkspaceBindingAddFolderForClient(
     props.hostClient,
   );
+  const addBindingFolder = addFolderMutation.mutateAsync;
+  const recordRecentWorkspace = useWorkspaceRecordRecentWorkspace({
+    client: props.hostClient,
+  }).mutate;
   const pendingRemovePaths = usePendingRemoveBindingEntryPaths({
     epicId: surface.epicId,
     ownerId: surface.ownerId,
@@ -2108,8 +2132,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   // off the working tree (or the user's remembered choice, unless that is Local)
   // once its disk metadata resolves, then dropped - so a later adjustment is
   // never re-clobbered. Established binding folders are untouched (binding wins).
-  const pendingDefaultPathsRef = useRef<Set<string> | null>(null);
-  const pendingDefaultPaths = (pendingDefaultPathsRef.current ??= new Set());
+  const pendingDefaultPathsRef = useRef(new Set<string>());
 
   // Terminal-agent "Update": apply every staged folder edit to the binding in a
   // single worktree.create (resolveIntent merges per-folder), then resume the
@@ -2142,7 +2165,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     // A just-added git folder may still be waiting for metadata so the default
     // new-worktree seed can be staged. Keep Update enabled, but don't resume
     // until those pending defaults either stage or resolve as no-op.
-    if ((pendingDefaultPathsRef.current?.size ?? 0) > 0) return;
+    if (pendingDefaultPathsRef.current.size > 0) return;
     // Defensive: the button is already gated on the same condition, but guard
     // against an empty apply (nothing staged AND no committed add/remove).
     if (stagedEntries.length === 0 && editor.dirtyPathsSinceResume.size === 0) {
@@ -2239,7 +2262,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
 
   useEffect(() => {
     const pending = pendingDefaultPathsRef.current;
-    if (pending === null || pending.size === 0) return;
+    if (pending.size === 0) return;
     for (const path of [...pending]) {
       const summary = resolvedSummariesByPath.get(path) ?? null;
       if (summary === null) continue; // unresolved or not loaded yet - wait
@@ -2296,6 +2319,57 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   );
   const activeRunLocksBinding =
     surface.kind === "chat" && surface.isOwnerActive;
+  const activeRunLocksBindingRef = useRef(activeRunLocksBinding);
+  useLayoutEffect(() => {
+    activeRunLocksBindingRef.current = activeRunLocksBinding;
+  }, [activeRunLocksBinding]);
+
+  const activatePreparedFoldersForOwner = useCallback(
+    async (
+      folders: ReadonlyArray<PreparedWorkspaceFolder>,
+    ): Promise<ReadonlyArray<string>> => {
+      const activePaths = new Set(bindingWorkspacePaths);
+      const activatedPaths: string[] = [];
+      const addedPaths: string[] = [];
+      for (const folder of folders) {
+        if (surface.kind === "chat" && activeRunLocksBindingRef.current) break;
+        if (activePaths.has(folder.workspacePath)) {
+          activatedPaths.push(folder.workspacePath);
+          continue;
+        }
+        // oxlint-disable-next-line react-doctor/async-await-in-loop -- sequential is required: concurrent setEntryMode writes race on the single owner-binding row and lose folders.
+        const added = await addBindingFolder({
+          epicId: surface.epicId,
+          ownerId: surface.ownerId,
+          ownerKind,
+          workspacePath: folder.workspacePath,
+        })
+          .then(() => true)
+          .catch(() => false);
+        if (!added) continue;
+        pendingDefaultPathsRef.current.add(folder.workspacePath);
+        activatedPaths.push(folder.workspacePath);
+        addedPaths.push(folder.workspacePath);
+      }
+      if (addedPaths.length === 0) return activatedPaths;
+      if (surface.kind === "terminal-agent") {
+        markBindingDirtyWithoutResume(addedPaths);
+      } else {
+        handleBindingCommitted(addedPaths);
+      }
+      return activatedPaths;
+    },
+    [
+      addBindingFolder,
+      bindingWorkspacePaths,
+      handleBindingCommitted,
+      markBindingDirtyWithoutResume,
+      ownerKind,
+      surface.epicId,
+      surface.kind,
+      surface.ownerId,
+    ],
+  );
 
   // Free functions (not useCallback) matching HEAD: they close over render
   // locals and are only invoked from event handlers / item onLocate, never
@@ -2303,37 +2377,19 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const addFoldersToOwnerBinding = async (): Promise<boolean> => {
     const result = await folderActions.pickAndPrepareFolders(false);
     if (result === null) return false;
-    const addedWorkspacePaths: string[] = [];
-    // Add each picked folder independently and sequentially: the binding is a
-    // single read-modify-write row, so parallel writes would clobber one
-    // another - but one folder failing must not abort the rest (the add
-    // mutation's onError already surfaces a per-folder toast).
-    for (const folder of result.folders) {
-      // oxlint-disable-next-line react-doctor/async-await-in-loop -- sequential is required: concurrent setEntryMode writes race on the single owner-binding row and lose folders.
-      const ok = await addFolderMutation
-        .mutateAsync({
-          epicId: surface.epicId,
-          ownerId: surface.ownerId,
-          ownerKind,
-          workspacePath: folder.workspacePath,
-        })
-        .then(() => true)
-        .catch(() => false);
-      if (ok) {
-        pendingDefaultPaths.add(folder.workspacePath);
-        addedWorkspacePaths.push(folder.workspacePath);
+    const activatedPaths = await activatePreparedFoldersForOwner(
+      result.folders,
+    );
+    if (surface.kind === "chat") {
+      for (const path of activatedPaths) {
+        recordRecentWorkspace({
+          path,
+          bumpRecency: true,
+          failureFeedback: "silent",
+        });
       }
     }
-    if (addedWorkspacePaths.length === 0) return false;
-    // The folders are in the binding now, but adding never resumes the PTY —
-    // the explicit "Update" does. Mark dirty so "Update" is enabled (a non-git
-    // add stages nothing). Chat has no PTY to resume (no-op callback).
-    if (surface.kind === "terminal-agent") {
-      markBindingDirtyWithoutResume(addedWorkspacePaths);
-    } else {
-      handleBindingCommitted(addedWorkspacePaths);
-    }
-    return true;
+    return activatedPaths.length > 0;
   };
 
   // One folder intent from the unified picker maps to the existing in-Epic
@@ -2564,7 +2620,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                             ownerKind,
                             workspacePath,
                           });
-                          pendingDefaultPathsRef.current?.add(workspacePath);
+                          pendingDefaultPathsRef.current.add(workspacePath);
                           return true;
                         } catch {
                           return false;
@@ -2578,7 +2634,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                             ownerKind,
                             workspacePath,
                           });
-                          pendingDefaultPathsRef.current?.delete(workspacePath);
+                          pendingDefaultPathsRef.current.delete(workspacePath);
                           unstageWorktreeEntry(stagedKey, workspacePath);
                           return true;
                         } catch {
@@ -2617,7 +2673,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                 },
                 {
                   onSuccess: () => {
-                    pendingDefaultPathsRef.current?.delete(ws.workspacePath);
+                    pendingDefaultPathsRef.current.delete(ws.workspacePath);
                     unstageWorktreeEntry(stagedKey, ws.workspacePath);
                     if (surface.kind === "terminal-agent") {
                       markBindingDirtyWithoutResume([ws.workspacePath]);
@@ -2708,7 +2764,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                   // to seed - its summary never arrives, so left in place the
                   // path would pin the pending-defaults guard and block
                   // Update's resume forever.
-                  pendingDefaultPathsRef.current?.delete(ws.workspacePath);
+                  pendingDefaultPathsRef.current.delete(ws.workspacePath);
                   // And if metadata DID resolve first, the seeding effect may
                   // already have staged a default worktree intent for this
                   // path - unstage it, or the next Update would call
@@ -2746,6 +2802,58 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       workspaces,
     ],
   );
+
+  const recentWorkspaces = useRecentWorkspaces({
+    client: props.hostClient,
+    hostId: props.activeHostId,
+    activePaths: bindingWorkspacePaths,
+    activatePreparedFolders: activatePreparedFoldersForOwner,
+    disabled: surface.kind !== "chat" || activeRunLocksBinding,
+    surface: stagedKey.surface,
+  });
+  const {
+    moveToRecent: moveBoundWorkspaceToRecent,
+    movingPath: recentWorkspacesMovingPath,
+    supported: recentWorkspacesSupported,
+  } = recentWorkspaces;
+  const recentAwareWorkspaceRunItems = useMemo<ReadonlyArray<WorkspaceRunItem>>(
+    () =>
+      workspaceRunItems.map((item) => {
+        if (!recentWorkspacesSupported || item.onRemove === null) return item;
+        const removeFromBinding = item.onRemove;
+        return {
+          ...item,
+          removePending:
+            item.removePending ||
+            recentWorkspacesMovingPath === item.displayPath,
+          onRemove: () => {
+            if (activeRunLocksBindingRef.current) return;
+            void moveBoundWorkspaceToRecent(item.displayPath).then((moved) => {
+              if (moved && !activeRunLocksBindingRef.current) {
+                removeFromBinding();
+              }
+            });
+          },
+        };
+      }),
+    [
+      moveBoundWorkspaceToRecent,
+      recentWorkspacesMovingPath,
+      recentWorkspacesSupported,
+      workspaceRunItems,
+    ],
+  );
+  const recentWorkspacesSection = recentWorkspacesSupported ? (
+    <RecentWorkspacesSection
+      entries={recentWorkspaces.entries}
+      activeCount={bindingWorkspacePaths.length}
+      pendingPath={recentWorkspaces.pendingPath}
+      failedPaths={recentWorkspaces.failedPaths}
+      onAdd={recentWorkspaces.add}
+      onLocate={recentWorkspaces.locate}
+      onForget={recentWorkspaces.forget}
+    />
+  ) : null;
 
   // Setup/teardown editor, hosted here so it outlives the popover. In-epic
   // surfaces carry the real owner + live binding, so an edit can target a bound
@@ -2824,7 +2932,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         </div>
         <div className="min-w-0 flex-[1_1_auto] max-w-[min(100%,34rem)] overflow-hidden">
           <WorkspaceFolderSummaryControl
-            items={workspaceRunItems}
+            items={recentAwareWorkspaceRunItems}
             readOnly={readOnly}
             bindingResolved={surface.bindingResolved}
             addFolderPending={
@@ -2854,9 +2962,9 @@ function InEpicSurface(props: InEpicSurfaceProps) {
             onEditEnvironment={handleEditEnvironment}
             refresh={summariesRefresh}
             popoverTestId="workspace-rows-popover"
-            recentWorkspaces={null}
-            recentWorkspaceCount={0}
-            moveToRecent={false}
+            recentWorkspaces={recentWorkspacesSection}
+            recentWorkspaceCount={recentWorkspaces.entries.length}
+            moveToRecent={recentWorkspacesSupported}
             // The terminal-agent toolbar is anchored at the TOP of its tile, so the
             // editor must open DOWNWARD into the terminal body (plenty of room).
             // Opening upward (chat's default, where the composer is bottom-anchored)

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -2808,7 +2808,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     hostId: props.activeHostId,
     activePaths: bindingWorkspacePaths,
     activatePreparedFolders: activatePreparedFoldersForOwner,
-    disabled: surface.kind !== "chat" || activeRunLocksBinding,
+    disabled:
+      surface.kind !== "chat" ||
+      activeRunLocksBinding ||
+      !surface.bindingResolved,
     surface: stagedKey.surface,
   });
   const {

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-recent-workspaces.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-recent-workspaces.ts
@@ -1,21 +1,18 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { PreparedWorkspaceFolder } from "@traycer/protocol/host/epic/unary-schemas";
 import type { WorkspaceRecentEntry } from "@traycer/protocol/host/workspace/unary-schemas";
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostNegotiatedMethodVersion } from "@/hooks/host/use-host-negotiated-method-version";
 import { useWorkspaceListRecentWorkspaces } from "@/hooks/workspace/use-workspace-list-recent-workspaces-query";
 import { useWorkspaceRecordRecentWorkspace } from "@/hooks/workspace/use-workspace-record-recent-workspace-mutation";
-import {
-  preparedWorkspaceFolderToWorkspaceFolderInfo,
-  useWorkspaceFolderActionsForClient,
-} from "@/hooks/workspace/use-workspace-folder-actions";
+import { useWorkspaceFolderActionsForClient } from "@/hooks/workspace/use-workspace-folder-actions";
 import type { HostRpcRegistry } from "@/lib/host";
 import { hostQueryKeys } from "@/lib/query-keys";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import type { WorktreeStagingKey } from "@/stores/worktree/worktree-intent-staging-store";
-import type { HomeWorkspaceSource } from "./use-home-workspace-source";
 
 interface MutationContext {
   readonly hostId: string | null;
@@ -30,6 +27,7 @@ interface RecentWorkspaceState {
   readonly hostId: string | null;
   readonly failedPaths: ReadonlySet<string>;
   readonly hiddenPaths: ReadonlySet<string>;
+  readonly pendingPath: string | null;
   readonly movingWorkspace: MovingWorkspace | null;
   readonly announcement: string;
 }
@@ -56,6 +54,7 @@ function emptyRecentWorkspaceState(
     hostId,
     failedPaths: EMPTY_PATHS,
     hiddenPaths: EMPTY_PATHS,
+    pendingPath: null,
     movingWorkspace: null,
     announcement: "",
   };
@@ -64,10 +63,16 @@ function emptyRecentWorkspaceState(
 export function useRecentWorkspaces(args: {
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly hostId: string | null;
-  readonly workspaceSource: HomeWorkspaceSource;
+  readonly activePaths: ReadonlyArray<string>;
+  readonly activatePreparedFolders: (
+    folders: ReadonlyArray<PreparedWorkspaceFolder>,
+    hostId: string,
+  ) => Promise<ReadonlyArray<string>>;
   readonly disabled: boolean;
   readonly surface: WorktreeStagingKey["surface"];
 }): RecentWorkspacesController {
+  const activatePreparedFolders = args.activatePreparedFolders;
+  const analyticsSurface = args.surface;
   const version = useHostNegotiatedMethodVersion(
     args.client,
     "workspace.prepareFolders",
@@ -93,8 +98,10 @@ export function useRecentWorkspaces(args: {
   ).pickAndPrepareFolders;
   const activeHostId = args.hostId;
   const activeHostIdRef = useRef(activeHostId);
+  const pendingPathRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     activeHostIdRef.current = activeHostId;
+    pendingPathRef.current = null;
   }, [activeHostId]);
   const [state, setState] = useState<RecentWorkspaceState>(() =>
     emptyRecentWorkspaceState(activeHostId),
@@ -106,6 +113,7 @@ export function useRecentWorkspaces(args: {
   const {
     failedPaths: currentFailedPaths,
     hiddenPaths: currentHiddenPaths,
+    pendingPath: currentPendingPath,
     movingWorkspace: currentMovingWorkspace,
     announcement: currentAnnouncement,
   } = currentState;
@@ -184,6 +192,10 @@ export function useRecentWorkspaces(args: {
   });
   const prepareRecent = prepareMutation.mutateAsync;
   const forgetRecent = forgetMutation.mutateAsync;
+  const activePathSet = useMemo(
+    () => new Set(args.activePaths),
+    [args.activePaths],
+  );
 
   const forget = useCallback(
     async (workspacePath: string): Promise<boolean> => {
@@ -194,7 +206,7 @@ export function useRecentWorkspaces(args: {
       try {
         await forgetRecent(workspacePath);
         Analytics.getInstance().track(AnalyticsEvent.WorkspaceRecentForgotten, {
-          surface: args.surface,
+          surface: analyticsSurface,
         });
         updateState((current) => ({
           ...current,
@@ -220,60 +232,46 @@ export function useRecentWorkspaces(args: {
         return false;
       }
     },
-    [args.surface, forgetRecent, updateState],
+    [analyticsSurface, forgetRecent, updateState],
   );
 
   const add = useCallback(
     async (workspacePath: string): Promise<boolean> => {
+      if (pendingPathRef.current !== null) return false;
       const dispatchHostId = activeHostIdRef.current;
+      if (dispatchHostId === null) return false;
+      pendingPathRef.current = workspacePath;
       updateState((current) => ({
         ...current,
         failedPaths: withoutPath(current.failedPaths, workspacePath),
+        pendingPath: workspacePath,
       }));
-      try {
-        const response = await prepareRecent(workspacePath);
-        if (
-          dispatchHostId === null ||
-          activeHostIdRef.current !== dispatchHostId ||
-          response.folders.length === 0
-        ) {
-          updateState((current) => ({
-            ...current,
-            failedPaths: new Set(current.failedPaths).add(workspacePath),
-          }));
-          Analytics.getInstance().track(AnalyticsEvent.WorkspaceContextAdded, {
-            source: "recent",
-            outcome: "failed",
-            surface: args.surface,
-          });
-          return false;
-        }
-        const alreadyActive = response.folders.every((folder) =>
-          args.workspaceSource.folders.includes(folder.workspacePath),
-        );
-        args.workspaceSource.addResolvedFolders(
-          response.folders.map((folder) =>
-            preparedWorkspaceFolderToWorkspaceFolderInfo(
-              folder,
+      const response = await prepareRecent(workspacePath).catch(() => null);
+      const activatedPaths =
+        response !== null &&
+        activeHostIdRef.current === dispatchHostId &&
+        response.folders.length > 0
+          ? await activatePreparedFolders(
+              response.folders,
               dispatchHostId,
-            ),
-          ),
+            ).catch(() => [])
+          : [];
+      const succeeded =
+        response !== null &&
+        activeHostIdRef.current === dispatchHostId &&
+        activatedPaths.length > 0;
+      if (response !== null && succeeded) {
+        const alreadyActive = response.folders.every((folder) =>
+          activePathSet.has(folder.workspacePath),
         );
-        for (const folder of response.folders) {
+        for (const path of activatedPaths) {
           recordRecent({
-            path: folder.workspacePath,
+            path,
             bumpRecency: true,
             failureFeedback: "silent",
           });
         }
-        const canonicalPaths = new Set(
-          response.folders.map((folder) => folder.workspacePath),
-        );
-        if (!canonicalPaths.has(workspacePath)) {
-          updateState((current) => ({
-            ...current,
-            hiddenPaths: new Set(current.hiddenPaths).add(workspacePath),
-          }));
+        if (!activatedPaths.includes(workspacePath)) {
           void forgetRecent(workspacePath).catch(() => {
             updateState((current) => ({
               ...current,
@@ -283,32 +281,40 @@ export function useRecentWorkspaces(args: {
         }
         updateState((current) => ({
           ...current,
+          hiddenPaths: new Set([
+            ...current.hiddenPaths,
+            workspacePath,
+            ...activatedPaths,
+          ]),
           announcement: alreadyActive
             ? "Workspace is already in context."
             : "Workspace added to context.",
         }));
-        Analytics.getInstance().track(AnalyticsEvent.WorkspaceContextAdded, {
-          source: "recent",
-          outcome: "succeeded",
-          surface: args.surface,
-        });
-        return true;
-      } catch {
+      } else {
         updateState((current) => ({
           ...current,
           failedPaths: new Set(current.failedPaths).add(workspacePath),
         }));
-        Analytics.getInstance().track(AnalyticsEvent.WorkspaceContextAdded, {
-          source: "recent",
-          outcome: "failed",
-          surface: args.surface,
-        });
-        return false;
       }
+      Analytics.getInstance().track(AnalyticsEvent.WorkspaceContextAdded, {
+        source: "recent",
+        outcome: succeeded ? "succeeded" : "failed",
+        surface: analyticsSurface,
+      });
+      if (pendingPathRef.current === workspacePath) {
+        pendingPathRef.current = null;
+      }
+      updateState((current) => ({
+        ...current,
+        pendingPath:
+          current.pendingPath === workspacePath ? null : current.pendingPath,
+      }));
+      return succeeded;
     },
     [
-      args.surface,
-      args.workspaceSource,
+      activatePreparedFolders,
+      analyticsSurface,
+      activePathSet,
       forgetRecent,
       prepareRecent,
       recordRecent,
@@ -318,21 +324,33 @@ export function useRecentWorkspaces(args: {
 
   const locate = useCallback(
     async (workspacePath: string): Promise<boolean> => {
-      const result = await pickAndPrepareFolders(true);
+      const result = await pickAndPrepareFolders(false);
       if (result === null || activeHostIdRef.current !== result.hostId) {
         return false;
       }
-      const folders = result.folders.map((folder) =>
-        preparedWorkspaceFolderToWorkspaceFolderInfo(folder, result.hostId),
+      const activatedPaths = await activatePreparedFolders(
+        result.folders,
+        result.hostId,
       );
-      if (folders.length === 0) return false;
-      args.workspaceSource.addResolvedFolders(folders);
+      if (activatedPaths.length === 0) return false;
+      for (const path of activatedPaths) {
+        recordRecent({
+          path,
+          bumpRecency: true,
+          failureFeedback: "silent",
+        });
+      }
       let replacementForgotten = true;
-      if (!folders.some((folder) => folder.path === workspacePath)) {
+      if (!activatedPaths.includes(workspacePath)) {
         replacementForgotten = await forget(workspacePath);
       }
       updateState((current) => ({
         ...current,
+        hiddenPaths: new Set([
+          ...current.hiddenPaths,
+          workspacePath,
+          ...activatedPaths,
+        ]),
         failedPaths: replacementForgotten
           ? withoutPath(current.failedPaths, workspacePath)
           : new Set(current.failedPaths).add(workspacePath),
@@ -343,15 +361,16 @@ export function useRecentWorkspaces(args: {
       Analytics.getInstance().track(AnalyticsEvent.WorkspaceContextAdded, {
         source: "browse",
         outcome: replacementForgotten ? "succeeded" : "failed",
-        surface: args.surface,
+        surface: analyticsSurface,
       });
       return true;
     },
     [
-      args.surface,
-      args.workspaceSource,
+      activatePreparedFolders,
+      analyticsSurface,
       forget,
       pickAndPrepareFolders,
+      recordRecent,
       updateState,
     ],
   );
@@ -362,35 +381,36 @@ export function useRecentWorkspaces(args: {
       if (dispatchHostId === null) return false;
       const moving = { hostId: dispatchHostId, path: workspacePath };
       updateState((current) => ({ ...current, movingWorkspace: moving }));
+      let moved = false;
       try {
         await recordRecentAsync({
           path: workspacePath,
           bumpRecency: false,
           failureFeedback: "move_warning",
         });
-        if (activeHostIdRef.current !== moving.hostId) {
-          return false;
+        if (activeHostIdRef.current === moving.hostId) {
+          updateState((current) => ({
+            ...current,
+            hiddenPaths: withoutPath(current.hiddenPaths, workspacePath),
+            announcement: "Workspace moved to Recent.",
+          }));
+          Analytics.getInstance().track(AnalyticsEvent.WorkspaceMovedToRecent, {
+            surface: analyticsSurface,
+          });
+          moved = true;
         }
-        updateState((current) => ({
-          ...current,
-          announcement: "Workspace moved to Recent.",
-        }));
-        Analytics.getInstance().track(AnalyticsEvent.WorkspaceMovedToRecent, {
-          surface: args.surface,
-        });
-        return true;
       } catch {
-        return false;
-      } finally {
-        updateState((current) => ({
-          ...current,
-          movingWorkspace:
-            current.movingWorkspace === moving ? null : current.movingWorkspace,
-        }));
+        moved = false;
       }
+      updateState((current) => ({
+        ...current,
+        movingWorkspace:
+          current.movingWorkspace === moving ? null : current.movingWorkspace,
+      }));
+      return moved;
     },
     [
-      args.surface,
+      analyticsSurface,
       currentMovingWorkspace,
       recordRecentAsync,
       supported,
@@ -398,18 +418,17 @@ export function useRecentWorkspaces(args: {
     ],
   );
 
-  const activePaths = args.workspaceSource.folders;
   const entries = useMemo(
     () =>
       supported
         ? (recentsQuery.data?.recentWorkspaces ?? []).filter(
             (entry) =>
-              !activePaths.includes(entry.path) &&
+              !activePathSet.has(entry.path) &&
               !currentHiddenPaths.has(entry.path),
           )
         : [],
     [
-      activePaths,
+      activePathSet,
       currentHiddenPaths,
       recentsQuery.data?.recentWorkspaces,
       supported,
@@ -419,7 +438,7 @@ export function useRecentWorkspaces(args: {
   return {
     supported,
     entries,
-    pendingPath: prepareMutation.isPending ? prepareMutation.variables : null,
+    pendingPath: currentPendingPath,
     movingPath: currentMovingWorkspace?.path ?? null,
     failedPaths: currentFailedPaths,
     announcement: currentAnnouncement,

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-recent-workspaces.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-recent-workspaces.ts
@@ -324,14 +324,14 @@ export function useRecentWorkspaces(args: {
 
   const locate = useCallback(
     async (workspacePath: string): Promise<boolean> => {
-      const result = await pickAndPrepareFolders(false);
+      const result = await pickAndPrepareFolders(false).catch(() => null);
       if (result === null || activeHostIdRef.current !== result.hostId) {
         return false;
       }
       const activatedPaths = await activatePreparedFolders(
         result.folders,
         result.hostId,
-      );
+      ).catch((): ReadonlyArray<string> => []);
       if (activatedPaths.length === 0) return false;
       for (const path of activatedPaths) {
         recordRecent({

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
@@ -35,7 +35,7 @@ export function WorkspaceFolderRows(props: {
   readonly onEditEnvironment: (workspacePath: string) => void;
   readonly readOnly: boolean;
   readonly bindingResolved: boolean;
-  /** Creation-time Recent tier; null for read-only and live-binding surfaces. */
+  /** Recent tier; null for read-only and terminal-agent binding surfaces. */
   readonly recentWorkspaces: ReactNode;
   readonly moveToRecent: boolean;
   // True only when the rows live inside a popover (in-epic): nested popovers


### PR DESCRIPTION
## Summary
- expose the existing Recent folders disclosure in live chat workspace binding editors while leaving terminal-agent bindings unchanged
- route Recent additions and Move to Recent through the chat owner-binding mutations and active-run safety checks
- await asynchronous binding activation so failures keep Recent rows available, and remember successful chat folder attachments

## Verification
- focused selector suites: 21 tests passed
- React Compiler mode: 10 tests passed
- repository pre-commit affected build, compile, lint, and format checks passed
- React Doctor: no correctness or performance errors; existing manual-memoization warnings remain