### PR TITLE
fix(gui-app): rehydrate persisted history search against defaults

### DIFF
--- a/clients/gui-app/src/lib/history-search.ts
+++ b/clients/gui-app/src/lib/history-search.ts
@@ -82,6 +82,52 @@ export const DEFAULT_HISTORY_SEARCH: HistorySearchState = {
   sortExplicit: false,
 };
 
+const persistedHistorySearchSchema = z.object({
+  query: z.string().optional(),
+  repos: z.array(z.string()).optional(),
+  repoMode: historyMatchModeSchema.optional(),
+  workspaces: z
+    .array(z.object({ hostId: z.string(), workspacePath: z.string() }))
+    .optional(),
+  workspaceMode: historyMatchModeSchema.optional(),
+  chatHosts: z.array(z.string()).optional(),
+  chatHostMode: historyMatchModeSchema.optional(),
+  ownershipScopes: z.array(historyOwnershipSchema).optional(),
+  sort: historySortSchema.optional(),
+  sortExplicit: z.boolean().optional(),
+});
+
+/**
+ * Total over unknown persisted shapes. A stored `search` written by a build
+ * that predates a field addition (e.g. `chatHosts`, #1303) is missing that
+ * field entirely, and zustand's default rehydration merge takes the nested
+ * object verbatim - so every reader of the new field would crash on
+ * `undefined`. Fill absent fields from defaults instead of trusting the
+ * persisted shape to match the current `HistorySearchState`.
+ */
+export function normalizePersistedHistorySearch(
+  value: unknown,
+): HistorySearchState {
+  const parsed = persistedHistorySearchSchema.safeParse(value);
+  if (!parsed.success) return DEFAULT_HISTORY_SEARCH;
+  return {
+    query: parsed.data.query ?? DEFAULT_HISTORY_SEARCH.query,
+    repos: parsed.data.repos ?? DEFAULT_HISTORY_SEARCH.repos,
+    repoMode: parsed.data.repoMode ?? DEFAULT_HISTORY_SEARCH.repoMode,
+    workspaces: parsed.data.workspaces ?? DEFAULT_HISTORY_SEARCH.workspaces,
+    workspaceMode:
+      parsed.data.workspaceMode ?? DEFAULT_HISTORY_SEARCH.workspaceMode,
+    chatHosts: parsed.data.chatHosts ?? DEFAULT_HISTORY_SEARCH.chatHosts,
+    chatHostMode:
+      parsed.data.chatHostMode ?? DEFAULT_HISTORY_SEARCH.chatHostMode,
+    ownershipScopes:
+      parsed.data.ownershipScopes ?? DEFAULT_HISTORY_SEARCH.ownershipScopes,
+    sort: parsed.data.sort ?? DEFAULT_HISTORY_SEARCH.sort,
+    sortExplicit:
+      parsed.data.sortExplicit ?? DEFAULT_HISTORY_SEARCH.sortExplicit,
+  };
+}
+
 export function parseHistorySearch(
   raw: Record<string, unknown>,
 ): HistorySearchState {

--- a/clients/gui-app/src/stores/home/__tests__/history-search-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/history-search-store.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_HISTORY_SEARCH,
+  type HistorySearchState,
+} from "@/lib/history-search";
+import { useHistorySearchStore } from "@/stores/home/history-search-store";
+
+// Hand-transcribed from `HISTORY_SEARCH_PERSIST_KEY` in
+// `history-search-store.ts` (`persistKey(STORE_KEYS.historySearch)`), not
+// derived from the builder - a divergence must fail HERE rather than pass a
+// circular comparison against itself (see `src/lib/persist/__tests__/keys.test.ts`).
+const HISTORY_SEARCH_PERSIST_KEY = "traycer-gui-app:history-search";
+
+describe("useHistorySearchStore persisted-state rehydration", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useHistorySearchStore.setState({ search: DEFAULT_HISTORY_SEARCH });
+  });
+
+  it("fills in chatHosts/chatHostMode missing from a pre-#1303 persisted payload while preserving the fields it did carry", async () => {
+    window.localStorage.setItem(
+      HISTORY_SEARCH_PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          search: {
+            query: "auth",
+            repos: ["traycerai/traycer"],
+            repoMode: "any",
+            workspaces: [],
+            workspaceMode: "any",
+            ownershipScopes: ["mine"],
+            sort: "oldest",
+            sortExplicit: true,
+          },
+        },
+        version: 1,
+      }),
+    );
+
+    // The former crash site: rehydrating pre-#1303 state must not leave
+    // `chatHosts` undefined for the renderer's `.length` read.
+    await useHistorySearchStore.persist.rehydrate();
+
+    const search = useHistorySearchStore.getState().search;
+    expect(search.chatHosts).toEqual([]);
+    expect(search.chatHostMode).toBe("any");
+    // Fields the older build DID persist must survive the normalization,
+    // not silently fall back to defaults alongside the missing ones.
+    expect(search.query).toBe("auth");
+    expect(search.repos).toEqual(["traycerai/traycer"]);
+    expect(search.repoMode).toBe("any");
+    expect(search.workspaces).toEqual([]);
+    expect(search.workspaceMode).toBe("any");
+    expect(search.ownershipScopes).toEqual(["mine"]);
+    expect(search.sort).toBe("oldest");
+    expect(search.sortExplicit).toBe(true);
+  });
+
+  it("falls back to DEFAULT_HISTORY_SEARCH for a corrupted (non-object) persisted `search` instead of throwing", async () => {
+    window.localStorage.setItem(
+      HISTORY_SEARCH_PERSIST_KEY,
+      JSON.stringify({ state: { search: "garbage" }, version: 1 }),
+    );
+
+    // Rehydration must complete without throwing, unlike the old verbatim
+    // shallow merge, which handed a string to every `HistorySearchState` reader.
+    await useHistorySearchStore.persist.rehydrate();
+
+    expect(useHistorySearchStore.getState().search).toEqual(
+      DEFAULT_HISTORY_SEARCH,
+    );
+  });
+
+  it("round-trips a current-shape persisted state, including chatHosts/chatHostMode, unchanged", async () => {
+    const persistedSearch: HistorySearchState = {
+      query: "bug",
+      repos: ["traycerai/traycer"],
+      repoMode: "all",
+      workspaces: [{ hostId: "host-a", workspacePath: "/tmp/ws" }],
+      workspaceMode: "any",
+      chatHosts: ["host-a", "host-b"],
+      chatHostMode: "all",
+      ownershipScopes: ["mine", "shared"],
+      sort: "title-asc",
+      sortExplicit: true,
+    };
+    window.localStorage.setItem(
+      HISTORY_SEARCH_PERSIST_KEY,
+      JSON.stringify({ state: { search: persistedSearch }, version: 1 }),
+    );
+
+    await useHistorySearchStore.persist.rehydrate();
+
+    expect(useHistorySearchStore.getState().search).toEqual(persistedSearch);
+  });
+});

