### PR TITLE
docs(protocol): name the right party in the @1.3 no-gate argument

### DIFF
--- a/protocol/src/host/epic/subscribe.ts
+++ b/protocol/src/host/epic/subscribe.ts
@@ -556,16 +556,25 @@ export const epicSubscribeServerFrameSchemaV12 = z.discriminatedUnion("kind", [
 //
 // Both halves are the SAME kind of additive growth as `@1.2`'s `roomId` - a
 // new PROPERTY on an existing shape, not a new frame KIND - so neither needs
-// an emission gate, for the asymmetry spelled out in the `@1.2` note above.
-// The version fact lives entirely in the schema:
+// an emission gate. But they are safe for DIFFERENT reasons, and the two are
+// chained rather than parallel:
 //
-//   - Request: the dispatcher parses params with the NEGOTIATED contract's
-//     `openRequestSchema` and hands the PARSED value to the resolver, so a
-//     sub-`@1.3` peer's `seedOffer` is stripped before the resolver exists.
-//     Nothing has to ask what was negotiated.
-//   - Response: `seededFromOffer` can only be set when an offer arrived, which
-//     can only happen at `@1.3`; and a sub-`@1.3` peer parsing with its own
-//     frozen meta would strip the key regardless.
+//   - Response: `seededFromOffer` is @1.2's argument exactly - consumer
+//     tolerance. A peer below `@1.3` parses the meta with its own frozen
+//     schema and strips a key it does not know, so the host may publish
+//     unconditionally.
+//   - Request: STRONGER than tolerance. The dispatcher validates params
+//     against the NEGOTIATED contract and hands the resolver the PARSED
+//     value, so an offer arriving on a connection that settled below `@1.3`
+//     is dropped before any resolver sees it. Not "no harm if it arrives" -
+//     it does not arrive. Note the party: the offer comes from a
+//     `@1.3`-CAPABLE client, which offers unconditionally because it cannot
+//     know the negotiated minor when it builds its first open request. A peer
+//     that predates the field has no `seedOffer` to strip.
+//
+// The chain: the response claim ("can only be set when an offer arrived")
+// holds BECAUSE the request-side gate does. Lose that gate and the response
+// half goes with it.
 //
 // So there is no `supportsDeltaSeed()` sibling to `supportsDirtyFrames()`, and
 // deliberately so: the gate that does not exist has no degraded path to get


### PR DESCRIPTION
Comment-only. No schema, wire, or behaviour change — every changed line is a comment (verified mechanically, not by eye).

## The defect

The `epic.subscribe@1.3` summary block in `subscribe.ts` said:

> a sub-`@1.3` peer's `seedOffer` is stripped before the resolver exists

**A peer that predates the field has no `seedOffer` to strip** — it has never heard of it. The case the dispatcher actually handles is the opposite one: a **`@1.3`-capable client** offering on a connection that settled **below** `@1.3`. That is not an edge case, it is the normal path, because a client offers unconditionally — it cannot know the negotiated minor when it builds its first open request.

**This is not hypothetical: it already misled a reader.** Someone updating the host's canonical-manifest assertion for `@1.3` mirrored this sentence into `bootstrap-stream.test.ts` and had to be corrected in review.

The precise statement was in the file the whole time — `epicSubscribeOpenRequestSchema`'s own note, ~400 lines earlier, correctly says "a client that negotiated `@1.0`-`@1.2`". The loose one sat under the `@1.3` heading, which is where a reader looks first. **The least authoritative text in the file was the most likely to be read**, and proximity to the topic heading is not evidence of precision.

## The second error in the same block

It also asserted both halves need no gate *"for the asymmetry spelled out in the `@1.2` note above"* — collapsing two different arguments into one:

| Half | Why it is safe |
| --- | --- |
| **Response** (`seededFromOffer`) | `@1.2`'s argument exactly — **consumer tolerance**. A peer below `@1.3` parses the meta with its own frozen schema and strips a key it does not know, so the host may publish unconditionally. |
| **Request** (`seedOffer`) | **Stronger than tolerance.** The dispatcher validates params against the *negotiated* contract and hands the resolver the *parsed* value, so an out-of-version offer is dropped before any resolver sees it. Not "no harm if it arrives" — it does not arrive. |

`@1.2` has no analogue of the second, because `@1.2` added nothing the host could *act on*.

And they are **chained, not parallel**: the response claim ("`seededFromOffer` can only be set when an offer arrived") holds *because* the request-side gate does. Lose that gate and the response half goes with it — a dependency the old text never stated.

## Why this is its own PR

A wrong comment in the protocol is a separate defect from the stale assertion it caused in a host test — different repo, different failure, different reviewer. Comment-only, so `1a6bfe6e54` stays an ancestor of `main`, `oss-pin-ancestry` keeps passing, and no submodule pin bump is required.

## Verification

Every changed line confirmed to be a comment by filtering the diff, rather than by reading it. `prettier --check` clean, `eslint --max-warnings 0` clean, `bun run compile` green across all 5 projects.