### PR TITLE
refactor(cli): the slot planner stages only bytes it can vouch for

### DIFF
--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -2194,8 +2194,10 @@ it("packaged, a MANIFEST-anchored stage ignores the slot's claimed version", asy
 // registered service.
 //
 // It asks that of the link's TARGET, never of the slot, and the three
-// tests below are the whole truth table: target newer, target older, target
-// unable to answer. Which path is probed is itself load-bearing - a probe
+// tests below are the whole truth table: target newer (deferred to, never
+// copied - the planner stages only manifest-anchored bytes or the running
+// image), target older, target unable to answer. Which path is probed is
+// itself load-bearing - a probe
 // SPAWNS what it is given, every packaged CLI refreshes before it parses
 // `--version`, and spawned THROUGH the symlink the child's
 // `process.execPath` resolves to the target, missing the
@@ -2208,7 +2210,7 @@ it("packaged, a MANIFEST-anchored stage ignores the slot's claimed version", asy
 // Windows symlink creation needs Developer Mode, which CI runners do not
 // grant - `symlinkSync` throws before the behavior under test runs.
 it.skipIf(process.platform === "win32")(
-  "packaged, no manifest, legacy SYMLINK to a NEWER binary: de-symlinks from the link's target",
+  "packaged, no manifest, legacy SYMLINK to a NEWER binary: leaves the link for the target to heal, copies nothing",
   async () => {
     seaState.current = true;
     const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
@@ -2232,13 +2234,17 @@ it.skipIf(process.platform === "win32")(
       refreshWellKnownSlotIfStale(ENVIRONMENT),
     );
 
-    expect(result?.staged).toBe("staged");
+    // The canned mock's child only PRINTS - it does not run the refresh the
+    // real spawned CLI would. That is exactly what lets this test isolate
+    // the parent's own conduct: with the healer inert, an untouched symlink
+    // proves the parent copied nothing and deferred the repair, rather than
+    // staging bytes it merely found at the end of a link. The re-entrant
+    // test below drives the real child and pins the healed end state.
+    expect(result).toBeNull();
     const stat = lstatSync(wellKnownPath);
-    expect(stat.isSymbolicLink()).toBe(false);
-    expect(stat.isFile()).toBe(true);
-    // Both halves matter: the target's bytes (no downgrade) in a real file
-    // (no dangling link). Asserting only the first would pass on an
-    // untouched symlink.
+    expect(stat.isSymbolicLink()).toBe(true);
+    // Still the target's bytes through the link - and not the running
+    // binary's, which is the demotion this arm must never perform.
     expect(readFileSync(wellKnownPath, "utf8")).toBe(targetBytes);
     expect(readFileSync(wellKnownPath, "utf8")).not.toBe(runningBytes);
     // The recursion pin: every spawn was the TARGET, never the slot.

--- a/clients/traycer-cli/src/store/well-known-cli.ts
+++ b/clients/traycer-cli/src/store/well-known-cli.ts
@@ -466,38 +466,45 @@ async function slotRefreshPlan(
     // service, which is the very downgrade the guard exists to prevent.
     //
     // The question is asked of the link's TARGET rather than of the slot
-    // because the target is what the bytes ARE - not as a recursion
-    // defence, which it never was. Probing either spelling re-enters this
-    // planner in the child, since the lexical `resolve(wellKnownPath) ===
-    // source` check above cannot see that a symlinked slot and its target
-    // name one file. What ends the recursion is `slotOutranksRunning`
-    // declining to spawn this process's own image: the child launched as
-    // the target asks nothing, stages the slot from itself, de-symlinks it,
-    // and answers. Stated once, there.
+    // because the target is what the bytes ARE. Probing either spelling
+    // re-enters this planner in the child, since the lexical
+    // `resolve(wellKnownPath) === source` check above cannot see that a
+    // symlinked slot and its target name one file. What ends the recursion
+    // is `slotOutranksRunning` declining to spawn this process's own image.
+    // Stated once, there.
     //
-    // Preserving the target only on a version answer, rather than on
-    // `realpath` succeeding, is the other half. Bytes that resolve are not
-    // therefore a CLI: a link may point at a shim, another tool, or
-    // anything else that survived the years since some installer wrote it,
-    // and copying that into the slot hands the registered service and the
-    // host a program that will never repair itself - the repair path here
-    // runs only when a real CLI is invoked, and after this the thing being
-    // invoked is not one. So a target that cannot say what it is loses to
-    // the running packaged CLI, which demonstrably can. (What "usable"
-    // means is exactly what it means one branch below, and both halves are
-    // decided in `slotOutranksRunning`: it answered `--version` with
-    // something parseable, AND it is a binary the slot may hold at all -
-    // an npm install answers that question perfectly well and still must
-    // never be copied here.)
+    // A target that outranks is left ALONE - never copied. This planner
+    // stages only bytes an authority vouches for: the manifest's binary, or
+    // the image this process is running. Bytes merely FOUND at the end of a
+    // link are neither, and every trust once extended to them needed its own
+    // guard (a spelling that named this process's own image, an npm script
+    // that answers `--version` fine, a FIFO that blocks the read). Those
+    // guards all remain, because the probe still spawns the target - but no
+    // verdict they produce can put foreign bytes in the slot any more.
     //
-    // Not strictly newer - older, equal, unreadable, dangling - all fall
-    // through to the ordinary stage from `source`, which de-symlinks and
-    // refreshes in one step. That is also what made copy-not-symlink the
-    // rule: a link nobody can vouch for must not survive as one.
+    // Declining to copy is not declining to repair; it is delegating the
+    // repair to its rightful author. "Strictly newer than this process"
+    // implies the target carries this same refresh - it runs before
+    // commander parses the `--version` the probe just asked for - so the
+    // child, launched as the target, declines to probe its own image and
+    // stages the slot from itself, de-symlinking it with exactly the bytes
+    // this arm used to copy. By the time the probe's answer arrives here the
+    // link is normally already a regular file. When the child could not act
+    // (it lost the CLI lock to a sibling writer), the link survives one more
+    // round: bounded staleness the next probe or the target's next own run
+    // repairs, never a wedge. And a link that later DANGLES stops answering,
+    // loses seniority, and is staged over - self-healing Desktop's old
+    // symlink slot never had.
+    //
+    // Not strictly newer - older, equal, unreadable, ineligible, dangling -
+    // all fall through to the ordinary stage from `source`, which
+    // de-symlinks and refreshes in one step. That is also what made
+    // copy-not-symlink the rule: a link nobody can vouch for must not
+    // survive as one.
     if (!anchored) {
       const target = await realpath(wellKnownPath).catch(() => null);
       if (target !== null && (await slotOutranksRunning(target))) {
-        return { kind: "stage", source: target };
+        return { kind: "current" };
       }
     }
     return { kind: "stage", source };
@@ -590,11 +597,19 @@ async function slotOutranksRunning(candidatePath: string): Promise<boolean> {
   //
   // A version answer is exactly what an npm CLI gives (the shebang runs it),
   // so without this an old Desktop symlink pointing at a newer npm install
-  // puts a Node script behind `bin/traycer`, and nothing repairs it: the next
-  // packaged run probes that slot, the script answers newer again, and the
-  // guard leaves it there forever while the service cannot start. Refusing
-  // here is also what makes that state RECOVERABLE if it is ever reached by
-  // hand - `false` stages the running SEA over it.
+  // would hold seniority forever: the script answers newer on every probe,
+  // the guard leaves the link standing, and the registered service keeps
+  // spawning a shebang whose `node` never resolves. Refusing makes the link
+  // lose the contest and get staged over with the running SEA - and the same
+  // for a script somehow sitting AT the slot by hand.
+  //
+  // Eligibility is also what makes the symlink arm's delegation sound. That
+  // arm leaves an outranking target alone on the grounds that the target,
+  // spawned by this very probe, repairs the slot itself - which only a
+  // PACKAGED CLI does (`isPackagedRun` gates the refresh). Checked here,
+  // before the spawn, every target that can win the contest is a real
+  // executable image, so the thing deferred to is a thing that carries the
+  // healer.
   if (!(await isSlotEligibleBinary(candidatePath))) return false;
   let reported: string;
   try {


### PR DESCRIPTION
Follow-up to #1314, doing the simplification the review churn there pointed at.

## The change

The unanchored symlink arm was the one place the slot planner would copy bytes into `bin/traycer` that no authority vouched for — bytes merely **found** at the end of a legacy Desktop link. Every defect the last three review rounds of #1314 surfaced lived in exactly that trust:

- a spelling that named this process's own image and recursed (fixed by the identity guard),
- an npm script that answers `--version` fine and wedges the registered service (fixed by slot eligibility),
- a FIFO that blocks the eligibility read with no deadline (fixed by stat-isFile + `O_NONBLOCK`).

Each got its own guard; the class kept producing members because the trust itself was the defect. This PR retires the trust and keeps every guard: a target that outranks the running process is now left **alone** (`current`), and every stage the planner performs sources from the manifest's binary or the running image — files the process can actually vouch for.

## Why leaving the link is sound

Declining to copy is delegating the repair to its rightful author, and the delegation holds by construction:

1. **"Strictly newer than this process" implies the target carries this same refresh** — it runs before commander parses the `--version` the probe just asked for. The child, launched as the target, declines to probe its own image and stages the slot from itself, de-symlinking it with exactly the bytes this arm used to copy — normally before the probe's answer even arrives in the parent.
2. **Eligibility is checked before the spawn**, so every target that can win the contest is a real executable image — the kind `isPackagedRun` lets run the healer. A script cannot be deferred to, only staged over.
3. **No new wedge.** A link the child could not heal (lost the CLI lock to a sibling writer) survives one round of bounded staleness; a link that later dangles stops answering, loses seniority, and is staged over.

The residual this closes for good: a non-Traycer binary that prints a plausible newer version could previously have its bytes **installed into the slot**. Now the worst an impostor gets is an untouched symlink — recoverable by every later run — instead of occupancy.

## Tests

77 in the CLI store suite, 317 across the four CLI suites, 139 across the desktop CLI suites — all green. The canned-mock NEWER-target case now asserts the parent's own conduct (result `null`, link untouched, only the target spawned); the mock's inert child is exactly what isolates that. The re-entrant test drives the real child and pins the healed end state (regular file, target bytes, nesting depth 1) unchanged. Mutation probe: restoring the `stage`-from-target return fails the reworked test and nothing else.
