### PR TITLE
fix(cli,desktop): patient slot-ownership probe, and the downgrade guard on the symlink arm

### DIFF
--- a/clients/desktop/src/electron-main/cli/__tests__/cli-discovery-path-scan.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/cli-discovery-path-scan.test.ts
@@ -137,8 +137,9 @@ describe.skipIf(process.platform === "win32")(
       process.env.PATH = [squatterDir, realDir].join(delimiter);
       stageBundledArchCli();
 
-      const { discoverCli } = await import("../cli-discovery");
-      const result = await discoverCli();
+      const { discoverCli, CLI_INVOCATION_PROBE_TIMEOUT_MS } =
+        await import("../cli-discovery");
+      const result = await discoverCli(CLI_INVOCATION_PROBE_TIMEOUT_MS);
       expect(result.kind).toBe("path");
       if (result.kind === "path") {
         expect(result.binaryPath).toBe(real);
@@ -154,8 +155,9 @@ describe.skipIf(process.platform === "win32")(
       process.env.PATH = squatterDir;
       const bundled = stageBundledArchCli();
 
-      const { discoverCli } = await import("../cli-discovery");
-      const result = await discoverCli();
+      const { discoverCli, CLI_INVOCATION_PROBE_TIMEOUT_MS } =
+        await import("../cli-discovery");
+      const result = await discoverCli(CLI_INVOCATION_PROBE_TIMEOUT_MS);
       expect(result.kind).toBe("bundled");
       if (result.kind === "bundled") {
         expect(result.binaryPath).toBe(bundled);
@@ -168,8 +170,9 @@ describe.skipIf(process.platform === "win32")(
       writePathCli(squatterDir, false);
       process.env.PATH = squatterDir;
 
-      const { discoverCli } = await import("../cli-discovery");
-      const result = await discoverCli();
+      const { discoverCli, CLI_INVOCATION_PROBE_TIMEOUT_MS } =
+        await import("../cli-discovery");
+      const result = await discoverCli(CLI_INVOCATION_PROBE_TIMEOUT_MS);
       expect(result.kind).toBe("none");
     });
 
@@ -183,8 +186,9 @@ describe.skipIf(process.platform === "win32")(
       process.env.PATH = [firstDir, secondDir].join(delimiter);
       stageBundledArchCli();
 
-      const { discoverCli } = await import("../cli-discovery");
-      const result = await discoverCli();
+      const { discoverCli, CLI_INVOCATION_PROBE_TIMEOUT_MS } =
+        await import("../cli-discovery");
+      const result = await discoverCli(CLI_INVOCATION_PROBE_TIMEOUT_MS);
       expect(result.kind).toBe("path");
       if (result.kind === "path") {
         expect(result.binaryPath).toBe(first);

--- a/clients/desktop/src/electron-main/cli/__tests__/cli-discovery-path-vet.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/cli-discovery-path-vet.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  CLI_INVOCATION_PROBE_TIMEOUT_MS,
+  CLI_RECONCILE_PROBE_TIMEOUT_MS,
   resetCliProbeCacheForTests,
   vetPathCliCandidate,
 } from "../cli-discovery";
@@ -42,7 +44,10 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
     const dir = await makeTempDir();
     const candidate = join(dir, "traycer");
     await writeScript(candidate, "printf '1.2.3\\n'");
-    const vetted = await vetPathCliCandidate(candidate);
+    const vetted = await vetPathCliCandidate(
+      candidate,
+      CLI_INVOCATION_PROBE_TIMEOUT_MS,
+    );
     expect(vetted).toEqual({ version: "1.2.3" });
   });
 
@@ -55,14 +60,18 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
       candidate,
       "printf '[desktop] logger initialised\\n[desktop] single-instance lock unavailable - quitting\\n'",
     );
-    expect(await vetPathCliCandidate(candidate)).toBeNull();
+    expect(
+      await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS),
+    ).toBeNull();
   });
 
   it("rejects a candidate that exits non-zero", async () => {
     const dir = await makeTempDir();
     const candidate = join(dir, "traycer");
     await writeScript(candidate, "exit 1");
-    expect(await vetPathCliCandidate(candidate)).toBeNull();
+    expect(
+      await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS),
+    ).toBeNull();
   });
 
   it("caches the probe verdict per binary path for the process lifetime", async () => {
@@ -75,12 +84,12 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
         return line.length > 0;
       }).length;
 
-    await vetPathCliCandidate(candidate);
-    await vetPathCliCandidate(candidate);
+    await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS);
+    await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS);
     expect(await execCount()).toBe(1);
 
     resetCliProbeCacheForTests();
-    await vetPathCliCandidate(candidate);
+    await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS);
     expect(await execCount()).toBe(2);
   });
 
@@ -90,8 +99,12 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
     const countFile = join(dir, "exec-count");
     await writeScript(candidate, `echo x >> '${countFile}'\nexit 1`);
 
-    expect(await vetPathCliCandidate(candidate)).toBeNull();
-    expect(await vetPathCliCandidate(candidate)).toBeNull();
+    expect(
+      await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS),
+    ).toBeNull();
+    expect(
+      await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS),
+    ).toBeNull();
     const count = (await readFile(countFile, "utf8"))
       .split("\n")
       .filter((line) => line.length > 0).length;
@@ -104,7 +117,10 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
     await mkdir(packageDir, { recursive: true });
     const candidate = join(packageDir, "traycer");
     await writeScript(candidate, "printf '1.2.3\\n'");
-    const vetted = await vetPathCliCandidate(candidate);
+    const vetted = await vetPathCliCandidate(
+      candidate,
+      CLI_INVOCATION_PROBE_TIMEOUT_MS,
+    );
     expect(vetted).toEqual({ version: "1.2.3", source: "npm" });
   });
 
@@ -126,7 +142,10 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
       `echo x >> '${countFile}'\nsleep 3\nprintf '1.2.3\\n'`,
     );
 
-    const first = await vetPathCliCandidate(candidate);
+    const first = await vetPathCliCandidate(
+      candidate,
+      CLI_INVOCATION_PROBE_TIMEOUT_MS,
+    );
     expect(first).toBeNull();
 
     // A cached `timeout` verdict would answer this SECOND call from the
@@ -134,7 +153,10 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
     // just the (identical, null) verdict - is what actually pins the
     // non-caching: a same-verdict-twice check alone cannot distinguish
     // "re-probed and timed out again" from "returned the cached one".
-    const second = await vetPathCliCandidate(candidate);
+    const second = await vetPathCliCandidate(
+      candidate,
+      CLI_INVOCATION_PROBE_TIMEOUT_MS,
+    );
     expect(second).toBeNull();
     const count = (await readFile(countFile, "utf8"))
       .split("\n")
@@ -148,4 +170,57 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
   // verdict) and asserts exactly one exec across two `vetPathCliCandidate`
   // calls, which is this same property under a different name. Not
   // duplicated here.
+
+  // The deadline belongs to the CALLER. Not caching a timeout was only half
+  // the fix: the launch reconcile's fall-through installs the bundled CLI
+  // and writes a Desktop-owned manifest, and a manifest outranks PATH in
+  // every later discovery - so for the one prober that can hand ownership
+  // away there is no "next time" to retry into. The same fixture that the
+  // impatient deadline condemns must vet CLEAN at the reconcile's.
+  it("the patient deadline vets a slow-but-real CLI the impatient one drops", async () => {
+    const dir = await makeTempDir();
+    const candidate = join(dir, "traycer");
+    await writeScript(candidate, "sleep 3\nprintf '1.2.3\\n'");
+
+    // Positive control: the same binary, the same code path, 2s deadline.
+    // Without it a green below could equally mean "the fixture is fast now".
+    expect(
+      await vetPathCliCandidate(candidate, CLI_INVOCATION_PROBE_TIMEOUT_MS),
+    ).toBeNull();
+
+    expect(
+      await vetPathCliCandidate(candidate, CLI_RECONCILE_PROBE_TIMEOUT_MS),
+    ).toEqual({ version: "1.2.3" });
+  }, 20_000);
+
+  // Patience must not leak onto the impatient path. The cache shares the
+  // in-flight PROMISE, so a status poll landing mid-reconcile would inherit
+  // the reconcile's 15s deadline and stall the invocation path for the
+  // whole of it unless it races its own. Started patient, joined impatient:
+  // the joiner must give up on its own schedule, well before the fixture
+  // answers.
+  it("an impatient joiner does not inherit an in-flight patient deadline", async () => {
+    const dir = await makeTempDir();
+    const candidate = join(dir, "traycer");
+    // Six seconds, not three: the margin between "raced at its own 2s" and
+    // "waited for the patient probe" has to survive a loaded CI runner
+    // without the assertion below going flaky in either direction.
+    await writeScript(candidate, "sleep 6\nprintf '1.2.3\\n'");
+
+    const patient = vetPathCliCandidate(
+      candidate,
+      CLI_RECONCILE_PROBE_TIMEOUT_MS,
+    );
+    const startedAt = Date.now();
+    const joined = await vetPathCliCandidate(
+      candidate,
+      CLI_INVOCATION_PROBE_TIMEOUT_MS,
+    );
+    const waitedMs = Date.now() - startedAt;
+
+    expect(joined).toBeNull();
+    expect(waitedMs).toBeLessThan(4_000);
+    // ...and the patient probe it joined still lands its real verdict.
+    expect(await patient).toEqual({ version: "1.2.3" });
+  }, 20_000);
 });

--- a/clients/desktop/src/electron-main/cli/__tests__/cli-discovery-path-vet.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/cli-discovery-path-vet.test.ts
@@ -193,6 +193,43 @@ describe.skipIf(process.platform === "win32")("vetPathCliCandidate", () => {
     ).toEqual({ version: "1.2.3" });
   }, 20_000);
 
+  // The same join, the other way round, and the direction that actually
+  // costs something. A status poll's 2s probe can be in flight when the
+  // detached reconcile arrives - on the very machine this matters for
+  // there is no manifest, so both paths walk PATH - and joining it would
+  // hand the reconcile a verdict about someone else's patience. Its
+  // verdicts are not recoverable: a dropped PATH candidate becomes a
+  // Desktop-owned manifest that outranks PATH from then on. It must get a
+  // probe that can actually run for 15s.
+  it("a patient caller does not inherit a shorter in-flight deadline", async () => {
+    const dir = await makeTempDir();
+    const candidate = join(dir, "traycer");
+    const countFile = join(dir, "exec-count");
+    await writeScript(
+      candidate,
+      `echo x >> '${countFile}'\nsleep 3\nprintf '1.2.3\\n'`,
+    );
+
+    const impatient = vetPathCliCandidate(
+      candidate,
+      CLI_INVOCATION_PROBE_TIMEOUT_MS,
+    );
+    const patient = await vetPathCliCandidate(
+      candidate,
+      CLI_RECONCILE_PROBE_TIMEOUT_MS,
+    );
+
+    // Inheriting the 2s probe would make this null - the fixture needs 3s.
+    expect(patient).toEqual({ version: "1.2.3" });
+    // The impatient caller still gets its own (correct, impatient) answer.
+    expect(await impatient).toBeNull();
+    // Two spawns, necessarily: the deadlines cannot share one process.
+    const count = (await readFile(countFile, "utf8"))
+      .split("\n")
+      .filter((line) => line.length > 0).length;
+    expect(count).toBe(2);
+  }, 20_000);
+
   // Patience must not leak onto the impatient path. The cache shares the
   // in-flight PROMISE, so a status poll landing mid-reconcile would inherit
   // the reconcile's 15s deadline and stall the invocation path for the

