### PR TITLE
fix(gui-app): link resource-monitor agent rows to their live agents

### DIFF
--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -2648,6 +2648,56 @@ describe("ResourceMonitorPopover", () => {
     expect(tabNavigationMock.activateTabIntent).toHaveBeenCalledTimes(1);
   });
 
+  it("opens an untitled live-only agent under the untitled-agent fallback, not a blank tile", async () => {
+    // `useEpicTabDisplayTitle` projects an untitled agent's live title as
+    // `null` and lands on the tile's own `name`, so an unnamed record has to
+    // carry the render-tier fallback itself or the tab strip renders blank.
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    liveAgentsMock.byAgentId["chat-untitled"] = {
+      kind: "chat",
+      title: null,
+      hostId: "host-1",
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-untitled",
+              },
+              harnessId: "claude",
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Untitled agent/,
+    });
+    expect(row.disabled).toBe(false);
+    fireEvent.click(row);
+
+    const input = tabNavigationMock.resourceEpicTabIntent.mock.calls[0]?.[0];
+    if (!isRecord(input)) throw new Error("expected resource intent input");
+    if (!isRecord(input.preparation)) {
+      throw new Error("expected resource preparation");
+    }
+    if (!isRecord(input.preparation.node)) {
+      throw new Error("expected resource tile node");
+    }
+    expect(input.preparation.node.name).toBe("Untitled agent");
+  });
+
   it("links an agent row that only the live epic projection knows (no tile, no canvas record)", async () => {
     routerMock.pathname = "/epics/epic-1/tab-1";
     liveAgentsMock.byAgentId["chat-live"] = {

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -226,17 +226,51 @@ const liveArtifactTitleMock = vi.hoisted(() => ({
   title: null as string | null,
 }));
 
+interface LiveAgentMockEntry {
+  readonly kind: "chat" | "terminal-agent";
+  readonly title: string | null;
+  readonly hostId: string | null;
+}
+
+const liveAgentsMock = vi.hoisted(() => {
+  const byAgentId: Record<string, LiveAgentMockEntry> = {};
+  return { byAgentId };
+});
+
 vi.mock("@/lib/epic-selectors", () => ({
   useRegisteredEpicLiveArtifactTitle: (
     _epicId: string,
     artifactId: string | null,
   ) => (artifactId === "chat-1" ? liveArtifactTitleMock.title : null),
-  useRegisteredEpicLiveArtifactTitles: (
-    refs: readonly { readonly artifactId: string | null }[],
+  useRegisteredEpicLiveAgents: (
+    refs: readonly {
+      readonly epicId: string;
+      readonly agentId: string | null;
+    }[],
   ) =>
-    refs.map((ref) =>
-      ref.artifactId === "chat-1" ? liveArtifactTitleMock.title : null,
-    ),
+    refs.map((ref) => {
+      if (
+        ref.agentId !== null &&
+        Object.hasOwn(liveAgentsMock.byAgentId, ref.agentId)
+      ) {
+        return liveAgentsMock.byAgentId[ref.agentId];
+      }
+      // `null` stands for "this window has no live projection for the epic",
+      // the state the canvas-record path exists to cover. An EMPTY title is a
+      // live agent that is merely untitled, and the real hook normalizes that
+      // to `title: null` - not to an absent agent.
+      if (ref.agentId === "chat-1" && liveArtifactTitleMock.title !== null) {
+        return {
+          kind: "chat" as const,
+          title:
+            liveArtifactTitleMock.title === ""
+              ? null
+              : liveArtifactTitleMock.title,
+          hostId: null,
+        };
+      }
+      return null;
+    }),
 }));
 
 vi.mock("@/lib/history-navigation/use-history-nav-available", () => ({
@@ -792,6 +826,7 @@ afterEach(() => {
   navigateNestedMock.mockClear();
   historyNavAvailableMock.enabled = true;
   liveArtifactTitleMock.title = null;
+  liveAgentsMock.byAgentId = {};
   canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId["tile-term-1"] = {
     id: "term-1",
     instanceId: "tile-term-1",
@@ -2611,6 +2646,100 @@ describe("ResourceMonitorPopover", () => {
     expect(input.preparation.node.type).toBe("chat");
     expect(input.preparation.node.hostId).toBe("host-1");
     expect(tabNavigationMock.activateTabIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("links an agent row that only the live epic projection knows (no tile, no canvas record)", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    liveAgentsMock.byAgentId["chat-live"] = {
+      kind: "chat",
+      title: "Live Agent",
+      hostId: null,
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-live",
+              },
+              harnessId: "claude",
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Live Agent/,
+    });
+    expect(row.disabled).toBe(false);
+    fireEvent.click(row);
+
+    expect(tabNavigationMock.resourceEpicTabIntent).toHaveBeenCalledTimes(1);
+    const input = tabNavigationMock.resourceEpicTabIntent.mock.calls[0]?.[0];
+    expect(isRecord(input)).toBe(true);
+    if (!isRecord(input)) throw new Error("expected resource intent input");
+    expect(input.epicId).toBe("epic-1");
+    expect(input.tabId).toBeNull();
+    expect(isRecord(input.preparation)).toBe(true);
+    if (!isRecord(input.preparation)) {
+      throw new Error("expected resource preparation");
+    }
+    expect(input.preparation.kind).toBe("open-tile");
+    expect(isRecord(input.preparation.node)).toBe(true);
+    if (!isRecord(input.preparation.node)) {
+      throw new Error("expected resource tile node");
+    }
+    expect(input.preparation.node.id).toBe("chat-live");
+    expect(input.preparation.node.type).toBe("chat");
+    expect(input.preparation.node.name).toBe("Live Agent");
+    // Falls back to the wire owner's host: the live chat's own hostId is null.
+    expect(input.preparation.node.hostId).toBe("host-1");
+  });
+
+  it("cannot open an agent row when the epic is not mounted in this window (no live projection, no tile, no canvas record)", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-live",
+              },
+              harnessId: "claude",
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Untitled agent/,
+    });
+    expect(row.disabled).toBe(true);
+    fireEvent.click(row);
+
+    expect(tabNavigationMock.resourceEpicTabIntent).not.toHaveBeenCalled();
+    expect(tabNavigationMock.activateTabIntent).not.toHaveBeenCalled();
+    expect(navigateNestedMock).not.toHaveBeenCalled();
   });
 
   it("does not carry a prepared nested focus target on browser builds (no persistent history)", async () => {

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -2706,6 +2706,98 @@ describe("ResourceMonitorPopover", () => {
     expect(input.preparation.node.hostId).toBe("host-1");
   });
 
+  it("ignores a live agent whose projection names a different host than the process", async () => {
+    // An epic's projection spans hosts and agent ids are host-minted, so a
+    // same-id entry from another host must not enable this row - opening it
+    // would bind the tile to a machine the process is not running on.
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    liveAgentsMock.byAgentId["chat-live"] = {
+      kind: "chat",
+      title: "Live Agent",
+      hostId: "host-other",
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-live",
+              },
+              harnessId: "claude",
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(screen.queryByText("Live Agent")).toBeNull();
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Untitled agent/,
+    });
+    expect(row.disabled).toBe(true);
+    fireEvent.click(row);
+
+    expect(tabNavigationMock.resourceEpicTabIntent).not.toHaveBeenCalled();
+    expect(tabNavigationMock.activateTabIntent).not.toHaveBeenCalled();
+    expect(navigateNestedMock).not.toHaveBeenCalled();
+  });
+
+  it("links a live agent whose projection host matches the process host", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    liveAgentsMock.byAgentId["chat-live"] = {
+      kind: "chat",
+      title: "Live Agent",
+      hostId: "host-1",
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-live",
+              },
+              harnessId: "claude",
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Live Agent/,
+    });
+    expect(row.disabled).toBe(false);
+    fireEvent.click(row);
+
+    const input = tabNavigationMock.resourceEpicTabIntent.mock.calls[0]?.[0];
+    if (!isRecord(input)) throw new Error("expected resource intent input");
+    if (!isRecord(input.preparation)) {
+      throw new Error("expected resource preparation");
+    }
+    if (!isRecord(input.preparation.node)) {
+      throw new Error("expected resource tile node");
+    }
+    expect(input.preparation.node.hostId).toBe("host-1");
+  });
+
   it("cannot open an agent row when the epic is not mounted in this window (no live projection, no tile, no canvas record)", async () => {
     routerMock.pathname = "/epics/epic-1/tab-1";
     const stub = installStubFactory();

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -4379,7 +4379,11 @@ function openResourceOwner(args: {
         id: record.id,
         instanceId: uuidv4(),
         type: recordType,
-        name: record.name,
+        // The tile's `name` is the fallback `useEpicTabDisplayTitle` lands on
+        // when the live doc has no title, and an untitled agent projects as
+        // `null` there - so an unnamed record has to carry the render-tier
+        // fallback itself, exactly as the palette's openers do.
+        name: displayTitle(record.name, "agent"),
         hostId: record.hostId,
       },
       preview: false,

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -42,7 +42,11 @@ import type {
 import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import type { EpicNodeRecord } from "@/lib/artifacts/node-display";
 import { displayTitle } from "@/lib/display-title";
-import { useRegisteredEpicLiveArtifactTitles } from "@/lib/epic-selectors";
+import {
+  useRegisteredEpicLiveAgents,
+  type RegisteredEpicAgentRef,
+  type RegisteredEpicLiveAgent,
+} from "@/lib/epic-selectors";
 import { terminalSessionTitle } from "@/lib/terminals/terminal-title";
 import { Button } from "@/components/ui/button";
 import {
@@ -1256,7 +1260,23 @@ function ResourceMonitorPanel(props: {
     void tombstoneEvidence;
     return buildCanvasResourceIndex(canvas);
   }, [canvas, tombstoneEvidence]);
-  const recordByOwner = useMemo(() => buildRecordByOwner(canvas), [canvas]);
+  // The live epic projection is what says an agent row EXISTS (and what it is
+  // called): the canvas's own record list only ever holds what this window
+  // created, so an agent created by another window, device or agent would
+  // otherwise render as a dead, unlinked row.
+  const liveAgentRefs = useMemo(
+    () => collectLiveAgentRefs(projection.entries),
+    [projection.entries],
+  );
+  const liveAgents = useRegisteredEpicLiveAgents(liveAgentRefs);
+  const liveAgentByOwner = useMemo(
+    () => indexLiveAgentsByOwner(liveAgentRefs, liveAgents),
+    [liveAgentRefs, liveAgents],
+  );
+  const recordByOwner = useMemo(
+    () => buildRecordByOwner(canvas, liveAgentByOwner),
+    [canvas, liveAgentByOwner],
+  );
   const epicTitleById = useMemo(() => buildEpicTitleById(tasks), [tasks]);
   const taskRows = useMemo(
     () =>
@@ -1277,32 +1297,15 @@ function ResourceMonitorPanel(props: {
       sortOption,
     ],
   );
-  const liveOwnerTitleEntries = useMemo(
-    () =>
-      taskRows.flatMap((task) =>
-        flattenOwnerRows(task.owners).map((owner) => ({
-          ownerKey: ownerRowKey(owner),
-          epicId: owner.snapshot.owner.epicId,
-          artifactId:
-            owner.snapshot.owner.kind === "terminal"
-              ? null
-              : owner.snapshot.owner.ownerId,
-        })),
-      ),
-    [taskRows],
-  );
-  const liveOwnerTitles = useRegisteredEpicLiveArtifactTitles(
-    liveOwnerTitleEntries,
-  );
   const liveOwnerTitleByKey = useMemo(
     () =>
       new Map(
-        liveOwnerTitleEntries.map((entry, index) => [
-          entry.ownerKey,
-          liveOwnerTitles[index],
+        [...liveAgentByOwner].map(([key, live]): [string, string | null] => [
+          key,
+          live.agent.title,
         ]),
       ),
-    [liveOwnerTitleEntries, liveOwnerTitles],
+    [liveAgentByOwner],
   );
   const search = useMemo(
     () =>
@@ -3406,11 +3409,6 @@ function buildSyntheticAgentRow(
   return null;
 }
 
-/** A task section's rows in render order: each top-level row, then its shells. */
-function flattenOwnerRows(rows: readonly OwnerDisplayRow[]): OwnerDisplayRow[] {
-  return rows.flatMap((row) => [row, ...row.shells]);
-}
-
 /**
  * The owner rows currently on screen in a task section: a parent's shells
  * count only once the parent is expanded - by hand, or by the search
@@ -4080,10 +4078,90 @@ function buildCanvasResourceIndex(
   return { locationByOwner, closedTileByOwner, tabOrderByOwner };
 }
 
+/**
+ * Every agent the snapshot can name, for the live-projection lookup: each
+ * chat / terminal-agent owner, plus each shell's creator - a creator whose own
+ * program has exited has no owner row, and its Synthetic Agent Row needs the
+ * same lookup to exist and to open. A plain terminal is not an agent.
+ */
+function collectLiveAgentRefs(
+  entries: readonly GlobalResourceEpicEntry[],
+): readonly LiveAgentRef[] {
+  const byKey = new Map<string, LiveAgentRef>();
+  for (const entry of entries) {
+    for (const snapshot of entry.owners) {
+      const owner = snapshot.owner;
+      const agentId = liveAgentIdForSnapshot(snapshot);
+      if (agentId === null) continue;
+      const key = `${owner.epicId}\x1f${agentId}`;
+      if (!byKey.has(key)) {
+        byKey.set(key, {
+          epicId: owner.epicId,
+          agentId,
+          processHostId: owner.hostId,
+        });
+      }
+    }
+  }
+  return [...byKey.values()];
+}
+
+/** The agent a snapshot names: the owner itself, or the shell's creator. */
+function liveAgentIdForSnapshot(
+  snapshot: OwnerResourceSnapshotWireV14,
+): string | null {
+  const owner = snapshot.owner;
+  if (isAgentOwnerKind(owner.kind)) return owner.ownerId;
+  if (owner.kind !== "managed-command") return null;
+  const creatorId = snapshot.managedCommand?.createdByAgentId ?? "";
+  return creatorId.length === 0 ? null : creatorId;
+}
+
+interface LiveAgentRef extends RegisteredEpicAgentRef {
+  readonly agentId: string;
+  /**
+   * The host running the agent's process - the agent's host by construction,
+   * and the fallback for a legacy chat projection that recorded none.
+   */
+  readonly processHostId: string;
+}
+
+interface LiveOwnerAgent {
+  readonly epicId: string;
+  readonly agentId: string;
+  readonly agent: RegisteredEpicLiveAgent;
+  readonly hostId: string;
+}
+
+/** Live agents keyed by owner key, the kind coming from the projection slice. */
+function indexLiveAgentsByOwner(
+  refs: readonly LiveAgentRef[],
+  agents: readonly (RegisteredEpicLiveAgent | null)[],
+): ReadonlyMap<string, LiveOwnerAgent> {
+  const byOwner = new Map<string, LiveOwnerAgent>();
+  refs.forEach((ref, index) => {
+    const agent = agents[index] ?? null;
+    if (agent === null) return;
+    byOwner.set(ownerKey(ref.epicId, agent.kind, ref.agentId), {
+      epicId: ref.epicId,
+      agentId: ref.agentId,
+      agent,
+      hostId: agent.hostId ?? ref.processHostId,
+    });
+  });
+  return byOwner;
+}
+
+/**
+ * The record behind an agent row: the live projection first (it is the one
+ * source that knows about agents this window never created), the canvas's own
+ * record list as the legacy fallback.
+ */
 function buildRecordByOwner(
   canvas: CanvasResourceSnapshot,
+  liveAgentByOwner: ReadonlyMap<string, LiveOwnerAgent>,
 ): ReadonlyMap<string, EpicNodeRecord> {
-  return new Map(
+  const records = new Map<string, EpicNodeRecord>(
     Object.entries(canvas.artifactTreeByEpicId).flatMap(
       ([epicId, epicRecords]) =>
         (epicRecords ?? []).flatMap((record): [string, EpicNodeRecord][] => {
@@ -4093,6 +4171,17 @@ function buildRecordByOwner(
         }),
     ),
   );
+  for (const [key, live] of liveAgentByOwner) {
+    // An untitled live agent keeps whatever name the legacy record had.
+    records.set(key, {
+      id: live.agentId,
+      parentId: null,
+      name: live.agent.title ?? records.get(key)?.name ?? "",
+      type: live.agent.kind,
+      hostId: live.hostId,
+    });
+  }
+  return records;
 }
 
 function sortTaskRows(
@@ -4264,7 +4353,10 @@ function openResourceOwner(args: {
   ) {
     return false;
   }
-  const record = findOwnerRecord(args.canvas, snapshot);
+  // The row's record is the live projection's agent when this window has the
+  // epic mounted (an agent created elsewhere has no other representation
+  // here), else the canvas's own legacy record.
+  const record = args.row.record;
   if (record === null) return false;
   const recordType = record.type;
   if (recordType !== "chat" && recordType !== "terminal-agent") return false;
@@ -4373,14 +4465,6 @@ function focusForOwner(snapshot: OwnerResourceSnapshotWireV14): EpicRouteFocus {
     focusThreadId: undefined,
     migrationSource: undefined,
   };
-}
-
-function findOwnerRecord(
-  canvas: CanvasResourceSnapshot,
-  snapshot: OwnerResourceSnapshotWireV14,
-): EpicNodeRecord | null {
-  const records = canvas.artifactTreeByEpicId[snapshot.owner.epicId] ?? [];
-  return records.find((record) => record.id === snapshot.owner.ownerId) ?? null;
 }
 
 function taskLabel(

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -4119,10 +4119,7 @@ function liveAgentIdForSnapshot(
 
 interface LiveAgentRef extends RegisteredEpicAgentRef {
   readonly agentId: string;
-  /**
-   * The host running the agent's process - the agent's host by construction,
-   * and the fallback for a legacy chat projection that recorded none.
-   */
+  /** The host whose resource stream reported this agent's process. */
   readonly processHostId: string;
 }
 
@@ -4133,7 +4130,17 @@ interface LiveOwnerAgent {
   readonly hostId: string;
 }
 
-/** Live agents keyed by owner key, the kind coming from the projection slice. */
+/**
+ * Live agents keyed by owner key, the kind coming from the projection slice.
+ *
+ * An epic's projection spans hosts, and an agent id is host-minted rather than
+ * globally unique, so a projection entry only describes THIS row when it names
+ * the same host the process was reported from. A disagreement is dropped rather
+ * than reconciled: enabling the row on the projection's host would open a tile
+ * bound to a machine the process is not running on. A `null` projection host is
+ * the legacy pre-`hostId` chat record, which names no host to disagree with, so
+ * it keeps the wire owner's.
+ */
 function indexLiveAgentsByOwner(
   refs: readonly LiveAgentRef[],
   agents: readonly (RegisteredEpicLiveAgent | null)[],
@@ -4142,11 +4149,12 @@ function indexLiveAgentsByOwner(
   refs.forEach((ref, index) => {
     const agent = agents[index] ?? null;
     if (agent === null) return;
+    if (agent.hostId !== null && agent.hostId !== ref.processHostId) return;
     byOwner.set(ownerKey(ref.epicId, agent.kind, ref.agentId), {
       epicId: ref.epicId,
       agentId: ref.agentId,
       agent,
-      hostId: agent.hostId ?? ref.processHostId,
+      hostId: ref.processHostId,
     });
   });
   return byOwner;

--- a/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
@@ -19,7 +19,7 @@ import {
   useEpicAgentReference,
   useEpicSyncPillState,
   useMaybeEpicTuiAgentHarnessId,
-  useRegisteredEpicLiveArtifactTitles,
+  useRegisteredEpicLiveAgents,
 } from "@/lib/epic-selectors";
 
 const featureSettings = vi.hoisted(() => ({ enabled: true }));
@@ -53,12 +53,12 @@ afterEach(() => {
   handles.length = 0;
 });
 
-describe("useRegisteredEpicLiveArtifactTitles", () => {
+describe("useRegisteredEpicLiveAgents", () => {
   it("subscribes when a registered handle initially has no title", () => {
     const registry = __getOpenEpicRegistryForTests();
     const { result } = renderHook(() =>
-      useRegisteredEpicLiveArtifactTitles([
-        { epicId: "epic-late-handle", artifactId: "chat-1" },
+      useRegisteredEpicLiveAgents([
+        { epicId: "epic-late-handle", agentId: "chat-1" },
       ]),
     );
     expect(result.current).toEqual([null]);
@@ -78,7 +78,9 @@ describe("useRegisteredEpicLiveArtifactTitles", () => {
     act(() => {
       registry.acquire("epic-late-handle", () => handle);
     });
-    expect(result.current).toEqual([null]);
+    expect(result.current).toEqual([
+      { kind: "chat", title: null, hostId: "host-a" },
+    ]);
 
     act(() => {
       handle.store.setState({
@@ -91,17 +93,19 @@ describe("useRegisteredEpicLiveArtifactTitles", () => {
       });
     });
 
-    expect(result.current).toEqual(["Generated title"]);
+    expect(result.current).toEqual([
+      { kind: "chat", title: "Generated title", hostId: "host-a" },
+    ]);
   });
 
   it("subscribes to a late handle when the refs identity is stable", () => {
     const registry = __getOpenEpicRegistryForTests();
     const { result } = renderHook(() => {
       const refs = useMemo(
-        () => [{ epicId: "epic-stable-refs", artifactId: "chat-1" }],
+        () => [{ epicId: "epic-stable-refs", agentId: "chat-1" }],
         [],
       );
-      return useRegisteredEpicLiveArtifactTitles(refs);
+      return useRegisteredEpicLiveAgents(refs);
     });
     expect(result.current).toEqual([null]);
 
@@ -120,7 +124,9 @@ describe("useRegisteredEpicLiveArtifactTitles", () => {
     act(() => {
       registry.acquire("epic-stable-refs", () => handle);
     });
-    expect(result.current).toEqual([null]);
+    expect(result.current).toEqual([
+      { kind: "chat", title: null, hostId: "host-a" },
+    ]);
 
     act(() => {
       handle.store.setState({
@@ -133,7 +139,38 @@ describe("useRegisteredEpicLiveArtifactTitles", () => {
       });
     });
 
-    expect(result.current).toEqual(["Stable refs title"]);
+    expect(result.current).toEqual([
+      { kind: "chat", title: "Stable refs title", hostId: "host-a" },
+    ]);
+  });
+
+  it("resolves a tuiAgents entry to a terminal-agent live agent", () => {
+    const registry = __getOpenEpicRegistryForTests();
+    const handle = createOpenEpicStore({
+      epicId: "epic-terminal-agent",
+      userId: null,
+      streamClientFactory: fakeStreamClientFactory,
+      onAuthError: null,
+    });
+    handle.store.setState({
+      tuiAgents: {
+        allIds: ["agent-1"],
+        byId: { "agent-1": tuiAgent("agent-1", "codex") },
+      },
+    });
+    act(() => {
+      registry.acquire("epic-terminal-agent", () => handle);
+    });
+
+    const { result } = renderHook(() =>
+      useRegisteredEpicLiveAgents([
+        { epicId: "epic-terminal-agent", agentId: "agent-1" },
+      ]),
+    );
+
+    expect(result.current).toEqual([
+      { kind: "terminal-agent", title: "Codex", hostId: "host-a" },
+    ]);
   });
 });
 

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -761,21 +761,41 @@ export function useRegisteredEpicLiveArtifactTitle(
   );
 }
 
-export interface RegisteredEpicArtifactTitleRef {
+export interface RegisteredEpicAgentRef {
   readonly epicId: string;
-  readonly artifactId: string | null;
+  /** Chat or terminal-agent id; `null` for a ref with no agent to resolve. */
+  readonly agentId: string | null;
 }
 
 /**
- * Reactive live titles for a dynamic collection of artifacts. Global list
- * surfaces cannot call the single-artifact hook in a data-dependent loop, so
- * this subscribes once to the registry and every currently referenced epic.
+ * What an epic's live projection knows about one agent: which slice it lives
+ * in (`chats` → `chat`, `tuiAgents` → `terminal-agent`), its Y.Doc title
+ * (`null` while untitled) and its recorded host (`null` for a legacy chat
+ * that predates the field).
  */
-export function useRegisteredEpicLiveArtifactTitles(
-  refs: readonly RegisteredEpicArtifactTitleRef[],
-): readonly (string | null)[] {
+export interface RegisteredEpicLiveAgent {
+  readonly kind: "chat" | "terminal-agent";
+  readonly title: string | null;
+  readonly hostId: string | null;
+}
+
+/**
+ * Reactive live agent projections for a dynamic collection of agent refs.
+ * Global list surfaces (the resource monitor) live outside any
+ * `EpicSessionProvider` and cannot call a per-agent hook in a data-dependent
+ * loop, so this subscribes once to the registry and every currently
+ * referenced epic. `null` for a ref whose epic is not mounted in this window
+ * or whose id names no agent in that epic's projection.
+ *
+ * This is the same Y.Doc-backed source a canvas tab reads, so it is also the
+ * authority on whether an agent EXISTS - a client-local record list cannot be:
+ * an agent created by another window, device or agent never enters one.
+ */
+export function useRegisteredEpicLiveAgents(
+  refs: readonly RegisteredEpicAgentRef[],
+): readonly (RegisteredEpicLiveAgent | null)[] {
   const registry = getOpenEpicRegistry();
-  const encodedTitles = useSyncExternalStore(
+  const encodedAgents = useSyncExternalStore(
     (listener) => {
       const unsubscribeByHandle = new Map<object, () => void>();
       const reconcileHandleSubscriptions = () => {
@@ -804,40 +824,72 @@ export function useRegisteredEpicLiveArtifactTitles(
         for (const unsubscribe of unsubscribeByHandle.values()) unsubscribe();
       };
     },
-    () => registeredArtifactTitlesSnapshot(registry, refs),
-    () => JSON.stringify(refs.map(() => [0, null])),
+    () => registeredAgentsSnapshot(registry, refs),
+    () => JSON.stringify(refs.map(() => null)),
   );
-  return useMemo(
-    () => decodeRegisteredArtifactTitles(encodedTitles),
-    [encodedTitles],
-  );
+  return useMemo(() => decodeRegisteredAgents(encodedAgents), [encodedAgents]);
 }
 
-function registeredArtifactTitlesSnapshot(
+/**
+ * Encoded per-ref tuples (`[kind, title, hostId]`, or `null`) so
+ * `useSyncExternalStore` compares by value: the registry and every store
+ * notify on unrelated changes, and a fresh array per notification would
+ * re-render the whole list surface each time.
+ */
+function registeredAgentsSnapshot(
   registry: OpenEpicSessionRegistry,
-  refs: readonly RegisteredEpicArtifactTitleRef[],
+  refs: readonly RegisteredEpicAgentRef[],
 ): string {
   return JSON.stringify(
     refs.map((ref) => {
-      const handle = registry.peek(ref.epicId);
-      return [
-        handle === null ? 0 : 1,
-        liveArtifactTitleFromHandle(handle, ref.artifactId),
-      ];
+      const agent = liveAgentFromHandle(registry.peek(ref.epicId), ref.agentId);
+      return agent === null ? null : [agent.kind, agent.title, agent.hostId];
     }),
   );
 }
 
-function decodeRegisteredArtifactTitles(
-  encodedTitles: string,
-): readonly (string | null)[] {
-  const decoded: unknown = JSON.parse(encodedTitles);
+function decodeRegisteredAgents(
+  encodedAgents: string,
+): readonly (RegisteredEpicLiveAgent | null)[] {
+  const decoded: unknown = JSON.parse(encodedAgents);
   if (!Array.isArray(decoded)) return [];
-  return decoded.map((entry) => {
+  return decoded.map((entry): RegisteredEpicLiveAgent | null => {
     if (!Array.isArray(entry)) return null;
+    const kind: unknown = entry[0];
     const title: unknown = entry[1];
-    return typeof title === "string" ? title : null;
+    const hostId: unknown = entry[2];
+    if (kind !== "chat" && kind !== "terminal-agent") return null;
+    return {
+      kind,
+      title: typeof title === "string" ? title : null,
+      hostId: typeof hostId === "string" ? hostId : null,
+    };
   });
+}
+
+function liveAgentFromHandle(
+  handle: OpenEpicStoreHandle | null,
+  agentId: string | null,
+): RegisteredEpicLiveAgent | null {
+  if (handle === null || agentId === null) return null;
+  const state = handle.store.getState();
+  if (Object.hasOwn(state.chats.byId, agentId)) {
+    const chat = state.chats.byId[agentId];
+    return {
+      kind: "chat",
+      title: chat.title.length > 0 ? chat.title : null,
+      hostId: chat.hostId,
+    };
+  }
+  if (Object.hasOwn(state.tuiAgents.byId, agentId)) {
+    const agent = state.tuiAgents.byId[agentId];
+    return {
+      kind: "terminal-agent",
+      title: agent.title.length > 0 ? agent.title : null,
+      hostId: agent.hostId,
+    };
+  }
+  return null;
 }
 
 function liveArtifactTitleFromHandle(


### PR DESCRIPTION
## Summary

A chat / terminal-agent row in the resource monitor was clickable only when this window could resolve the wire owner `{epicId, kind, ownerId}` to something local: an open tile, a retained closed-tile payload, or an `EpicNodeRecord` in the canvas store's `artifactTreeByEpicId`.

That last fallback never fires in a real client — nothing in production writes agent records into `artifactTreeByEpicId` (its only writers, `seedEpic` / `addRootArtifact` / `addChildArtifact`, are reached from tests). So in practice a row was linked **only while its tile was open in this window**. Every agent created by another window, another device, or by an agent on the user's behalf rendered as a dead row: no link, no title, "Untitled agent" under a provider name.

Reported from a live staging session as "all the Claude Code and about half the Codex agents don't have a link in the resource monitor" — those were exactly the agents whose tiles were not open in the window that had the popover.

## What changed

- `lib/epic-selectors.ts` — `useRegisteredEpicLiveArtifactTitles` (titles only) becomes `useRegisteredEpicLiveAgents`, returning `{ kind, title, hostId }` per ref from the open-epic registry's live projection (`chats.byId` → `chat`, `tuiAgents.byId` → `terminal-agent`). This is the same Y.Doc-backed source a canvas tab reads, and the only local source that knows about agents this window never created.
- `components/resources/resource-monitor-popover.tsx` — collects every agent the snapshot names (chat / terminal-agent owners, plus each shell's `createdByAgentId` so a Synthetic Agent Row resolves too) and merges the live agents into the record index. Openability, the row label, and the opened tile's node now come from one lookup instead of two subscriptions. `hostId` falls back to the wire owner's host for a legacy chat that recorded none; an untitled live agent keeps whatever name a legacy record had. Dead `findOwnerRecord` / `flattenOwnerRows` removed.

An agent whose epic is not mounted in this window still has no local source and stays unlinked — deliberately, rather than opening a tile for an agent nothing in the client can vouch for.

## Tests

- `epic-selectors.test.tsx` — the two existing subscription tests convert to the new hook's shape; a new case covers a `tuiAgents` entry resolving to `terminal-agent`.
- `resource-monitor-popover.test.tsx` — new: "links an agent row that only the live epic projection knows (no tile, no canvas record)" and its negative twin for an unmounted epic. Both were ablation-verified: neutralizing the live merge in `buildRecordByOwner` turns the positive test red (`row.disabled` true), and dropping the untitled-agent name fallback turns the persisted-title test red.
- 106 tests pass across the two files; `bun run compile`, `eslint`, and `prettier` are clean.

## Related issue

<!-- none -->

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [x] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
