### PR TITLE
fix(protocol): attribute agent-initiated stops

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/monitor.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/monitor.test.ts
@@ -48,11 +48,11 @@ const {
     sessions.push(session);
     return handle;
   });
-  // Defaults to the latest negotiated minor (@1.2) the monitor itself
+  // Defaults to the latest negotiated minor (@1.3) the monitor itself
   // targets - every existing test in this file exercises a fully-current
   // host, so this preserves prior behavior. Mixed-version negotiation is
   // covered by its own dedicated tests, which override this per-test.
-  const getMethodSchemaVersionMock = vi.fn(() => ({ major: 1, minor: 2 }));
+  const getMethodSchemaVersionMock = vi.fn(() => ({ major: 1, minor: 3 }));
   return {
     subscribeMock,
     getMethodSchemaVersionMock,
@@ -359,6 +359,76 @@ describe("role awareness frames (negotiated @1.1)", () => {
     expect(lines.filter((line) => line.includes("[traycer roles]"))).toEqual(
       [],
     );
+
+    stdoutSpy.mockRestore();
+    void result;
+  });
+});
+
+describe("stop initiator notices (negotiated @1.3)", () => {
+  function emitCancelledNotice(
+    stopInitiator:
+      | { readonly type: "user" }
+      | {
+          readonly type: "agent";
+          readonly agentId: string;
+          readonly agentTitle: string | null;
+        },
+  ): void {
+    sessions[0].serverFrame?.({
+      kind: "notice",
+      hasBinaryPayload: false,
+      notice: {
+        kind: "inactivity",
+        senderAgentId: "a1",
+        responseId: "response-1",
+        receiverAgentId: "receiver-1",
+        receiverTitle: "Worker",
+        receiverHarnessId: "codex",
+        epicId: "e1",
+        reason: "receiver-cancelled",
+        detail: null,
+        droppedReceivers: null,
+        stopInitiator,
+        noticedAt: 123,
+      },
+    });
+  }
+
+  it("names the agent responsible for a stop", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const result = runMonitor({ agentId: "a1", epicId: "e1" }).catch((e) => e);
+    await flush(0);
+
+    emitCancelledNotice({
+      type: "agent",
+      agentId: "5b8d8768-1d43-42ef-bd99-d57a066e86f2",
+      agentTitle: "Review",
+    });
+
+    const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain(
+      "was stopped by agent Review (5b8d8768-1d43-42ef-bd99-d57a066e86f2)",
+    );
+    expect(output).not.toContain("stopped by the user");
+
+    stdoutSpy.mockRestore();
+    void result;
+  });
+
+  it("keeps human-initiated stops attributed to the user", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const result = runMonitor({ agentId: "a1", epicId: "e1" }).catch((e) => e);
+    await flush(0);
+
+    emitCancelledNotice({ type: "user" });
+
+    const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("was stopped by the user");
 
     stdoutSpy.mockRestore();
     void result;

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -7,6 +7,7 @@ import {
   agentInboxSubscribeServerFrameSchema,
   agentInboxSubscribeServerFrameSchemaV10,
   agentInboxSubscribeServerFrameSchemaV11,
+  agentInboxSubscribeServerFrameSchemaV12,
   type AgentInboxMessage,
   type AgentInboxNotice,
 } from "@traycer/protocol/host/agent/inbox";
@@ -611,6 +612,12 @@ type NormalizedServerFrame =
   | { readonly kind: "role-awareness"; readonly event: RoleAwarenessEvent }
   | { readonly kind: "pong" };
 
+function noticeWithoutStopProvenance(
+  notice: Omit<AgentInboxNotice, "stopInitiator">,
+): AgentInboxNotice {
+  return { ...notice, stopInitiator: null };
+}
+
 /**
  * Parses against the schema tree matching the NEGOTIATED minor, not always
  * the latest one this build knows. A new monitor talking to an old host
@@ -629,7 +636,10 @@ function parseServerFrame(
       return { kind: "message", item: parsed.data.item, eventId: null };
     }
     if (parsed.data.kind === "notice") {
-      return { kind: "notice", notice: parsed.data.notice };
+      return {
+        kind: "notice",
+        notice: noticeWithoutStopProvenance(parsed.data.notice),
+      };
     }
     return { kind: "pong" };
   }
@@ -640,7 +650,31 @@ function parseServerFrame(
       return { kind: "message", item: parsed.data.item, eventId: null };
     }
     if (parsed.data.kind === "notice") {
-      return { kind: "notice", notice: parsed.data.notice };
+      return {
+        kind: "notice",
+        notice: noticeWithoutStopProvenance(parsed.data.notice),
+      };
+    }
+    if (parsed.data.kind === "role-awareness") {
+      return { kind: "role-awareness", event: parsed.data.event };
+    }
+    return { kind: "pong" };
+  }
+  if (negotiated !== null && negotiated.major === 1 && negotiated.minor === 2) {
+    const parsed = agentInboxSubscribeServerFrameSchemaV12.safeParse(envelope);
+    if (!parsed.success) return null;
+    if (parsed.data.kind === "message") {
+      return {
+        kind: "message",
+        item: parsed.data.item,
+        eventId: parsed.data.item.eventId,
+      };
+    }
+    if (parsed.data.kind === "notice") {
+      return {
+        kind: "notice",
+        notice: noticeWithoutStopProvenance(parsed.data.notice),
+      };
     }
     if (parsed.data.kind === "role-awareness") {
       return { kind: "role-awareness", event: parsed.data.event };
@@ -854,8 +888,17 @@ function inactivityHeadline(
         ? `${receiverLabel} is blocked waiting on a human — it ${detail} — and will not reply until someone responds`
         : `${receiverLabel} is blocked waiting on a human and will not reply until someone responds`;
     case "receiver-cancelled":
-      return `${receiverLabel} was stopped by the user — your message could not be delivered and this request is now closed`;
+      return `${receiverLabel} was stopped by ${stopInitiatorLabel(notice)} — your message could not be delivered and this request is now closed`;
   }
+}
+
+function stopInitiatorLabel(notice: AgentInboxNotice): string {
+  const initiator = notice.stopInitiator;
+  if (initiator === null || initiator.type === "user") return "the user";
+  const title = initiator.agentTitle?.trim();
+  return title !== undefined && title.length > 0
+    ? `agent ${title} (${initiator.agentId})`
+    : `agent ${initiator.agentId}`;
 }
 
 function printInboxNotice(notice: AgentInboxNotice): void {
@@ -910,7 +953,7 @@ function printReceiverCancelledNotice(
   const plural = dropped.length > 1;
   const headlineLines = plural
     ? [
-        `[traycer inbox] inactivity notice — ${dropped.length} messages you sent could not be delivered; the user stopped the agents you were waiting on:`,
+        `[traycer inbox] inactivity notice — ${dropped.length} messages you sent could not be delivered; ${stopInitiatorLabel(notice)} stopped the agents you were waiting on:`,
         ...dropped.map(
           (thread) =>
             `[traycer inbox]   · agent ${thread.receiverAgentId} (responseId ${thread.responseId})`,

--- a/protocol/src/host/agent/__tests__/agent-inbox-subscribe-v13-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-inbox-subscribe-v13-compat.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentInboxSubscribeServerFrameSchemaV12,
+  agentInboxSubscribeServerFrameSchemaV13,
+} from "@traycer/protocol/host/agent/inbox";
+
+const AGENT_STOP_NOTICE = {
+  kind: "notice" as const,
+  hasBinaryPayload: false as const,
+  notice: {
+    kind: "inactivity" as const,
+    senderAgentId: "sender-agent",
+    responseId: "response-1",
+    receiverAgentId: "stopped-agent",
+    receiverTitle: "Stopped agent",
+    receiverHarnessId: "codex",
+    epicId: "epic-1",
+    reason: "receiver-cancelled" as const,
+    detail: null,
+    droppedReceivers: [
+      { receiverAgentId: "stopped-agent", responseId: "response-1" },
+    ],
+    noticedAt: 1_000,
+    stopInitiator: {
+      type: "agent" as const,
+      agentId: "review-agent",
+      agentTitle: "Review",
+    },
+  },
+};
+
+describe("agent.inbox.subscribe v1.3 compatibility", () => {
+  it("preserves structured stop-initiator provenance for current clients", () => {
+    const parsed = agentInboxSubscribeServerFrameSchemaV13.parse(
+      AGENT_STOP_NOTICE,
+    );
+
+    expect(parsed).toMatchObject({
+      notice: {
+        stopInitiator: {
+          type: "agent",
+          agentId: "review-agent",
+          agentTitle: "Review",
+        },
+      },
+    });
+  });
+
+  it("keeps the released v1.2 notice tree frozen", () => {
+    const parsed = agentInboxSubscribeServerFrameSchemaV12.parse(
+      AGENT_STOP_NOTICE,
+    );
+
+    if (parsed.kind !== "notice") {
+      throw new Error("Expected a notice frame.");
+    }
+    expect(parsed.notice).not.toHaveProperty("stopInitiator");
+  });
+});

--- a/protocol/src/host/agent/__tests__/agent-roles-contracts.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-roles-contracts.test.ts
@@ -254,9 +254,9 @@ describe("role awareness rides the NEGOTIATED stream minor", () => {
     ).toBe(true);
   });
 
-  it("installs all three minors, with @1.2 latest", () => {
+  it("installs all four minors, with @1.3 latest", () => {
     const line = hostStreamRpcRegistry["agent.inbox.subscribe"][1];
-    expect(line.latestMinor).toBe(2);
-    expect(Object.keys(line.versions).sort()).toEqual(["0", "1", "2"]);
+    expect(line.latestMinor).toBe(3);
+    expect(Object.keys(line.versions).sort()).toEqual(["0", "1", "2", "3"]);
   });
 });

--- a/protocol/src/host/agent/inbox.ts
+++ b/protocol/src/host/agent/inbox.ts
@@ -149,10 +149,11 @@ export const agentInboxNoticeSchema = z.object({
    *   - `awaiting-input` - the receiver is mid-turn but blocked on a human
    *     (asked a question / requested approval); it will not reply until a
    *     person responds. The prompt summary is in `detail`.
-   *   - `receiver-cancelled` - the user stopped the receiver agent outright,
-   *     so this message was dropped undelivered and the thread is closed.
-   *     Informational only: the sender must not re-send or spawn a
-   *     replacement (contrast `user-stopped`, where the thread stays open).
+   *   - `receiver-cancelled` - an authenticated user or agent stopped the
+   *     receiver agent outright, so this message was dropped undelivered and
+   *     the thread is closed. Informational only: the sender must not re-send
+   *     or spawn a replacement (contrast `user-stopped`, where the thread
+   *     stays open).
    */
   reason: z.enum([
     "turn-ended",
@@ -187,7 +188,28 @@ export const agentInboxNoticeSchema = z.object({
   /** Epoch millis the notice fired. */
   noticedAt: z.number().int(),
 });
-export type AgentInboxNotice = z.infer<typeof agentInboxNoticeSchema>;
+export type AgentInboxNoticeV12 = z.infer<typeof agentInboxNoticeSchema>;
+
+/** Authenticated actor that initiated an `agent.stop` cancellation. */
+export const agentStopInitiatorSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("user") }),
+  z.object({
+    type: z.literal("agent"),
+    agentId: z.string(),
+    agentTitle: z.string().nullable(),
+  }),
+]);
+
+/**
+ * `@1.3` notice shape: adds structured stop provenance. A distinct schema
+ * preserves the frozen @1.0-@1.2 trees; older monitors ignore the additive
+ * field while current renderers can name the responsible agent.
+ */
+export const agentInboxNoticeSchemaV13 = agentInboxNoticeSchema.extend({
+  /** Non-null only for `receiver-cancelled`. */
+  stopInitiator: agentStopInitiatorSchema.nullable(),
+});
+export type AgentInboxNotice = z.infer<typeof agentInboxNoticeSchemaV13>;
 
 // ─── Frozen agent.inbox.subscribe@1.0 shape (as shipped) ──────────────────
 //
