### PR TITLE
fix(gui-app,shared): calm the G4 re-point and the cold-start host flick

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
@@ -60,6 +60,18 @@ function stagedIntent(): WorktreeIntent | undefined {
   return useWorktreeIntentStagingStore.getState().intentByKey[STAGING_KEY_ID];
 }
 
+// The G4 toast, mocked so these tests assert the modal's decision to fire it
+// (and with what label) rather than sonner's internals. The staging store
+// itself stays REAL below (unlike the landing composer's wiring suite) - the
+// modal's `readStagedWorktreeIntent`/`clearForAllHosts` calls are exercised
+// against it directly.
+const toastMocks = vi.hoisted(() => ({
+  toastRepointedStagingReset: vi.fn<(hostLabel: string) => void>(),
+}));
+vi.mock("@/lib/composer/repointed-staging-toast", () => ({
+  toastRepointedStagingReset: toastMocks.toastRepointedStagingReset,
+}));
+
 interface PlacementTargetShape {
   readonly resolvedHostId: string | null;
   readonly client: { readonly getActiveHostId: () => string | null } | null;
@@ -427,6 +439,7 @@ afterEach(() => {
   testState.bodySubmit = null;
   testState.bodyStartTerminal = null;
   useNewConversationModalStore.getState().resetForTests();
+  toastMocks.toastRepointedStagingReset.mockReset();
 });
 
 describe("new-conversation modal shares the composer's placement semantics", () => {
@@ -535,7 +548,7 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     expect(testState.onSubmitted).not.toHaveBeenCalled();
   });
 
-  it("G4: a FOLLOWING modal clears its staged intent and says so when effective moves", () => {
+  it("G4: a FOLLOWING modal clears its staged intent and toasts when something was staged", () => {
     useWorktreeIntentStagingStore
       .getState()
       .setIntent(STAGING_KEY, STAGED_INTENT);
@@ -546,10 +559,34 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     });
 
     expect(stagedIntent()).toBeUndefined();
-    expect(noticeText()).toContain("now run on");
+    expect(toastMocks.toastRepointedStagingReset).toHaveBeenCalledTimes(1);
+    expect(toastMocks.toastRepointedStagingReset).toHaveBeenCalledWith(
+      testState.placement.current.hostLabel,
+    );
+    // The inline notice slot is `refused`-only now; a re-point is a toast.
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });
 
-  it("G4: a PINNED modal keeps its staged intent (D6)", () => {
+  it("G4: a FOLLOWING modal clears anyway but does not toast when nothing was staged", () => {
+    const clearForAllHostsSpy = vi.spyOn(
+      useWorktreeIntentStagingStore.getState(),
+      "clearForAllHosts",
+    );
+    renderModal();
+
+    act(() => {
+      notifyEffectiveHostChanged("host-a", "host-b");
+    });
+
+    expect(clearForAllHostsSpy).toHaveBeenCalledWith(STAGING_KEY);
+    expect(stagedIntent()).toBeUndefined();
+    expect(toastMocks.toastRepointedStagingReset).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
+
+    clearForAllHostsSpy.mockRestore();
+  });
+
+  it("G4: a PINNED modal keeps its staged intent and does not toast (D6)", () => {
     testState.pinIsPinned.current = true;
     testState.followsEffective.current = false;
     testState.placement.current = {
@@ -566,6 +603,7 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     });
 
     expect(stagedIntent()).toBeDefined();
+    expect(toastMocks.toastRepointedStagingReset).not.toHaveBeenCalled();
   });
 
   it("G4: a modal resting on the EPIC's host (default tier, unpinned) keeps its staged intent", () => {
@@ -592,6 +630,7 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     });
 
     expect(stagedIntent()).toBeDefined();
+    expect(toastMocks.toastRepointedStagingReset).not.toHaveBeenCalled();
     // And no move narrated: there is no notice at all.
     expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
@@ -1,5 +1,11 @@
 import { isValidElement, useRef, useState } from "react";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  type RenderResult,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
@@ -393,11 +399,12 @@ function workspaceControlsHostScope(element: unknown): unknown {
   return element.props.hostScope;
 }
 
-function renderModal(): void {
-  render(<Harness />);
+function renderModal(): RenderResult {
+  const view = render(<Harness />);
   act(() => {
     testState.installEditor?.();
   });
+  return view;
 }
 
 function noticeText(): string {
@@ -519,6 +526,43 @@ describe("new-conversation modal shares the composer's placement semantics", () 
 
     expect(testState.createChat).not.toHaveBeenCalled();
     expect(noticeText()).toContain("Build Box");
+  });
+
+  // Codex review finding: a §54 refusal names the placement it refused, so
+  // ANY change of the RESOLVED host retires it - a derivation move or the
+  // picker writing a new pin. A surviving alert would keep naming a placement
+  // this modal has already left.
+  it("clears a refused notice when the resolved host changes", () => {
+    testState.placement.current = {
+      resolvedHostId: "host-b",
+      // The chip renders host-b; this client would send to host-a - refused.
+      client: { getActiveHostId: () => "host-a" },
+      hostLabel: "Build Box",
+      isPinned: false,
+      namedHostDead: false,
+    };
+    const view = renderModal();
+    act(() => {
+      testState.bodySubmit?.();
+    });
+
+    expect(noticeText()).toContain("Build Box");
+
+    // The resolved host moves - to a placement that would itself be usable,
+    // which is the point: the notice must clear on the move alone, not on
+    // whether the new placement also refuses.
+    testState.placement.current = {
+      resolvedHostId: "host-c",
+      client: { getActiveHostId: () => "host-c" },
+      hostLabel: "Home Mac",
+      isPinned: false,
+      namedHostDead: false,
+    };
+    act(() => {
+      view.rerender(<Harness />);
+    });
+
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });
 
   it("refuses the TERMINAL path on the same verdict, creating nothing", () => {
@@ -691,6 +735,37 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     });
     expect(testState.createChat).toHaveBeenCalledTimes(1);
     expect(testState.recordPlacement).toHaveBeenCalledWith("host-a");
+  });
+
+  // Codex review finding: `clearForAllHosts` reaches every host's copy of the
+  // slot, so the "was anything staged" check that decides whether to toast
+  // must reach just as far. The narrower `readStagedWorktreeIntent` (scoped to
+  // the RESOLVED bucket) reported "nothing staged" here even though the clear
+  // below deleted the host-b copy - silently dropping the toast.
+  it("G4: toasts when the staged intent lives under a DIFFERENT host bucket than the resolved one", () => {
+    const otherHostKey = newConversationModalStagingKey(
+      "host-b",
+      "epic-1",
+      null,
+    );
+    useWorktreeIntentStagingStore
+      .getState()
+      .setIntent(otherHostKey, STAGED_INTENT);
+    renderModal();
+
+    act(() => {
+      notifyEffectiveHostChanged("host-a", "host-b");
+    });
+
+    expect(toastMocks.toastRepointedStagingReset).toHaveBeenCalledTimes(1);
+    expect(toastMocks.toastRepointedStagingReset).toHaveBeenCalledWith(
+      testState.placement.current.hostLabel,
+    );
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(otherHostKey)
+      ],
+    ).toBeUndefined();
   });
 
   it("does NOT record a placement on a refused submit - nothing was created", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-placement.test.tsx
@@ -565,6 +565,46 @@ describe("new-conversation modal shares the composer's placement semantics", () 
     expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });
 