--- a/clients/gui-app/src/stores/home/history-search-store.ts
+++ b/clients/gui-app/src/stores/home/history-search-store.ts
@@ -3,6 +3,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
 import {
   DEFAULT_HISTORY_SEARCH,
+  normalizePersistedHistorySearch,
   patchHistorySearch,
   type HistorySearchPatch,
   type HistorySearchState,
@@ -47,6 +48,20 @@ export const useHistorySearchStore = create<HistorySearchStoreState>()(
       storage: createJSONStorage(() => localStorage),
       // Persist only the data; the actions come from the initializer on rehydrate.
       partialize: (state) => ({ search: state.search }),
+      // The default shallow merge takes the persisted `search` verbatim, so a
+      // value written before a `HistorySearchState` field existed rehydrates
+      // without it and every `.length` read on the new field crashes the
+      // renderer (chatHosts, #1303). Normalize against defaults instead.
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        search: normalizePersistedHistorySearch(
+          isRecord(persistedState) ? persistedState.search : undefined,
+        ),
+      }),
     },
   ),
 );
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}


### PR DESCRIPTION
## Problem

#1303 added `chatHosts` / `chatHostMode` to `HistorySearchState`. The ambient history surfaces (home page's embedded epics list, history modal) read that state from the persisted `useHistorySearchStore` (localStorage `traycer-gui-app:history-search`). Zustand's default rehydration merge is shallow at the top level, so a `search` object persisted by a pre-#1303 build rehydrates **verbatim** — no `chatHosts` — and the first render of the epics list crashes the renderer:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at listCloudTasksRequestForHistorySearch (cloud-epic-tasks-query/query.ts:122)
    at EpicsListPanel render
```

Deterministic on every launch; "Refresh window" can never clear it because the poisoned state is persisted. Reproduced live on a staging install upgrading across #1303 (stack captured via CDP; persisted payload verified missing the fields). Every existing install that ever touched the ambient search/filter hits this on its first launch after updating to a build containing #1303 — the `/epics` route is unaffected because `parseHistorySearch` defaults every field from the URL.

## Fix

Add a `merge` to the store that routes the persisted value through a new `normalizePersistedHistorySearch` (zod-validated, same vocabulary as `parseHistorySearch`): absent fields fill from `DEFAULT_HISTORY_SEARCH`, unparseable input falls back to full defaults. This is the same merge-normalization pattern `landing-draft-store` and `workspace-folders-store` already use for this bug class, and it makes the next `HistorySearchState` field addition safe by construction — normalization runs on every rehydrate, unlike `migrate`, which never fires while the version stays at 1.

## Tests

`src/stores/home/__tests__/history-search-store.test.ts` — rehydrates via `persist.rehydrate()` (same code path as module-load hydration):
- pre-#1303 payload → `chatHosts: []` / `chatHostMode: "any"`, all carried fields preserved
- corrupted non-object `search` → full defaults, no throw
- current-shape payload (with chat-host fields) → round-trips unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)