### PR TITLE
fix(gui-app): make the boot card's "Open settings" work during startup

### DIFF
--- a/clients/gui-app/scripts/boot-escape-hatch-press-browser.mjs
+++ b/clients/gui-app/scripts/boot-escape-hatch-press-browser.mjs
@@ -1,0 +1,384 @@
+// The boot card's escape hatch must survive its own surface being replaced
+// mid-press.
+//
+// WHY A BROWSER GATE. The defect is an input-dispatch fact, not a React fact:
+// when the element a press started on leaves the document before release,
+// Chromium emits NO `click`, so an `onClick` handler never runs and the
+// navigation never happens. jsdom has no input pipeline - Testing Library
+// dispatches `click` directly - so every jsdom test of this button passes on
+// the broken build. This driver presses with `Input.dispatchMouseEvent`,
+// swaps the surface while the button is held, releases, and counts.
+//
+// Reproduced from a CDP capture of a real user press on the shipped card:
+// pointerdown/mousedown on `host-boot-open-settings`, mouseup 198ms later on
+// the tree that replaced it, and no click event at all.
+//
+//   bun scripts/boot-escape-hatch-press-browser.mjs
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { createServer as createTcpServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const fixtureUrlPath = "/src/__tests__/browser/boot-escape-hatch-press.html";
+const BUTTON = '[data-testid="host-boot-open-settings"]';
+const chromePath = await findChrome();
+const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-boot-press-"));
+const vitePort = await freePort();
+let devtoolsPort = await freePort();
+while (devtoolsPort === vitePort) devtoolsPort = await freePort();
+let chrome;
+let client;
+let viteProcess;
+
+try {
+  const pageUrl = `http://127.0.0.1:${vitePort}${fixtureUrlPath}`;
+  const requireFromHere = createRequire(import.meta.url);
+  const viteManifestPath = requireFromHere.resolve("vite/package.json");
+  const viteManifest = requireFromHere(viteManifestPath);
+  const viteEntry = path.resolve(
+    path.dirname(viteManifestPath),
+    viteManifest.bin.vite,
+  );
+  viteProcess = spawn(
+    "node",
+    [
+      viteEntry,
+      "--config",
+      path.join(projectRoot, "vitest.config.ts"),
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(vitePort),
+      "--strictPort",
+    ],
+    { cwd: projectRoot, stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let viteError = "";
+  viteProcess.stderr.setEncoding("utf8");
+  viteProcess.stderr.on("data", (chunk) => {
+    viteError += chunk;
+  });
+  await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
+
+  chrome = spawn(
+    chromePath,
+    [
+      "--headless=new",
+      "--disable-background-networking",
+      "--disable-component-update",
+      "--disable-default-apps",
+      "--disable-extensions",
+      "--disable-features=Translate",
+      "--disable-sync",
+      "--no-default-browser-check",
+      "--no-first-run",
+      "--no-sandbox",
+      `--remote-debugging-port=${devtoolsPort}`,
+      `--user-data-dir=${profilePath}`,
+      "about:blank",
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let chromeError = "";
+  chrome.stderr.setEncoding("utf8");
+  chrome.stderr.on("data", (chunk) => {
+    chromeError += chunk;
+  });
+  await waitForHttp(
+    `http://127.0.0.1:${devtoolsPort}/json/version`,
+    chrome,
+    () => chromeError,
+    "Chrome DevTools",
+  );
+  const targetResponse = await fetch(
+    `http://127.0.0.1:${devtoolsPort}/json/new?about:blank`,
+    { method: "PUT" },
+  );
+  if (!targetResponse.ok) {
+    throw new Error(`Chrome could not open a page: ${targetResponse.status}`);
+  }
+  const target = await targetResponse.json();
+  client = await connectCdp(target.webSocketDebuggerUrl);
+  await client.send("Runtime.enable");
+  await client.send("Page.enable");
+  await client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1200,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await client.send("Page.navigate", { url: pageUrl });
+  await waitFor(
+    client,
+    "the boot card",
+    `document.querySelector(${JSON.stringify(BUTTON)}) !== null &&
+     typeof window.__bootEscapeHatchProbe === "object"`,
+  );
+  await settle(client);
+
+  // ── THE MEASURED PREMISE ────────────────────────────────────────────────
+  // An ordinary press and release, no swap: exactly one activation. This runs
+  // first because it is what makes the swap case meaningful - if the button
+  // never activated at all, "it activates across a swap" would be satisfied by
+  // a fixture that is simply broken, and a double-fire would hide here.
+  await reset(client);
+  const centre = await rectCentre(client, BUTTON);
+  await press(client, centre, "left");
+  await release(client, centre, "left");
+  await settle(client);
+  assert.equal(
+    await activations(client),
+    1,
+    "an ordinary click must activate the escape hatch exactly once",
+  );
+
+  // ── THE REGRESSION ──────────────────────────────────────────────────────
+  // Press, replace the surface under the held pointer, release. Before the
+  // fix this was 0: Chromium emitted no click, so `onClick` never ran.
+  await reset(client);
+  const heldCentre = await rectCentre(client, BUTTON);
+  assert.equal(
+    await evaluate(client, `window.__bootEscapeHatchProbe.captureButton()`),
+    true,
+    "the fixture must be able to hold a reference to the pressed button",
+  );
+  await press(client, heldCentre, "left");
+  await evaluate(client, `window.__bootEscapeHatchProbe.swap()`);
+  // The swap must genuinely DETACH the pressed node. If React reconciled the
+  // two surfaces into the same element, the browser would still fire a click
+  // and this case would pass without testing anything.
+  await waitFor(
+    client,
+    "the pressed button to be detached by the surface swap",
+    `window.__bootEscapeHatchProbe.capturedIsConnected() === false &&
+     document.querySelector(${JSON.stringify(BUTTON)}) !== null`,
+  );
+  await release(client, heldCentre, "left");
+  await settle(client);
+  assert.equal(
+    await activations(client),
+    1,
+    "a press on the escape hatch must activate it even when the boot surface " +
+      "is replaced before the release (no click event is emitted at all)",
+  );
+
+  // ── NON-PRIMARY BUTTON ──────────────────────────────────────────────────
+  // Press-start activation must not turn a right-click into a navigation.
+  await reset(client);
+  const rightCentre = await rectCentre(client, BUTTON);
+  await press(client, rightCentre, "right");
+  await release(client, rightCentre, "right");
+  await settle(client);
+  assert.equal(
+    await activations(client),
+    0,
+    "a secondary-button press must not activate the escape hatch",
+  );
+
+  console.log(
+    "BOOT ESCAPE HATCH PRESS REGRESSION PASSED: activates once on an ordinary " +
+      "click, activates across a surface swap that emits no click, and ignores " +
+      "a secondary-button press.",
+  );
+} catch (error) {
+  console.error("BOOT ESCAPE HATCH PRESS REGRESSION FAILED:", error);
+  process.exitCode = 1;
+} finally {
+  client?.close();
+  chrome?.kill("SIGKILL");
+  viteProcess?.kill("SIGKILL");
+  await delay(300);
+  try {
+    await rm(profilePath, { recursive: true, force: true });
+  } catch {
+    // A leftover temp profile is not a test result.
+  }
+}
+
+async function reset(client) {
+  await evaluate(client, `window.__bootEscapeHatchProbe.reset()`);
+  await waitFor(
+    client,
+    "the runtime boot surface after reset",
+    `document.querySelector('[data-testid="host-runtime-boot-fallback"]') !== null &&
+     window.__bootEscapeHatchProbe.activations() === 0`,
+  );
+  await settle(client);
+}
+
+function activations(client) {
+  return evaluate(client, `window.__bootEscapeHatchProbe.activations()`);
+}
+
+async function press(client, point, button) {
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mouseMoved",
+    x: point.x,
+    y: point.y,
+  });
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: point.x,
+    y: point.y,
+    button,
+    buttons: button === "left" ? 1 : 2,
+    clickCount: 1,
+  });
+}
+
+async function release(client, point, button) {
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: point.x,
+    y: point.y,
+    button,
+    buttons: 0,
+    clickCount: 1,
+  });
+}
+
+async function rectCentre(client, selector) {
+  const point = await evaluate(
+    client,
+    `(() => {
+       const el = document.querySelector(${JSON.stringify(selector)});
+       if (el === null) return null;
+       const r = el.getBoundingClientRect();
+       return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + r.height / 2) };
+     })()`,
+  );
+  if (point === null) throw new Error(`element not found: ${selector}`);
+  return point;
+}
+
+function settle(client) {
+  return evaluate(client, `new Promise((r) => setTimeout(r, 250))`);
+}
+
+async function findChrome() {
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("No Chrome/Chromium binary found");
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port =
+        typeof address === "object" && address !== null ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url, child, readError, label) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`${label} exited early: ${readError()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // not up yet
+    }
+    await delay(150);
+  }
+  throw new Error(`${label} did not become reachable: ${readError()}`);
+}
+
+function connectCdp(url) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    const pending = new Map();
+    let nextId = 0;
+    const connectTimer = setTimeout(
+      () => reject(new Error("CDP connect timed out")),
+      15_000,
+    );
+    socket.addEventListener("error", (event) =>
+      reject(new Error(String(event))),
+    );
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (typeof message.id !== "number") return;
+      const request = pending.get(message.id);
+      if (request === undefined) return;
+      pending.delete(message.id);
+      if (message.error === undefined) request.resolve(message.result);
+      else request.reject(new Error(message.error.message));
+    });
+    socket.addEventListener("open", () => {
+      clearTimeout(connectTimer);
+      resolve({
+        send(method, params = {}) {
+          return new Promise((requestResolve, requestReject) => {
+            const id = ++nextId;
+            pending.set(id, { resolve: requestResolve, reject: requestReject });
+            socket.send(JSON.stringify({ id, method, params }));
+          });
+        },
+        close() {
+          socket.close();
+        },
+      });
+    });
+  });
+}
+
+async function evaluate(client, expression) {
+  const response = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (response.exceptionDetails !== undefined) {
+    throw new Error(
+      response.exceptionDetails.exception?.description ??
+        response.exceptionDetails.text ??
+        "Browser evaluation failed",
+    );
+  }
+  return response.result.value;
+}
+
+async function waitFor(client, label, expression) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (await evaluate(client, expression)) return;
+    await delay(50);
+  }
+  const pageState = await evaluate(
+    client,
+    `({ text: document.body.innerText, html: document.body.innerHTML.slice(0, 3000) })`,
+  );
+  throw new Error(
+    `Timed out waiting for ${label}:\n${JSON.stringify(pageState, null, 2)}`,
+  );
+}

--- a/clients/gui-app/scripts/run-tests.ts
+++ b/clients/gui-app/scripts/run-tests.ts
@@ -127,6 +127,14 @@ if (runsFirstShard) {
     // check nobody enables is a coverage gap wearing a test's name.
     runBrowserRegression("scripts/quit-intercept-cancel-browser.mjs");
     runBrowserRegression("scripts/destructive-dialog-focus-browser.mjs");
+    // Same gate again, and the strongest case for it in this list: the boot
+    // card's escape hatch is lost to an INPUT-DISPATCH rule - a press whose
+    // element is removed before release emits no click at all - and jsdom
+    // dispatches `click` directly, so every jsdom test of that button passes
+    // on the broken build. Ablated before wiring: reverting the button to
+    // `onClick` turns this red (0 activations) while its ordinary-click
+    // premise stays green.
+    runBrowserRegression("scripts/boot-escape-hatch-press-browser.mjs");
     // NOT here, deliberately, and each for its own reason:
     // - `scripts/window-host-modal-alignment-browser.mjs` measures the
     //   local-bootstrap body against ONE LEFT EDGE (A1/A2/A5/PC4) - the design

--- a/clients/gui-app/src/__tests__/browser/boot-escape-hatch-press.html
+++ b/clients/gui-app/src/__tests__/browser/boot-escape-hatch-press.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Boot escape hatch - press survives a surface swap</title>
+    <style>
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./boot-escape-hatch-press.tsx"></script>
+  </body>
+</html>

--- a/clients/gui-app/src/__tests__/browser/boot-escape-hatch-press.tsx
+++ b/clients/gui-app/src/__tests__/browser/boot-escape-hatch-press.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { HostBootSurface } from "@/components/host/host-boot-surface";
+import { HostRuntimeBootFallback } from "@/components/host/host-runtime-boot-fallback";
+import { APP_HEADER_HEIGHT_CLASS } from "@/components/layout/header/app-header-height";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { cn } from "@/lib/utils";
+import "@/index.css";
+
+/**
+ * Browser fixture for the boot card's escape hatch surviving a surface swap.
+ *
+ * WHY IT CANNOT BE A JSDOM TEST. The defect is a browser INPUT-DISPATCH fact:
+ * when the element a press started on is removed from the document before
+ * release, Chromium emits no `click` at all, so `onClick` never runs. Testing
+ * Library dispatches `click` directly, so the broken build passes every jsdom
+ * test ever written for this button. The only instrument that can see it is a
+ * real browser driven through `Input.dispatchMouseEvent` - see
+ * `scripts/boot-escape-hatch-press-browser.mjs`.
+ *
+ * The shape reproduced here is the measured one, from a CDP capture of a real
+ * user press on the production card:
+ *
+ *   pointerdown -> button[host-boot-open-settings]
+ *   mousedown   -> button[host-boot-open-settings]
+ *   ... the launch hands off to the next boot surface ...
+ *   mouseup     -> the tree that replaced it
+ *   (no click)
+ *
+ * WHAT IS REAL: the button and both cards are production components
+ * (`HostRuntimeBootFallback` -> `HostBootSurface` -> `BootOpenSettingsButton`).
+ * The two phases are the two REAL surfaces a launch crosses, drawn the way
+ * their owners draw them, so the swap unmounts a real card and mounts a real
+ * one rather than shuffling a stand-in. Only the trigger is synthetic: the
+ * driver calls `swap()` where a launch would advance on its own.
+ */
+
+let activations = 0;
+let capturedButton: Element | null = null;
+
+interface BootEscapeHatchProbe {
+  readonly activations: () => number;
+  readonly reset: () => void;
+  readonly swap: () => void;
+  readonly captureButton: () => boolean;
+  readonly capturedIsConnected: () => boolean;
+}
+
+declare global {
+  interface Window {
+    __bootEscapeHatchProbe: BootEscapeHatchProbe;
+  }
+}
+
+/**
+ * The gate/narrator phase: a DIFFERENT React tree drawing the same card, which
+ * is precisely what makes the swap invisible to a user and fatal to a press.
+ * The frame mirrors `DefaultHostReadyGate`'s column so the card lands in the
+ * same place - a card that moved would let a driver "miss" the button for
+ * ordinary layout reasons and call it a regression.
+ */
+export function GatePhase(props: { readonly onOpenSettings: () => void }) {
+  return (
+    <div className="flex min-h-svh w-full flex-col bg-background text-foreground">
+      <div aria-hidden className={cn("shrink-0", APP_HEADER_HEIGHT_CLASS)} />
+      <div className="flex flex-1 items-center justify-center p-6">
+        <HostBootSurface
+          testId="host-gate-attach-pending"
+          onConfigureShell={() => undefined}
+          onOpenSettings={props.onOpenSettings}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function Fixture() {
+  const [phase, setPhase] = useState<"runtime" | "gate">("runtime");
+  const [generation, setGeneration] = useState<number>(0);
+
+  const onOpenSettings = (): void => {
+    activations += 1;
+  };
+
+  // Installed in an EFFECT, never during render: the driver only needs the
+  // handle once the tree is on screen, and a render-time write to a
+  // module-scoped binding is both a lint error here and a real hazard under
+  // concurrent rendering.
+  useEffect(() => {
+    window.__bootEscapeHatchProbe = {
+      activations: () => activations,
+      reset: () => {
+        activations = 0;
+        capturedButton = null;
+        setPhase("runtime");
+        setGeneration((current) => current + 1);
+      },
+      swap: () => {
+        setPhase("gate");
+      },
+      captureButton: () => {
+        capturedButton = document.querySelector(
+          '[data-testid="host-boot-open-settings"]',
+        );
+        return capturedButton !== null;
+      },
+      capturedIsConnected: () =>
+        capturedButton !== null && capturedButton.isConnected,
+    };
+  }, []);
+
+  // `key` on the phase, so React cannot reconcile the two surfaces into one
+  // set of DOM nodes and quietly keep the pressed element alive - which would
+  // make this fixture pass against the very defect it exists to catch.
+  return phase === "runtime" ? (
+    <HostRuntimeBootFallback
+      key={`runtime-${String(generation)}`}
+      onConfigureShell={() => undefined}
+      onOpenSettings={onOpenSettings}
+    />
+  ) : (
+    <GatePhase
+      key={`gate-${String(generation)}`}
+      onOpenSettings={onOpenSettings}
+    />
+  );
+}
+
+/**
+ * The provider stack the boot body needs, and no more: the bootstrap-log
+ * disclosure reads `traycer host status` through the runner host and its
+ * TanStack query. A shell with no CLI (`MockRunnerHost`'s default) is the
+ * honest configuration here - the disclosure self-hides, `Open settings`
+ * still renders, and this fixture is about the escape hatch, not the log.
+ */
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function buildRunnerHost(): MockRunnerHost {
+  return new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+}
+
+const container = document.getElementById("root");
+if (container === null) throw new Error("#root element not found");
+createRoot(container).render(
+  <QueryClientProvider client={queryClient}>
+    <RunnerHostProvider runnerHost={buildRunnerHost()}>
+      <Fixture />
+    </RunnerHostProvider>
+  </QueryClientProvider>,
+);

--- a/clients/gui-app/src/components/host/host-boot-surface.tsx
+++ b/clients/gui-app/src/components/host/host-boot-surface.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { HostBootCard } from "@/components/centered-card";
 import { LocalHostLoadingContent } from "@/components/local-host-loading";
+import { usePressStartActivation } from "@/lib/host/press-start-activation";
 
 /**
  * The WHOLE boot card - headline, progress bar, details disclosure and
@@ -34,11 +35,19 @@ import { LocalHostLoadingContent } from "@/components/local-host-loading";
  *    (web/mobile have no bootstrap log to show), which is the one honest
  *    absence in this family - see `BootstrapLogDisclosure`.
  *  - `Open settings` navigates the router instance, which exists from app
- *    construction even before `RouterProvider` mounts. On the earliest phase
- *    the navigation is therefore QUEUED: it takes effect the moment the router
- *    mounts, and Settings bypasses the readiness gate - so a user staring at a
- *    stuck launch can still get to the page that fixes it. That is the escape
- *    hatch this family must never lose.
+ *    construction even before `RouterProvider` mounts, so a navigation made on
+ *    the earliest phase commits (measured: `router.navigate` sets the location
+ *    on an unmounted router) and Settings bypasses the readiness gate - a user
+ *    staring at a stuck launch can still reach the page that fixes it. That is
+ *    the escape hatch this family must never lose, and it has been lost twice:
+ *      1. the press never became a CLICK, because this card is replaced
+ *         mid-press (`usePressStartActivation`);
+ *      2. the committed route was then overwritten by the desktop's restored
+ *         route, because the route observer did not exist this early
+ *         (`TabNavigationRouteBridge`, now mounted above `HostRuntimeProvider`).
+ *    Both were invisible from inside this file: the card looked unchanged
+ *    either way. Changing how this button activates, or where that bridge
+ *    mounts, reopens one of them.
  */
 export function HostBootSurface(props: {
   readonly testId: string | null;
@@ -65,14 +74,20 @@ export function HostBootSurface(props: {
  * accent link beside a muted toggle reads as the card's primary action - on a
  * surface whose primary action is "wait". The escape hatch stays present and
  * clickable; it just stops shouting.
+ *
+ * It activates on PRESS, not on click, and that is load-bearing rather than
+ * stylistic: this button's own surface is replaced mid-launch, and a press
+ * whose element is removed before release produces no click event at all. See
+ * `usePressStartActivation` for the capture that established it.
  */
 export function BootOpenSettingsButton(props: {
   readonly onOpenSettings: () => void;
 }): ReactNode {
+  const activation = usePressStartActivation(props.onOpenSettings);
   return (
     <button
       type="button"
-      onClick={props.onOpenSettings}
+      {...activation}
       data-testid="host-boot-open-settings"
       className="inline-flex items-center text-ui-xs text-muted-foreground hover:text-foreground"
     >

--- a/clients/gui-app/src/components/layout/bridges/__tests__/tab-navigation-route-bridge.test.tsx
+++ b/clients/gui-app/src/components/layout/bridges/__tests__/tab-navigation-route-bridge.test.tsx
@@ -144,11 +144,23 @@ afterEach(() => {
   __resetTabNavigationControllerForTesting();
 });
 
+/**
+ * Models the real module's ONE-SHOT semantics: `consumeDesktopRestoredRoute`
+ * nulls `pendingRestoredRoute` as it reads it. A stub that answered the same
+ * route on every call could not tell "the token was spent" from "the token is
+ * still pending", which is exactly the distinction the remount case below is
+ * about.
+ */
 function seedRestoredRoute(route: string | null): void {
+  let pending = route;
   vi.spyOn(
     DesktopTabsPersistence,
     "consumeDesktopRestoredRoute",
-  ).mockReturnValue(route);
+  ).mockImplementation(() => {
+    const value = pending;
+    pending = null;
+    return value;
+  });
 }
 
 describe("TabNavigationRouteBridge restored-route replacement", () => {
@@ -328,6 +340,45 @@ describe("TabNavigationRouteBridge restored-route replacement", () => {
     });
 
     expect(testState.replaceCalls).toEqual([]);
+  });
+
+  it("spends the launch route even when the escape hatch wins, so a later remount cannot replay it", () => {
+    // Raised in review (#1328). Declining to APPLY the restored route is not a
+    // reason to leave it PENDING: `pendingRestoredRoute` is cleared only by
+    // `WindowsBridgeProvider`'s cleanup, and that provider outlives auth
+    // changes, while `RootComponent` unmounts and remounts this bridge on
+    // sign-out/sign-in. A stale token surviving that gap gets spent by the
+    // later mount - after the location has lost the marker - and replaces
+    // whatever the user is looking at with an epic from the previous session.
+    seedRestoredRoute("/epics/stale-epic/stale-tab");
+    testState.routerLocation = {
+      pathname: "/settings/host",
+      search: {},
+      searchStr: "",
+      state: { [STARTUP_NAVIGATION_INTENT_KEY]: true },
+    };
+
+    const { unmount } = render(<TabNavigationRouteBridge />);
+    expect(
+      testState.replaceCalls,
+      "the escape hatch outranks the restore on this mount",
+    ).toEqual([]);
+
+    // Sign-out unmounts the bridge; sign-in remounts it. By then the user has
+    // navigated on, so the current location carries no marker.
+    unmount();
+    testState.routerLocation = {
+      pathname: "/epics/current-epic/current-tab",
+      search: {},
+      searchStr: "",
+      state: {},
+    };
+    render(<TabNavigationRouteBridge />);
+
+    expect(
+      testState.replaceCalls,
+      "a spent launch token must not be replayed onto a later session",
+    ).toEqual([]);
   });
 
   it("does not replace at all when nothing was restored", async () => {

--- a/clients/gui-app/src/components/layout/bridges/__tests__/tab-navigation-route-bridge.test.tsx
+++ b/clients/gui-app/src/components/layout/bridges/__tests__/tab-navigation-route-bridge.test.tsx
@@ -13,6 +13,7 @@ import {
   settingsTabIntent,
   tabNavigationController,
 } from "@/lib/tab-navigation";
+import { STARTUP_NAVIGATION_INTENT_KEY } from "@/lib/host/startup-navigation-intent";
 import { withOverlayCleared } from "@/lib/system-tab-overlay-search";
 import { useTabsStore } from "@/stores/tabs/store";
 import * as DesktopTabsPersistence from "@/stores/tabs/desktop-tabs-persistence";
@@ -52,6 +53,7 @@ function parseCanonicalSearch(rawSearch: string): Record<string, unknown> {
 // are skipped or none are registered. The controller and the persistence
 // module are the real ones.
 const testState = vi.hoisted(() => ({
+  hydrated: true,
   subscriber: null as ((input: HistoryObserverInput) => void) | null,
   replaceCalls: [] as Array<ReplaceCall>,
   blockerRegistered: false,
@@ -71,7 +73,15 @@ vi.mock("@tanstack/react-router", () => ({
   useRouter: () => ({
     navigate: testState.navigate,
     options: { parseSearch: testState.parseSearch },
-    state: { location: testState.routerLocation },
+    // A GETTER, because the real router's `state.location` is live: reading it
+    // twice across a navigation must not hand back the first value. Capturing
+    // the object once let a test mutate `testState.routerLocation` and still be
+    // served the stale location - a shape production cannot produce, and one
+    // that hid whether the marker below was really being read off the current
+    // location.
+    get state() {
+      return { location: testState.routerLocation };
+    },
     history: {
       subscribe: (listener: (input: HistoryObserverInput) => void) => {
         testState.subscriber = listener;
@@ -101,10 +111,11 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("@/providers/windows-bridge-context", () => ({
-  useWindowsBridgeHydrated: () => true,
+  useWindowsBridgeHydrated: () => testState.hydrated,
 }));
 
 beforeEach(() => {
+  testState.hydrated = true;
   testState.subscriber = null;
   testState.replaceCalls = [];
   testState.blockerRegistered = false;
@@ -197,6 +208,126 @@ describe("TabNavigationRouteBridge restored-route replacement", () => {
     expect(observed.mock.calls[0][1]).toBe("PUSH");
     // The persisted route keeps the RAW query string, leading `?` included.
     expect(activeRoute).toHaveBeenCalledWith("/epics/e1?focusedAt=7&tab=b");
+  });
+
+  it("lets an escape-hatch navigation made before hydration outrank the desktop restored route", () => {
+    // THE REGRESSION, in the arm where this bridge DOES see the commit: the
+    // press landed after it mounted but before Windows hydration. The restored
+    // route must stand down for a navigation that declares itself. (The arm
+    // where the press happens on the first boot surface - before this bridge
+    // exists at all - is the case below it, which never observes anything.)
+    testState.hydrated = false;
+    seedRestoredRoute("/epics/epic-1/tab-1?focusPaneId=p1");
+    // `rerender`, never a second `render`: a second mount is a second bridge
+    // with fresh refs, which would consume the restored route for reasons that
+    // have nothing to do with the behaviour under test.
+    const { rerender } = render(<TabNavigationRouteBridge />);
+
+    // The press commits `/settings/host` while Windows hydration is still in
+    // flight - the ordering a cold launch actually produces.
+    act(() => {
+      testState.routerLocation = {
+        pathname: "/settings/host",
+        search: {},
+        searchStr: "",
+        state: {},
+      };
+      testState.subscriber?.({
+        location: {
+          pathname: "/settings/host",
+          // The escape hatch DECLARES itself (see `TraycerApp`); the marker is
+          // what separates it from the routing traffic a launch makes on its
+          // own, and it is why the restore below stands down.
+          state: { [STARTUP_NAVIGATION_INTENT_KEY]: true },
+          search: "",
+        },
+        action: { type: "PUSH" },
+      });
+    });
+
+    // Hydration lands afterwards, carrying the restored route with it.
+    act(() => {
+      testState.hydrated = true;
+      rerender(<TabNavigationRouteBridge />);
+    });
+
+    expect(
+      testState.replaceCalls,
+      "the restored route must not overwrite an explicit user navigation",
+    ).toEqual([]);
+    expect(
+      useTabsStore.getState().systemTabs.settings,
+      "the queued settings commit must materialize once hydration releases",
+    ).not.toBeNull();
+  });
+
+  it("still restores the desktop route when a cold launch redirects itself to / before hydration", () => {
+    // THE COUNTER-CASE, and the reason intent is DECLARED rather than inferred.
+    // A cold launch REPLACES to `/` with no user input at all: every protected
+    // route runs `requireSignedIn` (`src/lib/router-auth.ts`), which redirects
+    // while the auth store is still `signed-out` and stored tokens validate.
+    // An earlier attempt latched on ANY pre-hydration commit, which vetoed the
+    // restore and stranded the window on the landing page instead of the tab it
+    // had at shutdown. `persistent-history.ts` refuses to persist that same
+    // transient `/` for exactly this reason.
+    //
+    // It is pinned here even though this bridge mounts too late to see that
+    // redirect today, because "mount it earlier" is a standing temptation on
+    // this file - and it is the change that makes this reachable.
+    testState.hydrated = false;
+    seedRestoredRoute("/epics/epic-1/tab-1?focusPaneId=p1");
+
+    const { rerender } = render(<TabNavigationRouteBridge />);
+
+    act(() => {
+      testState.routerLocation = {
+        pathname: "/",
+        search: {},
+        searchStr: "",
+        state: {},
+      };
+      testState.subscriber?.({
+        // No marker: nothing about this came from the user.
+        location: { pathname: "/", state: {}, search: "" },
+        action: { type: "REPLACE" },
+      });
+    });
+
+    act(() => {
+      testState.hydrated = true;
+      rerender(<TabNavigationRouteBridge />);
+    });
+
+    expect(
+      testState.replaceCalls,
+      "an auth-fallback redirect must not be mistaken for user intent",
+    ).toEqual([
+      { path: "/epics/epic-1/tab-1?focusPaneId=p1", ignoreBlocker: true },
+    ]);
+  });
+
+  it("honours the escape-hatch marker on the current location even if the commit was never observed", () => {
+    // The subscription is installed in a passive effect, so there is a gap
+    // between first paint and it going live. The marker rides in history
+    // state, so the decision does not depend on having watched the commit go
+    // by - it is read off the location itself.
+    testState.hydrated = false;
+    seedRestoredRoute("/epics/epic-1/tab-1");
+    const { rerender } = render(<TabNavigationRouteBridge />);
+
+    act(() => {
+      // Location changed with NO subscriber notification at all.
+      testState.routerLocation = {
+        pathname: "/settings/host",
+        search: {},
+        searchStr: "",
+        state: { [STARTUP_NAVIGATION_INTENT_KEY]: true },
+      };
+      testState.hydrated = true;
+      rerender(<TabNavigationRouteBridge />);
+    });
+
+    expect(testState.replaceCalls).toEqual([]);
   });
 
   it("does not replace at all when nothing was restored", async () => {

--- a/clients/gui-app/src/components/layout/bridges/tab-navigation-route-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/tab-navigation-route-bridge.tsx
@@ -111,14 +111,23 @@ export function TabNavigationRouteBridge(): null {
 
   useEffect(() => {
     if (!hydrationReady) return;
-    // Read off the CURRENT location as well as the observed one, so this does
-    // not depend on the subscription having been live when the commit landed.
-    // The marker rides in history state, so a press taken in the gap between
-    // first paint and this bridge's passive effects is still honoured.
+    // SPEND the launch's restored route unconditionally, then decide whether to
+    // apply it. It is a one-shot for THIS launch, and leaving it pending when
+    // the user's intent wins is not inert: only `WindowsBridgeProvider`'s
+    // cleanup clears it, and that provider outlives auth changes, while THIS
+    // bridge is unmounted and remounted by `RootComponent` on sign-out/sign-in.
+    // A later mount - by which point the current location no longer carries the
+    // marker - would then spend the stale token and replace whatever the user
+    // was looking at with an epic from the previous session.
+    const pendingRestoredRoute = consumeDesktopRestoredRoute();
+    // Read the marker off the CURRENT location as well as the observed commit,
+    // so this does not depend on the subscription having been live when the
+    // commit landed. The marker rides in history state, so a press taken in the
+    // gap between first paint and this bridge's passive effects is honoured.
     const startupIntent =
       startupIntentBeforeHydrationRef.current ||
       isStartupNavigationIntent(router.state.location.state);
-    const restoredRoute = startupIntent ? null : consumeDesktopRestoredRoute();
+    const restoredRoute = startupIntent ? null : pendingRestoredRoute;
     if (restoredRoute !== null) {
       // Replace the current persisted entry BEFORE T3's first startup
       // synchronization. The subscription deliberately ignores this one

--- a/clients/gui-app/src/components/layout/bridges/tab-navigation-route-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/tab-navigation-route-bridge.tsx
@@ -1,22 +1,58 @@
 import { useEffect, useRef } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { tabNavigationController } from "@/lib/tab-navigation";
+import { isStartupNavigationIntent } from "@/lib/host/startup-navigation-intent";
 import { useWindowsBridgeHydrated } from "@/providers/windows-bridge-context";
 import {
   consumeDesktopRestoredRoute,
   updateDesktopTabsActiveRoute,
 } from "@/stores/tabs/desktop-tabs-persistence";
 
+export interface TabNavigationHistoryEvent {
+  readonly location: {
+    readonly pathname: string;
+    readonly state: unknown;
+    // `HistoryLocation.search` is the raw query string, never a parsed
+    // object. Declaring the wider union invited a lossy re-serializer that
+    // dropped every non-string param (`focusedAt` and friends), while the
+    // hydration writer below persisted `searchStr` intact - so the stored
+    // route depended on which writer ran last.
+    readonly search: string;
+  };
+  readonly action: {
+    readonly type: "PUSH" | "REPLACE" | "BACK" | "FORWARD" | "GO";
+  };
+}
+
 /**
- * Observes committed history entries once at the signed-in root. The
+ * Observes committed history entries for the whole app lifetime. The
  * controller, rather than route render effects, distinguishes an internal
  * activation envelope from an external route (including Back and Forward).
+ *
+ * IT DOES NOT SEE THE WHOLE LAUNCH, and must not be "fixed" by mounting it
+ * earlier. It mounts in `RootComponent`, inside `RouterProvider`, so it does
+ * not exist during the first boot surface (`HostRuntimeBootFallback` renders
+ * as `HostRuntimeProvider`'s fallback, above the router). A navigation made
+ * there - the boot card's `Open settings` escape hatch is the only one a user
+ * can make - is therefore never observed, and the restored-route replay below
+ * used to overwrite it: measured, an explicit `/settings/host` replaced by
+ * `/epics/<id>/<tab>` on every warm launch, so the escape hatch appeared to do
+ * nothing.
+ *
+ * The fix is NOT earlier mounting. That navigation DECLARES itself in history
+ * state (`startup-navigation-intent.ts`) and the hydration effect reads the
+ * marker off the CURRENT location, so it survives whether or not this bridge
+ * was subscribed when the commit landed. Mounting above `HostRuntimeProvider`
+ * was tried and reverted: from up there this observer also sees the transient
+ * `/` a cold launch redirects ITSELF to - `requireSignedIn` fires while stored
+ * tokens are still validating - and treating that as user intent vetoes the
+ * restore, stranding the window on the landing page.
  */
 export function TabNavigationRouteBridge(): null {
   const router = useRouter();
   const hydrationReady = useWindowsBridgeHydrated();
   const hydrationReadyRef = useRef(hydrationReady);
-  const observedBeforeHydrationRef = useRef(false);
+  const startupIntentBeforeHydrationRef = useRef(false);
   const skipRestoredRouteObservationRef = useRef(false);
 
   useEffect(() => {
@@ -30,24 +66,20 @@ export function TabNavigationRouteBridge(): null {
       state: router.state.location.state,
       search: router.state.location.search,
     }));
-    const observe = (input: {
-      readonly location: {
-        readonly pathname: string;
-        readonly state: unknown;
-        // `HistoryLocation.search` is the raw query string, never a parsed
-        // object. Declaring the wider union invited a lossy re-serializer that
-        // dropped every non-string param (`focusedAt` and friends), while the
-        // hydration writer below persisted `searchStr` intact - so the stored
-        // route depended on which writer ran last.
-        readonly search: string;
-      };
-      readonly action: {
-        readonly type: "PUSH" | "REPLACE" | "BACK" | "FORWARD" | "GO";
-      };
-    }): void => {
+    const observe = (input: TabNavigationHistoryEvent): void => {
       if (skipRestoredRouteObservationRef.current) return;
-      if (!hydrationReadyRef.current) {
-        observedBeforeHydrationRef.current = true;
+      // ONLY a DECLARED escape-hatch navigation counts as user intent here.
+      // This used to latch on any pre-hydration commit, which was safe only
+      // while this bridge mounted too late to see startup traffic: a cold
+      // launch REPLACES to `/` on its own, because every protected route runs
+      // `requireSignedIn` while stored tokens are still validating. Latching on
+      // that would veto the restore below and strand the window on the landing
+      // page instead of the tab it was showing at shutdown.
+      if (
+        !hydrationReadyRef.current &&
+        isStartupNavigationIntent(input.location.state)
+      ) {
+        startupIntentBeforeHydrationRef.current = true;
       }
       // Same serialization as the hydration writer below: the raw query string
       // straight through, including its leading `?`.
@@ -79,9 +111,14 @@ export function TabNavigationRouteBridge(): null {
 
   useEffect(() => {
     if (!hydrationReady) return;
-    const restoredRoute = observedBeforeHydrationRef.current
-      ? null
-      : consumeDesktopRestoredRoute();
+    // Read off the CURRENT location as well as the observed one, so this does
+    // not depend on the subscription having been live when the commit landed.
+    // The marker rides in history state, so a press taken in the gap between
+    // first paint and this bridge's passive effects is still honoured.
+    const startupIntent =
+      startupIntentBeforeHydrationRef.current ||
+      isStartupNavigationIntent(router.state.location.state);
+    const restoredRoute = startupIntent ? null : consumeDesktopRestoredRoute();
     if (restoredRoute !== null) {
       // Replace the current persisted entry BEFORE T3's first startup
       // synchronization. The subscription deliberately ignores this one

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
@@ -9,6 +9,7 @@ import { ReportIssueAction } from "@/components/report-issue/report-issue-action
 import { getClientAppVersion } from "@/lib/app-version";
 import { cn } from "@/lib/utils";
 import { createReportIssueContext } from "@/lib/report-issue-context";
+import { usePressStartActivation } from "@/lib/host/press-start-activation";
 import type { HostProgressView } from "@/lib/host/host-progress-copy";
 import {
   hostUpdateSkew,
@@ -290,6 +291,7 @@ function NarrationActions(
     readonly align: "center" | "end";
   },
 ): ReactNode {
+  const settingsActivation = usePressStartActivation(props.onOpenSettings);
   return (
     <div
       className={cn(
@@ -336,12 +338,19 @@ function NarrationActions(
           bypasses the readiness gate - the shell page edits host
           config without a running host, so this is the escape hatch
           for a host that cannot start. Gating it behind the failure
-          it exists to fix is the lockout this whole surface prevents. */}
+          it exists to fix is the lockout this whole surface prevents.
+
+          It activates on PRESS (`usePressStartActivation`), unlike its
+          neighbours in this row, and the asymmetry is deliberate: this card
+          can be replaced by the next boot surface between a press and its
+          release, which produces no click at all. Retry / Update host are
+          MUTATIONS and keep click semantics, so a press the user drags away
+          from does not fire them. */}
       <Button
         type="button"
         size="sm"
         variant={props.settingsEmphasis === "button" ? "outline" : "link"}
-        onClick={props.onOpenSettings}
+        {...settingsActivation}
         data-testid="window-host-modal-open-settings"
         data-emphasis={props.settingsEmphasis}
       >

--- a/clients/gui-app/src/lib/host/__tests__/press-start-activation.test.tsx
+++ b/clients/gui-app/src/lib/host/__tests__/press-start-activation.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { usePressStartActivation } from "@/lib/host/press-start-activation";
+
+/**
+ * The half of `usePressStartActivation` that jsdom CAN see.
+ *
+ * jsdom has no input pipeline: it dispatches whatever event you name, so it
+ * cannot reproduce the defect this hook exists for (a press whose element is
+ * removed before release, which emits no click in a real browser). That case
+ * belongs to `scripts/boot-escape-hatch-press-browser.mjs` and is asserted
+ * there against real Chromium input.
+ *
+ * What is testable here is the ACTIVATION ALGEBRA - which combinations of
+ * events must produce exactly one call, and which must produce none. Those
+ * are decisions this hook makes in plain JavaScript, and pinning them here
+ * keeps the browser gate focused on the one thing only it can answer.
+ */
+function Probe(props: { readonly onActivate: () => void }) {
+  const activation = usePressStartActivation(props.onActivate);
+  return (
+    <button type="button" {...activation} data-testid="probe">
+      Open settings
+    </button>
+  );
+}
+
+function renderProbe(): { readonly activate: Mock<() => void> } {
+  const activate = vi.fn<() => void>();
+  render(<Probe onActivate={activate} />);
+  return { activate };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("usePressStartActivation", () => {
+  it("fires once for a primary press followed by its click", () => {
+    // The ordinary case, and the one a double-fire would break: the pointer
+    // press activates, and the click the browser derives from it must not
+    // activate a second time.
+    const { activate } = renderProbe();
+    const button = screen.getByTestId("probe");
+
+    fireEvent.pointerDown(button, { button: 0, isPrimary: true });
+    fireEvent.click(button, { detail: 1 });
+
+    expect(activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires on the press alone, without any click", () => {
+    // The whole point: in a real browser this is what a press across a surface
+    // swap looks like - press, no click, ever.
+    const { activate } = renderProbe();
+
+    fireEvent.pointerDown(screen.getByTestId("probe"), {
+      button: 0,
+      isPrimary: true,
+    });
+
+    expect(activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires for keyboard activation, which arrives as a click with detail 0", () => {
+    // Enter/Space on a focused button, a screen reader's activation and a
+    // programmatic `.click()` all arrive this way, with no pointer press
+    // behind them. Press-start activation must not cost the keyboard path.
+    const { activate } = renderProbe();
+
+    fireEvent.click(screen.getByTestId("probe"), { detail: 0 });
+
+    expect(activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a secondary-button press", () => {
+    const { activate } = renderProbe();
+
+    fireEvent.pointerDown(screen.getByTestId("probe"), {
+      button: 2,
+      isPrimary: true,
+    });
+
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a non-primary pointer", () => {
+    // A second touch point in a multi-touch gesture is not an activation.
+    const { activate } = renderProbe();
+
+    fireEvent.pointerDown(screen.getByTestId("probe"), {
+      button: 0,
+      isPrimary: false,
+    });
+
+    expect(activate).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/lib/host/press-start-activation.ts
+++ b/clients/gui-app/src/lib/host/press-start-activation.ts
@@ -1,0 +1,86 @@
+import {
+  useCallback,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+/**
+ * Handlers for a control that must survive its own surface being replaced
+ * mid-press. Spread onto the element; never combine with a separate `onClick`.
+ */
+export interface PressStartActivation {
+  readonly onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onClick: (event: ReactMouseEvent<HTMLElement>) => void;
+}
+
+/**
+ * Activation that fires on PRESS rather than on click, for the boot card's
+ * escape hatch.
+ *
+ * WHY THIS EXISTS - measured, not theorised. A launch crosses several boot
+ * surfaces (`HostRuntimeBootFallback`, the gate's card, the narrator's
+ * `WindowHostStartupCard`), and they are deliberately pixel-identical, so the
+ * card looks continuous while the DOM under it is replaced. A CDP capture of a
+ * real user press on the production `Open settings` link recorded:
+ *
+ *   pointerdown -> button[host-boot-open-settings]
+ *   mousedown   -> button[host-boot-open-settings]
+ *   mouseup     -> the tree that replaced it, 198ms later
+ *   (no click event at all)
+ *
+ * Chromium emitted NO click, because the pressed element had been removed from
+ * the document before release. `onClick` therefore never ran, the navigation
+ * never happened, and the user saw an unchanged card - the whole reported bug.
+ * The card's clickable lifetime on that machine was ~300-500ms per launch, so
+ * a press only has to be slightly late to straddle a hand-off.
+ *
+ * Do not "fix" this back to a plain `onClick`, and do not try to hold the
+ * surface still while a pointer is down: pointer capture does not survive the
+ * node being removed, and gating readiness hand-offs on pointer lifecycle
+ * (pointercancel, window blur, lost capture) trades a lost click for a stuck
+ * launch.
+ *
+ * ONLY FOR SAFE NAVIGATION. This is for escape hatches that a user can repeat
+ * harmlessly - opening Settings. It must NOT be used for mutations (Retry,
+ * Update host, Reinstall): press-start activation deliberately ignores
+ * drag-away and pointer-cancel, so a press that the user changes their mind
+ * about still fires. That is the right trade for "let me out of this stuck
+ * launch" and the wrong one for anything that changes state.
+ *
+ * TOUCH. A primary touch activates at gesture start, before it is known to be
+ * a tap rather than a scroll or long-press. Accepted for this control on this
+ * surface, where there is nothing to scroll.
+ *
+ * KEYBOARD IS UNAFFECTED. A keyboard-activated button (Enter/Space), a screen
+ * reader's activation and a programmatic `.click()` all arrive as a click with
+ * `detail === 0` and no pointer press behind them, so they take the `onClick`
+ * path. Any click with `detail >= 1` is the tail of a pointer press this hook
+ * already handled at `pointerdown` - it is dropped, so the action fires once,
+ * not twice.
+ */
+export function usePressStartActivation(
+  onActivate: () => void,
+): PressStartActivation {
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>): void => {
+      // Primary button of the primary pointer only. Without this, a
+      // right-click (which opens a context menu and fires no click) or a
+      // secondary touch point would navigate.
+      if (event.button !== 0 || !event.isPrimary) return;
+      // Deliberately no `preventDefault()`: it would suppress focus and the
+      // compatibility mouse events, changing behaviour well beyond this fix.
+      onActivate();
+    },
+    [onActivate],
+  );
+
+  const onClick = useCallback(
+    (event: ReactMouseEvent<HTMLElement>): void => {
+      if (event.detail !== 0) return;
+      onActivate();
+    },
+    [onActivate],
+  );
+
+  return { onPointerDown, onClick };
+}

--- a/clients/gui-app/src/lib/host/startup-navigation-intent.ts
+++ b/clients/gui-app/src/lib/host/startup-navigation-intent.ts
@@ -1,0 +1,36 @@
+/**
+ * Marks a navigation as an EXPLICIT user escape made from a boot surface, so
+ * the desktop's restored-route replay can tell it apart from the routing
+ * traffic a launch generates on its own.
+ *
+ * WHY A MARKER AND NOT "did we observe a commit before hydration". The route
+ * bridge used to infer intent from that question, which was only safe while it
+ * mounted late enough to miss startup traffic. It observes from app
+ * construction now, and a cold launch REPLACES the restored route with `/`
+ * all by itself: every protected route runs `requireSignedIn`, which does
+ * `redirect({ to: "/" })` while the auth store is still `signed-out` (stored
+ * tokens have not finished validating - see `bindAuthInvalidation` in
+ * `router.tsx`). Treating that as user intent vetoes the restore and strands
+ * the window on the landing page instead of the epic tab it was showing at
+ * shutdown. `persistent-history.ts` already refuses to PERSIST that transient
+ * `/` for exactly the same reason; this is the same fact, one layer up.
+ *
+ * So intent is DECLARED by the navigation that has it, never inferred from
+ * history traffic. Today the only declarers are the boot card's two escape
+ * hatches (`Open settings`, `Configure shell…`) in `TraycerApp` - the app is
+ * not mounted yet on those surfaces, so nothing else can navigate.
+ *
+ * It rides in history state, which means it survives the gap between paint and
+ * the bridge's subscription: the bridge can read it off the CURRENT location
+ * at hydration time whether or not it saw the commit go by.
+ */
+export const STARTUP_NAVIGATION_INTENT_KEY = "__traycerStartupNavigationIntent";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Whether a history entry's state carries the escape-hatch marker. */
+export function isStartupNavigationIntent(state: unknown): boolean {
+  return isRecord(state) && state[STARTUP_NAVIGATION_INTENT_KEY] === true;
+}

--- a/clients/gui-app/src/routes/root-route-components.tsx
+++ b/clients/gui-app/src/routes/root-route-components.tsx
@@ -15,8 +15,8 @@ import { NotificationEmissionController } from "@/components/layout/bridges/noti
 import { NotificationFocusBridge } from "@/components/layout/bridges/notification-focus-bridge";
 import { SystemTabModalHost } from "@/components/layout/dialogs/system-tab-modal-host";
 import { WindowHostModalHost } from "@/components/layout/dialogs/window-host-modal-host";
-import { TrayOpenEpicBridge } from "@/components/layout/bridges/tray-open-epic-bridge";
 import { TabNavigationRouteBridge } from "@/components/layout/bridges/tab-navigation-route-bridge";
+import { TrayOpenEpicBridge } from "@/components/layout/bridges/tray-open-epic-bridge";
 import { ProviderProfileAddFlowHost } from "@/components/providers/provider-profile-add-flow-host";
 import { EpicAccessCoordinator } from "@/providers/epic-access-coordinator";
 import { OnboardingPage } from "@/components/onboarding/onboarding-page";
@@ -69,7 +69,18 @@ export function RootComponent() {
       <NotificationEmissionController />
       {/* This is the permanent route -> layout authority. It must observe
           commits while HostReadyGate swaps its children; only materialization
-          is hydration-gated inside the controller. */}
+          is hydration-gated inside the controller.
+
+          It does NOT exist during the first boot surface (`HostRuntimeProvider`
+          renders its fallback above `RouterProvider`), so it cannot observe a
+          navigation made there - the boot card's `Open settings` escape hatch
+          is exactly that. That navigation survives anyway because it DECLARES
+          itself in history state and this bridge reads the marker off the
+          CURRENT location at hydration; see `startup-navigation-intent.ts`.
+          Mounting this earlier is not the fix and was measured to cost more
+          than it buys: from up there it also sees the transient `/` that a cold
+          launch redirects ITSELF to (`requireSignedIn` fires while stored
+          tokens are still validating), which is not user intent. */}
       {authStatus === "signed-in" ? <TabNavigationRouteBridge /> : null}
       {/* The window narrator (D10). It MUST be outside HostReadyGate: the gate
           replaces its children during cold start, so a modal mounted inside it

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -50,6 +50,7 @@ import { ThemeProvider } from "@/providers/theme-provider";
 import { WindowsBridgeAuthSessionBridge } from "@/providers/windows-bridge-auth-session";
 import { WindowsBridgeProvider } from "@/providers/windows-bridge-provider";
 import { ResourceTelemetryBridge } from "@/providers/resource-telemetry-bridge";
+import { STARTUP_NAVIGATION_INTENT_KEY } from "@/lib/host/startup-navigation-intent";
 import { createAppRouter, type AppRouter } from "@/router";
 // Side-effect import: installs the WCO → `.wco` class bridge at module
 // load (mirrors `theme-applier.ts`). The class drives the `wco:`
@@ -120,15 +121,33 @@ export function TraycerApp(props: TraycerAppProps): ReactNode {
     () => createAppRouter(props.initialRoute ?? null, desktopWindowId),
     [desktopWindowId, props.initialRoute],
   );
+  // Both escape hatches DECLARE themselves as user intent in history state.
+  // They can be taken on a boot surface, before the app or the route bridge
+  // exists, and the marker is what stops the desktop's restored-route replay
+  // from overwriting them - without it that replay cannot tell a user's
+  // navigation from the transient `/` a cold launch redirects to on its own.
+  // See `startup-navigation-intent.ts`.
   const configureShell = useCallback(() => {
-    void router.navigate({ to: "/settings/shell" });
+    void router.navigate({
+      to: "/settings/shell",
+      state: (previous) => ({
+        ...previous,
+        [STARTUP_NAVIGATION_INTENT_KEY]: true,
+      }),
+    });
   }, [router]);
   // The host-unavailable card's escape hatch. `/settings/host` rather than the
   // settings index: the card is shown when no host can be reached, and that is
   // the page that manages them. Settings bypasses the readiness gate, so this
   // stays reachable from inside a full-screen block.
   const openSettings = useCallback(() => {
-    void router.navigate({ to: "/settings/host" });
+    void router.navigate({
+      to: "/settings/host",
+      state: (previous) => ({
+        ...previous,
+        [STARTUP_NAVIGATION_INTENT_KEY]: true,
+      }),
+    });
   }, [router]);
   // THE FIRST of a launch's three boot surfaces - see
   // `HostRuntimeBootFallback` for why it is the same card as the other two and


### PR DESCRIPTION
Pressing `Open settings` on the "Starting Traycer…" card did nothing, reported from production. Two independent defects, either one sufficient.

## The press never became a click

A launch crosses several boot surfaces — `HostRuntimeBootFallback`, the readiness gate's card, the window narrator's — separate React trees drawing a deliberately pixel-identical card. When one replaced another between mousedown and mouseup, Chromium emitted no `click` at all, so `onClick` never ran. Captured on the shipped build over CDP:

```
pointerdown -> button[host-boot-open-settings]
mousedown   -> button[host-boot-open-settings]
mouseup     -> the tree that replaced it, 198ms later
(no click event, ever)
```

Corroborated independently: the window's persistent history stack keeps `/settings/*` entries (they are never pruned) and had no `/settings/host` entry at all — the navigation never happened.

The card's clickable lifetime is ~300-500ms per launch. Nothing was stalled and nothing covered the button — rAF gaps under 16ms, hit-tests as itself, `pointer-events: auto` throughout.

## The committed route was then overwritten

`TabNavigationRouteBridge` inferred "the user navigated" from any pre-hydration history commit, so the desktop restored-route replay took the route back — an explicit `/settings/host` replaced by `/epics/<id>/<tab>` on every warm launch.

## Changes

- **`usePressStartActivation`** — activates on primary `pointerdown`, keeps `onClick` for keyboard/AT (`detail === 0`), drops the pointer-derived click so nothing fires twice. Applied to the two Settings escape hatches only, never to Retry / Update host / Reinstall, which are mutations and keep click semantics. Deliberate tradeoff: a press dragged away from still navigates.
- **`startup-navigation-intent.ts`** — intent is declared, not inferred. Both escape hatches mark their navigation in history state; the bridge vetoes the restore only for that marker, read off the *current* location so it does not depend on subscription timing. A cold launch's own transient `/` redirect (`requireSignedIn` firing while tokens validate) is therefore still classified as not-user-intent, and a warm launch restores normally.

Mounting the bridge above `HostRuntimeProvider` was tried and reverted: from up there it also observes that redirect, and vetoing on it strands the window on the landing page.

## Tests

jsdom cannot see the press half — no input pipeline, `click` is dispatched directly, so every jsdom test of this button passes on the broken build. The regression is a real-Chromium driver (`boot-escape-hatch-press-browser.mjs`) on the existing `RUN_DIFF_EDIT_BROWSER_REGRESSION` lane: press, swap the surface under the held pointer, release, assert exactly one activation.

Each fix was ablated:

| Ablation | Result |
| --- | --- |
| button back to `onClick` | browser regression red (0 activations); ordinary-click premise stays green |
| intent inferred instead of declared | 2 bridge cases red, including the cold-launch `/` counter-case |

Also added: a jsdom unit test for the hook's activation algebra (single fire, press-without-click, keyboard `detail === 0`, secondary button, non-primary pointer).

## Verified live

Against a dev-desktop build, reproducing the production trace exactly — `pointerdown`/`mousedown` on the button, `mouseup` on the replacement surface, **no click event** — with Settings opening anyway. Also confirmed a launch with no press still restores its epic tab, and that keyboard `Enter` still opens Settings (click with `detail: 0`).
