### PR TITLE
fix(gui-app): keep "Retry name" spinning through the retry it started

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-identity-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-identity-card.test.tsx
@@ -36,6 +36,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -289,5 +290,146 @@ describe("<HostSettingsPanel /> Overview identity card — window binding", () =
 
     await screen.findByText("Studio Mac");
     expect(screen.queryByTestId("host-make-active")).toBeNull();
+  });
+});
+
+/**
+ * A rejected `host.identity.get`, and the button it puts in the pencil's place.
+ *
+ * The state under test is the one BETWEEN the two reads. `failed` used to be
+ * `identityQuery.isError`, and TanStack returns a query with no data behind it
+ * to `pending` the moment a refetch starts (`fetchState` clears `error`) — so
+ * the arm holding the retry button unmounted on the click that started the
+ * retry, and the disabled pencil flickered in for the length of the read. The
+ * three tests below pin the whole cycle rather than only the fix: the in-flight
+ * window, and BOTH settled exits, because the counter the fix reads
+ * (`errorUpdateCount`) never resets and "does the button then latch forever" is
+ * the first thing that has to be answered.
+ */
+describe("<HostSettingsPanel /> Overview identity card — the failed-name retry", () => {
+  /** A fixture whose identity read fails, then parks until the test releases it. */
+  function buildRetryFixture(second: {
+    readonly gate: Promise<void>;
+    readonly succeeds: boolean;
+  }): { readonly fixture: OverviewHostFixture; readonly calls: () => number } {
+    let calls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      effectiveName: "Studio Mac",
+      overrideHandlers: {
+        "host.identity.get": async () => {
+          calls += 1;
+          if (calls === 1) throw new Error("identity read refused");
+          await second.gate;
+          if (!second.succeeds) throw new Error("identity read refused again");
+          return {
+            systemName: "studio.local",
+            customName: "Studio Mac",
+            effectiveName: "Studio Mac",
+          };
+        },
+      },
+    });
+    return { fixture, calls: () => calls };
+  }
+
+  function mountRetryPanel(fixture: OverviewHostFixture): void {
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+  }
+
+  /**
+   * The native `disabled` property, not `toBeDisabled()`: jest-dom's matchers
+   * are not wired into this suite, so the matcher would be undefined rather
+   * than failing informatively.
+   */
+  function isDisabled(element: HTMLElement): boolean {
+    return element instanceof HTMLButtonElement && element.disabled;
+  }
+
+  it("keeps 'Retry name' mounted and spinning for the whole retry it started", async () => {
+    // Held in an object rather than a `let`: TS narrows a captured `let` to
+    // `null` at the call site because it cannot prove the executor ran.
+    const second: { release: () => void } = { release: () => undefined };
+    const gate = new Promise<void>((resolve) => {
+      second.release = resolve;
+    });
+    const { fixture, calls } = buildRetryFixture({ gate, succeeds: true });
+    mountRetryPanel(fixture);
+
+    const retry = await screen.findByTestId("host-overview-retry-identity");
+    // Idle: worded, pressable, and NOT spinning. The spinner's absence here is
+    // what makes its presence below evidence of the retry rather than of the
+    // button simply always carrying one.
+    expect(retry.textContent).toBe("Retry name");
+    expect(isDisabled(retry)).toBe(false);
+    expect(
+      screen.queryByTestId("host-overview-retry-identity-spinner"),
+    ).toBeNull();
+
+    fireEvent.click(retry);
+
+    // The whole point of the fix, and an equality rather than a tolerance: the
+    // SAME button is still on screen, now spinning. `findBy` would pass on a
+    // remount too, so the node identity is asserted directly.
+    expect(
+      await screen.findByTestId("host-overview-retry-identity-spinner"),
+    ).toBeTruthy();
+    expect(screen.getByTestId("host-overview-retry-identity")).toBe(retry);
+    expect(isDisabled(retry)).toBe(true);
+    // The regression itself: the arm used to swap for the pencil, which is a
+    // different affordance for a different job and is disabled while it shows.
+    expect(screen.queryByRole("button", { name: "Edit name" })).toBeNull();
+    expect(calls()).toBe(2);
+
+    await act(async () => {
+      second.release();
+      await gate;
+    });
+
+    expect(await screen.findByText("Studio Mac")).toBeTruthy();
+  });
+
+  it("hands the pencil back once the retry succeeds — the failure is not latched", async () => {
+    const { fixture } = buildRetryFixture({
+      gate: Promise.resolve(),
+      succeeds: true,
+    });
+    mountRetryPanel(fixture);
+
+    fireEvent.click(await screen.findByTestId("host-overview-retry-identity"));
+
+    // `errorUpdateCount` never returns to zero, so this is the assertion that
+    // says the fix reads it as one half of a conjunction and not on its own:
+    // a settled identity retires the retry arm however many times it failed
+    // before.
+    const pencil = await screen.findByRole("button", { name: "Edit name" });
+    expect(isDisabled(pencil)).toBe(false);
+    expect(screen.queryByTestId("host-overview-retry-identity")).toBeNull();
+  });
+
+  it("returns a pressable 'Retry name' when the retry fails again", async () => {
+    const { fixture, calls } = buildRetryFixture({
+      gate: Promise.resolve(),
+      succeeds: false,
+    });
+    mountRetryPanel(fixture);
+
+    fireEvent.click(await screen.findByTestId("host-overview-retry-identity"));
+
+    // Settling in error a second time has to release the spinner, or the fix
+    // would have traded a flicker for a permanently busy control.
+    await waitFor(() => {
+      expect(calls()).toBe(2);
+      expect(
+        screen.queryByTestId("host-overview-retry-identity-spinner"),
+      ).toBeNull();
+    });
+    const retry = screen.getByTestId("host-overview-retry-identity");
+    expect(retry.textContent).toBe("Retry name");
+    expect(isDisabled(retry)).toBe(false);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -771,7 +771,17 @@ export function HostOverviewPanel(props: {
               // otherwise Save calls a method the handshake already declined.
               degrade={renameDegrade}
               loaded={identity !== null}
-              failed={identity === null && identityQuery.isError}
+              // NOT `isError`, which goes false the instant the retry starts.
+              // TanStack's `fetchState` clears `error` and returns `status` to
+              // `pending` whenever a fetch begins with no data behind it, so an
+              // `isError` gate unmounts the arm on the click that starts the
+              // read — taking the spinner inside it with it, and flickering the
+              // disabled pencil in for the duration of the very retry the
+              // person just pressed. `errorUpdateCount` is the settle counter
+              // the reducer never resets, so `no identity && it has settled in
+              // error at least once` says exactly what this prop means: the
+              // last settled read failed and there is still no name to edit.
+              failed={identity === null && identityQuery.errorUpdateCount > 0}
               retrying={identityQuery.isFetching}
               onRetry={() => {
                 void identityQuery.refetch();

--- a/clients/gui-app/src/components/settings/panels/host-overview-status-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-status-card.tsx
@@ -84,7 +84,12 @@ export function HostOverviewActionButton(props: {
       {pending ? (
         <AgentSpinningDots
           className="mr-2 size-3"
-          testId={undefined}
+          // Named, unlike this card's other spinners: this one is the only
+          // evidence that the button a person pressed is still the button doing
+          // the work, and `disabled` cannot stand in for it — three different
+          // props drive that. See the retry-name pin in
+          // `host-overview-identity-card.test.tsx`.
+          testId={`${testId}-spinner`}
           variant={undefined}
         />
       ) : null}
@@ -129,7 +134,15 @@ export function HostOverviewNameAction(props: {
   readonly degrade: OverviewDegradeReason | null;
   /** The identity read has answered, so there is a name to edit. */
   readonly loaded: boolean;
-  /** The identity read REJECTED — distinct from "has not answered yet". */
+  /**
+   * The last SETTLED identity read rejected and there is still no name —
+   * distinct from "has not answered yet".
+   *
+   * Deliberately not "the query is in its error state": this arm owns the
+   * retry's own spinner, so it has to stay mounted ACROSS the retry, and a
+   * query with no data behind it leaves its error state the moment a refetch
+   * starts. The caller derives it accordingly (`host-overview-panel.tsx`).
+   */
   readonly failed: boolean;
   readonly retrying: boolean;
   readonly onRetry: () => void;
@@ -144,6 +157,13 @@ export function HostOverviewNameAction(props: {
   // nothing short of a remount ever cleared it. The failed read keeps a
   // WORDED button — an icon that means "your name failed to load, press to
   // try again" is not a pictogram anyone owns.
+  //
+  // `pending` below is only reachable because `failed` outlives the retry it
+  // starts (see the prop's own note). Sibling `host-doctor-card.tsx` had the
+  // identical shape and was fixed the OTHER way — by deleting its unreachable
+  // pending gate — because there a shared "Running Doctor…" line already owns
+  // the in-flight surface. This button has no such replacement: drop the
+  // spinner here and the press has no acknowledgement at all.
   if (props.failed) {
     return (
       <HostOverviewActionButton


### PR DESCRIPTION
## The defect

Settings ▸ Host Overview replaces the rename pencil with a worded **Retry name** button when `host.identity.get` rejects. That arm owns the retry's own spinner — and it could never render it.

```tsx
failed={identity === null && identityQuery.isError}   // ← the bug
retrying={identityQuery.isFetching}
```

TanStack's `fetchState` clears `error` and returns `status` to `pending` whenever a fetch starts with **no data behind it** (`query-core@5.101.4`, `query.js:411`):

```js
...data === void 0 && { error: null, status: "pending" }
```

So `isError` goes false on the click that starts the retry. The arm unmounts, the spinner inside it goes with it, and the **disabled pencil** — a different affordance for a different job — flickers in for the length of the read. If the retry fails, "Retry name" returns.

What the person sees: press a button, the button vanishes and is replaced by an inert control, then comes back. No acknowledgement of the press they just made.

## The fix

`errorUpdateCount` is the one settle counter the reducer never resets — `fetch` doesn't touch it and `success` doesn't either; only an `error` action increments it. Paired with `identity === null` it states exactly what the prop means:

```tsx
failed={identity === null && identityQuery.errorUpdateCount > 0}
```

"the last settled read failed and there is still no name to edit" — true across the refetch, so the arm stays mounted and `pending` becomes reachable.

It is deliberately **one half of a conjunction**. `errorUpdateCount` never returns to zero, so `identity === null` is what retires the arm on success instead of latching it forever; there is a test for exactly that.

## Why not the sibling's fix

`host-doctor-card.tsx` had the identical shape and was fixed the *other* way in `c8e3d922` — by **deleting** its unreachable pending gate — because a shared "Running Doctor…" line already owns its in-flight surface. This button has no replacement spinner, so dropping the gate would leave the press with no acknowledgement at all. Both files now carry a note pointing at the other.

`host-doctor-rpc-card.tsx` is correct as written and untouched: its rerun is a **mutation**, whose `isPending` no arm swap can hide.

## Tests

Three pins in `host-overview-identity-card.test.tsx`, covering the whole cycle rather than only the fix:

| Pin | What it holds |
| --- | --- |
| in-flight window | the **same node** is still on screen and spinning; the pencil is absent |
| success exit | the pencil returns enabled — the failure is not latched |
| second-failure exit | a pressable "Retry name" returns — no permanently busy control |

The first fails without the fix (`Unable to find [data-testid="host-overview-retry-identity-spinner"]`) and passes with it; the other two are guard pins that bound the fix in both directions, and hold either way by design.

`HostOverviewActionButton`'s spinner gained a derived `data-testid` so "still spinning" is a direct assertion rather than a proxy on `disabled`, which three different props drive. It has exactly one call site — this button.

## Verification

- `bunx vitest run` — 10 Overview/doctor suites, **105 passed** (was 102)
- `bun run compile --skip-nx-cache` — **5/5 projects**
- `react-doctor --scope changed` — no issues

## Provenance

Pre-existing since `ae445fdb` (#1156, 2026-08-14). Found by a class sweep during #1306 and deliberately left out of that diff — #1306 was ten review rounds deep and its dominant failure mode was *the fix for one finding returning as its sibling*, so adding an untouched file to correct a flicker traded real convergence risk for a cosmetic gain. This is that deferred ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)