### PR TITLE
feat(protocol,shared,gui-app): delta-seed epic reattach (epic.subscribe@1.3)

### DIFF
--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -421,10 +421,11 @@ export function EpicSessionProvider(
     const streamClientFactory: EpicStreamClientFactory = (
       factoryEpicId,
       callbacks,
+      seedOfferProvider,
     ) => {
       const override = getEpicStreamClientFactoryOverride();
       if (override !== null) {
-        return override(factoryEpicId, callbacks);
+        return override(factoryEpicId, callbacks, seedOfferProvider);
       }
       // `targetHostId` is non-null here: the acquire effect gates on it above,
       // and it is a `const`, so that narrowing flows into this factory closure.
@@ -439,6 +440,7 @@ export function EpicSessionProvider(
             wsStreamClient: ws,
             epicId: factoryEpicId,
             callbacks,
+            seedOfferProvider,
           }),
       );
       return {

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/delta-seed-reattach.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/delta-seed-reattach.test.ts
@@ -1,0 +1,418 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import type { EpicStreamCallbacks } from "@traycer-clients/shared/host-transport/epic-stream-client";
+import type { SnapshotMetaEpic } from "@traycer/protocol/host/epic/snapshot-meta";
+import type { EpicSubscribeClientSeedOffer } from "@traycer/protocol/host/epic/subscribe";
+import {
+  createOpenEpicStore,
+  type EpicStreamClientFactory,
+} from "@/stores/epics/open-epic/store";
+
+/**
+ * `epic.subscribe@1.3` delta-seeded reattach - gui-app store side.
+ *
+ * `doc` (the local replica) always merges via `Y.applyUpdate`, so it is safe
+ * either way a snapshot is routed. `hostCoverageDoc` is the dangerous one: a
+ * FULL snapshot rebuilds it from scratch (safe - full snapshots are
+ * self-sufficient), but a DELTA deliberately omits everything the host knows
+ * this client already had, so routing a delta to the rebuild arm would
+ * silently collapse coverage down to the handful of bytes that changed. This
+ * suite is the seam `applyRootSeedToHostCoverage` protects.
+ */
+
+interface FakeStreamHandle {
+  readonly callbacks: EpicStreamCallbacks;
+  readonly seedOfferProvider: () => EpicSubscribeClientSeedOffer | null;
+}
+
+function fakeFactory(): {
+  factory: EpicStreamClientFactory;
+  handle: () => FakeStreamHandle;
+} {
+  let current: FakeStreamHandle | null = null;
+  const factory: EpicStreamClientFactory = (
+    _epicId,
+    callbacks,
+    seedOfferProvider,
+  ) => {
+    current = { callbacks, seedOfferProvider };
+    return {
+      applyUpdate: () => {},
+      awareness: () => {},
+      applyArtifactRoomUpdate: () => {},
+      artifactRoomAwareness: () => {},
+      retryMigration: () => {},
+      close: () => {},
+    };
+  };
+  return {
+    factory,
+    handle: () => {
+      if (current === null) throw new Error("factory not invoked");
+      return current;
+    },
+  };
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function stateVectorBase64(doc: Y.Doc): string {
+  return encodeBase64(Y.encodeStateVector(doc));
+}
+
+function decodeBase64(base64: string): Uint8Array {
+  return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+}
+
+function buildMeta(options: {
+  readonly role: "owner" | "editor" | "viewer";
+  readonly hostDoc: Y.Doc;
+  readonly roomId?: string;
+  readonly seededFromOffer?: true;
+}): SnapshotMetaEpic {
+  return {
+    schemaVersion: "1.0",
+    epicLight: {
+      id: "epic-a",
+      title: "Epic A",
+      initialUserPrompt: "",
+      ticketCount: 0,
+      specCount: 0,
+      storyCount: 0,
+      reviewCount: 0,
+      status: "open",
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: "u",
+      version: "1",
+    },
+    permissionRole: options.role,
+    repos: [],
+    workspaces: [],
+    repoMapping: [],
+    workspaceFolders: [],
+    unresolvedRepos: [],
+    hostStateVectorBase64: stateVectorBase64(options.hostDoc),
+    roomId: options.roomId,
+    seededFromOffer: options.seededFromOffer,
+  };
+}
+
+/** `[0, 0]` is Yjs's encoding for "no update needed" - full convergence. */
+const EMPTY_UPDATE_BYTES = [0, 0];
+
+describe("epic.subscribe@1.3 delta-seeded reattach - hostCoverageDoc merge safety", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("merges a delta into hostCoverageDoc instead of rebuilding - coverage keeps content from BOTH cycles", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    // Cycle 1: a full snapshot seeding content X.
+    const originDoc = new Y.Doc();
+    originDoc.getMap("epic").set("x", "content-x");
+    const fullSnapshotBytes = Y.encodeStateAsUpdate(originDoc);
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc: originDoc, roomId: "room-1" }),
+      fullSnapshotBytes,
+    );
+
+    const offerAfterFull = handle().seedOfferProvider();
+    expect(offerAfterFull).not.toBeNull();
+    if (offerAfterFull === null) throw new Error("expected an offer");
+
+    // Cycle 2: the host adds content Y and answers a reattach with a DELTA
+    // computed against the offer above - exactly what the real resolver does
+    // (`encodeRootSeed` in `epic-stream-resolver.ts`).
+    originDoc.getMap("epic").set("y", "content-y");
+    const deltaBytes = Y.encodeStateAsUpdate(
+      originDoc,
+      decodeBase64(offerAfterFull.stateVectorBase64),
+    );
+    handle().callbacks.onSnapshot(
+      buildMeta({
+        role: "editor",
+        hostDoc: originDoc,
+        roomId: "room-1",
+        seededFromOffer: true,
+      }),
+      deltaBytes,
+    );
+
+    // Prove coverage holds BOTH X and Y: diffing the true origin doc against
+    // the NEW offer's state vector must be the empty update. If the delta had
+    // instead been routed to the rebuild arm, coverage would only reflect Y
+    // (or nothing X-related would have integrated at all, since the delta's
+    // clock range for `originDoc`'s clientID has no predecessor in a fresh
+    // doc), and this diff would come back non-empty.
+    const offerAfterDelta = handle().seedOfferProvider();
+    expect(offerAfterDelta).not.toBeNull();
+    if (offerAfterDelta === null) throw new Error("expected an offer");
+    const remainder = Y.encodeStateAsUpdate(
+      originDoc,
+      decodeBase64(offerAfterDelta.stateVectorBase64),
+    );
+    expect(Array.from(remainder)).toEqual(EMPTY_UPDATE_BYTES);
+
+    opened.dispose();
+  });
+
+  it("the seed offer is null before any snapshot has landed (cold open sends no offer)", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    expect(handle().seedOfferProvider()).toBeNull();
+
+    opened.dispose();
+  });
+
+  it("after a full snapshot carrying a roomId, the offer is non-null and carries that exact roomId", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    const hostDoc = new Y.Doc();
+    hostDoc.getMap("epic").set("title", "hello");
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc, roomId: "room-xyz" }),
+      Y.encodeStateAsUpdate(hostDoc),
+    );
+
+    const offer = handle().seedOfferProvider();
+    expect(offer).not.toBeNull();
+    expect(offer?.roomId).toBe("room-xyz");
+
+    opened.dispose();
+  });
+
+  it("a snapshot whose meta.roomId is absent (a pre-@1.2 host) leaves the offer null", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    const hostDoc = new Y.Doc();
+    hostDoc.getMap("epic").set("title", "hello");
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc }),
+      Y.encodeStateAsUpdate(hostDoc),
+    );
+
+    expect(handle().seedOfferProvider()).toBeNull();
+
+    opened.dispose();
+  });
+
+  it("after a replica reset (requestFreshSnapshot), the offer returns to null", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    const hostDoc = new Y.Doc();
+    hostDoc.getMap("epic").set("title", "hello");
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc, roomId: "room-xyz" }),
+      Y.encodeStateAsUpdate(hostDoc),
+    );
+    expect(handle().seedOfferProvider()).not.toBeNull();
+
+    opened.requestFreshSnapshot();
+
+    expect(handle().seedOfferProvider()).toBeNull();
+
+    opened.dispose();
+  });
+});
+
+describe("epic.subscribe@1.3 delta-seeded reattach - hostCoverageDoc doc-identity generation guard", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("18) a delta whose basis doc was replaced mid-flight (permission-loss race) is NOT merged, and the offer goes null", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    const originDoc = new Y.Doc();
+    originDoc.getMap("epic").set("x", "content-x");
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc: originDoc, roomId: "room-1" }),
+      Y.encodeStateAsUpdate(originDoc),
+    );
+
+    // Read the offer - this is the request the eventual delta will race
+    // against.
+    const offer = handle().seedOfferProvider();
+    expect(offer).not.toBeNull();
+    if (offer === null) throw new Error("expected an offer");
+
+    // The reply's round trip loses: permission is revoked before the delta
+    // lands, which replaces (not merges into) hostCoverageDoc.
+    handle().callbacks.onPermissionChanged(null);
+
+    // The delta arrives late, computed against the NOW-DISCARDED doc.
+    originDoc.getMap("epic").set("y", "content-y");
+    const staleDeltaBytes = Y.encodeStateAsUpdate(
+      originDoc,
+      decodeBase64(offer.stateVectorBase64),
+    );
+    handle().callbacks.onSnapshot(
+      buildMeta({
+        role: "editor",
+        hostDoc: originDoc,
+        roomId: "room-1",
+        seededFromOffer: true,
+      }),
+      staleDeltaBytes,
+    );
+
+    // If the guard had not fired, this merge would have set a roomId (and
+    // corrupted the empty post-revocation doc). No offer means no room id
+    // was taken - the merge was skipped.
+    expect(handle().seedOfferProvider()).toBeNull();
+
+    opened.dispose();
+  });
+
+  it("19) the control for 18 - no intervening replacement, the delta DOES merge", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    const originDoc = new Y.Doc();
+    originDoc.getMap("epic").set("x", "content-x");
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc: originDoc, roomId: "room-1" }),
+      Y.encodeStateAsUpdate(originDoc),
+    );
+
+    const offer = handle().seedOfferProvider();
+    expect(offer).not.toBeNull();
+    if (offer === null) throw new Error("expected an offer");
+
+    originDoc.getMap("epic").set("y", "content-y");
+    const deltaBytes = Y.encodeStateAsUpdate(
+      originDoc,
+      decodeBase64(offer.stateVectorBase64),
+    );
+    handle().callbacks.onSnapshot(
+      buildMeta({
+        role: "editor",
+        hostDoc: originDoc,
+        roomId: "room-1",
+        seededFromOffer: true,
+      }),
+      deltaBytes,
+    );
+
+    // Merge succeeded: coverage now reflects BOTH x and y, proven the same
+    // way as the base safety test - diffing the true origin doc against the
+    // new offer's vector comes back empty.
+    const offerAfterDelta = handle().seedOfferProvider();
+    expect(offerAfterDelta).not.toBeNull();
+    if (offerAfterDelta === null) throw new Error("expected an offer");
+    const remainder = Y.encodeStateAsUpdate(
+      originDoc,
+      decodeBase64(offerAfterDelta.stateVectorBase64),
+    );
+    expect(Array.from(remainder)).toEqual(EMPTY_UPDATE_BYTES);
+
+    opened.dispose();
+  });
+
+  it("20) coverage advancing via an ordinary update while an offer is outstanding is NOT treated as staleness - the later delta still merges", () => {
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    const originDoc = new Y.Doc();
+    originDoc.getMap("epic").set("x", "content-x");
+    handle().callbacks.onSnapshot(
+      buildMeta({ role: "editor", hostDoc: originDoc, roomId: "room-1" }),
+      Y.encodeStateAsUpdate(originDoc),
+    );
+
+    const offer = handle().seedOfferProvider();
+    expect(offer).not.toBeNull();
+    if (offer === null) throw new Error("expected an offer");
+    const svAfterFullSnapshot = decodeBase64(offer.stateVectorBase64);
+
+    // Ordinary forward movement: an `onUpdate` frame merges into coverage
+    // via `Y.applyUpdate` directly - it must NOT bump the generation, since
+    // this is the same doc, just further along.
+    originDoc.getMap("epic").set("y", "content-y");
+    const ordinaryUpdateBytes = Y.encodeStateAsUpdate(
+      originDoc,
+      svAfterFullSnapshot,
+    );
+    handle().callbacks.onUpdate(ordinaryUpdateBytes);
+
+    // A late delta computed against the ORIGINAL offer (predating y) still
+    // arrives and must still merge - it is a superset of what coverage
+    // needs, and coverage moving forward under an in-flight offer is the
+    // harmless direction the guard deliberately does not reject.
+    originDoc.getMap("epic").set("z", "content-z");
+    const deltaBytes = Y.encodeStateAsUpdate(originDoc, svAfterFullSnapshot);
+    handle().callbacks.onSnapshot(
+      buildMeta({
+        role: "editor",
+        hostDoc: originDoc,
+        roomId: "room-1",
+        seededFromOffer: true,
+      }),
+      deltaBytes,
+    );
+
+    // Coverage must now hold x, y AND z - proof the delta was not silently
+    // dropped by a guard that (wrongly) treated forward movement as
+    // staleness.
+    const offerAfterDelta = handle().seedOfferProvider();
+    expect(offerAfterDelta).not.toBeNull();
+    if (offerAfterDelta === null) throw new Error("expected an offer");
+    const remainder = Y.encodeStateAsUpdate(
+      originDoc,
+      decodeBase64(offerAfterDelta.stateVectorBase64),
+    );
+    expect(Array.from(remainder)).toEqual(EMPTY_UPDATE_BYTES);
+
+    opened.dispose();
+  });
+});

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -17,6 +17,7 @@ import type {
 } from "@traycer/protocol/host/epic/chat-records";
 import type { ChatRecordDelta } from "@traycer-clients/shared/host-transport/chat-records-stream-client";
 import type { SnapshotMetaEpic } from "@traycer/protocol/host/epic/snapshot-meta";
+import type { EpicSubscribeClientSeedOffer } from "@traycer/protocol/host/epic/subscribe";
 import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
 import type {
   StreamCloseReason,
@@ -83,6 +84,13 @@ import { appLogger } from "@/lib/logger";
 export type EpicStreamClientFactory = (
   epicId: string,
   callbacks: EpicStreamCallbacks,
+  /**
+   * Reports the host-originated root state this store already holds, so a
+   * reattach is served as a delta instead of the whole document. Passed
+   * straight through to `EpicStreamClient`, which re-reads it before every
+   * wire subscribe — so it must stay a live read, never a captured value.
+   */
+  seedOfferProvider: () => EpicSubscribeClientSeedOffer | null,
 ) => Pick<
   EpicStreamClient,
   | "applyUpdate"
@@ -827,6 +835,63 @@ export function createOpenEpicStore(
   let doc = new Y.Doc();
   let awareness = new Awareness(doc);
   let hostCoverageDoc = new Y.Doc();
+  /**
+   * The room {@link hostCoverageDoc}'s contents came from, or `null` when it
+   * holds nothing attributable to a room — a fresh store, a replica reset, or
+   * state seeded by a pre-`@1.2` host that never reported a `roomId`.
+   *
+   * Gates the reattach seed offer: without a room name there is nothing safe
+   * to offer, because a major migration mints a NEW room for the same
+   * `epicId` and a host diffing against the wrong room's state would omit
+   * bytes this client genuinely lacks.
+   */
+  let hostCoverageRoomId: string | null = null;
+  /**
+   * Bumped every time {@link hostCoverageDoc} is REPLACED (never when it is
+   * merged into). Identifies the doc instance a seed offer was taken from, so
+   * a delta can be checked against the doc it was actually diffed against
+   * rather than against whatever `hostCoverageDoc` happens to name when the
+   * reply lands.
+   *
+   * Needed because doc identity is not carried on the wire: the offer says
+   * "here is my state vector" and the reply says "this is a delta", and
+   * nothing in that pair names the doc. Between the two lies a network round
+   * trip in which the store may have thrown the doc away.
+   *
+   * DO NOT MAKE THIS BUMP ON EVERY UPDATE. A counter sitting beside a Y.Doc
+   * looks like it should track every change, and tightening it that way would
+   * silently disable delta-seed for any actively-syncing epic — every offer
+   * would be invalidated by the next inbound update before its reply landed,
+   * every reattach would fall back to the full document, and every test would
+   * stay green. `applyRootSeedToHostCoverage`'s "forward movement still
+   * merges" test exists to catch exactly that edit.
+   *
+   * The reason only replacement counts is an asymmetry in Yjs itself: a delta
+   * computed against an OLDER state vector is a SUPERSET of what the doc still
+   * needs, and applying it is idempotent. So coverage moving FORWARD under an
+   * in-flight offer is harmless — ordinary updates, and even a resolver
+   * re-emitting a second delta against the original offer (`retryMigration`
+   * re-runs the host's `initialize()` without re-reading params), all converge.
+   * REPLACEMENT is the only thing that destroys the basis the host diffed
+   * against, so replacement is the only thing that invalidates an offer.
+   *
+   * This guard is the WHOLE protection, deliberately. Two of the three paths
+   * that replace coverage happen to be safe without it — `requestFreshSnapshot`
+   * runs synchronously and ends by bumping `streamGeneration`, so its stale
+   * frames are dropped; a room migration cannot produce a delta at all, since
+   * the host rejects an offer naming a different room. Neither of those is a
+   * declared property: the first survives only until someone makes a step in
+   * that block async, and nothing anywhere pins it. Do not restore either as
+   * the reason this is safe. The third path — `onPermissionChanged(null)`,
+   * which clears coverage WITHOUT ending the stream cycle — was never covered
+   * by them at all.
+   */
+  let hostCoverageGeneration = 0;
+  /**
+   * The value of {@link hostCoverageGeneration} at the moment the live seed
+   * offer was read, or `null` when no offer is outstanding.
+   */
+  let offeredCoverageGeneration: number | null = null;
 
   // In-flight `readAttachmentBytes` waits. Held here (not per call) so a replica
   // swap can re-point each one at the live doc's attachments map instead of
@@ -1829,7 +1894,121 @@ export function createOpenEpicStore(
     if (snapshotBytes !== null) {
       Y.applyUpdate(hostCoverageDoc, snapshotBytes);
     }
+    // Whatever room the discarded doc represented, the replacement does not
+    // represent it: callers either reset coverage to empty or rebase it onto a
+    // full snapshot whose room only `applyRootSeedToHostCoverage` knows. Left
+    // stale, this would offer a new room's state under the old room's name.
+    hostCoverageRoomId = null;
+    // The doc any outstanding offer was taken from no longer exists, so a
+    // delta computed against it can no longer be applied anywhere.
+    hostCoverageGeneration += 1;
     previous.destroy();
+  };
+
+  /**
+   * Folds this cycle's root payload into {@link hostCoverageDoc} and records
+   * the room it came from.
+   *
+   * THE SEAM THE `seededFromOffer` FLAG EXISTS FOR. A full snapshot is
+   * self-sufficient, so coverage is rebuilt from it — that is what
+   * {@link replaceHostCoverageDoc} does and what every pre-`@1.3` cycle did. A
+   * DELTA is not self-sufficient: it deliberately omits everything the host
+   * knew this client already had, so rebuilding a fresh doc from it would
+   * discard exactly the state the delta was computed to leave out, silently
+   * collapsing coverage to the handful of bytes that changed. It must be
+   * merged into the existing doc instead.
+   *
+   * WHY THE REBUILD ARM STILL EXISTS — and it is NOT to bound growth.
+   *
+   * Merging deltas forever does not make this doc grow. Yjs integrates
+   * operations into a struct store keyed by client and clock; it does not
+   * append the update messages that delivered them. So the encoded size is a
+   * function of the document's operation set, not of how many merges built it.
+   * Measured: 50 reattach cycles merging deltas produce a byte-IDENTICAL doc
+   * to rebuilding from a full snapshot each cycle (ratio 1.000000), and with
+   * deletions, in-place edits and redundant full-snapshot re-delivery mixed in,
+   * 1.000108 — 78 bytes on 722 KB of fragmentation noise, with identical
+   * content and identical state vectors. A client that reattaches fifty times
+   * on a flaky link therefore needs no periodic re-baseline, and none is
+   * armed.
+   *
+   * The rebuild arm earns its place on CORRECTNESS instead: a full snapshot
+   * may come from a DIFFERENT ROOM. A major migration mints a new room for the
+   * same `epicId`, and merging its snapshot into coverage built from the old
+   * room would union two logically different documents. Discarding the old doc
+   * is the only correct handling, and the arms line up with that by
+   * construction — a room change makes the host reject the offer
+   * (`offer.roomId !== storage.getRoomId()`), so it answers with a full
+   * snapshot and no `seededFromOffer`, which lands here on exactly the rebuild
+   * arm that drops the stale room.
+   */
+  const applyRootSeedToHostCoverage = (
+    meta: SnapshotMetaEpic,
+    snapshotBytes: Uint8Array,
+  ): void => {
+    if (meta.seededFromOffer !== true) {
+      replaceHostCoverageDoc(snapshotBytes);
+      hostCoverageRoomId = meta.roomId ?? null;
+      offeredCoverageGeneration = null;
+      return;
+    }
+    // A delta, so it is only meaningful against the doc whose state vector was
+    // offered. If that doc has been replaced since (permission loss clears
+    // coverage without ending the stream cycle), merging here would fold a
+    // diff into a doc it was never computed against, and the result would
+    // silently hold only the bytes that changed.
+    //
+    // Leave coverage untouched in that case, and take no room id — so no
+    // further offer is made until a full snapshot re-establishes a basis. The
+    // replica still receives these bytes at the call site, so the user's view
+    // is unaffected; only host-coverage precision degrades, and it degrades by
+    // UNDER-stating what the host has. That is the safe direction: coverage is
+    // read to decide whether local work is durable, and over-reporting dirty
+    // work costs a redundant reconcile, while under-reporting it would claim
+    // unsynced edits are safe.
+    if (offeredCoverageGeneration !== hostCoverageGeneration) {
+      offeredCoverageGeneration = null;
+      return;
+    }
+    Y.applyUpdate(hostCoverageDoc, snapshotBytes);
+    hostCoverageRoomId = meta.roomId ?? null;
+    offeredCoverageGeneration = null;
+  };
+
+  /**
+   * The reattach offer: what this client has already received from the host,
+   * so the host can answer a resubscribe with only what changed.
+   *
+   * Read live at every wire subscribe, including reconnects — never cached.
+   *
+   * Offers {@link hostCoverageDoc}'s state vector rather than the local
+   * replica's, and the distinction is load-bearing rather than stylistic.
+   * `doc` additionally holds local edits the host may not have accepted yet;
+   * naming those in the offer would tell the host "I already have this", and
+   * the delta it computed would omit the host's own copy of anything it had
+   * in fact accepted and not echoed back. The replica would still converge —
+   * it holds those bytes locally — but `hostCoverageDoc` would not, leaving
+   * host coverage understated and the sync pill claiming unsynced work that
+   * is actually durable. Coverage is precisely "what the host has sent me",
+   * which is exactly the question a seed offer asks.
+   *
+   * `doc ⊇ hostCoverageDoc` always (both receive every snapshot and update;
+   * only `doc` also receives local edits), so a delta computed against
+   * coverage is a superset of what the replica needs and applying it to both
+   * converges.
+   */
+  const readSeedOffer = (): EpicSubscribeClientSeedOffer | null => {
+    if (hostCoverageRoomId === null) {
+      offeredCoverageGeneration = null;
+      return null;
+    }
+    // Record WHICH doc this vector describes, so the reply can be checked
+    // against it rather than against whatever `hostCoverageDoc` names by then.
+    offeredCoverageGeneration = hostCoverageGeneration;
+    return {
+      stateVectorBase64: encodeDocStateVectorBase64(hostCoverageDoc),
+      roomId: hostCoverageRoomId,
+    };
   };
 
   bindCurrentReplica();
@@ -2006,8 +2185,13 @@ export function createOpenEpicStore(
               // deterministic full re-project below.
               projector.suspend();
               try {
+                // The replica merges either way: a delta and a full snapshot
+                // are both just updates to apply here, and `doc` is never
+                // rebuilt on this path. It is host COVERAGE that has a
+                // rebuild-vs-merge decision, and it is the one that would lose
+                // state if a delta reached the rebuild arm.
                 Y.applyUpdate(doc, snapshotBytes, STREAM_ORIGIN);
-                replaceHostCoverageDoc(snapshotBytes);
+                applyRootSeedToHostCoverage(meta, snapshotBytes);
               } finally {
                 projector.resume();
               }
@@ -2600,7 +2784,7 @@ export function createOpenEpicStore(
               if (nextStatus !== "open") return;
               emitCurrentAwareness(awareness, doc, client);
             },
-          });
+          }, readSeedOffer);
           streamClient = client;
         };
 

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -2177,614 +2177,632 @@ export function createOpenEpicStore(
           hasFreshRootSnapshotForOpenCycle = false;
 
           let client: OpenEpicStreamClient | null = null;
-          client = options.streamClientFactory(epicId, {
-            onSnapshot: (meta, snapshotBytes) => {
-              if (disposed || generation !== streamGeneration) return;
-              // Suspend projector so the per-event observeDeep storm
-              // triggered by `Y.applyUpdate` does not race with the
-              // deterministic full re-project below.
-              projector.suspend();
-              try {
-                // The replica merges either way: a delta and a full snapshot
-                // are both just updates to apply here, and `doc` is never
-                // rebuilt on this path. It is host COVERAGE that has a
-                // rebuild-vs-merge decision, and it is the one that would lose
-                // state if a delta reached the rebuild arm.
-                Y.applyUpdate(doc, snapshotBytes, STREAM_ORIGIN);
-                applyRootSeedToHostCoverage(meta, snapshotBytes);
-              } finally {
-                projector.resume();
-              }
-              const reconcileUpdate = Y.encodeStateAsUpdate(
-                doc,
-                decodeBase64(meta.hostStateVectorBase64),
-              );
-              const dirtyState = resolvePublicDirtyState(
-                get().dirtyWatermarkStateVectorBase64,
-                meta.hostStateVectorBase64,
-              );
-              // Only writable roles may push the reconcile delta back. A
-              // viewer's local doc carries no legitimate offline edits, and the
-              // delta vs `hostStateVectorBase64` can be non-trivial purely
-              // because the host re-encoded its snapshot and state vector at
-              // different instants on an actively-syncing room. Sending it as a
-              // viewer hits the host's guarded `applyCollabUpdate`, which
-              // refuses the mutate AND evicts the warm slot - tearing the room
-              // down mid-open. Mirror the same gate as `applyLocalUpdate`.
-              if (
-                isNonTrivialYUpdate(reconcileUpdate) &&
-                isWritablePermissionRole(meta.permissionRole)
-              ) {
-                client?.applyUpdate(reconcileUpdate);
-              }
-              clearUnsyncedQueue();
-              currentRole = meta.permissionRole;
-              hasFreshRootSnapshotForOpenCycle = true;
-              const slices = projector.projectFull();
-              set((state) => ({
-                snapshotMeta: meta,
-                permissionRole: meta.permissionRole,
-                accessLost:
-                  meta.permissionRole === null ? state.accessLost : false,
-                snapshotLoaded: true,
-                snapshotFetchError: null,
-                // The snapshot landing is the unambiguous "migration
-                // succeeded" signal - there is nothing further to render.
-                migration:
-                  state.migration.status === "idle"
-                    ? state.migration
-                    : IDLE_MIGRATION_SLICE,
-                ...dirtyState,
-                ...slices,
-                unsyncedQueueSize: 0,
-              }));
-              if (!isWritablePermissionRole(currentRole)) {
-                const hadArtifactRoomState =
-                  Object.keys(get().artifactRooms.stateByArtifactRoomId)
-                    .length > 0;
-                clearAllPendingArtifactRoomUpdates();
-                destroyAllArtifactRoomReplicas();
+          client = options.streamClientFactory(
+            epicId,
+            {
+              onSnapshot: (meta, snapshotBytes) => {
+                if (disposed || generation !== streamGeneration) return;
+                // Suspend projector so the per-event observeDeep storm
+                // triggered by `Y.applyUpdate` does not race with the
+                // deterministic full re-project below.
+                projector.suspend();
+                try {
+                  // The replica merges either way: a delta and a full snapshot
+                  // are both just updates to apply here, and `doc` is never
+                  // rebuilt on this path. It is host COVERAGE that has a
+                  // rebuild-vs-merge decision, and it is the one that would lose
+                  // state if a delta reached the rebuild arm.
+                  Y.applyUpdate(doc, snapshotBytes, STREAM_ORIGIN);
+                  applyRootSeedToHostCoverage(meta, snapshotBytes);
+                } finally {
+                  projector.resume();
+                }
+                const reconcileUpdate = Y.encodeStateAsUpdate(
+                  doc,
+                  decodeBase64(meta.hostStateVectorBase64),
+                );
+                const dirtyState = resolvePublicDirtyState(
+                  get().dirtyWatermarkStateVectorBase64,
+                  meta.hostStateVectorBase64,
+                );
+                // Only writable roles may push the reconcile delta back. A
+                // viewer's local doc carries no legitimate offline edits, and the
+                // delta vs `hostStateVectorBase64` can be non-trivial purely
+                // because the host re-encoded its snapshot and state vector at
+                // different instants on an actively-syncing room. Sending it as a
+                // viewer hits the host's guarded `applyCollabUpdate`, which
+                // refuses the mutate AND evicts the warm slot - tearing the room
+                // down mid-open. Mirror the same gate as `applyLocalUpdate`.
+                if (
+                  isNonTrivialYUpdate(reconcileUpdate) &&
+                  isWritablePermissionRole(meta.permissionRole)
+                ) {
+                  client?.applyUpdate(reconcileUpdate);
+                }
+                clearUnsyncedQueue();
+                currentRole = meta.permissionRole;
+                hasFreshRootSnapshotForOpenCycle = true;
+                const slices = projector.projectFull();
+                set((state) => ({
+                  snapshotMeta: meta,
+                  permissionRole: meta.permissionRole,
+                  accessLost:
+                    meta.permissionRole === null ? state.accessLost : false,
+                  snapshotLoaded: true,
+                  snapshotFetchError: null,
+                  // The snapshot landing is the unambiguous "migration
+                  // succeeded" signal - there is nothing further to render.
+                  migration:
+                    state.migration.status === "idle"
+                      ? state.migration
+                      : IDLE_MIGRATION_SLICE,
+                  ...dirtyState,
+                  ...slices,
+                  unsyncedQueueSize: 0,
+                }));
+                if (!isWritablePermissionRole(currentRole)) {
+                  const hadArtifactRoomState =
+                    Object.keys(get().artifactRooms.stateByArtifactRoomId)
+                      .length > 0;
+                  clearAllPendingArtifactRoomUpdates();
+                  destroyAllArtifactRoomReplicas();
+                  set((state) => {
+                    const publicDirtyState = resolvePublicDirtyState(
+                      state.dirtyWatermarkStateVectorBase64,
+                      state.latestHostStateVectorBase64,
+                    );
+                    if (!hadArtifactRoomState) return publicDirtyState;
+                    return {
+                      bindingVersion: state.bindingVersion + 1,
+                      artifactRooms: EMPTY_ARTIFACT_ROOMS_SLICE,
+                      ...publicDirtyState,
+                    };
+                  });
+                  return;
+                }
+                if (transportStatus === "open") {
+                  flushAllPendingArtifactRoomUpdates();
+                }
+              },
+              onUpdate: (updateBytes) => {
+                if (disposed || generation !== streamGeneration) return;
+                Y.applyUpdate(doc, updateBytes, STREAM_ORIGIN);
+                Y.applyUpdate(hostCoverageDoc, updateBytes);
+                // Skip the expensive state-vector encode on the steady-stream
+                // clean-to-clean case: with no dirty watermark, coverage check
+                // is trivially satisfied and `latestHostStateVectorBase64`
+                // would only be consulted after the next local edit, at which
+                // point the next onUpdate path below will recompute it.
+                if (get().dirtyWatermarkStateVectorBase64 === null) return;
+                const latestHostStateVectorBase64 =
+                  encodeDocStateVectorBase64(hostCoverageDoc);
+                set((state) =>
+                  resolvePublicDirtyState(
+                    state.dirtyWatermarkStateVectorBase64,
+                    latestHostStateVectorBase64,
+                  ),
+                );
+              },
+              onEarlyMeta: (earlyMeta) => {
+                if (disposed || generation !== streamGeneration) return;
+                // Metadata-only frame from the host - populate snapshotMeta
+                // so workspace-derived UI (git status, file tree, sidebar
+                // repo chip, permission display) starts working before the
+                // full Y.Doc snapshot lands. Intentionally does NOT flip
+                // `snapshotLoaded` - canvas content still gates on the real
+                // `onSnapshot` callback.
+                //
+                // We do NOT update the closure-scoped `currentRole` here:
+                // that variable gates local writes (`applyLocalUpdate`,
+                // artifact-room `docUpdateHandler`). The early
+                // `permissionRole` is the host's projection of cloud
+                // `epic.permission.role`, which can disagree with the
+                // snapshot-derived role (which factors in team memberships
+                // via `derivePermissionRole`). Allowing early-meta to flip
+                // `currentRole` would fail-closed for a team-derived owner
+                // (writes silently dropped for ~8s) or fail-open for a
+                // stale-cached editor (writes go out but host rejects).
+                // Snapshot is authoritative - leave `currentRole` alone.
+                //
+                // The merged `snapshotMeta` uses placeholders for
+                // `schemaVersion` and `hostStateVectorBase64` since
+                // earlyMeta doesn't know them. Consumers must not read
+                // those two fields before `snapshotLoaded === true`.
+                const meta: SnapshotMetaEpic = {
+                  ...earlyMeta,
+                  schemaVersion: "",
+                  hostStateVectorBase64: "",
+                };
+                set((state) => ({
+                  snapshotMeta: meta,
+                  permissionRole: earlyMeta.permissionRole,
+                  // Mirror the snapshot's accessLost-clear semantics so a
+                  // role-restored reconnect doesn't leave the renderer in a
+                  // self-contradicting state (sidebar shows editor while the
+                  // session is still flagged access-lost for the access
+                  // coordinator).
+                  accessLost:
+                    earlyMeta.permissionRole === null
+                      ? state.accessLost
+                      : false,
+                }));
+              },
+              onAwareness: (awarenessBytes) => {
+                if (disposed || generation !== streamGeneration) return;
+                applyAwarenessUpdate(awareness, awarenessBytes, "remote");
+              },
+              onArtifactRoomSnapshot: (
+                artifactRoomId,
+                snapshotBytes,
+                hostArtifactRoomStateVectorBase64,
+              ) => {
+                if (disposed || generation !== streamGeneration) return;
+                // A room nobody is editing never materializes: keep the bytes
+                // and flip availability so the tile can render its state, and
+                // let the first lease pay for the `Y.Doc`. There is nothing to
+                // reconcile on this path - a cold room has no local edits by
+                // construction - so the whole reconcile/queue dance below is
+                // reachable only for rooms an editor is (or was) bound to.
+                if (
+                  !artifactRoomReplicas.has(artifactRoomId) &&
+                  !isArtifactRoomLeased(artifactRoomId)
+                ) {
+                  recordColdArtifactRoomBytes(
+                    artifactRoomId,
+                    snapshotBytes,
+                    hostArtifactRoomStateVectorBase64,
+                  );
+                  set((state) => ({
+                    artifactRooms: {
+                      stateByArtifactRoomId: {
+                        ...state.artifactRooms.stateByArtifactRoomId,
+                        [artifactRoomId]: "ready",
+                      },
+                    },
+                  }));
+                  return;
+                }
+                // Reuse any prior replica for this artifactRoom so a snapshot during
+                // reconnect/recovery does NOT destroy local in-flight
+                // edits. The host is now the merge source - its bytes
+                // get applied on top of the existing local replica, and
+                // dirty tracking drives a reconcile fan-out for any local
+                // edits the host has not yet seen.
+                const hadPrior = artifactRoomReplicas.has(artifactRoomId);
+                const entry = getOrCreateArtifactRoomReplica(artifactRoomId);
+                Y.applyUpdate(entry.doc, snapshotBytes, BIN_STREAM_ORIGIN);
+                entry.latestHostStateVectorBase64 =
+                  hostArtifactRoomStateVectorBase64;
+                // If the local replica is ahead of the host's snapshot,
+                // ship a reconcile update so offline edits round-trip.
+                const reconcileUpdate = Y.encodeStateAsUpdate(
+                  entry.doc,
+                  decodeBase64(hostArtifactRoomStateVectorBase64),
+                );
+                const reconcileNeeded = isNonTrivialYUpdate(reconcileUpdate);
+                const canSendNow = canSendArtifactRoomBodyWritesNow();
+                if (reconcileNeeded && canSendNow) {
+                  streamClient?.applyArtifactRoomUpdate(
+                    artifactRoomId,
+                    reconcileUpdate,
+                  );
+                  // Reconcile shipped: every local update is already
+                  // represented in the merged replica, so the single
+                  // reconcile subsumes both the queue and any prior
+                  // pending reconcile. Convergence is proven by the next
+                  // coverage check, not by replaying each queued frame.
+                  clearPendingRoomUpdates(entry);
+                  entry.pendingReconcileUpdate = null;
+                } else if (
+                  reconcileNeeded &&
+                  isWritablePermissionRole(currentRole)
+                ) {
+                  // Stream is reconnecting/closed, or raw-open before the
+                  // fresh root snapshot. Stash the reconcile so the root
+                  // snapshot permission gate can flush it later. Without this,
+                  // clearing `pendingUpdates` here would silently drop the only
+                  // outbound propagation path for local edits made during the
+                  // reconnect window. The merged-replica reconcile subsumes
+                  // those queued frames.
+                  entry.pendingReconcileUpdate = reconcileUpdate;
+                  clearPendingRoomUpdates(entry);
+                } else {
+                  // Either no divergence (reconcile is trivial) or the
+                  // role is viewer/null (fail-closed). In both cases
+                  // there is nothing safe to send and nothing to retain.
+                  clearPendingRoomUpdates(entry);
+                  entry.pendingReconcileUpdate = null;
+                }
+                if (
+                  latestHostCoversDirtyWatermark(
+                    hostArtifactRoomStateVectorBase64,
+                    entry.dirtyWatermarkStateVectorBase64,
+                  )
+                ) {
+                  entry.dirtyWatermarkStateVectorBase64 = null;
+                }
                 set((state) => {
-                  const publicDirtyState = resolvePublicDirtyState(
+                  const stateByArtifactRoomId = {
+                    ...state.artifactRooms.stateByArtifactRoomId,
+                    [artifactRoomId]: "ready" as EpicArtifactRoomAvailability,
+                  };
+                  const dirtyState = resolvePublicDirtyState(
                     state.dirtyWatermarkStateVectorBase64,
                     state.latestHostStateVectorBase64,
                   );
-                  if (!hadArtifactRoomState) return publicDirtyState;
                   return {
-                    bindingVersion: state.bindingVersion + 1,
-                    artifactRooms: EMPTY_ARTIFACT_ROOMS_SLICE,
-                    ...publicDirtyState,
+                    // Bumping bindingVersion only when the artifactRoom replica is
+                    // a fresh one - for an already-bound replica we keep
+                    // the editor mounted so user typing is uninterrupted.
+                    bindingVersion: hadPrior
+                      ? state.bindingVersion
+                      : state.bindingVersion + 1,
+                    artifactRooms: { stateByArtifactRoomId },
+                    ...dirtyState,
                   };
                 });
-                return;
-              }
-              if (transportStatus === "open") {
-                flushAllPendingArtifactRoomUpdates();
-              }
-            },
-            onUpdate: (updateBytes) => {
-              if (disposed || generation !== streamGeneration) return;
-              Y.applyUpdate(doc, updateBytes, STREAM_ORIGIN);
-              Y.applyUpdate(hostCoverageDoc, updateBytes);
-              // Skip the expensive state-vector encode on the steady-stream
-              // clean-to-clean case: with no dirty watermark, coverage check
-              // is trivially satisfied and `latestHostStateVectorBase64`
-              // would only be consulted after the next local edit, at which
-              // point the next onUpdate path below will recompute it.
-              if (get().dirtyWatermarkStateVectorBase64 === null) return;
-              const latestHostStateVectorBase64 =
-                encodeDocStateVectorBase64(hostCoverageDoc);
-              set((state) =>
-                resolvePublicDirtyState(
-                  state.dirtyWatermarkStateVectorBase64,
-                  latestHostStateVectorBase64,
-                ),
-              );
-            },
-            onEarlyMeta: (earlyMeta) => {
-              if (disposed || generation !== streamGeneration) return;
-              // Metadata-only frame from the host - populate snapshotMeta
-              // so workspace-derived UI (git status, file tree, sidebar
-              // repo chip, permission display) starts working before the
-              // full Y.Doc snapshot lands. Intentionally does NOT flip
-              // `snapshotLoaded` - canvas content still gates on the real
-              // `onSnapshot` callback.
-              //
-              // We do NOT update the closure-scoped `currentRole` here:
-              // that variable gates local writes (`applyLocalUpdate`,
-              // artifact-room `docUpdateHandler`). The early
-              // `permissionRole` is the host's projection of cloud
-              // `epic.permission.role`, which can disagree with the
-              // snapshot-derived role (which factors in team memberships
-              // via `derivePermissionRole`). Allowing early-meta to flip
-              // `currentRole` would fail-closed for a team-derived owner
-              // (writes silently dropped for ~8s) or fail-open for a
-              // stale-cached editor (writes go out but host rejects).
-              // Snapshot is authoritative - leave `currentRole` alone.
-              //
-              // The merged `snapshotMeta` uses placeholders for
-              // `schemaVersion` and `hostStateVectorBase64` since
-              // earlyMeta doesn't know them. Consumers must not read
-              // those two fields before `snapshotLoaded === true`.
-              const meta: SnapshotMetaEpic = {
-                ...earlyMeta,
-                schemaVersion: "",
-                hostStateVectorBase64: "",
-              };
-              set((state) => ({
-                snapshotMeta: meta,
-                permissionRole: earlyMeta.permissionRole,
-                // Mirror the snapshot's accessLost-clear semantics so a
-                // role-restored reconnect doesn't leave the renderer in a
-                // self-contradicting state (sidebar shows editor while the
-                // session is still flagged access-lost for the access
-                // coordinator).
-                accessLost:
-                  earlyMeta.permissionRole === null ? state.accessLost : false,
-              }));
-            },
-            onAwareness: (awarenessBytes) => {
-              if (disposed || generation !== streamGeneration) return;
-              applyAwarenessUpdate(awareness, awarenessBytes, "remote");
-            },
-            onArtifactRoomSnapshot: (
-              artifactRoomId,
-              snapshotBytes,
-              hostArtifactRoomStateVectorBase64,
-            ) => {
-              if (disposed || generation !== streamGeneration) return;
-              // A room nobody is editing never materializes: keep the bytes
-              // and flip availability so the tile can render its state, and
-              // let the first lease pay for the `Y.Doc`. There is nothing to
-              // reconcile on this path - a cold room has no local edits by
-              // construction - so the whole reconcile/queue dance below is
-              // reachable only for rooms an editor is (or was) bound to.
-              if (
-                !artifactRoomReplicas.has(artifactRoomId) &&
-                !isArtifactRoomLeased(artifactRoomId)
-              ) {
-                recordColdArtifactRoomBytes(
-                  artifactRoomId,
-                  snapshotBytes,
-                  hostArtifactRoomStateVectorBase64,
-                );
-                set((state) => ({
-                  artifactRooms: {
-                    stateByArtifactRoomId: {
-                      ...state.artifactRooms.stateByArtifactRoomId,
-                      [artifactRoomId]: "ready",
-                    },
-                  },
-                }));
-                return;
-              }
-              // Reuse any prior replica for this artifactRoom so a snapshot during
-              // reconnect/recovery does NOT destroy local in-flight
-              // edits. The host is now the merge source - its bytes
-              // get applied on top of the existing local replica, and
-              // dirty tracking drives a reconcile fan-out for any local
-              // edits the host has not yet seen.
-              const hadPrior = artifactRoomReplicas.has(artifactRoomId);
-              const entry = getOrCreateArtifactRoomReplica(artifactRoomId);
-              Y.applyUpdate(entry.doc, snapshotBytes, BIN_STREAM_ORIGIN);
-              entry.latestHostStateVectorBase64 =
-                hostArtifactRoomStateVectorBase64;
-              // If the local replica is ahead of the host's snapshot,
-              // ship a reconcile update so offline edits round-trip.
-              const reconcileUpdate = Y.encodeStateAsUpdate(
-                entry.doc,
-                decodeBase64(hostArtifactRoomStateVectorBase64),
-              );
-              const reconcileNeeded = isNonTrivialYUpdate(reconcileUpdate);
-              const canSendNow = canSendArtifactRoomBodyWritesNow();
-              if (reconcileNeeded && canSendNow) {
-                streamClient?.applyArtifactRoomUpdate(
-                  artifactRoomId,
-                  reconcileUpdate,
-                );
-                // Reconcile shipped: every local update is already
-                // represented in the merged replica, so the single
-                // reconcile subsumes both the queue and any prior
-                // pending reconcile. Convergence is proven by the next
-                // coverage check, not by replaying each queued frame.
-                clearPendingRoomUpdates(entry);
-                entry.pendingReconcileUpdate = null;
-              } else if (
-                reconcileNeeded &&
-                isWritablePermissionRole(currentRole)
-              ) {
-                // Stream is reconnecting/closed, or raw-open before the
-                // fresh root snapshot. Stash the reconcile so the root
-                // snapshot permission gate can flush it later. Without this,
-                // clearing `pendingUpdates` here would silently drop the only
-                // outbound propagation path for local edits made during the
-                // reconnect window. The merged-replica reconcile subsumes
-                // those queued frames.
-                entry.pendingReconcileUpdate = reconcileUpdate;
-                clearPendingRoomUpdates(entry);
-              } else {
-                // Either no divergence (reconcile is trivial) or the
-                // role is viewer/null (fail-closed). In both cases
-                // there is nothing safe to send and nothing to retain.
-                clearPendingRoomUpdates(entry);
-                entry.pendingReconcileUpdate = null;
-              }
-              if (
-                latestHostCoversDirtyWatermark(
-                  hostArtifactRoomStateVectorBase64,
-                  entry.dirtyWatermarkStateVectorBase64,
-                )
-              ) {
-                entry.dirtyWatermarkStateVectorBase64 = null;
-              }
-              set((state) => {
-                const stateByArtifactRoomId = {
-                  ...state.artifactRooms.stateByArtifactRoomId,
-                  [artifactRoomId]: "ready" as EpicArtifactRoomAvailability,
-                };
-                const dirtyState = resolvePublicDirtyState(
-                  state.dirtyWatermarkStateVectorBase64,
-                  state.latestHostStateVectorBase64,
-                );
-                return {
-                  // Bumping bindingVersion only when the artifactRoom replica is
-                  // a fresh one - for an already-bound replica we keep
-                  // the editor mounted so user typing is uninterrupted.
-                  bindingVersion: hadPrior
-                    ? state.bindingVersion
-                    : state.bindingVersion + 1,
-                  artifactRooms: { stateByArtifactRoomId },
-                  ...dirtyState,
-                };
-              });
-              // The snapshot may have been what cleared this replica's last
-              // local divergence, so re-test the linger arm here: without it a
-              // room whose editor closed while it was still dirty would stay
-              // materialized for the rest of the session.
-              scheduleArtifactRoomCooldown(artifactRoomId);
-            },
-            onArtifactRoomUpdate: (
-              artifactRoomId,
-              updateBytes,
-              hostArtifactRoomStateVectorBase64,
-            ) => {
-              if (disposed || generation !== streamGeneration) return;
-              const entry = artifactRoomReplicas.get(artifactRoomId);
-              if (entry === undefined) {
-                // Cold room: accumulate the bytes rather than materializing a
-                // doc for a body nothing is displaying. An unknown room is
-                // still skipped - `recordColdArtifactRoomBytes` only extends
-                // rooms the host has already snapshotted.
-                const cold = coldArtifactRooms.get(artifactRoomId);
-                if (cold === undefined) return;
-                pushColdArtifactRoomUpdate(cold, updateBytes);
-                cold.latestHostStateVectorBase64 =
+                // The snapshot may have been what cleared this replica's last
+                // local divergence, so re-test the linger arm here: without it a
+                // room whose editor closed while it was still dirty would stay
+                // materialized for the rest of the session.
+                scheduleArtifactRoomCooldown(artifactRoomId);
+              },
+              onArtifactRoomUpdate: (
+                artifactRoomId,
+                updateBytes,
+                hostArtifactRoomStateVectorBase64,
+              ) => {
+                if (disposed || generation !== streamGeneration) return;
+                const entry = artifactRoomReplicas.get(artifactRoomId);
+                if (entry === undefined) {
+                  // Cold room: accumulate the bytes rather than materializing a
+                  // doc for a body nothing is displaying. An unknown room is
+                  // still skipped - `recordColdArtifactRoomBytes` only extends
+                  // rooms the host has already snapshotted.
+                  const cold = coldArtifactRooms.get(artifactRoomId);
+                  if (cold === undefined) return;
+                  pushColdArtifactRoomUpdate(cold, updateBytes);
+                  cold.latestHostStateVectorBase64 =
+                    hostArtifactRoomStateVectorBase64;
+                  return;
+                }
+                Y.applyUpdate(entry.doc, updateBytes, BIN_STREAM_ORIGIN);
+                entry.latestHostStateVectorBase64 =
                   hostArtifactRoomStateVectorBase64;
-                return;
-              }
-              Y.applyUpdate(entry.doc, updateBytes, BIN_STREAM_ORIGIN);
-              entry.latestHostStateVectorBase64 =
-                hostArtifactRoomStateVectorBase64;
-              if (
-                latestHostCoversDirtyWatermark(
-                  hostArtifactRoomStateVectorBase64,
-                  entry.dirtyWatermarkStateVectorBase64,
-                )
-              ) {
-                entry.dirtyWatermarkStateVectorBase64 = null;
-              }
-              refreshPublicDirtyState?.();
-              scheduleArtifactRoomCooldown(artifactRoomId);
-            },
-            onArtifactRoomAwareness: (artifactRoomId, awarenessBytes) => {
-              if (disposed || generation !== streamGeneration) return;
-              // Apply inbound awareness to the artifact-room-scoped Awareness
-              // instance, NOT the root Epic awareness. CollaborationCaret
-              // bindings on artifact-room-doc fragments listen on this instance, so
-              // routing them through the root awareness would mis-attribute
-              // cursors and lose the per-artifact-room presence channel.
-              const entry = artifactRoomReplicas.get(artifactRoomId);
-              if (entry === undefined) {
-                // Cold room: retain the frame rather than dropping it. Without
-                // this a collaborator already present in a room this client
-                // has never opened stays invisible until their next renewal.
-                recordColdArtifactRoomAwareness(artifactRoomId, awarenessBytes);
-                return;
-              }
-              applyAwarenessUpdate(
-                entry.awareness,
-                awarenessBytes,
-                BIN_AWARENESS_REMOTE_ORIGIN,
-              );
-              // A peer leaving can drop the presence pin that was holding this
-              // room hot, so re-test it here rather than waiting for a doc
-              // frame that may never come.
-              scheduleArtifactRoomCooldown(artifactRoomId);
-            },
-            onArtifactRoomState: (artifactRoomId, nextState) => {
-              if (disposed || generation !== streamGeneration) return;
-              if (nextState !== "ready") {
-                // A artifactRoom transitioning out of `ready` invalidates the
-                // local replica - the next `artifactRoomSnapshot` will rebuild.
-                // The cold copy is invalidated with it; leases survive, so a
-                // mounted editor re-materializes from that next snapshot.
-                cancelArtifactRoomCooldown(artifactRoomId);
-                coldArtifactRooms.delete(artifactRoomId);
-                artifactRoomTouchSeq.delete(artifactRoomId);
-                destroyArtifactRoomReplica(artifactRoomId);
-              }
-              set((prev) => {
-                const current =
-                  prev.artifactRooms.stateByArtifactRoomId[artifactRoomId];
-                if (current === nextState) return prev;
-                const stateByArtifactRoomId = {
-                  ...prev.artifactRooms.stateByArtifactRoomId,
-                  [artifactRoomId]: nextState,
-                };
-                const dirtyState = resolvePublicDirtyState(
-                  prev.dirtyWatermarkStateVectorBase64,
-                  prev.latestHostStateVectorBase64,
+                if (
+                  latestHostCoversDirtyWatermark(
+                    hostArtifactRoomStateVectorBase64,
+                    entry.dirtyWatermarkStateVectorBase64,
+                  )
+                ) {
+                  entry.dirtyWatermarkStateVectorBase64 = null;
+                }
+                refreshPublicDirtyState?.();
+                scheduleArtifactRoomCooldown(artifactRoomId);
+              },
+              onArtifactRoomAwareness: (artifactRoomId, awarenessBytes) => {
+                if (disposed || generation !== streamGeneration) return;
+                // Apply inbound awareness to the artifact-room-scoped Awareness
+                // instance, NOT the root Epic awareness. CollaborationCaret
+                // bindings on artifact-room-doc fragments listen on this instance, so
+                // routing them through the root awareness would mis-attribute
+                // cursors and lose the per-artifact-room presence channel.
+                const entry = artifactRoomReplicas.get(artifactRoomId);
+                if (entry === undefined) {
+                  // Cold room: retain the frame rather than dropping it. Without
+                  // this a collaborator already present in a room this client
+                  // has never opened stays invisible until their next renewal.
+                  recordColdArtifactRoomAwareness(
+                    artifactRoomId,
+                    awarenessBytes,
+                  );
+                  return;
+                }
+                applyAwarenessUpdate(
+                  entry.awareness,
+                  awarenessBytes,
+                  BIN_AWARENESS_REMOTE_ORIGIN,
                 );
-                return {
-                  bindingVersion:
-                    nextState !== "ready"
-                      ? prev.bindingVersion + 1
-                      : prev.bindingVersion,
-                  artifactRooms: { stateByArtifactRoomId },
-                  ...dirtyState,
-                };
-              });
-            },
-            onArtifactRoomDirty: (artifactRoomId, dirty) => {
-              if (disposed || generation !== streamGeneration) return;
-              set((prev) => {
-                const current =
-                  prev.artifactRoomDirtyByArtifactRoomId[artifactRoomId] ??
-                  false;
-                if (current === dirty) return prev;
-                return {
-                  artifactRoomDirtyByArtifactRoomId: {
-                    ...prev.artifactRoomDirtyByArtifactRoomId,
-                    [artifactRoomId]: dirty,
-                  },
-                };
-              });
-            },
-            onRootDirty: (dirty) => {
-              if (disposed || generation !== streamGeneration) return;
-              set((prev) => {
-                if (prev.rootDirty === dirty) return prev;
-                // A delta does not establish that this subscription has seen
-                // every room. Only the atomic dirtySnapshot can make
-                // dirtiness known for sync-pill purposes.
-                return { rootDirty: dirty };
-              });
-            },
-            onDirtySnapshot: (rootDirty, rooms) => {
-              if (disposed || generation !== streamGeneration) return;
-              const artifactRoomDirtyByArtifactRoomId: Record<string, boolean> =
-                {};
-              for (const room of rooms) {
-                artifactRoomDirtyByArtifactRoomId[room.artifactRoomId] =
-                  room.dirty;
-              }
-              set({
-                rootDirty,
-                hasDirtySnapshotForOpenCycle: true,
-                artifactRoomDirtyByArtifactRoomId,
-              });
-            },
-            onPermissionChanged: (permissionRole) => {
-              if (disposed || generation !== streamGeneration) return;
-              if (permissionRole === null) {
-                clearUnsyncedQueue();
-                clearAllPendingArtifactRoomUpdates();
-                replaceHostCoverageDoc(null);
-                currentRole = null;
-                set({
-                  permissionRole: null,
-                  accessLost: true,
-                  unsyncedQueueSize: 0,
-                  ...knownCleanDirtyState(),
+                // A peer leaving can drop the presence pin that was holding this
+                // room hot, so re-test it here rather than waiting for a doc
+                // frame that may never come.
+                scheduleArtifactRoomCooldown(artifactRoomId);
+              },
+              onArtifactRoomState: (artifactRoomId, nextState) => {
+                if (disposed || generation !== streamGeneration) return;
+                if (nextState !== "ready") {
+                  // A artifactRoom transitioning out of `ready` invalidates the
+                  // local replica - the next `artifactRoomSnapshot` will rebuild.
+                  // The cold copy is invalidated with it; leases survive, so a
+                  // mounted editor re-materializes from that next snapshot.
+                  cancelArtifactRoomCooldown(artifactRoomId);
+                  coldArtifactRooms.delete(artifactRoomId);
+                  artifactRoomTouchSeq.delete(artifactRoomId);
+                  destroyArtifactRoomReplica(artifactRoomId);
+                }
+                set((prev) => {
+                  const current =
+                    prev.artifactRooms.stateByArtifactRoomId[artifactRoomId];
+                  if (current === nextState) return prev;
+                  const stateByArtifactRoomId = {
+                    ...prev.artifactRooms.stateByArtifactRoomId,
+                    [artifactRoomId]: nextState,
+                  };
+                  const dirtyState = resolvePublicDirtyState(
+                    prev.dirtyWatermarkStateVectorBase64,
+                    prev.latestHostStateVectorBase64,
+                  );
+                  return {
+                    bindingVersion:
+                      nextState !== "ready"
+                        ? prev.bindingVersion + 1
+                        : prev.bindingVersion,
+                    artifactRooms: { stateByArtifactRoomId },
+                    ...dirtyState,
+                  };
                 });
-                return;
-              }
-
-              const previous = get().permissionRole;
-              if (
-                previous !== null &&
-                previous !== "viewer" &&
-                permissionRole === "viewer"
-              ) {
-                clearUnsyncedQueue();
-                clearAllPendingArtifactRoomUpdates();
-                currentRole = permissionRole;
-                set({
-                  permissionRole,
-                  unsyncedQueueSize: 0,
-                });
-                requestFreshSnapshotImpl?.();
-                return;
-              }
-
-              currentRole = permissionRole;
-              set({ permissionRole });
-            },
-            onEpicDeleted: (attribution) => {
-              if (disposed || generation !== streamGeneration) return;
-              // Record the remote-delete signal + attribution. The app-level
-              // access coordinator observes this and force-closes the tab
-              // (redirecting an active tab to landing); no further local work
-              // is needed here.
-              set({ epicDeleted: attribution });
-            },
-            onMigrationStarted: () => {
-              if (disposed || generation !== streamGeneration) return;
-              // First tick of a migration. Snap the slice into the running
-              // shape with placeholder counts so the modal can render the
-              // Prepare row immediately - the host will follow up with a
-              // `migrationProgress(prepare, 0, 1)` frame right away.
-              set({
-                migration: {
-                  status: "running",
-                  phase: "prepare",
-                  chunksDone: 0,
-                  chunksTotal: 1,
-                },
-              });
-            },
-            onMigrationProgress: (phase, chunksDone, chunksTotal) => {
-              if (disposed || generation !== streamGeneration) return;
-              set({
-                migration: {
-                  status: "running",
-                  phase,
-                  chunksDone,
-                  chunksTotal: chunksTotal > 0 ? chunksTotal : 1,
-                },
-              });
-            },
-            onMigrationFailed: (reason) => {
-              if (disposed || generation !== streamGeneration) return;
-              // Host kept the WS alive so the modal's Retry button can fire
-              // `retryMigration` in-stream. Log the `reason` so support can
-              // diagnose failed migrations from a renderer console dump even
-              // when the host log is unavailable; the modal copy itself is
-              // fixed and never displays this string.
-              appLogger.warn("[epic-migration] host reported migrationFailed", {
-                epicId,
-                reason,
-              });
-              set({
-                migration: ERROR_MIGRATION_SLICE,
-              });
-            },
-            onMigrationNotAllowed: () => {
-              if (disposed || generation !== streamGeneration) return;
-              // The epic needs a major migration this caller may not perform
-              // (viewer / sub-editor). The host did not start one and there is
-              // nothing to retry, so this is a distinct terminal state from
-              // `error`: the modal shows a fixed "ask an owner/editor" message.
-              set({
-                migration: NOT_ALLOWED_MIGRATION_SLICE,
-              });
-            },
-            onCloudSyncStatus: (status) => {
-              if (disposed || generation !== streamGeneration) return;
-              const previousCloudSyncStatus = cloudSyncStatus;
-              cloudSyncStatus = status;
-              hasFreshCloudSyncStatus = true;
-              if (
-                hasConnectedOnce &&
-                previousCloudSyncStatus !== "connected" &&
-                status === "connected"
-              ) {
-                // Wake-recovery latency marker: the host<->cloud link is back
-                // online. Paired with the `[stream] reconnectAll` log, the gap
-                // between them is the measured time-to-online after wake (the
-                // gate the plan tracks on a real device). `warn` is the only
-                // info-ish console level this workspace's lint permits.
-                // `hasConnectedOnce` keeps this to genuine RE-connections (wake)
-                // - not the first connect or a `requestFreshSnapshot` re-open,
-                // which would pollute the trace.
-                appLogger.debug("[epic-stream] cloud sync connected", {
-                  epicId,
-                });
-              }
-              // A genuine cloud "connected" frame is the ONLY thing that latches
-              // "connected once" - never the optimistic default - so a new
-              // room's pre-connect catch-up reads as the bootstrap "connecting"
-              // while a drop AFTER a real connect reads as "reconnecting".
-              if (status === "connected") hasConnectedOnce = true;
-              syncCurrentConnectionStatus();
-              set(connectionStateSlice());
-              flushPendingWritesAfterReconnect(client);
-            },
-            onConnectionStatus: (status, reason) => {
-              if (disposed || generation !== streamGeneration) return;
-              const previousTransportStatus = transportStatus;
-              transportStatus = status;
-              const startedSubscriptionCycle =
-                previousTransportStatus !== "open" && status === "open";
-              if (
-                hasConnectedOnce &&
-                previousTransportStatus !== "open" &&
-                status === "open"
-              ) {
-                // Wake-recovery sub-marker: the renderer<->host stream
-                // re-subscribed, so the host has the live request context
-                // again. The gap from here to `[epic-stream] cloud sync
-                // connected` isolates the host<->cloud recovery latency.
-                // `warn` is the only info-ish console level lint permits here.
-                // Gated on `hasConnectedOnce` so it marks only RE-connections
-                // (wake), not the initial connect or a fresh-snapshot re-open.
-                appLogger.debug("[epic-stream] transport open", {
-                  epicId,
-                  contextRegistered: true,
-                });
-              }
-              const cycleDurabilityState = startedSubscriptionCycle
-                ? resetDurabilityProofForOpenCycle()
-                : null;
-              const nextStatus = syncCurrentConnectionStatus();
-              hasFreshRootSnapshotForOpenCycle = false;
-              set(
-                cycleDurabilityState === null
-                  ? connectionStateSlice()
-                  : {
-                      ...cycleDurabilityState,
-                      ...connectionStateSlice(),
+              },
+              onArtifactRoomDirty: (artifactRoomId, dirty) => {
+                if (disposed || generation !== streamGeneration) return;
+                set((prev) => {
+                  const current =
+                    prev.artifactRoomDirtyByArtifactRoomId[artifactRoomId] ??
+                    false;
+                  if (current === dirty) return prev;
+                  return {
+                    artifactRoomDirtyByArtifactRoomId: {
+                      ...prev.artifactRoomDirtyByArtifactRoomId,
+                      [artifactRoomId]: dirty,
                     },
-              );
-              // Convert a fatal close into the modal's error state, but only
-              // when a migration had actually started - a fatal close before
-              // any `migrationStarted` is a normal connection error owned by
-              // `snapshotFetchError`, not the migration modal. UNAUTHORIZED
-              // also bypasses the modal so the auth/unavailable handlers
-              // below can still recover the session; leaving the user pinned
-              // on a migration-error modal after a token expiry would block
-              // re-auth entirely.
-              if (
-                isFatalMigrationClose(status, reason, get().migration.status)
-              ) {
-                // Convert the fatal close into the modal's error state and
-                // return - letting control fall through would ALSO populate
-                // `snapshotFetchError` from the same fatalError, surfacing
-                // two redundant failure UIs (migration modal AND the snapshot
-                // empty-state) for one underlying cause. The migration
-                // modal's Retry/Close already covers recovery; Close routes
-                // the user away cleanly.
+                  };
+                });
+              },
+              onRootDirty: (dirty) => {
+                if (disposed || generation !== streamGeneration) return;
+                set((prev) => {
+                  if (prev.rootDirty === dirty) return prev;
+                  // A delta does not establish that this subscription has seen
+                  // every room. Only the atomic dirtySnapshot can make
+                  // dirtiness known for sync-pill purposes.
+                  return { rootDirty: dirty };
+                });
+              },
+              onDirtySnapshot: (rootDirty, rooms) => {
+                if (disposed || generation !== streamGeneration) return;
+                const artifactRoomDirtyByArtifactRoomId: Record<
+                  string,
+                  boolean
+                > = {};
+                for (const room of rooms) {
+                  artifactRoomDirtyByArtifactRoomId[room.artifactRoomId] =
+                    room.dirty;
+                }
+                set({
+                  rootDirty,
+                  hasDirtySnapshotForOpenCycle: true,
+                  artifactRoomDirtyByArtifactRoomId,
+                });
+              },
+              onPermissionChanged: (permissionRole) => {
+                if (disposed || generation !== streamGeneration) return;
+                if (permissionRole === null) {
+                  clearUnsyncedQueue();
+                  clearAllPendingArtifactRoomUpdates();
+                  replaceHostCoverageDoc(null);
+                  currentRole = null;
+                  set({
+                    permissionRole: null,
+                    accessLost: true,
+                    unsyncedQueueSize: 0,
+                    ...knownCleanDirtyState(),
+                  });
+                  return;
+                }
+
+                const previous = get().permissionRole;
+                if (
+                  previous !== null &&
+                  previous !== "viewer" &&
+                  permissionRole === "viewer"
+                ) {
+                  clearUnsyncedQueue();
+                  clearAllPendingArtifactRoomUpdates();
+                  currentRole = permissionRole;
+                  set({
+                    permissionRole,
+                    unsyncedQueueSize: 0,
+                  });
+                  requestFreshSnapshotImpl?.();
+                  return;
+                }
+
+                currentRole = permissionRole;
+                set({ permissionRole });
+              },
+              onEpicDeleted: (attribution) => {
+                if (disposed || generation !== streamGeneration) return;
+                // Record the remote-delete signal + attribution. The app-level
+                // access coordinator observes this and force-closes the tab
+                // (redirecting an active tab to landing); no further local work
+                // is needed here.
+                set({ epicDeleted: attribution });
+              },
+              onMigrationStarted: () => {
+                if (disposed || generation !== streamGeneration) return;
+                // First tick of a migration. Snap the slice into the running
+                // shape with placeholder counts so the modal can render the
+                // Prepare row immediately - the host will follow up with a
+                // `migrationProgress(prepare, 0, 1)` frame right away.
+                set({
+                  migration: {
+                    status: "running",
+                    phase: "prepare",
+                    chunksDone: 0,
+                    chunksTotal: 1,
+                  },
+                });
+              },
+              onMigrationProgress: (phase, chunksDone, chunksTotal) => {
+                if (disposed || generation !== streamGeneration) return;
+                set({
+                  migration: {
+                    status: "running",
+                    phase,
+                    chunksDone,
+                    chunksTotal: chunksTotal > 0 ? chunksTotal : 1,
+                  },
+                });
+              },
+              onMigrationFailed: (reason) => {
+                if (disposed || generation !== streamGeneration) return;
+                // Host kept the WS alive so the modal's Retry button can fire
+                // `retryMigration` in-stream. Log the `reason` so support can
+                // diagnose failed migrations from a renderer console dump even
+                // when the host log is unavailable; the modal copy itself is
+                // fixed and never displays this string.
+                appLogger.warn(
+                  "[epic-migration] host reported migrationFailed",
+                  {
+                    epicId,
+                    reason,
+                  },
+                );
                 set({
                   migration: ERROR_MIGRATION_SLICE,
                 });
-                return;
-              }
-              if (isFatalClose(status, reason)) {
-                const { details } = reason;
-                if (isUnavailableFatal(details)) {
+              },
+              onMigrationNotAllowed: () => {
+                if (disposed || generation !== streamGeneration) return;
+                // The epic needs a major migration this caller may not perform
+                // (viewer / sub-editor). The host did not start one and there is
+                // nothing to retry, so this is a distinct terminal state from
+                // `error`: the modal shows a fixed "ask an owner/editor" message.
+                set({
+                  migration: NOT_ALLOWED_MIGRATION_SLICE,
+                });
+              },
+              onCloudSyncStatus: (status) => {
+                if (disposed || generation !== streamGeneration) return;
+                const previousCloudSyncStatus = cloudSyncStatus;
+                cloudSyncStatus = status;
+                hasFreshCloudSyncStatus = true;
+                if (
+                  hasConnectedOnce &&
+                  previousCloudSyncStatus !== "connected" &&
+                  status === "connected"
+                ) {
+                  // Wake-recovery latency marker: the host<->cloud link is back
+                  // online. Paired with the `[stream] reconnectAll` log, the gap
+                  // between them is the measured time-to-online after wake (the
+                  // gate the plan tracks on a real device). `warn` is the only
+                  // info-ish console level this workspace's lint permits.
+                  // `hasConnectedOnce` keeps this to genuine RE-connections (wake)
+                  // - not the first connect or a `requestFreshSnapshot` re-open,
+                  // which would pollute the trace.
+                  appLogger.debug("[epic-stream] cloud sync connected", {
+                    epicId,
+                  });
+                }
+                // A genuine cloud "connected" frame is the ONLY thing that latches
+                // "connected once" - never the optimistic default - so a new
+                // room's pre-connect catch-up reads as the bootstrap "connecting"
+                // while a drop AFTER a real connect reads as "reconnecting".
+                if (status === "connected") hasConnectedOnce = true;
+                syncCurrentConnectionStatus();
+                set(connectionStateSlice());
+                flushPendingWritesAfterReconnect(client);
+              },
+              onConnectionStatus: (status, reason) => {
+                if (disposed || generation !== streamGeneration) return;
+                const previousTransportStatus = transportStatus;
+                transportStatus = status;
+                const startedSubscriptionCycle =
+                  previousTransportStatus !== "open" && status === "open";
+                if (
+                  hasConnectedOnce &&
+                  previousTransportStatus !== "open" &&
+                  status === "open"
+                ) {
+                  // Wake-recovery sub-marker: the renderer<->host stream
+                  // re-subscribed, so the host has the live request context
+                  // again. The gap from here to `[epic-stream] cloud sync
+                  // connected` isolates the host<->cloud recovery latency.
+                  // `warn` is the only info-ish console level lint permits here.
+                  // Gated on `hasConnectedOnce` so it marks only RE-connections
+                  // (wake), not the initial connect or a fresh-snapshot re-open.
+                  appLogger.debug("[epic-stream] transport open", {
+                    epicId,
+                    contextRegistered: true,
+                  });
+                }
+                const cycleDurabilityState = startedSubscriptionCycle
+                  ? resetDurabilityProofForOpenCycle()
+                  : null;
+                const nextStatus = syncCurrentConnectionStatus();
+                hasFreshRootSnapshotForOpenCycle = false;
+                set(
+                  cycleDurabilityState === null
+                    ? connectionStateSlice()
+                    : {
+                        ...cycleDurabilityState,
+                        ...connectionStateSlice(),
+                      },
+                );
+                // Convert a fatal close into the modal's error state, but only
+                // when a migration had actually started - a fatal close before
+                // any `migrationStarted` is a normal connection error owned by
+                // `snapshotFetchError`, not the migration modal. UNAUTHORIZED
+                // also bypasses the modal so the auth/unavailable handlers
+                // below can still recover the session; leaving the user pinned
+                // on a migration-error modal after a token expiry would block
+                // re-auth entirely.
+                if (
+                  isFatalMigrationClose(status, reason, get().migration.status)
+                ) {
+                  // Convert the fatal close into the modal's error state and
+                  // return - letting control fall through would ALSO populate
+                  // `snapshotFetchError` from the same fatalError, surfacing
+                  // two redundant failure UIs (migration modal AND the snapshot
+                  // empty-state) for one underlying cause. The migration
+                  // modal's Retry/Close already covers recovery; Close routes
+                  // the user away cleanly.
+                  set({
+                    migration: ERROR_MIGRATION_SLICE,
+                  });
+                  return;
+                }
+                if (isFatalClose(status, reason)) {
+                  const { details } = reason;
+                  if (isUnavailableFatal(details)) {
+                    set({
+                      snapshotFetchError: snapshotFetchErrorFrom(details),
+                    });
+                    return;
+                  }
+                  if (details.code === "UNAUTHORIZED") {
+                    // The stream owns UNAUTHORIZED recovery now: it stays
+                    // "reconnecting" and self-revalidates, so a terminal
+                    // closed/UNAUTHORIZED means it GAVE UP - the credential was
+                    // rejected (the stream's revalidator already signed out) or
+                    // the host kept rejecting a still-valid bearer (reload
+                    // required). Surface the error so the user isn't stranded on a
+                    // silent "closed"; keep the revalidate as the sign-out
+                    // cascade's net (single-flight, a no-op once already settled).
+                    set({
+                      snapshotFetchError: snapshotFetchErrorFrom(details),
+                    });
+                    options.onAuthError?.();
+                    return;
+                  }
                   set({ snapshotFetchError: snapshotFetchErrorFrom(details) });
                   return;
                 }
-                if (details.code === "UNAUTHORIZED") {
-                  // The stream owns UNAUTHORIZED recovery now: it stays
-                  // "reconnecting" and self-revalidates, so a terminal
-                  // closed/UNAUTHORIZED means it GAVE UP - the credential was
-                  // rejected (the stream's revalidator already signed out) or
-                  // the host kept rejecting a still-valid bearer (reload
-                  // required). Surface the error so the user isn't stranded on a
-                  // silent "closed"; keep the revalidate as the sign-out
-                  // cascade's net (single-flight, a no-op once already settled).
-                  set({ snapshotFetchError: snapshotFetchErrorFrom(details) });
-                  options.onAuthError?.();
-                  return;
-                }
-                set({ snapshotFetchError: snapshotFetchErrorFrom(details) });
-                return;
-              }
-              if (nextStatus !== "open") return;
-              emitCurrentAwareness(awareness, doc, client);
+                if (nextStatus !== "open") return;
+                emitCurrentAwareness(awareness, doc, client);
+              },
             },
-          }, readSeedOffer);
+            readSeedOffer,
+          );
           streamClient = client;
         };
 

--- a/clients/shared/host-transport/__tests__/epic-stream-client-delta-seed.test.ts
+++ b/clients/shared/host-transport/__tests__/epic-stream-client-delta-seed.test.ts
@@ -1,0 +1,262 @@
+/**
+ * `epic.subscribe@1.3` delta-seeded reattach - `EpicStreamClient` side.
+ *
+ * Covers the two OSS client contracts the ticket calls out:
+ *
+ *   - `subscribeWithParamsProvider` params carry `seedOffer` only when the
+ *     provider returns non-null, and the no-offer case OMITS the key rather
+ *     than sending `seedOffer: undefined`.
+ *   - The provider is read live at every wire subscribe (including a
+ *     reconnect's re-declare), never captured once at construction.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type { EpicSubscribeClientSeedOffer } from "@traycer/protocol/host/epic/subscribe";
+import {
+  createRequestContext,
+  identityFromAuthenticatedUser,
+  type RequestContext,
+} from "@traycer/protocol/auth/request-context";
+import { mockLocalHostEntry } from "../../host-client/mock/mock-host-directory";
+import { createAuthenticatedUserFixture } from "../../test-fixtures/authenticated-user";
+import type {
+  WebSocketCloseEvent,
+  WebSocketErrorEvent,
+  WebSocketOpenEvent,
+} from "../ws-factory";
+import type {
+  IStreamWebSocketFactory,
+  StreamWebSocketLike,
+  StreamWebSocketMessageEvent,
+} from "../ws-stream-factory";
+import { WsStreamClient } from "../ws-stream-client";
+import {
+  EpicStreamClient,
+  type EpicStreamCallbacks,
+} from "../epic-stream-client";
+import { NO_TRANSPORT_EVIDENCE } from "@traycer-clients/shared/host-selection/transport-evidence";
+
+class StubStreamWebSocket implements StreamWebSocketLike {
+  onopen: ((event: WebSocketOpenEvent) => void) | null = null;
+  onmessage: ((event: StreamWebSocketMessageEvent) => void) | null = null;
+  onerror: ((event: WebSocketErrorEvent) => void) | null = null;
+  onclose: ((event: WebSocketCloseEvent) => void) | null = null;
+
+  readonly textSent: string[] = [];
+  readonly binarySent: Uint8Array[] = [];
+  closed: { readonly code: number; readonly reason: string } | null = null;
+
+  send(data: string | Uint8Array): void {
+    if (typeof data === "string") {
+      this.textSent.push(data);
+      return;
+    }
+    this.binarySent.push(data);
+  }
+
+  close(code: number, reason: string): void {
+    this.closed = { code, reason };
+  }
+
+  fireOpen(): void {
+    this.onopen?.({ type: "open" });
+  }
+
+  fireText(data: unknown): void {
+    this.onmessage?.({ type: "text", data: JSON.stringify(data) });
+  }
+
+  fireClose(code: number, reason: string, wasClean: boolean): void {
+    this.onclose?.({ code, reason, wasClean });
+  }
+}
+
+function makeFactory(): {
+  readonly factory: IStreamWebSocketFactory;
+  readonly sockets: StubStreamWebSocket[];
+} {
+  const sockets: StubStreamWebSocket[] = [];
+  const factory: IStreamWebSocketFactory = {
+    create(): StreamWebSocketLike {
+      const socket = new StubStreamWebSocket();
+      sockets.push(socket);
+      return socket;
+    },
+  };
+  return { factory, sockets };
+}
+
+function makeRequestContext(bearer: string): RequestContext {
+  const fixture = createAuthenticatedUserFixture(undefined);
+  return createRequestContext({
+    identity: identityFromAuthenticatedUser(fixture),
+    bearerToken: bearer,
+    origin: "renderer",
+    connectionId: undefined,
+    operationId: undefined,
+    externalAbortSignal: undefined,
+  });
+}
+
+function makeWsStreamClient(
+  factory: IStreamWebSocketFactory,
+): WsStreamClient<typeof hostStreamRpcRegistry> {
+  const ctx = makeRequestContext("token");
+  return new WsStreamClient({
+    registry: hostStreamRpcRegistry,
+    endpoint: () => mockLocalHostEntry,
+    bearer: () => ctx?.credentials ?? null,
+    auth: null,
+    hostCredentialMint: null,
+    evidence: NO_TRANSPORT_EVIDENCE,
+    webSocketFactory: factory,
+    dialTimeoutMs: 10_000,
+    openAckTimeoutMs: 10_000,
+    pingIntervalMs: 60_000,
+    pongTimeoutMs: 120_000,
+    initialBackoffMs: 10,
+    maxBackoffMs: 1_000,
+  });
+}
+
+function completeHandshake(socket: StubStreamWebSocket): void {
+  socket.fireOpen();
+  const openParsed = JSON.parse(socket.textSent[0]) as {
+    readonly manifest: Record<string, { major: number; minor: number }>;
+  };
+  socket.fireText({
+    kind: "openAck",
+    manifest: openParsed.manifest,
+  });
+}
+
+function parseText(raw: string): Record<string, unknown> {
+  const value = JSON.parse(raw);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Expected object text frame");
+  }
+  return value as Record<string, unknown>;
+}
+
+/** Every callback the contract requires, as no-ops - none are exercised here. */
+function noopCallbacks(): EpicStreamCallbacks {
+  return {
+    onSnapshot: () => {},
+    onEarlyMeta: () => {},
+    onUpdate: () => {},
+    onAwareness: () => {},
+    onPermissionChanged: () => {},
+    onEpicDeleted: () => {},
+    onArtifactRoomSnapshot: () => {},
+    onArtifactRoomUpdate: () => {},
+    onArtifactRoomAwareness: () => {},
+    onArtifactRoomState: () => {},
+    onArtifactRoomDirty: () => {},
+    onRootDirty: () => {},
+    onDirtySnapshot: () => {},
+    onCloudSyncStatus: () => {},
+    onMigrationStarted: () => {},
+    onMigrationProgress: () => {},
+    onMigrationFailed: () => {},
+    onMigrationNotAllowed: () => {},
+    onConnectionStatus: () => {},
+  };
+}
+
+describe("EpicStreamClient delta-seeded reattach (epic.subscribe@1.3)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("omits seedOffer entirely (not seedOffer: undefined) when the provider returns null", () => {
+    const { factory, sockets } = makeFactory();
+    const client = new EpicStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      epicId: "epic-1",
+      callbacks: noopCallbacks(),
+      seedOfferProvider: () => null,
+    });
+    completeHandshake(sockets[0]);
+
+    const subscribeEnvelope = parseText(sockets[0].textSent[1]);
+    expect(subscribeEnvelope).toEqual({
+      kind: "subscribe",
+      method: "epic.subscribe",
+      schemaVersion: { major: 1, minor: 3 },
+      params: { epicId: "epic-1" },
+    });
+    expect(
+      (subscribeEnvelope.params as Record<string, unknown>) ?? {},
+    ).not.toHaveProperty("seedOffer");
+
+    client.close();
+  });
+
+  it("carries seedOffer on the wire when the provider returns an offer", () => {
+    const { factory, sockets } = makeFactory();
+    const offer: EpicSubscribeClientSeedOffer = {
+      stateVectorBase64: "AQ==",
+      roomId: "room-1",
+    };
+    const client = new EpicStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      epicId: "epic-1",
+      callbacks: noopCallbacks(),
+      seedOfferProvider: () => offer,
+    });
+    completeHandshake(sockets[0]);
+
+    expect(parseText(sockets[0].textSent[1])).toEqual({
+      kind: "subscribe",
+      method: "epic.subscribe",
+      schemaVersion: { major: 1, minor: 3 },
+      params: {
+        epicId: "epic-1",
+        seedOffer: { stateVectorBase64: "AQ==", roomId: "room-1" },
+      },
+    });
+
+    client.close();
+  });
+
+  it("re-reads the seed offer provider at every wire subscribe - a reconnect sees the CURRENT offer, not the one captured at construction", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    const { factory, sockets } = makeFactory();
+    let currentOffer: EpicSubscribeClientSeedOffer | null = null;
+    const client = new EpicStreamClient({
+      wsStreamClient: makeWsStreamClient(factory),
+      epicId: "epic-1",
+      callbacks: noopCallbacks(),
+      seedOfferProvider: () => currentOffer,
+    });
+
+    completeHandshake(sockets[0]);
+    expect(parseText(sockets[0].textSent[1])).toMatchObject({
+      params: { epicId: "epic-1" },
+    });
+
+    // The underlying doc advances while this physical session stays live -
+    // exactly the case a captured-once value would miss.
+    currentOffer = { stateVectorBase64: "Ag==", roomId: "room-2" };
+
+    sockets[0].fireClose(1006, "physical connection lost", false);
+    vi.advanceTimersByTime(10);
+    expect(sockets).toHaveLength(2);
+
+    completeHandshake(sockets[1]);
+    expect(parseText(sockets[1].textSent[1])).toMatchObject({
+      params: {
+        epicId: "epic-1",
+        seedOffer: { stateVectorBase64: "Ag==", roomId: "room-2" },
+      },
+    });
+
+    client.close();
+    vi.useRealTimers();
+  });
+});

