### PR TITLE
fix(gui-app): close compatibility terminals from sidebar

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -208,6 +208,14 @@ import {
   useEpicCanvasStore,
 } from "@/stores/epics/canvas/store";
 import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+import {
+  recordProviderLoginTerminal,
+  useProviderLoginTerminalsStore,
+} from "@/stores/providers/provider-login-terminals";
+import {
+  recordSetupTerminal,
+  useSetupTerminalsStore,
+} from "@/stores/worktree/setup-terminals";
 
 function createTestQueryClient(): QueryClient {
   return new QueryClient({
@@ -241,13 +249,52 @@ function resolveCloseRequest(vars: { readonly terminalId: string }): {
   return { terminalId: vars.terminalId, revision: 2 };
 }
 
-function seedOpenTerminalTab(authority: "legacy" | "host" | "future"): void {
+function seedEmptyTab(): void {
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useEpicCanvasStore.setState({
     tabsById: {
       [TAB_ID]: { tabId: TAB_ID, epicId: "epic-1", name: "Epic 1" },
     },
   });
+}
+
+/**
+ * Setup and provider-login shells are host-created `terminal.list`
+ * compatibility rows: import-exempt, so their canvas ref stays legacy-shaped
+ * even against a capable host, and absent from the durable collection.
+ */
+function seedOpenCompatibilityTab(origin: "setup" | "provider-login"): void {
+  seedEmptyTab();
+  const base = {
+    id: SESSION_ID,
+    instanceId: "inst-term-1",
+    type: "terminal" as const,
+    name: "New Terminal",
+    titleSource: "default" as const,
+    hostId: "host-1",
+    cwd: "/tmp/work",
+  };
+  const ref: EpicTerminalRef =
+    origin === "setup"
+      ? { ...base, origin: "setup" }
+      : { ...base, origin: "provider-login", originProviderId: "claude-code" };
+  useEpicCanvasStore.getState().openTileInTab(TAB_ID, ref);
+}
+
+function recordCompatibilityOrigin(origin: "setup" | "provider-login"): void {
+  if (origin === "setup") {
+    recordSetupTerminal({ hostId: "host-1", sessionId: SESSION_ID });
+    return;
+  }
+  recordProviderLoginTerminal({
+    hostId: "host-1",
+    sessionId: SESSION_ID,
+    providerId: "claude-code",
+  });
+}
+
+function seedOpenTerminalTab(authority: "legacy" | "host" | "future"): void {
+  seedEmptyTab();
   let ref: EpicTerminalRef = {
     id: SESSION_ID,
     instanceId: "inst-term-1",
@@ -312,6 +359,16 @@ describe("terminal sidebar Close", () => {
     durableAuthority.renamePending = false;
     durableAuthority.collectionIncludesSession = false;
     terminalSessions.value = [RUNNING_SESSION];
+    // Both origin registries are persisted module-level singletons, so an entry
+    // recorded by one test would otherwise outlive it.
+    useProviderLoginTerminalsStore.setState(
+      useProviderLoginTerminalsStore.getInitialState(),
+      true,
+    );
+    useSetupTerminalsStore.setState(
+      useSetupTerminalsStore.getInitialState(),
+      true,
+    );
     seedOpenTerminalTab("legacy");
   });
 
@@ -458,6 +515,44 @@ describe("terminal sidebar Close", () => {
     expect(durableCloseMutateAsync).toHaveBeenCalledTimes(1);
     expect(killMutate).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { origin: "setup", openRef: true },
+    { origin: "setup", openRef: false },
+    { origin: "provider-login", openRef: true },
+    { origin: "provider-login", openRef: false },
+  ] as const)(
+    "closes a capable host's $origin compatibility row through terminal.kill (open canvas ref: $openRef)",
+    ({ origin, openRef }) => {
+      // The durable close resolver needs an authorized persistent record.
+      // Setup and provider-login shells deliberately never enter the durable
+      // collection, so `terminal.plain.close` would answer terminal-not-found
+      // and strand the row behind a generic failure toast.
+      durableAuthority.capability = "capable";
+      durableAuthority.canMutate = true;
+      durableAuthority.collectionIncludesSession = false;
+      recordCompatibilityOrigin(origin);
+      if (openRef) {
+        seedOpenCompatibilityTab(origin);
+        expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).not.toBeNull();
+      } else {
+        seedEmptyTab();
+        expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).toBeNull();
+      }
+      const { getByTestId } = render(
+        wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+      );
+
+      const close = getByTestId(`epic-terminal-sidebar-kill-menu-${SESSION_ID}`);
+      expect(close.getAttribute("disabled")).toBeNull();
+      fireEvent.click(close);
+
+      expect(killMutate).toHaveBeenCalledWith({ sessionId: SESSION_ID });
+      expect(durableCloseMutateAsync).not.toHaveBeenCalled();
+      // The legacy local canvas close stays synchronous for these rows.
+      expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).toBeNull();
+    },
+  );
 
   it("disables close while capable-host support is unknown", () => {
     durableAuthority.capability = "unknown";

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -34,12 +34,14 @@ const durableAuthority = vi.hoisted<{
   capability: "unknown" | "legacy" | "capable";
   canMutate: boolean;
   closePending: boolean;
+  killPending: boolean;
   renamePending: boolean;
   collectionIncludesSession: boolean;
 }>(() => ({
   capability: "legacy",
   canMutate: false,
   closePending: false,
+  killPending: false,
   renamePending: false,
   collectionIncludesSession: false,
 }));
@@ -112,7 +114,10 @@ vi.mock("@/hooks/terminal/use-terminal-list-query", () => ({
 }));
 
 vi.mock("@/hooks/terminal/use-terminal-kill-for-mutation", () => ({
-  useTerminalKillFor: () => ({ mutate: killMutate, isPending: false }),
+  useTerminalKillFor: () => ({
+    mutate: killMutate,
+    isPending: durableAuthority.killPending,
+  }),
 }));
 
 vi.mock("@/hooks/terminal/use-terminal-rename-for-mutation", () => ({
@@ -356,6 +361,7 @@ describe("terminal sidebar Close", () => {
     durableAuthority.capability = "legacy";
     durableAuthority.canMutate = false;
     durableAuthority.closePending = false;
+    durableAuthority.killPending = false;
     durableAuthority.renamePending = false;
     durableAuthority.collectionIncludesSession = false;
     terminalSessions.value = [RUNNING_SESSION];
@@ -567,6 +573,77 @@ describe("terminal sidebar Close", () => {
     expect(killMutate).not.toHaveBeenCalled();
     expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).not.toBeNull();
   });
+
+  it.each([
+    {
+      name: "stale durable authority",
+      canMutate: false,
+      includesSession: true,
+      closePending: false,
+      killPending: false,
+      compatibilityRow: false,
+    },
+    {
+      name: "pending durable close",
+      canMutate: true,
+      includesSession: true,
+      closePending: true,
+      killPending: false,
+      compatibilityRow: false,
+    },
+    {
+      name: "pending compatibility kill",
+      canMutate: true,
+      includesSession: false,
+      closePending: false,
+      killPending: true,
+      compatibilityRow: true,
+    },
+  ] as const)(
+    "disables close for $name",
+    ({
+      canMutate,
+      includesSession,
+      closePending,
+      killPending,
+      compatibilityRow,
+    }) => {
+      durableAuthority.capability = "capable";
+      durableAuthority.canMutate = canMutate;
+      durableAuthority.collectionIncludesSession = includesSession;
+      durableAuthority.closePending = closePending;
+      durableAuthority.killPending = killPending;
+      if (compatibilityRow) {
+        recordCompatibilityOrigin("setup");
+        seedOpenCompatibilityTab("setup");
+      } else {
+        seedOpenTerminalTab("host");
+      }
+      const { getByTestId } = render(
+        wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+      );
+
+      const dropdownClose = getByTestId(
+        `epic-terminal-sidebar-kill-menu-${SESSION_ID}`,
+      );
+      expect(dropdownClose.getAttribute("disabled")).not.toBeNull();
+      fireEvent.click(dropdownClose);
+
+      fireEvent.contextMenu(
+        getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`),
+      );
+      const contextClose = getByTestId(
+        `epic-terminal-sidebar-context-kill-${SESSION_ID}`,
+      );
+      expect(contextClose.getAttribute("data-disabled")).not.toBeNull();
+      fireEvent.keyDown(contextClose, { key: "Enter" });
+      fireEvent.click(contextClose);
+
+      expect(durableCloseMutateAsync).not.toHaveBeenCalled();
+      expect(killMutate).not.toHaveBeenCalled();
+      expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).not.toBeNull();
+    },
+  );
 
   it.each([
     { capability: "capable", canMutate: true },

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -549,7 +549,9 @@ describe("terminal sidebar Close", () => {
         wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
       );
 
-      const close = getByTestId(`epic-terminal-sidebar-kill-menu-${SESSION_ID}`);
+      const close = getByTestId(
+        `epic-terminal-sidebar-kill-menu-${SESSION_ID}`,
+      );
       expect(close.getAttribute("disabled")).toBeNull();
       fireEvent.click(close);
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -545,13 +545,11 @@ describe("terminal sidebar Close", () => {
         seedEmptyTab();
         expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).toBeNull();
       }
-      const { getByTestId } = render(
+      const { getByRole } = render(
         wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
       );
 
-      const close = getByTestId(
-        `epic-terminal-sidebar-kill-menu-${SESSION_ID}`,
-      );
+      const close = getByRole("button", { name: "Close" });
       expect(close.getAttribute("disabled")).toBeNull();
       fireEvent.click(close);
 
@@ -621,22 +619,18 @@ describe("terminal sidebar Close", () => {
       } else {
         seedOpenTerminalTab("host");
       }
-      const { getByTestId } = render(
+      const { getByRole, getByTestId } = render(
         wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
       );
 
-      const dropdownClose = getByTestId(
-        `epic-terminal-sidebar-kill-menu-${SESSION_ID}`,
-      );
+      const dropdownClose = getByRole("button", { name: "Close" });
       expect(dropdownClose.getAttribute("disabled")).not.toBeNull();
       fireEvent.click(dropdownClose);
 
       fireEvent.contextMenu(
         getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`),
       );
-      const contextClose = getByTestId(
-        `epic-terminal-sidebar-context-kill-${SESSION_ID}`,
-      );
+      const contextClose = getByRole("menuitem", { name: "Close" });
       expect(contextClose.getAttribute("data-disabled")).not.toBeNull();
       fireEvent.keyDown(contextClose, { key: "Enter" });
       fireEvent.click(contextClose);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -310,11 +310,11 @@ function TerminalsPanelBodyLive(props: {
             tabId={tabId}
             hostId={activeHostId}
             onOpen={openExisting}
-            closeCapability={durableAuthority.capability.status}
-            closeCanMutate={durableAuthority.canMutate}
+            capability={durableAuthority.capability.status}
+            canMutate={durableAuthority.canMutate}
             closePending={durableMutations.close.isPending}
             onDurableClose={requestDurableClose}
-            durableRenameTerminalIds={Object.keys(
+            durableTerminalIds={Object.keys(
               durableAuthority.collection?.terminalsById ?? {},
             )}
             durableRenamePending={durableMutations.rename.isPending}
@@ -361,11 +361,11 @@ interface TerminalSidebarBodyProps {
   readonly tabId: string;
   readonly hostId: string;
   readonly onOpen: (session: CanonicalTerminalSessionInfo) => void;
-  readonly closeCapability: "unknown" | "legacy" | "capable";
-  readonly closeCanMutate: boolean;
+  readonly capability: "unknown" | "legacy" | "capable";
+  readonly canMutate: boolean;
   readonly closePending: boolean;
   readonly onDurableClose: (terminalId: string) => void;
-  readonly durableRenameTerminalIds: readonly string[];
+  readonly durableTerminalIds: readonly string[];
   readonly durableRenamePending: boolean;
   readonly onDurableRename: (
     terminalId: string,
@@ -374,19 +374,33 @@ interface TerminalSidebarBodyProps {
   ) => void;
 }
 
-type TerminalSidebarRenameMode = "disabled" | "legacy" | "capable";
+type TerminalSidebarMutationMode = "disabled" | "legacy" | "capable";
 
-function resolveTerminalSidebarRenameMode(args: {
+/**
+ * Which lifetime authority owns a row's rename/close, resolved PER ROW.
+ * `capability` and `canMutate` are host-wide, but the sidebar merges two
+ * sources: durable projection rows (plain-terminal registry) and
+ * `terminal.list` compatibility rows for host-created setup / provider-login
+ * shells, which deliberately never enter the durable collection.
+ *
+ * `canMutate` is only true against a settled, fresh collection snapshot, so
+ * checking it BEFORE the projection is what makes a missing projection mean
+ * "not durable-backed" rather than "not loaded yet". Unknown capability and a
+ * stale capable authority both stay fail-closed.
+ */
+function resolveTerminalSidebarMutationMode(args: {
   readonly capability: "unknown" | "legacy" | "capable";
   readonly canMutate: boolean;
   readonly hasProjection: boolean;
-}): TerminalSidebarRenameMode {
+}): TerminalSidebarMutationMode {
   if (args.capability === "legacy") return "legacy";
   if (args.capability !== "capable") return "disabled";
   if (!args.canMutate) return "disabled";
   // A row with no durable projection is a `terminal.list` compatibility row
   // (setup / provider-login shell). The host still serves `terminal.rename`
-  // for it, so keep the legacy path instead of disabling rename.
+  // and `terminal.kill` for it - and only those: the durable resolvers require
+  // an authorized persistent record and would answer terminal-not-found. So
+  // keep the legacy path instead of disabling the action.
   if (!args.hasProjection) return "legacy";
   return "capable";
 }
@@ -455,34 +469,40 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
       />
     );
   }
-  const durableRenameTerminalIds = new Set(props.durableRenameTerminalIds);
+  const durableTerminalIds = new Set(props.durableTerminalIds);
   return (
     <ul
       aria-label="Epic terminals"
       className="space-y-0.5"
       data-testid="epic-terminal-sidebar-list"
     >
-      {props.sessions.map((session) => (
-        <TerminalRow
-          key={session.sessionId}
-          epicId={props.epicId}
-          tabId={props.tabId}
-          hostId={props.hostId}
-          session={session}
-          onOpen={props.onOpen}
-          closeCapability={props.closeCapability}
-          closeCanMutate={props.closeCanMutate}
-          closePending={props.closePending}
-          onDurableClose={props.onDurableClose}
-          renameMode={resolveTerminalSidebarRenameMode({
-            capability: props.closeCapability,
-            canMutate: props.closeCanMutate,
-            hasProjection: durableRenameTerminalIds.has(session.sessionId),
-          })}
-          durableRenamePending={props.durableRenamePending}
-          onDurableRename={props.onDurableRename}
-        />
-      ))}
+      {props.sessions.map((session) => {
+        // One resolution per row, shared by rename and close: both actions
+        // follow the same lifetime authority, and letting them disagree is
+        // exactly how a compatibility row ended up renaming through
+        // `terminal.rename` while closing through `terminal.plain.close`.
+        const mutationMode = resolveTerminalSidebarMutationMode({
+          capability: props.capability,
+          canMutate: props.canMutate,
+          hasProjection: durableTerminalIds.has(session.sessionId),
+        });
+        return (
+          <TerminalRow
+            key={session.sessionId}
+            epicId={props.epicId}
+            tabId={props.tabId}
+            hostId={props.hostId}
+            session={session}
+            onOpen={props.onOpen}
+            closeMode={mutationMode}
+            closePending={props.closePending}
+            onDurableClose={props.onDurableClose}
+            renameMode={mutationMode}
+            durableRenamePending={props.durableRenamePending}
+            onDurableRename={props.onDurableRename}
+          />
+        );
+      })}
     </ul>
   );
 }
@@ -493,11 +513,10 @@ interface TerminalRowProps {
   readonly hostId: string;
   readonly session: CanonicalTerminalSessionInfo;
   readonly onOpen: (session: CanonicalTerminalSessionInfo) => void;
-  readonly closeCapability: "unknown" | "legacy" | "capable";
-  readonly closeCanMutate: boolean;
+  readonly closeMode: TerminalSidebarMutationMode;
   readonly closePending: boolean;
   readonly onDurableClose: (terminalId: string) => void;
-  readonly renameMode: TerminalSidebarRenameMode;
+  readonly renameMode: TerminalSidebarMutationMode;
   readonly durableRenamePending: boolean;
   readonly onDurableRename: (
     terminalId: string,
@@ -508,8 +527,6 @@ interface TerminalRowProps {
 
 function TerminalRow(props: TerminalRowProps) {
   const {
-    closeCapability,
-    closeCanMutate,
     closePending,
     durableRenamePending,
     epicId,
@@ -558,6 +575,11 @@ function TerminalRow(props: TerminalRowProps) {
   if (renameMode === "capable") renamePending = durableRenamePending;
   if (renameMode === "legacy") renamePending = legacyRename.isPending;
   const canRename = renameMode !== "disabled" && !renamePending;
+  const closeMode = hasUnsupportedFutureRef ? "disabled" : props.closeMode;
+  let closeActionPending = false;
+  if (closeMode === "capable") closeActionPending = closePending;
+  if (closeMode === "legacy") closeActionPending = kill.isPending;
+  const canClose = closeMode !== "disabled" && !closeActionPending;
 
   const label = terminalSessionLabel(session);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -638,19 +660,19 @@ function TerminalRow(props: TerminalRowProps) {
   // immediate and mount-independent. `findOpenArtifactInTab` returns null when
   // no tab is open for this session, so a sidebar-only session just gets killed.
   const requestClose = () => {
-    if (hasUnsupportedFutureRef) return;
-    if (closeCapability === "capable") {
-      if (!closeCanMutate || closePending) return;
+    if (!canClose) return;
+    if (closeMode === "capable") {
       onDurableClose(session.sessionId);
       return;
     }
-    if (closeCapability === "unknown" || kill.isPending) return;
     const found = findOpenArtifactInTab(tabId, session.sessionId);
     if (found !== null) {
-      // This branch is reachable only after the manifest positively identifies
-      // an old host. Register that evidence for the synchronous store boundary
-      // so it preserves the legacy local-close behavior without weakening the
-      // coordinator's fail-closed default for unregistered refs.
+      // This branch is reachable only for a row whose lifetime the legacy
+      // session manager owns - a positively-known old host, or a capable
+      // host's compatibility row with no durable projection. Register that
+      // evidence for the synchronous store boundary so it preserves the legacy
+      // local-close behavior without weakening the coordinator's fail-closed
+      // default for unregistered refs.
       withLegacyTerminalCloseAuthority(
         {
           instanceId: found.instanceId,
@@ -682,12 +704,7 @@ function TerminalRow(props: TerminalRowProps) {
     sessionId: session.sessionId,
     // Not a pending flag: it also encodes "not permitted" (unsupported future
     // ref, unknown capability, no mutation authority).
-    closeDisabled:
-      hasUnsupportedFutureRef ||
-      closeCapability === "unknown" ||
-      (closeCapability === "capable"
-        ? !closeCanMutate || closePending
-        : kill.isPending),
+    closeDisabled: !canClose,
     onStartRename: startRename,
     renameDisabled: !canRename,
     onRequestClose: requestClose,


### PR DESCRIPTION
## Summary
- route sidebar close actions by each row's durable projection, not only host capability
- keep setup and provider-login compatibility shells on the legacy terminal.kill fallback
- cover both open and sidebar-only compatibility rows with focused regressions

## Validation
- bun run --filter @traycer-clients/gui-app test src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx