### PR TITLE
feat(protocol,shared,gui-app): bound managed command output windows

### DIFF
--- a/clients/gui-app/src/__tests__/acceptance/managed-command-s4-output-window.test.tsx
+++ b/clients/gui-app/src/__tests__/acceptance/managed-command-s4-output-window.test.tsx
@@ -127,6 +127,7 @@ interface OutputWire {
 
 let wire: OutputWire | null = null;
 let epicHandle: OpenEpicStoreHandle | null = null;
+let restoreLayoutGeometry: () => void;
 // Counts every stream open, mount and Retry alike - a Retry test's proof that
 // it opened a NEW stream rather than resuming the failed one.
 let outputWireFactoryCalls = 0;
@@ -153,6 +154,14 @@ function installOutputWire(over: {
           // Everything the viewer sends must itself be a valid client frame.
           current.sentLoadOlder.push(
             managedCommandSubscribeOutputClientFrameSchema.parse(frame),
+          );
+        },
+        resnapshot: () => {
+          current.sentLoadOlder.push(
+            managedCommandSubscribeOutputClientFrameSchema.parse({
+              kind: "resnapshot",
+              hasBinaryPayload: false,
+            }),
           );
         },
         close: () => undefined,
@@ -223,10 +232,14 @@ function emitOutput(lines: readonly ManagedCommandLogLine[]): void {
     kind: "output",
     hasBinaryPayload: false,
     lines,
+    start: { segmentId: "seg-live", byteOffset: T0 },
   });
   if (frame.kind !== "output") throw new Error("unreachable");
   act(() => {
-    connectedWire().callbacks.onOutput(frame.lines);
+    connectedWire().callbacks.onOutput({
+      lines: frame.lines,
+      start: frame.start,
+    });
   });
 }
 