--- a/clients/shared/host-transport/__tests__/epic-stream-client-delta-seed.test.ts
+++ b/clients/shared/host-transport/__tests__/epic-stream-client-delta-seed.test.ts
@@ -108,6 +108,7 @@ function makeWsStreamClient(
     bearer: () => ctx?.credentials ?? null,
     auth: null,
     hostCredentialMint: null,
+    onHostCredentialState: null,
     evidence: NO_TRANSPORT_EVIDENCE,
     webSocketFactory: factory,
     dialTimeoutMs: 10_000,

--- a/clients/shared/host-transport/__tests__/epic-stream-client-scoped-root-artifact-room-contract.test.ts
+++ b/clients/shared/host-transport/__tests__/epic-stream-client-scoped-root-artifact-room-contract.test.ts
@@ -322,16 +322,23 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
-    // T5 (artifactRoomDirty) bumped the registry's latestMinor to 1, then
-    // @1.2 (roomId on the snapshot frame's meta) bumped it again to 2 - the
-    // client now opens at {major:1, minor:2}.
+    // T5 (artifactRoomDirty) bumped the registry's latestMinor to 1, @1.2
+    // (roomId on the snapshot frame's meta) bumped it to 2, and @1.3
+    // (delta-seed reattach) bumped it to 3 - the client now opens at
+    // {major:1, minor:3}.
+    //
+    // `params` stays `{epicId}` here because this client offers no seed
+    // (`seedOfferProvider: () => null`), and a null offer omits the key
+    // rather than sending `seedOffer: undefined`. That is the cold-open row
+    // of the skew matrix, asserted on the wire.
     expect(parseText(sockets[0].textSent[1])).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-1" },
     });
     client.close();
