### PR TITLE
build: give the type-checkers room, and stop running eight of them at once

### DIFF
--- a/clients/gui-app/package.json
+++ b/clients/gui-app/package.json
@@ -10,7 +10,7 @@
     ".": "./index.ts"
   },
   "scripts": {
-    "compile": "tsc -b",
+    "compile": "NODE_OPTIONS=--max-old-space-size=6144 tsc -b",
     "lint": "NODE_OPTIONS=--max-old-space-size=6144 eslint . --cache --fix --max-warnings 0",
     "react-doctor": "npx -y react-doctor@latest . --verbose --offline --blocking warning",
     "format": "bun x prettier --write .",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "dev-desktop": "bun scripts/dev-desktop.js",
-    "compile": "nx run-many --target=compile --all --tui=false",
-    "build": "nx run-many --target=build --all --exclude=@traycer-clients/desktop --tui=false",
+    "compile": "nx run-many --target=compile --all --parallel=${NX_COMPILE_PARALLEL:-3} --tui=false",
+    "build": "nx run-many --target=build --all --exclude=@traycer-clients/desktop --parallel=${NX_COMPILE_PARALLEL:-3} --tui=false",
     "format": "nx run-many --target=format --all --tui=false",
     "lint": "nx run-many --target=lint --all --tui=false",
     "test": "nx run-many --target=test --all --tui=false",

--- a/scripts/pre_commit_workspace_checks.sh
+++ b/scripts/pre_commit_workspace_checks.sh
@@ -9,6 +9,24 @@ pushd "$gitroot" >/dev/null
 
 nx_parallel="${NX_PARALLEL:-8}"
 
+# Compile and build get their OWN, lower fan-out. Lint and format stream files
+# one at a time, so eight of them cost little; `tsc` holds a whole type program
+# resident, and these are not comparable workloads. Measured peak RSS for a
+# single process, macOS, TypeScript 5.x:
+#
+#   traycer-clients-gui-app  `tsc -b`        ~3.5 GB
+#   @traycer/protocol        `tsc --noEmit`  ~1.35 GB
+#   @traycer-clients/shared  `tsc --noEmit`  ~1.15 GB
+#
+# A change touching protocol + shared + gui-app makes all three (plus their
+# dependents) affected at once, so at --parallel=8 the compile step alone asks
+# for ~6 GB before counting desktop, the CLI, and nx's own workers. That
+# exhausts a CI runner and thrashes a developer machine, and it surfaces as a
+# failed task rather than anything that names memory.
+#
+# Override with NX_COMPILE_PARALLEL when you know the box can take it.
+nx_compile_parallel="${NX_COMPILE_PARALLEL:-3}"
+
 run_full_checks() {
   echo "Running full workspace checks..."
   bun run lint
@@ -19,14 +37,15 @@ run_full_checks() {
 
 run_affected() {
   local args=("$@")
-  bun x nx affected --target=lint "${args[@]}"
-  bun x nx affected --target=format "${args[@]}"
-  bun x nx affected --targets=compile,build "${args[@]}"
+  bun x nx affected --target=lint "${args[@]}" --parallel="${nx_parallel}"
+  bun x nx affected --target=format "${args[@]}" --parallel="${nx_parallel}"
+  bun x nx affected --targets=compile,build "${args[@]}" \
+    --parallel="${nx_compile_parallel}"
 }
 
 if [ -n "${CI:-}" ] && [ -n "${NX_BASE:-}" ] && [ -n "${NX_HEAD:-}" ]; then
   echo "Affected workspace checks (${NX_BASE}..${NX_HEAD})..."
-  run_affected --base="${NX_BASE}" --head="${NX_HEAD}" --parallel="${nx_parallel}" --tui=false
+  run_affected --base="${NX_BASE}" --head="${NX_HEAD}" --tui=false
 else
   base_ref=""
   for ref in origin/main main HEAD~1; do
@@ -40,7 +59,7 @@ else
     run_full_checks
   else
     echo "Affected workspace checks (base: ${base_ref})..."
-    run_affected --base="${base_ref}" --parallel="${nx_parallel}" --tui=false
+    run_affected --base="${base_ref}" --tui=false
   fi
 fi
 


### PR DESCRIPTION
`traycer-clients-gui-app`'s `tsc -b` peaks at **~3.5 GB against Node's ~4 GB default heap** — roughly 13% of headroom — and no compile target in this repo sets `--max-old-space-size`. It has been surviving on a margin that shrinks with every file added.

This surfaced as compiles failing on CI and stalling locally on a PR that happened to touch three packages at once. That PR was not the cause; it was just the first change wide enough to make `nx affected` select protocol + shared + gui-app together.

## Measurements

Peak RSS, single process, macOS:

| Target | Command | Peak RSS |
| --- | --- | --- |
| `traycer-clients-gui-app` | `tsc -b` | **3.46 GB** |
| `@traycer/protocol` | `tsc --noEmit` | 1.35 GB |
| `@traycer-clients/shared` | `tsc --noEmit` | 1.15 GB |

## Controls

Raising a limit is only worth doing if the limit is actually binding, so both directions were checked rather than assumed:

- **Negative** — `NODE_OPTIONS=--max-old-space-size=3000` (below the measured peak): dies `Abort trap: 6`, **exit 134**, heap-OOM in the log. This proves the ceiling is reachable *and* that `NODE_OPTIONS` reaches this compile at all.
- **Positive** — default ceiling: completes, exit 0, at the 3.46 GB peak above.

Bun's expansion of `${NX_COMPILE_PARALLEL:-3}` inside a `package.json` script was also verified directly (default `3`, override honoured) rather than assumed.

## Changes

**1. `gui-app`'s `compile` gets `--max-old-space-size=6144`.** This matches the ceiling its own `lint` script has carried for some time. The package was already known to need 6 GB for one tool; the other never got it.

**2. `compile` and `build` get their own, lower fan-out** (`NX_COMPILE_PARALLEL`, default 3), leaving `lint` and `format` at 8. Lint and format stream files one at a time, so eight at once costs little; `tsc` holds a whole type program resident. They are not comparable workloads and should not have shared one `--parallel`.

**3. The root `compile`/`build` scripts get the same bound**, so a plain `bun run compile` is covered and not just the pre-commit path.

Note that `--max-old-space-size` raises a cap rather than reserving anything, so change 1 on its own would have permitted *more* concurrent usage. The two changes are meant to go together.

## Why this reads as flake

The resulting failure names neither memory nor a file — it surfaces as a failed Nx task, and an exit code that invites a guess about signals. On the PR that triggered this investigation it was misread as CI capacity and cost a wasted re-run. That is the diagnostic cost of the current settings, independent of the crashes.

## Verification

Committed through the repo's own `pre-commit`, with `build · compile · lint · format (nx affected)` **passing** — so the modified script ran the real affected compile at the new parallelism with the new ceiling. `shellcheck` clean.
