### PR TITLE
fix(gui-app): only restore unconfirmed sends from an earlier connection on snapshot

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/chat-queue-reconciler.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-queue-reconciler.test.ts
@@ -305,6 +305,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 0,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -326,6 +327,7 @@ describe("chat-queue-reconciler", () => {
         },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 0,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -335,7 +337,7 @@ describe("chat-queue-reconciler", () => {
       expect(result.pendingUserMessages).toEqual([]);
     });
 
-    it("creates failedSendRestoration for unconfirmed send with restore content", () => {
+    it("creates failedSendRestoration for an unconfirmed send from an earlier connection", () => {
       const pendingAction = createPendingAction("action-1", "msg-1", "send");
       const input: ReconcileSnapshotInput = {
         pendingActions: { "action-1": pendingAction },
@@ -344,6 +346,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 1,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -352,6 +355,52 @@ describe("chat-queue-reconciler", () => {
       expect(result.failedSendRestoration).not.toBeNull();
       expect(result.failedSendRestoration?.clientActionId).toBe("action-1");
       expect(result.failedSendRestoration?.content).toEqual(CONTENT);
+    });
+
+    it("keeps an unconfirmed send from the snapshot's own connection pending, without restoration", () => {
+      // A steady-state refresh snapshot (turn finished, backlog backfill) built
+      // before the host processed the send lacks the message; the ack is still
+      // coming on this connection, so nothing is lost and nothing is restored.
+      const pendingAction = createPendingAction("action-1", "msg-1", "send");
+      const pendingUser = createPendingUserMessage("action-1", "msg-1");
+      const input: ReconcileSnapshotInput = {
+        pendingActions: { "action-1": pendingAction },
+        pendingUserMessages: [pendingUser],
+        messages: [],
+        queue: { status: "idle", items: [] },
+        failedSendRestoration: null,
+        nowMs: 5000,
+        connectionEpoch: 0,
+      };
+
+      const result = reconcileSnapshotChange(input);
+
+      expect(result.pendingActions).toEqual({ "action-1": pendingAction });
+      expect(result.acceptedActions).toEqual({});
+      expect(result.pendingUserMessages).toEqual([pendingUser]);
+      expect(result.failedSendRestoration).toBeNull();
+    });
+
+    it("keeps an unconfirmed editUserMessage from the snapshot's own connection pending", () => {
+      const pendingAction = createPendingAction(
+        "action-1",
+        "msg-1",
+        "editUserMessage",
+      );
+      const input: ReconcileSnapshotInput = {
+        pendingActions: { "action-1": pendingAction },
+        pendingUserMessages: [],
+        messages: [],
+        queue: { status: "idle", items: [] },
+        failedSendRestoration: null,
+        nowMs: 5000,
+        connectionEpoch: 0,
+      };
+
+      const result = reconcileSnapshotChange(input);
+
+      expect(result.pendingActions).toEqual({ "action-1": pendingAction });
+      expect(result.failedSendRestoration).toBeNull();
     });
 
     it("preserves existing failedSendRestoration and does not overwrite", () => {
@@ -368,6 +417,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: existingRestore,
         nowMs: 5000,
+        connectionEpoch: 1,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -384,6 +434,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 0,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -435,6 +486,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 1,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -470,6 +522,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 0,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -499,6 +552,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 1,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -528,6 +582,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "idle", items: [] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 0,
       };
 
       const result = reconcileSnapshotChange(input);
@@ -590,6 +645,7 @@ describe("chat-queue-reconciler", () => {
         queue: { status: "running", items: [managedItem] },
         failedSendRestoration: null,
         nowMs: 5000,
+        connectionEpoch: 1,
       };
 
       const result = reconcileSnapshotChange(input);

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -1472,6 +1472,79 @@ describe("createChatSessionStore", () => {
     });
   });
 
+  it("keeps an in-flight send pending when a same-connection refresh snapshot omits it", () => {
+    // The host broadcasts snapshots on a live connection for unrelated
+    // reasons (a turn finishing, a pump-backlog backfill). One built before
+    // the host processed this send naturally lacks the message - that is not
+    // evidence the send was lost, and restoring it would re-fill the composer
+    // with a prompt that then lands in the transcript anyway.
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+
+    harness.handle.store
+      .getState()
+      .sendMessage(
+        CONTENT,
+        { type: "user", userId: OWNER_ID },
+        SETTINGS,
+        "auto",
+      );
+    const frame = harness.sent[0];
+    if (frame.kind !== "send") throw new Error("Expected send frame");
+
+    // No connection-status transition: this snapshot rides the same epoch
+    // the send was dispatched on.
+    emitSnapshot(callbacks, "owner");
+
+    expect(
+      harness.handle.store.getState().pendingActions[frame.clientActionId],
+    ).toMatchObject({ action: "send", messageId: frame.messageId });
+    expect(
+      harness.handle.store
+        .getState()
+        .pendingUserMessages.map((message) => message.messageId),
+    ).toEqual([frame.messageId]);
+    expect(harness.handle.store.getState().failedSendRestoration).toBeNull();
+
+    // The ack and the durable message then settle it normally.
+    callbacks.onActionAck({
+      kind: "actionAck",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      clientActionId: frame.clientActionId,
+      action: "send",
+      status: "accepted",
+      reason: null,
+      code: null,
+      backgroundStopTaskIds: [],
+    });
+    callbacks.onMessageAccepted({
+      kind: "messageAccepted",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      message: {
+        role: "user",
+        messageId: frame.messageId,
+        sender: { type: "user", userId: OWNER_ID },
+        message: { kind: "user", content: CONTENT },
+        timestamp: 2,
+        sessionAnchor: null,
+      },
+    });
+
+    expect(harness.handle.store.getState().pendingActions).toEqual({});
+    expect(harness.handle.store.getState().pendingUserMessages).toEqual([]);
+    expect(harness.handle.store.getState().failedSendRestoration).toBeNull();
+    expect(
+      harness.handle.store
+        .getState()
+        .messages.some((message) => message.messageId === frame.messageId),
+    ).toBe(true);
+  });
+
   it("clears a pending send when reconnect snapshot contains the accepted message", () => {
     const harness = createHarness();
     const callbacks = harness.callbacks();

--- a/clients/gui-app/src/stores/chats/chat-queue-reconciler.ts
+++ b/clients/gui-app/src/stores/chats/chat-queue-reconciler.ts
@@ -43,6 +43,13 @@ export type ReconcileSnapshotInput = {
   readonly queue: ChatQueueState;
   readonly failedSendRestoration: FailedSendRestorationState | null;
   readonly nowMs: number;
+  /**
+   * The connection the snapshot arrived on (the store's live epoch). A pending
+   * send stamped with an OLDER epoch was dispatched on a connection that is
+   * gone, so this snapshot is authoritative on its fate; one stamped with this
+   * epoch is still in flight and its ack is still coming.
+   */
+  readonly connectionEpoch: number;
 };
 
 /**
@@ -104,6 +111,18 @@ export function reconcileQueueChange(
  * Reconcile pending actions against a snapshot. Clears pending actions whose
  * messages have been confirmed in the snapshot or are in the queue.
  *
+ * A send the snapshot does NOT show is only declared lost (dropped, with its
+ * content restored to the composer) when it was dispatched on an EARLIER
+ * connection than the snapshot's - its ack died with that connection, so the
+ * snapshot is the authority on whether it landed. A send from the CURRENT
+ * connection stays pending: the host broadcasts snapshots on a live connection
+ * for many unrelated reasons (a turn finishing, a pump-backlog backfill), and
+ * one built before the host processed the send frame naturally lacks the
+ * message without that send being lost. Its ack (or `messageAccepted`) is still
+ * coming; if the connection drops first, the epoch bumps and the next snapshot
+ * settles it. Restoring here would re-fill the composer with a prompt that then
+ * lands in the transcript anyway.
+ *
  * Pure function - all timing inputs must be passed explicitly.
  */
 export function reconcileSnapshotChange(
@@ -153,6 +172,7 @@ export function reconcileSnapshotChange(
         };
       }
       if (
+        pending.connectionEpoch >= input.connectionEpoch ||
         pending.restoreContent === null ||
         next.failedSendRestoration !== null
       ) {

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -1155,7 +1155,10 @@ export function createChatSessionStoreWithNotificationDependencies(
           // swept edits restore their staged worktree intent). Controls
           // re-enable; the user can re-issue against the state the snapshot
           // shows. Message sends stay - `reconcileSnapshotChange` settles those
-          // by messageId with composer restoration.
+          // by messageId with composer restoration, and only for sends from
+          // an earlier epoch: this same connection's in-flight sends keep
+          // waiting for their ack (a steady-state refresh snapshot is not
+          // evidence they were lost).
           const pending = reconcileSnapshotChange({
             pendingActions: sweep.pendingActions,
             pendingUserMessages: state.pendingUserMessages,
@@ -1163,6 +1166,7 @@ export function createChatSessionStoreWithNotificationDependencies(
             queue: frame.snapshot.queue,
             failedSendRestoration: state.failedSendRestoration,
             nowMs: now,
+            connectionEpoch,
           });
           // `reconcileSnapshotChange` only settles sends still awaiting their
           // ack. A send whose accepted ack landed before the connection died


### PR DESCRIPTION
## Symptom

After pressing Enter the message lands in the transcript, but the composer re-fills with the prompt that was just submitted. Intermittent; most often when sending right as the previous turn finishes, or during heavy streaming.

## Root cause

`reconcileSnapshotChange` treated **every** `snapshot` frame as authoritative on the fate of a pending send: if the send's `messageId` was in neither the snapshot's messages nor its queue, the pending was dropped and its content pushed into `failedSendRestoration`, which the handoff driver then wrote back into the composer draft (`restoreAndAckFailed` → `replaceDraft`).

But the host broadcasts snapshots on the **same connection** for many unrelated reasons — `finishActiveTurn` pushes one on every turn end, the pump-backlog backfill pushes another. A snapshot built before the host processed the send frame naturally lacks the message; the client read that as "lost", restored the draft, and then the real `actionAck` + `messageAccepted` arrived and the message landed anyway.

```mermaid
sequenceDiagram
  participant GUI
  participant Host
  GUI->>Host: send(msgId) [pendingActions += cid]
  Note over Host: finishActiveTurn() of previous turn
  Host-->>GUI: snapshot (no msgId yet)
  Note over GUI: reconcileSnapshotChange → failedSendRestoration → replaceDraft (prompt back in composer)
  Host->>Host: handleSend → append message
  Host-->>GUI: actionAck accepted
  Host-->>GUI: messageAccepted (message in transcript)
```

Every other pending slot on the snapshot path was already gated on `connectionEpoch` (`sweepStalePendingActions`, `sweepStaleRestoreSlot`, `transcriptBaselineEpoch` — the store even says "a steady-state refresh on this same connection does not re-baseline"). Sends were the one exception.

## Fix

Thread `connectionEpoch` into `ReconcileSnapshotInput` and only declare a send lost (drop + restore) when `pending.connectionEpoch < connectionEpoch`, i.e. it was dispatched on a connection that is gone. A same-epoch send stays pending — its ack is still coming, or the connection drops, the epoch bumps, and the next snapshot settles it. The promote-to-accepted branch (snapshot *does* show the message) is unchanged for all epochs. Same gate now also covers a same-connection `editUserMessage`.

## Tests

- Reconciler: same-connection unconfirmed `send` / `editUserMessage` stay pending with no restoration; the existing reconnect-restore cases now carry an explicit older epoch.
- Store (integrated): a refresh snapshot on the same connection omits the send → still pending, optimistic row kept, no restoration; the following ack + `messageAccepted` settle it. The existing "restores an unconfirmed send when a reconnect snapshot omits it" case (which bumps the epoch via `reconnecting`) is unchanged and still passes.
- Ablation: removing the gate turns exactly the three new cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
