### PR TITLE
fix(gui-app): read shared-subscription state through the store, not at render

### DIFF
--- a/clients/gui-app/src/hooks/pr/shared-stream-subscription.ts
+++ b/clients/gui-app/src/hooks/pr/shared-stream-subscription.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useReducer, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useReducer,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 /**
  * The ref-counted session-sharing machinery behind the `pr.*` subscription
@@ -46,14 +52,82 @@ export function resetSharedStreamSubscriptions<TFrame>(
   registry.clear();
 }
 
+/**
+ * Render-side change channel, keyed by registry and session key.
+ *
+ * The entry a consumer renders from is mutable module state: the subscribe
+ * effect creates it AFTER the first commit, and the session factories mutate
+ * `lastEvent` / `isTerminal` in place and fan out through `consumers`. The
+ * desktop renderer runs the React Compiler, which memoizes an imperative
+ * `registry.get(key)` (and a `entry.lastEvent` read) during render on the
+ * identity of its inputs - registry, key, entry - none of which change when
+ * the entry appears or its frame moves. A plain render-time read therefore
+ * froze at `undefined`: error frames never surfaced and `sendRefresh` was
+ * inert. `useSyncExternalStore` owns the value, so the compiler caching its
+ * callbacks is harmless.
+ *
+ * Keyed outside the entry so a consumer can subscribe before its entry exists
+ * and so a DISABLED instance (one reading a sibling's live session) is
+ * notified by the sibling's fan-out.
+ */
+const entryListenersByRegistry = new WeakMap<
+  object,
+  Map<string, Set<() => void>>
+>();
+
+function entryListenersFor<TFrame>(
+  registry: SharedStreamSubscriptionRegistry<TFrame>,
+): Map<string, Set<() => void>> {
+  // The channel never reads the registry's values - it only keys listeners by
+  // the registry object - so the frame type is irrelevant here.
+  let listeners = entryListenersByRegistry.get(registry);
+  if (listeners === undefined) {
+    listeners = new Map();
+    entryListenersByRegistry.set(registry, listeners);
+  }
+  return listeners;
+}
+
+function subscribeToEntry<TFrame>(
+  registry: SharedStreamSubscriptionRegistry<TFrame>,
+  key: string | null,
+): (listener: () => void) => () => void {
+  return (onStoreChange) => {
+    if (key === null) return () => undefined;
+    const byKey = entryListenersFor(registry);
+    let listeners = byKey.get(key);
+    if (listeners === undefined) {
+      listeners = new Set();
+      byKey.set(key, listeners);
+    }
+    listeners.add(onStoreChange);
+    return () => {
+      const current = byKey.get(key);
+      if (current === undefined) return;
+      current.delete(onStoreChange);
+      if (current.size === 0) byKey.delete(key);
+    };
+  };
+}
+
+function notifyEntryChanged<TFrame>(
+  registry: SharedStreamSubscriptionRegistry<TFrame>,
+  key: string,
+): void {
+  const listeners = entryListenersFor(registry).get(key);
+  if (listeners === undefined) return;
+  for (const listener of [...listeners]) listener();
+}
+
 export interface SharedStreamSubscriptionResult<TFrame> {
   /**
-   * The registry entry for this hook's key, or `undefined` when there is
-   * none. Present even while this hook instance is DISABLED: another consumer
-   * may hold a live session for the same key, and its last frame is still the
-   * truth about that stream.
+   * The last frame the session at this hook's key delivered, or `null` when
+   * there is no entry or no frame yet. Present even while this hook instance
+   * is DISABLED: another consumer may hold a live session for the same key,
+   * and its last frame is still the truth about that stream. Read through
+   * the store (see `entryListenersByRegistry`), never off the entry.
    */
-  readonly subscription: SharedStreamSubscription<TFrame> | undefined;
+  readonly lastEvent: TFrame | null;
   /**
    * Refreshes on this hook's own session. After a terminal error the session
    * is dead and its `sendRefresh` is a no-op, so a user "refresh"/"Try again"
@@ -89,13 +163,6 @@ export function useSharedStreamSubscription<TFrame>(args: {
 }): SharedStreamSubscriptionResult<TFrame> {
   const { registry, sessionKey, enabled, createSession, onConsumerJoined } =
     args;
-
-  // Re-render channel for subscription events that do NOT write the query
-  // cache (fatal/non-fatal error frames, terminal closes). Cache-writing
-  // frames re-render through each hook's own `useQuery`.
-  const [, forceRender] = useReducer((renderCount: number) => {
-    return renderCount + 1;
-  }, 0);
 
   const { consumerLabel } = args;
   const [consumerId] = useState(() => Symbol(consumerLabel));
@@ -138,8 +205,16 @@ export function useSharedStreamSubscription<TFrame>(args: {
     }
 
     shared.refCount += 1;
-    shared.consumers.set(consumerId, forceRender);
+    // The session factories fan every frame / terminal close out through
+    // `consumers`; this consumer forwards that onto the render-side channel
+    // for every hook instance at this key (including disabled readers).
+    shared.consumers.set(consumerId, () =>
+      notifyEntryChanged(registry, sessionKey),
+    );
     onConsumerJoined(shared);
+    // The render that scheduled this effect read the channel before the entry
+    // existed (or saw a terminal one about to be replaced); re-read it now.
+    notifyEntryChanged(registry, sessionKey);
 
     return () => {
       // Look up the CURRENT entry at this key rather than closing over the
@@ -158,6 +233,7 @@ export function useSharedStreamSubscription<TFrame>(args: {
       if (current.refCount === 0) {
         current.unsubscribeFromStream();
         if (registry.get(sessionKey) === current) registry.delete(sessionKey);
+        notifyEntryChanged(registry, sessionKey);
       }
     };
   }, [
@@ -170,21 +246,39 @@ export function useSharedStreamSubscription<TFrame>(args: {
     retryNonce,
   ]);
 
-  const subscription =
-    sessionKey === null ? undefined : registry.get(sessionKey);
+  // Memoized on its inputs because `useSyncExternalStore` compares the
+  // subscriber by reference: a fresh closure per render would tear the
+  // listener down and re-add it every time.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      subscribeToEntry(registry, sessionKey)(onStoreChange),
+    [registry, sessionKey],
+  );
+  const lastEvent = useSyncExternalStore(
+    subscribe,
+    () =>
+      sessionKey === null
+        ? null
+        : (registry.get(sessionKey)?.lastEvent ?? null),
+    () => null,
+  );
 
   const sendRefresh = useCallback(() => {
+    // Resolved at CALL time, never captured at render: the entry is mutable
+    // module state and a render-time capture is exactly what the compiler
+    // would freeze (see `entryListenersByRegistry`).
+    const current = sessionKey === null ? undefined : registry.get(sessionKey);
     // Branching on the last ERROR frame instead would swallow the refresh
     // entirely after a NONFATAL error: that leaves the session live and
     // `isTerminal` false, so `retry()` would only bump the nonce, the
     // subscribe effect would reuse the very same entry, and no frame would
     // ever be sent.
-    if (subscription?.isTerminal === true) {
+    if (current?.isTerminal === true) {
       retry();
       return;
     }
-    subscription?.sendRefresh();
-  }, [subscription, retry]);
+    current?.sendRefresh();
+  }, [registry, sessionKey, retry]);
 
-  return { subscription, sendRefresh };
+  return { lastEvent, sendRefresh };
 }

--- a/clients/gui-app/src/hooks/pr/use-pr-detail-subscription.ts
+++ b/clients/gui-app/src/hooks/pr/use-pr-detail-subscription.ts
@@ -204,7 +204,7 @@ export function usePrDetailSubscription(args: {
     [queryClient, activeArgs],
   );
 
-  const { subscription, sendRefresh } = useSharedStreamSubscription({
+  const { lastEvent, sendRefresh } = useSharedStreamSubscription({
     registry: subscriptions,
     sessionKey,
     enabled: stableArgs.enabled && stableArgs.methodSupported,
@@ -230,7 +230,6 @@ export function usePrDetailSubscription(args: {
     enabled: false,
   });
 
-  const lastEvent = subscription?.lastEvent ?? null;
   const errorEvent = lastEvent?.kind === "error" ? lastEvent : null;
   const data = queryData ?? null;
 

--- a/clients/gui-app/src/hooks/pr/use-pr-list-subscription.ts
+++ b/clients/gui-app/src/hooks/pr/use-pr-list-subscription.ts
@@ -132,7 +132,7 @@ export function usePrListSubscription(args: {
     [queryClient, activeArgs],
   );
 
-  const { subscription, sendRefresh } = useSharedStreamSubscription({
+  const { lastEvent, sendRefresh } = useSharedStreamSubscription({
     registry: subscriptions,
     sessionKey,
     enabled: stableArgs.enabled,
@@ -157,7 +157,6 @@ export function usePrListSubscription(args: {
     enabled: false,
   });
 
-  const lastEvent = subscription?.lastEvent ?? null;
   const errorEvent = lastEvent?.kind === "error" ? lastEvent : null;
   const data = queryData ?? null;
 

--- a/clients/gui-app/src/hooks/workspace/use-workspace-file-list-subscription.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-file-list-subscription.ts
@@ -1,5 +1,11 @@
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
-import { useEffect, useMemo, useReducer, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
 import type {
@@ -55,9 +61,9 @@ interface ActiveSubscriptionArgs {
 }
 
 interface SharedSubscription {
+  /** This entry's slot in `subscriptions`; the `entryListeners` channel key. */
+  readonly key: string;
   refCount: number;
-  /** Re-render channel for state that never reaches the query cache. */
-  consumers: Map<symbol, () => void>;
   /** Per-consumer requested coverage; the stream watches their union. */
   watchRequests: Map<symbol, ReadonlySet<string>>;
   /** Per-consumer prune sink, so each panel collapses its own expansion. */
@@ -91,6 +97,48 @@ function subscriptionKeyFor(
   return `${client.instanceId}|${args.hostId}|${args.workspacePath}`;
 }
 
+/**
+ * Change channel for the entry-scoped state a consumer reads during render
+ * (`hasListing`, `error`). Keyed by subscription key rather than held on the
+ * entry so a consumer can subscribe BEFORE its entry exists - the lifecycle
+ * effect creates the entry after the first commit - and survive its teardown.
+ *
+ * Why a channel at all: the desktop renderer runs the React Compiler, which
+ * memoizes an imperative `subscriptions.get(key)` performed during render on
+ * the identity of its inputs. Those inputs (client, host, workspace) do not
+ * change when the entry is created or when its first listing lands, so a
+ * plain render-time read froze at "no entry yet" and the file tree spun
+ * forever over rows it was already showing. `useSyncExternalStore` owns the
+ * value, so the compiler caching its callbacks is harmless.
+ */
+const entryListeners = new Map<string, Set<() => void>>();
+
+function subscribeToEntry(
+  key: string | null,
+): (listener: () => void) => () => void {
+  return (onStoreChange) => {
+    if (key === null) return () => undefined;
+    let listeners = entryListeners.get(key);
+    if (listeners === undefined) {
+      listeners = new Set();
+      entryListeners.set(key, listeners);
+    }
+    listeners.add(onStoreChange);
+    return () => {
+      const current = entryListeners.get(key);
+      if (current === undefined) return;
+      current.delete(onStoreChange);
+      if (current.size === 0) entryListeners.delete(key);
+    };
+  };
+}
+
+function notifyEntryChanged(key: string): void {
+  const listeners = entryListeners.get(key);
+  if (listeners === undefined) return;
+  for (const listener of [...listeners]) listener();
+}
+
 /** Test helper to reset module state. */
 export function __resetWorkspaceFileListSubscriptionsForTesting(): void {
   for (const shared of subscriptions.values()) shared.unsubscribeFromStream();
@@ -121,12 +169,6 @@ export function useWorkspaceFileListSubscription(args: {
     args.hostId,
     args.workspacePath,
   );
-  // Events that do not write the query cache (terminal errors) still have to
-  // re-render their consumers; a disabled query is not reliably notified by
-  // invalidation, so they ride this channel instead.
-  const [, forceRender] = useReducer((renderCount: number) => {
-    return renderCount + 1;
-  }, 0);
   const [consumerId] = useState(() => Symbol("workspace-file-list-consumer"));
 
   const { epicId, hostId, workspacePath, enabled } = args;
@@ -156,6 +198,7 @@ export function useWorkspaceFileListSubscription(args: {
     let shared = subscriptions.get(key);
     if (shared === undefined) {
       shared = createSharedSubscription(
+        key,
         wsStreamClient,
         queryClient,
         activeArgs,
@@ -164,7 +207,6 @@ export function useWorkspaceFileListSubscription(args: {
     }
 
     shared.refCount += 1;
-    shared.consumers.set(consumerId, forceRender);
     shared.pruneListeners.set(consumerId, (directoryPaths) => {
       pruneExpandedPaths(epicId, hostId, workspacePath, directoryPaths);
     });
@@ -172,16 +214,19 @@ export function useWorkspaceFileListSubscription(args: {
     // themselves live on the shared entry, and an idle workspace produces no
     // later frame to refill it), so republish on join.
     publishListings(shared, queryClient, activeArgs);
+    // The render that scheduled this effect read the entry-scoped snapshot
+    // before the entry existed (or with a stale one); re-read it now.
+    notifyEntryChanged(key);
 
     return () => {
       shared.refCount -= 1;
-      shared.consumers.delete(consumerId);
       shared.pruneListeners.delete(consumerId);
       shared.watchRequests.delete(consumerId);
       // No grace period (ADR-0003): tear down as soon as the last consumer goes.
       if (shared.refCount === 0) {
         shared.unsubscribeFromStream();
         subscriptions.delete(key);
+        notifyEntryChanged(key);
         return;
       }
       syncCoverage(shared);
@@ -245,12 +290,28 @@ export function useWorkspaceFileListSubscription(args: {
     enabled: false,
   });
 
-  const shared =
+  // Entry-scoped state is read through the store, never imperatively - see
+  // `entryListeners`. The subscriber is memoized on `key` because
+  // `useSyncExternalStore` compares it by reference: a fresh closure per
+  // render would tear the listener down and re-add it every time.
+  const key =
     wsStreamClient === null || hostId === null || workspacePath === null
-      ? undefined
-      : subscriptions.get(
-          subscriptionKeyFor(wsStreamClient, { hostId, workspacePath }),
-        );
+      ? null
+      : subscriptionKeyFor(wsStreamClient, { hostId, workspacePath });
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => subscribeToEntry(key)(onStoreChange),
+    [key],
+  );
+  const hasListing = useSyncExternalStore(
+    subscribe,
+    () => key !== null && subscriptions.get(key)?.hasListing === true,
+    () => false,
+  );
+  const error = useSyncExternalStore(
+    subscribe,
+    () => (key === null ? null : (subscriptions.get(key)?.error ?? null)),
+    () => null,
+  );
 
   const projection = useMemo(
     () =>
@@ -261,22 +322,22 @@ export function useWorkspaceFileListSubscription(args: {
     [directories, requestedWatchPaths],
   );
 
-  const error = shared?.error ?? null;
   return {
     ...projection,
-    isPending: shared?.hasListing !== true && error === null,
+    isPending: !hasListing && error === null,
     error,
   };
 }
 
 function createSharedSubscription(
+  key: string,
   wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>,
   queryClient: QueryClient,
   args: ActiveSubscriptionArgs,
 ): SharedSubscription {
   const shared: SharedSubscription = {
+    key,
     refCount: 0,
-    consumers: new Map(),
     watchRequests: new Map(),
     pruneListeners: new Map(),
     listings: new Map(),
@@ -336,7 +397,7 @@ function openStreamSession(
       shared.appliedWatchPaths = new Set();
       shared.error = null;
       syncCoverage(shared);
-      notifyConsumers(shared);
+      notifyEntryChanged(shared.key);
       return;
     }
     if (status !== "closed") return;
@@ -345,7 +406,7 @@ function openStreamSession(
     // would sit pending forever.
     shared.session = null;
     shared.error = describeStreamClose(reason);
-    notifyConsumers(shared);
+    notifyEntryChanged(shared.key);
   });
 }
 
@@ -363,8 +424,12 @@ function handleServerFrame(
       entries: frame.entries,
       truncated: frame.truncated,
     });
+    const isFirstListing = !shared.hasListing;
     shared.hasListing = true;
     publishListings(shared, queryClient, args);
+    // Only the flip is render-relevant; every later listing reaches consumers
+    // through the query cache.
+    if (isFirstListing) notifyEntryChanged(shared.key);
     return;
   }
   // `pruned`: the host stopped serving these directories. Their covered
@@ -459,10 +524,6 @@ function publishListings(
     workspaceQueryKeys.fileList(args.hostId, args.workspacePath),
     new Map(shared.listings),
   );
-}
-
-function notifyConsumers(shared: SharedSubscription): void {
-  for (const consumer of shared.consumers.values()) consumer();
 }
 
 function describeStreamClose(reason: StreamCloseReason | null): string | null {

--- a/clients/gui-app/vitest.config.ts
+++ b/clients/gui-app/vitest.config.ts
@@ -13,8 +13,14 @@ const MAX_TEST_WORKERS = Math.min(
   2,
   Math.max(1, Math.floor(availableParallelism / 2)),
 );
+// `use-workspace-file-list-subscription` is here for the same reason: its
+// pending flag used to be a render-time read of a module-level registry, which
+// the compiler cached at "no entry yet" forever (the file tree's permanent
+// spinner). Only the compiled hook can regress that way, so only the compiled
+// hook can prove the fix. The `pr.*` shared-subscription trio had the same
+// shape (`registry.get(key)` and `entry.lastEvent` read at render).
 const REACT_COMPILER_REGRESSION_FILES =
-  /[/\\](?:composer-prompt-editor|use-(?:chat|landing|new-conversation)-prompt-stash-adapters)\.(?:ts|tsx)$/;
+  /[/\\](?:composer-prompt-editor|use-(?:chat|landing|new-conversation)-prompt-stash-adapters|use-workspace-file-list-subscription|shared-stream-subscription|use-pr-(?:list|detail)-subscription)\.(?:ts|tsx)$/;
 
 export default defineConfig({
   // Run the affected composer boundary through the packaged desktop


### PR DESCRIPTION
The workspace file tree in the sidebar showed a spinner forever, centred over
the rows it was already rendering. Reported from staging; reproduced there and
diagnosed in the live renderer.

## Why

`useWorkspaceFileListSubscription` derived its pending flag from an imperative
read of module state performed **during render**:

```ts
const shared = subscriptions.get(subscriptionKeyFor(wsStreamClient, { hostId, workspacePath }));
isPending: shared?.hasListing !== true && error === null
```

The desktop renderer enables the React Compiler, which memoizes that lookup on
the identity of its inputs — stream client, host id, workspace path. None of
them change when the subscribe effect creates the entry (that happens after the
first commit) or when its first `listing` frame lands, so the compiled hook
cached `undefined` on the very first render and kept serving it. `isPending`
stayed `true` for the life of the panel while the `useQuery` mirror — a
genuinely reactive read of the same stream's data — kept delivering rows.

Confirmed in the running staging app over CDP: the `fileList` query held its
root listing, stamped 66 ms after the host accepted the subscribe, while the
`Loading files` overlay was still mounted; the served bundle carries the cached
lookup as `E = (t[45]!==l||…) ? yT.get(bT(r,{…})) : t[48]`. Nothing in the
source says "freeze" — only the compiled output does, which is why the suite
never caught it (gui-app's Vitest applies the compiler preset to a filter list
that did not include these hooks).

Sweeping the other module-level registries in `gui-app` turned up one more with
the same shape: the `pr.*` shared-subscription machinery read its registry entry
and that entry's `lastEvent` at render, so error frames never surfaced and
`sendRefresh` ran against a frozen `undefined` — the reason its "Try again"
could not reconnect a terminal session.

## What changes

Both hooks read entry-scoped state through `useSyncExternalStore` over a per-key
listener channel, the way `use-git-list-changed-files-subscription` already
does. The channel is keyed outside the entry deliberately: a consumer subscribes
before its entry exists and must survive that entry's teardown, and a *disabled*
PR consumer reading a sibling's live session still has to be notified by the
sibling's fan-out.

`useSharedStreamSubscription` now returns `lastEvent` rather than the mutable
entry. Handing a module-state object to a caller is what invited the render-time
read in the first place; both PR hooks already reduced it to `lastEvent` on the
next line. `sendRefresh` resolves its entry at call time instead of capturing
one at render.

Frame-driven notification is unchanged in shape: the file-list hook notifies on
the `hasListing` flip only (every later listing reaches consumers through the
query cache), on session open/close, and on last-consumer teardown; the PR hooks
reuse the session factories' existing `consumers` fan-out and forward it onto
the render channel.

## Protocol

None. No wire contract, no host change.

## Testing

The four affected hook files join the compiler-enabled Vitest transform list —
only the compiled hook can regress this way, so only the compiled hook can prove
the fix. Compiled and **before** the change, the existing assertions fail:

- `use-workspace-file-list-subscription`: 2/7 fail (`isPending` never clears
  after the root listing; a terminal close never surfaces).
- `use-pr-list-subscription` / `use-pr-detail-subscription`: 4/12 fail (nonfatal
  refresh, and a second consumer's ref count across a retry).

After it, 66 tests across the 9 suites that touch these hooks pass, including
the PR panel components.