@@ -344,6 +351,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -365,6 +373,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -384,6 +393,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -419,6 +429,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -440,6 +451,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -515,6 +527,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -550,6 +563,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -591,6 +605,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 
@@ -615,6 +630,7 @@ describe("EpicStreamClient scoped root/artifact-room contract (B6)", () => {
       wsStreamClient: makeWsStreamClient(factory),
       epicId: "epic-1",
       callbacks: recorder.callbacks,
+      seedOfferProvider: () => null,
     });
     completeHandshake(sockets[0]);
 

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -366,7 +366,7 @@ describe("WsStreamClient", () => {
     expect(subscribeFrame).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-1" },
     });
 
@@ -404,7 +404,7 @@ describe("WsStreamClient", () => {
     expect(parseText(stub.textSent[1])).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-1" },
     });
 
@@ -476,7 +476,7 @@ describe("WsStreamClient", () => {
     expect(parseText(stub.textSent[1])).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-1" },
     });
 
@@ -1400,7 +1400,7 @@ describe("WsStreamClient", () => {
     expect(firstSubscribe).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-42" },
     });
 
@@ -1420,7 +1420,7 @@ describe("WsStreamClient", () => {
     expect(secondSubscribe).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-42" },
     });
 
@@ -1604,7 +1604,7 @@ describe("WsStreamClient", () => {
     expect(parseText(sockets[1].socket.textSent[1])).toEqual({
       kind: "subscribe",
       method: "epic.subscribe",
-      schemaVersion: { major: 1, minor: 2 },
+      schemaVersion: { major: 1, minor: 3 },
       params: { epicId: "epic-42" },
     });
     expect(statuses.at(-1)).toBe("open");

--- a/clients/shared/host-transport/epic-stream-client.ts
+++ b/clients/shared/host-transport/epic-stream-client.ts
@@ -5,6 +5,7 @@ import {
   type EpicCloudSyncStatus,
   type EpicMigrationPhase,
   type EpicSubscribeClientFrame,
+  type EpicSubscribeClientSeedOffer,
   type EpicSubscribeServerFrame,
 } from "@traycer/protocol/host/epic/subscribe";
 
@@ -54,6 +55,18 @@ import type { IStreamClient } from "./i-stream-client";
  * forgot about.
  */
 export interface EpicStreamCallbacks {
+  /**
+   * Initial root-doc state for this subscribe cycle.
+   *
+   * `meta.seededFromOffer === true` means `snapshotBytes` is a **delta**
+   * against the state vector this client offered through
+   * `seedOfferProvider`, not a self-sufficient snapshot: it MUST be merged
+   * into the very doc that produced that offer, and MUST NOT be used to
+   * replace a doc or seed a fresh one. Anything else - including a full
+   * snapshot that arrived despite an offer - is self-sufficient and safe to
+   * apply either way. Both cases apply with the same `Y.applyUpdate`, so this
+   * distinction constrains WHICH DOC, never how.
+   */
   readonly onSnapshot: (
     meta: SnapshotMetaEpic,
     snapshotBytes: Uint8Array,
@@ -216,6 +229,26 @@ export interface EpicStreamClientOptions {
   readonly wsStreamClient: IStreamClient<HostStreamRpcRegistry>;
   readonly epicId: string;
   readonly callbacks: EpicStreamCallbacks;
+  /**
+   * Reports the root-doc state this client ALREADY holds, so a reattach can be
+   * served as a delta instead of re-shipping the whole document. Read
+   * immediately before every wire subscribe, including the re-declare after a
+   * reconnect — so it must be a cheap, synchronous, side-effect-free read of
+   * live state, never a cached value computed once.
+   *
+   * Returns `null` whenever there is nothing safe to offer, and the caller is
+   * expected to use that freely: no doc yet (a cold open — first-open cost is
+   * not what this mechanism addresses), or a doc whose originating `roomId` is
+   * unknown, which happens for state seeded by a pre-`@1.2` host that never
+   * reported one. Offering a vector without its room would let the host diff
+   * against a doc from a room a migration has since replaced.
+   *
+   * Required rather than optional: every construction site must decide whether
+   * it can offer state. A wrapper that silently defaulted to "no offer" would
+   * leave the reattach cost this class exists to remove, and would do it
+   * invisibly.
+   */
+  readonly seedOfferProvider: () => EpicSubscribeClientSeedOffer | null;
 }
 
 /**
@@ -239,9 +272,24 @@ export class EpicStreamClient {
     this.callbacks = options.callbacks;
     this.closed = false;
 
-    this.session = options.wsStreamClient.subscribe("epic.subscribe", {
-      epicId: options.epicId,
-    });
+    // `subscribeWithParamsProvider`, not `subscribe`: the offer has to be read
+    // at each wire subscribe, because the reattach is the only moment it is
+    // worth anything. Freezing params at construction would send the state the
+    // doc had when the tab opened — on the first subscribe that is `null`
+    // (nothing loaded yet), so every later reconnect would re-request the whole
+    // document, which is the exact behaviour this class exists to remove.
+    this.session = options.wsStreamClient.subscribeWithParamsProvider(
+      "epic.subscribe",
+      () => {
+        const seedOffer = options.seedOfferProvider();
+        // Omit the key entirely rather than sending an explicit `undefined`:
+        // the field is `.optional()`, and absence is the wire encoding of
+        // "no offer".
+        return seedOffer === null
+          ? { epicId: options.epicId }
+          : { epicId: options.epicId, seedOffer };
+      },
+    );
     this.session.onServerFrame((envelope, binaryPayload) => {
       this.handleServerFrame(envelope, binaryPayload);
     });

--- a/clients/shared/host-transport/host-stream-client.ts
+++ b/clients/shared/host-transport/host-stream-client.ts
@@ -3,8 +3,6 @@ import type {
   VersionedStreamRpcRegistry,
 } from "@traycer/protocol/framework/versioned-stream-rpc";
 import type { IStreamClient } from "./i-stream-client";
-import type { IStreamSession } from "./i-stream-session";
-import type { ParamsOf } from "./ws-stream-client";
 import type { StreamMethodSupport } from "./ws-stream-client";
 
 /**
@@ -23,15 +21,9 @@ import type { StreamMethodSupport } from "./ws-stream-client";
 export interface IHostStreamClient<
   Registry extends VersionedStreamRpcRegistry,
 > extends IStreamClient<Registry> {
-  /**
-   * Opens a stream whose params are read immediately before every wire
-   * subscribe, including reconnects. Dynamic resume cursors use this instead
-   * of freezing the cursor that happened to be current at session creation.
-   */
-  subscribeWithParamsProvider<Method extends keyof Registry & string>(
-    method: Method,
-    paramsProvider: () => ParamsOf<Registry, Method>,
-  ): IStreamSession;
+  // `subscribeWithParamsProvider` is inherited from `IStreamClient`: it is a
+  // subscribe-shaped capability, and the typed wrappers that use it depend on
+  // that narrower seam.
   close(reason: string): void;
   isClosed(): boolean;
   /** The reason recorded at close, or `null` while still open. */

--- a/clients/shared/host-transport/i-stream-client.ts
+++ b/clients/shared/host-transport/i-stream-client.ts
@@ -29,6 +29,29 @@ export interface IStreamClient<Registry extends VersionedStreamRpcRegistry> {
   ): IStreamSession;
 
   /**
+   * Opens a session whose params are re-read immediately before EVERY wire
+   * subscribe, including the re-declare that follows a physical reconnect —
+   * rather than freezing whatever was current when the session was created.
+   *
+   * On this seam rather than only on `IHostStreamClient` because it is a
+   * subscribe-shaped capability, and the wrappers that need it (an epic
+   * offering the root state it already holds, and any future resume cursor)
+   * depend on this narrow interface. Leaving it upstairs would make a wrapper
+   * that offers reattach state non-substitutable over a remote transport —
+   * exactly the substitutability this seam exists to provide, and exactly the
+   * transport that needs the feature most.
+   *
+   * The provider must be a pure, synchronous read: it may report applied
+   * client state, but must not create transport or application state as a
+   * side effect. `WsStreamClient` and `RemoteStreamClient` both implement it,
+   * and both re-invoke it on reconnect.
+   */
+  subscribeWithParamsProvider<Method extends keyof Registry & string>(
+    method: Method,
+    paramsProvider: () => ParamsOf<Registry, Method>,
+  ): IStreamSession;
+
+  /**
    * The schema version the peer negotiated for `method`, or `null` when it is
    * not (yet) known. Wrappers use it to gate additive minor-line features
    * (e.g. `ChatStreamClient.sameTurnSteeringProtocolSupported`).

--- a/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
+++ b/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
@@ -25,7 +25,7 @@ describe("validateVersionedStreamRpcRegistry", () => {
     expect(() => {
       validateVersionedStreamRpcRegistry(hostStreamRpcRegistry);
     }).not.toThrow();
-    expect(hostStreamRpcRegistry["epic.subscribe"][1].latestMinor).toBe(2);
+    expect(hostStreamRpcRegistry["epic.subscribe"][1].latestMinor).toBe(3);
     expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(6);
     expect(
       hostStreamRpcRegistry["notifications.subscribe"][1].latestMinor,

--- a/protocol/src/host/epic/__tests__/epic-subscribe-delta-seed.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-subscribe-delta-seed.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  epicSubscribeOpenRequestSchema,
+  epicSubscribeOpenRequestSchemaV10,
+  epicSubscribeServerFrameSchemaV13,
+  epicSubscribeV10,
+  epicSubscribeV11,
+  epicSubscribeV12,
+  epicSubscribeV13,
+} from "@traycer/protocol/host/epic/subscribe";
+import {
+  snapshotMetaEpicSchema,
+  snapshotMetaEpicSchemaV10,
+  snapshotMetaEpicSchemaV12,
+} from "@traycer/protocol/host/epic/snapshot-meta";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+
+/**
+ * `epic.subscribe@1.3` - delta-seeded reattach. Covers the two new optional
+ * wire keys (`seedOffer` on the open request, `seededFromOffer` on the
+ * snapshot frame's `meta`) and the registry/contract wiring around them.
+ */
+
+const baseMetaV10Fields = {
+  schemaVersion: "1.0.0",
+  epicLight: null,
+  permissionRole: "owner" as const,
+  repos: [],
+  workspaces: [],
+  repoMapping: [],
+  workspaceFolders: [],
+  unresolvedRepos: [],
+  hostStateVectorBase64: "AQ==",
+};
+
+describe("epic.subscribe@1.3 open request - seedOffer", () => {
+  it("strips seedOffer under the frozen @1.0/@1.1/@1.2 open request shape", () => {
+    const parsed = epicSubscribeOpenRequestSchemaV10.parse({
+      epicId: "epic-1",
+      seedOffer: {
+        stateVectorBase64: "AQ==",
+        roomId: "room-1",
+      },
+    });
+    expect(parsed).toEqual({ epicId: "epic-1" });
+    expect("seedOffer" in parsed).toBe(false);
+  });
+
+  it("accepts a well-formed seedOffer under @1.3", () => {
+    const parsed = epicSubscribeOpenRequestSchema.parse({
+      epicId: "epic-1",
+      seedOffer: {
+        stateVectorBase64: "AQ==",
+        roomId: "room-1",
+      },
+    });
+    expect(parsed.seedOffer).toEqual({
+      stateVectorBase64: "AQ==",
+      roomId: "room-1",
+    });
+  });
+
+  it("accepts an @1.3 open request with no seedOffer at all", () => {
+    const parsed = epicSubscribeOpenRequestSchema.parse({ epicId: "epic-1" });
+    expect(parsed.epicId).toBe("epic-1");
+    expect(parsed.seedOffer).toBeUndefined();
+  });
+
+  it("rejects a seedOffer missing roomId", () => {
+    expect(() =>
+      epicSubscribeOpenRequestSchema.parse({
+        epicId: "epic-1",
+        seedOffer: { stateVectorBase64: "AQ==" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a seedOffer missing stateVectorBase64", () => {
+    expect(() =>
+      epicSubscribeOpenRequestSchema.parse({
+        epicId: "epic-1",
+        seedOffer: { roomId: "room-1" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a seedOffer with an empty-string roomId", () => {
+    expect(() =>
+      epicSubscribeOpenRequestSchema.parse({
+        epicId: "epic-1",
+        seedOffer: { stateVectorBase64: "AQ==", roomId: "" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a seedOffer with an empty-string stateVectorBase64", () => {
+    expect(() =>
+      epicSubscribeOpenRequestSchema.parse({
+        epicId: "epic-1",
+        seedOffer: { stateVectorBase64: "", roomId: "room-1" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("epic.subscribe@1.3 snapshot meta - seededFromOffer", () => {
+  it("the frozen @1.0/@1.1 meta shape has no seededFromOffer key", () => {
+    const parsed = snapshotMetaEpicSchemaV10.parse(baseMetaV10Fields);
+    expect("seededFromOffer" in parsed).toBe(false);
+  });
+
+  it("the frozen @1.2 meta shape has no seededFromOffer key", () => {
+    const parsed = snapshotMetaEpicSchemaV12.parse({
+      ...baseMetaV10Fields,
+      roomId: "room-1",
+    });
+    expect("seededFromOffer" in parsed).toBe(false);
+  });
+
+  it("strips seededFromOffer when a @1.3-built meta is parsed under the frozen @1.2 shape", () => {
+    const parsed = snapshotMetaEpicSchemaV12.parse({
+      ...baseMetaV10Fields,
+      roomId: "room-1",
+      seededFromOffer: true,
+    });
+    expect("seededFromOffer" in parsed).toBe(false);
+  });
+
+  it("accepts seededFromOffer: true at @1.3", () => {
+    const parsed = snapshotMetaEpicSchema.parse({
+      ...baseMetaV10Fields,
+      roomId: "room-1",
+      seededFromOffer: true,
+    });
+    expect(parsed.seededFromOffer).toBe(true);
+  });
+
+  it("accepts an @1.3 meta with seededFromOffer absent (full snapshot)", () => {
+    const parsed = snapshotMetaEpicSchema.parse({
+      ...baseMetaV10Fields,
+      roomId: "room-1",
+    });
+    expect(parsed.seededFromOffer).toBeUndefined();
+  });
+
+  it("rejects seededFromOffer: false - absence is the only encoding of full snapshot", () => {
+    expect(() =>
+      snapshotMetaEpicSchema.parse({
+        ...baseMetaV10Fields,
+        roomId: "room-1",
+        seededFromOffer: false,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("epic.subscribe@1.3 contracts and registry wiring", () => {
+  it("keeps @1.0/@1.1/@1.2 openRequestSchema pinned to the frozen V10 object", () => {
+    expect(epicSubscribeV10.openRequestSchema).toBe(
+      epicSubscribeOpenRequestSchemaV10,
+    );
+    expect(epicSubscribeV11.openRequestSchema).toBe(
+      epicSubscribeOpenRequestSchemaV10,
+    );
+    expect(epicSubscribeV12.openRequestSchema).toBe(
+      epicSubscribeOpenRequestSchemaV10,
+    );
+  });
+
+  it("wires @1.3's openRequestSchema and serverFrameSchema to the grown shapes", () => {
+    expect(epicSubscribeV13.openRequestSchema).toBe(
+      epicSubscribeOpenRequestSchema,
+    );
+    expect(epicSubscribeV13.serverFrameSchema).toBe(
+      epicSubscribeServerFrameSchemaV13,
+    );
+    expect(epicSubscribeV13.schemaVersion).toEqual({ major: 1, minor: 3 });
+  });
+
+  it("registers epic.subscribe@1.3 as the latest minor with a 3: version entry", () => {
+    const line = hostStreamRpcRegistry["epic.subscribe"][1];
+    expect(line.latestMinor).toBe(3);
+    expect(line.versions[3]?.contract).toBe(epicSubscribeV13);
+    expect(line.versions[0]?.contract).toBe(epicSubscribeV10);
+    expect(line.versions[1]?.contract).toBe(epicSubscribeV11);
+    expect(line.versions[2]?.contract).toBe(epicSubscribeV12);
+  });
+});

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -104,6 +104,7 @@ import {
   epicSubscribeV10,
   epicSubscribeV11,
   epicSubscribeV12,
+  epicSubscribeV13,
 } from "@traycer/protocol/host/epic/subscribe";
 import {
   listCloudChatPayloadsRequestSchema,
@@ -839,4 +840,9 @@ export const epicGetChatRunSettingsV10 = defineRpcContract({
   responseSchema: getChatRunSettingsResponseSchema,
 });
 
-export { epicSubscribeV10, epicSubscribeV11, epicSubscribeV12 };
+export {
+  epicSubscribeV10,
+  epicSubscribeV11,
+  epicSubscribeV12,
+  epicSubscribeV13,
+};

--- a/protocol/src/host/epic/snapshot-meta.ts
+++ b/protocol/src/host/epic/snapshot-meta.ts
@@ -70,15 +70,15 @@ export const snapshotMetaEpicSchemaV10 = z.object({
 export type SnapshotMetaEpicV10 = z.infer<typeof snapshotMetaEpicSchemaV10>;
 
 /**
- * `epic.subscribe@1.2` snapshot metadata: adds the room identity.
+ * Frozen `epic.subscribe@1.2` snapshot metadata: adds the room identity.
  *
- * The LATEST installed shape - host code builds meta against this, and every
- * client-side `SnapshotMetaEpic` type flows from it. A NEW schema object
- * (not a mutation of {@link snapshotMetaEpicSchemaV10}) per the
- * frozen-per-minor rule: `@1.0`/`@1.1` connections keep parsing the frozen
- * shape above and silently strip the extra key a `@1.2`-built frame carries.
+ * IMMUTABLE, for the same reason {@link snapshotMetaEpicSchemaV10} is. A NEW
+ * schema object (not a mutation of the V10 shape) per the frozen-per-minor
+ * rule: `@1.0`/`@1.1` connections keep parsing the frozen shape above and
+ * silently strip the extra key a `@1.2`-built frame carries. `@1.3` extends
+ * THIS shape the same way - see {@link snapshotMetaEpicSchema}.
  */
-export const snapshotMetaEpicSchema = snapshotMetaEpicSchemaV10.extend({
+export const snapshotMetaEpicSchemaV12 = snapshotMetaEpicSchemaV10.extend({
   /**
    * The concrete cloud collaboration room the host opened for this snapshot.
    *
@@ -103,6 +103,46 @@ export const snapshotMetaEpicSchema = snapshotMetaEpicSchemaV10.extend({
    * fact instead of a runtime coin flip.
    */
   roomId: z.string().optional(),
+});
+export type SnapshotMetaEpicV12 = z.infer<typeof snapshotMetaEpicSchemaV12>;
+
+/**
+ * `epic.subscribe@1.3` snapshot metadata: adds the delta-seed basis marker.
+ *
+ * The LATEST installed shape - host code builds meta against this, and every
+ * client-side `SnapshotMetaEpic` type flows from it. Another new schema
+ * object rather than a mutation of {@link snapshotMetaEpicSchemaV12}, per the
+ * frozen-per-minor rule.
+ */
+export const snapshotMetaEpicSchema = snapshotMetaEpicSchemaV12.extend({
+  /**
+   * Present ONLY when the snapshot frame's binary payload is a Yjs **delta**
+   * computed against the state vector this client offered in the open
+   * request's `seedOffer` - i.e. the bytes are NOT self-sufficient and MUST be
+   * merged into the very doc that produced that offer.
+   *
+   * Absence means the payload is a full snapshot. That is the encoding for
+   * every case that is not a served delta, and they are deliberately
+   * indistinguishable on the wire: a pre-`@1.3` host, a client that made no
+   * offer (cold open), an offer the host rejected (unparseable state vector,
+   * or a `roomId` that does not name the room the bytes came from), and any
+   * host-side fallback all look identical to the client. A full snapshot is
+   * always safe to apply, so collapsing them costs nothing and removes every
+   * branch where a client could mistake one for the other.
+   *
+   * `z.literal(true)` rather than `z.boolean()` deliberately: the fact is
+   * two-state, so this leaves exactly ONE representation of "full snapshot"
+   * (absence) instead of two (absence and `false`), and no consumer can
+   * branch on `=== false` where it meant `!== true`.
+   *
+   * LOAD-BEARING, not cosmetic. Both a full snapshot and a delta are applied
+   * with the same `Y.applyUpdate`, so this does not select an apply function -
+   * it forbids the renderer's plain-swap path. The renderer decides between
+   * merging into the existing replica and swapping in a fresh doc (the seam
+   * `roomId` was added for at `@1.2`); handing a delta to the swap branch
+   * would drop every byte the delta legitimately omitted.
+   */
+  seededFromOffer: z.literal(true).optional(),
 });
 export type SnapshotMetaEpic = z.infer<typeof snapshotMetaEpicSchema>;
 

--- a/protocol/src/host/epic/subscribe.ts
+++ b/protocol/src/host/epic/subscribe.ts
@@ -19,8 +19,17 @@
  *                    carries the snapshot metadata; a Y.Doc snapshot rides
  *                    the paired binary payload. The meta shape is the one
  *                    field that varies by minor: `@1.0`/`@1.1` carry the
- *                    frozen `snapshotMetaEpicSchemaV10`, while **@1.2** adds
- *                    `roomId` (`snapshotMetaEpicSchema`).
+ *                    frozen `snapshotMetaEpicSchemaV10`, **@1.2** adds
+ *                    `roomId` (`snapshotMetaEpicSchemaV12`), and **@1.3**
+ *                    adds `seededFromOffer` (`snapshotMetaEpicSchema`) - the
+ *                    marker that the payload is a DELTA against the state
+ *                    vector the client offered, not a self-sufficient
+ *                    snapshot.
+ *
+ * The open request likewise varies by minor: `@1.0`-`@1.2` carry the frozen
+ * `{epicId}` (`epicSubscribeOpenRequestSchemaV10`), while **@1.3** adds the
+ * optional `seedOffer` that makes a reattach cost what actually changed
+ * rather than re-shipping the whole document.
  * - `update`       - incremental Y.Doc update for the root Epic doc.
  * - `awareness`    - awareness update (cursors, selections, presence) for
  *                    the root Epic doc.
@@ -79,11 +88,83 @@ import {
   earlyMetaEpicSchema,
   snapshotMetaEpicSchema,
   snapshotMetaEpicSchemaV10,
+  snapshotMetaEpicSchemaV12,
 } from "@traycer/protocol/host/epic/snapshot-meta";
 
-export const epicSubscribeOpenRequestSchema = z.object({
+/**
+ * The frozen `@1.0` / `@1.1` / `@1.2` open request, as shipped.
+ *
+ * IMMUTABLE, like every other frozen-per-minor shape in this file. A key added
+ * here would be a same-version wire-shape change on three already-released
+ * lines. `@1.3` extends it below.
+ */
+export const epicSubscribeOpenRequestSchemaV10 = z.object({
   epicId: z.string(),
 });
+export type EpicSubscribeOpenRequestV10 = z.infer<
+  typeof epicSubscribeOpenRequestSchemaV10
+>;
+
+/**
+ * A reattaching client's offer of the root-doc state it ALREADY holds, so the
+ * host can answer with a Yjs delta instead of re-shipping the whole document.
+ *
+ * The two fields travel together as one object rather than as two sibling
+ * request keys because neither is meaningful alone: a state vector without its
+ * provenance is precisely the hazard `@1.2`'s `roomId` was introduced for. The
+ * nesting makes "both or neither" structural, so there is no cross-field
+ * runtime check for a later reader to overlook.
+ */
+export const epicSubscribeClientSeedOfferSchema = z.object({
+  /**
+   * Base64-encoded `Y.encodeStateVector` of the live root Epic doc the client
+   * still holds. The host answers `Y.encodeStateAsUpdate(doc, thisVector)` -
+   * everything it has that the client does not.
+   */
+  stateVectorBase64: z.string().min(1),
+  /**
+   * The room the offered state came from - the `roomId` off the snapshot meta
+   * that seeded this client's doc. The host serves a delta only when this
+   * names the room it is about to encode from, and otherwise falls back to a
+   * full snapshot.
+   *
+   * Required inside the offer, not optional. A major schema migration mints a
+   * NEW room for the same `epicId`, so a state vector alone cannot distinguish
+   * "what this client is missing from this room" from "state belonging to the
+   * pre-migration room": diffing against the latter would union two logically
+   * different documents. A client that cannot name its room - one seeded by a
+   * pre-`@1.2` host, which never sent `roomId` - therefore sends NO offer and
+   * takes a full snapshot rather than guessing.
+   */
+  roomId: z.string().min(1),
+});
+export type EpicSubscribeClientSeedOffer = z.infer<
+  typeof epicSubscribeClientSeedOfferSchema
+>;
+
+/**
+ * The LATEST installed open request (`@1.3`): the frozen shape plus an
+ * optional {@link epicSubscribeClientSeedOfferSchema}.
+ *
+ * `.optional()` and never `.default()`. A `.default()` request field
+ * materializes a key the caller never wrote, which splits the GUI's query
+ * cache between the caller's params and the parsed params for what is
+ * logically one subscription.
+ *
+ * NOTE - the offer needs no capability gate on either side, and that falls out
+ * of the dispatcher rather than being arranged. The host validates params with
+ * the NEGOTIATED contract's `openRequestSchema` and passes the PARSED result
+ * downstream (`stream-dispatcher.ts`), so a client that negotiated `@1.0`-
+ * `@1.2` has this key stripped before any resolver sees it, and a pre-`@1.3`
+ * host strips it the same way because zod objects are non-strict. A client may
+ * therefore offer unconditionally - it cannot know the negotiated minor when
+ * it builds its first open request anyway - and an unrecognized offer degrades
+ * to today's full snapshot with no error on any path.
+ */
+export const epicSubscribeOpenRequestSchema =
+  epicSubscribeOpenRequestSchemaV10.extend({
+    seedOffer: epicSubscribeClientSeedOfferSchema.optional(),
+  });
 export type EpicSubscribeOpenRequest = z.infer<
   typeof epicSubscribeOpenRequestSchema
 >;
@@ -453,7 +534,7 @@ export const epicSubscribeServerFrameSchemaV11 = z.discriminatedUnion("kind", [
 const epicSubscribeSnapshotServerFrameSchemaV12 = z.object({
   kind: z.literal("snapshot"),
   epicId: z.string(),
-  meta: snapshotMetaEpicSchema,
+  meta: snapshotMetaEpicSchemaV12,
   hasBinaryPayload: z.literal(true),
 });
 
@@ -465,8 +546,53 @@ export const epicSubscribeServerFrameSchemaV12 = z.discriminatedUnion("kind", [
   epicSubscribeRootDirtyServerFrameSchema,
 ]);
 
+// ─── `epic.subscribe@1.3` - additive: delta-seeded reattach ───────────────
+//
+// The open request gains an optional `seedOffer` (the state vector of the root
+// doc a reattaching client still holds), and the `snapshot` frame's `meta`
+// gains `seededFromOffer` marking a payload that is a delta against that
+// offer. `@1.0`-`@1.2` stay installed and FROZEN, on both the request and the
+// meta.
+//
+// Both halves are the SAME kind of additive growth as `@1.2`'s `roomId` - a
+// new PROPERTY on an existing shape, not a new frame KIND - so neither needs
+// an emission gate, for the asymmetry spelled out in the `@1.2` note above.
+// The version fact lives entirely in the schema:
+//
+//   - Request: the dispatcher parses params with the NEGOTIATED contract's
+//     `openRequestSchema` and hands the PARSED value to the resolver, so a
+//     sub-`@1.3` peer's `seedOffer` is stripped before the resolver exists.
+//     Nothing has to ask what was negotiated.
+//   - Response: `seededFromOffer` can only be set when an offer arrived, which
+//     can only happen at `@1.3`; and a sub-`@1.3` peer parsing with its own
+//     frozen meta would strip the key regardless.
+//
+// So there is no `supportsDeltaSeed()` sibling to `supportsDirtyFrames()`, and
+// deliberately so: the gate that does not exist has no degraded path to get
+// wrong.
+
+/**
+ * The `@1.3` snapshot frame - identical to
+ * {@link epicSubscribeSnapshotServerFrameSchemaV12} except that `meta` can
+ * carry the delta-seed basis marker.
+ */
+const epicSubscribeSnapshotServerFrameSchemaV13 = z.object({
+  kind: z.literal("snapshot"),
+  epicId: z.string(),
+  meta: snapshotMetaEpicSchema,
+  hasBinaryPayload: z.literal(true),
+});
+
+export const epicSubscribeServerFrameSchemaV13 = z.discriminatedUnion("kind", [
+  epicSubscribeSnapshotServerFrameSchemaV13,
+  ...epicSubscribeSharedNonSnapshotServerFrameSchemasV10,
+  epicSubscribeDirtySnapshotServerFrameSchema,
+  epicSubscribeArtifactRoomDirtyServerFrameSchema,
+  epicSubscribeRootDirtyServerFrameSchema,
+]);
+
 /** The latest installed shape. Host code builds frames against this. */
-export const epicSubscribeServerFrameSchema = epicSubscribeServerFrameSchemaV12;
+export const epicSubscribeServerFrameSchema = epicSubscribeServerFrameSchemaV13;
 export type EpicSubscribeServerFrame = z.infer<
   typeof epicSubscribeServerFrameSchema
 >;
@@ -517,7 +643,7 @@ export type EpicSubscribeClientFrame = z.infer<
 export const epicSubscribeV10 = defineStreamRpcContract({
   method: "epic.subscribe",
   schemaVersion: { major: 1, minor: 0 } as const,
-  openRequestSchema: epicSubscribeOpenRequestSchema,
+  openRequestSchema: epicSubscribeOpenRequestSchemaV10,
   serverFrameSchema: epicSubscribeServerFrameSchemaV10,
   clientFrameSchema: epicSubscribeClientFrameSchema,
 });
@@ -525,7 +651,7 @@ export const epicSubscribeV10 = defineStreamRpcContract({
 export const epicSubscribeV11 = defineStreamRpcContract({
   method: "epic.subscribe",
   schemaVersion: { major: 1, minor: 1 } as const,
-  openRequestSchema: epicSubscribeOpenRequestSchema,
+  openRequestSchema: epicSubscribeOpenRequestSchemaV10,
   serverFrameSchema: epicSubscribeServerFrameSchemaV11,
   clientFrameSchema: epicSubscribeClientFrameSchema,
 });
@@ -533,7 +659,15 @@ export const epicSubscribeV11 = defineStreamRpcContract({
 export const epicSubscribeV12 = defineStreamRpcContract({
   method: "epic.subscribe",
   schemaVersion: { major: 1, minor: 2 } as const,
-  openRequestSchema: epicSubscribeOpenRequestSchema,
+  openRequestSchema: epicSubscribeOpenRequestSchemaV10,
   serverFrameSchema: epicSubscribeServerFrameSchemaV12,
+  clientFrameSchema: epicSubscribeClientFrameSchema,
+});
+
+export const epicSubscribeV13 = defineStreamRpcContract({
+  method: "epic.subscribe",
+  schemaVersion: { major: 1, minor: 3 } as const,
+  openRequestSchema: epicSubscribeOpenRequestSchema,
+  serverFrameSchema: epicSubscribeServerFrameSchemaV13,
   clientFrameSchema: epicSubscribeClientFrameSchema,
 });

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -344,6 +344,7 @@ import {
   epicSubscribeV10,
   epicSubscribeV11,
   epicSubscribeV12,
+  epicSubscribeV13,
   epicUpdateArtifactStatusV10,
   epicUpdateTitleV10,
 } from "@traycer/protocol/host/epic/contracts";
@@ -7600,7 +7601,16 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
       // minor parses with its own frozen schema and strips the unknown key
       // (see the @1.2 note in `epic/subscribe.ts` for the full asymmetry).
       // @1.0 and @1.1 keep the pre-roomId meta shape.
-      latestMinor: 2,
+      // @1.3 adds the optional `seedOffer` to the OPEN REQUEST (a reattaching
+      // client's root-doc state vector) and `seededFromOffer` to the snapshot
+      // frame's `meta`, so a reattach transfers what changed instead of the
+      // whole document. Like @1.2 - and unlike @1.1's frame kinds - neither
+      // needs an emission gate: both are new PROPERTIES on existing shapes.
+      // The request half additionally self-gates, because the dispatcher
+      // validates params against the NEGOTIATED contract and passes the parsed
+      // value on, so a sub-@1.3 peer's offer is stripped before any resolver
+      // runs.
+      latestMinor: 3,
       versions: {
         0: {
           contract: epicSubscribeV10,
@@ -7610,6 +7620,9 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
         },
         2: {
           contract: epicSubscribeV12,
+        },
+        3: {
+          contract: epicSubscribeV13,
         },
       },
     },


### PR DESCRIPTION
## Why

A 573-artifact epic serves a **~34.8 MB full Y.Doc snapshot on every subscribe**, including every reattach. On a ~6 Mbps link that is ~46 s re-paid for bytes the client already holds; on a flaky link that reattaches every few minutes it makes remote hosts unusable. T1–T3 made that survivable — this makes reconnection cost proportional to what actually changed.

Governing rulings: a 36 MB epic on a ~6 Mbps link is **normal** remote operation, not a degraded client; and transport-class failures must **never** be user-facing fatal. Every rejected or malformed offer degrades silently to today's full snapshot.

## The surface — `epic.subscribe@1.3`

Two additive optional keys, both new **properties on existing shapes** (not new frame kinds), so neither needs an emission gate:

| Direction | Key |
| --- | --- |
| client → host, open request | `seedOffer { stateVectorBase64, roomId }` |
| host → client, snapshot `meta` | `seededFromOffer?: true` |

Frozen prior minors become new frozen **copies**, never mutations: `epicSubscribeOpenRequestSchemaV10` (@1.0–@1.2) and `snapshotMetaEpicSchemaV12` (@1.2).

**There is no version branch anywhere for this, by design.** `stream-dispatcher` validates params against the *negotiated* contract and passes the parsed value downstream, so a sub-@1.3 peer's offer is stripped before any resolver sees it; zod's non-strict objects make a pre-@1.3 host strip it identically. A client can therefore offer unconditionally — it cannot know the negotiated minor when it builds its first open request. The gate that does not exist has no degraded path to get wrong.

Two deliberate shape decisions:

- **`roomId` is required inside the offer.** A major migration mints a new room for the same `epicId`, so a state vector without provenance could be diffed against a doc that is not an earlier state of this one. A client that cannot name its room (state seeded by a pre-@1.2 host) sends no offer and takes a full snapshot.
- **`seededFromOffer` is `z.literal(true).optional()`**, so absence is the *only* encoding of "full snapshot". A pre-@1.3 host, a cold open, a rejected offer and a host-side fallback are deliberately indistinguishable, and no consumer can branch on `=== false` where it meant `!== true`.

## Client

`EpicStreamClient` moves from `subscribe` to `subscribeWithParamsProvider`, so the offer is read at **each wire subscribe** rather than frozen at construction — frozen, the first read is always `null` and every later reconnect re-fetches the whole document, which is the behaviour this exists to remove.

`subscribeWithParamsProvider` moves from `IHostStreamClient` down to `IStreamClient`. It is a subscribe-shaped capability, and leaving it upstairs would make a wrapper that offers reattach state non-substitutable over the remote transport — the transport that needs this most.

## The gui-app half, which is where the sharp edge is

**The offer comes from `hostCoverageDoc`, not the local replica.** The replica also holds local edits the host may not have echoed back; naming those would make the host omit its own copy of anything it *had* accepted, leaving coverage permanently understated even though the replica converges. Coverage is definitionally "what the host has sent me" — exactly the question a seed offer asks. `doc ⊇ hostCoverageDoc` always, so the delta is a superset of what the replica needs.

**`applyRootSeedToHostCoverage` is the seam the flag exists for.** A full snapshot *rebuilds* coverage; a delta *merges* into it. Rebuilding from a delta would discard precisely the state the delta was computed to omit, silently collapsing coverage from the whole document to the few KB that changed — nothing throws, the replica still looks right, and the sync pill starts claiming durable work is unsynced.

Growth is not a reason to rebuild. Yjs integrates operations into a struct store rather than appending update messages, so 50 merged reattaches produce a **byte-identical** doc to 50 rebuilds (measured ratio 1.000000; 1.000108 with tombstones, in-place edits and redundant re-delivery — 78 bytes on 722 KB, identical state vectors). No periodic re-baseline is armed. The rebuild arm is kept for **correctness**: it drops a stale room across a migration.

**Doc identity is not carried on the wire**, so `hostCoverageGeneration` carries it locally: it bumps only when the coverage doc is *replaced*, is recorded when an offer is read, and is checked before merging a delta. Forward movement is deliberately not staleness — a delta against an older state vector is a superset — so only replacement invalidates an offer. Without this, `onPermissionChanged(null)`, which clears coverage without ending the stream cycle, could fold a delta into an empty doc.

## Skew matrix — compat is policy, so skew is supported

| Client | Host | Result |
| --- | --- | --- |
| new, offers sv | new | **delta** — the fix |
| new, offers sv | old (≤@1.2) | unknown key stripped → full snapshot |
| old (≤@1.2) | new | no offer → full snapshot |
| new, cold open | any | no offer → full snapshot |

Row 3 is **structurally unreachable rather than merely safe**, and worth stating precisely: the only producer of `seededFromOffer` is a host that received and validated an offer, which a ≤@1.2 peer cannot send. Do not read this row as "old clients handle deltas fine" — an old client that somehow *did* receive a delta would apply it as a replacement basis and lose everything the delta was diffed against. The structure is the guarantee.

## Verification

- **Compat gate green with a positive control.** Adding a probe frame kind to the frozen @1.0 union turned it **red** with findings naming `epic.subscribe@1.0`/`@1.1`; removing it restored green. Note the released baseline pins this method at `{1,1}` and has never seen @1.2 or @1.3, so the gate cannot validate @1.3 against a peer — what it proves, and what the control shows it is sensitive to, is that adding @1.3 did not disturb the released minors.
- **Every degraded path tested separately**, each paired with a positive control differing only in the state vector — so a malformed-sv test cannot pass by having been rejected on room mismatch instead.
- **The dispatcher-gating invariant is pinned** by a test driving the real `StreamDispatcher`: an @1.2-negotiated request carrying `seedOffer` must reach the resolver with it stripped.
- **Mutation-probed** (inverse-edit restore, verified zero residue): forcing a full encode turns the byte-size proof red; forcing the coverage rebuild arm turns the merge-safety test red; skipping the generation check turns the race test red while its two controls stay green.

36 new tests. Both graphs compile; lint clean at `--max-warnings 0`.

The internal host resolver leg lands separately and follows the submodule pin bump.

## Note for reviewers: the desktop CI red on the first push was not this change

The initial run showed `@traycer-clients/desktop` failing (`compare-semver`, `compare-host-versions`, `shell-quit-state`). Investigated rather than re-run:

- Cloned clean `main` and ran those three files in isolation — **two failed there**, with none of this branch's code present.
- Ran the **full** desktop suite on clean `main` — **108/108 passed**.
- Ran the **full** desktop suite on this branch — **108/108 passed**.

So those tests fail as a narrow subset and pass in the full suite, on `main` and on this branch alike. The failure mode is the inverse of an ordinary flake: **isolation breaks them, not concurrency.** A narrow desktop run is currently not a trustworthy instrument.

My own first local run reported three desktop failures for a separate reason — it ran two full suites concurrently in one shell, so that was contention flake. Recorded here so nobody re-derives either conclusion.

The genuine failures on the first push were two sets of `epic.subscribe` minor pins outside the epic suites (`versioned-stream-rpc.test.ts`, `ws-stream-client.test.ts`), fixed in `78a93133`.


## Three ways a local check looked authoritative while measuring less than the gate

Recorded because each one produced a **false pass** — the dangerous direction — and each was caught by something other than the check itself.

**1. CI compiles the PR *merge* commit; your worktree compiles your branch.** This branch forked from a `main` predating #1305, which made `onHostCredentialState` a **required** `WsStreamClientOptions` field. So the working tree type-checked the old option set and CI type-checked the new one — same source, two different contracts, and a green local compile over a tree CI could not build. Fixed by merging `origin/main` in and keeping the branch current. A branch that touches protocol + shared + gui-app is the most exposed to this, because `nx affected` selects the widest set.

**2. `pre-commit` is not installed in this worktree's OSS submodule gitdir**, and `core.hooksPath` is unset. The repo guidance "don't run compile/lint/format before committing, pre-commit already does" is only true where the hook exists — here it silently did not, so OSS commits were never hook-verified and the formatter had to be run by hand.

**3. The tell for (2) was nearly missed, and this is the part worth carrying.** The first OSS commit's log showed a *complete, passing* pre-commit run — trailing whitespace, nx affected, DCO, all Passed. **That output was not from this commit.** The same log also contained a commit line for a branch never touched here: another agent committing concurrently, its stdout interleaved into a shared log. A passing run you did not perform is the most dangerous possible artifact, because it arrives looking like diligence.

The discriminator: **the later commit's log had *zero* hook lines.** That — not a passing run — is what a hookless worktree actually looks like. If a hook's output is present, check it belongs to your commit.

**Related, same shape:** an exit code is a summary; the log is the evidence. A `pre-commit` red was initially read as "exit 130 = 128+2 = SIGINT, a killed job" — reasoning from the number while a `TS2345` sat in the log. Exit 130 is simply how `bun run compile` reports a failed Nx task here. Never infer a cause from the summary when the evidence is in hand.
