### PR TITLE
fix(shared): retry relay policy kills (#1312) [v1.2.0]

### DIFF
--- a/clients/shared/host-client/REMOTE-TRANSPORT.md
+++ b/clients/shared/host-client/REMOTE-TRANSPORT.md
@@ -257,8 +257,10 @@ sequenceDiagram
 frames, not losing them to a host-less relay) and marks streams reconnecting;
 `host_attached` → resume on the **same** Noise session (no re-handshake). Only a
 socket drop or `peer_gone`/`killed` triggers a full attach. `peer_gone`/`killed`
-reasons `revoked` / `policy_violation` are **terminal**; `host_gone` /
-`reauth_timeout` → full-resume with backoff.
+reason `revoked` is **terminal**. `host_gone` / `reauth_timeout` → full-resume
+with ordinary backoff. `policy_violation` and every unknown/future reason →
+full-resume at the capped backoff rung and report an indeterminate relay loss,
+never a host refusal.
 
 ## 10. Re-auth & peer-enforced host standing (R4-D2)
 

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -76,7 +76,11 @@ import {
 } from "@traycer/protocol/host-transport/chunking";
 import { RemoteSession, type RemoteSessionOptions } from "../remote-session";
 import { RemoteStreamClient } from "../remote-stream-client";
-import { INBOUND_CREDIT_GRANT_BATCH } from "../config";
+import {
+  INBOUND_CREDIT_GRANT_BATCH,
+  RECONNECT_INITIAL_BACKOFF_MS,
+  RECONNECT_MAX_BACKOFF_MS,
+} from "../config";
 import type {
   StreamCloseReason,
   StreamFrameEnvelope,
@@ -291,6 +295,15 @@ class FakeRelayHost {
     connection.socket.onmessage?.({
       type: "text",
       data: JSON.stringify({ type: state }),
+    });
+  }
+
+  /** Relay control frame: the peer/session was killed for a relay reason. */
+  sendRelayKill(type: "peer_gone" | "killed", reason: string): void {
+    const connection = this.liveConnection();
+    connection.socket.onmessage?.({
+      type: "text",
+      data: JSON.stringify({ type, reason }),
     });
   }
 
@@ -1074,6 +1087,117 @@ describe("RemoteSession terminal close notification", () => {
         expect(relay.errors).toEqual([]);
       } finally {
         session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+});
+
+describe("RemoteSession relay policy kills", () => {
+  it.each(["peer_gone", "killed"] as const)(
+    "%s{policy_violation} drops without going terminal and schedules the capped reconnect",
+    async (controlType) => {
+      const relay = new FakeRelayHost();
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const recorder = new RecordingEvidence();
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        evidence: recorder,
+      });
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+
+        relay.sendRelayKill(controlType, "policy_violation");
+
+        expect(session.isReady()).toBe(false);
+        expect(session.isClosed()).toBe(false);
+        expect(session.terminalFatal()).toBeNull();
+        expect(setTimeoutSpy).toHaveBeenCalledWith(
+          expect.any(Function),
+          RECONNECT_MAX_BACKOFF_MS,
+        );
+        const indeterminates = recorder.callsNamed("reportDialIndeterminate");
+        expect(indeterminates).toHaveLength(1);
+        expect(indeterminates[0].hostId).toBe("host-1");
+        expect(indeterminates[0].transportKind).toBe("remote-relay");
+        expect(recorder.callsNamed("reportDialRefusal")).toHaveLength(0);
+      } finally {
+        session.close();
+        setTimeoutSpy.mockRestore();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+
+  it(
+    "peer_gone{revoked} remains terminal with an UNAUTHORIZED verdict",
+    async () => {
+      const relay = new FakeRelayHost();
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const session = buildSession(relay, lease, null);
+      let closedEvents = 0;
+      session.onClosed(() => {
+        closedEvents += 1;
+      });
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+
+        relay.sendRelayKill("peer_gone", "revoked");
+
+        await vi.waitFor(() => expect(session.isClosed()).toBe(true), WAIT);
+        expect(closedEvents).toBe(1);
+        expect(session.terminalFatal()).toEqual({
+          code: "UNAUTHORIZED",
+          reason: "Host access was revoked",
+          incompatibleMethods: null,
+          upgradeGuidance: null,
+        });
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+
+  it.each(["peer_gone", "killed"] as const)(
+    "%s{future_reason} is parsed as a capped retryable transport loss",
+    async (controlType) => {
+      const relay = new FakeRelayHost();
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const recorder = new RecordingEvidence();
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        evidence: recorder,
+      });
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+
+        relay.sendRelayKill(controlType, "future_reason");
+
+        expect(session.isReady()).toBe(false);
+        expect(session.isClosed()).toBe(false);
+        expect(session.terminalFatal()).toBeNull();
+        expect(setTimeoutSpy).toHaveBeenCalledWith(
+          expect.any(Function),
+          RECONNECT_MAX_BACKOFF_MS,
+        );
+        expect(setTimeoutSpy).not.toHaveBeenCalledWith(
+          expect.any(Function),
+          RECONNECT_INITIAL_BACKOFF_MS,
+        );
+        const indeterminates = recorder.callsNamed("reportDialIndeterminate");
+        expect(indeterminates).toHaveLength(1);
+        expect(indeterminates[0].hostId).toBe("host-1");
+        expect(indeterminates[0].transportKind).toBe("remote-relay");
+        expect(recorder.callsNamed("reportDialRefusal")).toHaveLength(0);
+      } finally {
+        session.close();
+        setTimeoutSpy.mockRestore();
       }
     },
     TEST_BUDGET_MS,

--- a/clients/shared/host-transport/remote/relay-socket.ts
+++ b/clients/shared/host-transport/remote/relay-socket.ts
@@ -34,9 +34,20 @@ import {
 const KEEPALIVE_PING = "relay-ping";
 const KEEPALIVE_PONG = "relay-pong";
 
-/** Relay session-kill / peer-death reasons (mirror relay-do `KillReason`). */
+/**
+ * Relay session-kill / peer-death reasons (mirror relay-do `KillReason`).
+ *
+ * The relay can add a reason before this client updates. Preserve that reason
+ * rather than rejecting its control frame: unknown kills are transport losses
+ * and therefore retryable by default. The known literals remain here for the
+ * one reason with stronger semantics (`revoked`) and for call-site discovery.
+ */
 export type RelayKillReason =
-  "reauth_timeout" | "revoked" | "host_gone" | "policy_violation";
+  | "reauth_timeout"
+  | "revoked"
+  | "host_gone"
+  | "policy_violation"
+  | (string & {});
 
 export interface RelaySocketHandlers {
   /** The relay assigned this client session its `sid`; bridging is live. */
@@ -303,13 +314,6 @@ type RelayControlInbound =
   | { type: "killed"; reason: RelayKillReason }
   | { type: "error"; code: string; message: string };
 
-const KILL_REASONS: ReadonlySet<string> = new Set([
-  "reauth_timeout",
-  "revoked",
-  "host_gone",
-  "policy_violation",
-]);
-
 function parseRelayControl(raw: string): RelayControlInbound | null {
   let parsed: unknown;
   try {
@@ -338,10 +342,9 @@ function parseRelayControl(raw: string): RelayControlInbound | null {
   }
   if (
     (type === "peer_gone" || type === "killed") &&
-    typeof record.reason === "string" &&
-    KILL_REASONS.has(record.reason)
+    typeof record.reason === "string"
   ) {
-    const reason = record.reason as RelayKillReason;
+    const reason: RelayKillReason = record.reason;
     return type === "peer_gone"
       ? { type: "peer_gone", reason }
       : { type: "killed", reason };

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -152,11 +152,12 @@ function qosForStreamMethod(method: string): QosClassValue {
  * place. What is NOT shared is the verdict that leaves it:
  *
  *  - `host-transport-plane` - the relay socket closed, a Noise/handshake step
- *    was rejected, the peer went away, a phase deadline elapsed with the host
- *    silent. The host's own transport plane answered (or failed to), so this
- *    is `confirmed-refusal` evidence.
+ *    was rejected, a known host-leg peer loss arrived, or a phase deadline
+ *    elapsed with the host silent. The host's own transport plane answered (or
+ *    failed to), so this is `confirmed-refusal` evidence.
  *  - `not-host-evidence` - we tore the connection down ourselves (a caller's
- *    reconnect nudge) or could not present a credential (no bearer). The host
+ *    reconnect nudge), could not present a credential (no bearer), or the
+ *    relay killed only its client leg for a policy/future reason. The host
  *    refused nothing; it may be perfectly healthy. Reported `indeterminate`.
  *
  * This is the durable classification rule applied one layer down from where
@@ -193,6 +194,20 @@ function sessionFatalProvenance(
   return details.code === "UNAUTHORIZED"
     ? "not-host-evidence"
     : "host-transport-plane";
+}
+
+/**
+ * Relay `policy_violation` is commonly a client-leg congestion decision, not
+ * a statement from the host. Unknown relay kill reasons must fail the same
+ * way: new relays can emit them before this client learns their semantics.
+ * Only the two established host-leg losses are evidence about host liveness.
+ */
+function relayKillProvenance(
+  reason: RelayKillReason,
+): ConnectionLossProvenance {
+  return reason === "reauth_timeout" || reason === "host_gone"
+    ? "host-transport-plane"
+    : "not-host-evidence";
 }
 
 export interface RemoteSessionOptions<
@@ -1946,23 +1961,27 @@ export class RemoteSession<
     if (!this.isCurrent(generation)) {
       return;
     }
-    if (reason === "revoked" || reason === "policy_violation") {
+    if (reason === "revoked") {
       this.goTerminalFatal({
         code: "UNAUTHORIZED",
-        reason:
-          reason === "revoked"
-            ? "Host access was revoked"
-            : "Session closed by relay policy",
+        reason: "Host access was revoked",
         incompatibleMethods: null,
         upgradeGuidance: null,
       });
       return;
     }
-    this.handleConnectionLost(
-      generation,
-      `peer-gone:${reason}`,
-      "host-transport-plane",
-    );
+    const provenance = relayKillProvenance(reason);
+    if (provenance === "not-host-evidence") {
+      // A relay policy kill can be congestion (for example, the relay's
+      // client-leg buffer limit), not an authorization verdict. Future relay
+      // kill reasons are conservatively treated the same way: retry them, but
+      // never redial an unknown overloaded session at the ordinary 1s rung.
+      // The two known non-congestion losses retain their regular schedule.
+      // Keep this in the existing reconnect state machine; only its entry rung
+      // differs.
+      this.raiseReconnectBackoffToMax();
+    }
+    this.handleConnectionLost(generation, `peer-gone:${reason}`, provenance);
   }
 
   /**
@@ -2311,6 +2330,20 @@ export class RemoteSession<
       this.beginConnectGuarded();
     }, delay);
     return delay;
+  }
+
+  /**
+   * Starts a congestion-triggered reconnect at the capped backoff rung while
+   * preserving the ordinary scheduler and its ready-boundary reset.
+   */
+  private raiseReconnectBackoffToMax(): void {
+    const attemptAtMaxBackoff = Math.ceil(
+      Math.log2(RECONNECT_MAX_BACKOFF_MS / RECONNECT_INITIAL_BACKOFF_MS),
+    );
+    this.reconnectAttempt = Math.max(
+      this.reconnectAttempt,
+      attemptAtMaxBackoff,
+    );
   }
 
   /**


### PR DESCRIPTION
Cherry-pick of #1312 (`86cb43e9`, squash-merged to `main`) onto the v1.2.0 release train. Applied with `-x`; the resulting diff is **byte-identical** to the source commit — 4 files, 191 insertions, 29 deletions, no conflicts.

## Why this is a v1.2.0 blocker

Field report on v1.2.0-rc.1: a remote host loading a large epic had its relay session killed for congestion (`policy_violation`), and the client rendered that as a **terminal** `UNAUTHORIZED "Session closed by relay policy"` — a red dead-end whose Retry re-ran the identical doomed bootstrap. Congestion was being presented to the user as revocation. Two standing rulings govern this: a transport-class failure must never be user-facing fatal, and a large epic over a slow link is normal remote operation rather than a slow session.

## What it does

- `policy_violation` and every unknown/future relay kill reason now rejoin the ordinary reconnect funnel at the capped (30 s) rung instead of going terminal.
- Those same losses are classified `not-host-evidence`, so they report as an **indeterminate** dial rather than a confirmed refusal — relay congestion can no longer accumulate toward deriving a live host as dead.
- `revoked`, plan-entitlement, and protocol-floor verdicts stay terminal.
- Both `peer_gone` and `killed` legs funnel through the same policy.

## Base-specific verification

A clean cherry-pick is not automatically a correct one, so the dependency on this older base was checked rather than assumed. The named `inert-indeterminate` outcome that `main` uses does not exist on `release-v1.2.0` — but the guarantee does: `selection-authority-engine.ts:1364` early-returns on an `indeterminate` report ("`indeterminate` is inert by contract"), which `main` later refactored into that named outcome. The provenance plumbing this change relies on (`ConnectionLossProvenance`, `not-host-evidence`, `reportDialIndeterminate`, `raiseReconnectBackoffToMax`, `RECONNECT_MAX_BACKOFF_MS`) is all present on this branch. So the "congestion never counts as host-death evidence" property holds here exactly as it does on main.

Review history on the source PR: Codex raised the host-death-evidence path as P1 and the stale contract doc as P2 (both fixed); a suggestion to relocate `RelayKillReason` into `@traycer/protocol` was declined, since the relay control vocabulary is relay-owned and separately mirrored by the host, while `@traycer/protocol` versions the client⇄host contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)