### PR TITLE
fix(gui-app,desktop): honest fallback answers across the install commit boundary

### DIFF
--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
@@ -819,6 +819,40 @@ describe("maintenanceInstallVersion IPC", () => {
     expect(installVersion).not.toHaveBeenCalled();
   });
 
+  it("classifies every version-moving lane as update work, and only those", async () => {
+    // `install`/`apply` move the version by definition; `activate` is the
+    // activation tail of an install; `ensure` shells `host ensure`, which
+    // installs or updates whenever the record is missing or stale. Reporting
+    // any of these as generic contention presents real update work as a
+    // retryable failure - the fallback releases its accepted-update latch
+    // and re-offers Install mid-update. Everything else holds the same
+    // exclusive lane without touching the version and MUST stay `false`: an
+    // `already-updating` answer arms that latch to wait on progress those
+    // operations never publish. Iterates the fenced kind list so a NEW
+    // MutationKind fails here and forces this classification decision.
+    const updateWorkKinds: readonly MutationKind[] = [
+      "install",
+      "apply",
+      "activate",
+      "ensure",
+    ];
+    const bridge = makeBridge();
+    const handler = await registerInstallHandler(bridge);
+    for (const kind of ALL_MUTATION_KINDS) {
+      bridge.options.hostController.lifecycleAdmissionBlock = {
+        kind: "mutation",
+        lane: { kind, progress: null, startedAt: "2026-08-12T00:00:00Z" },
+      };
+      await expect(
+        handler(null, { version: "1.2.0", force: false }),
+      ).resolves.toEqual({
+        kind: "lane-busy",
+        updateInFlight: updateWorkKinds.includes(kind),
+        message: laneBusyRestartMessage(kind),
+      });
+    }
+  });
+
   it("dispatches installVersion when nothing blocks admission", async () => {
     const installVersion = vi.fn((version: string, force: boolean) =>
       Promise.resolve({

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
@@ -820,13 +820,16 @@ describe("maintenanceInstallVersion IPC", () => {
   });
 
   it("classifies every version-moving lane as update work, and only those", async () => {
-    // `install`/`apply` move the version by definition; `activate` is the
-    // activation tail of an install. Everything else at `progress: null` -
-    // including `ensure`, whose no-op fast path returns before its first
-    // progress callback - MUST stay `false`: an `already-updating` answer
-    // arms the caller's accepted-update latch, and on a pre-1.2.0 host
-    // nothing releases it before the full 60s timer, because these hosts
-    // never publish `host.status.updateProgress`.
+    // This bit never admits anything - the install is already refused - it
+    // only chooses between `already-updating` (which ARMS the caller's
+    // accepted-update latch) and a retryable refusal. On a pre-1.2.0 host
+    // nothing releases that latch before the full 60s timer (these hosts
+    // never publish `host.status.updateProgress`), so `true` is reserved
+    // for lanes whose work can OUTLAST the latch: the minutes-long
+    // version movers. `activate` is deliberately `false` - the lane kind
+    // cannot separate the genuine update tail from the legacy
+    // `activationUnknown` stamp-repair, and both are seconds-long either
+    // way.
     //
     // Compile-time exhaustive: `satisfies Record<MutationKind, boolean>`
     // makes a NEW MutationKind a type error here until it gets an explicit
@@ -836,7 +839,7 @@ describe("maintenanceInstallVersion IPC", () => {
     const updateWorkByKind = {
       install: true,
       apply: true,
-      activate: true,
+      activate: false,
       // At `progress: null`. The numeric-evidence gate that can flip an
       // ensure to `true` has its own tests below.
       ensure: false,

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
@@ -826,13 +826,31 @@ describe("maintenanceInstallVersion IPC", () => {
     // progress callback - MUST stay `false`: an `already-updating` answer
     // arms the caller's accepted-update latch, and on a pre-1.2.0 host
     // nothing releases it before the full 60s timer, because these hosts
-    // never publish `host.status.updateProgress`. Iterates the fenced kind
-    // list so a NEW MutationKind fails here and forces the decision.
-    const updateWorkKinds: readonly MutationKind[] = [
-      "install",
-      "apply",
-      "activate",
-    ];
+    // never publish `host.status.updateProgress`.
+    //
+    // Compile-time exhaustive: `satisfies Record<MutationKind, boolean>`
+    // makes a NEW MutationKind a type error here until it gets an explicit
+    // decision, and the sorted-census equality below pins the runtime loop
+    // to the same set - `readonly MutationKind[]` alone would permit a
+    // subset, letting a new kind compile without ever entering the loop.
+    const updateWorkByKind = {
+      install: true,
+      apply: true,
+      activate: true,
+      // At `progress: null`. The numeric-evidence gate that can flip an
+      // ensure to `true` has its own tests below.
+      ensure: false,
+      register: false,
+      deregister: false,
+      respawn: false,
+      recoverIfDown: false,
+      freePortAndRestart: false,
+      uninstallHost: false,
+      removeTraycer: false,
+    } satisfies Record<MutationKind, boolean>;
+    expect([...ALL_MUTATION_KINDS].sort()).toEqual(
+      Object.keys(updateWorkByKind).sort(),
+    );
     const bridge = makeBridge();
     const handler = await registerInstallHandler(bridge);
     for (const kind of ALL_MUTATION_KINDS) {
@@ -844,44 +862,78 @@ describe("maintenanceInstallVersion IPC", () => {
         handler(null, { version: "1.2.0", force: false }),
       ).resolves.toEqual({
         kind: "lane-busy",
-        updateInFlight: updateWorkKinds.includes(kind),
+        updateInFlight: updateWorkByKind[kind],
         message: laneBusyRestartMessage(kind),
       });
     }
   });
 
-  it("counts an ensure lane as update work only once it reports provisioning progress", async () => {
-    // The evidence gate: `host ensure` emits its first progress event only
-    // AFTER the no-op fast path (installed + registered + running + version
-    // satisfied) has been passed - so a lane with progress is materially
-    // provisioning (staging bytes, registering, starting), the window a
-    // competing install must not race, while a lane without it is the common
-    // just-verifying contention that must stay generic so the caller's
-    // accepted-update latch is not armed for a minute over a no-op.
+  it("counts an ensure lane as update work only on numeric progress evidence", async () => {
+    // The evidence must be a NUMBER, not mere progress presence: `host
+    // ensure`'s service branches (register, start, the repair retry)
+    // narrate through the same null-metric `host-provision` events without
+    // touching the version, so presence alone would lock the caller's
+    // update controls for a minute over a service repair. Only the
+    // version-moving path reports numerics - the staging download's
+    // `bytes`/`totalBytes`/`percent`, the extract's `workUnits`.
     const bridge = makeBridge();
     const handler = await registerInstallHandler(bridge);
-    bridge.options.hostController.lifecycleAdmissionBlock = {
-      kind: "mutation",
-      lane: {
-        kind: "ensure",
+    const cases = [
+      {
+        // The Codex round-3 case: a service-only ensure on an
+        // already-current host - same stage string, no numerics.
         progress: {
           stage: "host-provision",
           percent: null,
           bytes: null,
           totalBytes: null,
-          message: "installing host (1.2.0)",
+          message: "registering OS service for installed host",
           workUnits: null,
         },
-        startedAt: "2026-08-12T00:00:00Z",
+        updateInFlight: false,
       },
-    };
-    await expect(
-      handler(null, { version: "1.2.0", force: false }),
-    ).resolves.toEqual({
-      kind: "lane-busy",
-      updateInFlight: true,
-      message: laneBusyRestartMessage("ensure"),
-    });
+      {
+        // Staging download: bytes are moving toward a version change.
+        progress: {
+          stage: "download",
+          percent: 42,
+          bytes: 42_000_000,
+          totalBytes: 100_000_000,
+          message: "downloading host 1.2.0",
+          workUnits: null,
+        },
+        updateInFlight: true,
+      },
+      {
+        // Extract: entry-driven work units, the other numeric producer.
+        progress: {
+          stage: "extract",
+          percent: null,
+          bytes: null,
+          totalBytes: null,
+          message: "extracting host 1.2.0",
+          workUnits: 120,
+        },
+        updateInFlight: true,
+      },
+    ];
+    for (const testCase of cases) {
+      bridge.options.hostController.lifecycleAdmissionBlock = {
+        kind: "mutation",
+        lane: {
+          kind: "ensure",
+          progress: testCase.progress,
+          startedAt: "2026-08-12T00:00:00Z",
+        },
+      };
+      await expect(
+        handler(null, { version: "1.2.0", force: false }),
+      ).resolves.toEqual({
+        kind: "lane-busy",
+        updateInFlight: testCase.updateInFlight,
+        message: laneBusyRestartMessage("ensure"),
+      });
+    }
   });
 
   it("dispatches installVersion when nothing blocks admission", async () => {

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
@@ -821,20 +821,17 @@ describe("maintenanceInstallVersion IPC", () => {
 
   it("classifies every version-moving lane as update work, and only those", async () => {
     // `install`/`apply` move the version by definition; `activate` is the
-    // activation tail of an install; `ensure` shells `host ensure`, which
-    // installs or updates whenever the record is missing or stale. Reporting
-    // any of these as generic contention presents real update work as a
-    // retryable failure - the fallback releases its accepted-update latch
-    // and re-offers Install mid-update. Everything else holds the same
-    // exclusive lane without touching the version and MUST stay `false`: an
-    // `already-updating` answer arms that latch to wait on progress those
-    // operations never publish. Iterates the fenced kind list so a NEW
-    // MutationKind fails here and forces this classification decision.
+    // activation tail of an install. Everything else at `progress: null` -
+    // including `ensure`, whose no-op fast path returns before its first
+    // progress callback - MUST stay `false`: an `already-updating` answer
+    // arms the caller's accepted-update latch, and on a pre-1.2.0 host
+    // nothing releases it before the full 60s timer, because these hosts
+    // never publish `host.status.updateProgress`. Iterates the fenced kind
+    // list so a NEW MutationKind fails here and forces the decision.
     const updateWorkKinds: readonly MutationKind[] = [
       "install",
       "apply",
       "activate",
-      "ensure",
     ];
     const bridge = makeBridge();
     const handler = await registerInstallHandler(bridge);
@@ -851,6 +848,40 @@ describe("maintenanceInstallVersion IPC", () => {
         message: laneBusyRestartMessage(kind),
       });
     }
+  });
+
+  it("counts an ensure lane as update work only once it reports provisioning progress", async () => {
+    // The evidence gate: `host ensure` emits its first progress event only
+    // AFTER the no-op fast path (installed + registered + running + version
+    // satisfied) has been passed - so a lane with progress is materially
+    // provisioning (staging bytes, registering, starting), the window a
+    // competing install must not race, while a lane without it is the common
+    // just-verifying contention that must stay generic so the caller's
+    // accepted-update latch is not armed for a minute over a no-op.
+    const bridge = makeBridge();
+    const handler = await registerInstallHandler(bridge);
+    bridge.options.hostController.lifecycleAdmissionBlock = {
+      kind: "mutation",
+      lane: {
+        kind: "ensure",
+        progress: {
+          stage: "host-provision",
+          percent: null,
+          bytes: null,
+          totalBytes: null,
+          message: "installing host (1.2.0)",
+          workUnits: null,
+        },
+        startedAt: "2026-08-12T00:00:00Z",
+      },
+    };
+    await expect(
+      handler(null, { version: "1.2.0", force: false }),
+    ).resolves.toEqual({
+      kind: "lane-busy",
+      updateInFlight: true,
+      message: laneBusyRestartMessage("ensure"),
+    });
   });
 
   it("dispatches installVersion when nothing blocks admission", async () => {

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -136,34 +136,39 @@ function nullableString(raw: unknown, key: string): string | null {
 /**
  * Whether an admission block represents UPDATE work.
  *
- * The answer prices a real lock: the fallback maps `true` to the protocol's
- * `already-updating`, which arms the Overview's accepted-update latch - and
- * on a pre-1.2.0 host the only releases are a scope flip or the full 60s
- * timer, because the `host.status.updateProgress` frame that normally frees
- * it is a field these hosts never publish. Overclaiming therefore locks the
- * page's update and lifecycle controls for a minute; underclaiming presents
- * real update work as a retryable failure that releases the latch and
- * invites a competing install submission. Each kind is judged against that
- * price:
+ * Scope first: the lane is exclusive and the caller has ALREADY refused the
+ * competing install by the time it asks - this bit never admits anything.
+ * It picks between two presentations of that refusal: `true` becomes the
+ * protocol's `already-updating` (an informational toast that ARMS the
+ * Overview's accepted-update latch), `false` a retryable refusal carrying
+ * the lane's message. On a pre-1.2.0 host the latch releases only on a
+ * scope flip or its full 60s timer - the `host.status.updateProgress`
+ * frame that normally frees it is a field these hosts never publish - so a
+ * wrong `true` is a minute-long lock of the page's update and lifecycle
+ * controls, while a wrong `false` is an error-styled toast whose text
+ * (`laneBusyRestartMessage`) still names the update. That asymmetry sets
+ * the rule: answer `true` only when the lane work can OUTLAST the latch it
+ * arms, so the lock is protecting a swap that is genuinely still running.
  *
- *  - `install` / `apply` move the version by definition.
- *  - `activate` is the activation tail of an install (packaged-macOS
- *    post-commit, or clearing pendingActivation debt) - an update mid-swap,
- *    when a competing submission is at its most dangerous.
- *  - `ensure` only with NUMERIC evidence. Mere non-null progress is not it:
- *    `host ensure`'s service branches - `runServiceRegister`, `runStart`,
- *    the repair retry - narrate through the same null-metric
- *    `host-provision` events without ever touching the version, so a
- *    service repair on an already-current host would read as an update.
- *    What only the version-moving path emits is a NUMBER: the staging
- *    download reports `bytes`/`totalBytes`/`percent` and the extract
- *    reports `workUnits`, and those are the long windows a competing
- *    install must not race. The no-op fast path (already installed,
- *    registered, running, version satisfied - the common contention on a
- *    page that requires a running host) returns before any progress at
- *    all. The brief null-metric moments inside a real install (source
- *    resolution, the locked promote) fall to generic contention - the
- *    cheap direction, a retryable refusal rather than a minute-long lock.
+ *  - `install` / `apply` qualify by definition: version-moving, and
+ *    minutes-long against the 60s window.
+ *  - `ensure` qualifies only with NUMERIC progress evidence. Its service
+ *    branches (`runServiceRegister`, `runStart`, the repair retry) narrate
+ *    through the same null-metric `host-provision` events without touching
+ *    the version, and its no-op fast path returns before any progress at
+ *    all; only the version-moving path reports numbers - the staging
+ *    download's `bytes`/`totalBytes`/`percent`, the extract's `workUnits` -
+ *    and those are its long windows. Null-metric moments inside a real
+ *    install (source resolution, the locked promote) fall to the retryable
+ *    side, the cheap direction.
+ *  - `activate` does NOT qualify, deliberately. The lane cannot say which
+ *    arm triggered it: the genuine update tail (pendingActivation) and the
+ *    legacy stamp-repair (`activationUnknown` - a record with
+ *    `runtimeVersion: null`, which launch converge activates with NO update
+ *    staged, on exactly this pre-1.2.0 population) are one kind at
+ *    admission. Both are a seconds-long service cycle either way - work the
+ *    60s latch would outlive many times over, guarding a swap that already
+ *    finished while the page sits locked.
  *
  * Every other kind (register, deregister, respawn, recoverIfDown,
  * freePortAndRestart, uninstallHost, removeTraycer) and the login-item
@@ -182,11 +187,7 @@ function admissionBlockIsUpdateWork(block: LifecycleAdmissionBlock): boolean {
         progress.workUnits !== null)
     );
   }
-  return (
-    block.lane.kind === "install" ||
-    block.lane.kind === "apply" ||
-    block.lane.kind === "activate"
-  );
+  return block.lane.kind === "install" || block.lane.kind === "apply";
 }
 
 /**

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -136,34 +136,41 @@ function nullableString(raw: unknown, key: string): string | null {
 /**
  * Whether an admission block represents UPDATE work.
  *
- * Four lane intents can be moving the host's version while they hold the
- * lane - the same four `laneBusyRestartMessage` already groups under
- * "installing an update", so the two taxonomies answer with one voice:
+ * The answer prices a real lock: the fallback maps `true` to the protocol's
+ * `already-updating`, which arms the Overview's accepted-update latch - and
+ * on a pre-1.2.0 host the only releases are a scope flip or the full 60s
+ * timer, because the `host.status.updateProgress` frame that normally frees
+ * it is a field these hosts never publish. Overclaiming therefore locks the
+ * page's update and lifecycle controls for a minute; underclaiming presents
+ * real update work as a retryable failure that releases the latch and
+ * invites a competing install submission. Each kind is judged against that
+ * price:
  *
- *  - `install` / `apply` move it by definition;
+ *  - `install` / `apply` move the version by definition.
  *  - `activate` is the activation tail of an install (packaged-macOS
- *    post-commit, or clearing pendingActivation debt) - an update mid-swap;
- *  - `ensure` shells `host ensure`, which installs or updates whenever the
- *    record is missing or stale, and from outside the lane that is
- *    indistinguishable from a plain start.
+ *    post-commit, or clearing pendingActivation debt) - an update mid-swap,
+ *    when a competing submission is at its most dangerous.
+ *  - `ensure` only WITH EVIDENCE: `host ensure`'s no-op fast path (already
+ *    installed, registered, running, version satisfied - the common
+ *    contention on a page that requires a running host) returns before its
+ *    first progress callback, so a lane still at `progress: null` is either
+ *    that no-op or has not started provisioning - generic contention either
+ *    way. A non-null `progress` means the CLI passed the fast path and is
+ *    materially provisioning (staging bytes, registering, starting), the
+ *    window a competing install must not race.
  *
- * The asymmetry decides the ambiguous `ensure` case: overclaiming costs a
- * transient "already updating" notice on a self-clearing lane, while
- * underclaiming presents REAL update work as a retryable failure - the
- * fallback releases its accepted-update latch and invites a competing
- * install submission. Every other kind (register, deregister, respawn,
- * recoverIfDown, freePortAndRestart, uninstallHost, removeTraycer) and the
- * login-item refresh take the same exclusive lane without ever touching the
- * version. Listed positively so a NEW `MutationKind` defaults to "not an
- * update".
+ * Every other kind (register, deregister, respawn, recoverIfDown,
+ * freePortAndRestart, uninstallHost, removeTraycer) and the login-item
+ * refresh take the same exclusive lane without ever touching the version.
+ * Listed positively so a NEW `MutationKind` defaults to "not an update".
  */
 function admissionBlockIsUpdateWork(block: LifecycleAdmissionBlock): boolean {
   if (block.kind === "login-item-refresh") return false;
+  if (block.lane.kind === "ensure") return block.lane.progress !== null;
   return (
     block.lane.kind === "install" ||
     block.lane.kind === "apply" ||
-    block.lane.kind === "activate" ||
-    block.lane.kind === "ensure"
+    block.lane.kind === "activate"
   );
 }
 

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -150,14 +150,20 @@ function nullableString(raw: unknown, key: string): string | null {
  *  - `activate` is the activation tail of an install (packaged-macOS
  *    post-commit, or clearing pendingActivation debt) - an update mid-swap,
  *    when a competing submission is at its most dangerous.
- *  - `ensure` only WITH EVIDENCE: `host ensure`'s no-op fast path (already
- *    installed, registered, running, version satisfied - the common
- *    contention on a page that requires a running host) returns before its
- *    first progress callback, so a lane still at `progress: null` is either
- *    that no-op or has not started provisioning - generic contention either
- *    way. A non-null `progress` means the CLI passed the fast path and is
- *    materially provisioning (staging bytes, registering, starting), the
- *    window a competing install must not race.
+ *  - `ensure` only with NUMERIC evidence. Mere non-null progress is not it:
+ *    `host ensure`'s service branches - `runServiceRegister`, `runStart`,
+ *    the repair retry - narrate through the same null-metric
+ *    `host-provision` events without ever touching the version, so a
+ *    service repair on an already-current host would read as an update.
+ *    What only the version-moving path emits is a NUMBER: the staging
+ *    download reports `bytes`/`totalBytes`/`percent` and the extract
+ *    reports `workUnits`, and those are the long windows a competing
+ *    install must not race. The no-op fast path (already installed,
+ *    registered, running, version satisfied - the common contention on a
+ *    page that requires a running host) returns before any progress at
+ *    all. The brief null-metric moments inside a real install (source
+ *    resolution, the locked promote) fall to generic contention - the
+ *    cheap direction, a retryable refusal rather than a minute-long lock.
  *
  * Every other kind (register, deregister, respawn, recoverIfDown,
  * freePortAndRestart, uninstallHost, removeTraycer) and the login-item
@@ -166,7 +172,16 @@ function nullableString(raw: unknown, key: string): string | null {
  */
 function admissionBlockIsUpdateWork(block: LifecycleAdmissionBlock): boolean {
   if (block.kind === "login-item-refresh") return false;
-  if (block.lane.kind === "ensure") return block.lane.progress !== null;
+  if (block.lane.kind === "ensure") {
+    const progress = block.lane.progress;
+    return (
+      progress !== null &&
+      (progress.percent !== null ||
+        progress.bytes !== null ||
+        progress.totalBytes !== null ||
+        progress.workUnits !== null)
+    );
+  }
   return (
     block.lane.kind === "install" ||
     block.lane.kind === "apply" ||

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -136,17 +136,35 @@ function nullableString(raw: unknown, key: string): string | null {
 /**
  * Whether an admission block represents UPDATE work.
  *
- * `install` and `apply` are the two lane intents that move the host's
- * version; every other kind (register, deregister, respawn, recoverIfDown,
- * freePortAndRestart, uninstallHost, removeTraycer, ensure, activate) and the
- * login-item refresh take the same exclusive lane without being an update.
- * Listed positively so a NEW `MutationKind` defaults to "not an update" -
- * the safe direction, since the alternative is telling someone an update is
- * running when none is.
+ * Four lane intents can be moving the host's version while they hold the
+ * lane - the same four `laneBusyRestartMessage` already groups under
+ * "installing an update", so the two taxonomies answer with one voice:
+ *
+ *  - `install` / `apply` move it by definition;
+ *  - `activate` is the activation tail of an install (packaged-macOS
+ *    post-commit, or clearing pendingActivation debt) - an update mid-swap;
+ *  - `ensure` shells `host ensure`, which installs or updates whenever the
+ *    record is missing or stale, and from outside the lane that is
+ *    indistinguishable from a plain start.
+ *
+ * The asymmetry decides the ambiguous `ensure` case: overclaiming costs a
+ * transient "already updating" notice on a self-clearing lane, while
+ * underclaiming presents REAL update work as a retryable failure - the
+ * fallback releases its accepted-update latch and invites a competing
+ * install submission. Every other kind (register, deregister, respawn,
+ * recoverIfDown, freePortAndRestart, uninstallHost, removeTraycer) and the
+ * login-item refresh take the same exclusive lane without ever touching the
+ * version. Listed positively so a NEW `MutationKind` defaults to "not an
+ * update".
  */
 function admissionBlockIsUpdateWork(block: LifecycleAdmissionBlock): boolean {
   if (block.kind === "login-item-refresh") return false;
-  return block.lane.kind === "install" || block.lane.kind === "apply";
+  return (
+    block.lane.kind === "install" ||
+    block.lane.kind === "apply" ||
+    block.lane.kind === "activate" ||
+    block.lane.kind === "ensure"
+  );
 }
 
 /**

--- a/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
@@ -107,20 +107,23 @@ describe("mapInstallVersionOutcome", () => {
     );
   });
 
-  it("maps the POST-commit busy (continuation: activate) to accepted, not an error", () => {
-    // Packaged macOS commits the selected bytes BEFORE activation, so a busy
-    // outcome carrying `continuation: "activate"` describes an install that
-    // already happened. The error channel would release the accepted-update
-    // latch and re-offer Install for a version that is on disk - a second
-    // submission is the competing-install harm the lane-busy refusal exists
-    // to prevent. `accepted` keeps the latch armed, same as a completed ok.
-    expect(
-      mapInstallVersionOutcome({
-        kind: "busy",
-        continuation: "activate",
-        message: "Installed; restart Traycer to finish activating it.",
-      }),
-    ).toEqual({ outcome: "accepted" });
+  it("throws for the POST-commit busy (continuation: activate) too, carrying the actionable message", () => {
+    // Priced decision (see mapInstallVersionOutcome's doc): `accepted` here
+    // would show a false "Updating…" toast, discard this actionable message,
+    // and arm the accepted latch - which a pre-1.2.0 host can never release
+    // early (no `host.status.updateProgress`, no self-restart), locking the
+    // very controls the message asks the user to reach for. The refusal
+    // renders the message and leaves the page live for that restart.
+    expectHostRpcError(
+      () =>
+        mapInstallVersionOutcome({
+          kind: "busy",
+          continuation: "activate",
+          message:
+            "The update was installed, but the host has work in progress; restart it to finish.",
+        }),
+      "The update was installed, but the host has work in progress; restart it to finish.",
+    );
   });
 
   it("throws HostRpcError for deferred, carrying the lane message", () => {
@@ -309,9 +312,12 @@ describe("buildMaintenanceFallbackServeMap", () => {
     },
   );
 
-  it("resolves a dispatched POST-commit busy (continuation: activate) as accepted", async () => {
-    // The resolution path, not the error path: the accepted-update latch
-    // must stay armed for an install whose bytes are already committed.
+  it("rejects a dispatched POST-commit busy (continuation: activate) with the restart-to-finish message", async () => {
+    // The error path ON PURPOSE: it releases the accepted latch, which is
+    // what leaves the restart controls live for the action this message
+    // names - `accepted` would lock them for the full 60s timer instead,
+    // since a pre-1.2.0 host never publishes the progress frame that
+    // releases the latch early.
     const management = buildOverviewManagement({
       maintenanceInstallVersion: () =>
         Promise.resolve({
@@ -319,14 +325,22 @@ describe("buildMaintenanceFallbackServeMap", () => {
           outcome: {
             kind: "busy" as const,
             continuation: "activate" as const,
-            message: "Installed; restart Traycer to finish activating it.",
+            message:
+              "The update was installed, but the host has work in progress; restart it to finish.",
           },
         }),
     });
     const serve = buildMaintenanceFallbackServeMap(management, LOCAL_HOST_ID);
     await expect(
       serve["host.update.install"]({ version: "1.2.0", force: false }),
-    ).resolves.toEqual({ outcome: "accepted" });
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(HostRpcError);
+      if (!(error instanceof HostRpcError)) return false;
+      expect(error.message).toBe(
+        "The update was installed, but the host has work in progress; restart it to finish.",
+      );
+      return true;
+    });
   });
 
   it("maps a dispatched failed through mapInstallVersionOutcome to cli-failed", async () => {

--- a/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
@@ -95,7 +95,7 @@ describe("mapInstallVersionOutcome", () => {
     expect(mapInstallVersionOutcome(outcome)).toEqual({ outcome: "accepted" });
   });
 
-  it("throws HostRpcError for busy, carrying the lane message", () => {
+  it("throws HostRpcError for the PRE-commit busy (retry-with-force), carrying the lane message", () => {
     expectHostRpcError(
       () =>
         mapInstallVersionOutcome({
@@ -105,6 +105,22 @@ describe("mapInstallVersionOutcome", () => {
         }),
       "Host is busy installing another version.",
     );
+  });
+
+  it("maps the POST-commit busy (continuation: activate) to accepted, not an error", () => {
+    // Packaged macOS commits the selected bytes BEFORE activation, so a busy
+    // outcome carrying `continuation: "activate"` describes an install that
+    // already happened. The error channel would release the accepted-update
+    // latch and re-offer Install for a version that is on disk - a second
+    // submission is the competing-install harm the lane-busy refusal exists
+    // to prevent. `accepted` keeps the latch armed, same as a completed ok.
+    expect(
+      mapInstallVersionOutcome({
+        kind: "busy",
+        continuation: "activate",
+        message: "Installed; restart Traycer to finish activating it.",
+      }),
+    ).toEqual({ outcome: "accepted" });
   });
 
   it("throws HostRpcError for deferred, carrying the lane message", () => {
@@ -292,6 +308,26 @@ describe("buildMaintenanceFallbackServeMap", () => {
       expect(management.installVersion).not.toHaveBeenCalled();
     },
   );
+
+  it("resolves a dispatched POST-commit busy (continuation: activate) as accepted", async () => {
+    // The resolution path, not the error path: the accepted-update latch
+    // must stay armed for an install whose bytes are already committed.
+    const management = buildOverviewManagement({
+      maintenanceInstallVersion: () =>
+        Promise.resolve({
+          kind: "dispatched" as const,
+          outcome: {
+            kind: "busy" as const,
+            continuation: "activate" as const,
+            message: "Installed; restart Traycer to finish activating it.",
+          },
+        }),
+    });
+    const serve = buildMaintenanceFallbackServeMap(management, LOCAL_HOST_ID);
+    await expect(
+      serve["host.update.install"]({ version: "1.2.0", force: false }),
+    ).resolves.toEqual({ outcome: "accepted" });
+  });
 
   it("maps a dispatched failed through mapInstallVersionOutcome to cli-failed", async () => {
     const management = buildOverviewManagement({

--- a/clients/gui-app/src/lib/host/local-maintenance-fallback-client.ts
+++ b/clients/gui-app/src/lib/host/local-maintenance-fallback-client.ts
@@ -103,23 +103,28 @@ function isFallbackMethod(
  *    brief post-completion tail overlaps the host's own restart, when
  *    lifecycle controls SHOULD be locked; the latch's bounded timer and the
  *    reconnect close it.
- *  - `busy` splits on WHERE the lane stopped, because the two continuations
- *    sit on opposite sides of the commit:
- *      - `retry-with-force` is a PRE-commit refusal (the host's busy claim
- *        held) - nothing was dispatched, so it throws like `deferred` below.
- *      - `activate` is POST-commit (packaged macOS: the selected bytes are
- *        installed; only activation is pending) → `accepted`. The accepted
- *        latch must STAY armed here - an error path would release it and
- *        re-offer Install for a version that is already on disk, and a
- *        second submission is exactly the competing-install harm the
- *        lane-busy refusal above exists to prevent. What comes next
- *        (restart/activate to finish) is the desktop controller's own
- *        status/installation-info story, same as after a completed `ok`.
- *  - `deferred` (and busy/`retry-with-force`) → a typed mutation error
- *    carrying the lane's own message. Both are self-clearing "retry when
- *    idle" conditions; the error channel releases the accepted latch
- *    (nothing was dispatched) and the page's existing failure toast renders
- *    the message.
+ *  - `busy` / `deferred` → a typed mutation error carrying the lane's own
+ *    message. For `retry-with-force` and `deferred` that is uncontroversial:
+ *    both are pre-commit, self-clearing "retry when idle" refusals, and the
+ *    error channel releases the accepted latch (nothing was dispatched).
+ *
+ *    The POST-commit busy (`continuation: "activate"` - packaged macOS: the
+ *    bytes are installed, only activation is pending) throws TOO, and that
+ *    is a priced decision, not an oversight. Both mappings are wrong in
+ *    some direction, because no wire arm says "installed, restart to
+ *    finish"; they differ in what the wrongness costs:
+ *      - `accepted` shows a false "Updating…" success toast, DISCARDS the
+ *        one actionable message ("The update was installed, but the host
+ *        has work in progress; restart it to finish."), and arms the
+ *        accepted latch - which on a pre-1.2.0 host nothing can release
+ *        early (no `host.status.updateProgress` is ever published and no
+ *        restart happens on its own), so every control the user needs for
+ *        that restart is locked for the full 60s timer.
+ *      - the thrown refusal renders that actionable message and leaves the
+ *        page live so the user can take the restart it names (the page's
+ *        own force-offer). The residual risk is a redundant re-submission
+ *        of a version already on disk - bounded, and the toast is telling
+ *        the user to restart, not to reinstall.
  *  - `failed` / `stage-fingerprint-mismatch` / `installed-not-converged` →
  *    `cli-failed`, the host's own taxonomy for "the CLI tried and couldn't".
  *    The wire arm carries no message, so the lane's message goes to the log.
@@ -131,16 +136,6 @@ export function mapInstallVersionOutcome(
     case "ok":
       return { outcome: "accepted" };
     case "busy":
-      if (outcome.continuation === "activate") {
-        return { outcome: "accepted" };
-      }
-      throw new HostRpcError({
-        code: "RPC_ERROR",
-        message: outcome.message,
-        requestId: "local-maintenance-fallback",
-        method: "host.update.install",
-        fatalDetails: null,
-      });
     case "deferred":
       throw new HostRpcError({
         code: "RPC_ERROR",

--- a/clients/gui-app/src/lib/host/local-maintenance-fallback-client.ts
+++ b/clients/gui-app/src/lib/host/local-maintenance-fallback-client.ts
@@ -103,11 +103,23 @@ function isFallbackMethod(
  *    brief post-completion tail overlaps the host's own restart, when
  *    lifecycle controls SHOULD be locked; the latch's bounded timer and the
  *    reconnect close it.
- *  - `busy` / `deferred` → a typed mutation error carrying the lane's own
- *    message. Both are self-clearing "retry when idle" conditions; the error
- *    channel releases the accepted latch (nothing was dispatched) and the
- *    page's existing failure toast renders the message. The busy
- *    continuation affordance is deliberately NOT carried on this lane.
+ *  - `busy` splits on WHERE the lane stopped, because the two continuations
+ *    sit on opposite sides of the commit:
+ *      - `retry-with-force` is a PRE-commit refusal (the host's busy claim
+ *        held) - nothing was dispatched, so it throws like `deferred` below.
+ *      - `activate` is POST-commit (packaged macOS: the selected bytes are
+ *        installed; only activation is pending) → `accepted`. The accepted
+ *        latch must STAY armed here - an error path would release it and
+ *        re-offer Install for a version that is already on disk, and a
+ *        second submission is exactly the competing-install harm the
+ *        lane-busy refusal above exists to prevent. What comes next
+ *        (restart/activate to finish) is the desktop controller's own
+ *        status/installation-info story, same as after a completed `ok`.
+ *  - `deferred` (and busy/`retry-with-force`) → a typed mutation error
+ *    carrying the lane's own message. Both are self-clearing "retry when
+ *    idle" conditions; the error channel releases the accepted latch
+ *    (nothing was dispatched) and the page's existing failure toast renders
+ *    the message.
  *  - `failed` / `stage-fingerprint-mismatch` / `installed-not-converged` →
  *    `cli-failed`, the host's own taxonomy for "the CLI tried and couldn't".
  *    The wire arm carries no message, so the lane's message goes to the log.
@@ -119,6 +131,16 @@ export function mapInstallVersionOutcome(
     case "ok":
       return { outcome: "accepted" };
     case "busy":
+      if (outcome.continuation === "activate") {
+        return { outcome: "accepted" };
+      }
+      throw new HostRpcError({
+        code: "RPC_ERROR",
+        message: outcome.message,
+        requestId: "local-maintenance-fallback",
+        method: "host.update.install",
+        fatalDetails: null,
+      });
     case "deferred":
       throw new HostRpcError({
         code: "RPC_ERROR",


### PR DESCRIPTION
Follow-up to #1306, fixing the two review findings that landed two minutes after its merge (both verified real before touching code).

**`admissionBlockIsUpdateWork` undercounted update work.** Only `install`/`apply` lanes answered `updateInFlight: true`, but an `activate` lane is the activation tail of an install (packaged-macOS post-commit / pendingActivation debt) and an `ensure` lane shells `host ensure`, which installs or updates whenever the record is missing or stale. A fallback install racing either lane was answered as generic contention — a thrown refusal that releases the accepted-update latch and re-offers Install while an update is actually running. The predicate now names the same four kinds `laneBusyRestartMessage` already groups as update work, so the two taxonomies answer with one voice. The ambiguous `ensure` case is decided by the asymmetry (recorded in the doc): overclaiming costs a transient notice on a self-clearing lane; underclaiming presents real update work as a retryable failure.

**`mapInstallVersionOutcome` treated post-commit busy as a pre-dispatch refusal.** The two `BusyContinuation`s sit on opposite sides of the commit: `retry-with-force` is a pre-commit refusal (nothing dispatched — the throw is right), but `activate` is packaged-macOS post-commit: the selected bytes are installed and only activation is pending. Collapsing it into the error channel released the accepted latch and invited a second submission for a version already on disk — exactly the competing-install harm the lane-busy refusal exists to prevent. It now maps to `accepted`, keeping the latch armed; what comes next (restart/activate to finish) is the desktop controller's own status story, same as after a completed `ok`.

## Testing

- New exhaustive pin iterates the fenced `MutationKind` list: the four version-moving kinds answer `updateInFlight: true`, every other kind stays `false` (an `already-updating` answer arms the caller's latch to wait on progress those operations never publish). A new `MutationKind` fails this pin and forces the classification decision.
- New pins at both levels for the busy split: unit (`activate` → `accepted`, `retry-with-force` → thrown, message carried) and serve-map integration (dispatched post-commit busy resolves `accepted`).
- Break-verified both: narrowing the predicate back to install/apply fails exactly the classification pin; short-circuiting the continuation branch fails exactly the two new busy pins.
- `bun run compile --skip-nx-cache` clean (5/5); desktop IPC+host suites 684/684; fallback client 39/39; Overview integration 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)