--- a/clients/desktop/src/electron-main/cli/cli-discovery.ts
+++ b/clients/desktop/src/electron-main/cli/cli-discovery.ts
@@ -527,21 +527,51 @@ async function inferNpmPathSource(
 // REAL slow CLI can produce: a packaged `traycer --version` runs its slot
 // refresh before commander parses, and on a first launch with a stale slot
 // that is a ~100 MB copy - killing it at 2s and calling the binary
-// not-a-CLI would stage the bundled CLI over a working package-manager
-// install and pin that misclassification for the whole desktop session.
+// not-a-CLI stages the bundled CLI over a working package-manager install,
+// which writes a Desktop-owned manifest that outranks PATH in every later
+// discovery. That consequence is permanent, not per-session, which is why
+// the caller's deadline (below) matters more than the verdict's cache.
 type CliVersionProbe =
   | { readonly kind: "version"; readonly version: string }
   | { readonly kind: "not-a-cli" }
   | { readonly kind: "timeout" };
 
+/**
+ * How long a `--version` probe waits, chosen by what the CALLER can afford
+ * rather than by what the binary deserves.
+ *
+ * Impatient (`CLI_INVOCATION_PROBE_TIMEOUT_MS`): discovery on the invocation path runs
+ * on every status poll, and an uncached `timeout` verdict costs the full
+ * deadline every time. Two seconds is what that path can spend.
+ *
+ * Patient (`CLI_RECONCILE_PROBE_TIMEOUT_MS`): the launch reconcile runs
+ * once, detached (`void timed("deferred", "cli-reconcile", ...)`), and is
+ * the only prober whose verdict can hand slot OWNERSHIP to Desktop - a
+ * timed-out vet drops the PATH candidate, discovery falls through to the
+ * bundled CLI, and installing that writes a Desktop-owned manifest which
+ * wins every later discovery. Nothing re-probes PATH after that, so
+ * dropping the timeout from the cache buys the retry no chance to happen;
+ * the misclassification is permanent, not per-session. The one binary shape
+ * that legitimately blows a 2s deadline is a REAL packaged CLI refreshing
+ * its ~100 MB slot before commander parses - and it needs to be given the
+ * time to finish exactly once, because each killed probe abandons the copy
+ * and the next one starts over. Fifteen seconds covers that copy on a slow
+ * volume; past it the candidate is treated as unusable and the bundled CLI
+ * is staged, because refusing to stage on an unanswerable probe is how the
+ * oss #872 squatter bricked first launch.
+ */
+export const CLI_INVOCATION_PROBE_TIMEOUT_MS = 2_000;
+export const CLI_RECONCILE_PROBE_TIMEOUT_MS = 15_000;
+
 export async function probeCliVersion(
   binaryPath: string,
+  timeoutMs: number,
 ): Promise<CliVersionProbe> {
   return new Promise((resolve) => {
     execFile(
       binaryPath,
       ["--version"],
-      { timeout: 2_000, windowsHide: true },
+      { timeout: timeoutMs, windowsHide: true },
       (error, stdout) => {
         if (error) {
           resolve(error.killed ? { kind: "timeout" } : { kind: "not-a-cli" });
@@ -572,17 +602,63 @@ export async function probeCliVersion(
 // patience, not the binary, and the very refresh that made the first probe
 // slow repairs the slot so the next one is fast. Pinning it would hold the
 // misclassification for the whole session.
-const pathProbeCache = new Map<string, Promise<CliVersionProbe>>();
+//
+// The two verdicts that ARE cached (`version`, `not-a-cli`) are facts about
+// the binary, so they are shared across deadlines: an impatient caller may
+// answer from a patient probe's result and vice versa. Only the deadline an
+// in-flight probe was STARTED with is deadline-specific, which is what the
+// entry records - see `cachedProbeCliVersion`.
+interface PathProbeEntry {
+  readonly deadlineMs: number;
+  readonly probe: Promise<CliVersionProbe>;
+}
 
-function cachedProbeCliVersion(binaryPath: string): Promise<CliVersionProbe> {
+const pathProbeCache = new Map<string, PathProbeEntry>();
+
+function cachedProbeCliVersion(
+  binaryPath: string,
+  timeoutMs: number,
+): Promise<CliVersionProbe> {
   const cached = pathProbeCache.get(binaryPath);
-  if (cached !== undefined) return cached;
-  const probe = probeCliVersion(binaryPath);
-  pathProbeCache.set(binaryPath, probe);
+  if (cached !== undefined) {
+    // Joining an in-flight probe must never lengthen the joiner's own wait.
+    // The reconcile's probe runs for up to 15s; a status poll's discovery
+    // landing in that window would otherwise inherit that deadline and
+    // stall the invocation path for the whole of it. It waits its own 2s
+    // and reports its own timeout instead - the patient probe keeps running
+    // and still publishes its verdict for whoever asks next.
+    if (cached.deadlineMs <= timeoutMs) return cached.probe;
+    return raceProbeDeadline(cached.probe, timeoutMs);
+  }
+  const probe = probeCliVersion(binaryPath, timeoutMs);
+  pathProbeCache.set(binaryPath, { deadlineMs: timeoutMs, probe });
   void probe.then((verdict) => {
-    if (verdict.kind === "timeout") pathProbeCache.delete(binaryPath);
+    if (verdict.kind === "timeout") {
+      pathProbeCache.delete(binaryPath);
+      return;
+    }
+    // Settled on a fact about the BINARY, so the deadline it was reached
+    // under stops mattering: recording it as zero lets every later caller
+    // answer from it directly instead of pointlessly racing a promise that
+    // is already resolved.
+    pathProbeCache.set(binaryPath, { deadlineMs: 0, probe });
   });
   return probe;
+}
+
+async function raceProbeDeadline(
+  probe: Promise<CliVersionProbe>,
+  timeoutMs: number,
+): Promise<CliVersionProbe> {
+  let timer: NodeJS.Timeout | null = null;
+  const ownDeadline = new Promise<CliVersionProbe>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+  });
+  try {
+    return await Promise.race([probe, ownDeadline]);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
 }
 
 export function resetCliProbeCacheForTests(): void {
@@ -601,8 +677,9 @@ export function resetCliProbeCacheForTests(): void {
  */
 export async function vetPathCliCandidate(
   binaryPath: string,
+  probeTimeoutMs: number,
 ): Promise<{ readonly version: string; readonly source?: "npm" } | null> {
-  const probed = await cachedProbeCliVersion(binaryPath);
+  const probed = await cachedProbeCliVersion(binaryPath, probeTimeoutMs);
   if (probed.kind !== "version") {
     // Both non-answers ignore the candidate for THIS discovery - adopting
     // an unvetted binary is the oss #872 failure either way - but only
@@ -688,8 +765,15 @@ function devCliWrapperPath(): string {
  * that cannot answer falls through to the bundled CLI instead of being
  * adopted (oss #872). Version-trust policy beyond that ("PATH CLI newer
  * than bundled, trust it") stays with the caller (cli-reconcile).
+ *
+ * `probeTimeoutMs` is that vet's deadline, and it is the caller's to choose
+ * rather than this function's: falling through to the bundled CLI costs a
+ * status poll nothing and costs the launch reconcile the slot's ownership.
+ * See `CLI_INVOCATION_PROBE_TIMEOUT_MS` / `CLI_RECONCILE_PROBE_TIMEOUT_MS`.
  */
-export async function discoverCli(): Promise<CliDiscoveryResult> {
+export async function discoverCli(
+  probeTimeoutMs: number,
+): Promise<CliDiscoveryResult> {
   const manifest = await readCliManifest();
   if (manifest !== null && (await isExecutable(manifest.binaryPath))) {
     return {
@@ -718,7 +802,7 @@ export async function discoverCli(): Promise<CliDiscoveryResult> {
     // squatter earlier in PATH hide a real CLI behind it (and report
     // "no CLI anywhere" when the app ships no bundled binary).
     for (const candidate of await findCliCandidatesOnPath()) {
-      const vetted = await vetPathCliCandidate(candidate);
+      const vetted = await vetPathCliCandidate(candidate, probeTimeoutMs);
       if (vetted !== null) {
         return { kind: "path", binaryPath: candidate, ...vetted };
       }

--- a/clients/desktop/src/electron-main/cli/cli-discovery.ts
+++ b/clients/desktop/src/electron-main/cli/cli-discovery.ts
@@ -604,44 +604,69 @@ export async function probeCliVersion(
 // misclassification for the whole session.
 //
 // The two verdicts that ARE cached (`version`, `not-a-cli`) are facts about
-// the binary, so they are shared across deadlines: an impatient caller may
-// answer from a patient probe's result and vice versa. Only the deadline an
-// in-flight probe was STARTED with is deadline-specific, which is what the
-// entry records - see `cachedProbeCliVersion`.
-interface PathProbeEntry {
-  readonly deadlineMs: number;
-  readonly probe: Promise<CliVersionProbe>;
-}
+// the binary, so once settled they answer every caller whatever its
+// patience. A probe still RUNNING is not that: it carries the deadline it
+// was started with, and that deadline is only good enough for a caller
+// willing to wait no longer. The entry therefore says which of the two it
+// is rather than leaving the distinction to a sentinel value.
+type PathProbeEntry =
+  | { readonly kind: "settled"; readonly probe: Promise<CliVersionProbe> }
+  | {
+      readonly kind: "in-flight";
+      readonly deadlineMs: number;
+      readonly probe: Promise<CliVersionProbe>;
+    };
 
 const pathProbeCache = new Map<string, PathProbeEntry>();
 
+// Every (entry state x caller deadline) pair, stated once so none of them
+// is decided by accident:
+//
+//   settled                  -> answer from it, whatever the deadline.
+//   in-flight, D === T       -> join it.
+//   in-flight, D  >  T       -> join, but stop waiting at T. Otherwise a
+//                               status poll landing inside the reconcile's
+//                               15s probe would stall the invocation path
+//                               for all of it.
+//   in-flight, D  <  T       -> do NOT join: that probe gets killed at D
+//                               and hands back a `timeout` describing
+//                               someone else's patience. For the reconcile
+//                               that verdict is not recoverable - it drops
+//                               the PATH candidate and installs a
+//                               Desktop-owned manifest that outranks PATH
+//                               from then on. Start a probe that can
+//                               actually run for T and let it supersede.
 function cachedProbeCliVersion(
   binaryPath: string,
   timeoutMs: number,
 ): Promise<CliVersionProbe> {
   const cached = pathProbeCache.get(binaryPath);
   if (cached !== undefined) {
-    // Joining an in-flight probe must never lengthen the joiner's own wait.
-    // The reconcile's probe runs for up to 15s; a status poll's discovery
-    // landing in that window would otherwise inherit that deadline and
-    // stall the invocation path for the whole of it. It waits its own 2s
-    // and reports its own timeout instead - the patient probe keeps running
-    // and still publishes its verdict for whoever asks next.
-    if (cached.deadlineMs <= timeoutMs) return cached.probe;
-    return raceProbeDeadline(cached.probe, timeoutMs);
+    if (cached.kind === "settled") return cached.probe;
+    if (cached.deadlineMs === timeoutMs) return cached.probe;
+    if (cached.deadlineMs > timeoutMs) {
+      return raceProbeDeadline(cached.probe, timeoutMs);
+    }
   }
   const probe = probeCliVersion(binaryPath, timeoutMs);
-  pathProbeCache.set(binaryPath, { deadlineMs: timeoutMs, probe });
+  const entry: PathProbeEntry = {
+    kind: "in-flight",
+    deadlineMs: timeoutMs,
+    probe,
+  };
+  pathProbeCache.set(binaryPath, entry);
   void probe.then((verdict) => {
+    // Only ever replaces its OWN entry. A more patient probe may have
+    // superseded this one while it ran, and neither of this probe's
+    // outcomes may disturb that: a `timeout` deleting the entry would
+    // discard a probe that is still running, and a verdict overwriting it
+    // would put the shorter deadline's answer back in front of it.
+    if (pathProbeCache.get(binaryPath) !== entry) return;
     if (verdict.kind === "timeout") {
       pathProbeCache.delete(binaryPath);
       return;
     }
-    // Settled on a fact about the BINARY, so the deadline it was reached
-    // under stops mattering: recording it as zero lets every later caller
-    // answer from it directly instead of pointlessly racing a promise that
-    // is already resolved.
-    pathProbeCache.set(binaryPath, { deadlineMs: 0, probe });
+    pathProbeCache.set(binaryPath, { kind: "settled", probe });
   });
   return probe;
 }

--- a/clients/desktop/src/electron-main/cli/cli-reconcile.ts
+++ b/clients/desktop/src/electron-main/cli/cli-reconcile.ts
@@ -321,10 +321,18 @@ export async function reconcileCli(
       // inside fifteen seconds is not serving the host either. Patience is
       // where this is fought; refusal is not.
       //
-      // Stage it into the Desktop-owned slot (a symlink on
-      // POSIX) so the bundle-blind host has a deterministic, space-free
-      // `~/.traycer/cli[/<slot>]/bin/traycer` to put on PATH for the monitor /
-      // title hooks / terminal agents. Nothing else self-heals this slot.
+      // Stage it into the Desktop-owned slot - a COPY on every platform, see
+      // `installBundledCli` - so the bundle-blind host has a deterministic,
+      // space-free `~/.traycer/cli[/<slot>]/bin/traycer` to put on PATH for
+      // the monitor / title hooks / terminal agents. Nothing else self-heals
+      // this slot.
+      //
+      // Said "a symlink on POSIX" until now, which is what it was before the
+      // pre-copy era ended and is no longer true of any platform. Left
+      // uncorrected it reads as a live design note rather than history, and
+      // it has already been cited that way in review - the link is exactly
+      // what was removed, because a bundle remove/replace left it DANGLING
+      // with no healer but the next successful app launch.
       const installed = await deps.installBundledCli({
         bundledCliPath: bundledPath,
         version: bundledVersion,

--- a/clients/desktop/src/electron-main/cli/cli-reconcile.ts
+++ b/clients/desktop/src/electron-main/cli/cli-reconcile.ts
@@ -1,5 +1,6 @@
 import { access } from "node:fs/promises";
 import {
+  CLI_RECONCILE_PROBE_TIMEOUT_MS,
   cliBinariesDiffer,
   compareSemver,
   discoverCli,
@@ -189,14 +190,23 @@ export function defaultReconcileCliDeps(): ReconcileCliDeps {
     readCliManifest,
     resolveBundledCliPath,
     readBundledCliVersion,
-    discoverCli,
+    // The PATIENT deadline on both probing deps, and the reason is the same
+    // for each: this pass is detached, runs once per launch, and is the
+    // only prober whose verdict decides who OWNS the slot. A real CLI busy
+    // copying ~100 MB into the well-known slot is precisely the binary this
+    // pass must not misread, and each killed probe abandons that copy for
+    // the next one to start over. See `CLI_RECONCILE_PROBE_TIMEOUT_MS`.
+    discoverCli: () => discoverCli(CLI_RECONCILE_PROBE_TIMEOUT_MS),
     // The reconcile's contract is version-or-null; the probe's third state
     // (timeout) collapses to null here on purpose. Both reconcile call
     // sites treat null as "could not determine", never as "not a CLI" -
     // the adopt/condemn distinction that made the timeout worth a state of
     // its own lives in `vetPathCliCandidate`.
     probeCliVersion: async (binaryPath: string): Promise<string | null> => {
-      const probed = await probeCliVersion(binaryPath);
+      const probed = await probeCliVersion(
+        binaryPath,
+        CLI_RECONCILE_PROBE_TIMEOUT_MS,
+      );
       return probed.kind === "version" ? probed.version : null;
     },
     installBundledCli,
@@ -299,7 +309,19 @@ export async function reconcileCli(
     ) {
       // Fresh install: no manifest, and either no `traycer` on PATH or only
       // a probe-failed imposter under that name, but the app ships a bundled
-      // CLI. Stage it into the Desktop-owned slot (a symlink on
+      // CLI.
+      //
+      // "Probe-failed" here includes a candidate that answered nothing at
+      // all within `CLI_RECONCILE_PROBE_TIMEOUT_MS`, and that arm is a
+      // deliberate policy call rather than an oversight: staging writes a
+      // Desktop-owned manifest that outranks PATH from then on, so it is
+      // the expensive direction - but deferring instead would re-open oss
+      // #872, where a `traycer` that never answers left the slot unstaged
+      // and first launch bricked. A binary that cannot say what it is
+      // inside fifteen seconds is not serving the host either. Patience is
+      // where this is fought; refusal is not.
+      //
+      // Stage it into the Desktop-owned slot (a symlink on
       // POSIX) so the bundle-blind host has a deterministic, space-free
       // `~/.traycer/cli[/<slot>]/bin/traycer` to put on PATH for the monitor /
       // title hooks / terminal agents. Nothing else self-heals this slot.

--- a/clients/desktop/src/electron-main/cli/traycer-cli.ts
+++ b/clients/desktop/src/electron-main/cli/traycer-cli.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn } from "node:child_process";
 import { log } from "../app/logger";
 import {
+  CLI_INVOCATION_PROBE_TIMEOUT_MS,
   cliBinaryName,
   discoverCli,
   resolveBundledCliPath,
@@ -130,7 +131,10 @@ export interface TraycerCliInvocation {
 }
 
 export async function resolveTraycerCliInvocation(): Promise<TraycerCliInvocation> {
-  const discovered = await discoverCli();
+  // The impatient deadline: this runs on every CLI invocation, status polls
+  // included, and nothing it decides can change who owns the slot - an
+  // unvetted candidate here only means this call uses the bundled binary.
+  const discovered = await discoverCli(CLI_INVOCATION_PROBE_TIMEOUT_MS);
   if (discovered.kind !== "none") {
     return { command: discovered.binaryPath, args: [] };
   }

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -2039,6 +2039,76 @@ it("packaged, no manifest, slot version probe fails: stages (seniority unprovabl
   expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
 });
 
+// Answering `--version` proves a program RUNS, not that it may hold the
+// slot. `isInterpreterDistribution` already refuses to nominate an npm
+// install for exactly one reason - the slot is spawned by the host daemon
+// and the registered service, where `#!/usr/bin/env node` resolves `node`
+// off the service manager's PATH - but that rule reads the MANIFEST, and
+// this guard only ever runs unanchored, where there is none.
+//
+// So the seniority contest must ask the file. An npm CLI answers a version
+// perfectly well, and this is the direction that matters: without the
+// check the slot keeps a Node script that reports itself newer on every
+// later probe, so the guard protects it forever while the service cannot
+// start. Staging over it is the recovery path.
+it("packaged, no manifest, a slot that is an INTERPRETER SCRIPT loses however new it claims to be", async () => {
+  seaState.current = true;
+  const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+    await import("../well-known-cli");
+  const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+  mkdirSync(dirname(wellKnownPath), { recursive: true });
+  const scriptBytes = '#!/usr/bin/env node\nconsole.log("1.9.9");\n';
+  writeFileSync(wellKnownPath, scriptBytes);
+  const running = join(workHome, "running-binary");
+  const runningBytes = "binary A - the running packaged CLI";
+  writeFileSync(running, runningBytes);
+  // Mapped, so the probe would answer STRICTLY NEWER and the guard would
+  // preserve it - this test is about eligibility, not about a failed spawn.
+  slotProbeControl.versionForPath.set(wellKnownPath, "9.9.9\n");
+
+  const result = await withExecPath(running, () =>
+    refreshWellKnownSlotIfStale(ENVIRONMENT),
+  );
+
+  expect(result?.staged).toBe("staged");
+  expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+  expect(readFileSync(wellKnownPath, "utf8")).not.toBe(scriptBytes);
+});
+
+// The same rule on the other call site, which is how it is actually
+// reachable in the field: an old Desktop left a symlink, and it points at an
+// npm install that is genuinely NEWER. Copying those bytes is what puts a
+// Node script behind `bin/traycer`.
+it.skipIf(process.platform === "win32")(
+  "packaged, no manifest, legacy SYMLINK to a newer INTERPRETER SCRIPT: stages the running binary",
+  async () => {
+    seaState.current = true;
+    const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+      await import("../well-known-cli");
+    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+    mkdirSync(dirname(wellKnownPath), { recursive: true });
+    const linkTarget = join(workHome, "npm-installed-cli");
+    const scriptBytes = '#!/usr/bin/env node\nconsole.log("9.9.9");\n';
+    writeFileSync(linkTarget, scriptBytes);
+    symlinkSync(linkTarget, wellKnownPath);
+    const running = join(workHome, "running-binary");
+    const runningBytes = "binary A - the running packaged SEA";
+    writeFileSync(running, runningBytes);
+    const resolvedTarget = realpathSync(linkTarget);
+    slotProbeControl.versionForPath.set(resolvedTarget, "9.9.9\n");
+
+    const result = await withExecPath(running, () =>
+      refreshWellKnownSlotIfStale(ENVIRONMENT),
+    );
+
+    expect(result?.staged).toBe("staged");
+    // A real file holding the SEA - not the script, and not a surviving link.
+    expect(lstatSync(wellKnownPath).isSymbolicLink()).toBe(false);
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+    expect(readFileSync(wellKnownPath, "utf8")).not.toBe(scriptBytes);
+  },
+);
+
 // An ANCHORED nomination - the manifest names a different existing binary
 // - is trusted outright: the guard only ever applies to the two
 // self-nominated (unanchored) cases, so a manifest-driven stage must
@@ -2175,14 +2245,18 @@ it.skipIf(process.platform === "win32")(
 );
 
 // The third cell, and the one that decides whether `realpath` succeeding is
-// enough on its own: a link resolving to something that is NOT a CLI - a
-// shim, another tool, anything an old installer left behind. Copying those
-// bytes in would hand the registered service and the host a program that
-// never runs this refresh, so nothing would ever repair the slot; only a
-// separate, by-hand invocation of a real CLI could. The running packaged
-// CLI demonstrably can answer, so it wins. Driven by the mock's default
-// spawn failure for an unmapped path - what pointing `execFile` at a
+// enough on its own: a link resolving to something that is NOT a CLI -
+// another tool, anything an old installer left behind. Copying those bytes
+// in would hand the registered service and the host a program that never
+// runs this refresh, so nothing would ever repair the slot; only a separate,
+// by-hand invocation of a real CLI could. The running packaged CLI
+// demonstrably can answer, so it wins. Driven by the mock's default spawn
+// failure for an unmapped path - what pointing `execFile` at a
 // non-executable actually does.
+//
+// Deliberately NOT a shebang script, which is the neighbouring cell: that
+// one is refused for being ineligible for the slot before anything spawns,
+// and a fixture carrying both properties could not tell the two apart.
 it.skipIf(process.platform === "win32")(
   "packaged, no manifest, legacy SYMLINK to something that cannot answer: stages the running binary",
   async () => {
@@ -2192,7 +2266,7 @@ it.skipIf(process.platform === "win32")(
     const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
     mkdirSync(dirname(wellKnownPath), { recursive: true });
     const linkTarget = join(workHome, "not-a-traycer-cli-at-all");
-    const targetBytes = '#!/bin/sh\nexec some-other-tool "$@"\n';
+    const targetBytes = "binary C - some other tool an installer left behind";
     writeFileSync(linkTarget, targetBytes);
     symlinkSync(linkTarget, wellKnownPath);
     const running = join(workHome, "running-binary");

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -2037,19 +2038,22 @@ it("packaged, a MANIFEST-anchored stage ignores the slot's claimed version", asy
 // the running binary over a link that points at a NEWER CLI demotes the
 // registered service.
 //
-// It cannot settle that by asking the slot its version, and that is the
-// point of the two tests below. A probe SPAWNS the slot, every packaged CLI
-// refreshes before it parses `--version`, and through a symlink the child's
-// `process.execPath` resolves to the TARGET - so the child misses the
+// It asks that of the link's TARGET, never of the slot, and the three
+// tests below are the whole truth table: target newer, target older, target
+// unable to answer. Which path is probed is itself load-bearing - a probe
+// SPAWNS what it is given, every packaged CLI refreshes before it parses
+// `--version`, and spawned THROUGH the symlink the child's
+// `process.execPath` resolves to the target, missing the
 // `resolve(wellKnownPath) === source` short-circuit that protects the
-// regular-file case, re-enters this planner, and spawns a probe of its own.
-// Staging from the link's own TARGET reaches the same conclusion without
-// asking: same bytes, no link left to dangle, nothing spawned.
+// regular-file case, so it re-enters this planner and spawns again. Every
+// case therefore asserts on what was spawned as well as on the bytes: a
+// recursive planner reaches the same staging decision, so the bytes alone
+// cannot see it.
 //
 // Windows symlink creation needs Developer Mode, which CI runners do not
 // grant - `symlinkSync` throws before the behavior under test runs.
 it.skipIf(process.platform === "win32")(
-  "packaged, no manifest, legacy SYMLINK: de-symlinks from the link's target without spawning a probe",
+  "packaged, no manifest, legacy SYMLINK to a NEWER binary: de-symlinks from the link's target",
   async () => {
     seaState.current = true;
     const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
@@ -2063,6 +2067,11 @@ it.skipIf(process.platform === "win32")(
     const running = join(workHome, "running-binary");
     const runningBytes = "binary A - an older stray SEA run once";
     writeFileSync(running, runningBytes);
+    // `realpath`, because that is what the planner resolves the link to:
+    // on macOS the temp dir's /var canonicalises to /private/var, and a
+    // mapping under the other spelling would silently never be found.
+    const resolvedTarget = realpathSync(linkTarget);
+    slotProbeControl.versionForPath.set(resolvedTarget, "9.9.9\n");
 
     const result = await withExecPath(running, () =>
       refreshWellKnownSlotIfStale(ENVIRONMENT),
@@ -2077,23 +2086,22 @@ it.skipIf(process.platform === "win32")(
     // untouched symlink.
     expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
     expect(readFileSync(wellKnownPath, "utf8")).not.toBe(runningBytes);
-    // The recursion pin, and the reason this suite counts spawns at all.
-    // A probe of the slot here is a probe THROUGH the link, and the bytes
-    // above cannot tell that apart: the recursive planner reaches the same
-    // staging decision, just after spawning a ~100 MB process per level.
-    expect(slotProbeControl.spawnedPaths).toEqual([]);
+    // The recursion pin: every spawn was the TARGET, never the slot.
+    // Asserted as a set - the planner evaluates once unlocked and once
+    // under the lock, and that count is not what this is about.
+    expect(new Set(slotProbeControl.spawnedPaths)).toEqual(
+      new Set([resolvedTarget]),
+    );
+    expect(slotProbeControl.spawnedPaths).not.toContain(wellKnownPath);
   },
 );
 
-// ...and the version question is not dropped, only deferred to the arm that
-// can ask it safely. Two invocations: the first de-symlinks to the target's
-// bytes, the second finds a REGULAR-FILE slot (whose probe cannot recurse,
-// since a child launched from it self-nominates it and short-circuits),
-// probes it, and refreshes a genuinely older slot from the running binary.
-// "0.0.0-alpha.1" vs the vitest-resolved "0.0.0-local": SemVer compares
-// pre-release identifiers alphabetically, 'a' < 'l', so the slot is older.
+// A target that reports itself OLDER has no seniority to assert, so the
+// ordinary stage from the running binary de-symlinks and refreshes in one
+// step. "0.0.0-alpha.1" vs the vitest-resolved "0.0.0-local": SemVer
+// compares pre-release identifiers alphabetically, 'a' < 'l'.
 it.skipIf(process.platform === "win32")(
-  "packaged, no manifest, legacy SYMLINK to an OLDER binary: de-symlinks first, then the next run refreshes it",
+  "packaged, no manifest, legacy SYMLINK to an OLDER binary: stages the running binary over the link",
   async () => {
     seaState.current = true;
     const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
@@ -2101,31 +2109,67 @@ it.skipIf(process.platform === "win32")(
     const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
     mkdirSync(dirname(wellKnownPath), { recursive: true });
     const linkTarget = join(workHome, "older-cli-the-link-points-at");
-    const targetBytes = "binary B - an older CLI";
-    writeFileSync(linkTarget, targetBytes);
+    writeFileSync(linkTarget, "binary B - an older CLI");
     symlinkSync(linkTarget, wellKnownPath);
     const running = join(workHome, "running-binary");
     const runningBytes = "binary A - the running, newer CLI";
     writeFileSync(running, runningBytes);
-    slotProbeControl.versionForPath.set(wellKnownPath, "0.0.0-alpha.1\n");
+    const resolvedTarget = realpathSync(linkTarget);
+    slotProbeControl.versionForPath.set(resolvedTarget, "0.0.0-alpha.1\n");
 
-    const first = await withExecPath(running, () =>
+    const result = await withExecPath(running, () =>
       refreshWellKnownSlotIfStale(ENVIRONMENT),
     );
 
-    expect(first?.staged).toBe("staged");
+    expect(result?.staged).toBe("staged");
     expect(lstatSync(wellKnownPath).isSymbolicLink()).toBe(false);
-    expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
-    expect(slotProbeControl.spawnedPaths).toEqual([]);
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+    expect(new Set(slotProbeControl.spawnedPaths)).toEqual(
+      new Set([resolvedTarget]),
+    );
+    expect(slotProbeControl.spawnedPaths).not.toContain(wellKnownPath);
+  },
+);
 
-    const second = await withExecPath(running, () =>
+// The third cell, and the one that decides whether `realpath` succeeding is
+// enough on its own: a link resolving to something that is NOT a CLI - a
+// shim, another tool, anything an old installer left behind. Copying those
+// bytes in would hand the registered service and the host a program that
+// never runs this refresh, so nothing would ever repair the slot; only a
+// separate, by-hand invocation of a real CLI could. The running packaged
+// CLI demonstrably can answer, so it wins. Driven by the mock's default
+// spawn failure for an unmapped path - what pointing `execFile` at a
+// non-executable actually does.
+it.skipIf(process.platform === "win32")(
+  "packaged, no manifest, legacy SYMLINK to something that cannot answer: stages the running binary",
+  async () => {
+    seaState.current = true;
+    const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+      await import("../well-known-cli");
+    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+    mkdirSync(dirname(wellKnownPath), { recursive: true });
+    const linkTarget = join(workHome, "not-a-traycer-cli-at-all");
+    const targetBytes = '#!/bin/sh\nexec some-other-tool "$@"\n';
+    writeFileSync(linkTarget, targetBytes);
+    symlinkSync(linkTarget, wellKnownPath);
+    const running = join(workHome, "running-binary");
+    const runningBytes = "binary A - the running packaged CLI";
+    writeFileSync(running, runningBytes);
+    // No `versionForPath` entry for the target: it cannot say what it is.
+    const resolvedTarget = realpathSync(linkTarget);
+
+    const result = await withExecPath(running, () =>
       refreshWellKnownSlotIfStale(ENVIRONMENT),
     );
 
-    expect(second?.staged).toBe("staged");
+    expect(result?.staged).toBe("staged");
+    expect(lstatSync(wellKnownPath).isSymbolicLink()).toBe(false);
     expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
-    // The slot is a real file by now, so this probe is the safe kind.
-    expect(slotProbeControl.spawnedPaths).toContain(wellKnownPath);
+    expect(readFileSync(wellKnownPath, "utf8")).not.toBe(targetBytes);
+    expect(new Set(slotProbeControl.spawnedPaths)).toEqual(
+      new Set([resolvedTarget]),
+    );
+    expect(slotProbeControl.spawnedPaths).not.toContain(wellKnownPath);
   },
 );
 

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -158,8 +158,15 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 // `execFile` is pointed at one of this suite's plain-text fixture binaries -
 // so every EXISTING test in this file (none of which populate the map) keeps
 // staging after a failed probe exactly as it did before this guard existed.
+//
+// `spawnedPaths` records every probe the planner actually issues. Some
+// properties here are about a spawn NOT happening - probing a slot that is
+// a symlink re-enters this planner in the child and recurses - and a
+// verdict assertion cannot see that: the recursive and the non-recursive
+// plan agree on the bytes, and differ only in what they spawned.
 const slotProbeControl = vi.hoisted(() => ({
   versionForPath: new Map<string, string>(),
+  spawnedPaths: [] as string[],
 }));
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
@@ -167,6 +174,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   const run = (
     file: string,
   ): { readonly error: Error | null; readonly stdout: string } => {
+    slotProbeControl.spawnedPaths.push(file);
     const mapped = slotProbeControl.versionForPath.get(file);
     if (mapped === undefined) {
       return {
@@ -219,6 +227,7 @@ beforeEach(() => {
   utimesControl.noop = false;
   statControl.failEaccesForPath = null;
   slotProbeControl.versionForPath = new Map();
+  slotProbeControl.spawnedPaths = [];
   vi.resetModules();
 });
 
@@ -2022,21 +2031,25 @@ it("packaged, a MANIFEST-anchored stage ignores the slot's claimed version", asy
   expect(readFileSync(wellKnownPath, "utf8")).toBe(anchoredBytes);
 });
 
-// The same guard on the LEGACY-SYMLINK arm, which decides the same thing
-// (which bytes replace the slot) and so owes the same rule. Unguarded, an
-// older stray SEA run once on a machine whose link points at a NEWER CLI
-// replaced the link with a copy of itself and demoted the registered
-// service - the downgrade the guard exists to prevent, through a different
-// door. The remedy differs from the regular-file arm's: leaving a symlink
-// in place is not an option (a moved target leaves it dangling, which is
-// why copy-not-symlink is the rule), so the slot is staged from the LINK'S
-// OWN TARGET. De-symlinked AND not downgraded, rather than one or the
-// other.
+// The LEGACY-SYMLINK arm owes the same rule as `guardedStage` - an
+// unanchored nomination may fill or refresh a slot, never demote one -
+// because it decides the same thing: which bytes replace the slot. Copying
+// the running binary over a link that points at a NEWER CLI demotes the
+// registered service.
+//
+// It cannot settle that by asking the slot its version, and that is the
+// point of the two tests below. A probe SPAWNS the slot, every packaged CLI
+// refreshes before it parses `--version`, and through a symlink the child's
+// `process.execPath` resolves to the TARGET - so the child misses the
+// `resolve(wellKnownPath) === source` short-circuit that protects the
+// regular-file case, re-enters this planner, and spawns a probe of its own.
+// Staging from the link's own TARGET reaches the same conclusion without
+// asking: same bytes, no link left to dangle, nothing spawned.
 //
 // Windows symlink creation needs Developer Mode, which CI runners do not
 // grant - `symlinkSync` throws before the behavior under test runs.
 it.skipIf(process.platform === "win32")(
-  "packaged, no manifest, legacy SYMLINK to a NEWER binary: de-symlinks from the link's target, not the running binary",
+  "packaged, no manifest, legacy SYMLINK: de-symlinks from the link's target without spawning a probe",
   async () => {
     seaState.current = true;
     const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
@@ -2050,9 +2063,6 @@ it.skipIf(process.platform === "win32")(
     const running = join(workHome, "running-binary");
     const runningBytes = "binary A - an older stray SEA run once";
     writeFileSync(running, runningBytes);
-    // The probe spawns the SLOT path; through a live link that is the
-    // target's answer.
-    slotProbeControl.versionForPath.set(wellKnownPath, "9.9.9\n");
 
     const result = await withExecPath(running, () =>
       refreshWellKnownSlotIfStale(ENVIRONMENT),
@@ -2067,18 +2077,23 @@ it.skipIf(process.platform === "win32")(
     // untouched symlink.
     expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
     expect(readFileSync(wellKnownPath, "utf8")).not.toBe(runningBytes);
+    // The recursion pin, and the reason this suite counts spawns at all.
+    // A probe of the slot here is a probe THROUGH the link, and the bytes
+    // above cannot tell that apart: the recursive planner reaches the same
+    // staging decision, just after spawning a ~100 MB process per level.
+    expect(slotProbeControl.spawnedPaths).toEqual([]);
   },
 );
 
-// The other direction: a link whose target reports itself OLDER has no
-// seniority to assert, so the ordinary de-symlink-from-the-running-binary
-// stage proceeds exactly as it did before the guard existed. ("0.0.0-alpha.1"
-// vs the vitest-resolved "0.0.0-local" - alphabetical pre-release compare,
-// 'a' < 'l'.) The third case, a DANGLING link, is pinned by "upgrades a
-// legacy symlink at the well-known path to a regular-file copy" above: its
-// link target does not exist, so the probe cannot answer and the stage runs.
+// ...and the version question is not dropped, only deferred to the arm that
+// can ask it safely. Two invocations: the first de-symlinks to the target's
+// bytes, the second finds a REGULAR-FILE slot (whose probe cannot recurse,
+// since a child launched from it self-nominates it and short-circuits),
+// probes it, and refreshes a genuinely older slot from the running binary.
+// "0.0.0-alpha.1" vs the vitest-resolved "0.0.0-local": SemVer compares
+// pre-release identifiers alphabetically, 'a' < 'l', so the slot is older.
 it.skipIf(process.platform === "win32")(
-  "packaged, no manifest, legacy SYMLINK to an OLDER binary: stages the running binary over the link",
+  "packaged, no manifest, legacy SYMLINK to an OLDER binary: de-symlinks first, then the next run refreshes it",
   async () => {
     seaState.current = true;
     const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
@@ -2086,20 +2101,31 @@ it.skipIf(process.platform === "win32")(
     const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
     mkdirSync(dirname(wellKnownPath), { recursive: true });
     const linkTarget = join(workHome, "older-cli-the-link-points-at");
-    writeFileSync(linkTarget, "binary B - an older CLI");
+    const targetBytes = "binary B - an older CLI";
+    writeFileSync(linkTarget, targetBytes);
     symlinkSync(linkTarget, wellKnownPath);
     const running = join(workHome, "running-binary");
     const runningBytes = "binary A - the running, newer CLI";
     writeFileSync(running, runningBytes);
     slotProbeControl.versionForPath.set(wellKnownPath, "0.0.0-alpha.1\n");
 
-    const result = await withExecPath(running, () =>
+    const first = await withExecPath(running, () =>
       refreshWellKnownSlotIfStale(ENVIRONMENT),
     );
 
-    expect(result?.staged).toBe("staged");
+    expect(first?.staged).toBe("staged");
     expect(lstatSync(wellKnownPath).isSymbolicLink()).toBe(false);
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
+    expect(slotProbeControl.spawnedPaths).toEqual([]);
+
+    const second = await withExecPath(running, () =>
+      refreshWellKnownSlotIfStale(ENVIRONMENT),
+    );
+
+    expect(second?.staged).toBe("staged");
     expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+    // The slot is a real file by now, so this probe is the safe kind.
+    expect(slotProbeControl.spawnedPaths).toContain(wellKnownPath);
   },
 );
 

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -2109,6 +2109,48 @@ it.skipIf(process.platform === "win32")(
   },
 );
 
+// Reading a candidate's first bytes must never be able to BLOCK. Opening a
+// FIFO for reading waits for a writer that may never come, with no deadline
+// of its own and upstream of the `execFile` timeout that bounds every other
+// wait here - and since each packaged command awaits this refresh before
+// commander parses argv, a FIFO at the slot would hang every CLI invocation
+// on the machine, including the ones run to repair it.
+//
+// So the assertion is simply that the refresh RETURNS, and the mutation
+// signature is a timeout rather than a wrong value. A real FIFO, because
+// that is the whole point - `mkfifo` through the unmocked `execFileSync`
+// (this suite replaces `execFile` only).
+it.skipIf(process.platform === "win32")(
+  "packaged, no manifest, a FIFO at the slot cannot hang the refresh",
+  async () => {
+    seaState.current = true;
+    const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+      await import("../well-known-cli");
+    const { execFileSync } = await import("node:child_process");
+    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+    mkdirSync(dirname(wellKnownPath), { recursive: true });
+    execFileSync("mkfifo", [wellKnownPath]);
+    const running = join(workHome, "running-binary");
+    const runningBytes = "binary A - the running packaged CLI";
+    writeFileSync(running, runningBytes);
+    // Mapped so that a probe, if one were reached, would report the slot
+    // strictly newer - the test must fail on the BLOCK, not on a verdict.
+    slotProbeControl.versionForPath.set(wellKnownPath, "9.9.9\n");
+
+    const result = await withExecPath(running, () =>
+      refreshWellKnownSlotIfStale(ENVIRONMENT),
+    );
+
+    // Returned at all is the property. Repairing the slot is the bonus: a
+    // FIFO cannot serve the host or the registered service, so staging over
+    // it is the recovery path.
+    expect(result?.staged).toBe("staged");
+    expect(statSync(wellKnownPath).isFIFO()).toBe(false);
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+  },
+  10_000,
+);
+
 // An ANCHORED nomination - the manifest names a different existing binary
 // - is trusted outright: the guard only ever applies to the two
 // self-nominated (unanchored) cases, so a manifest-driven stage must

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -165,18 +165,55 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 // a symlink re-enters this planner in the child and recurses - and a
 // verdict assertion cannot see that: the recursive and the non-recursive
 // plan agree on the bytes, and differ only in what they spawned.
+//
+// `onSpawn` is what a path assertion still cannot reach: WHAT THE CHILD DOES.
+// A probe launches a packaged CLI, and a packaged CLI runs this same refresh
+// before commander parses `--version` - so "which path was spawned" and "does
+// spawning it recurse" are different questions, and a mock that only prints a
+// canned version answers the first while silently passing the second. A test
+// that cares installs a child here that re-enters the real entry point under
+// the spawned binary's identity, which is the only shape that can fail on
+// recursion. Default `null` - a process that merely prints - keeps every
+// other test in this file at one level.
 const slotProbeControl = vi.hoisted(() => ({
   versionForPath: new Map<string, string>(),
   spawnedPaths: [] as string[],
+  onSpawn: null as ((file: string) => Promise<void>) | null,
 }));
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
   const { promisify } = await import("node:util");
+  const { readFileSync } = await import("node:fs");
+  // A version belongs to BYTES, not to a path, and the difference is only
+  // invisible while nothing copies. Staging copies: a probe of a slot that
+  // was just staged from a mapped fixture is a probe of that fixture's
+  // image, and it reports that fixture's version - so a path-keyed lookup
+  // alone would answer "not executable" for a binary the map describes,
+  // which reads as a downgrade the production code did not commit. The
+  // mapped path stays the fast path; identical content is how a copy is
+  // recognised as the same program.
+  const versionOf = (file: string): string | undefined => {
+    const direct = slotProbeControl.versionForPath.get(file);
+    if (direct !== undefined) return direct;
+    let bytes: string;
+    try {
+      bytes = readFileSync(file, "utf8");
+    } catch {
+      return undefined;
+    }
+    for (const [path, version] of slotProbeControl.versionForPath) {
+      try {
+        if (readFileSync(path, "utf8") === bytes) return version;
+      } catch {
+        continue;
+      }
+    }
+    return undefined;
+  };
   const run = (
     file: string,
   ): { readonly error: Error | null; readonly stdout: string } => {
-    slotProbeControl.spawnedPaths.push(file);
-    const mapped = slotProbeControl.versionForPath.get(file);
+    const mapped = versionOf(file);
     if (mapped === undefined) {
       return {
         error: Object.assign(
@@ -194,19 +231,24 @@ vi.mock("node:child_process", async (importOriginal) => {
     _options: unknown,
     callback: (error: Error | null, stdout: string, stderr: string) => void,
   ): unknown => {
+    slotProbeControl.spawnedPaths.push(file);
     const { error, stdout } = run(file);
     callback(error, stdout, "");
     return {};
   };
   Object.defineProperty(mockExecFile, promisify.custom, {
-    value: (file: string) =>
-      new Promise<{ stdout: string; stderr: string }>(
-        (resolvePromise, reject) => {
-          const { error, stdout } = run(file);
-          if (error !== null) reject(error);
-          else resolvePromise({ stdout, stderr: "" });
-        },
-      ),
+    value: async (
+      file: string,
+    ): Promise<{ stdout: string; stderr: string }> => {
+      // Recorded at LAUNCH, before the child runs, so a re-entrant child's
+      // own spawns land after its parent's in `spawnedPaths`.
+      slotProbeControl.spawnedPaths.push(file);
+      const child = slotProbeControl.onSpawn;
+      if (child !== null) await child(file);
+      const { error, stdout } = run(file);
+      if (error !== null) throw error;
+      return { stdout, stderr: "" };
+    },
   });
   return { ...actual, execFile: mockExecFile };
 });
@@ -229,6 +271,7 @@ beforeEach(() => {
   statControl.failEaccesForPath = null;
   slotProbeControl.versionForPath = new Map();
   slotProbeControl.spawnedPaths = [];
+  slotProbeControl.onSpawn = null;
   vi.resetModules();
 });
 
@@ -2170,6 +2213,79 @@ it.skipIf(process.platform === "win32")(
       new Set([resolvedTarget]),
     );
     expect(slotProbeControl.spawnedPaths).not.toContain(wellKnownPath);
+  },
+);
+
+// The three cases above pin WHICH path is probed. None of them can fail on
+// the thing that actually costs users a machine, because their spawned child
+// only prints: a probe launches a packaged CLI, that CLI runs this refresh
+// before commander parses `--version`, and whether IT probes in turn is a
+// question no canned answer is asked.
+//
+// So this one runs the real child. `onSpawn` re-enters the real entry point
+// under the spawned binary's identity - exactly what the operating system
+// would do - and the assertion is on nesting DEPTH, because that is what
+// distinguishes the two outcomes. A planner that lets a child probe does not
+// merely repeat work: each level is a fresh ~100 MB process, `execFile`'s
+// timeout can only kill the level it launched, and every deeper descendant
+// is orphaned. The depth cap is what keeps a regression from hanging this
+// suite instead of failing it; the recursion is otherwise unbounded.
+//
+// A child that spawns nothing is the fix stated as a measurement: maximum
+// depth 1 means every probe in the run was issued by the top-level process.
+it.skipIf(process.platform === "win32")(
+  "packaged, no manifest, legacy SYMLINK to a REAL CLI: the spawned child probes nothing",
+  async () => {
+    seaState.current = true;
+    const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+      await import("../well-known-cli");
+    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+    mkdirSync(dirname(wellKnownPath), { recursive: true });
+    const linkTarget = join(workHome, "newer-cli-the-link-points-at");
+    const targetBytes = "binary B - the newer CLI the legacy link points at";
+    writeFileSync(linkTarget, targetBytes);
+    symlinkSync(linkTarget, wellKnownPath);
+    const running = join(workHome, "running-binary");
+    writeFileSync(running, "binary A - an older stray SEA run once");
+    const resolvedTarget = realpathSync(linkTarget);
+    slotProbeControl.versionForPath.set(resolvedTarget, "9.9.9\n");
+
+    let liveDepth = 0;
+    let maxDepth = 0;
+    slotProbeControl.onSpawn = async (file: string): Promise<void> => {
+      liveDepth += 1;
+      maxDepth = Math.max(maxDepth, liveDepth);
+      try {
+        // Past this the run is already a fork bomb and the only question
+        // left is whether the suite reports it or hangs. Thrown rather than
+        // returned because the production catch turns any spawn failure into
+        // `false`, which would otherwise let an unfixed planner unwind
+        // quietly - `maxDepth` is what fails the test either way.
+        if (liveDepth <= 3) {
+          await withExecPath(file, () =>
+            refreshWellKnownSlotIfStale(ENVIRONMENT),
+          );
+        }
+      } finally {
+        liveDepth -= 1;
+      }
+    };
+
+    const result = await withExecPath(running, () =>
+      refreshWellKnownSlotIfStale(ENVIRONMENT),
+    );
+
+    expect(maxDepth).toBe(1);
+    // And the end state is still the one the arm exists to produce: the
+    // newer bytes, in a real file. The child de-symlinks the slot from its
+    // own image on the way past, so this run converges rather than staging
+    // again - `current` and `staged` are both correct here, a downgrade is
+    // not.
+    expect(result?.staged).not.toBe("failed");
+    const stat = lstatSync(wellKnownPath);
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(stat.isFile()).toBe(true);
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
   },
 );
 

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -2022,6 +2022,87 @@ it("packaged, a MANIFEST-anchored stage ignores the slot's claimed version", asy
   expect(readFileSync(wellKnownPath, "utf8")).toBe(anchoredBytes);
 });
 
+// The same guard on the LEGACY-SYMLINK arm, which decides the same thing
+// (which bytes replace the slot) and so owes the same rule. Unguarded, an
+// older stray SEA run once on a machine whose link points at a NEWER CLI
+// replaced the link with a copy of itself and demoted the registered
+// service - the downgrade the guard exists to prevent, through a different
+// door. The remedy differs from the regular-file arm's: leaving a symlink
+// in place is not an option (a moved target leaves it dangling, which is
+// why copy-not-symlink is the rule), so the slot is staged from the LINK'S
+// OWN TARGET. De-symlinked AND not downgraded, rather than one or the
+// other.
+//
+// Windows symlink creation needs Developer Mode, which CI runners do not
+// grant - `symlinkSync` throws before the behavior under test runs.
+it.skipIf(process.platform === "win32")(
+  "packaged, no manifest, legacy SYMLINK to a NEWER binary: de-symlinks from the link's target, not the running binary",
+  async () => {
+    seaState.current = true;
+    const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+      await import("../well-known-cli");
+    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+    mkdirSync(dirname(wellKnownPath), { recursive: true });
+    const linkTarget = join(workHome, "newer-cli-the-link-points-at");
+    const targetBytes = "binary B - the newer CLI the legacy link points at";
+    writeFileSync(linkTarget, targetBytes);
+    symlinkSync(linkTarget, wellKnownPath);
+    const running = join(workHome, "running-binary");
+    const runningBytes = "binary A - an older stray SEA run once";
+    writeFileSync(running, runningBytes);
+    // The probe spawns the SLOT path; through a live link that is the
+    // target's answer.
+    slotProbeControl.versionForPath.set(wellKnownPath, "9.9.9\n");
+
+    const result = await withExecPath(running, () =>
+      refreshWellKnownSlotIfStale(ENVIRONMENT),
+    );
+
+    expect(result?.staged).toBe("staged");
+    const stat = lstatSync(wellKnownPath);
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(stat.isFile()).toBe(true);
+    // Both halves matter: the target's bytes (no downgrade) in a real file
+    // (no dangling link). Asserting only the first would pass on an
+    // untouched symlink.
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
+    expect(readFileSync(wellKnownPath, "utf8")).not.toBe(runningBytes);
+  },
+);
+
+// The other direction: a link whose target reports itself OLDER has no
+// seniority to assert, so the ordinary de-symlink-from-the-running-binary
+// stage proceeds exactly as it did before the guard existed. ("0.0.0-alpha.1"
+// vs the vitest-resolved "0.0.0-local" - alphabetical pre-release compare,
+// 'a' < 'l'.) The third case, a DANGLING link, is pinned by "upgrades a
+// legacy symlink at the well-known path to a regular-file copy" above: its
+// link target does not exist, so the probe cannot answer and the stage runs.
+it.skipIf(process.platform === "win32")(
+  "packaged, no manifest, legacy SYMLINK to an OLDER binary: stages the running binary over the link",
+  async () => {
+    seaState.current = true;
+    const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+      await import("../well-known-cli");
+    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+    mkdirSync(dirname(wellKnownPath), { recursive: true });
+    const linkTarget = join(workHome, "older-cli-the-link-points-at");
+    writeFileSync(linkTarget, "binary B - an older CLI");
+    symlinkSync(linkTarget, wellKnownPath);
+    const running = join(workHome, "running-binary");
+    const runningBytes = "binary A - the running, newer CLI";
+    writeFileSync(running, runningBytes);
+    slotProbeControl.versionForPath.set(wellKnownPath, "0.0.0-alpha.1\n");
+
+    const result = await withExecPath(running, () =>
+      refreshWellKnownSlotIfStale(ENVIRONMENT),
+    );
+
+    expect(result?.staged).toBe("staged");
+    expect(lstatSync(wellKnownPath).isSymbolicLink()).toBe(false);
+    expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+  },
+);
+
 // `wellKnownSlotRefreshHasConverged` answers whether a refresh right now
 // would find nothing to copy - the convergence probe behind the supervised
 // entry's restart decision. A `staged` outcome alone is not sufficient

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -432,13 +432,11 @@ async function slotRefreshPlan(
   // exists for must keep converging, and a slot that cannot say what it is
   // has no seniority to assert.
   //
-  // Only ever reached with a REGULAR-FILE slot, and that is a safety
-  // precondition rather than an accident of ordering: spawning the slot
-  // runs a CLI that itself refreshes before printing a version, and only a
-  // regular-file slot makes that child stop at the
-  // `resolve(wellKnownPath) === source` check above instead of re-entering
-  // the planner. The symlink arm below asks the same question of the link's
-  // TARGET for that reason - see there.
+  // Only ever reached with a REGULAR-FILE slot, since the symlink arm below
+  // returns first. That ordering is no longer load-bearing for recursion
+  // safety, though it once was argued to be: `slotOutranksRunning` refuses to
+  // spawn this process's own image whatever spelling names it, and that is
+  // the single place the rule is now stated.
   const guardedStage = async (): Promise<SlotRefreshPlan> => {
     if (!anchored && (await slotOutranksRunning(wellKnownPath))) {
       return { kind: "current" };
@@ -464,18 +462,15 @@ async function slotRefreshPlan(
     // over a link that points at a NEWER CLI demotes the registered
     // service, which is the very downgrade the guard exists to prevent.
     //
-    // The question is asked of the link's TARGET, never of the slot, and
-    // the difference is what keeps the probe from re-entering this planner.
-    // `slotOutranksRunning` spawns what it is given, and every packaged CLI
-    // runs this refresh before it parses `--version`. Spawned through a
-    // REGULAR-FILE slot the child self-nominates the slot it was launched
-    // from and stops at the `resolve(wellKnownPath) === source` check
-    // above; spawned through a SYMLINK its `process.execPath` resolves to
-    // the target, that lexical check misses, and it arrives right back here
-    // to spawn a probe of its own - a fresh ~100 MB process per level until
-    // the deadlines unwind. Spawned AS the target it is the ordinary case
-    // again: it sees the same symlinked slot, stages the slot from that
-    // same target, and answers. One copy, no recursion.
+    // The question is asked of the link's TARGET rather than of the slot
+    // because the target is what the bytes ARE - not as a recursion
+    // defence, which it never was. Probing either spelling re-enters this
+    // planner in the child, since the lexical `resolve(wellKnownPath) ===
+    // source` check above cannot see that a symlinked slot and its target
+    // name one file. What ends the recursion is `slotOutranksRunning`
+    // declining to spawn this process's own image: the child launched as
+    // the target asks nothing, stages the slot from itself, de-symlinks it,
+    // and answers. Stated once, there.
     //
     // Preserving the target only on a version answer, rather than on
     // `realpath` succeeding, is the other half. Bytes that resolve are not
@@ -543,19 +538,45 @@ async function slotRefreshPlan(
   return { kind: "adopt", source, sourceStat: mirroredSource };
 }
 
-// Ask the slot binary its version and answer whether it outranks the running
-// process. `true` is the ONLY answer that suppresses an unanchored stage, so
-// every failure - a slot that will not execute, prints garbage, or hangs
-// past the timeout - is `false`: refusing to converge on an unprovable
-// seniority claim would strand the hookless cohort the fallback serves.
+// Ask a candidate binary its version and answer whether it outranks the
+// running process. `true` is the ONLY answer that suppresses an unanchored
+// stage, so every failure - a candidate that will not execute, prints
+// garbage, or hangs past the timeout - is `false`: refusing to converge on an
+// unprovable seniority claim would strand the hookless cohort the fallback
+// serves.
 //
-// The spawned slot runs its own startup refresh first, which cannot recurse:
-// launched FROM the slot it self-nominates, the slot IS the source, and its
-// plan is `current` before any spawn.
-async function slotOutranksRunning(wellKnownPath: string): Promise<boolean> {
+// NEVER spawns this process's own image, and that check lives here rather
+// than at the call sites because it is the whole reason this function is safe
+// to call. What gets spawned is a packaged CLI, and a packaged CLI runs this
+// same refresh before commander parses `--version` - so a probe of ourselves
+// is a probe that re-enters this planner in the child, reaches this line
+// again, and spawns another ~100 MB process per level until the timeouts
+// unwind, orphaning every descendant deeper than the one `execFile` can kill.
+//
+// Two call sites have now been written believing a PATH comparison upstream
+// made that impossible, and both were wrong in the same way: recursion is a
+// question about binary IDENTITY, `resolve` compares SPELLING, and a symlink
+// is precisely where one file has two of them. `resolve(wellKnownPath) ===
+// source` is only accidentally an identity test - true for a regular-file
+// slot, false for a symlinked one naming the very same bytes. So the identity
+// test belongs in front of the spawn, once, where no third call site can
+// reintroduce it, and `canonicalBinaryPath` is what collapses the spellings.
+//
+// `false` is not a bail-out here but the exact answer: nothing is strictly
+// newer than itself. Its effect - stage - is also right, since bytes
+// identical to the running image cannot demote anything, and for the symlink
+// arm it is what finally turns a legacy link into the regular file the
+// copy-not-symlink rule wants.
+async function slotOutranksRunning(candidatePath: string): Promise<boolean> {
+  if (
+    (await canonicalBinaryPath(candidatePath)) ===
+    (await canonicalBinaryPath(process.execPath))
+  ) {
+    return false;
+  }
   let reported: string;
   try {
-    const { stdout } = await execFileAsync(wellKnownPath, ["--version"], {
+    const { stdout } = await execFileAsync(candidatePath, ["--version"], {
       timeout: SLOT_VERSION_PROBE_TIMEOUT_MS,
       windowsHide: true,
     });

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -432,8 +432,13 @@ async function slotRefreshPlan(
   // exists for must keep converging, and a slot that cannot say what it is
   // has no seniority to assert.
   //
-  // The legacy-symlink arm below owes the same rule and asks the same
-  // question, but answers it with a different remedy - see there.
+  // Only ever reached with a REGULAR-FILE slot, and that is a safety
+  // precondition rather than an accident of ordering: spawning the slot
+  // runs a CLI that itself refreshes before printing a version, and only a
+  // regular-file slot makes that child stop at the
+  // `resolve(wellKnownPath) === source` check above instead of re-entering
+  // the planner. The symlink arm below therefore answers the same question
+  // without asking it - see there.
   const guardedStage = async (): Promise<SlotRefreshPlan> => {
     if (!anchored && (await slotOutranksRunning(wellKnownPath))) {
       return { kind: "current" };
@@ -455,24 +460,37 @@ async function slotRefreshPlan(
     // De-symlinking must not double as a downgrade. This arm decides what
     // `guardedStage` decides for a regular-file slot - which bytes replace
     // the slot - so it owes the same rule: an unanchored nomination may
-    // fill or refresh a slot, never demote one. Left unguarded, an older
-    // stray SEA run once on a machine whose legacy link points at a NEWER
-    // CLI replaced the link with a copy of itself and demoted the
-    // registered service, which is the exact downgrade the guard was added
-    // to prevent, reached through a different door.
+    // fill or refresh a slot, never demote one. Copying the running binary
+    // over a link that points at a NEWER CLI demotes the registered
+    // service, which is the very downgrade the guard exists to prevent.
     //
-    // The resolution keeps both invariants instead of trading one for the
-    // other: when the link outranks this process, stage from the link's own
-    // TARGET. The slot stops being a symlink (nothing left to dangle) and
-    // still holds the newer binary's bytes. Copying the running binary
-    // would satisfy only the first.
+    // It does NOT resolve that by asking the version question, and the
+    // reason is that this arm cannot ask it safely. `slotOutranksRunning`
+    // spawns the slot, and every packaged CLI runs this refresh before it
+    // parses `--version`: through a REGULAR-FILE slot the child
+    // self-nominates the slot it was launched from and stops at the
+    // `resolve(wellKnownPath) === source` check above, but through a
+    // SYMLINK the child's `process.execPath` resolves to the TARGET, that
+    // lexical check misses, and the child arrives right back here and
+    // spawns its own probe. Each level a fresh ~100 MB process, until the
+    // probe deadlines unwind - and the original process then stages its
+    // own older bytes anyway.
     //
-    // A DANGLING link cannot answer the version probe, so it falls straight
-    // through to the ordinary stage below and self-heals - the case that
-    // made copy-not-symlink the rule stays fixed. `realpath` failing after
-    // a successful probe (a target unlinked in between) falls through the
-    // same way.
-    if (!anchored && (await slotOutranksRunning(wellKnownPath))) {
+    // The question does not have to be asked. Staging from the link's own
+    // TARGET preserves whatever the slot already resolved to while making
+    // it a real file, so it cannot downgrade anything by construction:
+    // same bytes, no link left to dangle. Whether those bytes are actually
+    // newer than this process is then settled on the NEXT invocation by
+    // the regular-file arm below, where the probe is safe (that arm's slot
+    // is a real file, so its child short-circuits) and cheap.
+    //
+    // A DANGLING link resolves to nothing and falls through to the
+    // ordinary stage from `source`, self-healing exactly as it did before
+    // this guard existed - the case that made copy-not-symlink the rule.
+    // So does a link pointing at something that cannot answer for itself:
+    // the next invocation's regular-file probe fails and re-stages from
+    // the running binary.
+    if (!anchored) {
       const target = await realpath(wellKnownPath).catch(() => null);
       if (target !== null) return { kind: "stage", source: target };
     }

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -426,11 +426,14 @@ async function slotRefreshPlan(
   // runs one command on a machine whose slot holds a newer CLI. The manifest
   // normally arbitrates exactly this; with none, the only remaining witness
   // is the slot binary itself, so before an unanchored stage over an
-  // existing regular file the slot is asked its version once and left alone
+  // existing slot binary the slot is asked its version once and left alone
   // when it reports itself STRICTLY newer than this process. An unreadable
   // or unparseable answer stages: the hookless-upgrade cohort this fallback
   // exists for must keep converging, and a slot that cannot say what it is
   // has no seniority to assert.
+  //
+  // The legacy-symlink arm below owes the same rule and asks the same
+  // question, but answers it with a different remedy - see there.
   const guardedStage = async (): Promise<SlotRefreshPlan> => {
     if (!anchored && (await slotOutranksRunning(wellKnownPath))) {
       return { kind: "current" };
@@ -447,7 +450,32 @@ async function slotRefreshPlan(
   // therefore never "already fresh"; it is always restaged into a real
   // file.
   const slotStat = await lstatOrNull(wellKnownPath);
-  if (slotStat === null || slotStat.isSymbolicLink()) {
+  if (slotStat === null) return { kind: "stage", source };
+  if (slotStat.isSymbolicLink()) {
+    // De-symlinking must not double as a downgrade. This arm decides what
+    // `guardedStage` decides for a regular-file slot - which bytes replace
+    // the slot - so it owes the same rule: an unanchored nomination may
+    // fill or refresh a slot, never demote one. Left unguarded, an older
+    // stray SEA run once on a machine whose legacy link points at a NEWER
+    // CLI replaced the link with a copy of itself and demoted the
+    // registered service, which is the exact downgrade the guard was added
+    // to prevent, reached through a different door.
+    //
+    // The resolution keeps both invariants instead of trading one for the
+    // other: when the link outranks this process, stage from the link's own
+    // TARGET. The slot stops being a symlink (nothing left to dangle) and
+    // still holds the newer binary's bytes. Copying the running binary
+    // would satisfy only the first.
+    //
+    // A DANGLING link cannot answer the version probe, so it falls straight
+    // through to the ordinary stage below and self-heals - the case that
+    // made copy-not-symlink the rule stays fixed. `realpath` failing after
+    // a successful probe (a target unlinked in between) falls through the
+    // same way.
+    if (!anchored && (await slotOutranksRunning(wellKnownPath))) {
+      const target = await realpath(wellKnownPath).catch(() => null);
+      if (target !== null) return { kind: "stage", source: target };
+    }
     return { kind: "stage", source };
   }
   // The staging record is the authority whenever it applies, because it is

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -437,8 +437,8 @@ async function slotRefreshPlan(
   // runs a CLI that itself refreshes before printing a version, and only a
   // regular-file slot makes that child stop at the
   // `resolve(wellKnownPath) === source` check above instead of re-entering
-  // the planner. The symlink arm below therefore answers the same question
-  // without asking it - see there.
+  // the planner. The symlink arm below asks the same question of the link's
+  // TARGET for that reason - see there.
   const guardedStage = async (): Promise<SlotRefreshPlan> => {
     if (!anchored && (await slotOutranksRunning(wellKnownPath))) {
       return { kind: "current" };
@@ -464,35 +464,41 @@ async function slotRefreshPlan(
     // over a link that points at a NEWER CLI demotes the registered
     // service, which is the very downgrade the guard exists to prevent.
     //
-    // It does NOT resolve that by asking the version question, and the
-    // reason is that this arm cannot ask it safely. `slotOutranksRunning`
-    // spawns the slot, and every packaged CLI runs this refresh before it
-    // parses `--version`: through a REGULAR-FILE slot the child
-    // self-nominates the slot it was launched from and stops at the
-    // `resolve(wellKnownPath) === source` check above, but through a
-    // SYMLINK the child's `process.execPath` resolves to the TARGET, that
-    // lexical check misses, and the child arrives right back here and
-    // spawns its own probe. Each level a fresh ~100 MB process, until the
-    // probe deadlines unwind - and the original process then stages its
-    // own older bytes anyway.
+    // The question is asked of the link's TARGET, never of the slot, and
+    // the difference is what keeps the probe from re-entering this planner.
+    // `slotOutranksRunning` spawns what it is given, and every packaged CLI
+    // runs this refresh before it parses `--version`. Spawned through a
+    // REGULAR-FILE slot the child self-nominates the slot it was launched
+    // from and stops at the `resolve(wellKnownPath) === source` check
+    // above; spawned through a SYMLINK its `process.execPath` resolves to
+    // the target, that lexical check misses, and it arrives right back here
+    // to spawn a probe of its own - a fresh ~100 MB process per level until
+    // the deadlines unwind. Spawned AS the target it is the ordinary case
+    // again: it sees the same symlinked slot, stages the slot from that
+    // same target, and answers. One copy, no recursion.
     //
-    // The question does not have to be asked. Staging from the link's own
-    // TARGET preserves whatever the slot already resolved to while making
-    // it a real file, so it cannot downgrade anything by construction:
-    // same bytes, no link left to dangle. Whether those bytes are actually
-    // newer than this process is then settled on the NEXT invocation by
-    // the regular-file arm below, where the probe is safe (that arm's slot
-    // is a real file, so its child short-circuits) and cheap.
+    // Preserving the target only on a version answer, rather than on
+    // `realpath` succeeding, is the other half. Bytes that resolve are not
+    // therefore a CLI: a link may point at a shim, another tool, or
+    // anything else that survived the years since some installer wrote it,
+    // and copying that into the slot hands the registered service and the
+    // host a program that will never repair itself - the repair path here
+    // runs only when a real CLI is invoked, and after this the thing being
+    // invoked is not one. So a target that cannot say what it is loses to
+    // the running packaged CLI, which demonstrably can. (What "usable"
+    // means is exactly what it means one branch below: it answered
+    // `--version` with something parseable. No stronger signal exists
+    // without running more of it.)
     //
-    // A DANGLING link resolves to nothing and falls through to the
-    // ordinary stage from `source`, self-healing exactly as it did before
-    // this guard existed - the case that made copy-not-symlink the rule.
-    // So does a link pointing at something that cannot answer for itself:
-    // the next invocation's regular-file probe fails and re-stages from
-    // the running binary.
+    // Not strictly newer - older, equal, unreadable, dangling - all fall
+    // through to the ordinary stage from `source`, which de-symlinks and
+    // refreshes in one step. That is also what made copy-not-symlink the
+    // rule: a link nobody can vouch for must not survive as one.
     if (!anchored) {
       const target = await realpath(wellKnownPath).catch(() => null);
-      if (target !== null) return { kind: "stage", source: target };
+      if (target !== null && (await slotOutranksRunning(target))) {
+        return { kind: "stage", source: target };
+      }
     }
     return { kind: "stage", source };
   }

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
+import { constants } from "node:fs";
 import type { Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import {
@@ -637,9 +638,32 @@ async function isSlotEligibleBinary(binaryPath: string): Promise<boolean> {
   ) {
     return false;
   }
+  // REGULAR FILE first, and this ordering is the load-bearing part. Opening a
+  // FIFO for reading BLOCKS until a writer appears - forever, with no
+  // deadline of its own, and upstream of the `execFile` timeout that bounds
+  // everything else here. Every packaged command awaits this refresh before
+  // commander parses argv, so a FIFO at the slot (or a legacy link resolving
+  // to one) would hang every CLI invocation on the machine, including the
+  // ones that exist to repair it. A wedge with no recovery path is the one
+  // outcome this module is under orders never to create.
+  //
+  // It is also the honest question: the slot must hold an executable image,
+  // and a directory, socket, device or FIFO is not one whatever its first
+  // bytes would say.
+  const candidateStat = await statOrNull(binaryPath);
+  if (candidateStat === null || !candidateStat.isFile()) return false;
   let handle: FileHandle;
   try {
-    handle = await open(binaryPath, "r");
+    // O_NONBLOCK closes the window between the stat above and this open, in
+    // which the candidate could become a FIFO. A no-op for the regular file
+    // this is reached with; absent on Windows, which has no FIFO to open
+    // this way.
+    handle = await open(
+      binaryPath,
+      process.platform === "win32"
+        ? constants.O_RDONLY
+        : constants.O_RDONLY | constants.O_NONBLOCK,
+    );
   } catch {
     return false;
   }

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -2,10 +2,12 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import type { Stats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
 import {
   chmod,
   copyFile,
   lstat,
+  open,
   readFile,
   readdir,
   realpath,
@@ -481,9 +483,11 @@ async function slotRefreshPlan(
     // runs only when a real CLI is invoked, and after this the thing being
     // invoked is not one. So a target that cannot say what it is loses to
     // the running packaged CLI, which demonstrably can. (What "usable"
-    // means is exactly what it means one branch below: it answered
-    // `--version` with something parseable. No stronger signal exists
-    // without running more of it.)
+    // means is exactly what it means one branch below, and both halves are
+    // decided in `slotOutranksRunning`: it answered `--version` with
+    // something parseable, AND it is a binary the slot may hold at all -
+    // an npm install answers that question perfectly well and still must
+    // never be copied here.)
     //
     // Not strictly newer - older, equal, unreadable, dangling - all fall
     // through to the ordinary stage from `source`, which de-symlinks and
@@ -574,6 +578,23 @@ async function slotOutranksRunning(candidatePath: string): Promise<boolean> {
   ) {
     return false;
   }
+  // Answering `--version` proves a program runs, not that it may HOLD the
+  // slot, and the difference has a rule already: `isInterpreterDistribution`
+  // refuses to nominate an npm install at all, because the slot is spawned by
+  // the host daemon and the registered service, where a `#!/usr/bin/env node`
+  // shebang resolves `node` off the SERVICE manager's PATH rather than a
+  // login shell's. That rule is keyed on the MANIFEST, and every caller here
+  // is unanchored - no manifest, by definition - so the file has to be asked
+  // directly.
+  //
+  // A version answer is exactly what an npm CLI gives (the shebang runs it),
+  // so without this an old Desktop symlink pointing at a newer npm install
+  // puts a Node script behind `bin/traycer`, and nothing repairs it: the next
+  // packaged run probes that slot, the script answers newer again, and the
+  // guard leaves it there forever while the service cannot start. Refusing
+  // here is also what makes that state RECOVERABLE if it is ever reached by
+  // hand - `false` stages the running SEA over it.
+  if (!(await isSlotEligibleBinary(candidatePath))) return false;
   let reported: string;
   try {
     const { stdout } = await execFileAsync(candidatePath, ["--version"], {
@@ -589,6 +610,48 @@ async function slotOutranksRunning(candidatePath: string): Promise<boolean> {
 
 const SLOT_VERSION_PROBE_TIMEOUT_MS = 10_000;
 const execFileAsync = promisify(execFile);
+
+// Whether a binary may OCCUPY the slot, as opposed to merely being able to
+// run. See `isInterpreterDistribution` for the rule this enforces without a
+// manifest to read it from.
+//
+// Deliberately a NEGATIVE test. Proving a file IS a packaged executable means
+// recognising Mach-O, ELF and PE magic on every platform this ships to, and
+// being wrong there REFUSES a legitimate newer CLI - the silent downgrade
+// this whole guard exists to prevent. Being wrong the other way only stages
+// the running SEA, which is always a working CLI, and always converges. So
+// the question asked is the narrow one the failure is actually about: does
+// this file start with a shebang.
+//
+// Two bytes, not `readFile`: the candidate is a ~100 MB binary in the case
+// this runs for.
+//
+// On Windows the slot is `traycer.exe` and Scheduled Tasks spawns it as an
+// image, so a non-`.exe` target - npm's `.cmd`/`.ps1` shims, a bare shell
+// script - cannot serve there whatever its first bytes are. Unreadable
+// counts as ineligible for the same fail-safe reason.
+async function isSlotEligibleBinary(binaryPath: string): Promise<boolean> {
+  if (
+    process.platform === "win32" &&
+    !binaryPath.toLowerCase().endsWith(".exe")
+  ) {
+    return false;
+  }
+  let handle: FileHandle;
+  try {
+    handle = await open(binaryPath, "r");
+  } catch {
+    return false;
+  }
+  try {
+    const { buffer, bytesRead } = await handle.read(Buffer.alloc(2), 0, 2, 0);
+    return !(bytesRead === 2 && buffer[0] === 0x23 && buffer[1] === 0x21);
+  } catch {
+    return false;
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
 
 // A nominated slot source, and whether an install AUTHORITY vouches for it.
 // `anchored: false` marks the two self-nominations - no manifest at all, and


### PR DESCRIPTION
Follow-up to #1301, closing the two findings Codex posted against it ~30 seconds after it merged. Both are the same shape as the round they came from: a rule that change introduced, applied to one arm and missing from its sibling.

## P1 — the reconcile's probe was impatient about a decision it cannot take back

`clients/desktop/src/electron-main/cli/cli-discovery.ts`

Not caching `timeout` verdicts was only half a fix. When the PATH vet times out, `discoverCli()` drops the candidate, reconcile's no-manifest branch stages the bundled CLI, and that install writes a **Desktop-owned manifest** — which outranks PATH in every later discovery. Nothing re-probes PATH afterwards, so the retry an uncached verdict promises has nowhere to happen: a hookless package-manager install silently loses the slot **permanently**, not for a session. (The CLI side then agrees: its `authoritativeSlotSource` reads that manifest, finds it naming the slot itself, and plans `current` forever.)

The binary shape that legitimately blows a 2s deadline is a **real** packaged CLI copying ~100 MB into the well-known slot before commander parses — and since each killed probe abandons that copy, repeated impatience never converges where one patient probe does.

- Split deadline: `CLI_INVOCATION_PROBE_TIMEOUT_MS` (2s) on the invocation path, `CLI_RECONCILE_PROBE_TIMEOUT_MS` (15s) on the detached launch reconcile — the only prober whose verdict can hand slot ownership away.
- Joining an in-flight probe no longer inherits its deadline: the cache shares the promise, so a status poll landing mid-reconcile would otherwise stall for the full 15s. It races its own 2s; the patient probe runs on and still publishes its verdict.
- Settled `version` / `not-a-cli` verdicts stay shared across deadlines — those are facts about the binary, not about anyone's patience.

**Not** the suggested remedy (defer the reconciliation pass). Deferring is only bounded per-pass: a `traycer` that never answers times out every launch, so the slot would never be staged and oss #872's bricked first launch comes back. Past 15s the bundled CLI is still staged, with the reasoning recorded at the branch.

## P2 — the legacy-symlink arm skipped the downgrade guard

`clients/traycer-cli/src/store/well-known-cli.ts`

`slotRefreshPlan`'s symlink arm returned `stage` before `guardedStage()` could run, so an older stray SEA run once on a machine whose legacy slot link points at a **newer** CLI replaced the link with a copy of itself and demoted the registered service — the exact downgrade #1301 added the guard to prevent, through a different door.

Leaving the link alone is not the remedy (a moved target leaves it dangling, which is why copy-not-symlink is the rule). So when the link outranks this process, the slot is staged from the **link's own target**: de-symlinked *and* not downgraded, rather than one or the other. A dangling link cannot answer the probe and self-heals exactly as before.

## Verification

| Suite | Result |
| --- | --- |
| `traycer-cli` store (`well-known-cli`) | 72 pass (+2) |
| desktop `electron-main/cli` (12 files) | 121 pass (+2) |

Every new assertion mutation-probed, red then green again:

| Mutation | Kills |
| --- | --- |
| `!anchored` → `anchored` in the symlink arm | exactly the symlink test, nothing else |
| `CLI_RECONCILE_PROBE_TIMEOUT_MS` → 2s | both new vet tests |
| joiner returns the cached promise unconditionally | the joiner test, at the fixture's full 6s |