+  it("P2 FIX - and keeps it retired across a round trip back to the refused host", () => {
+    // The per-Epic pin is as sticky as the landing composer's, so B -> C -> B
+    // happens on its own. Retiring the refusal on the FIRST move is what makes
+    // the return quiet; comparing it against the host it was raised for would
+    // bring the alert back with no submit behind it.
+    const resolveTo = (hostId: string, hostLabel: string): void => {
+      testState.placement.current = {
+        resolvedHostId: hostId,
+        client: { getActiveHostId: () => hostId },
+        hostLabel,
+        isPinned: true,
+        namedHostDead: false,
+      };
+    };
+    testState.placement.current = {
+      resolvedHostId: "host-b",
+      client: { getActiveHostId: () => "host-a" },
+      hostLabel: "Build Box",
+      isPinned: true,
+      namedHostDead: false,
+    };
+    const view = renderModal();
+    act(() => {
+      testState.bodySubmit?.();
+    });
+    expect(noticeText()).toContain("Build Box");
+
+    resolveTo("host-c", "Home Mac");
+    act(() => {
+      view.rerender(<Harness />);
+    });
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
+
+    resolveTo("host-b", "Build Box");
+    act(() => {
+      view.rerender(<Harness />);
+    });
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
+  });
+
   it("refuses the TERMINAL path on the same verdict, creating nothing", () => {
     useNewConversationModalStore
       .getState()

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -72,10 +72,8 @@ import { useEpicSessionHostId } from "@/hooks/epic/use-epic-session-host-id";
 import { resolveLandingPlacement } from "@/lib/composer/landing-placement";
 import { toastRepointedStagingReset } from "@/lib/composer/repointed-staging-toast";
 import { subscribeFollowingSurfaceReset } from "@/stores/host/surface-host-selection-store";
-import {
-  ComposerHostNotice,
-  type ComposerHostNoticeState,
-} from "@/components/home/composer/composer-host-notice";
+import { ComposerHostNotice } from "@/components/home/composer/composer-host-notice";
+import { useComposerHostNotice } from "@/hooks/composer/use-composer-host-notice";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { LEADER_SCOPE_NEW_CONVERSATION_MODAL } from "@/lib/keybindings/leader-scope";
 import {
@@ -140,6 +138,7 @@ import {
   useWorkspaceFoldersStore,
 } from "@/stores/workspace/workspace-folders-store";
 import {
+  anyHostHasStagedWorktreeIntent,
   newConversationModalStagingKey,
   readStagedWorktreeIntent,
   useWorktreeIntentStagingStore,
@@ -774,12 +773,11 @@ export function NewConversationModalBody(props: {
   // §54 refusal copy, as on the landing composer. The G4 re-point used to
   // share this slot; it narrates as a toast now, and only when it actually
   // reset staged intent.
-  const [hostNotice, setHostNotice] = useState<ComposerHostNoticeState | null>(
-    null,
-  );
-  const dismissHostNotice = useCallback(() => {
-    setHostNotice(null);
-  }, []);
+  const {
+    notice: hostNotice,
+    raise: raiseHostNotice,
+    dismiss: dismissHostNotice,
+  } = useComposerHostNotice(resolvedHostId);
   // G4: this modal FOLLOWS the effective host only when nothing else answered
   // its placement - no named host, no per-Epic pin in force, no session host
   // in force - and only then does a derivation move re-point it. Its staged
@@ -792,7 +790,11 @@ export function NewConversationModalBody(props: {
   useEffect(() => {
     return subscribeFollowingSurfaceReset(({ nextEffectiveHostId }) => {
       if (!composerFollowsEffective) return;
-      const hadStagedIntent = readStagedWorktreeIntent(stagingKey) !== null;
+      // Asked at `clearForAllHosts`'s breadth, not the resolved bucket's: this
+      // modal's slot can hold an intent staged while it was pinned elsewhere,
+      // and the clear below deletes that too. A narrower check would report
+      // "nothing staged" for a choice the user just lost.
+      const hadStagedIntent = anyHostHasStagedWorktreeIntent(stagingKey);
       clearStagedIntent(stagingKey);
       if (hadStagedIntent) {
         toastRepointedStagingReset(hostLabelFor(nextEffectiveHostId));
@@ -840,7 +842,7 @@ export function NewConversationModalBody(props: {
     // modal exactly as the user left them, with the reason inline.
     const placementVerdict = resolveLandingPlacement(submitTarget);
     if (placementVerdict.kind === "refused") {
-      setHostNotice({ kind: "refused", message: placementVerdict.message });
+      raiseHostNotice({ kind: "refused", message: placementVerdict.message });
       return;
     }
     // No render-vs-live drift check needed here (main's #1231 added one for
@@ -975,6 +977,7 @@ export function NewConversationModalBody(props: {
     epicId,
     parentId,
     placement,
+    raiseHostNotice,
     recordPlacement,
     rememberEpicIntent,
     setEpicRunSettings,
@@ -991,7 +994,7 @@ export function NewConversationModalBody(props: {
       // anything reports the failure.
       const placementVerdict = resolveLandingPlacement(submitTarget);
       if (placementVerdict.kind === "refused") {
-        setHostNotice({ kind: "refused", message: placementVerdict.message });
+        raiseHostNotice({ kind: "refused", message: placementVerdict.message });
         return;
       }
       // The staged key and this create both derive from the same captured
@@ -1036,6 +1039,7 @@ export function NewConversationModalBody(props: {
       epicId,
       parentId,
       placement,
+      raiseHostNotice,
       recordPlacement,
       rememberEpicIntent,
       tabId,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -70,6 +70,7 @@ import type { HostRpcRegistry } from "@/lib/host";
 import { useEpicConversationPlacement } from "@/hooks/host/use-composer-placement";
 import { useEpicSessionHostId } from "@/hooks/epic/use-epic-session-host-id";
 import { resolveLandingPlacement } from "@/lib/composer/landing-placement";
+import { toastRepointedStagingReset } from "@/lib/composer/repointed-staging-toast";
 import { subscribeFollowingSurfaceReset } from "@/stores/host/surface-host-selection-store";
 import {
   ComposerHostNotice,
@@ -507,6 +508,7 @@ export function NewConversationModalBody(props: {
   const hostClient = composerPlacement.target.client;
   const submitTarget = composerPlacement.submitTarget;
   const composerFollowsEffective = composerPlacement.followsEffective;
+  const hostLabelFor = composerPlacement.hostLabelFor;
   // "Last created chat's host": every create in this modal writes the Epic's
   // placement memory with the host it resolved, at SUBMIT (beside the settings
   // memory) rather than on the create's success - the model picker's memory
@@ -769,8 +771,9 @@ export function NewConversationModalBody(props: {
     />
   );
   const header = <NewConversationModalHeader switcher={switcher} />;
-  // §54 refusal copy and the G4 re-point notice share one slot, as on the
-  // landing composer.
+  // §54 refusal copy, as on the landing composer. The G4 re-point used to
+  // share this slot; it narrates as a toast now, and only when it actually
+  // reset staged intent.
   const [hostNotice, setHostNotice] = useState<ComposerHostNoticeState | null>(
     null,
   );
@@ -784,13 +787,18 @@ export function NewConversationModalBody(props: {
   // and must not travel; the §51 folder set stays, per the orchestrator's
   // ruling on the landing row. A modal resting on its pin or on the Epic's
   // host is not moved by the derivation and must not narrate a move (D6).
+  // A move that reset nothing stays silent: the switch itself is
+  // `toastSelectionSwitched`'s to tell.
   useEffect(() => {
     return subscribeFollowingSurfaceReset(({ nextEffectiveHostId }) => {
       if (!composerFollowsEffective) return;
+      const hadStagedIntent = readStagedWorktreeIntent(stagingKey) !== null;
       clearStagedIntent(stagingKey);
-      setHostNotice({ kind: "repointed", hostId: nextEffectiveHostId });
+      if (hadStagedIntent) {
+        toastRepointedStagingReset(hostLabelFor(nextEffectiveHostId));
+      }
     });
-  }, [clearStagedIntent, composerFollowsEffective, stagingKey]);
+  }, [clearStagedIntent, composerFollowsEffective, hostLabelFor, stagingKey]);
   const cleanupAfterSubmit = useCallback((): void => {
     clearDraft(epicId);
     clearStagedIntent(stagingKey);
@@ -1072,11 +1080,7 @@ export function NewConversationModalBody(props: {
       workspaceDisabledHint={composerDisabledHint}
       header={header}
       topBanner={
-        <ComposerHostNotice
-          notice={hostNotice}
-          hostLabelFor={composerPlacement.hostLabelFor}
-          onDismiss={dismissHostNotice}
-        />
+        <ComposerHostNotice notice={hostNotice} onDismiss={dismissHostNotice} />
       }
       stashControl={
         <PromptStashControl

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-placement-wiring.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-placement-wiring.test.tsx
@@ -55,6 +55,18 @@ const STAGED_INTENT: WorktreeIntent = {
   ],
 };
 
+// The composer's mutable READ target, for the §54-notice suite below: the
+// `useComposerPlacement` mock reads this on every call, so mutating it and
+// forcing a re-render is how a test presents a DIFFERENT resolved host to an
+// already-mounted composer. A plain top-level `let` (not `vi.hoisted`, unlike
+// `testState`) because it is assigned from `READ_TARGET`, itself a `const`
+// declared below the imports - referencing it from a `vi.hoisted` factory
+// (which runs hoisted above every other module-level statement) would hit the
+// TDZ. Safe here because `vi.mock` factories are only ever CALLED lazily, at
+// the point React first invokes the mocked hook - long after this module's
+// top-level code, including this assignment, has finished running.
+let landingTarget: LandingPlacementTarget = READ_TARGET;
+
 const testState = vi.hoisted(() => ({
   bodySubmit: null as (() => void) | null,
   installEditor: null as (() => void) | null,
@@ -78,6 +90,14 @@ const testState = vi.hoisted(() => ({
   // default so the deposed-pin arm below is the realistic shape, not a case
   // `isPinned` would never actually take.
   composerIsPinned: true,
+  /**
+   * The §54 refusal `useLandingComposerActions().submit` hands back - `null`
+   * for a create that goes through, `{message}` for a submit-time refusal.
+   * Real refusal DERIVATION (`resolveLandingPlacement`) has its own unit
+   * suite; this file only needs to pin that the composer's `hostNotice` slot
+   * reacts correctly to whatever `actions.submit` returns.
+   */
+  submitRefusal: null as { readonly message: string } | null,
 }));
 
 // `.clear`/`.migrateKeyForAllHosts` are the only members the G4 effect and
@@ -121,6 +141,12 @@ vi.mock("@/components/home/composer/composer-body", async () => {
       testState.installEditor = () => {
         props.editorRef.current = editorHandle();
       };
+      // Drives `handleDocumentChange` so a §54-notice test can make
+      // `hasSubmittableContent` true without a real editor mount - the same
+      // seam `landing-composer-submit-gate.test.tsx` uses.
+      testState.snapshot = () => {
+        props.onDocumentChange(DIRTY_CONTENT, { from: 1, to: 1 });
+      };
       // Renders `topBanner` for real (unlike every other prop here) so the
       // G4 tests below can assert on `ComposerHostNotice`'s actual DOM output
       // instead of reaching into component-internal state.
@@ -134,11 +160,14 @@ vi.mock("@/hooks/host/use-composer-placement", () => ({
     pin: {
       selection: null,
       setSelection: () => undefined,
-      resolvedHostId: "host-a",
+      resolvedHostId: landingTarget.resolvedHostId,
       isPinned: testState.composerIsPinned,
       latchOnFirstUse: () => undefined,
     },
-    target: READ_TARGET,
+    // Read fresh on every call (not captured once) so a test can mutate
+    // `landingTarget` and force a re-render to present a different resolved
+    // host to an already-mounted composer - see the §54-notice suite below.
+    target: landingTarget,
     submitTarget: SUBMIT_TARGET,
     hostLabelFor: () => "Studio Mac",
     followsEffective: testState.composerFollowsEffective,
@@ -148,7 +177,10 @@ vi.mock("@/hooks/host/use-composer-placement", () => ({
 vi.mock("@/components/home/hooks/use-landing-composer-actions", () => ({
   useLandingComposerActions: (target: { readonly hostLabel: string }) => {
     testState.actionsTarget = target;
-    return { submit: () => null, selectTerminalAgent: () => null };
+    return {
+      submit: () => testState.submitRefusal,
+      selectTerminalAgent: () => null,
+    };
   },
 }));
 
@@ -185,6 +217,11 @@ vi.mock("@/stores/composer/composer-run-settings-store", () => {
   const state = {
     globalLastRunSettings: null,
     setGlobalRunSettings: vi.fn(),
+    // The imperative draft-mint path (`handleDocumentChange`) reads this
+    // directly off `getState()`, not through the selector hook below - the
+    // §54-notice suite exercises that path (it types content), which
+    // `landing-composer-submit-gate.test.tsx` already required this for.
+    getGlobalRunSettings: () => null,
   };
   const selectGlobalLastRunSettings = () => null;
   const useComposerRunSettingsStore = Object.assign(
@@ -334,8 +371,11 @@ afterEach(() => {
   testState.actionsTarget = null;
   testState.bodySubmit = null;
   testState.installEditor = null;
+  testState.snapshot = null;
   testState.composerFollowsEffective = true;
   testState.composerIsPinned = true;
+  testState.submitRefusal = null;
+  landingTarget = READ_TARGET;
   stagingStoreMocks.clear.mockReset();
   stagingStoreMocks.migrateKeyForAllHosts.mockReset();
   stagingStoreMocks.readStagedWorktreeIntent.mockReset();
@@ -462,5 +502,74 @@ describe("landing composer G4 re-point", () => {
     expect(screen.queryByTestId("composer-host-notice")).toBeNull();
     expect(stagingStoreMocks.clear).not.toHaveBeenCalled();
     expect(toastMocks.toastRepointedStagingReset).not.toHaveBeenCalled();
+  });
+});
+
+// Codex review finding: a §54 refusal names the placement it refused, so ANY
+// change of the RESOLVED host retires it - a derivation move, or the picker
+// writing a new pin. Real refusal DERIVATION has its own unit suite
+// (`resolveLandingPlacement`); this only pins that the composer's own
+// `hostNotice` slot reacts to a resolved-host change, whatever produced the
+// refusal it is currently showing.
+describe("landing composer clears a refused §54 notice on host change", () => {
+  it("clears the notice once the resolved host moves, even to a placement that is itself usable", () => {
+    landingTarget = {
+      resolvedHostId: "host-b",
+      client: null,
+      hostLabel: "Build Box",
+      isPinned: false,
+      namedHostDead: false,
+    };
+    testState.submitRefusal = { message: "Build Box is not reachable." };
+    const view = render(
+      <LandingComposer
+        draftId={null}
+        pendingCreateId="pending-1"
+        initialSettings={null}
+        workspaceControls={() => null}
+      />,
+    );
+    // Make the content submittable so `handleSubmit` actually reaches
+    // `actions.submit` instead of being gated out beforehand.
+    testState.snapshot?.();
+    view.rerender(
+      <LandingComposer
+        draftId={null}
+        pendingCreateId="pending-1"
+        initialSettings={null}
+        workspaceControls={() => null}
+      />,
+    );
+
+    act(() => {
+      testState.bodySubmit?.();
+    });
+
+    expect(screen.getByTestId("composer-host-notice").textContent).toContain(
+      "Build Box is not reachable.",
+    );
+
+    // The resolved host moves to a DIFFERENT, itself-usable placement - the
+    // point is that the notice clears on the move alone, not on whether the
+    // new placement would also refuse.
+    landingTarget = {
+      resolvedHostId: "host-c",
+      client: null,
+      hostLabel: "Home Mac",
+      isPinned: false,
+      namedHostDead: false,
+    };
+    act(() => {
+      view.rerender(
+        <LandingComposer
+          draftId={null}
+          pendingCreateId="pending-1"
+          initialSettings={null}
+          workspaceControls={() => null}
+        />,
+      );
+    });
+
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-placement-wiring.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-placement-wiring.test.tsx
@@ -6,6 +6,8 @@ import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { LandingPlacementTarget } from "@/lib/composer/landing-placement";
 import { notifyEffectiveHostChanged } from "@/stores/host/surface-host-selection-store";
+import type { WorktreeIntent } from "@traycer/protocol/host/worktree-schemas";
+import type { WorktreeStagingKey } from "@/stores/worktree/worktree-intent-staging-store";
 import { LandingComposer } from "@/components/home/composer/landing-composer";
 
 /**
@@ -41,6 +43,18 @@ const SUBMIT_TARGET: LandingPlacementTarget = {
   namedHostDead: false,
 };
 
+/** A per-machine choice: exactly the state G4 must not carry across hosts. */
+const STAGED_INTENT: WorktreeIntent = {
+  entries: [
+    {
+      kind: "local",
+      workspacePath: "/repo",
+      repoIdentifier: null,
+      isPrimary: true,
+    },
+  ],
+};
+
 const testState = vi.hoisted(() => ({
   bodySubmit: null as (() => void) | null,
   installEditor: null as (() => void) | null,
@@ -69,9 +83,16 @@ const testState = vi.hoisted(() => ({
 // `.clear`/`.migrateKeyForAllHosts` are the only members the G4 effect and
 // the create path touch (`.getState()` only, never the reactive hook), so a
 // bare `getState()` stub is a complete fixture for this module.
+// `readStagedWorktreeIntent` is a plain named export (not read off
+// `.getState()`), so it is mocked as its own top-level export here - the
+// component imports it directly to decide whether the G4 move actually reset
+// anything before it toasts.
 const stagingStoreMocks = vi.hoisted(() => ({
   clear: vi.fn(),
   migrateKeyForAllHosts: vi.fn(),
+  readStagedWorktreeIntent: vi.fn<
+    (key: WorktreeStagingKey) => WorktreeIntent | null
+  >(() => null),
 }));
 vi.mock("@/stores/worktree/worktree-intent-staging-store", () => ({
   useWorktreeIntentStagingStore: {
@@ -80,6 +101,16 @@ vi.mock("@/stores/worktree/worktree-intent-staging-store", () => ({
       migrateKeyForAllHosts: stagingStoreMocks.migrateKeyForAllHosts,
     }),
   },
+  readStagedWorktreeIntent: stagingStoreMocks.readStagedWorktreeIntent,
+}));
+
+// The G4 toast, mocked so these tests assert the composer's decision to fire
+// it (and with what label) rather than sonner's internals.
+const toastMocks = vi.hoisted(() => ({
+  toastRepointedStagingReset: vi.fn<(hostLabel: string) => void>(),
+}));
+vi.mock("@/lib/composer/repointed-staging-toast", () => ({
+  toastRepointedStagingReset: toastMocks.toastRepointedStagingReset,
 }));
 
 vi.mock("@/components/home/composer/composer-body", async () => {
@@ -307,6 +338,9 @@ afterEach(() => {
   testState.composerIsPinned = true;
   stagingStoreMocks.clear.mockReset();
   stagingStoreMocks.migrateKeyForAllHosts.mockReset();
+  stagingStoreMocks.readStagedWorktreeIntent.mockReset();
+  stagingStoreMocks.readStagedWorktreeIntent.mockReturnValue(null);
+  toastMocks.toastRepointedStagingReset.mockReset();
 });
 
 function editorHandle(): ComposerPromptEditorHandle {
@@ -350,14 +384,15 @@ describe("landing composer placement wiring", () => {
   });
 });
 
-describe("landing composer G4 re-point notice", () => {
-  it("fires the re-pointed notice and resets staged intent for a DEPOSED pin (isPinned true, honoredSelection null)", () => {
+describe("landing composer G4 re-point", () => {
+  it("clears staged intent and toasts for a DEPOSED pin (isPinned true, honoredSelection null) when intent was staged", () => {
     // A deposed pin still reads `pin.isPinned: true` (the pin itself is never
     // cleared by death - only `honoredSelection` goes null), but the
     // composer's resolved host has fallen back to `effective`, so it IS
     // following and a derivation move DOES re-point it. Gating G4 on
     // `isPinned` instead of `followsEffective` would wrongly suppress this.
     testState.composerFollowsEffective = true;
+    stagingStoreMocks.readStagedWorktreeIntent.mockReturnValue(STAGED_INTENT);
     render(
       <LandingComposer
         draftId={null}
@@ -371,16 +406,45 @@ describe("landing composer G4 re-point notice", () => {
       notifyEffectiveHostChanged("host-a", "host-b");
     });
 
-    const notice = screen.getByTestId("composer-host-notice");
-    expect(notice.dataset.noticeKind).toBe("repointed");
     expect(stagingStoreMocks.clear).toHaveBeenCalledWith({
       surface: "landing",
       hostId: "host-a",
       draftId: null,
     });
+    expect(toastMocks.toastRepointedStagingReset).toHaveBeenCalledTimes(1);
+    expect(toastMocks.toastRepointedStagingReset).toHaveBeenCalledWith(
+      "Studio Mac",
+    );
+    // The inline notice slot is `refused`-only now; a re-point is a toast.
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });
 
-  it("does not fire the notice or reset staged intent for a composer resting on its own pin", () => {
+  it("clears staged intent but does not toast for a DEPOSED pin when nothing was staged", () => {
+    testState.composerFollowsEffective = true;
+    stagingStoreMocks.readStagedWorktreeIntent.mockReturnValue(null);
+    render(
+      <LandingComposer
+        draftId={null}
+        pendingCreateId="pending-1"
+        initialSettings={null}
+        workspaceControls={() => null}
+      />,
+    );
+
+    act(() => {
+      notifyEffectiveHostChanged("host-a", "host-b");
+    });
+
+    expect(stagingStoreMocks.clear).toHaveBeenCalledWith({
+      surface: "landing",
+      hostId: "host-a",
+      draftId: null,
+    });
+    expect(toastMocks.toastRepointedStagingReset).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
+  });
+
+  it("does not clear staged intent or toast for a composer resting on its own pin", () => {
     testState.composerFollowsEffective = false;
     render(
       <LandingComposer
@@ -397,5 +461,6 @@ describe("landing composer G4 re-point notice", () => {
 
     expect(screen.queryByTestId("composer-host-notice")).toBeNull();
     expect(stagingStoreMocks.clear).not.toHaveBeenCalled();
+    expect(toastMocks.toastRepointedStagingReset).not.toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-placement-wiring.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-placement-wiring.test.tsx
@@ -572,4 +572,74 @@ describe("landing composer clears a refused §54 notice on host change", () => {
 
     expect(screen.queryByTestId("composer-host-notice")).toBeNull();
   });
+
+  it("P2 FIX - does not resurrect it on the way back: a sticky pin's A -> B -> A round trip leaves the refusal retired", () => {
+    // A pin is a preference, not a binding: a surface whose pinned host dies
+    // auto-follows and RETURNS when the host is usable again, so A -> B -> A
+    // is an ordinary Tuesday rather than a corner case. Holding the refusal
+    // beside the host it was raised for and rendering it whenever they match
+    // would make that return re-open a stale alert with no submit in between -
+    // hiding the notice instead of retiring it.
+    landingTarget = {
+      resolvedHostId: "host-b",
+      client: null,
+      hostLabel: "Build Box",
+      isPinned: true,
+      namedHostDead: false,
+    };
+    testState.submitRefusal = { message: "Build Box is not reachable." };
+    const view = render(
+      <LandingComposer
+        draftId={null}
+        pendingCreateId="pending-1"
+        initialSettings={null}
+        workspaceControls={() => null}
+      />,
+    );
+    testState.snapshot?.();
+    view.rerender(
+      <LandingComposer
+        draftId={null}
+        pendingCreateId="pending-1"
+        initialSettings={null}
+        workspaceControls={() => null}
+      />,
+    );
+    act(() => {
+      testState.bodySubmit?.();
+    });
+    expect(screen.getByTestId("composer-host-notice").textContent).toContain(
+      "Build Box is not reachable.",
+    );
+
+    const resolveTo = (hostId: string, hostLabel: string): void => {
+      landingTarget = {
+        resolvedHostId: hostId,
+        client: null,
+        hostLabel,
+        isPinned: true,
+        namedHostDead: false,
+      };
+      act(() => {
+        view.rerender(
+          <LandingComposer
+            draftId={null}
+            pendingCreateId="pending-1"
+            initialSettings={null}
+            workspaceControls={() => null}
+          />,
+        );
+      });
+    };
+
+    // The pinned host goes away and the surface follows `effective`...
+    resolveTo("host-c", "Home Mac");
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
+
+    // ...and then comes back, which is what the pin's stickiness is FOR. The
+    // refusal was retired on the first move, so there is nothing left to
+    // resurrect.
+    resolveTo("host-b", "Build Box");
+    expect(screen.queryByTestId("composer-host-notice")).toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/home/composer/composer-host-notice.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-host-notice.tsx
@@ -1,55 +1,41 @@
 import type { ReactNode } from "react";
-import { AlertTriangle, Info, X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { AlertTriangle, X } from "lucide-react";
 
 /**
- * The composer's one host-placement notice slot (selection model §2/§54).
+ * The composer's host-placement refusal slot (selection model §2/§54):
+ * submit-time re-validation refused to create. Nothing was created, the
+ * draft is untouched, and this states why. It is deliberately inline rather
+ * than a toast: a toast that scrolls away leaves the user pressing send
+ * again on a composer that still looks fine.
  *
- *  - `refused`: submit-time re-validation refused to create. Nothing was
- *    created, the draft is untouched, and this states why. It is deliberately
- *    inline rather than a toast: a toast that scrolls away leaves the user
- *    pressing send again on a composer that still looks fine.
- *  - `repointed`: G4 - derivation moved the effective host under a FOLLOWING
- *    composer, so its device changed and its host-dependent staging was reset.
- *    Informational, not a blocker.
+ * The G4 `repointed` kind used to share this slot. It is a toast now
+ * (`toastRepointedStagingReset`), and only when the move actually reset
+ * staged worktree/branch intent: a derivation move is informational, not a
+ * blocker, and the persistent banner outlived the condition it described -
+ * after a failover round trip it announced the user's own host as news.
  */
-export type ComposerHostNoticeState =
-  | { readonly kind: "refused"; readonly message: string }
-  | { readonly kind: "repointed"; readonly hostId: string | null };
+export interface ComposerHostNoticeState {
+  readonly kind: "refused";
+  readonly message: string;
+}
 
 interface ComposerHostNoticeProps {
   readonly notice: ComposerHostNoticeState | null;
-  /** Resolved late so a device that only just reached the directory is named. */
-  readonly hostLabelFor: (hostId: string | null) => string;
   readonly onDismiss: () => void;
 }
 
 export function ComposerHostNotice(props: ComposerHostNoticeProps): ReactNode {
   const notice = props.notice;
   if (notice === null) return null;
-  const refused = notice.kind === "refused";
   return (
     <div
-      role={refused ? "alert" : "status"}
+      role="alert"
       data-testid="composer-host-notice"
       data-notice-kind={notice.kind}
-      className={cn(
-        "relative flex w-full max-w-full min-w-0 items-start gap-2 rounded-md border px-3 py-2 text-ui-sm",
-        refused
-          ? "border-amber-500/30 bg-amber-500/10"
-          : "border-border/60 bg-foreground/5",
-      )}
+      className="relative flex w-full max-w-full min-w-0 items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-ui-sm"
     >
-      {refused ? (
-        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
-      ) : (
-        <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-      )}
-      <p className="min-w-0 flex-1 text-foreground">
-        {refused
-          ? notice.message
-          : `New tasks now run on ${props.hostLabelFor(notice.hostId)}. Worktree and branch choices were reset for it — check the workspace before sending.`}
-      </p>
+      <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
+      <p className="min-w-0 flex-1 text-foreground">{notice.message}</p>
       <button
         type="button"
         aria-label="Dismiss"

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -94,10 +94,8 @@ import {
 import { ComposerModeSwitcher } from "@/components/home/composer/composer-mode-switcher";
 import { useComposerPlacement } from "@/hooks/host/use-composer-placement";
 import { subscribeFollowingSurfaceReset } from "@/stores/host/surface-host-selection-store";
-import {
-  ComposerHostNotice,
-  type ComposerHostNoticeState,
-} from "@/components/home/composer/composer-host-notice";
+import { ComposerHostNotice } from "@/components/home/composer/composer-host-notice";
+import { useComposerHostNotice } from "@/hooks/composer/use-composer-host-notice";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { usePromptStash } from "@/hooks/composer/use-prompt-stash";
 import { PromptStashControl } from "@/components/chat/composer/prompt-stash-control";
@@ -596,12 +594,11 @@ export function LandingComposer(props: LandingComposerProps) {
   // Submit-time refusal copy (selection model §54). The G4 re-point used to
   // share this slot; it narrates as a toast now, and only when it actually
   // reset staged intent — see the effect below.
-  const [hostNotice, setHostNotice] = useState<ComposerHostNoticeState | null>(
-    null,
-  );
-  const dismissHostNotice = useCallback(() => {
-    setHostNotice(null);
-  }, []);
+  const {
+    notice: hostNotice,
+    raise: raiseHostNotice,
+    dismiss: dismissHostNotice,
+  } = useComposerHostNotice(resolvedHostId);
   // G4: this composer FOLLOWS the effective host only when nothing else
   // answered its placement - no override, no pin IN FORCE - and only then
   // does a derivation move re-point it and its host-dependent state must not
@@ -633,6 +630,10 @@ export function LandingComposer(props: LandingComposerProps) {
         hostId: activeHostId,
         draftId,
       } as const;
+      // Checked at the SAME breadth this clears at - one bucket, the host the
+      // composer is leaving. The modal's equivalent asks across every host
+      // because it clears across every host; pairing the two is what keeps
+      // "we warn exactly when we destroyed something" true on both surfaces.
       const hadStagedIntent = readStagedWorktreeIntent(stagingKey) !== null;
       useWorktreeIntentStagingStore.getState().clear(stagingKey);
       if (hadStagedIntent) {
@@ -738,20 +739,20 @@ export function LandingComposer(props: LandingComposerProps) {
     // Nothing was created when a refusal comes back - the draft, its content
     // and its staged workspace are exactly as the user left them, and the
     // reason is stated inline above the composer rather than as a toast.
-    setHostNotice(
+    raiseHostNotice(
       refusal === null ? null : { kind: "refused", message: refusal.message },
     );
-  }, [actions, canSubmit, draftId, pickerStore, toolbarStore]);
+  }, [actions, canSubmit, draftId, pickerStore, raiseHostNotice, toolbarStore]);
 
   const handleStartTerminal = useCallback(
     (launch: TerminalAgentLaunch) => {
       if (!workspaceCanStart || isSubmitting) return;
       const refusal = actions.selectTerminalAgent(launch, draftId);
-      setHostNotice(
+      raiseHostNotice(
         refusal === null ? null : { kind: "refused", message: refusal.message },
       );
     },
-    [actions, draftId, isSubmitting, workspaceCanStart],
+    [actions, draftId, isSubmitting, raiseHostNotice, workspaceCanStart],
   );
 
   const handleRemoveImage = useCallback(

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -65,7 +65,11 @@ import {
   useComposerRunSettingsStore,
 } from "@/stores/composer/composer-run-settings-store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
-import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
+import {
+  readStagedWorktreeIntent,
+  useWorktreeIntentStagingStore,
+} from "@/stores/worktree/worktree-intent-staging-store";
+import { toastRepointedStagingReset } from "@/lib/composer/repointed-staging-toast";
 import {
   draftRuntimeRegistry,
   EMPTY_DRAFT_RUNTIME_CONTENT,
@@ -589,9 +593,9 @@ export function LandingComposer(props: LandingComposerProps) {
     workspaceCanStart &&
     hasSubmittableContent;
 
-  // Submit-time refusal copy (selection model §54) and the G4 re-point notice
-  // share one slot: both say "this composer's device is not what you think",
-  // and showing two stacked banners about the same host would be noise.
+  // Submit-time refusal copy (selection model §54). The G4 re-point used to
+  // share this slot; it narrates as a toast now, and only when it actually
+  // reset staged intent — see the effect below.
   const [hostNotice, setHostNotice] = useState<ComposerHostNoticeState | null>(
     null,
   );
@@ -616,15 +620,26 @@ export function LandingComposer(props: LandingComposerProps) {
   // blip. The folders re-resolve against the new host through the picker's
   // existing absent-row + Locate affordance, which names the dangle instead of
   // hiding it - and submit re-validation stands behind both.
+  //
+  // Narrated as a toast, and ONLY when the move reset something: the switch
+  // itself is `toastSelectionSwitched`'s to tell, and a persistent banner
+  // here outlived the condition it described — a startup failover round trip
+  // left it announcing the user's own host as news over an empty composer.
   useEffect(() => {
     return subscribeFollowingSurfaceReset(({ nextEffectiveHostId }) => {
       if (!composerFollowsEffective) return;
-      useWorktreeIntentStagingStore
-        .getState()
-        .clear({ surface: "landing", hostId: activeHostId, draftId });
-      setHostNotice({ kind: "repointed", hostId: nextEffectiveHostId });
+      const stagingKey = {
+        surface: "landing",
+        hostId: activeHostId,
+        draftId,
+      } as const;
+      const hadStagedIntent = readStagedWorktreeIntent(stagingKey) !== null;
+      useWorktreeIntentStagingStore.getState().clear(stagingKey);
+      if (hadStagedIntent) {
+        toastRepointedStagingReset(hostLabelFromDirectory(nextEffectiveHostId));
+      }
     });
-  }, [activeHostId, composerFollowsEffective, draftId]);
+  }, [activeHostId, composerFollowsEffective, draftId, hostLabelFromDirectory]);
   const { dictationControl, dictationPreparing } = useComposerDictation({
     editorRef,
     isActive: chatComposerActive,
@@ -784,7 +799,6 @@ export function LandingComposer(props: LandingComposerProps) {
         <>
           <ComposerHostNotice
             notice={hostNotice}
-            hostLabelFor={hostLabelFromDirectory}
             onDismiss={dismissHostNotice}
           />
           {rateLimitPrompt.kind === "visible" ? (

--- a/clients/gui-app/src/hooks/composer/use-composer-host-notice.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-host-notice.ts
@@ -10,43 +10,44 @@ interface ComposerHostNoticeControl {
 }
 
 /**
- * The composer's §54 refusal slot, stamped with the placement it refused.
+ * The composer's §54 refusal slot, retired whenever the placement moves.
  *
  * A refusal is a statement ABOUT A HOST - "the client this create would go out
  * on no longer addresses the host the chip is showing" - so it stops being
- * true the moment the surface resolves somewhere else. Both ways that happens
- * retire it: a derivation move under a following composer (G4), and the
- * picker writing a new pin. Neither is a special case here, because the
- * premise travels WITH the value and staleness is decided at render.
+ * true the moment the surface resolves somewhere else. Every way that happens
+ * retires it: a derivation move under a following composer (G4), the picker
+ * writing a new pin, a pinned host dying and the surface auto-following. None
+ * is a special case here, because the trigger is the RESOLVED HOST CHANGING
+ * rather than any of the routes that change it - the enumeration being exactly
+ * what a targeted fix gets wrong when a fourth route is added later.
  *
- * Deliberately not an effect that clears on host change. Beyond tripping
- * `react-hooks/set-state-in-effect`, a clear-on-change effect renders the
- * stale alert for one commit before removing it, and it has to enumerate the
- * triggers - the enumeration being exactly what a targeted fix gets wrong when
- * a third way to re-point a surface is added later.
+ * RETIRED, NOT HIDDEN, and the distinction is the whole reason this is state
+ * and not a comparison. A pin is sticky (`AGENTS.md`: a surface whose pinned
+ * host dies auto-follows and RETURNS when it is usable again), so A → B → A is
+ * an ordinary round trip, not a corner. Merely holding the refusal beside the
+ * host it was raised for and rendering it while they match would resurrect a
+ * stale alert on the way back, with no submit in between and nothing on screen
+ * to explain it.
+ *
+ * Cleared during render (React's documented "adjusting state when props
+ * change"), like `useWindowNarration`'s served latch: an effect would trip
+ * `react-hooks/set-state-in-effect`, and it would also paint the stale alert
+ * for one commit before removing it.
  */
 export function useComposerHostNotice(
   resolvedHostId: string | null,
 ): ComposerHostNoticeControl {
-  const [raised, setRaised] = useState<{
-    readonly notice: ComposerHostNoticeState;
-    readonly hostId: string | null;
-  } | null>(null);
-  const raise = useCallback(
-    (notice: ComposerHostNoticeState | null): void => {
-      setRaised(notice === null ? null : { notice, hostId: resolvedHostId });
-    },
-    [resolvedHostId],
-  );
+  const [raised, setRaised] = useState<ComposerHostNoticeState | null>(null);
+  const [raisedFor, setRaisedFor] = useState<string | null>(resolvedHostId);
+  if (raisedFor !== resolvedHostId) {
+    setRaisedFor(resolvedHostId);
+    if (raised !== null) setRaised(null);
+  }
+  const raise = useCallback((notice: ComposerHostNoticeState | null): void => {
+    setRaised(notice);
+  }, []);
   const dismiss = useCallback((): void => {
     setRaised(null);
   }, []);
-  return {
-    notice:
-      raised !== null && raised.hostId === resolvedHostId
-        ? raised.notice
-        : null,
-    raise,
-    dismiss,
-  };
+  return { notice: raised, raise, dismiss };
 }

--- a/clients/gui-app/src/hooks/composer/use-composer-host-notice.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-host-notice.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import type { ComposerHostNoticeState } from "@/components/home/composer/composer-host-notice";
+
+interface ComposerHostNoticeControl {
+  /** The notice to render, or null when none applies to the current host. */
+  readonly notice: ComposerHostNoticeState | null;
+  /** Raise a notice for the surface's CURRENT placement, or clear with null. */
+  readonly raise: (notice: ComposerHostNoticeState | null) => void;
+  readonly dismiss: () => void;
+}
+
+/**
+ * The composer's §54 refusal slot, stamped with the placement it refused.
+ *
+ * A refusal is a statement ABOUT A HOST - "the client this create would go out
+ * on no longer addresses the host the chip is showing" - so it stops being
+ * true the moment the surface resolves somewhere else. Both ways that happens
+ * retire it: a derivation move under a following composer (G4), and the
+ * picker writing a new pin. Neither is a special case here, because the
+ * premise travels WITH the value and staleness is decided at render.
+ *
+ * Deliberately not an effect that clears on host change. Beyond tripping
+ * `react-hooks/set-state-in-effect`, a clear-on-change effect renders the
+ * stale alert for one commit before removing it, and it has to enumerate the
+ * triggers - the enumeration being exactly what a targeted fix gets wrong when
+ * a third way to re-point a surface is added later.
+ */
+export function useComposerHostNotice(
+  resolvedHostId: string | null,
+): ComposerHostNoticeControl {
+  const [raised, setRaised] = useState<{
+    readonly notice: ComposerHostNoticeState;
+    readonly hostId: string | null;
+  } | null>(null);
+  const raise = useCallback(
+    (notice: ComposerHostNoticeState | null): void => {
+      setRaised(notice === null ? null : { notice, hostId: resolvedHostId });
+    },
+    [resolvedHostId],
+  );
+  const dismiss = useCallback((): void => {
+    setRaised(null);
+  }, []);
+  return {
+    notice:
+      raised !== null && raised.hostId === resolvedHostId
+        ? raised.notice
+        : null,
+    raise,
+    dismiss,
+  };
+}

--- a/clients/gui-app/src/hooks/host/use-reactive-local-host-id.ts
+++ b/clients/gui-app/src/hooks/host/use-reactive-local-host-id.ts
@@ -1,0 +1,49 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { useHostBinding } from "@/lib/host";
+
+/**
+ * Reactively projects THIS MACHINE's host id - the directory's retained
+ * identity, not the identity of whatever local entry happens to exist right
+ * now.
+ *
+ * ⚠ NOT `useReactiveLocalHostEntry()?.hostId`, and the difference is the whole
+ * reason this hook exists. `getLocalEntry()` is rebuilt from the runner host's
+ * snapshot, and `onLocalHostChange(null)` - which is what a local host
+ * RESTARTING looks like - sets it to null. So the entry loses the id for
+ * exactly the interval a caller asking "is this machine the one cycling?"
+ * needs it, and answers `null` at the moment it matters. `getLocalHostId()` is
+ * the durable answer: seeded from the shell's pid metadata and re-adopted from
+ * every local snapshot, it survives the gap by design.
+ *
+ * `null` on shells with no local host (browser/mobile) and before the runtime
+ * has resolved a binding - genuinely "there is no local machine here", rather
+ * than "the local machine is between lives".
+ *
+ * No field-equality cache, unlike the entry hook: this is a string, so
+ * `useSyncExternalStore`'s own `Object.is` check is already exact and a
+ * benign re-emit cannot churn consumers.
+ */
+export function useReactiveLocalHostId(): string | null {
+  const binding = useHostBinding();
+  const directory = binding?.directory ?? null;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (directory === null) {
+        return () => undefined;
+      }
+      const subscription = directory.onChange(() => {
+        callback();
+      });
+      return () => {
+        subscription.dispose();
+      };
+    },
+    [directory],
+  );
+  const getSnapshot = useCallback(
+    () => (directory === null ? null : directory.getLocalHostId()),
+    [directory],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/clients/gui-app/src/hooks/host/use-window-narration.ts
+++ b/clients/gui-app/src/hooks/host/use-window-narration.ts
@@ -9,7 +9,7 @@ import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
 import { useHostLeases } from "@/hooks/host/use-host-lease";
 import { useSelectionAuthorityAttached } from "@/hooks/host/use-selection-authority-attached";
 import { useSelectionAuthorityStore } from "@/stores/host/selection-authority-store";
-import { useReactiveLocalHostEntry } from "@/hooks/host/use-reactive-local-host-entry";
+import { useReactiveLocalHostId } from "@/hooks/host/use-reactive-local-host-id";
 import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 
 /**
@@ -44,7 +44,12 @@ export function useWindowNarration(): WindowNarrationState {
   // statement about the SHELL and stays true while the target is a remote. The
   // restarting-target grace needs the identity, or it tells a local boot story
   // over a remote machine this app has no lifecycle for.
-  const localHostId = useReactiveLocalHostEntry()?.hostId ?? null;
+  //
+  // The DURABLE id, never `useReactiveLocalHostEntry()?.hostId`: the entry is
+  // nulled by `onLocalHostChange(null)`, which is precisely what a restarting
+  // local host looks like, so the entry answers null for exactly the interval
+  // this arm is about and the grace would collapse in the state it exists for.
+  const localHostId = useReactiveLocalHostId();
 
   const servingNow =
     attached && isServingLease(findLease(leases, effectiveHostId));

--- a/clients/gui-app/src/hooks/host/use-window-narration.ts
+++ b/clients/gui-app/src/hooks/host/use-window-narration.ts
@@ -9,6 +9,7 @@ import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
 import { useHostLeases } from "@/hooks/host/use-host-lease";
 import { useSelectionAuthorityAttached } from "@/hooks/host/use-selection-authority-attached";
 import { useSelectionAuthorityStore } from "@/stores/host/selection-authority-store";
+import { useReactiveLocalHostEntry } from "@/hooks/host/use-reactive-local-host-entry";
 import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 
 /**
@@ -39,6 +40,11 @@ export function useWindowNarration(): WindowNarrationState {
   // `NarratingWindowHostModal`'s doc). Outside a provider - web, harnesses -
   // there is no local host to expect, which is also the correct answer.
   const localHostExpected = useRunnerHostOrNull()?.hasLocalHost ?? false;
+  // WHICH host is this machine's, which `hasLocalHost` cannot answer: it is a
+  // statement about the SHELL and stays true while the target is a remote. The
+  // restarting-target grace needs the identity, or it tells a local boot story
+  // over a remote machine this app has no lifecycle for.
+  const localHostId = useReactiveLocalHostEntry()?.hostId ?? null;
 
   const servingNow =
     attached && isServingLease(findLease(leases, effectiveHostId));
@@ -68,6 +74,7 @@ export function useWindowNarration(): WindowNarrationState {
         leases,
         hasBeenServed,
         localHostExpected,
+        localHostId,
       }),
     [
       attached,
@@ -75,6 +82,7 @@ export function useWindowNarration(): WindowNarrationState {
       hasBeenServed,
       leases,
       localHostExpected,
+      localHostId,
       targetHostId,
     ],
   );

--- a/clients/gui-app/src/lib/composer/repointed-staging-toast.ts
+++ b/clients/gui-app/src/lib/composer/repointed-staging-toast.ts
@@ -1,0 +1,21 @@
+import { toast } from "sonner";
+
+/**
+ * G4 narration for a FOLLOWING composer the derivation just re-pointed
+ * (selection model §2): its staged worktree/branch choices named paths and
+ * refs on the machine the user picked them on, so they were reset rather
+ * than silently carried to the new host.
+ *
+ * Fired ONLY when the move actually reset staged intent. A move that reset
+ * nothing stays silent here - `toastSelectionSwitched` already narrates the
+ * failover/recovery itself, and re-announcing every derivation move made a
+ * startup failover round trip end on a persistent banner presenting the
+ * user's own host as news. A toast, not the inline notice slot: the reset
+ * is informational, not a submit blocker, and the composer's workspace
+ * picker plus §54 submit re-validation stand behind it either way.
+ */
+export function toastRepointedStagingReset(hostLabel: string): void {
+  toast.info(
+    `Worktree and branch choices were reset for ${hostLabel} — check the workspace before sending.`,
+  );
+}

--- a/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
@@ -244,6 +244,69 @@ describe("HostDirectoryService", () => {
     vi.restoreAllMocks();
   });
 
+  it("P2 FIX - tells listeners when the shell seed adopts a local host id, on a machine whose host has not announced", async () => {
+    // The seed is the ONE `adoptLocalHostId` caller with no emit behind it -
+    // `onLocalHostChange` emits immediately after its own call, and the poll
+    // path's `emitIfSnapshotChanged` can decline. It is also a real state
+    // change: `snapshot()` reads `lastKnownLocalHostId` to neutralise this
+    // machine's registry twin into a `bootingLocalEntry`.
+    //
+    // A machine with NO local snapshot is the population that matters, and it
+    // is also the cold start: nothing has announced, so the durable id is the
+    // only thing that can answer "which host is mine" - and a consumer that
+    // subscribed and was never told still believes the answer is null.
+    const host = makeHost(null);
+    const directory = makeDirectory({
+      authContextId: null,
+      credentialGeneration: null,
+      runnerHost: host,
+      localHostIdSeeder: () => Promise.resolve("desktop-pid-123"),
+      remoteFetcher: null,
+    });
+    await directory.start();
+
+    expect(directory.getLocalHostId()).toBe("desktop-pid-123");
+    // The live entry is null here and always was - which is exactly why a
+    // consumer reading `getLocalEntry()?.hostId` cannot see this machine.
+    expect(directory.getLocalEntry()).toBeNull();
+  });
+
+  it("P2 FIX - and on the POLL reseed, where the merged snapshot is unchanged and emitIfSnapshotChanged would otherwise decline", async () => {
+    // The start path happens to be covered already (the local-host
+    // subscription emits right after the seed), so this is the arm that
+    // actually needs the emit: the host announces itself to the SHELL later,
+    // the poll picks the id up, and nothing else about the merged snapshot
+    // moves - no local entry, no remote rows - so the poll's own
+    // change-gated emit correctly declines and every consumer is left
+    // believing this machine has no id.
+    vi.useFakeTimers();
+    const host = makeHost(null);
+    let seededId: string | null = null;
+    const directory = makeDirectory({
+      authContextId: null,
+      credentialGeneration: null,
+      runnerHost: host,
+      localHostIdSeeder: () => Promise.resolve(seededId),
+      remoteFetcher: null,
+    });
+
+    await directory.start();
+    expect(directory.getLocalHostId()).toBeNull();
+
+    let notifications = 0;
+    directory.onChange(() => {
+      notifications += 1;
+    });
+
+    // The shell can answer now. Nothing else has changed.
+    seededId = "desktop-pid-123";
+    await vi.advanceTimersByTimeAsync(HOST_DIRECTORY_REFRESH_POLL_MS);
+
+    expect(directory.getLocalHostId()).toBe("desktop-pid-123");
+    expect(await directory.list()).toEqual([]);
+    expect(notifications).toBe(1);
+  });
+
   it("seeds the local entry from the runner-host onLocalHostChange subscription", async () => {
     const host = makeHost(localSnapshot);
     const directory = makeDirectory({

--- a/clients/gui-app/src/lib/host/__tests__/window-narration.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/window-narration.test.ts
@@ -53,6 +53,11 @@ function baseInput(
     // a shell that can actually boot a local host, and every case below that
     // does not say otherwise is describing a desktop launch.
     localHostExpected: true,
+    // This machine is `host-local` throughout, so a case whose target is
+    // `host-local` is a LOCAL target and one that names anything else is
+    // remote - the distinction the restarting-target arm turns on, and one no
+    // test can express through `localHostExpected` alone.
+    localHostId: "host-local",
     ...overrides,
   };
 }
@@ -245,6 +250,35 @@ describe("deriveWindowNarration", () => {
           isTargetHost: false,
           detail,
         },
+      });
+    });
+
+    it("P2 FIX - a restarting REMOTE target is not a local launch: the arm needs the target to be this machine, which localHostExpected cannot say", () => {
+      // `localHostExpected` describes the SHELL - "can this app boot some
+      // local host" - and stays true on a desktop whose target is a remote.
+      // The authority's own hold is local-target-only, so with a preferred
+      // remote cycling and the rest of the fleet offline it derives a REAL ∅.
+      // Relabelling that as cold-start put this machine's provisioning card
+      // (Retry, install progress, the bootstrap log) in front of a host this
+      // app has no lifecycle for, and withheld the offline recovery until the
+      // remote's restart episode expired.
+      const state = deriveWindowNarration(
+        baseInput({
+          attached: true,
+          effectiveHostId: null,
+          hasBeenServed: false,
+          targetHostId: "host-remote",
+          localHostId: "host-local",
+          leases: [
+            lease({ hostId: "host-remote", status: "restarting-expected" }),
+            deadLease("host-local", { reason: "offline" }),
+          ],
+        }),
+      );
+      expect(state).toEqual({
+        kind: "narrating",
+        cause: "no-usable-host",
+        variant: { kind: "offline" },
       });
     });
 

--- a/clients/gui-app/src/lib/host/__tests__/window-narration.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/window-narration.test.ts
@@ -212,6 +212,66 @@ describe("deriveWindowNarration", () => {
       });
     });
 
+    it("P2 FIX - yields to an ACTIONABLE verdict even while the target is restarting: an incompatible other host still gets update-host", () => {
+      // The restarting-target arm has no clock, and the lease it reads can
+      // stay `restarting-expected` for the outage signal's ceiling - fifteen
+      // minutes, far past the authority's twenty-second hold. So whatever it
+      // hides, it can hide for the whole outage. Hiding `offline` costs
+      // nothing (the startup card carries the same Retry), but hiding a fix
+      // the user could walk right now is a lockout with a spinner on it.
+      const detail = {
+        code: "protocol-major-behind",
+        hostVersion: "1.2.3",
+        minSupportedVersion: "1.3.0",
+      } as const;
+      const state = deriveWindowNarration(
+        baseInput({
+          attached: true,
+          effectiveHostId: null,
+          hasBeenServed: false,
+          targetHostId: "host-local",
+          leases: [
+            lease({ hostId: "host-local", status: "restarting-expected" }),
+            deadLease("host-remote", { reason: "incompatible", detail }),
+          ],
+        }),
+      );
+      expect(state).toEqual({
+        kind: "narrating",
+        cause: "no-usable-host",
+        variant: {
+          kind: "update-host",
+          hostId: "host-remote",
+          isTargetHost: false,
+          detail,
+        },
+      });
+    });
+
+    it("P2 FIX - and still holds it for a merely-offline fleet: the gate is the VERDICT, not the presence of a dead lease", () => {
+      // The other side of the same rule, and the reason it is stated over the
+      // scan's answer rather than over deadness: a retired laptop still
+      // resolves to `offline`, so the launch story survives it. Losing this
+      // would restore the flash the arm above was added to remove.
+      const state = deriveWindowNarration(
+        baseInput({
+          attached: true,
+          effectiveHostId: null,
+          hasBeenServed: false,
+          targetHostId: "host-local",
+          leases: [
+            lease({ hostId: "host-local", status: "restarting-expected" }),
+            deadLease("host-retired", { reason: "removed" }),
+          ],
+        }),
+      );
+      expect(state).toEqual({
+        kind: "narrating",
+        cause: "cold-start",
+        variant: { kind: "offline" },
+      });
+    });
+
     it("does not extend that exception past the first service - a restarting target after serving is the ∅ verdict", () => {
       // The grace is a LAUNCH statement in both of its arms. Once the window
       // has been served, ∅ is always the verdict, whatever the target's lease

--- a/clients/gui-app/src/lib/host/__tests__/window-narration.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/window-narration.test.ts
@@ -184,6 +184,57 @@ describe("deriveWindowNarration", () => {
       });
     });
 
+    it("holds the grace through a dead lease while the TARGET is restarting - the authority is waiting on purpose", () => {
+      // The authority's cold-start hold answers ∅ for a bounded window while a
+      // never-proven local target cycles, declining a usable fallback so the
+      // app does not hop to a remote and get dragged back seconds later. So
+      // this ∅ does not mean "nothing can serve" - and without this arm, one
+      // retired machine anywhere in the account (dead, and every account
+      // accumulates them) would put "No host is available" over a launch that
+      // is going perfectly well, with a working remote sitting right there.
+      const state = deriveWindowNarration(
+        baseInput({
+          attached: true,
+          effectiveHostId: null,
+          hasBeenServed: false,
+          targetHostId: "host-local",
+          leases: [
+            lease({ hostId: "host-local", status: "restarting-expected" }),
+            lease({ hostId: "host-remote", status: "ready" }),
+            deadLease("host-retired", { reason: "offline" }),
+          ],
+        }),
+      );
+      expect(state).toEqual({
+        kind: "narrating",
+        cause: "cold-start",
+        variant: { kind: "offline" },
+      });
+    });
+
+    it("does not extend that exception past the first service - a restarting target after serving is the ∅ verdict", () => {
+      // The grace is a LAUNCH statement in both of its arms. Once the window
+      // has been served, ∅ is always the verdict, whatever the target's lease
+      // happens to say.
+      const state = deriveWindowNarration(
+        baseInput({
+          attached: true,
+          effectiveHostId: null,
+          hasBeenServed: true,
+          targetHostId: "host-local",
+          leases: [
+            lease({ hostId: "host-local", status: "restarting-expected" }),
+            deadLease("host-retired", { reason: "offline" }),
+          ],
+        }),
+      );
+      expect(state).toEqual({
+        kind: "narrating",
+        cause: "no-usable-host",
+        variant: { kind: "offline" },
+      });
+    });
+
     it("keeps update-host reachable at first launch - the grace must not swallow a dead incompatible host", () => {
       // The sharp edge of the rule above: `update-host` and `plan-restricted`
       // BOTH derive from dead leases, so a grace that ignored deadness would

--- a/clients/gui-app/src/lib/host/host-directory-service.ts
+++ b/clients/gui-app/src/lib/host/host-directory-service.ts
@@ -905,6 +905,15 @@ export class HostDirectoryService implements IHostDirectoryService {
       return;
     }
     this.adoptLocalHostId(hostId);
+    // THE SEED PATH IS A STATE CHANGE AND HAS TO SAY SO. `snapshot()` reads
+    // `lastKnownLocalHostId` to neutralise this machine's registry twin into a
+    // `bootingLocalEntry`, so adopting an id here changes what every listener
+    // would compute - and this is the one caller of `adoptLocalHostId` with no
+    // emit behind it (`onLocalHostChange` emits immediately after its own
+    // call). Without this, the durable id could move from null to a real id
+    // with nobody told, which `emit`'s own doc already promises cannot happen
+    // for a re-enrollment.
+    this.emit();
     appLogger.debug("[host-directory] seeded local host id from shell", {
       hostId,
     });

--- a/clients/gui-app/src/lib/host/window-narration.ts
+++ b/clients/gui-app/src/lib/host/window-narration.ts
@@ -271,10 +271,26 @@ export function deriveWindowNarration(
     // `plan-restricted` reachable at first launch: both derive from dead
     // leases. After the window has served once, ∅ is always the verdict arm;
     // the grace is strictly a launch statement.
+    //
+    // UNLESS THE TARGET ITSELF IS RESTARTING, which is a start in progress
+    // stated by the authority's own lease rather than inferred from the
+    // absence of conclusions. The authority holds ∅ for a bounded window while
+    // a never-proven local target cycles (its cold-start hold), deliberately
+    // declining a usable fallback so the app does not hop and hop back - so
+    // during that hold ∅ does NOT mean "nothing can serve this window", and
+    // the scan below would say so anyway the moment the account contains one
+    // dead machine (a retired laptop, an incompatible one). That is the same
+    // reasoning the non-∅ cold-start arm already applies further down:
+    // whatever else is wrong out there belongs to the surface chip or the
+    // tile, not to the window's launch story. Bounded by construction - the
+    // authority's hold lapses, and with it this lease state - so `update-host`
+    // and `plan-restricted` stay reachable, just not mid-restart.
+    const targetLease = findLease(input.leases, input.targetHostId);
     if (
       !input.hasBeenServed &&
       input.localHostExpected &&
-      input.leases.every((lease) => lease.status !== "dead")
+      (targetLease?.status === "restarting-expected" ||
+        input.leases.every((lease) => lease.status !== "dead"))
     ) {
       return {
         kind: "narrating",

--- a/clients/gui-app/src/lib/host/window-narration.ts
+++ b/clients/gui-app/src/lib/host/window-narration.ts
@@ -117,6 +117,17 @@ export interface WindowNarrationInput {
    * cannot happen.
    */
   readonly localHostExpected: boolean;
+  /**
+   * THIS MACHINE's host id, or null when there is none.
+   *
+   * Carried separately from {@link localHostExpected} because they answer
+   * different questions and one cannot stand in for the other:
+   * `localHostExpected` is "can this shell boot SOME local host", a property
+   * of the shell, and stays true on a desktop whose target is a remote
+   * machine. Only this field can settle whether the host the restarting-target
+   * arm is waiting on is the one this app can actually start.
+   */
+  readonly localHostId: string | null;
 }
 
 /**
@@ -272,17 +283,29 @@ export function deriveWindowNarration(
     // leases. After the window has served once, ∅ is always the verdict arm;
     // the grace is strictly a launch statement.
     //
-    // UNLESS THE TARGET ITSELF IS RESTARTING, which is a start in progress
-    // stated by the authority's own lease rather than inferred from the
-    // absence of conclusions. The authority holds ∅ for a bounded window while
-    // a never-proven local target cycles (its cold-start hold), deliberately
-    // declining a usable fallback so the app does not hop and hop back - so
-    // during that hold ∅ does NOT mean "nothing can serve this window", and
-    // the scan below would say so anyway the moment the account contains one
-    // dead machine (a retired laptop). That is the same reasoning the non-∅
-    // cold-start arm already applies further down: whatever else is wrong out
-    // there belongs to the surface chip or the tile, not to the window's
-    // launch story.
+    // UNLESS THE LOCAL TARGET ITSELF IS RESTARTING, which is a start in
+    // progress stated by the authority's own lease rather than inferred from
+    // the absence of conclusions. The authority holds ∅ for a bounded window
+    // while a never-proven local target cycles (its cold-start hold),
+    // deliberately declining a usable fallback so the app does not hop and hop
+    // back - so during that hold ∅ does NOT mean "nothing can serve this
+    // window", and the scan below would say so anyway the moment the account
+    // contains one dead machine (a retired laptop). That is the same reasoning
+    // the non-∅ cold-start arm already applies further down: whatever else is
+    // wrong out there belongs to the surface chip or the tile, not to the
+    // window's launch story.
+    //
+    // ⚠ THE TARGET MUST BE THIS MACHINE, and `localHostExpected` cannot
+    // establish that - it says the SHELL can boot some local host, which stays
+    // true on a desktop whose target is a remote. Without the identity check,
+    // a preferred REMOTE cycling while the rest of the fleet is offline read
+    // as a launch: the authority skips its (local-only) hold and derives a
+    // real ∅, while this arm relabelled that verdict `cold-start` and put the
+    // local provisioning card - Retry, install progress, the bootstrap log -
+    // in front of a machine this app cannot start, withholding the offline
+    // recovery until the remote's restart episode expired. The narrator's
+    // grace and the authority's hold have to be gated on the SAME premise, or
+    // one of them is narrating a state the other never entered.
     //
     // ⚠ ONLY WHERE THE SCAN WOULD HAVE SAID `offline` ANYWAY, and that gate is
     // the difference between softening a verdict and SUPPRESSING one. This arm
@@ -307,11 +330,15 @@ export function deriveWindowNarration(
     // actionable by default, which is the safe direction to be wrong in.
     const targetLease = findLease(input.leases, input.targetHostId);
     const noHostVariant = deriveNoHostVariant(input.leases, input.targetHostId);
+    const localTargetRestarting =
+      input.targetHostId !== null &&
+      input.targetHostId === input.localHostId &&
+      targetLease?.status === "restarting-expected";
     if (
       !input.hasBeenServed &&
       input.localHostExpected &&
       noHostVariant.kind === "offline" &&
-      (targetLease?.status === "restarting-expected" ||
+      (localTargetRestarting ||
         input.leases.every((lease) => lease.status !== "dead"))
     ) {
       return {

--- a/clients/gui-app/src/lib/host/window-narration.ts
+++ b/clients/gui-app/src/lib/host/window-narration.ts
@@ -279,16 +279,38 @@ export function deriveWindowNarration(
     // declining a usable fallback so the app does not hop and hop back - so
     // during that hold ∅ does NOT mean "nothing can serve this window", and
     // the scan below would say so anyway the moment the account contains one
-    // dead machine (a retired laptop, an incompatible one). That is the same
-    // reasoning the non-∅ cold-start arm already applies further down:
-    // whatever else is wrong out there belongs to the surface chip or the
-    // tile, not to the window's launch story. Bounded by construction - the
-    // authority's hold lapses, and with it this lease state - so `update-host`
-    // and `plan-restricted` stay reachable, just not mid-restart.
+    // dead machine (a retired laptop). That is the same reasoning the non-∅
+    // cold-start arm already applies further down: whatever else is wrong out
+    // there belongs to the surface chip or the tile, not to the window's
+    // launch story.
+    //
+    // ⚠ ONLY WHERE THE SCAN WOULD HAVE SAID `offline` ANYWAY, and that gate is
+    // the difference between softening a verdict and SUPPRESSING one. This arm
+    // has no clock: it reads a lease status the outage signal can hold for
+    // `LOCAL_EXPECTED_OUTAGE_CEILING_MS` (15 minutes), far past the authority's
+    // 20-second hold, so anything it hides it can hide for the whole outage. On
+    // `offline` there is nothing to hide - the startup card carries the same
+    // recovery, promoting to Retry + Open settings at
+    // `LOCAL_HOST_SLOW_START_THRESHOLD_MS` and adding Report issue once the
+    // install settles in failure - and "Starting Traycer…" is the truer
+    // sentence while the boot is genuinely running. `update-host` is the
+    // opposite: a version fix the user could walk NOW (arm 3 of the scan - an
+    // incompatible OTHER host while the target cycles), and a local restart is
+    // not a reason to withhold it for a quarter of an hour.
+    //
+    // Asking `deriveNoHostVariant` rather than enumerating dead reasons is
+    // deliberate. `plan-restricted` happens to be unreachable in this
+    // population today (its arm needs EVERY lease dead, and a
+    // `restarting-expected` target is not), so an enumeration written against
+    // what is reachable now would be a rule that quietly stops matching when
+    // that precedence moves. Deferring to the scan itself makes a new variant
+    // actionable by default, which is the safe direction to be wrong in.
     const targetLease = findLease(input.leases, input.targetHostId);
+    const noHostVariant = deriveNoHostVariant(input.leases, input.targetHostId);
     if (
       !input.hasBeenServed &&
       input.localHostExpected &&
+      noHostVariant.kind === "offline" &&
       (targetLease?.status === "restarting-expected" ||
         input.leases.every((lease) => lease.status !== "dead"))
     ) {
@@ -301,7 +323,7 @@ export function deriveWindowNarration(
     return {
       kind: "narrating",
       cause: "no-usable-host",
-      variant: deriveNoHostVariant(input.leases, input.targetHostId),
+      variant: noHostVariant,
     };
   }
   if (input.hasBeenServed) return { kind: "silent" };

--- a/clients/gui-app/src/stores/worktree/__tests__/worktree-intent-staging-store.test.ts
+++ b/clients/gui-app/src/stores/worktree/__tests__/worktree-intent-staging-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { WorktreeFolderIntent } from "@traycer/protocol/host/worktree-schemas";
 import {
+  anyHostHasStagedWorktreeIntent,
   forkChatStagingKeysForEpic,
   newConversationModalStagingKey,
   pendingChildTerminalAgentStagingKey,
@@ -628,5 +629,73 @@ describe("worktree-intent-staging-store", () => {
     await useWorktreeIntentStagingStore.persist.rehydrate();
 
     expect(useWorktreeIntentStagingStore.getState().intentByKey).toEqual({});
+  });
+
+  // Pairs with `clearForAllHosts`'s reach: a caller that clears every bucket
+  // must ask about every bucket, or it silently drops an intent staged while
+  // the surface was pinned to another host (Codex review finding).
+  describe("anyHostHasStagedWorktreeIntent", () => {
+    const draftA: WorktreeStagingKey = {
+      surface: "landing",
+      hostId: HOST_A,
+      draftId: "draft-9",
+    };
+    const draftB: WorktreeStagingKey = { ...draftA, hostId: HOST_B };
+
+    it("is true when an intent is staged under the SAME host bucket", () => {
+      useWorktreeIntentStagingStore
+        .getState()
+        .stageEntry(draftA, localEntry("/a", true));
+
+      expect(anyHostHasStagedWorktreeIntent(draftA)).toBe(true);
+    });
+
+    it("is true when an intent is staged under a DIFFERENT host bucket for the same slot", () => {
+      // Staged while the surface was pinned to host B; asked at host A's
+      // bucket for the identical slot.
+      useWorktreeIntentStagingStore
+        .getState()
+        .stageEntry(draftB, localEntry("/b", true));
+
+      expect(anyHostHasStagedWorktreeIntent(draftA)).toBe(true);
+      expect(readStagedWorktreeIntent(draftA)).toBeNull();
+    });
+
+    it("is false when the slot is empty across every host", () => {
+      expect(anyHostHasStagedWorktreeIntent(draftA)).toBe(false);
+    });
+
+    it("does not conflate a DIFFERENT slot (draftId, epicId, parentId, surface)", () => {
+      useWorktreeIntentStagingStore
+        .getState()
+        .stageEntry(draftA, localEntry("/a", true));
+      // A different draftId, same host - a different `landing` slot.
+      const otherDraft: WorktreeStagingKey = {
+        ...draftA,
+        draftId: "draft-other",
+      };
+      expect(anyHostHasStagedWorktreeIntent(otherDraft)).toBe(false);
+
+      // A modal slot staged for one epic/parent must not answer for another
+      // epic, another parent, or the sibling `owner` surface.
+      const modalSlot = newConversationModalStagingKey(HOST_A, "epic-1", null);
+      useWorktreeIntentStagingStore
+        .getState()
+        .stageEntry(modalSlot, localEntry("/modal", true));
+
+      expect(
+        anyHostHasStagedWorktreeIntent(
+          newConversationModalStagingKey(HOST_A, "epic-2", null),
+        ),
+      ).toBe(false);
+      expect(
+        anyHostHasStagedWorktreeIntent(
+          newConversationModalStagingKey(HOST_A, "epic-1", "parent-1"),
+        ),
+      ).toBe(false);
+      expect(anyHostHasStagedWorktreeIntent(OWNER_KEY)).toBe(false);
+      // The staged slot itself still answers true.
+      expect(anyHostHasStagedWorktreeIntent(modalSlot)).toBe(true);
+    });
   });
 });

--- a/clients/gui-app/src/stores/worktree/worktree-intent-staging-store.ts
+++ b/clients/gui-app/src/stores/worktree/worktree-intent-staging-store.ts
@@ -743,6 +743,28 @@ export function readStagedWorktreeIntent(
 }
 
 /**
+ * Whether ANY host's copy of this slot holds a staged intent - the read that
+ * matches `clearForAllHosts`'s reach.
+ *
+ * A caller that clears every bucket must ask about every bucket: the same slot
+ * can hold an intent staged while the surface was pinned to another host, and
+ * a check scoped to the currently resolved bucket would report "nothing
+ * staged" while the clear deletes it. Pair the two by breadth - a single-bucket
+ * `clear` goes with {@link readStagedWorktreeIntent}, and this goes with
+ * `clearForAllHosts`.
+ */
+export function anyHostHasStagedWorktreeIntent(
+  key: WorktreeStagingKey,
+): boolean {
+  const identity = hostAgnosticStagingId(worktreeStagingKeyString(key));
+  const intentByKey = useWorktreeIntentStagingStore.getState().intentByKey;
+  return Object.keys(intentByKey).some(
+    (id) =>
+      hostAgnosticStagingId(id) === identity && intentByKey[id] !== undefined,
+  );
+}
+
+/**
  * Current in-memory edit sequence for a staging slot. Used to make rejected
  * action restoration conditional on no newer selection (including a clear).
  */

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -188,6 +188,24 @@ function readyLocalHostEnsurePort(): LocalHostEnsurePort {
   return { ensureReady: () => Promise.resolve({ ok: true }) };
 }
 
+/**
+ * A local `ensure` port whose promise NEVER settles - a hung provisioning
+ * lane (the same shape the B2 suite drives via `createDeferredEnsure()` with
+ * its `resolve` never called, made a named one-liner here because the P1 fix
+ * pins need it at the point a host FIRST becomes effective, not only at its
+ * own B2 ceiling).
+ *
+ * This is the exact mechanism behind the P1 regression: `deriveLease`'s
+ * in-flight-ensure arm reports the local host `connecting` - usable - for as
+ * long as this promise is outstanding, which is proof of NOTHING (no dial,
+ * no session, no announcement has ever reached the host). Only the engine's
+ * own {@link LOCAL_EXPECTED_OUTAGE_CEILING_MS}-equal B2 ceiling ever moves a
+ * lease held by a port like this one; the port itself never will.
+ */
+function neverResolvingLocalHostEnsurePort(): LocalHostEnsurePort {
+  return { ensureReady: () => new Promise(() => undefined) };
+}
+
 // -------------------------------------------------------------------- tests
 
 describe("SelectionAuthorityEngineImpl - attach fence", () => {
@@ -5260,19 +5278,35 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
    * Builds an engine with a CONTROLLABLE {@link LocalHostOutageSignal}, seeded
    * on an EMPTY fleet (`localHostId: null, hosts: []`). `createTestAuthority`
    * cannot be used here: it hardcodes `inertLocalHostOutageSignal`, and this
-   * suite's whole premise is a signal already `true` before the fleet ever
-   * names a local host.
+   * suite drives the signal itself - sometimes already `true` before the
+   * fleet ever names a local host (the TARGET-side hold: L is never usable,
+   * never effective, and the hold answers ∅), sometimes flipped `true` only
+   * AFTER a local host has already become effective some other way (the
+   * INCUMBENT-side hold, P1 fix: the per-host proof-of-life gate is what
+   * decides whether that incumbent's restart is bounded or not).
+   *
+   * `initialOutage` and `localHostEnsure` are REQUIRED, not defaulted (this
+   * repo's type-safety rules: no optional/defaulted params) - every caller
+   * states its own premise rather than inheriting one silently. A caller
+   * proving the TARGET-side hold passes `true` (matching the original
+   * fixture); a caller proving the INCUMBENT-side P1 fix passes `false` and
+   * flips it after the incumbent already exists.
    *
    * The empty seed matters as much as the signal: the constructor's own
    * fleet-seed commit runs with `localHostId: null` (no target, no local
-   * host), so it can never touch `mruEffectiveHostIds` - only the later
-   * `fleet.publish` the test drives is this process's FIRST look at L or R.
-   * Publishing L from construction instead would let the auto-ensure's
-   * transient `connecting` (usable, before the outage signal is even read)
-   * serve L on that very first commit and falsify the cold-start premise
-   * before a single assertion runs.
+   * host), so it can never touch `mruEffectiveHostIds` or any host's
+   * proof-of-life latch - only the later `fleet.publish` the test drives is
+   * this process's FIRST look at L or R. Publishing L from construction
+   * instead would let the auto-ensure's transient `connecting` (usable,
+   * before the outage signal is even read) serve L on that very first
+   * commit and falsify the cold-start premise before a single assertion
+   * runs.
    */
-  function coldBootAuthorityWithOutageSignal(clock: FakeAuthorityClock): {
+  function coldBootAuthorityWithOutageSignal(
+    clock: FakeAuthorityClock,
+    initialOutage: boolean,
+    localHostEnsure: LocalHostEnsurePort,
+  ): {
     readonly engine: SelectionAuthorityEngineImpl;
     readonly fleet: InMemoryHostFleetSource;
     readonly events: RecordedEngineEvent[];
@@ -5289,7 +5323,7 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
       current: () => ({ identityKey: "acct-1", generation: 0 }),
       onChanged: () => ({ dispose: () => undefined }),
     };
-    let outageState = true;
+    let outageState = initialOutage;
     const outageListeners = new Set<(inExpectedOutage: boolean) => void>();
     const outage: LocalHostOutageSignal = {
       inExpectedOutage: () => outageState,
@@ -5301,10 +5335,7 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
     const engine = new SelectionAuthorityEngineImpl({
       fleet,
       identity,
-      // PROVISIONABLE: once the outage ends, L must be able to serve at all -
-      // otherwise "lands on the target" would be measuring ∅ via the
-      // unavailable port instead of the hold ending cleanly.
-      localHostEnsure: readyLocalHostEnsurePort(),
+      localHostEnsure,
       localOutage: outage,
       clock,
       newIncarnationId: createIncrementingIncarnationIds(),
@@ -5328,7 +5359,11 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
 
   it("COLD START HOLD: a never-served process holds ∅ for a restarting LOCAL target instead of failing over to a usable remote", () => {
     const clock = createFakeAuthorityClock(0);
-    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
     const { engine, fleet } = authority;
 
     // The mutation lane was ALREADY cycling the local host before the fleet
@@ -5354,7 +5389,11 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
 
   it("LANDS ON THE TARGET ONCE: ending the outage before the ceiling adopts L directly, with no intermediate hop onto R", async () => {
     const clock = createFakeAuthorityClock(0);
-    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
     const { engine, fleet, events } = authority;
 
     fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
@@ -5386,7 +5425,11 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
 
   it("BOUNDED: the ceiling forces a fallback to R at 20s even with the LOCAL OUTAGE signal (a 15-minute hold) still true - the exact 'stuck on the startup screen' regression this ceiling prevents", () => {
     const clock = createFakeAuthorityClock(0);
-    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
     const { engine, fleet } = authority;
 
     fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
@@ -5417,7 +5460,11 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
 
   it("after the ceiling forces R, a later-usable local target recovers only through the ordinary RETURN_TO_TARGET_STABILITY_MS window - no special-casing", async () => {
     const clock = createFakeAuthorityClock(0);
-    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
     const { engine, fleet } = authority;
 
     fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
@@ -5426,8 +5473,10 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
 
     // The outage ends; L becomes usable. The engine is FailedOver now (R is
     // effective, L is target) - the ORDINARY M6 return-to-target window
-    // applies from here, not the hold (the hold's job ended the moment it
-    // forced this fallback - `mruEffectiveHostIds` is no longer empty).
+    // applies from here, not the hold (the hold's own ceiling already
+    // lapsed when it forced R, and `holdsForColdStart` never re-arms a
+    // window for the SAME host once its ceiling has lapsed - see the NO
+    // RE-ARM pin below).
     authority.setOutage(false);
     expect(findLease(engine.snapshot().leases, "L")?.status).not.toBe(
       "restarting-expected",
@@ -5447,6 +5496,194 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
 
     clock.advance(1);
     expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    authority.dispose();
+  });
+
+  it("P1 FIX - UNPROVEN INCUMBENT IS BOUNDED: a local host that became effective only because the engine's own ensure is in flight - never proven alive - gets the BOUNDED hold once it starts restarting, not the unbounded D5/M6 one", () => {
+    const clock = createFakeAuthorityClock(0);
+    // An ensure whose promise NEVER settles - the exact shape the review
+    // finding caught `noteEffective` recording: L reads `connecting` (usable)
+    // purely because THIS process's own launch-time ensure is outstanding,
+    // never because anything has actually answered it (arm 2 of
+    // `deriveLease`).
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      false,
+      neverResolvingLocalHostEnsurePort(),
+    );
+    const { engine, fleet } = authority;
+
+    // First look at L (local) and R (a fine, usable remote). No outage yet,
+    // so the never-dialed local host draws the launch ensure and derives
+    // `connecting` - usable - and is picked as both target and effective.
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("connecting");
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // The mutation lane starts cycling L a moment later - AFTER the ensure
+    // was already minted. This is exactly the case the module header's
+    // "COMPOSITION" pin protects: the outage signal alone cannot flip L's
+    // lease while this engine's own ensure is still outstanding for it, so
+    // nothing observable changes yet.
+    clock.advance(30_000);
+    authority.setOutage(true);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe("connecting");
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // The ensure's OWN in-flight ceiling (B2) is what finally retires the
+    // token - the outage's independent 15-minute ceiling (started 30s later)
+    // still has comfortable room left, so the freed arm reveals
+    // `restarting-expected`, not `dead`.
+    clock.advance(LOCAL_EXPECTED_OUTAGE_CEILING_MS - 30_000);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    // L is STILL the effective host - the D5/M6 exemption never newly
+    // selects a restarting host, but it does not throw the app off an
+    // already-effective one either. What changed is which ARM is holding
+    // it: the incumbent has never proved itself, so this is the bounded
+    // cold-start hold, not the unbounded one.
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // BOUNDED: comfortably inside the 20s ceiling, still held.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS - 1);
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // At the ceiling, with NO new evidence, the engine's own deadline timer
+    // falls through to the usable remote - the exact regression this pins:
+    // before the fix, `mruEffectiveHostIds` already held L (from the very
+    // first `noteEffective`, the moment L first read `connecting`), so the
+    // OLD gate read "already served" and took the unbounded arm, pinning the
+    // startup screen for the outage's full 15-minute ceiling with R sitting
+    // right there, usable.
+    clock.advance(1);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    authority.dispose();
+  });
+
+  it("P1 FIX - PROVEN INCUMBENT STAYS UNBOUNDED: a local host proved alive by its own successful ensure keeps the unbounded D5/M6 hold once it starts restarting", async () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      false,
+      readyLocalHostEnsurePort(),
+    );
+    const { engine, fleet } = authority;
+
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // Let the launch ensure settle: a `{ ok: true }` completion is FIRSTHAND
+    // proof of life (`onHostProvedAlive`) - the one thing the previous pin's
+    // incumbent never got.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Now the mutation lane starts cycling L. With the ensure already
+    // settled (no token left to mask arm 3), the outage signal reaches
+    // `deriveLease` directly and L reads `restarting-expected` at once.
+    authority.setOutage(true);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // UNBOUNDED: well past the 20s cold-start ceiling that bounded the
+    // UNPROVEN incumbent above - this is the D5/M6 hold at full strength,
+    // because `hasProvedAliveAtLeastOnce("L")` is true.
+    clock.advance(60_000);
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+
+    authority.dispose();
+  });
+
+  it("P1 FIX - RE-KEY ON HOST REPLACEMENT: a fleet republish that swaps the LOCAL identity mid-hold gives the new host its own full 20s window, not the old host's remaining time", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
+    const { engine, fleet } = authority;
+
+    // L1 is cycling before the fleet ever answers (the TARGET-side hold,
+    // like the "COLD START HOLD" pin above): ∅ while it is awaited.
+    fleet.publish(0, "L1", [
+      fleetHost("L1", "local"),
+      fleetHost("R", "remote"),
+    ]);
+    expect(findLease(engine.snapshot().leases, "L1")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // Comfortably inside L1's window.
+    clock.advance(15_000);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // The desktop republishes on a local-identity change (PID metadata,
+    // re-enrolment): a DIFFERENT host, L2, is now `localHostId`, and it is
+    // ALSO cycling (the outage signal is a port-level fact, not scoped to
+    // one host id).
+    fleet.publish(0, "L2", [
+      fleetHost("L2", "local"),
+      fleetHost("R", "remote"),
+    ]);
+    expect(findLease(engine.snapshot().leases, "L2")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // 10 more seconds - 25s total since L1's window opened, past what WOULD
+    // have been L1's 20s ceiling. Still held: L2 re-keyed the hold to ITS
+    // OWN start (t=15s), not L1's elapsed time.
+    clock.advance(10_000);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // 20s after the SWAP (t=15s + 20s = t=35s), L2's own window lapses.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS - 10_000);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    authority.dispose();
+  });
+
+  it("P1 FIX - NO RE-ARM AFTER LAPSE: once the ceiling has forced a fallback, further passes for the SAME still-restarting host do not re-engage the hold", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
+    const { engine, fleet } = authority;
+
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // The ceiling forces R, exactly as in the "BOUNDED" pin above.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // A FURTHER PASS for the SAME host, still restarting: the registry
+    // re-publishes the same membership (a periodic refresh, not a change).
+    // `holdsForColdStart("L", ...)` is invoked again on this pass - via the
+    // LOCAL-TARGET arm, since L is still the target and still
+    // `restarting-expected` - and must not re-arm a fresh window just
+    // because it is being asked about again.
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // More time and more passes - still no re-arm.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS);
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
 
     authority.dispose();
   });
@@ -5483,10 +5720,15 @@ describe("SelectionAuthorityEngineImpl - cold-start hold does not apply once the
     await Promise.resolve();
     await Promise.resolve();
 
-    // L now starts a deliberate restart while R is serving. If the hold's
-    // `mruEffectiveHostIds.length === 0` gate were wrong (or missing), this
-    // is exactly the shape a regression would show up in first - a process
-    // that has already served once, watching an UNRELATED host cycle.
+    // L now starts a deliberate restart while R - not L - is the current
+    // effective host. Under the per-host proof-of-life gate the hold's two
+    // arms only ever consider the CURRENT effective host (the incumbent arm)
+    // or the local TARGET (the second arm, gated on
+    // `targetHostId === localHostId`, false here since R is preferred and L
+    // is never the target). L is neither, so this is exactly the shape a
+    // regression in that per-host scoping would show up in first - a
+    // process serving one host entirely unaffected by an UNRELATED host
+    // cycling.
     engine.ingestEvidence(
       "A",
       incarnation,

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -5741,6 +5741,65 @@ describe("SelectionAuthorityEngineImpl - cold-start hold does not apply once the
 
     authority.dispose();
   });
+
+  it("P1 FIX - A SERVING FALLBACK IS NEVER DROPPED: with the local host as the TARGET, a later restart intent for it leaves the failed-over R serving instead of holding ∅", async () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: "L",
+        hosts: [fleetHost("L", "local"), fleetHost("R", "remote")],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+    });
+    const { engine } = authority;
+    const incarnation = attachReporter(engine, "A");
+
+    // NO PREFERENCE, so the target IS the local host (M5). That is the whole
+    // difference from the case above - there R was preferred and L was never
+    // the target, so `targetHostId === localHostId` was false and the
+    // target-side arm could not fire whatever it did. Here it is true, which
+    // is the population this pin is about.
+    expect(engine.snapshot().targetHostId).toBe("L");
+
+    // L is unprovisionable (the harness default port answers "unavailable")
+    // and then refuses its dials outright, so the app fails over to R exactly
+    // as D8 says. Settle the construction-time ensure first: its in-flight arm
+    // outranks the expected-outage arm, so a restart intent landing while it
+    // is outstanding would read `connecting` and prove nothing.
+    await Promise.resolve();
+    await Promise.resolve();
+    killHostWithRefusals(engine, "A", incarnation, "L");
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // THE REGRESSION. A restart intent for L - the user relaunching their own
+    // machine's host, or the launch lane reconciling - flips its lease from
+    // `dead` to `restarting-expected`. `restartingIncumbentHostId` is null (R
+    // is the incumbent and R is not restarting), so before the ∅ gate the
+    // target-side arm fired and answered null: a cold-start optimization
+    // taking a WORKING remote away from a user who was mid-sentence on it, for
+    // the whole ceiling. The hold exists to prevent a hop, not to cause an
+    // outage.
+    engine.ingestEvidence(
+      "A",
+      incarnation,
+      restartIntent("L", "tomb-relaunch", null, clock.now()),
+    );
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // And it stays R across the span the hold would have covered - the hold
+    // was never armed, rather than armed and immediately lapsed.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS / 2);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    authority.dispose();
+  });
 });
 
 describe("SelectionAuthorityEngineImpl - cold-start hold is LOCAL-target-only", () => {

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -5387,6 +5387,103 @@ describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL tar
     authority.dispose();
   });
 
+  it("P1 FIX - ONE WINDOW PER EPISODE: after the ceiling lapses onto R, a later ∅ adopts a newly-usable Q at once instead of re-arming a fresh hold on the still-restarting L", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      true,
+      readyLocalHostEnsurePort(),
+    );
+    const { engine, fleet } = authority;
+    const incarnation = attachReporter(engine, "A");
+
+    // 1. The ordinary cold start: L cycling, R a usable remote, hold engaged.
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // 2. The ceiling lapses and R takes over. The LAPSE ITSELF is what the
+    //    rest of this test is about: L has had its window for this episode.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS + 1);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // 3. R dies with nothing else usable, so the authority genuinely reaches ∅
+    //    - the transition that used to destroy the lapse record, because the
+    //    pass that saw R still effective decided no host was being awaited.
+    killHostWithRefusals(engine, "A", incarnation, "R");
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // 4. A usable Q appears while L is STILL cycling under the same intent -
+    //    no new restart episode, just a fleet that now has an answer.
+    clock.advance(1_000);
+    fleet.publish(0, "L", [
+      fleetHost("L", "local"),
+      fleetHost("R", "remote"),
+      fleetHost("Q", "remote"),
+    ]);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+
+    // THE REGRESSION: a second full 20s of ∅ - and this one narrates as the
+    // hard "No host is available" card, not as a launch, because the window
+    // has been served since. Q must be adopted on the spot.
+    expect(engine.snapshot().effectiveHostId).toBe("Q");
+
+    authority.dispose();
+  });
+
+  it("P1 FIX - NEVER A FIRST WINDOW AFTER SERVICE: a local restart that begins only after the app has been serving gets no ∅ hold at all, so a newly usable Q is adopted at once", async () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(
+      clock,
+      false,
+      unavailableLocalHostEnsurePort,
+    );
+    const { engine, fleet } = authority;
+    const incarnation = attachReporter(engine, "A");
+
+    // The app works: nothing is cycling, and derivation names a host. R,
+    // because this machine's host cannot be provisioned at all. Which host it
+    // is does not matter - what matters is that ∅ has stopped being a launch
+    // story for this process, because the window narrator renders any later ∅
+    // as the hard "No host is available" card.
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    // Settle the construction-time ensure: while it is outstanding L reads
+    // `connecting` (usable) and outranks R as the target, so the premise of
+    // this test - a process serving a REMOTE - only holds once it has come
+    // back unavailable.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // The remote dies too. Real ∅, correctly narrated as a verdict.
+    killHostWithRefusals(engine, "A", incarnation, "R");
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // NOW the local host starts cycling - the first restart episode this
+    // process has seen, so there is no lapsed record to stop a hold arming.
+    // The episode guard cannot help here; only "derivation has named a host
+    // before" can.
+    clock.advance(1_000);
+    authority.setOutage(true);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+
+    // A usable machine appears. Holding ∅ for it would put the ∅ modal in
+    // front of a user who was working a moment ago, for the full ceiling,
+    // with a host right there - the hold buying a modal rather than
+    // preventing a flicker.
+    fleet.publish(0, "L", [
+      fleetHost("L", "local"),
+      fleetHost("R", "remote"),
+      fleetHost("Q", "remote"),
+    ]);
+    expect(engine.snapshot().effectiveHostId).toBe("Q");
+
+    authority.dispose();
+  });
+
   it("LANDS ON THE TARGET ONCE: ending the outage before the ceiling adopts L directly, with no intermediate hop onto R", async () => {
     const clock = createFakeAuthorityClock(0);
     const authority = coldBootAuthorityWithOutageSignal(

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../selection-authority-contract";
 import {
   ATTACH_HANDOVER_CEILING_MS,
+  COLD_START_LOCAL_RESTART_HOLD_CEILING_MS,
   CONFIRMED_DEATH_REFUSAL_STREAK,
   EFFECTIVE_HOST_POST_SESSION_CEILING_MS,
   SESSION_ORDINAL_WINDOW,
@@ -41,6 +42,7 @@ import {
   fleetHost,
   findLease,
   recordEngineEvents,
+  type FakeAuthorityClock,
   type RecordedAuthorityLog,
   type RecordedEngineEvent,
   type RecordingAuthorityLog,
@@ -5246,6 +5248,301 @@ describe("selection authority dial-evidence instrumentation", () => {
       "connecting",
     );
     expect(dialLogs(log.records)[0].detail.refusalStreak).toBe(0);
+
+    authority.dispose();
+  });
+});
+
+// ---------------------------------------------------- cold-start hold (M7)
+
+describe("SelectionAuthorityEngineImpl - cold-start hold: a restarting LOCAL target is waited for, not failed over", () => {
+  /**
+   * Builds an engine with a CONTROLLABLE {@link LocalHostOutageSignal}, seeded
+   * on an EMPTY fleet (`localHostId: null, hosts: []`). `createTestAuthority`
+   * cannot be used here: it hardcodes `inertLocalHostOutageSignal`, and this
+   * suite's whole premise is a signal already `true` before the fleet ever
+   * names a local host.
+   *
+   * The empty seed matters as much as the signal: the constructor's own
+   * fleet-seed commit runs with `localHostId: null` (no target, no local
+   * host), so it can never touch `mruEffectiveHostIds` - only the later
+   * `fleet.publish` the test drives is this process's FIRST look at L or R.
+   * Publishing L from construction instead would let the auto-ensure's
+   * transient `connecting` (usable, before the outage signal is even read)
+   * serve L on that very first commit and falsify the cold-start premise
+   * before a single assertion runs.
+   */
+  function coldBootAuthorityWithOutageSignal(clock: FakeAuthorityClock): {
+    readonly engine: SelectionAuthorityEngineImpl;
+    readonly fleet: InMemoryHostFleetSource;
+    readonly events: RecordedEngineEvent[];
+    setOutage(inExpectedOutage: boolean): void;
+    dispose(): void;
+  } {
+    const fleet = new InMemoryHostFleetSource({
+      revision: 0,
+      identityGeneration: 0,
+      localHostId: null,
+      hosts: [],
+    });
+    const identity = {
+      current: () => ({ identityKey: "acct-1", generation: 0 }),
+      onChanged: () => ({ dispose: () => undefined }),
+    };
+    let outageState = true;
+    const outageListeners = new Set<(inExpectedOutage: boolean) => void>();
+    const outage: LocalHostOutageSignal = {
+      inExpectedOutage: () => outageState,
+      onChanged: (listener) => {
+        outageListeners.add(listener);
+        return { dispose: () => outageListeners.delete(listener) };
+      },
+    };
+    const engine = new SelectionAuthorityEngineImpl({
+      fleet,
+      identity,
+      // PROVISIONABLE: once the outage ends, L must be able to serve at all -
+      // otherwise "lands on the target" would be measuring ∅ via the
+      // unavailable port instead of the hold ending cleanly.
+      localHostEnsure: readyLocalHostEnsurePort(),
+      localOutage: outage,
+      clock,
+      newIncarnationId: createIncrementingIncarnationIds(),
+      preferredStore: new InMemoryPreferredHostStore(),
+      log: silentAuthorityLog,
+    });
+    const { events } = recordEngineEvents(engine);
+    return {
+      engine,
+      fleet,
+      events,
+      setOutage: (inExpectedOutage) => {
+        outageState = inExpectedOutage;
+        for (const listener of Array.from(outageListeners)) {
+          listener(inExpectedOutage);
+        }
+      },
+      dispose: () => engine.dispose(),
+    };
+  }
+
+  it("COLD START HOLD: a never-served process holds ∅ for a restarting LOCAL target instead of failing over to a usable remote", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const { engine, fleet } = authority;
+
+    // The mutation lane was ALREADY cycling the local host before the fleet
+    // ever answered - the launch-reconcile-races-boot shape the hold exists
+    // for. Publishing L (local, cycling) + R (remote, an ordinarily fine
+    // failover candidate) is this process's FIRST look at either host.
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(findLease(engine.snapshot().leases, "R")?.status).toBe("connecting");
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // Still held with no new evidence, comfortably inside the 20s ceiling -
+    // this is what distinguishes a genuine hold from a one-shot ∅ that just
+    // happens to be the first answer.
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS / 2);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+    expect(engine.snapshot().effectiveHostId).not.toBe("R");
+
+    authority.dispose();
+  });
+
+  it("LANDS ON THE TARGET ONCE: ending the outage before the ceiling adopts L directly, with no intermediate hop onto R", async () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const { engine, fleet, events } = authority;
+
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // Well inside the 20s ceiling - the boot was slow, not hung.
+    clock.advance(5_000);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // The mutation lane finishes; L is now a live candidate again.
+    authority.setOutage(false);
+    expect(findLease(engine.snapshot().leases, "L")?.status).not.toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    // The full event log never once pointed a window at R - the hold's whole
+    // job is to make that hop unnecessary when the target lands in time.
+    for (const event of events) {
+      if (event.kind !== "selection") continue;
+      expect(event.change.effectiveHostId).not.toBe("R");
+    }
+
+    // Let the ensure the outage's end just triggered settle before disposing.
+    await Promise.resolve();
+    await Promise.resolve();
+    authority.dispose();
+  });
+
+  it("BOUNDED: the ceiling forces a fallback to R at 20s even with the LOCAL OUTAGE signal (a 15-minute hold) still true - the exact 'stuck on the startup screen' regression this ceiling prevents", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const { engine, fleet } = authority;
+
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+
+    // Just short of the ceiling: still held, and the outage signal has not
+    // moved - the premise that the fall-through below is the CEILING firing,
+    // not the outage lapsing on its own (it will not for another ~14 minutes,
+    // LOCAL_EXPECTED_OUTAGE_CEILING_MS).
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS - 1);
+    expect(engine.snapshot().effectiveHostId).toBeNull();
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+
+    // The ceiling itself, reached with NO new evidence - the engine's own
+    // deadline timer, not a report, is what wakes this transition. L's lease
+    // is UNCHANGED (still restarting-expected): the hold decays on ITS OWN
+    // ceiling, not on the underlying episode lapsing.
+    clock.advance(1);
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    authority.dispose();
+  });
+
+  it("after the ceiling forces R, a later-usable local target recovers only through the ordinary RETURN_TO_TARGET_STABILITY_MS window - no special-casing", async () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = coldBootAuthorityWithOutageSignal(clock);
+    const { engine, fleet } = authority;
+
+    fleet.publish(0, "L", [fleetHost("L", "local"), fleetHost("R", "remote")]);
+    clock.advance(COLD_START_LOCAL_RESTART_HOLD_CEILING_MS);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // The outage ends; L becomes usable. The engine is FailedOver now (R is
+    // effective, L is target) - the ORDINARY M6 return-to-target window
+    // applies from here, not the hold (the hold's job ended the moment it
+    // forced this fallback - `mruEffectiveHostIds` is no longer empty).
+    authority.setOutage(false);
+    expect(findLease(engine.snapshot().leases, "L")?.status).not.toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // Let the ensure the outage's end just triggered settle. Until it does,
+    // `trackUsability`'s in-flight-ensure branch re-stamps L's `usableSince`
+    // to `now` on EVERY commit (F5: a booting host accrues no stability while
+    // its own request is outstanding), which would make the window below a
+    // moving target instead of the fixed 20s check it is meant to be.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    clock.advance(RETURN_TO_TARGET_STABILITY_MS - 1);
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    clock.advance(1);
+    expect(engine.snapshot().effectiveHostId).toBe("L");
+
+    authority.dispose();
+  });
+});
+
+describe("SelectionAuthorityEngineImpl - cold-start hold does not apply once the process has served", () => {
+  it("NOT A COLD START: serving remote R once, a later-cycling local L stays on R (the ordinary D8/M6 arms decide, unaffected by the hold)", async () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: "L",
+        hosts: [fleetHost("L", "local"), fleetHost("R", "remote")],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+      seedPreferred: "R",
+    });
+    const { engine } = authority;
+    const incarnation = attachReporter(engine, "A");
+    // R is preferred and serves directly at cold boot (never-dialed defaults
+    // to `connecting`, which is usable) - this process's FIRST non-null
+    // effective, which is what empties `mruEffectiveHostIds`' claim of "never
+    // served" for the rest of this identity epoch. L is never even the
+    // target here - the LOCAL-target-only half of the gate is pinned
+    // separately below.
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    // The construction-time launch ensure for the never-dialed local L (D14
+    // fires it whichever host is the target) is still in flight, and its
+    // in-flight arm outranks the expected-outage arm - so the tombstone
+    // below needs it settled first, or L would read `connecting` no matter
+    // what the tombstone says.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // L now starts a deliberate restart while R is serving. If the hold's
+    // `mruEffectiveHostIds.length === 0` gate were wrong (or missing), this
+    // is exactly the shape a regression would show up in first - a process
+    // that has already served once, watching an UNRELATED host cycle.
+    engine.ingestEvidence(
+      "A",
+      incarnation,
+      restartIntent("L", "tomb-cycle", null, clock.now()),
+    );
+    expect(findLease(engine.snapshot().leases, "L")?.status).toBe(
+      "restarting-expected",
+    );
+    expect(engine.snapshot().effectiveHostId).toBe("R");
+
+    authority.dispose();
+  });
+});
+
+describe("SelectionAuthorityEngineImpl - cold-start hold is LOCAL-target-only", () => {
+  it("REMOTE TARGET UNAFFECTED: a cold start with a restarting PREFERRED REMOTE still falls through to a usable remote instead of holding ∅", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: null,
+        hosts: [],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+      seedPreferred: "P",
+    });
+    const { engine, fleet } = authority;
+    const incarnation = attachReporter(engine, "A");
+
+    // Speculative evidence fed before the fleet has ever answered
+    // (`hasFleetAnswer` is still false, the empty-seed fleet has zero hosts)
+    // is accepted rather than dropped - the same loophole
+    // `clearPreferredOutsideFleet`'s doc describes for an unanswered port.
+    engine.ingestEvidence(
+      "A",
+      incarnation,
+      restartIntent("P", "tomb-remote", null, clock.now()),
+    );
+
+    // First real look at the fleet: P (preferred, remote) is mid-restart, R
+    // is a fine remote, and there is no local host at all.
+    fleet.publish(0, null, [
+      fleetHost("P", "remote"),
+      fleetHost("R", "remote"),
+    ]);
+    expect(engine.snapshot().targetHostId).toBe("P");
+    expect(findLease(engine.snapshot().leases, "P")?.status).toBe(
+      "restarting-expected",
+    );
+    // The hold's `targetHostId === localHostId` conjunct is false here (no
+    // local host exists at all), so derivation falls straight through to a
+    // usable remote instead of holding ∅ for the whole tombstone episode -
+    // the grace card the hold protects exists only where a LOCAL host is
+    // expected.
+    expect(engine.snapshot().effectiveHostId).toBe("R");
 
     authority.dispose();
   });

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -197,6 +197,29 @@ class BoundedIdSet {
 export const RETURN_TO_TARGET_STABILITY_MS = 20_000;
 
 /**
+ * Ceiling on the COLD-START HOLD (see `deriveDesiredEffective`): how long a
+ * process that has never served may answer ∅ for a `restarting-expected`
+ * LOCAL target before falling through to a usable fallback.
+ *
+ * The hold cannot ride the episode's own bounds, because they are not
+ * uniformly short: a restart tombstone lapses in 60s, but the local
+ * mutation-lane signal holds `restarting-expected` for up to
+ * {@link LOCAL_EXPECTED_OUTAGE_CEILING_MS} (15 minutes) - a converge that
+ * hangs must not hold the startup screen hostage for its whole ceiling when
+ * a working remote sits in the fleet.
+ *
+ * Deliberately EQUAL to {@link RETURN_TO_TARGET_STABILITY_MS}, because that
+ * equality is the argument for the hold itself: adopting a fallback at t=0
+ * puts the user on the target no earlier than boot + the return window, so
+ * waiting up to that same window for the boot is never slower to the
+ * target - it only trades at most 20s of fallback availability for zero
+ * hop churn in the common case where the boot is seconds. Past the
+ * ceiling the fallback is adopted exactly as before the hold existed.
+ */
+export const COLD_START_LOCAL_RESTART_HOLD_CEILING_MS =
+  RETURN_TO_TARGET_STABILITY_MS;
+
+/**
  * The minimal window on a candidate switch made WHILE already failed over
  * (M6). Short by design - it is not protecting a working arrangement, only
  * bounding a hop cascade: when a network drop makes several remotes report
@@ -769,6 +792,14 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    * two can never disagree about which move is waiting.
    */
   private pendingDampingDeadline: number | null = null;
+  /**
+   * When the cold-start hold first answered ∅ for a restarting local target,
+   * or null while the hold is not engaged (see `deriveDesiredEffective`).
+   * Cleared whenever the hold's premise stops holding, so a later episode
+   * measures its own window; kept across a lapsed ceiling, so a boot that
+   * outlived it cannot re-arm a fresh one.
+   */
+  private coldStartHoldStartedAt: number | null = null;
   /**
    * The in-flight local `ensure`, or null (D14).
    *
@@ -1861,6 +1892,9 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     this.options.preferredStore.save(outgoingIdentityKey, null);
     this.preferredHostId = this.options.preferredStore.load(this.identityKey);
     this.mruEffectiveHostIds.length = 0;
+    // The cold-start hold's window belongs to the identity that armed it;
+    // the incoming account's first boot measures its own.
+    this.coldStartHoldStartedAt = null;
     for (const record of this.reporters.values()) {
       // Generation high-waters survive (rule 4); only the attachment dies -
       // and with it any handover ceiling that was waiting to retire it. Plain
@@ -1989,6 +2023,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       targetHostId,
       localHostId,
       leases,
+      now,
     );
     return {
       preferredHostId,
@@ -2012,6 +2047,7 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     targetHostId: string | null,
     localHostId: string | null,
     leases: readonly HostLeaseSnapshot[],
+    now: number,
   ): string | null {
     // THE D5/M6 HOLD, and the reason derivation is no longer a pure function
     // of the leases alone. A host that is deliberately cycling keeps serving:
@@ -2027,6 +2063,46 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
       this.leaseFor(effectiveHostId, leases)?.status === "restarting-expected"
     ) {
       return effectiveHostId;
+    }
+    // THE COLD-START HOLD, the D5 hold's mirror for a process that has not
+    // served yet. `mruEffectiveHostIds` is empty until the first non-null
+    // effective of this identity epoch, so this arm can only fire before
+    // anything has served - it can never strand a working session on ∅.
+    // When the LOCAL host is the target and its lease says
+    // `restarting-expected` (the launch reconcile cycling it, a deliberate
+    // restart racing app boot), adopting a usable remote buys a guaranteed
+    // second move: the return-to-target window drags every window back
+    // ~20s later, and each hop re-points every following surface. Answering
+    // ∅ instead lets the window narrator's pre-serve grace render the boot
+    // as a start in progress (`deriveWindowNarration`'s cold-start arm).
+    //
+    // Bounded by ITS OWN ceiling, not the episode's: the lease can sit
+    // `restarting-expected` for the mutation lane's full 15-minute ceiling
+    // when a converge hangs, and a user with a working remote in the fleet
+    // must not stare at the startup card for that. The stamp starts when
+    // the hold first answers and `nextDeadline` wakes derivation at the
+    // ceiling, so a boot that outlives it falls through to the fallback
+    // arms below exactly as before this hold existed - and the shorter
+    // tombstone/outage lapses still end the hold early via their own
+    // deadline arms. LOCAL target only, on purpose: the grace card exists
+    // only where a local host is expected, so holding ∅ for a cycling
+    // REMOTE target would show "no usable host" over a working fallback.
+    if (
+      this.mruEffectiveHostIds.length === 0 &&
+      targetHostId !== null &&
+      targetHostId === localHostId &&
+      this.leaseFor(targetHostId, leases)?.status === "restarting-expected"
+    ) {
+      const holdStartedAt = this.coldStartHoldStartedAt ?? now;
+      this.coldStartHoldStartedAt = holdStartedAt;
+      if (now < holdStartedAt + COLD_START_LOCAL_RESTART_HOLD_CEILING_MS) {
+        return null;
+      }
+      // Ceiling lapsed: the boot is no longer something to wait for. Fall
+      // through with the stamp kept, so a still-restarting target cannot
+      // re-arm a fresh window on the next pass.
+    } else {
+      this.coldStartHoldStartedAt = null;
     }
     if (targetHostId !== null && this.isUsable(targetHostId, leases)) {
       return targetHostId;
@@ -2784,6 +2860,14 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // unrelated report happened to arrive.
     const damping = this.pendingDampingDeadline;
     if (damping !== null) consider(damping);
+    // The cold-start hold's own ceiling: its lapse is what un-sticks the
+    // startup screen when the boot outlives the wait, and on a quiet engine
+    // no report is coming to re-derive it - the same shape as the damping
+    // deadline above.
+    const coldStartHold = this.coldStartHoldStartedAt;
+    if (coldStartHold !== null) {
+      consider(coldStartHold + COLD_START_LOCAL_RESTART_HOLD_CEILING_MS);
+    }
     // A failed ensure holds the local lease dead for a cooldown; the lapse is
     // a lease change with no new evidence behind it, and it is what lets the
     // engine ask again.

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -2136,27 +2136,31 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // only where a local host is expected, so holding ∅ for a cycling REMOTE
     // target would show "no usable host" over a working fallback.
     //
-    // AND ONLY FROM ∅, which is the whole of what the second arm optimizes: a
-    // window that has nothing, deciding whether to grab a fallback it will
-    // hand straight back. Once something IS effective there is no flick left
-    // to prevent, and holding anyway would CAUSE the outage it exists to
-    // avoid - dial refusals move the app to remote R, a restart intent later
-    // flips local L's lease from `dead` to `restarting-expected`, and a
-    // target-side hold would drop a working R to ∅ for the ceiling. The
-    // incumbent arm above is the one that speaks for a serving host, and it
-    // asks about the INCUMBENT's lease precisely so a target that is not
-    // serving anyone cannot answer for it.
-    const awaitedHostId =
-      restartingIncumbentHostId ??
-      (effectiveHostId === null &&
+    // WHO IS BEING WAITED ON is a question about the LEASES, and is answered
+    // first and separately from whether this pass may wait. That split is not
+    // tidiness: `coldStartHold` is the record of a restart EPISODE, so its
+    // lifetime has to follow the episode rather than follow the arm. Deciding
+    // both at once destroyed the record whenever the arm happened not to
+    // apply, and a destroyed record is an ARMABLE one - the same still-cycling
+    // host could then be granted a second full window later in the same
+    // episode (cold start holds L, ceiling lapses, R is adopted and clears the
+    // record, R dies, and ∅ with L still restarting arms a fresh 20s wait
+    // while a usable Q sits in the fleet). The record now dies with the
+    // restart itself, so a lapse is permanent for that episode and the NEXT
+    // restart still gets its own window.
+    const targetAwaitedHostId =
       targetHostId !== null &&
       targetHostId === localHostId &&
       this.leaseFor(targetHostId, leases)?.status === "restarting-expected"
         ? targetHostId
-        : null);
+        : null;
+    const awaitedHostId = restartingIncumbentHostId ?? targetAwaitedHostId;
     if (awaitedHostId === null) {
       this.coldStartHold = null;
-    } else if (this.holdsForColdStart(awaitedHostId, now)) {
+    } else if (
+      this.coldStartArmApplies(restartingIncumbentHostId) &&
+      this.holdsForColdStart(awaitedHostId, now)
+    ) {
       // An incumbent keeps serving as itself; the target arm can only have
       // been reached from ∅, so its null STAYS at ∅ rather than taking
       // anything away, and the startup card narrates the boot.
@@ -2269,6 +2273,43 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    */
   private hasProvedAliveAtLeastOnce(hostId: string): boolean {
     return this.evidence.get(hostId)?.provedAliveAtLeastOnce === true;
+  }
+
+  /**
+   * Whether THIS PASS may wait at all - the policy half, kept apart from the
+   * "who is cycling" half so the hold record can outlive a pass that declines.
+   *
+   * The incumbent arm always applies: it hands a serving host back to itself,
+   * so waiting costs the user nothing.
+   *
+   * The target arm is a COLD-START arm and is held to that literally - only
+   * from ∅, and only before derivation has ever named a host:
+   *
+   *  - from ∅, because the whole thing it buys is skipping a hop the engine
+   *    would immediately undo. With something already effective there is no
+   *    hop to skip, and answering ∅ would take a working host away.
+   *  - never after derivation has named one, because ∅ is not narrated the
+   *    same way twice. The window narrator softens ∅ to "starting" only
+   *    before the window has been served; afterwards ∅ is the hard
+   *    "No host is available" card. A hold that engages later would sit that
+   *    card in front of a user for the ceiling with a usable host in the
+   *    fleet - the hold buying a modal instead of preventing a flicker.
+   *
+   * `mruEffectiveHostIds` is the honest question HERE even though the
+   * unbounded arm above must not read it. There it would mean "has served",
+   * which it does not (derivation records a host the moment it picks one,
+   * including a local host that is merely `connecting` under our own ensure).
+   * Here it means "has derivation ever pointed anywhere", which is exactly
+   * what it is, and it is used only to make this arm fire LESS.
+   */
+  private coldStartArmApplies(
+    restartingIncumbentHostId: string | null,
+  ): boolean {
+    if (restartingIncumbentHostId !== null) return true;
+    return (
+      this.selection.effectiveHostId === null &&
+      this.mruEffectiveHostIds.length === 0
+    );
   }
 
   /**

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -2135,9 +2135,21 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // LOCAL target only on the second arm, on purpose: the grace card exists
     // only where a local host is expected, so holding ∅ for a cycling REMOTE
     // target would show "no usable host" over a working fallback.
+    //
+    // AND ONLY FROM ∅, which is the whole of what the second arm optimizes: a
+    // window that has nothing, deciding whether to grab a fallback it will
+    // hand straight back. Once something IS effective there is no flick left
+    // to prevent, and holding anyway would CAUSE the outage it exists to
+    // avoid - dial refusals move the app to remote R, a restart intent later
+    // flips local L's lease from `dead` to `restarting-expected`, and a
+    // target-side hold would drop a working R to ∅ for the ceiling. The
+    // incumbent arm above is the one that speaks for a serving host, and it
+    // asks about the INCUMBENT's lease precisely so a target that is not
+    // serving anyone cannot answer for it.
     const awaitedHostId =
       restartingIncumbentHostId ??
-      (targetHostId !== null &&
+      (effectiveHostId === null &&
+      targetHostId !== null &&
       targetHostId === localHostId &&
       this.leaseFor(targetHostId, leases)?.status === "restarting-expected"
         ? targetHostId
@@ -2145,8 +2157,9 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     if (awaitedHostId === null) {
       this.coldStartHold = null;
     } else if (this.holdsForColdStart(awaitedHostId, now)) {
-      // An incumbent keeps serving as itself; a target that is not effective
-      // yet answers ∅ so the startup card narrates the boot.
+      // An incumbent keeps serving as itself; the target arm can only have
+      // been reached from ∅, so its null STAYS at ∅ rather than taking
+      // anything away, and the startup card narrates the boot.
       return restartingIncumbentHostId !== null ? awaitedHostId : null;
     }
     // Ceiling lapsed: the boot is no longer something to wait for, and the

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -523,6 +523,21 @@ interface HostEvidence {
   /** Authority-local deadline of the current tombstone episode, if any. */
   restartEpisodeEndsAt: number | null;
   /**
+   * Whether this host has EVER answered this process - any of the four proof
+   * kinds that funnel through {@link
+   * SelectionAuthorityEngineImpl.onHostProvedAlive} (a dial success, a session
+   * appearing, an announcement, a successful ensure).
+   *
+   * Unlike every other field here it is a LATCH, never cleared by later
+   * evidence: it records that the host was reachable once, which is what
+   * separates "deliberately cycling machine that works" from "machine this
+   * process has never reached". The D5/M6 restart hold is unbounded only for
+   * the former; see `deriveDesiredEffective`. A host leaving the fleet prunes
+   * the record, and an identity transition clears it, so neither carries a
+   * stale claim.
+   */
+  provedAliveAtLeastOnce: boolean;
+  /**
    * When this host's last live session ended WHILE IT WAS THE EFFECTIVE HOST,
    * or null (B1/C6). Only armed for the host the app is actually pointed at:
    * an idle host nobody is talking to produces no evidence either, and
@@ -540,6 +555,7 @@ function emptyHostEvidence(): HostEvidence {
     lastCountedRefusalDetail: null,
     compat: null,
     restartEpisodeEndsAt: null,
+    provedAliveAtLeastOnce: false,
     effectiveSessionLostAt: null,
   };
 }
@@ -793,13 +809,17 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    */
   private pendingDampingDeadline: number | null = null;
   /**
-   * When the cold-start hold first answered ∅ for a restarting local target,
-   * or null while the hold is not engaged (see `deriveDesiredEffective`).
-   * Cleared whenever the hold's premise stops holding, so a later episode
-   * measures its own window; kept across a lapsed ceiling, so a boot that
-   * outlived it cannot re-arm a fresh one.
+   * The host the cold-start hold is waiting on and when that wait began, or
+   * null while the hold is not engaged (see `deriveDesiredEffective`).
+   *
+   * Keyed by host because the local identity can be REPLACED mid-hold - the
+   * desktop fleet port republishes when its local host id changes - and the
+   * new host deserves its own bounded window rather than the remainder of the
+   * old one's. Cleared whenever the premise stops holding, so a later episode
+   * measures its own window; kept across a lapsed ceiling, so the same boot
+   * cannot re-arm a fresh one.
    */
-  private coldStartHoldStartedAt: number | null = null;
+  private coldStartHold: { hostId: string; startedAt: number } | null = null;
   /**
    * The in-flight local `ensure`, or null (D14).
    *
@@ -1411,6 +1431,9 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
    */
   private onHostProvedAlive(hostId: string): void {
     const evidence = this.hostEvidence(hostId);
+    // The latch, set at the one funnel every proof kind already passes
+    // through, so no producer has to remember it separately.
+    evidence.provedAliveAtLeastOnce = true;
     evidence.refusalStreak = 0;
     evidence.lastCountedRefusalDetail = null;
     evidence.restartEpisodeEndsAt = null;
@@ -1892,9 +1915,11 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     this.options.preferredStore.save(outgoingIdentityKey, null);
     this.preferredHostId = this.options.preferredStore.load(this.identityKey);
     this.mruEffectiveHostIds.length = 0;
-    // The cold-start hold's window belongs to the identity that armed it;
-    // the incoming account's first boot measures its own.
-    this.coldStartHoldStartedAt = null;
+    // The cold-start hold's window belongs to the identity that armed it; the
+    // incoming account's first boot measures its own. (The per-host
+    // proved-alive latch that exempts a restart from it rides `this.evidence`,
+    // which this transition clears a few lines below.)
+    this.coldStartHold = null;
     for (const record of this.reporters.values()) {
       // Generation high-waters survive (rule 4); only the attachment dies -
       // and with it any handover ceiling that was waiting to retire it. Plain
@@ -2057,53 +2082,75 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // third machine and dragged back 15-30s later. The exemption is a property
     // of the CURRENT EFFECTIVE lease, not of the preferred host - that is
     // exactly what M6 corrected.
+    //
+    // AT FULL (UNBOUNDED) STRENGTH ONLY FOR A HOST THIS PROCESS HAS ACTUALLY
+    // REACHED. That is what the hold is for: a working machine the user would
+    // otherwise be thrown off of, and dragged back to 15-30s later. A host
+    // that has never once answered is not that - it is a boot that may never
+    // finish - so it falls to the bounded hold below.
     const effectiveHostId = this.selection.effectiveHostId;
-    if (
+    const restartingIncumbentHostId =
       effectiveHostId !== null &&
       this.leaseFor(effectiveHostId, leases)?.status === "restarting-expected"
-    ) {
-      return effectiveHostId;
-    }
-    // THE COLD-START HOLD, the D5 hold's mirror for a process that has not
-    // served yet. `mruEffectiveHostIds` is empty until the first non-null
-    // effective of this identity epoch, so this arm can only fire before
-    // anything has served - it can never strand a working session on ∅.
-    // When the LOCAL host is the target and its lease says
-    // `restarting-expected` (the launch reconcile cycling it, a deliberate
-    // restart racing app boot), adopting a usable remote buys a guaranteed
-    // second move: the return-to-target window drags every window back
-    // ~20s later, and each hop re-points every following surface. Answering
-    // ∅ instead lets the window narrator's pre-serve grace render the boot
-    // as a start in progress (`deriveWindowNarration`'s cold-start arm).
-    //
-    // Bounded by ITS OWN ceiling, not the episode's: the lease can sit
-    // `restarting-expected` for the mutation lane's full 15-minute ceiling
-    // when a converge hangs, and a user with a working remote in the fleet
-    // must not stare at the startup card for that. The stamp starts when
-    // the hold first answers and `nextDeadline` wakes derivation at the
-    // ceiling, so a boot that outlives it falls through to the fallback
-    // arms below exactly as before this hold existed - and the shorter
-    // tombstone/outage lapses still end the hold early via their own
-    // deadline arms. LOCAL target only, on purpose: the grace card exists
-    // only where a local host is expected, so holding ∅ for a cycling
-    // REMOTE target would show "no usable host" over a working fallback.
+        ? effectiveHostId
+        : null;
     if (
-      this.mruEffectiveHostIds.length === 0 &&
-      targetHostId !== null &&
+      restartingIncumbentHostId !== null &&
+      this.hasProvedAliveAtLeastOnce(restartingIncumbentHostId)
+    ) {
+      this.coldStartHold = null;
+      return restartingIncumbentHostId;
+    }
+    // THE COLD-START HOLD: a restarting host worth waiting for, but only for
+    // a bounded window, because nothing has proved it can serve anyone.
+    //
+    // Two shapes reach it - the same situation seen from either side of the
+    // first derivation, which is why one rule covers both:
+    //
+    //  - the local TARGET is cycling and nothing is effective yet: answer ∅,
+    //    which the window narrator's pre-serve grace renders as a start in
+    //    progress (`deriveWindowNarration`'s cold-start arm) rather than as a
+    //    verdict. Adopting a usable remote instead buys a guaranteed second
+    //    move - the return-to-target window drags every window back ~20s
+    //    later, re-pointing every following surface twice.
+    //  - the UNPROVEN INCUMBENT is cycling: keep it, for the same reason and
+    //    the same bounded span. It narrates as cold-start too (an effective
+    //    host that has never served this window).
+    //
+    // Why proof of life and not "has anything been effective": `noteEffective`
+    // records a host the moment derivation picks it, and the local host is
+    // picked while it reads `connecting` under the engine's OWN in-flight
+    // ensure - i.e. while nothing has reached it. Gating on that would let a
+    // launch that hangs AFTER the fleet resolved take the unbounded arm above
+    // and pin the startup card for the outage ceiling's 15 minutes, with a
+    // usable remote sitting in the fleet. `onHostProvedAlive` is the one
+    // funnel all four proof kinds pass through, so the latch it sets is the
+    // honest form of the question.
+    //
+    // Keyed by the awaited host, so a fleet update that replaces the local
+    // identity gives the NEW host its own window instead of inheriting the
+    // old one's elapsed time; kept across a lapse, so the same host cannot
+    // re-arm a fresh window; cleared the moment the premise stops holding.
+    //
+    // LOCAL target only on the second arm, on purpose: the grace card exists
+    // only where a local host is expected, so holding ∅ for a cycling REMOTE
+    // target would show "no usable host" over a working fallback.
+    const awaitedHostId =
+      restartingIncumbentHostId ??
+      (targetHostId !== null &&
       targetHostId === localHostId &&
       this.leaseFor(targetHostId, leases)?.status === "restarting-expected"
-    ) {
-      const holdStartedAt = this.coldStartHoldStartedAt ?? now;
-      this.coldStartHoldStartedAt = holdStartedAt;
-      if (now < holdStartedAt + COLD_START_LOCAL_RESTART_HOLD_CEILING_MS) {
-        return null;
-      }
-      // Ceiling lapsed: the boot is no longer something to wait for. Fall
-      // through with the stamp kept, so a still-restarting target cannot
-      // re-arm a fresh window on the next pass.
-    } else {
-      this.coldStartHoldStartedAt = null;
+        ? targetHostId
+        : null);
+    if (awaitedHostId === null) {
+      this.coldStartHold = null;
+    } else if (this.holdsForColdStart(awaitedHostId, now)) {
+      // An incumbent keeps serving as itself; a target that is not effective
+      // yet answers ∅ so the startup card narrates the boot.
+      return restartingIncumbentHostId !== null ? awaitedHostId : null;
     }
+    // Ceiling lapsed: the boot is no longer something to wait for, and the
+    // arms below pick a fallback exactly as they did before this hold existed.
     if (targetHostId !== null && this.isUsable(targetHostId, leases)) {
       return targetHostId;
     }
@@ -2200,6 +2247,32 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // quiet would never be returned to.
     this.pendingDampingDeadline = admissibleAt;
     return effectiveHostId;
+  }
+
+  /**
+   * Whether this host has ever answered this process. See
+   * {@link HostEvidence.provedAliveAtLeastOnce}; absence of a record means
+   * nothing was ever reported for the host, which is not proof of anything.
+   */
+  private hasProvedAliveAtLeastOnce(hostId: string): boolean {
+    return this.evidence.get(hostId)?.provedAliveAtLeastOnce === true;
+  }
+
+  /**
+   * Whether the cold-start hold may still wait on `hostId`, arming or
+   * re-keying its window as a side effect.
+   *
+   * Re-keying on a different host is what stops a replacement local identity
+   * from inheriting the old host's elapsed time; keeping the stamp once the
+   * ceiling has lapsed is what stops the same host from re-arming a fresh
+   * window on the very next pass.
+   */
+  private holdsForColdStart(hostId: string, now: number): boolean {
+    const hold = this.coldStartHold;
+    const startedAt =
+      hold !== null && hold.hostId === hostId ? hold.startedAt : now;
+    this.coldStartHold = { hostId, startedAt };
+    return now < startedAt + COLD_START_LOCAL_RESTART_HOLD_CEILING_MS;
   }
 
   private leaseFor(
@@ -2864,9 +2937,11 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     // startup screen when the boot outlives the wait, and on a quiet engine
     // no report is coming to re-derive it - the same shape as the damping
     // deadline above.
-    const coldStartHold = this.coldStartHoldStartedAt;
+    const coldStartHold = this.coldStartHold;
     if (coldStartHold !== null) {
-      consider(coldStartHold + COLD_START_LOCAL_RESTART_HOLD_CEILING_MS);
+      consider(
+        coldStartHold.startedAt + COLD_START_LOCAL_RESTART_HOLD_CEILING_MS,
+      );
     }
     // A failed ensure holds the local lease dead for a cooldown; the lapse is
     // a lease change with no new evidence behind it, and it is what lets the


### PR DESCRIPTION
Two halves of one field report: *"This notification could have been just a toast and not persistent. Also, after I sent the above video and went back to the app, I was switched to another of my remote hosts automatically, and then, after a few seconds, it switched back to my local."* The reporter's final screenshot shows the banner naming **their own machine** — reproduced independently on a maintainer's laptop at app startup.

## 1. The re-point notice is a toast, and a conditional one

`ComposerHostNotice`'s `repointed` kind fired on **every** effective-host derivation move under a following composer, unconditionally — even when nothing was staged — and persisted until dismissed. A failover→recovery round trip therefore set it twice, the second overwriting the first, leaving a permanent banner announcing the host the user was on all along.

The staged worktree/branch **reset is unchanged** (those choices name paths and refs on the machine they were picked on, and must not silently travel). Only the narration moved: `toastRepointedStagingReset`, fired **only when the move actually reset staged intent**. A move that reset nothing is silent — `toastSelectionSwitched` already narrates failover/recovery, and the contract's own toast rule says a `fleet-shift` is bookkeeping, not a move the user must act on.

The inline slot keeps only the `refused` kind, which genuinely must not scroll away: it is a submit-time blocker, and a toast that disappears leaves the user pressing send on a composer that still looks fine.

## 2. Cold start waits for a restarting local host instead of flicking to a remote

At cold start the engine derives from `effectiveHostId === null` — the **NoHost** phase, where `applyDamping` deliberately applies **no window**. If the local host is mid-cycle (the launch reconcile, a deliberate restart racing app boot) its lease is `restarting-expected`, which `isUsableForSelection` excludes, so derivation adopted whatever remote was usable **instantly**. The engine was then `FailedOver`, so returning to the local target required the full `RETURN_TO_TARGET_STABILITY_MS` — hence: remote, ~20s, back to local. Two switch toasts, two re-points of every following surface, and the banner above.

`deriveDesiredEffective` now holds: while `mruEffectiveHostIds` is empty (nothing has ever served this identity epoch) and the **local** target's lease is `restarting-expected`, it answers `null`. That renders as the existing pre-serve grace card — "a start in progress, not a verdict" — with the boot's own stage bar and log disclosure, which `deriveWindowNarration` already implements and already documents this exact case. The app then lands on the local host **once**, silently.

Local target only: the grace card exists only where a local host is expected, so holding ∅ for a cycling *remote* target would show "no usable host" over a working fallback.

### The startup screen cannot stick

The hold carries its **own** ceiling, `COLD_START_LOCAL_RESTART_HOLD_CEILING_MS = RETURN_TO_TARGET_STABILITY_MS = 20s`, with its own `nextDeadline` arm, because the episode's bounds are **not** uniformly short — a restart tombstone lapses in 60s, but the mutation-lane arm holds `restarting-expected` for `LOCAL_EXPECTED_OUTAGE_CEILING_MS` (**15 minutes**), and a hung converge must not pin the startup screen while a working remote sits in the fleet.

The equality is the argument for the hold itself: adopting a fallback at t=0 puts the user on the target no earlier than boot + the return window, so waiting up to that same window is **never slower to the target** — it only trades ≤20s of fallback availability for zero hop churn in the common case where the boot takes seconds. Past the ceiling the fallback is adopted exactly as before this hold existed; the stamp is kept across the lapse so a still-restarting target cannot re-arm a fresh window, and it clears on identity transition.

Unchanged: no remote in the fleet (∅ with boot diagnostics and Retry was already the only honest answer), and anything mid-session — the `mruEffectiveHostIds` conjunct means the hold can never strand a working session.

## Tests

- **`selection-authority-engine.test.ts`** — 118 pass (5 new, 113 pre-existing unchanged; no existing pin needed updating). New: hold engages within the window; lands on the target once (asserted over the full event log — no `selection` event ever carries the remote); **bounded with the outage signal held true the entire time, falling through at exactly 20s via the engine's own deadline timer** — the stuck-startup-screen regression; post-ceiling recovery uses the ordinary return window with no special-casing; not-a-cold-start unaffected; remote target unaffected.
- **gui-app** — 17 pass across both composer surfaces: staged → cleared + one toast with the new host's label + no banner; unstaged → cleared, silent; pinned/non-following → neither.

Both packages compile clean; pre-commit (build/compile/lint/format) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)