@@ -289,9 +311,36 @@ export const agentInboxSubscribeServerFrameSchemaV12 = z.discriminatedUnion(
   ],
 );
 
+// ─── agent.inbox.subscribe@1.3 - additive: stop initiator provenance ──────
+
+export const agentInboxSubscribeServerFrameSchemaV13 = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("message"),
+      ...textFrameFields,
+      item: agentInboxMessageSchemaV12,
+    }),
+    z.object({
+      kind: z.literal("notice"),
+      ...textFrameFields,
+      notice: agentInboxNoticeSchemaV13,
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      ...textFrameFields,
+    }),
+    z.object({
+      kind: z.literal("role-awareness"),
+      ...textFrameFields,
+      event: roleAwarenessEventSchema,
+    }),
+  ],
+);
+
 /** The latest installed shape. Host code builds frames against this. */
 export const agentInboxSubscribeServerFrameSchema =
-  agentInboxSubscribeServerFrameSchemaV12;
+  agentInboxSubscribeServerFrameSchemaV13;
 export type AgentInboxSubscribeServerFrame = z.infer<
   typeof agentInboxSubscribeServerFrameSchema
 >;
@@ -330,6 +379,14 @@ export const agentInboxSubscribeV12 = defineStreamRpcContract({
   schemaVersion: { major: 1, minor: 2 } as const,
   openRequestSchema: agentInboxSubscribeOpenRequestSchema,
   serverFrameSchema: agentInboxSubscribeServerFrameSchemaV12,
+  clientFrameSchema: agentInboxSubscribeClientFrameSchema,
+});
+
+export const agentInboxSubscribeV13 = defineStreamRpcContract({
+  method: "agent.inbox.subscribe",
+  schemaVersion: { major: 1, minor: 3 } as const,
+  openRequestSchema: agentInboxSubscribeOpenRequestSchema,
+  serverFrameSchema: agentInboxSubscribeServerFrameSchemaV13,
   clientFrameSchema: agentInboxSubscribeClientFrameSchema,
 });
 

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -117,6 +117,7 @@ import {
   agentInboxSubscribeV10,
   agentInboxSubscribeV11,
   agentInboxSubscribeV12,
+  agentInboxSubscribeV13,
 } from "@traycer/protocol/host/agent/inbox";
 import { agentActivitySubscribeV10 } from "@traycer/protocol/host/agent/activity";
 import {
@@ -7846,7 +7847,8 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
       // already-known object is silently dropped by a @1.0/@1.1 monitor's own
       // non-strict zod parse, so the resolver builds the @1.2 shape
       // unconditionally rather than branching on negotiated minor.
-      latestMinor: 2,
+      // @1.3 adds structured stop-initiator provenance to notice frames.
+      latestMinor: 3,
       versions: {
         0: {
           contract: agentInboxSubscribeV10,
@@ -7856,6 +7858,9 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
         },
         2: {
           contract: agentInboxSubscribeV12,
+        },
+        3: {
+          contract: agentInboxSubscribeV13,
         },
       },
     },


### PR DESCRIPTION
## Summary
- add inbox protocol v1.3 stop-initiator provenance without changing frozen v1.0-v1.2 frames
- render agent-initiated stops with the responsible agent’s title and ID in CLI monitor output
- cover V13 compatibility and human/agent monitor wording

## Validation
- bun run --filter @traycer/protocol test src/host/agent/__tests__/agent-inbox-subscribe-v13-compat.test.ts src/host/__tests__/released-baseline-compat.test.ts
- bun run --filter @traycer-clients/traycer-cli test src/commands/__tests__/monitor.test.ts
- mandatory pre-commit affected build, compile, lint, format, and DCO checks