@@ -331,6 +344,21 @@ function setScrollGeometry(
 const START: ManagedCommandLogPosition = { segmentId: "seg-2", byteOffset: 0 };
 
 beforeEach(() => {
+  // The virtualizer reads offset geometry as it attaches. Give jsdom a real
+  // viewport and realistic row heights; per-test scroll geometry below still
+  // owns the follow/load-older decisions being exercised.
+  const heightSpy = vi
+    .spyOn(HTMLElement.prototype, "offsetHeight", "get")
+    .mockImplementation(function (this: HTMLElement) {
+      return this.dataset.index === undefined ? 600 : 24;
+    });
+  const widthSpy = vi
+    .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+    .mockReturnValue(800);
+  restoreLayoutGeometry = () => {
+    heightSpy.mockRestore();
+    widthSpy.mockRestore();
+  };
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useEpicCanvasStore.setState({
     tabsById: { [TAB_ID]: { tabId: TAB_ID, epicId: EPIC_ID, name: "Epic" } },
@@ -344,6 +372,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  restoreLayoutGeometry();
   __setManagedCommandOutputStreamClientFactoryForTests(null);
   epicHandle?.dispose();
   epicHandle = null;
@@ -471,12 +500,31 @@ describe("S4 · output window", () => {
     fireEvent.scroll(view);
     expect(screen.getByTestId("managed-command-output-jump-live")).toBeTruthy();
 
-    // ...so new lines no longer move the view.
+    // ...so new lines are discarded from the held history window and only
+    // advertise that fresh output is available.
     emitOutput([{ channel: "stdout", text: "line 2", atMs: T0 + 2 }]);
     expect(view.scrollTop).toBe(100);
+    expect(
+      screen.getByTestId("managed-command-output-jump-live").textContent,
+    ).toContain("New output available");
 
-    // The jump-to-live affordance resumes following.
+    // Jump requests one positioned replacement snapshot. The stale history
+    // stays put until that snapshot lands; no disconnected output is appended.
     fireEvent.click(screen.getByTestId("managed-command-output-jump-live"));
+    expect(connectedWire().sentLoadOlder).toContainEqual({
+      kind: "resnapshot",
+      hasBinaryPayload: false,
+    });
+    expect(view.scrollTop).toBe(100);
+    emitSnapshot({
+      command: makeCommand({}),
+      lines: [
+        { channel: "stdout", text: "line 1", atMs: T0 + 1 },
+        { channel: "stdout", text: "line 2", atMs: T0 + 2 },
+      ],
+      start: START,
+      reachedStart: false,
+    });
     expect(view.scrollTop).toBe(1_000);
     expect(screen.queryByTestId("managed-command-output-jump-live")).toBeNull();
     emitOutput([{ channel: "stdout", text: "line 3", atMs: T0 + 3 }]);

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx
@@ -45,6 +45,22 @@ const boundHostSupport = vi.hoisted<{ value: StreamMethodSupport }>(() => ({
   value: "supported",
 }));
 
+const virtualizerConfig = vi.hoisted<{ useFlushSync: boolean | null }>(() => ({
+  useFlushSync: null,
+}));
+
+vi.mock("@tanstack/react-virtual", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-virtual")>();
+  return {
+    ...actual,
+    useVirtualizer: (options: Parameters<typeof actual.useVirtualizer>[0]) => {
+      virtualizerConfig.useFlushSync = options.useFlushSync ?? null;
+      return actual.useVirtualizer(options);
+    },
+  };
+});
+
 vi.mock("@/hooks/agent/use-host-reachability", () => ({
   useHostReachability: () => ({
     status: reachability.value,
@@ -141,6 +157,7 @@ const noopStreamClientFactory: EpicStreamClientFactory = () => ({
 
 let epicHandle: OpenEpicStoreHandle;
 let sentFrames: ManagedCommandSubscribeOutputClientFrame[];
+let restoreLayoutGeometry: () => void;
 
 /**
  * `factoryCalls` lets a Retry test prove a fresh stream was actually opened
@@ -167,6 +184,9 @@ function installOutputStub(): {
       return {
         loadOlder: (frame) => {
           sentFrames.push(frame);
+        },
+        resnapshot: () => {
+          sentFrames.push({ kind: "resnapshot", hasBinaryPayload: false });
         },
         close: () => undefined,
         streamMethodSupport: boundStreamMethodSupport,
@@ -291,7 +311,7 @@ function setScrollGeometry(
 }
 
 function timeline(): HTMLElement {
-  return screen.getByRole("log");
+  return screen.getByTestId("managed-command-output-timeline");
 }
 
 function rowChannels(): string[] {
@@ -301,9 +321,25 @@ function rowChannels(): string[] {
 }
 
 beforeEach(() => {
+  // TanStack Virtual reads offset geometry synchronously when the scroll
+  // element attaches. jsdom's permanent 0x0 default would otherwise describe
+  // a genuinely invisible viewport and correctly produce no virtual rows.
+  const heightSpy = vi
+    .spyOn(HTMLElement.prototype, "offsetHeight", "get")
+    .mockImplementation(function (this: HTMLElement) {
+      return this.dataset.index === undefined ? 600 : 24;
+    });
+  const widthSpy = vi
+    .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+    .mockReturnValue(800);
+  restoreLayoutGeometry = () => {
+    heightSpy.mockRestore();
+    widthSpy.mockRestore();
+  };
   reachability.value = "reachable";
   defaultHostSupport.value = "supported";
   boundHostSupport.value = "supported";
+  virtualizerConfig.useFlushSync = null;
   sentFrames = [];
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useEpicCanvasStore.setState({
@@ -321,6 +357,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  restoreLayoutGeometry();
   __setManagedCommandOutputStreamClientFactoryForTests(null);
   epicHandle.dispose();
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
@@ -375,6 +412,25 @@ describe("managed-command output window", () => {
     expect(
       screen.getAllByTestId(/^managed-command-output-time-/)[0].textContent,
     ).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+  });
+
+  it("mounts only a viewport-sized window for a large output timeline", () => {
+    const stub = installOutputStub();
+    renderTile();
+
+    openAtTail(
+      stub.emit,
+      Array.from({ length: 10_000 }, (_, index) =>
+        line("stdout", `line-${index}`),
+      ),
+    );
+
+    const mountedRows = screen.queryAllByTestId(
+      /^managed-command-output-line-/,
+    );
+    expect(mountedRows.length).toBeGreaterThan(0);
+    expect(mountedRows.length).toBeLessThan(100);
+    expect(virtualizerConfig.useFlushSync).toBe(false);
   });
 
   it("floats live status over the log instead of titling itself", () => {
@@ -520,6 +576,41 @@ describe("managed-command output window", () => {
     expect(screen.queryByTestId("managed-command-output-jump-live")).toBeNull();
   });
 
+  it("owns Home and End as retained-start and live-tail navigation", () => {
+    const stub = installOutputStub();
+    renderTile();
+    openAtTail(stub.emit, [line("stdout", "held history")]);
+
+    const view = timeline();
+    setScrollGeometry(view, {
+      scrollTop: 1_000,
+      scrollHeight: 4_000,
+      clientHeight: 400,
+    });
+    view.focus();
+
+    expect(view.tabIndex).toBe(0);
+    expect(document.activeElement).toBe(view);
+    expect(fireEvent.keyDown(view, { key: "Home" })).toBe(false);
+    expect(view.scrollTop).toBe(0);
+    expect(sentFrames).toHaveLength(1);
+    expect(sentFrames[0].kind).toBe("loadOlder");
+
+    act(() => {
+      stub.emit().onOutput({
+        lines: [line("stdout", "arrived while paused")],
+        start: { segmentId: "seg-live", byteOffset: 80 },
+      });
+    });
+
+    expect(fireEvent.keyDown(view, { key: "End" })).toBe(false);
+    expect(view.scrollTop).toBe(4_000);
+    expect(sentFrames).toContainEqual({
+      kind: "resnapshot",
+      hasBinaryPayload: false,
+    });
+  });
+
   it("asks for older lines when the viewer reaches the top", () => {
     const stub = installOutputStub();
     renderTile();
@@ -572,6 +663,100 @@ describe("managed-command output window", () => {
     // Chromium's native scroll anchoring cannot save this: the spec disables it
     // at the very top, which is exactly where a load-older fires.
     expect(view.scrollTop).toBe(5_010);
+  });
+
+  it("includes a changed history-marker prefix when a terminal page also evicts the tail", () => {
+    const stub = installOutputStub();
+    renderTile();
+    openAtTail(stub.emit, [line("stdout", "tail-1"), line("stdout", "tail-2")]);
+
+    const view = timeline();
+    setScrollGeometry(view, {
+      scrollTop: 10,
+      scrollHeight: 4_000,
+      clientHeight: 400,
+    });
+    const list = screen.getByTestId("managed-command-output-virtual-list");
+    let listOffsetTop = 16;
+    Object.defineProperty(list, "offsetTop", {
+      configurable: true,
+      get: () => listOffsetTop,
+    });
+
+    // Thirty-nine valid pages leave the quiet command just below the cap.
+    // The fortieth both crosses it (evicting the stale tail) and declares the
+    // retained start, replacing the loading prefix with the terminal marker.
+    for (let page = 0; page < 40; page += 1) {
+      view.scrollTop = 10;
+      fireEvent.scroll(view);
+      const request = sentFrames.at(-1);
+      if (request?.kind !== "loadOlder") {
+        throw new Error("expected loadOlder");
+      }
+      const finalPage = page === 39;
+      // Exaggerated deliberately: TanStack adapts its unmeasured-row estimate
+      // from measured rows, so a distinctive prefix delta isolates the term
+      // this regression owns without coupling to virtualizer internals.
+      if (finalPage) listOffsetTop = 100_016;
+      act(() => {
+        stub.emit().onOlder({
+          requestId: request.requestId,
+          lines: Array.from({ length: 500 }, (_, index) =>
+            line("stdout", `older-${page}-${index}`),
+          ),
+          start: { segmentId: `seg-history-${page}`, byteOffset: 0 },
+          reachedStart: finalPage,
+        });
+      });
+    }
+
+    expect(view.scrollTop).toBeGreaterThan(100_000);
+    expect(screen.getByText("Start of the retained log")).not.toBeNull();
+    expect(screen.queryByText("tail-1")).toBeNull();
+  });
+
+  it("pauses live output while reading history and resnapshots on return to live", () => {
+    const stub = installOutputStub();
+    renderTile();
+    openAtTail(stub.emit, [line("stdout", "held history")]);
+
+    const view = timeline();
+    setScrollGeometry(view, {
+      scrollTop: 1_000,
+      scrollHeight: 4_000,
+      clientHeight: 400,
+    });
+    fireEvent.scroll(view);
+
+    act(() => {
+      stub.emit().onOutput({
+        lines: [line("stdout", "arrived while paused")],
+        start: { segmentId: "seg-live", byteOffset: 80 },
+      });
+    });
+
+    expect(screen.getByText("held history")).not.toBeNull();
+    expect(screen.queryByText("arrived while paused")).toBeNull();
+    expect(
+      screen.getByTestId("managed-command-output-jump-live").textContent,
+    ).toContain("New output available");
+
+    fireEvent.click(screen.getByTestId("managed-command-output-jump-live"));
+
+    expect(sentFrames).toContainEqual({
+      kind: "resnapshot",
+      hasBinaryPayload: false,
+    });
+    expect(
+      screen.getByTestId("managed-command-output-jump-live").textContent,
+    ).toContain("Loading live output");
+
+    openAtTail(stub.emit, [line("stdout", "arrived while paused")]);
+
+    expect(screen.getByText("arrived while paused")).not.toBeNull();
+    expect(screen.queryByText("held history")).toBeNull();
+    expect(screen.queryByTestId("managed-command-output-jump-live")).toBeNull();
+    expect(view.scrollTop).toBe(4_000);
   });
 
   it("drops the cached scrollback with the shell", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/managed-command-output-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/managed-command-output-tile.tsx
@@ -16,10 +16,12 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { useStore } from "zustand";
 import { ArrowDownToLine, Info } from "lucide-react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
@@ -80,6 +82,8 @@ import {
 const FOLLOW_SLACK_PX = 24;
 /** Distance from the top that asks for the next page of older lines. */
 const LOAD_OLDER_THRESHOLD_PX = 48;
+const OUTPUT_VIRTUAL_OVERSCAN = 12;
+const OUTPUT_VIRTUAL_INITIAL_RECT = { width: 0, height: 600 } as const;
 /**
  * One test id for whatever the window has to say instead of (or over) the log;
  * the notice's `data-availability` carries WHICH state it is.
@@ -256,7 +260,18 @@ function ManagedCommandOutputTileBody(props: {
   const connectionStatus = useStore(store, (state) => state.connectionStatus);
   const reachedStart = useStore(store, (state) => state.reachedStart);
   const loadingOlder = useStore(store, (state) => state.loadingOlder);
+  const detached = useStore(store, (state) => state.detached);
+  const resyncPending = useStore(store, (state) => state.resyncPending);
+  const newOutputAvailable = useStore(
+    store,
+    (state) => state.newOutputAvailable,
+  );
+  const timelineGeneration = useStore(
+    store,
+    (state) => state.timelineGeneration,
+  );
   const loadOlder = useStore(store, (state) => state.loadOlder);
+  const setOutputFollowing = useStore(store, (state) => state.setFollowing);
   // Asked of the client this window's own subscription rides on. The app-wide
   // reader answers for the DEFAULT host, and a tab is bound to its own host for
   // life - when the two differ, the default host's answer is about the wrong
@@ -286,6 +301,7 @@ function ManagedCommandOutputTileBody(props: {
     [readingIdentity],
   );
   const viewRef = useRef<HTMLDivElement>(null);
+  const outputListRef = useRef<HTMLDivElement>(null);
   const lastReadingAnchorRef = useRef<ManagedCommandReadingAnchor | null>(
     restoredReadingAnchor,
   );
@@ -293,20 +309,72 @@ function ManagedCommandOutputTileBody(props: {
   const [following, setFollowing] = useState(() =>
     initialManagedCommandFollowing(restoredReadingAnchor),
   );
+  const getScrollElement = useCallback(() => viewRef.current, []);
+  const estimateOutputRowSize = useCallback(
+    () => Math.ceil(terminalFont.fontSize * 1.5),
+    [terminalFont.fontSize],
+  );
+  const getOutputRowKey = useCallback(
+    (index: number) => lines[index]?.seq ?? index,
+    [lines],
+  );
+  // `useVirtualizer` returns fresh function identities each render; the React
+  // Compiler already treats the hook as incompatible, while this component's
+  // own inputs and derived callbacks remain memoized.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const outputVirtualizer = useVirtualizer({
+    count: lines.length,
+    getScrollElement,
+    estimateSize: estimateOutputRowSize,
+    getItemKey: getOutputRowKey,
+    overscan: OUTPUT_VIRTUAL_OVERSCAN,
+    initialRect: OUTPUT_VIRTUAL_INITIAL_RECT,
+    // Row measurement can land while the follow/prepend layout effects are
+    // committing. TanStack's synchronous default calls React `flushSync` from
+    // that ResizeObserver path, which React rejects and which turns a burst of
+    // output into repeated main-thread stalls. A normal scheduled rerender is
+    // sufficient: the estimate is already the exact height for ordinary rows.
+    useFlushSync: false,
+  });
+  const virtualRows = outputVirtualizer.getVirtualItems();
   // What the timeline looked like at the last moment we could measure it:
   // the oldest row's identity, and how tall the document was. A page of older
   // lines prepends content ABOVE the viewport, which slides everything the
   // human is reading down by exactly the height added.
   const anchorRef = useRef<{
     readonly firstSeq: number | null;
+    readonly lastSeq: number | null;
     readonly scrollHeight: number;
-  }>({ firstSeq: null, scrollHeight: 0 });
+    readonly scrollTop: number;
+    readonly listOffsetTop: number;
+  }>({
+    firstSeq: null,
+    lastSeq: null,
+    scrollHeight: 0,
+    scrollTop: 0,
+    listOffsetTop: 0,
+  });
+  const lastTimelineGenerationRef = useRef(timelineGeneration);
 
   const scrollToNewest = useCallback(() => {
     const view = viewRef.current;
     if (view === null) return;
     view.scrollTop = view.scrollHeight;
   }, []);
+
+  const setFollowMode = useCallback(
+    (nextFollowing: boolean) => {
+      setFollowing(nextFollowing);
+      setOutputFollowing(nextFollowing);
+    },
+    [setOutputFollowing],
+  );
+
+  // Seed the store before any user scroll. A restored, scrolled-back reader
+  // must keep their held history even if output lands immediately after mount.
+  useLayoutEffect(() => {
+    setOutputFollowing(following);
+  }, [following, setOutputFollowing]);
 
   const captureReadingPosition = useCallback((): void => {
     const view = viewRef.current;
@@ -372,23 +440,64 @@ function ManagedCommandOutputTileBody(props: {
     const view = viewRef.current;
     if (view === null) return;
     const firstSeq = lines.length > 0 ? lines[0].seq : null;
+    const lastSeq = lines.length > 0 ? lines[lines.length - 1].seq : null;
     const previous = anchorRef.current;
+    const listOffsetTop = outputListRef.current?.offsetTop ?? 0;
     const prepended =
       previous.firstSeq !== null &&
       firstSeq !== null &&
       firstSeq < previous.firstSeq;
     if (prepended) {
-      view.scrollTop += view.scrollHeight - previous.scrollHeight;
+      const tailWasEvicted =
+        previous.lastSeq !== null && lastSeq !== previous.lastSeq;
+      const previousFirstIndex = lines.findIndex(
+        (line) => line.seq === previous.firstSeq,
+      );
+      const previousFirstOffset =
+        previousFirstIndex < 0
+          ? undefined
+          : outputVirtualizer.getOffsetForIndex(
+              previousFirstIndex,
+              "start",
+            )?.[0];
+      // Paging while detached can prepend old rows and evict stale tail rows
+      // in the same update, so total scroll-height delta is not the prepend
+      // height. Anchor to the row that used to begin the document instead.
+      view.scrollTop =
+        !tailWasEvicted || previousFirstOffset === undefined
+          ? view.scrollTop + view.scrollHeight - previous.scrollHeight
+          : previousFirstOffset +
+            previous.scrollTop +
+            listOffsetTop -
+            previous.listOffsetTop;
     }
-    anchorRef.current = { firstSeq, scrollHeight: view.scrollHeight };
-  }, [lines]);
+    anchorRef.current = {
+      firstSeq,
+      lastSeq,
+      scrollHeight: view.scrollHeight,
+      scrollTop: view.scrollTop,
+      listOffsetTop,
+    };
+  }, [lines, outputVirtualizer]);
+
+  // The first snapshot participates in reading-position restore. Every later
+  // snapshot is a deliberate rebase (resnapshot or reconnect), so it restores
+  // the live latch and pins the replacement tail before paint.
+  useLayoutEffect(() => {
+    const previousGeneration = lastTimelineGenerationRef.current;
+    if (timelineGeneration === previousGeneration) return;
+    lastTimelineGenerationRef.current = timelineGeneration;
+    if (previousGeneration === 0) return;
+    setFollowMode(true);
+    scrollToNewest();
+  }, [scrollToNewest, setFollowMode, timelineGeneration]);
 
   // Following is a scroll effect, not render state: new lines land, then the
   // view is pinned back to the bottom.
   useEffect(() => {
-    if (!following) return;
+    if (!following || resyncPending) return;
     scrollToNewest();
-  }, [following, lines, scrollToNewest]);
+  }, [following, lines, resyncPending, scrollToNewest]);
 
   // A Terminal typography change resizes every row at once, so the geometry
   // both the follow latch and the prepend correction were measured against is
@@ -398,12 +507,20 @@ function ManagedCommandOutputTileBody(props: {
   useLayoutEffect(() => {
     const view = viewRef.current;
     if (view === null) return;
-    if (following) view.scrollTop = view.scrollHeight;
+    if (following && !resyncPending) view.scrollTop = view.scrollHeight;
     anchorRef.current = {
       firstSeq: anchorRef.current.firstSeq,
+      lastSeq: anchorRef.current.lastSeq,
       scrollHeight: view.scrollHeight,
+      scrollTop: view.scrollTop,
+      listOffsetTop: outputListRef.current?.offsetTop ?? 0,
     };
-  }, [following, terminalFont.fontFamily, terminalFont.fontSize]);
+  }, [
+    following,
+    resyncPending,
+    terminalFont.fontFamily,
+    terminalFont.fontSize,
+  ]);
 
   const onScroll = useCallback(() => {
     const view = viewRef.current;
@@ -412,13 +529,18 @@ function ManagedCommandOutputTileBody(props: {
     // way the measurable geometry changes.
     anchorRef.current = {
       firstSeq: anchorRef.current.firstSeq,
+      lastSeq: anchorRef.current.lastSeq,
       scrollHeight: view.scrollHeight,
+      scrollTop: view.scrollTop,
+      listOffsetTop: outputListRef.current?.offsetTop ?? 0,
     };
+    if (resyncPending) return;
     const distanceFromBottom =
       view.scrollHeight - view.scrollTop - view.clientHeight;
-    setFollowing(distanceFromBottom <= FOLLOW_SLACK_PX);
+    const nextFollowing = distanceFromBottom <= FOLLOW_SLACK_PX;
+    setFollowMode(nextFollowing);
     const nextAnchor = {
-      following: distanceFromBottom <= FOLLOW_SLACK_PX,
+      following: nextFollowing,
       scrollTop: view.scrollTop,
       scrollHeight: view.scrollHeight,
     };
@@ -427,7 +549,30 @@ function ManagedCommandOutputTileBody(props: {
     if (view.scrollTop <= LOAD_OLDER_THRESHOLD_PX) {
       loadOlder();
     }
-  }, [loadOlder, readingIdentity]);
+  }, [loadOlder, readingIdentity, resyncPending, setFollowMode]);
+
+  const onTimelineKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (
+        event.defaultPrevented ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        (event.key !== "Home" && event.key !== "End")
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.currentTarget.scrollTop =
+        event.key === "Home" ? 0 : event.currentTarget.scrollHeight;
+      // Programmatic scrolling emits a browser scroll event, but applying the
+      // latch synchronously keeps Home/End deterministic and makes returning
+      // to a detached live tail request its resnapshot immediately.
+      onScroll();
+    },
+    [onScroll],
+  );
 
   // Derived here, after the scroll machinery above, and read only by the JSX
   // below: what the window shows is a pure function of the store's signals
@@ -440,6 +585,9 @@ function ManagedCommandOutputTileBody(props: {
     deleted,
     fatalClose,
   });
+  let jumpLiveLabel = "Jump to live";
+  if (newOutputAvailable) jumpLiveLabel = "New output available";
+  if (resyncPending) jumpLiveLabel = "Loading live output…";
 
   // A terminal state, or a host that cannot serve the stream: the panel is the
   // sentence, and nothing of the log survives under it. Whatever this window
@@ -488,8 +636,13 @@ function ManagedCommandOutputTileBody(props: {
         <div
           ref={viewRef}
           onScroll={onScroll}
+          onKeyDown={onTimelineKeyDown}
+          tabIndex={0}
           data-testid="managed-command-output-timeline"
-          role="log"
+          role="textbox"
+          aria-readonly="true"
+          aria-multiline="true"
+          aria-live="polite"
           aria-label={
             command === null ? "Output" : MANAGED_COMMAND_OUTPUT_WINDOW_TITLE
           }
@@ -513,7 +666,7 @@ function ManagedCommandOutputTileBody(props: {
           // person opened it to read - so on a narrow pane the lane shrinks
           // and the cluster may overlap the tail of a long line, and on a wide
           // one it never grows past what the cluster actually needs.
-          className="h-full w-full overflow-y-auto py-2 pr-[min(30%,12rem)] pl-3 leading-relaxed"
+          className="h-full w-full overflow-y-auto py-2 pr-[min(30%,12rem)] pl-3 leading-relaxed focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset focus-visible:outline-none"
         >
           {loadingOlder ? (
             <div className="flex justify-center py-1">
@@ -542,24 +695,47 @@ function ManagedCommandOutputTileBody(props: {
               testId={AVAILABILITY_NOTICE_TEST_ID}
             />
           ) : null}
-          {lines.map((line) => (
-            <OutputRow key={line.seq} line={line} />
-          ))}
+          {lines.length === 0 ? null : (
+            <div
+              ref={outputListRef}
+              data-testid="managed-command-output-virtual-list"
+              className="relative w-full"
+              style={{ height: `${outputVirtualizer.getTotalSize()}px` }}
+            >
+              {virtualRows.map((virtualRow) => {
+                const line = lines[virtualRow.index];
+                return (
+                  <div
+                    key={virtualRow.key}
+                    data-index={virtualRow.index}
+                    ref={outputVirtualizer.measureElement}
+                    className="absolute top-0 left-0 w-full"
+                    style={{
+                      transform: `translateY(${virtualRow.start}px)`,
+                    }}
+                  >
+                    <OutputRow line={line} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
-        {following ? null : (
+        {following && !resyncPending ? null : (
           <Button
             type="button"
             variant="secondary"
             size="sm"
             data-testid="managed-command-output-jump-live"
             className="absolute bottom-3 left-1/2 -translate-x-1/2 shadow-sm"
+            disabled={resyncPending}
             onClick={() => {
-              setFollowing(true);
-              scrollToNewest();
+              setFollowMode(true);
+              if (!detached) scrollToNewest();
             }}
           >
             <ArrowDownToLine aria-hidden className="size-3.5" />
-            Jump to live
+            {jumpLiveLabel}
           </Button>
         )}
       </div>

--- a/clients/gui-app/src/hooks/managed-command/use-managed-command-output-session.ts
+++ b/clients/gui-app/src/hooks/managed-command/use-managed-command-output-session.ts
@@ -82,6 +82,7 @@ export function useManagedCommandOutputSession(args: {
         );
         return {
           loadOlder: (frame) => owned.client.stream.loadOlder(frame),
+          resnapshot: () => owned.client.stream.resnapshot(),
           close: owned.close,
           streamMethodSupport: owned.client.streamMethodSupport,
         };

--- a/clients/gui-app/src/stores/managed-commands/__tests__/managed-command-output-store.test.ts
+++ b/clients/gui-app/src/stores/managed-commands/__tests__/managed-command-output-store.test.ts
@@ -11,6 +11,8 @@ import type { ManagedCommandOutputStreamCallbacks } from "@traycer-clients/share
 import {
   createManagedCommandOutputStore,
   MANAGED_COMMAND_OLDER_PAGE_LINES,
+  MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES,
+  MANAGED_COMMAND_OUTPUT_RETENTION_TARGET_LINES,
   type ManagedCommandOutputStoreHandle,
 } from "@/stores/managed-commands/managed-command-output-store";
 
@@ -57,6 +59,7 @@ interface Harness {
   readonly handle: ManagedCommandOutputStoreHandle;
   readonly emit: () => ManagedCommandOutputStreamCallbacks;
   readonly sent: ManagedCommandSubscribeOutputClientFrame[];
+  readonly resnapshotCalls: () => number;
 }
 
 /** The one client frame the viewer sends; narrowed for the assertions below. */
@@ -72,6 +75,7 @@ function loadOlderFrame(
 function harness(): Harness {
   let captured: ManagedCommandOutputStreamCallbacks | null = null;
   const sent: ManagedCommandSubscribeOutputClientFrame[] = [];
+  let resnapshotCalls = 0;
   const handle = createManagedCommandOutputStore({
     epicId: "epic-1",
     commandId: "cmd-1",
@@ -80,6 +84,9 @@ function harness(): Harness {
       return {
         loadOlder: (frame) => {
           sent.push(frame);
+        },
+        resnapshot: () => {
+          resnapshotCalls += 1;
         },
         close: () => undefined,
         streamMethodSupport: null,
@@ -93,6 +100,7 @@ function harness(): Harness {
       return captured;
     },
     sent,
+    resnapshotCalls: () => resnapshotCalls,
   };
 }
 
@@ -114,10 +122,125 @@ describe("managed-command output store", () => {
     const h = harness();
 
     openAtTail(h);
-    h.emit().onOutput([line("live-1"), line("live-2")]);
+    h.emit().onOutput({
+      lines: [line("live-1"), line("live-2")],
+      start: position("seg-2", 80),
+    });
 
     expect(texts(h.handle)).toEqual(["tail-1", "tail-2", "live-1", "live-2"]);
     expect(h.handle.store.getState().command).toEqual(COMMAND);
+  });
+
+  it("trims a following timeline only at a positioned frame boundary and pages the discarded gap back", () => {
+    const h = harness();
+    openAtTail(h);
+    const frameSize = 1_000;
+    const frameCount = Math.ceil(
+      (MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES + frameSize) / frameSize,
+    );
+
+    for (let frame = 0; frame < frameCount; frame += 1) {
+      h.emit().onOutput({
+        start: position("seg-live", frame * frameSize),
+        lines: Array.from({ length: frameSize }, (_, index) =>
+          line(`live-${frame}-${index}`),
+        ),
+      });
+    }
+
+    const retained = h.handle.store.getState();
+    expect(retained.lines.length).toBeLessThanOrEqual(
+      MANAGED_COMMAND_OUTPUT_RETENTION_TARGET_LINES + frameSize,
+    );
+    expect(retained.start).toEqual(position("seg-live", 5_000));
+    expect(retained.lines[0].text).toBe("live-5-0");
+    expect(retained.reachedStart).toBe(false);
+
+    retained.loadOlder();
+    const request = loadOlderFrame(h.sent[0]);
+    expect(request.before).toEqual(position("seg-live", 5_000));
+    h.emit().onOlder({
+      requestId: request.requestId,
+      start: position("seg-live", 4_000),
+      lines: [line("recovered-before-boundary")],
+      reachedStart: false,
+    });
+    expect(texts(h.handle).slice(0, 2)).toEqual([
+      "recovered-before-boundary",
+      "live-5-0",
+    ]);
+  });
+
+  it("abandons a stalled older page before trimming a following timeline", () => {
+    const h = harness();
+    openAtTail(h);
+    h.handle.store.getState().loadOlder();
+    const stalledRequest = loadOlderFrame(h.sent[0]);
+
+    const frameSize = MANAGED_COMMAND_MAX_WINDOW_LINES;
+    const frameCount =
+      Math.ceil(MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES / frameSize) + 1;
+    for (let frame = 0; frame < frameCount; frame += 1) {
+      h.emit().onOutput({
+        start: position("seg-live", frame * frameSize),
+        lines: Array.from({ length: frameSize }, (_, index) =>
+          line(`live-${frame}-${index}`),
+        ),
+      });
+    }
+
+    const trimmed = h.handle.store.getState();
+    expect(trimmed.loadingOlder).toBe(false);
+    expect(trimmed.lines.length).toBeLessThanOrEqual(
+      MANAGED_COMMAND_OUTPUT_RETENTION_TARGET_LINES + frameSize,
+    );
+
+    const textsBeforeStaleReply = texts(h.handle);
+    h.emit().onOlder({
+      requestId: stalledRequest.requestId,
+      lines: [line("stale-older-page")],
+      start: position("seg-1", 0),
+      reachedStart: false,
+    });
+    expect(texts(h.handle)).toEqual(textsBeforeStaleReply);
+  });
+
+  it("does not append while the reader is scrolled back, then resnapshots when follow resumes", () => {
+    // Superseded design: a scrolled-back reader used to keep accumulating
+    // every live frame in the backing array, unbounded by scroll duration or
+    // output rate. It now detaches instead - live output is discarded and
+    // only counted, so the held history the reader is looking at never grows
+    // behind their back; resuming follow re-bases from a fresh tail rather
+    // than replaying everything that was withheld.
+    const h = harness();
+    openAtTail(h);
+    h.handle.store.getState().setFollowing(false);
+
+    for (let frame = 0; frame < 22; frame += 1) {
+      h.emit().onOutput({
+        start: position("seg-live", frame * 1_000),
+        lines: Array.from({ length: 1_000 }, (_, index) =>
+          line(`live-${frame}-${index}`),
+        ),
+      });
+    }
+
+    expect(h.handle.store.getState().lines).toHaveLength(2);
+    expect(h.handle.store.getState().start).toEqual(position("seg-2", 40));
+    expect(h.handle.store.getState().detached).toBe(true);
+    expect(h.handle.store.getState().newOutputAvailable).toBe(true);
+
+    h.handle.store.getState().setFollowing(true);
+    expect(h.resnapshotCalls()).toBe(1);
+
+    h.emit().onSnapshot({
+      command: COMMAND,
+      lines: [line("fresh-tail")],
+      start: position("seg-live", 22_000),
+      reachedStart: false,
+    });
+
+    expect(texts(h.handle)).toEqual(["fresh-tail"]);
   });
 
   it("pages backwards from the position it was handed, oldest lines in front", () => {
@@ -255,5 +378,145 @@ describe("managed-command output store", () => {
       signal: null,
       exitedAtMs: 90,
     });
+  });
+
+  it("scrolling up and back down without missing any output never resnapshots", () => {
+    const h = harness();
+    openAtTail(h);
+
+    h.handle.store.getState().setFollowing(false);
+    h.handle.store.getState().setFollowing(true);
+
+    // Nothing arrived while the reader was scrolled back, so there is nothing
+    // to re-base: a resnapshot round-trip here would be pure waste.
+    expect(h.resnapshotCalls()).toBe(0);
+    expect(h.handle.store.getState().detached).toBe(false);
+    expect(h.handle.store.getState().resyncPending).toBe(false);
+    expect(texts(h.handle)).toEqual(["tail-1", "tail-2"]);
+  });
+
+  it("discards live output while detached and flags that output was missed", () => {
+    const h = harness();
+    openAtTail(h);
+    h.handle.store.getState().setFollowing(false);
+
+    h.emit().onOutput({
+      lines: [line("missed-1")],
+      start: position("seg-2", 80),
+    });
+
+    expect(texts(h.handle)).toEqual(["tail-1", "tail-2"]);
+    expect(h.handle.store.getState().detached).toBe(true);
+    expect(h.handle.store.getState().newOutputAvailable).toBe(true);
+
+    // Further frames while still detached are discarded the same way; the
+    // reader's held history is never disturbed by output it cannot see yet.
+    h.emit().onOutput({
+      lines: [line("missed-2")],
+      start: position("seg-2", 90),
+    });
+    expect(texts(h.handle)).toEqual(["tail-1", "tail-2"]);
+  });
+
+  it("resuming from a detach sends exactly one resnapshot, discards output until it lands, and never resends while it is in flight", () => {
+    const h = harness();
+    openAtTail(h);
+    h.handle.store.getState().setFollowing(false);
+    h.emit().onOutput({
+      lines: [line("missed-1")],
+      start: position("seg-2", 80),
+    });
+
+    h.handle.store.getState().setFollowing(true);
+
+    expect(h.resnapshotCalls()).toBe(1);
+    expect(h.handle.store.getState().resyncPending).toBe(true);
+    // Still `detached` until the fresh snapshot actually lands - a viewer
+    // must keep showing "resyncing", not silently jump back to "live".
+    expect(h.handle.store.getState().detached).toBe(true);
+
+    // Jump-to-live pressed again mid-resync (or the latch flipping again from
+    // scroll momentum): must not fire a second resnapshot.
+    h.handle.store.getState().setFollowing(true);
+    expect(h.resnapshotCalls()).toBe(1);
+
+    // A page request while a resync is in flight would race the replacement
+    // snapshot; it must be refused rather than queued against a start the
+    // snapshot is about to invalidate.
+    h.handle.store.getState().loadOlder();
+    expect(h.sent).toHaveLength(0);
+
+    // Output racing the resnapshot request is discarded, not appended ahead
+    // of the replacement snapshot that is about to arrive.
+    h.emit().onOutput({
+      lines: [line("still-missed")],
+      start: position("seg-2", 90),
+    });
+    expect(texts(h.handle)).toEqual(["tail-1", "tail-2"]);
+
+    const lastSeqBeforeResync = h.handle.store.getState().lines.at(-1)?.seq;
+    const generationBeforeResync = h.handle.store.getState().timelineGeneration;
+
+    h.emit().onSnapshot({
+      command: COMMAND,
+      lines: [line("tail-3"), line("tail-4")],
+      start: position("seg-3", 0),
+      reachedStart: false,
+    });
+
+    const resynced = h.handle.store.getState();
+    expect(texts(h.handle)).toEqual(["tail-3", "tail-4"]);
+    expect(resynced.detached).toBe(false);
+    expect(resynced.resyncPending).toBe(false);
+    expect(resynced.newOutputAvailable).toBe(false);
+    expect(resynced.timelineGeneration).toBe(generationBeforeResync + 1);
+    // Row identities are never reset by a snapshot: the tile keys its
+    // virtualized rows on `seq`, so a reused id here would misfire its
+    // prepend-anchor correction as if the new tail had been scrolled to.
+    expect(resynced.lines[0].seq).toBeGreaterThan(lastSeqBeforeResync ?? -1);
+
+    // Following resumed, so ordinary live output appends again.
+    h.emit().onOutput({
+      lines: [line("live-after-resync")],
+      start: position("seg-3", 40),
+    });
+    expect(texts(h.handle)).toEqual(["tail-3", "tail-4", "live-after-resync"]);
+  });
+
+  it("resnapshots after backward paging evicts a quiet command's live tail", () => {
+    const h = harness();
+    openAtTail(h);
+    h.handle.store.getState().setFollowing(false);
+
+    // Every response respects the wire's 500-line page size. No live output
+    // arrives: tail eviction alone must still make the window require a fresh
+    // snapshot, or Jump to live would land on stale history forever.
+    for (let page = 0; page < 41; page += 1) {
+      h.handle.store.getState().loadOlder();
+      const request = loadOlderFrame(h.sent[page]);
+      h.emit().onOlder({
+        requestId: request.requestId,
+        lines: Array.from({ length: 500 }, (_, index) =>
+          line(`older-${page}-${index}`),
+        ),
+        start: position(`seg-history-${page}`, 0),
+        reachedStart: false,
+      });
+    }
+
+    const state = h.handle.store.getState();
+    // The reader asked for older history, so that side is kept; the stale
+    // pre-detach tail is what gets evicted to hold the cap.
+    expect(state.lines.length).toBeLessThanOrEqual(
+      MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES,
+    );
+    expect(state.lines[0].text).toBe("older-40-0");
+    expect(texts(h.handle)).not.toContain("tail-1");
+    expect(state.detached).toBe(true);
+    expect(state.newOutputAvailable).toBe(false);
+
+    state.setFollowing(true);
+    expect(h.resnapshotCalls()).toBe(1);
+    expect(h.handle.store.getState().resyncPending).toBe(true);
   });
 });

--- a/clients/gui-app/src/stores/managed-commands/managed-command-output-store.ts
+++ b/clients/gui-app/src/stores/managed-commands/managed-command-output-store.ts
@@ -23,14 +23,14 @@ import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
  *
  * The retained log runs to tens of megabytes, so the window holds only what it
  * has actually been served - the opening tail plus whatever the human scrolled
- * back to. Nothing is trimmed from the head in return: `start` is the host's
- * own cursor for "the oldest line you hold", and dropping lines behind it would
- * open a gap the wire has no way to express.
+ * back to. While following, old frames are trimmed at host-positioned
+ * boundaries; `start` advances with the cut, so the discarded gap remains
+ * reachable through the ordinary load-older path.
  */
 
 export type ManagedCommandOutputStreamClientHandle = Pick<
   ManagedCommandOutputStreamClient,
-  "loadOlder" | "close"
+  "loadOlder" | "resnapshot" | "close"
 > & {
   /**
    * Where this window reads what its bound host can serve: the negotiated
@@ -51,6 +51,10 @@ export type ManagedCommandOutputStreamClientFactory = (
 /** One scroll-up page. Well under the wire's 2,000-line ceiling. */
 export const MANAGED_COMMAND_OLDER_PAGE_LINES = 500;
 
+/** Hysteresis keeps a loud shell from slicing the timeline on every frame. */
+export const MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES = 20_000;
+export const MANAGED_COMMAND_OUTPUT_RETENTION_TARGET_LINES = 15_000;
+
 /**
  * A log line plus the identity the viewer needs and the wire does not carry.
  * Log lines have no id and repeat verbatim, so a row is identified by its
@@ -62,6 +66,8 @@ export const MANAGED_COMMAND_OLDER_PAGE_LINES = 500;
  */
 export interface ManagedCommandTimelineLine extends ManagedCommandLogLine {
   readonly seq: number;
+  /** Present only on the first row of a host-positioned wire frame. */
+  readonly frameStart: ManagedCommandLogPosition | null;
 }
 
 export interface ManagedCommandOutputState {
@@ -79,6 +85,14 @@ export interface ManagedCommandOutputState {
    */
   readonly reachedStart: boolean;
   readonly loadingOlder: boolean;
+  /** The held window no longer reaches the live tail and needs a resnapshot. */
+  readonly detached: boolean;
+  /** A fresh live-tail snapshot has been requested but has not landed yet. */
+  readonly resyncPending: boolean;
+  /** At least one live output frame arrived after the reader detached. */
+  readonly newOutputAvailable: boolean;
+  /** Increments whenever a snapshot replaces the entire timeline. */
+  readonly timelineGeneration: number;
   /** The command was deleted while this window was open. */
   readonly deleted: boolean;
   /**
@@ -89,6 +103,8 @@ export interface ManagedCommandOutputState {
    */
   readonly fatalClose: FatalErrorDetails | null;
   readonly loadOlder: () => void;
+  /** Reader intent controls whether head retention is allowed to advance. */
+  readonly setFollowing: (following: boolean) => void;
   readonly dispose: () => void;
 }
 
@@ -137,19 +153,87 @@ export function createManagedCommandOutputStore(
   // backwards, so every row keeps one identity for as long as the window lives.
   let nextAppendSeq = 0;
   let nextPrependSeq = -1;
+  let following = true;
+  let receivedSnapshot = false;
 
   const numberForward = (
     lines: readonly ManagedCommandLogLine[],
+    frameStart: ManagedCommandLogPosition,
   ): readonly ManagedCommandTimelineLine[] =>
-    lines.map((line) => ({ ...line, seq: nextAppendSeq++ }));
+    lines.map((line, index) => ({
+      ...line,
+      seq: nextAppendSeq++,
+      frameStart: index === 0 ? frameStart : null,
+    }));
 
   const numberBackward = (
     lines: readonly ManagedCommandLogLine[],
-  ): readonly ManagedCommandTimelineLine[] =>
-    [...lines]
+    frameStart: ManagedCommandLogPosition,
+  ): readonly ManagedCommandTimelineLine[] => {
+    const numbered: ManagedCommandTimelineLine[] = [...lines]
       .reverse()
-      .map((line) => ({ ...line, seq: nextPrependSeq-- }))
+      .map((line) => ({ ...line, seq: nextPrependSeq--, frameStart: null }))
       .reverse();
+    if (numbered.length === 0) return numbered;
+    numbered[0] = { ...numbered[0], frameStart };
+    return numbered;
+  };
+
+  const trimFollowingTimeline = (
+    state: ManagedCommandOutputState,
+  ): {
+    readonly lines: readonly ManagedCommandTimelineLine[];
+    readonly start: ManagedCommandLogPosition;
+    readonly reachedStart: false;
+  } | null => {
+    if (
+      !following ||
+      state.loadingOlder ||
+      state.lines.length <= MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES
+    ) {
+      return null;
+    }
+    const earliestCut =
+      state.lines.length - MANAGED_COMMAND_OUTPUT_RETENTION_TARGET_LINES;
+    for (let index = earliestCut; index < state.lines.length; index += 1) {
+      const frameStart = state.lines[index].frameStart;
+      if (frameStart === null) continue;
+      return {
+        lines: state.lines.slice(index),
+        start: frameStart,
+        reachedStart: false,
+      };
+    }
+    // A single wire frame is indivisible: retaining it is the only way to keep
+    // the cursor honest. The host bounds live frames, so this overflow is also
+    // bounded and the next positioned frame supplies a cut point.
+    return null;
+  };
+
+  const trimDetachedTimeline = (
+    state: ManagedCommandOutputState,
+  ): ManagedCommandOutputState => {
+    if (
+      following ||
+      state.lines.length <= MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES
+    ) {
+      return state;
+    }
+    // A detached reader is paging toward older output. Keep the oldest side
+    // they just asked for and evict the stale newest side; returning to live
+    // replaces the entire window with a fresh positioned snapshot anyway.
+    return {
+      ...state,
+      lines: state.lines.slice(
+        0,
+        MANAGED_COMMAND_OUTPUT_RETENTION_TARGET_LINES,
+      ),
+      // Even a quiet command is now missing its retained tail. There is no
+      // forward-page cursor, so returning live must replace this history
+      // window exactly like returning after discarded live output.
+      detached: true,
+    };
+  };
 
   const store = create<ManagedCommandOutputState>()((set, get) => ({
     connectionStatus: "connecting",
@@ -158,11 +242,30 @@ export function createManagedCommandOutputStore(
     start: null,
     reachedStart: false,
     loadingOlder: false,
+    detached: false,
+    resyncPending: false,
+    newOutputAvailable: false,
+    timelineGeneration: 0,
     deleted: false,
     fatalClose: null,
+    setFollowing: (nextFollowing) => {
+      following = nextFollowing;
+      if (!following) return;
+      const state = store.getState();
+      if (state.detached) {
+        if (state.resyncPending) return;
+        pendingOlderRequestId = null;
+        store.setState({ resyncPending: true, loadingOlder: false });
+        streamClient?.resnapshot();
+        return;
+      }
+      store.setState((current) => trimFollowingTimeline(current) ?? current);
+    },
     loadOlder: () => {
       const state = get();
-      if (state.reachedStart || state.loadingOlder) return;
+      if (state.reachedStart || state.loadingOlder || state.resyncPending) {
+        return;
+      }
       // Nothing can be paged in behind a shell the host has dropped or a
       // stream it has closed for good; asking would send a frame into a dead
       // session and leave the spinner waiting on a reply that never comes.
@@ -194,32 +297,74 @@ export function createManagedCommandOutputStore(
     onSnapshot: (snapshot) => {
       if (disposed) return;
       pendingOlderRequestId = null;
-      nextAppendSeq = 0;
-      nextPrependSeq = -1;
-      store.setState({
+      // A replacement snapshot (reconnect or explicit resnapshot) restores
+      // live-follow intent. The first snapshot preserves any reading anchor
+      // the tile restored before it arrived.
+      if (receivedSnapshot) following = true;
+      receivedSnapshot = true;
+      store.setState((state) => ({
         command: snapshot.command,
-        lines: numberForward(snapshot.lines),
+        lines: numberForward(snapshot.lines, snapshot.start),
         start: snapshot.start,
         reachedStart: snapshot.reachedStart,
         loadingOlder: false,
-      });
-    },
-    onOutput: (lines) => {
-      if (disposed || lines.length === 0) return;
-      store.setState((state) => ({
-        lines: [...state.lines, ...numberForward(lines)],
+        detached: false,
+        resyncPending: false,
+        newOutputAvailable: false,
+        timelineGeneration: state.timelineGeneration + 1,
       }));
+    },
+    onOutput: (frame) => {
+      if (disposed || frame.lines.length === 0) return;
+      store.setState((state) => {
+        if (!following || state.detached || state.resyncPending) {
+          if (state.detached && state.newOutputAvailable) return state;
+          return {
+            ...state,
+            detached: true,
+            newOutputAvailable: true,
+          };
+        }
+        const appended = {
+          ...state,
+          lines: [...state.lines, ...numberForward(frame.lines, frame.start)],
+        };
+        // A stalled backward page must not suspend the live-window bound. If
+        // output crosses the ceiling while that request is in flight, abandon
+        // the page before advancing `start`; accepting its old-before window
+        // afterward would splice a gap into the retained timeline.
+        const trimmable =
+          appended.loadingOlder &&
+          appended.lines.length > MANAGED_COMMAND_OUTPUT_RETENTION_MAX_LINES
+            ? { ...appended, loadingOlder: false }
+            : appended;
+        if (trimmable !== appended) pendingOlderRequestId = null;
+        const trimmed = trimFollowingTimeline(trimmable);
+        return trimmed === null ? trimmable : { ...trimmable, ...trimmed };
+      });
     },
     onOlder: (window) => {
       if (disposed) return;
       if (window.requestId !== pendingOlderRequestId) return;
       pendingOlderRequestId = null;
-      store.setState((state) => ({
-        lines: [...numberBackward(window.lines), ...state.lines],
-        start: window.start,
-        reachedStart: window.reachedStart,
-        loadingOlder: false,
-      }));
+      store.setState((state) => {
+        const prepended = {
+          ...state,
+          lines: [
+            ...numberBackward(window.lines, window.start),
+            ...state.lines,
+          ],
+          start: window.start,
+          reachedStart: window.reachedStart,
+          loadingOlder: false,
+        };
+        const followingTrim = trimFollowingTimeline(prepended);
+        return trimDetachedTimeline(
+          followingTrim === null
+            ? prepended
+            : { ...prepended, ...followingTrim },
+        );
+      });
     },
     onStatus: (command) => {
       if (disposed) return;

--- a/clients/shared/host-client/__tests__/host-client.test.ts
+++ b/clients/shared/host-client/__tests__/host-client.test.ts
@@ -1,5 +1,5 @@
 import { NO_TRANSPORT_EVIDENCE } from "@traycer-clients/shared/host-selection/transport-evidence";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   defineRpcContract,
@@ -11,6 +11,7 @@ import {
   type RequestContext,
 } from "@traycer/protocol/auth/request-context";
 import {
+  HOST_AVAILABILITY_SWEEP_WINDOW_MS,
   HostClient,
   type HostClientChangeEvent,
   type HostQueryInvalidationOptions,
@@ -371,6 +372,37 @@ describe("HostClient", () => {
     await flushAvailabilityCoalescing();
     expect(invalidator.calls).toEqual(["mock-local"]);
     expect(events).toEqual([]);
+  });
+
+  it("coalesces recovery bursts across wiring cooldowns while unannounced sweeps bypass the time gate", async () => {
+    vi.useFakeTimers();
+    try {
+      const { client, invalidator, events } = buildHostClientWithMock();
+
+      client.notifyHostAvailabilityRecovered("mock-local");
+      await flushAvailabilityCoalescing();
+      expect(invalidator.calls).toEqual(["mock-local"]);
+
+      await vi.advanceTimersByTimeAsync(HOST_AVAILABILITY_SWEEP_WINDOW_MS / 2);
+      client.notifyHostAvailabilityRecovered("mock-local");
+      await flushAvailabilityCoalescing();
+      expect(invalidator.calls).toHaveLength(1);
+
+      // Rotation/ready-boundary sweeps are correctness boundaries, not noisy
+      // recovery hints, so they remain immediate even inside the recovery gate.
+      client.invalidateHostScopeUnannounced("mock-local");
+      await flushAvailabilityCoalescing();
+      expect(invalidator.calls).toHaveLength(2);
+      expect(events).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(HOST_AVAILABILITY_SWEEP_WINDOW_MS / 2);
+      await flushAvailabilityCoalescing();
+      expect(invalidator.calls).toHaveLength(3);
+      expect(events).toHaveLength(2);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("delegates a requester's unary request to the messenger under that host's authority", async () => {

--- a/clients/shared/host-client/host-client.ts
+++ b/clients/shared/host-client/host-client.ts
@@ -39,6 +39,9 @@ export interface HostQueryInvalidationOptions {
   readonly refetchActive: boolean;
 }
 
+/** One host-wide recovery sweep per window, with one trailing delivery. */
+export const HOST_AVAILABILITY_SWEEP_WINDOW_MS = 10_000;
+
 /** Unsubscribe handle returned by `HostClient` event subscriptions. */
 export type HostClientUnsubscribe = () => void;
 
@@ -353,13 +356,25 @@ export class HostClient<Registry extends VersionedRpcRegistry> {
    * nothing failing anywhere. Naming the host is what makes the recovery
    * expressible at all now.
    *
-   * Delivery is coalesced per host per microtask tick (see
-   * {@link deliverHostScopeSweep}): one shared remote session's ready
-   * boundary fans out to every consumer wiring, each of which reports it here
-   * in the same tick with its own cooldown state.
+   * Delivery is coalesced per host both in the current microtask and across a
+   * short time window. Independent consumer wirings have independent recovery
+   * cooldowns, so their reports can otherwise arrive as a staggered burst.
    */
   notifyHostAvailabilityRecovered(hostId: string): void {
+    const gate = this.hostAvailabilitySweepGates.get(hostId);
+    if (gate !== undefined) {
+      if (!gate.leadingPending) gate.trailing = true;
+      return;
+    }
+    const opened = { leadingPending: true, trailing: false };
+    this.hostAvailabilitySweepGates.set(hostId, opened);
     this.deliverHostScopeSweep(hostId, true);
+    queueMicrotask(() => {
+      if (this.hostAvailabilitySweepGates.get(hostId) === opened) {
+        opened.leadingPending = false;
+      }
+    });
+    this.armHostAvailabilitySweepGate(hostId, opened);
   }
 
   /**
@@ -392,6 +407,33 @@ export class HostClient<Registry extends VersionedRpcRegistry> {
    */
   invalidateHostScopeUnannounced(hostId: string): void {
     this.deliverHostScopeSweep(hostId, false);
+  }
+
+  private readonly hostAvailabilitySweepGates = new Map<
+    string,
+    { leadingPending: boolean; trailing: boolean }
+  >();
+
+  private armHostAvailabilitySweepGate(
+    hostId: string,
+    gate: { leadingPending: boolean; trailing: boolean },
+  ): void {
+    setTimeout(() => {
+      if (this.hostAvailabilitySweepGates.get(hostId) !== gate) return;
+      if (!gate.trailing) {
+        this.hostAvailabilitySweepGates.delete(hostId);
+        return;
+      }
+      gate.trailing = false;
+      gate.leadingPending = true;
+      this.deliverHostScopeSweep(hostId, true);
+      queueMicrotask(() => {
+        if (this.hostAvailabilitySweepGates.get(hostId) === gate) {
+          gate.leadingPending = false;
+        }
+      });
+      this.armHostAvailabilitySweepGate(hostId, gate);
+    }, HOST_AVAILABILITY_SWEEP_WINDOW_MS);
   }
 
   /**

--- a/clients/shared/host-transport/managed-command-output-stream-client.ts
+++ b/clients/shared/host-transport/managed-command-output-stream-client.ts
@@ -29,6 +29,12 @@ export interface ManagedCommandOutputOlderWindow {
   readonly reachedStart: boolean;
 }
 
+export interface ManagedCommandOutputLiveFrame {
+  readonly lines: readonly ManagedCommandLogLine[];
+  /** Exact log boundary immediately before the first line. */
+  readonly start: ManagedCommandLogPosition;
+}
+
 /**
  * Typed handlers for a `managedCommand.subscribeOutput@1.0` session - one
  * command's log as an interleaved timeline of output and lifecycle records.
@@ -39,7 +45,7 @@ export interface ManagedCommandOutputOlderWindow {
  */
 export interface ManagedCommandOutputStreamCallbacks {
   readonly onSnapshot: (snapshot: ManagedCommandOutputSnapshot) => void;
-  readonly onOutput: (lines: readonly ManagedCommandLogLine[]) => void;
+  readonly onOutput: (frame: ManagedCommandOutputLiveFrame) => void;
   readonly onOlder: (window: ManagedCommandOutputOlderWindow) => void;
   readonly onStatus: (command: ManagedCommand) => void;
   readonly onDeleted: () => void;
@@ -58,8 +64,8 @@ export interface ManagedCommandOutputStreamClientOptions {
 
 /**
  * Typed wrapper over the host stream client for
- * `managedCommand.subscribeOutput@1.0`. The one upstream frame is `loadOlder`,
- * which pages backwards from a position the host itself minted.
+ * `managedCommand.subscribeOutput@1.0`. Upstream frames page backwards from a
+ * host-minted position or request a fresh tail after the reader detached.
  */
 export class ManagedCommandOutputStreamClient {
   private readonly session: IStreamSession;
@@ -87,6 +93,15 @@ export class ManagedCommandOutputStreamClient {
     this.session.sendClientFrame(frame, null);
   }
 
+  /** Replaces a detached historical window with a fresh live-tail snapshot. */
+  resnapshot(): void {
+    if (this.closed) return;
+    this.session.sendClientFrame(
+      { kind: "resnapshot", hasBinaryPayload: false },
+      null,
+    );
+  }
+
   /** Tears down the underlying session. Idempotent. */
   close(): void {
     if (this.closed) return;
@@ -110,7 +125,7 @@ export class ManagedCommandOutputStreamClient {
         return;
       }
       case "output": {
-        this.callbacks.onOutput(frame.lines);
+        this.callbacks.onOutput({ lines: frame.lines, start: frame.start });
         return;
       }
       case "older": {

--- a/protocol/src/host/managed-command/__tests__/managed-command-contracts.test.ts
+++ b/protocol/src/host/managed-command/__tests__/managed-command-contracts.test.ts
@@ -68,9 +68,18 @@ describe("managedCommand.subscribeOutput@1.0 frames", () => {
       managedCommandSubscribeOutputServerFrameSchema.parse({
         kind: "output",
         lines: [{ channel: "stdout", text: "partial", atMs: null }],
+        start: POSITION,
         hasBinaryPayload: false,
       }),
     ).toBeDefined();
+
+    expect(() =>
+      managedCommandSubscribeOutputServerFrameSchema.parse({
+        kind: "output",
+        lines: [{ channel: "stdout", text: "unpositioned", atMs: null }],
+        hasBinaryPayload: false,
+      }),
+    ).toThrow();
   });
 
   it("bounds one load-older window", () => {
@@ -92,6 +101,17 @@ describe("managedCommand.subscribeOutput@1.0 frames", () => {
         hasBinaryPayload: false,
       }),
     ).toThrow();
+  });
+
+  it("accepts a fieldless resnapshot request - the viewer's ask for a fresh live tail after detaching", () => {
+    // No `requestId`: unlike `loadOlder`, a resnapshot is answered with the
+    // same `snapshot` frame a reconnect produces, which the client already
+    // treats as a full reset regardless of which request produced it.
+    const parsed = managedCommandSubscribeOutputClientFrameSchema.parse({
+      kind: "resnapshot",
+      hasBinaryPayload: false,
+    });
+    expect(parsed).toEqual({ kind: "resnapshot", hasBinaryPayload: false });
   });
 });
 

--- a/protocol/src/host/managed-command/subscribe.ts
+++ b/protocol/src/host/managed-command/subscribe.ts
@@ -122,12 +122,15 @@ export const managedCommandSubscribeOutputServerFrameSchema =
       /** Nothing older than `start` is retained; the viewer stops asking. */
       reachedStart: z.boolean(),
     }),
-    // Lines appended since the last frame, oldest first. The client appends;
-    // there is no position to reconcile because the host never re-sends one.
+    // Lines appended since the last frame, oldest first. `start` is the exact
+    // log boundary before the first line. A following viewer may discard whole
+    // frames, advance its held start to this cursor, and later page the gap
+    // back without guessing byte offsets or losing rotation stability.
     z.object({
       kind: z.literal("output"),
       ...textFrameFields,
       lines: z.array(managedCommandLogLineSchema),
+      start: managedCommandLogPositionSchema,
     }),
     z.object({
       kind: z.literal("older"),
@@ -176,6 +179,13 @@ export const managedCommandSubscribeOutputClientFrameSchema =
         .int()
         .positive()
         .max(MANAGED_COMMAND_MAX_WINDOW_LINES),
+    }),
+    // Re-base a viewer that deliberately detached from live output while
+    // reading history. The host serializes this through the live pump so the
+    // next `output` starts exactly where the replacement snapshot ends.
+    z.object({
+      kind: z.literal("resnapshot"),
+      ...textFrameFields,
     }),
     z.object({
       kind: z.literal("ping"),


### PR DESCRIPTION
## Summary

- add host-positioned Monitor output frames and virtualize the timeline so large output cannot starve the renderer
- bound retained output with a 20,000-line ceiling and 15,000-line target; pause live appends while reading history and resnapshot when returning live
- restore Home and End navigation on the focusable output surface and keep scroll anchoring stable across prepend, eviction, and snapshot replacement
- coalesce staggered local-host recovery sweeps at the per-host sink to prevent recovery fan-out

The Monitor and shell protocol is unreleased, so this evolves the existing 1.0 contract directly without backward-compatibility shims.

## Related issue

No linked issue.

## Validation

- protocol managed-command contracts: 6 passed
- shared HostClient recovery suite: 11 passed
- GUI managed-command changed suites: 54 passed; output tile: 28 passed
- React Compiler companion: 10 passed
- deterministic 41 x 500-line retention regression confirms the stale live tail is evicted and return-to-live resnapshots
- affected pre-commit lint, format, compile, build, safety, and DCO hooks passed

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)