### PR TITLE
fix(gui-app): make the dead-tile banner ownership- and role-aware

### DIFF
--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -463,9 +463,16 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
     client: appWideClient,
     epicId,
     chatId: activeWorkspaceTarget?.sourceChatId ?? null,
-    // The tab this dialog forks FROM is bound to the source chat's host for
-    // life, so it disambiguates a host-minted id two hosts both minted.
-    sourceOwnerHostId: tabHostId,
+    // No tie-breaker from here, deliberately. The resolver wants the chat's
+    // OWNING host, and `tabHostId` is not reliably that: a `PublishedChatTile`
+    // renders through the host SERVING the copy, which is generally the
+    // viewer's own machine rather than the owner's (`published-chat-tile.tsx`
+    // keeps the two apart for exactly this reason). Handing it over would let
+    // a colliding `chatId` resolve to the viewer's own unrelated row - a wrong
+    // owner is worse than none, because the host TRUSTS the expectation it is
+    // given. Unambiguous lookups are unaffected; an ambiguous one degrades to
+    // settings-only, which is what it did before any tie-breaker existed.
+    sourceOwnerHostId: null,
   });
   // Cross-host, the workspace section resets to the target's own folder catalog
   // with NO seed: the source chat's paths name directories on another machine,

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -463,6 +463,9 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
     client: appWideClient,
     epicId,
     chatId: activeWorkspaceTarget?.sourceChatId ?? null,
+    // The tab this dialog forks FROM is bound to the source chat's host for
+    // life, so it disambiguates a host-minted id two hosts both minted.
+    sourceOwnerHostId: tabHostId,
   });
   // Cross-host, the workspace section resets to the target's own folder catalog
   // with NO seed: the source chat's paths name directories on another machine,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/bounded-loading-catalog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/bounded-loading-catalog.test.tsx
@@ -264,4 +264,25 @@ describe("S2 — host-starting is bounded, and Clone arrives AT the deadline", (
       screen.queryByRole("button", { name: "Clone agent" }),
     ).not.toBeNull();
   });
+
+  // Shared-chat support, wired through the REAL container: `epic.createChat`
+  // is editor-gated host-side, so a known viewer role must withhold the Clone
+  // button the same banner would otherwise offer - the alternative was a
+  // click that died on a bare "You don't have permission" toast. The
+  // editor-role sibling above is the control: same tile, same deadline, the
+  // button present.
+  it("withholds Clone at the deadline for a viewer role, and says why", async () => {
+    epicHarness.install(null, "viewer");
+    renderChatTile();
+    await settleEpicSession();
+
+    act(() => {
+      vi.advanceTimersByTime(HOST_STARTING_BUDGET_MS);
+    });
+
+    const banner = screen.getByTestId(`chat-dead-tile-${CHAT_ARTIFACT.id}`);
+    expect(banner).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Clone agent" })).toBeNull();
+    expect(banner.textContent).toContain("view-only access");
+  });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -292,7 +292,17 @@ vi.mock("@/components/epic-canvas/renderers/chat-tile", () => ({
   ChatDeadTileBannerContainer: (props: {
     readonly testId: string;
     readonly reason: string;
-  }) => <div data-testid={props.testId} data-reason={props.reason} />,
+    readonly sourceOwnerUserId?: string;
+  }) => (
+    <div
+      data-testid={props.testId}
+      data-reason={props.reason}
+      // Surfaced so the substitution arm's owner threading is assertable:
+      // the banner must receive the owner the OPENING ROW resolved, not be
+      // left to re-derive it from a second cloud lookup.
+      data-source-owner={props.sourceOwnerUserId}
+    />
+  ),
 }));
 
 vi.mock("@/components/epic-canvas/renderers/epic-node-tile", async () => {
@@ -1333,6 +1343,10 @@ describe("<TabGroupView /> published-copy fallback for an unreachable bound host
     // one state of the three that is allowed to tell the reader to go wake a
     // machine (ticket 47/48's copy split).
     expect(banner?.getAttribute("data-reason")).toBe("host-offline");
+    // The owner the opening row resolved rides into the banner - the ref in
+    // PUBLISHED_COPY_TILE_ID names user-1, and the banner's ownership
+    // verdict must come from that same row rather than a second lookup.
+    expect(banner?.getAttribute("data-source-owner")).toBe("user-1");
     // The live chat body must NOT render alongside the copy.
     expect(
       container.querySelector(`[data-testid="tile-${CHAT.id}"]`),

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -64,6 +64,7 @@ import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body
 import type {
   EpicCanvasTileRef,
   EpicNodeRef,
+  PublishedChatTileRef,
   SplitDirection,
   TilePane,
 } from "@/stores/epics/canvas/types";
@@ -691,7 +692,14 @@ function usePublishedChatFallbackRef(args: {
     EpicArtifactProjection | EpicChatProjection | EpicTuiAgentProjection | null;
   readonly activeHostId: string | null;
 }): {
-  readonly fallbackRef: EpicCanvasTileRef | null;
+  /**
+   * Narrowed to the published-chat shape (the only ref this hook ever
+   * builds) so the substitution mount can thread `ownerUserId` - the owner
+   * the OPENING ROW resolved - into the banner instead of leaving the
+   * banner's container to re-derive it from a second cloud lookup that can
+   * fail independently (cold-review finding).
+   */
+  readonly fallbackRef: PublishedChatTileRef | null;
   readonly ownerHostLabel: string;
   readonly reason: ChatDeadTileBannerReason;
   readonly isCloudKnown: boolean;
@@ -984,6 +992,12 @@ function ActiveTabBody(props: ActiveTabBodyProps) {
         <ChatDeadTileBanner
           hostLabel={ownerHostLabel}
           reason="chat-no-longer-shared"
+          // Both moot for this reason: the revoked copy never varies by owner
+          // and declares `offersClone: false`, so neither flag can render
+          // anything. Passed as the do-nothing pair, like `noopClone`.
+          ownedByViewer
+          cloneAllowed={false}
+          showsPublishedCopy={false}
           onClone={noopClone}
           cloning={false}
           className={undefined}
@@ -1003,7 +1017,13 @@ function ActiveTabBody(props: ActiveTabBodyProps) {
           sourceHostId={activeTab.hostId}
           hostLabel={ownerHostLabel}
           reason={deadTileBannerReason}
+          showsPublishedCopy
           testId={`chat-dead-tile-${activeTab.id}`}
+          // The owner the opening row already resolved (the fallback ref is
+          // only built once one exists) - threading it means the banner's
+          // ownership verdict cannot disagree with the copy rendered under
+          // it, and does not depend on the container's own cloud lookup.
+          sourceOwnerUserId={publishedFallbackRef.ownerUserId}
         />
         <EpicNodeTile
           node={publishedFallbackRef}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/dead-tile-banner-container.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/dead-tile-banner-container.test.tsx
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as Y from "yjs";
+import { TestRouterProvider } from "@/__tests__/with-test-router";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { ChatDeadTileBannerContainer } from "@/components/epic-canvas/renderers/chat-tile";
+import { TestEpicSessionWrapper } from "@/components/epic-canvas/__tests__/test-epic-session";
+import {
+  createEpicSessionTestHarness,
+  type TestEpicHarness,
+} from "@/components/epic-canvas/__tests__/test-epic-session-harness";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
+import type { PermissionRole } from "@traycer/protocol/host/epic/unary-schemas";
+
+/**
+ * THE OWNERSHIP WIRING, against the REAL container (cold-review P3).
+ *
+ * The banner unit tests inject `ownedByViewer` / `cloneAllowed` directly and
+ * the published tile's suite stubs this container, so before this file a
+ * regression in the container's own resolution - the auth-store identity
+ * read, the owner comparison, the role gate, the fail-open default - would
+ * leave every touched suite green. Here the real
+ * `ChatDeadTileBannerContainer` resolves everything itself: the source owner
+ * from the epic doc's chat record (the same local tier
+ * `useCloneSourceOwnerUserId` consults first), the viewer from the auth
+ * store, and the role from the epic session snapshot.
+ *
+ * The host-hook mock set mirrors `bounded-loading-catalog.test.tsx`, which
+ * already mounts this container the same way: the clone offer's host-runtime
+ * and mutation edges are severed, everything the file is about stays real.
+ */
+
+const MOCK_HOST_CLIENT = {
+  request: () => new Promise(() => {}),
+  getActiveHostId: () => "host-test",
+  getRequestContextUserId: () => "user-test",
+  getRequestContext: () => ({ userId: "user-test" }),
+  onChange: () => () => undefined,
+};
+const MOCK_HOST_DIRECTORY = {
+  onChange: () => ({ dispose() {} }),
+  findById: () => null,
+};
+
+vi.mock("@/lib/host", () => ({
+  useHostBinding: () => null,
+  useHostDirectory: () => MOCK_HOST_DIRECTORY,
+  useAuthService: () => ({
+    revalidateCurrentContext: () => Promise.resolve({ kind: "valid" as const }),
+  }),
+  useHostClient: () => MOCK_HOST_CLIENT,
+  useHostRuntimeClient: () => MOCK_HOST_CLIENT,
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@/hooks/epic/use-epic-chat-mutations")
+  >()),
+  useEpicCreateChatForHost: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicCreateChatForHostClient: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+
+vi.mock("@/hooks/host/use-host-stream-client-for", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@/hooks/host/use-host-stream-client-for")
+  >()),
+  useHostStreamClientFor: () => null,
+  useHostStreamClientBindingFor: () => null,
+}));
+
+vi.mock("@/lib/host/stream-runtime-context", () => ({
+  useWsStreamClient: () => null,
+  useStreamMethodSupport: () => null,
+  useStreamMethodSchemaVersion: () => null,
+}));
+
+vi.mock("@/hooks/host/use-addressable-host-id", () => ({
+  useAddressableHostId: () => "host-test",
+}));
+
+vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
+  useHostDirectoryList: () => ({ data: [], fetchStatus: "success" }),
+}));
+
+vi.mock("@/hooks/host/use-effective-host-id", () => ({
+  useEffectiveHostId: () => "host-test",
+}));
+
+vi.mock("@/components/report-issue/report-issue-action", () => ({
+  ReportIssueAction: () => null,
+}));
+
+const CHAT_ID = "chat-owned";
+const VIEWER_USER_ID = "viewer-user";
+const COLLABORATOR_USER_ID = "collaborator-user";
+
+/** A doc chat record carrying `userId` - the local tier the container's
+ *  owner lookup consults before any cloud row. */
+function seedChatOwnedBy(ownerUserId: string): (doc: Y.Doc) => void {
+  return (doc) => {
+    const epic = doc.getMap("epic");
+    const chats = new Y.Map<unknown>();
+    const chat = new Y.Map<unknown>();
+    chat.set("id", CHAT_ID);
+    chat.set("title", "Owned chat");
+    chat.set("parentId", null);
+    chat.set("createdAt", 0);
+    chat.set("updatedAt", 0);
+    chat.set("userId", ownerUserId);
+    chat.set("messages", new Y.Array<unknown>());
+    chats.set(CHAT_ID, chat);
+    epic.set("title", "Ownership epic");
+    epic.set("artifacts", new Y.Map<unknown>());
+    epic.set("chats", chats);
+  };
+}
+
+// One epic id (and harness) PER TEST: the session registry retains the most
+// recent session per epic id across acquires (the R-1 rotation), so a second
+// test reusing the id can be handed the previous test's session - whose
+// snapshot generation has moved on - and its installed role never lands.
+// Distinct ids make every test's session its own.
+let epicSeq = 0;
+let activeHarness: TestEpicHarness | null = null;
+
+function renderContainer(input: {
+  readonly ownerUserId: string;
+  /**
+   * The owner the mounting surface carries, mirroring the real foreign
+   * mounts: the published tile threads its ref's `ownerUserId` and the
+   * canvas substitution threads the fallback ref's. A collaborator's chat
+   * has no other local source - the epic projection filters out records
+   * that are not visible to the signed-in user, so the container's local
+   * tier can never resolve a foreign owner from the doc. The own-chat case
+   * passes `undefined` and exercises exactly that local tier.
+   */
+  readonly providedOwnerUserId: string | undefined;
+  readonly permissionRole: PermissionRole | null;
+  readonly showsPublishedCopy: boolean;
+}) {
+  const epicId = `epic-banner-container-${++epicSeq}`;
+  const harness = createEpicSessionTestHarness(epicId);
+  activeHarness = harness;
+  harness.install(seedChatOwnedBy(input.ownerUserId), input.permissionRole);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <TestRouterProvider>
+      <QueryClientProvider client={queryClient}>
+        <RunnerHostProvider
+          runnerHost={
+            new MockRunnerHost({
+              signInUrl: "https://example.com",
+              authnBaseUrl: "https://auth.example.com",
+              localHost: null,
+              hosts: [],
+              workspaceFolderPickerPaths: undefined,
+              hasLocalHost: undefined,
+              traycerCli: undefined,
+            })
+          }
+        >
+          <TestEpicSessionWrapper epicId={epicId}>
+            <ChatDeadTileBannerContainer
+              epicId={epicId}
+              tabId="tab-1"
+              chatId={CHAT_ID}
+              sourceHostId="owner-host-1"
+              hostLabel="owner-host-1"
+              reason="host-offline"
+              showsPublishedCopy={input.showsPublishedCopy}
+              testId="banner-under-test"
+              sourceOwnerUserId={input.providedOwnerUserId}
+            />
+          </TestEpicSessionWrapper>
+        </RunnerHostProvider>
+      </QueryClientProvider>
+    </TestRouterProvider>,
+  );
+}
+
+/** The harness delivers its snapshot on a `setTimeout(0)`; flush it so the
+ *  epic store holds the seeded chat and the installed role. */
+async function settleEpicSession(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useAuthStore.setState({
+    status: "signed-in",
+    profile: {
+      userId: VIEWER_USER_ID,
+      userName: "Viewer",
+      email: "viewer@example.com",
+    },
+    contextMetadata: { userId: VIEWER_USER_ID, username: "Viewer" },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  activeHarness?.teardown();
+  activeHarness = null;
+  __getOpenEpicRegistryForTests().disposeAll();
+});
+
+describe("ChatDeadTileBannerContainer - ownership + role resolution", () => {
+  it("resolves a collaborator's chat to the foreign copy and keeps Clone for an editor", async () => {
+    renderContainer({
+      ownerUserId: COLLABORATOR_USER_ID,
+      providedOwnerUserId: COLLABORATOR_USER_ID,
+      permissionRole: "editor",
+      showsPublishedCopy: true,
+    });
+    await settleEpicSession();
+
+    const text = screen.getByTestId("banner-under-test").textContent;
+    expect(text).toContain("belongs to another collaborator");
+    // The two claims the incident banner made and this copy must not: the
+    // machine's liveness, and a raw host id label.
+    expect(text).not.toContain("is offline");
+    expect(text).not.toContain("owner-host-1");
+    expect(screen.getByRole("button", { name: "Clone agent" })).toBeTruthy();
+  });
+
+  it("withholds Clone for a viewer role on a collaborator's chat, and says why", async () => {
+    renderContainer({
+      ownerUserId: COLLABORATOR_USER_ID,
+      providedOwnerUserId: COLLABORATOR_USER_ID,
+      permissionRole: "viewer",
+      showsPublishedCopy: true,
+    });
+    await settleEpicSession();
+
+    // `waitFor`, not a fixed settle: the role lands with the harness's
+    // snapshot, whose delivery timing varies under load, and this is the one
+    // assertion in the file that cannot pass until it has.
+    await waitFor(() => {
+      expect(screen.getByTestId("banner-under-test").textContent).toContain(
+        "view-only access",
+      );
+    });
+    const text = screen.getByTestId("banner-under-test").textContent;
+    expect(text).toContain("belongs to another collaborator");
+    expect(screen.queryByRole("button", { name: "Clone agent" })).toBeNull();
+  });
+
+  it("fails open on an unresolved role - the host's editor gate is the backstop", async () => {
+    renderContainer({
+      ownerUserId: COLLABORATOR_USER_ID,
+      providedOwnerUserId: COLLABORATOR_USER_ID,
+      permissionRole: null,
+      showsPublishedCopy: true,
+    });
+    await settleEpicSession();
+
+    expect(screen.getByRole("button", { name: "Clone agent" })).toBeTruthy();
+  });
+
+  it("keeps the own-chat copy when the record's owner IS the signed-in user", async () => {
+    renderContainer({
+      ownerUserId: VIEWER_USER_ID,
+      providedOwnerUserId: undefined,
+      permissionRole: "editor",
+      showsPublishedCopy: false,
+    });
+    await settleEpicSession();
+
+    const text = screen.getByTestId("banner-under-test").textContent;
+    expect(text).toContain("is offline");
+    expect(text).toContain("stays bound to");
+    expect(text).not.toContain("belongs to another collaborator");
+  });
+
+  it("never claims a published copy the mounting surface is not showing", async () => {
+    renderContainer({
+      ownerUserId: COLLABORATOR_USER_ID,
+      providedOwnerUserId: COLLABORATOR_USER_ID,
+      permissionRole: "editor",
+      showsPublishedCopy: false,
+    });
+    await settleEpicSession();
+
+    const text = screen.getByTestId("banner-under-test").textContent;
+    expect(text).toContain("belongs to another collaborator");
+    expect(text).not.toContain("published copy");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/dead-tile-banner.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/dead-tile-banner.test.tsx
@@ -79,6 +79,9 @@ describe("<ChatDeadTileBanner />", () => {
       <ChatDeadTileBanner
         hostLabel="mac-mini"
         reason="host-offline"
+        ownedByViewer
+        cloneAllowed
+        showsPublishedCopy={false}
         cloning={false}
         onClone={() => undefined}
         testId="chat-dead"
@@ -105,6 +108,9 @@ describe("<ChatDeadTileBanner />", () => {
       <ChatDeadTileBanner
         hostLabel="mac-mini"
         reason="chat-not-visible"
+        ownedByViewer
+        cloneAllowed
+        showsPublishedCopy={false}
         cloning={false}
         onClone={() => undefined}
         testId="chat-dead-absent"
@@ -133,6 +139,9 @@ describe("<ChatDeadTileBanner />", () => {
       <ChatDeadTileBanner
         hostLabel="mac-mini"
         reason="chat-not-on-this-host"
+        ownedByViewer
+        cloneAllowed
+        showsPublishedCopy={false}
         cloning={false}
         onClone={() => undefined}
         testId="chat-dead-here"
@@ -166,6 +175,9 @@ describe("<ChatDeadTileBanner />", () => {
       <ChatDeadTileBanner
         hostLabel="mac-mini"
         reason="chat-no-longer-shared"
+        ownedByViewer
+        cloneAllowed={false}
+        showsPublishedCopy={false}
         cloning={false}
         onClone={() => undefined}
         testId="chat-dead-revoked"
@@ -200,6 +212,9 @@ describe("<ChatDeadTileBanner />", () => {
         <ChatDeadTileBanner
           hostLabel="mac-mini"
           reason={reason}
+          ownedByViewer
+          cloneAllowed
+          showsPublishedCopy={false}
           cloning={false}
           onClone={() => undefined}
           testId={`chat-dead-${reason}`}
@@ -210,4 +225,166 @@ describe("<ChatDeadTileBanner />", () => {
       expect(screen.getByRole("status").textContent).toContain(phrase);
     },
   );
+
+  // Shared-chat support: a collaborator's chat reaches this banner because the
+  // owner's machine can never appear in the viewer's host directory - every
+  // "unreachable" verdict for it is a fact about THIS account's fleet, not
+  // evidence the machine is off. The pre-existing copy asserted exactly that
+  // liveness ("is offline") about a raw host id, which is the misleading
+  // banner this arm exists to replace.
+  describe("collaborator-owned chat (ownedByViewer=false)", () => {
+    it("says whose agent it is, claims no liveness, and names no host", () => {
+      render(
+        <ChatDeadTileBanner
+          hostLabel="085b919a-f0a6-42e5-b05e-241738d3dd6a"
+          reason="host-offline"
+          ownedByViewer={false}
+          cloneAllowed
+          showsPublishedCopy
+          cloning={false}
+          onClone={() => undefined}
+          testId="chat-dead-foreign"
+          className={undefined}
+        />,
+      );
+
+      const text = screen.getByTestId("chat-dead-foreign").textContent;
+      expect(text).toContain("belongs to another collaborator");
+      expect(text).toContain("last published copy");
+      // The two claims this copy must NOT make: the machine's liveness, and
+      // a host id label the reader can do nothing with.
+      expect(text).not.toContain("is offline");
+      expect(text).not.toContain("085b919a-f0a6-42e5-b05e-241738d3dd6a");
+      // An editor keeps the way out - the host's fork path deliberately
+      // permits a cross-user source in a shared epic.
+      expect(screen.getByRole("button", { name: "Clone agent" })).toBeTruthy();
+    });
+
+    it("withholds Clone and says why for a view-only collaborator", () => {
+      render(
+        <ChatDeadTileBanner
+          hostLabel="085b919a-f0a6-42e5-b05e-241738d3dd6a"
+          reason="host-offline"
+          ownedByViewer={false}
+          cloneAllowed={false}
+          showsPublishedCopy
+          cloning={false}
+          onClone={() => undefined}
+          testId="chat-dead-foreign-viewer"
+          className={undefined}
+        />,
+      );
+
+      const text = screen.getByTestId("chat-dead-foreign-viewer").textContent;
+      expect(text).toContain("belongs to another collaborator");
+      // The reason the button is absent, in the sentence - the alternative
+      // was a button whose click died on a bare "You don't have permission"
+      // toast, which is the defect this gate exists to remove.
+      expect(text).toContain("view-only access");
+      expect(screen.queryByRole("button", { name: "Clone agent" })).toBeNull();
+    });
+
+    // Cold-review finding: the first cut claimed "showing the last published
+    // copy" unconditionally, but the live tile mounts this banner above a
+    // load state or a cached live session - the claim must follow the
+    // mounting surface's presentation, not the reason.
+    it("claims no published copy when the mounting surface shows none", () => {
+      render(
+        <ChatDeadTileBanner
+          hostLabel="some-host-id"
+          reason="host-offline"
+          ownedByViewer={false}
+          cloneAllowed
+          showsPublishedCopy={false}
+          cloning={false}
+          onClone={() => undefined}
+          testId="chat-dead-foreign-no-copy"
+          className={undefined}
+        />,
+      );
+
+      const text = screen.getByTestId("chat-dead-foreign-no-copy").textContent;
+      expect(text).toContain("belongs to another collaborator");
+      expect(text).not.toContain("published copy");
+      expect(screen.getByRole("button", { name: "Clone agent" })).toBeTruthy();
+    });
+
+    // Cold-review finding: `chat-not-visible` / `chat-not-on-this-host` are
+    // picked only after a reachable host ANSWERED, so the foreign sentence
+    // must keep the missing-history fact there - "isn't connected" would
+    // invert the evidence.
+    it("keeps the missing-history fact - not a connectivity claim - when a host answered", () => {
+      for (const reason of [
+        "chat-not-visible",
+        "chat-not-on-this-host",
+      ] as const) {
+        const { unmount } = render(
+          <ChatDeadTileBanner
+            hostLabel="mac-mini"
+            reason={reason}
+            ownedByViewer={false}
+            cloneAllowed
+            showsPublishedCopy
+            cloning={false}
+            onClone={() => undefined}
+            testId={`chat-dead-foreign-${reason}`}
+            className={undefined}
+          />,
+        );
+
+        const text = screen.getByTestId(
+          `chat-dead-foreign-${reason}`,
+        ).textContent;
+        expect(text).toContain("belongs to another collaborator");
+        expect(text).toContain("history isn't available");
+        expect(text).not.toContain("isn't connected");
+        expect(text).not.toContain("mac-mini");
+        unmount();
+      }
+    });
+
+    it("keeps the revoked copy for a collaborator chat - that reason is about the viewer, not a host", () => {
+      render(
+        <ChatDeadTileBanner
+          hostLabel="mac-mini"
+          reason="chat-no-longer-shared"
+          ownedByViewer={false}
+          cloneAllowed={false}
+          showsPublishedCopy={false}
+          cloning={false}
+          onClone={() => undefined}
+          testId="chat-dead-foreign-revoked"
+          className={undefined}
+        />,
+      );
+
+      const text = screen.getByTestId("chat-dead-foreign-revoked").textContent;
+      expect(text).toContain("no longer shared with you");
+      expect(text).not.toContain("belongs to another collaborator");
+    });
+  });
+
+  // The own-chat viewer edge: a chat the viewer created before their role was
+  // downgraded. The reason copy still ends in "clone it and carry on", so the
+  // button's absence must be explained rather than silent.
+  it("withholds Clone on the viewer's own chat when the role can't create agents, and says why", () => {
+    render(
+      <ChatDeadTileBanner
+        hostLabel="mac-mini"
+        reason="host-offline"
+        ownedByViewer
+        cloneAllowed={false}
+        showsPublishedCopy={false}
+        cloning={false}
+        onClone={() => undefined}
+        testId="chat-dead-own-viewer"
+        className={undefined}
+      />,
+    );
+
+    const text = screen.getByTestId("chat-dead-own-viewer").textContent;
+    expect(text).toContain("is offline");
+    expect(text).toContain("view-only access");
+    expect(screen.queryByRole("button", { name: "Clone agent" })).toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/dead-tile-banner.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/dead-tile-banner.test.tsx
@@ -6,8 +6,23 @@ import {
   TerminalDeadTileBanner,
 } from "../dead-tile-banner";
 
+// Surfaced rather than stubbed to null: the report context is what a support
+// ticket carries, and it is the one part of this banner a reader never sees on
+// screen - so nothing but a test can catch it contradicting the sentence it
+// sits beside.
 vi.mock("@/components/report-issue/report-issue-action", () => ({
-  ReportIssueAction: () => null,
+  ReportIssueAction: (props: {
+    readonly context: {
+      readonly title: string;
+      readonly message: string | null;
+    };
+  }) => (
+    <span
+      data-testid="report-context"
+      data-title={props.context.title}
+      data-message={props.context.message ?? ""}
+    />
+  ),
 }));
 
 afterEach(cleanup);
@@ -386,5 +401,90 @@ describe("<ChatDeadTileBanner />", () => {
     expect(text).toContain("is offline");
     expect(text).toContain("view-only access");
     expect(screen.queryByRole("button", { name: "Clone agent" })).toBeNull();
+  });
+
+  // Every clone-offering sentence ENDS in the promise ("continuing here creates
+  // a new agent", "cloning creates a new agent from it"). Appending the denial
+  // to one of those produced a banner that offered and refused the same action
+  // in consecutive sentences, so the no-clone variant must not carry it at all.
+  it("never promises cloning in the same breath as refusing it", () => {
+    for (const reason of [
+      "host-offline",
+      "host-plan-restricted",
+      "chat-not-visible",
+      "chat-not-on-this-host",
+    ] as const) {
+      const { unmount } = render(
+        <ChatDeadTileBanner
+          hostLabel="mac-mini"
+          reason={reason}
+          ownedByViewer
+          cloneAllowed={false}
+          showsPublishedCopy={false}
+          cloning={false}
+          onClone={() => undefined}
+          testId={`chat-dead-no-clone-${reason}`}
+          className={undefined}
+        />,
+      );
+
+      const text = screen.getByTestId(
+        `chat-dead-no-clone-${reason}`,
+      ).textContent;
+      expect(text).toContain("view-only access");
+      expect(text).not.toContain("creates a new agent");
+      expect(text).not.toContain("cloning creates");
+      expect(screen.queryByRole("button", { name: "Clone agent" })).toBeNull();
+      unmount();
+    }
+  });
+
+  // The report rides along invisibly, so it can drift from the sentence
+  // without anyone noticing. For the two reasons a host ANSWERED on, claiming
+  // a disconnected host would file a ticket contradicting the screen.
+  it("files a foreign-owner report that matches the reason on screen", () => {
+    for (const reason of [
+      "chat-not-visible",
+      "chat-not-on-this-host",
+    ] as const) {
+      const { unmount } = render(
+        <ChatDeadTileBanner
+          hostLabel="mac-mini"
+          reason={reason}
+          ownedByViewer={false}
+          cloneAllowed
+          showsPublishedCopy
+          cloning={false}
+          onClone={() => undefined}
+          testId={`chat-dead-report-${reason}`}
+          className={undefined}
+        />,
+      );
+
+      const report = screen.getByTestId("report-context");
+      expect(report.getAttribute("data-message")).not.toContain(
+        "isn't connected",
+      );
+      expect(report.getAttribute("data-message")).toContain("history");
+      unmount();
+    }
+
+    // The unreachable arm keeps the connectivity claim, which is true there.
+    render(
+      <ChatDeadTileBanner
+        hostLabel="mac-mini"
+        reason="host-offline"
+        ownedByViewer={false}
+        cloneAllowed
+        showsPublishedCopy
+        cloning={false}
+        onClone={() => undefined}
+        testId="chat-dead-report-offline"
+        className={undefined}
+      />,
+    );
+    expect(
+      screen.getByTestId("report-context").getAttribute("data-message"),
+    ).toContain("isn't connected here");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-lock-reason.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-lock-reason.test.ts
@@ -23,6 +23,7 @@ describe("publishedChatLockReason", () => {
     const reason = publishedChatLockReason({
       ownerIsReachable: true,
       ownerIsThisHost: false,
+      ownedByViewer: true,
       ownerLabel: "Ada's Mac",
       unreadableCount: 0,
       fidelityNotice: null,
@@ -37,6 +38,7 @@ describe("publishedChatLockReason", () => {
     const reason = publishedChatLockReason({
       ownerIsReachable: true,
       ownerIsThisHost: true,
+      ownedByViewer: true,
       ownerLabel: "Ada's Mac",
       unreadableCount: 0,
       fidelityNotice: null,
@@ -60,6 +62,7 @@ describe("publishedChatLockReason", () => {
       const reason = publishedChatLockReason({
         ownerIsReachable: false,
         ownerIsThisHost,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 0,
         fidelityNotice: null,
@@ -70,6 +73,51 @@ describe("publishedChatLockReason", () => {
     }
   });
 
+  it("says whose agent it is - and claims no liveness - for a collaborator's chat", () => {
+    // A collaborator's machine can never appear in this account's host
+    // directory, so it reads "unreachable" unconditionally - "which is
+    // offline" would assert liveness this device cannot observe, the label
+    // has fallen back to a raw host id, and "sending resumes" promises a
+    // composer this viewer does not get. The ownership arm outranks BOTH
+    // reachability arms for exactly that reason.
+    for (const ownerIsReachable of [false, true]) {
+      const reason = publishedChatLockReason({
+        ownerIsReachable,
+        ownerIsThisHost: false,
+        ownedByViewer: false,
+        ownerLabel: "085b919a-f0a6-42e5-b05e-241738d3dd6a",
+        unreadableCount: 0,
+        fidelityNotice: null,
+        publishedAt: null,
+      });
+      expect(reason).toContain("belongs to another collaborator");
+      expect(reason).toContain("last published copy");
+      expect(reason).not.toContain("which is offline");
+      expect(reason).not.toContain("085b919a-f0a6-42e5-b05e-241738d3dd6a");
+      expect(reason).not.toContain("Sending resumes");
+    }
+  });
+
+  it("keeps the published-at and unreadable tails on the collaborator sentence", () => {
+    const publishedAt = Date.parse("2026-08-14T12:00:00Z");
+    const reason = publishedChatLockReason({
+      ownerIsReachable: false,
+      ownerIsThisHost: false,
+      ownedByViewer: false,
+      ownerLabel: "some-host-id",
+      unreadableCount: 2,
+      fidelityNotice: null,
+      publishedAt,
+    });
+    expect(reason).toContain("belongs to another collaborator");
+    expect(reason).toContain(
+      `Published ${formatAbsoluteDateTime(publishedAt)}.`,
+    );
+    expect(reason).toContain(
+      "2 items need a newer version of Traycer to render.",
+    );
+  });
+
   it("still appends the unreadable-item and fidelity tails to the same-host sentence", () => {
     // The tails are appended to whichever base was chosen - the split must
     // not drop them for the new arm.
@@ -77,6 +125,7 @@ describe("publishedChatLockReason", () => {
       publishedChatLockReason({
         ownerIsReachable: true,
         ownerIsThisHost: true,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 2,
         fidelityNotice: null,
@@ -87,6 +136,7 @@ describe("publishedChatLockReason", () => {
       publishedChatLockReason({
         ownerIsReachable: true,
         ownerIsThisHost: true,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 0,
         fidelityNotice: "1 attachment is unavailable.",
@@ -103,6 +153,7 @@ describe("publishedChatLockReason", () => {
       const reason = publishedChatLockReason({
         ownerIsReachable: true,
         ownerIsThisHost: true,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 0,
         fidelityNotice: null,
@@ -120,6 +171,7 @@ describe("publishedChatLockReason", () => {
       const reason = publishedChatLockReason({
         ownerIsReachable: true,
         ownerIsThisHost: true,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 0,
         fidelityNotice: null,
@@ -138,6 +190,7 @@ describe("publishedChatLockReason", () => {
       const reason = publishedChatLockReason({
         ownerIsReachable: true,
         ownerIsThisHost: true,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 2,
         fidelityNotice: null,
@@ -159,6 +212,7 @@ describe("publishedChatLockReason", () => {
       const reason = publishedChatLockReason({
         ownerIsReachable: true,
         ownerIsThisHost: true,
+        ownedByViewer: true,
         ownerLabel: "Ada's Mac",
         unreadableCount: 0,
         fidelityNotice: "1 attachment is unavailable.",
@@ -180,6 +234,7 @@ describe("replicaChatLockReason", () => {
     const reason = replicaChatLockReason({
       ownerIsReachable: true,
       ownerIsThisHost: false,
+      ownedByViewer: true,
       ownerLabel: "Ada's Mac",
       unreadableCount: 0,
     });
@@ -192,6 +247,7 @@ describe("replicaChatLockReason", () => {
     const reason = replicaChatLockReason({
       ownerIsReachable: true,
       ownerIsThisHost: true,
+      ownedByViewer: true,
       ownerLabel: "Ada's Mac",
       unreadableCount: 0,
     });
@@ -201,5 +257,21 @@ describe("replicaChatLockReason", () => {
     expect(reason).not.toContain("lives on");
     expect(reason).not.toContain("Ada's Mac");
     expect(reason).not.toContain("from this device");
+  });
+
+  it("says whose agent it is for a collaborator's chat, same precedence as the published arm", () => {
+    for (const ownerIsReachable of [false, true]) {
+      const reason = replicaChatLockReason({
+        ownerIsReachable,
+        ownerIsThisHost: false,
+        ownedByViewer: false,
+        ownerLabel: "085b919a-f0a6-42e5-b05e-241738d3dd6a",
+        unreadableCount: 0,
+      });
+      expect(reason).toContain("belongs to another collaborator");
+      expect(reason).toContain("synced copy");
+      expect(reason).not.toContain("which is offline");
+      expect(reason).not.toContain("085b919a-f0a6-42e5-b05e-241738d3dd6a");
+    }
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-tile.test.tsx
@@ -44,6 +44,7 @@ interface DeadTileBannerContainerProps {
   readonly sourceHostId: string;
   readonly hostLabel: string;
   readonly reason: ChatDeadTileBannerReason;
+  readonly showsPublishedCopy: boolean;
   readonly testId: string;
   readonly sourceOwnerUserId?: string;
 }
@@ -103,6 +104,15 @@ vi.mock("@/components/epic-canvas/renderers/chat-tile", async () => {
         <ChatDeadTileBanner
           hostLabel={props.hostLabel}
           reason={props.reason}
+          // The real container resolves these from the signed-in identity
+          // and the epic role; this suite mounts neither, and what it owns
+          // is the tile→container prop threading, so the banner renders the
+          // pre-collaborator defaults. `showsPublishedCopy` IS threading, so
+          // it forwards. The ownership wiring itself is pinned by
+          // `dead-tile-banner-container.test.tsx` against the real container.
+          ownedByViewer
+          cloneAllowed
+          showsPublishedCopy={props.showsPublishedCopy}
           onClone={() => undefined}
           cloning={false}
           className={undefined}
@@ -564,6 +574,9 @@ describe("PublishedChatTile - dead-tile clone banner", () => {
       sourceHostId: "owner-host-1",
       hostLabel: "Ada's Mac",
       reason: "host-offline",
+      // This tile really does render a copy under the banner, so the
+      // foreign-owner sentence may claim one.
+      showsPublishedCopy: true,
       testId: "published-chat-dead-tile-chat-1",
       // Off the ref - a post-restart host with swept registry facts cannot
       // answer the lookup, and the ref knew the owner the whole time.

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -70,8 +70,10 @@ import type { ChatComposerSubmitInput } from "@/components/chat/composer/chat-co
 import {
   useChatById,
   useEpicLiveArtifactTitle,
+  useEpicPermissionRole,
   useOpenEpicId,
 } from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
 import {
   mentionRootsFromWorktreeBinding,
@@ -101,6 +103,7 @@ import {
   type RenderedMessagesDisplayContext,
 } from "@/stores/chats/rendered-messages";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { useOwnedByViewer } from "@/hooks/chats/use-owned-by-viewer";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
 import { useHostBinding } from "@/lib/host";
 import { useCanvasHostId } from "@/components/epic-canvas/hooks/use-canvas-host-id";
@@ -434,6 +437,9 @@ export function ChatTile(props: ChatTileProps) {
               ? "host-plan-restricted"
               : "host-offline"
           }
+          // This mount's body is a load state or a cached live session -
+          // never a published copy the banner could truthfully point at.
+          showsPublishedCopy={false}
           testId={`chat-dead-tile-${node.id}`}
         />
       );
@@ -507,6 +513,13 @@ interface ChatDeadTileBannerContainerProps {
   readonly reason: ChatDeadTileBannerReason;
   readonly testId: string;
   /**
+   * Whether the mounting surface renders a readable copy under this banner.
+   * The published tile and the canvas substitution do; this live tile does
+   * not (the body below it is a load state or a cached live session). See
+   * `ChatDeadTileBannerProps.showsPublishedCopy`.
+   */
+  readonly showsPublishedCopy: boolean;
+  /**
    * The source chat's owner, when the mounting surface already carries it
    * (the published tile's ref does). Bypasses the cloud-list lookup below,
    * which a host with swept registry facts (post-restart) can fail to
@@ -545,6 +558,19 @@ export function ChatDeadTileBannerContainer(
     chatId: providedOwnerUserId === null ? props.chatId : null,
   });
   const sourceOwnerUserId = providedOwnerUserId ?? lookedUpOwnerUserId;
+  // The two facts the banner's copy and Clone offer vary on (shared-chat
+  // support). Ownership: only a POSITIVE mismatch against the signed-in user
+  // flips the foreign-owner copy - an unknown owner or identity stays on the
+  // own-chat sentences, which were this banner's whole vocabulary before
+  // collaborators existed. Role: `epic.createChat` is editor-gated host-side,
+  // so a known viewer gets the reason in the banner instead of a Clone button
+  // that dies on a bare "You don't have permission" toast; an unresolved role
+  // (`null`) keeps the offer - the host gate is the backstop, and withholding
+  // the way out of a dead tile needs evidence.
+  const permissionRole = useEpicPermissionRole();
+  const ownedByViewer = useOwnedByViewer(sourceOwnerUserId);
+  const cloneAllowed =
+    permissionRole === null || isEditableRole(permissionRole);
   const offer = useChatCloneOnHostSwitch({
     epicId: props.epicId,
     tabId: props.tabId,
@@ -560,6 +586,9 @@ export function ChatDeadTileBannerContainer(
     <ChatDeadTileBanner
       hostLabel={props.hostLabel}
       reason={props.reason}
+      ownedByViewer={ownedByViewer}
+      cloneAllowed={cloneAllowed}
+      showsPublishedCopy={props.showsPublishedCopy}
       onClone={offer.clone}
       cloning={offer.cloning}
       className={undefined}

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -556,6 +556,7 @@ export function ChatDeadTileBannerContainer(
     client: bannerAppHostClient,
     epicId: props.epicId,
     chatId: providedOwnerUserId === null ? props.chatId : null,
+    sourceOwnerHostId: props.sourceHostId,
   });
   const sourceOwnerUserId = providedOwnerUserId ?? lookedUpOwnerUserId;
   // The two facts the banner's copy and Clone offer vary on (shared-chat

--- a/clients/gui-app/src/components/epic-canvas/renderers/dead-tile-banner.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/dead-tile-banner.tsx
@@ -391,23 +391,41 @@ export interface ChatDeadTileBannerProps {
   readonly testId: string;
 }
 
+/**
+ * A reason's copy, keyed on whether it ends in an action the reader can take.
+ *
+ * Four of the five do: the transcript is readable (as a published copy or from
+ * the owner host) and cloning carries it onto a live host. `revoked` does not -
+ * the clone would have to read bytes the server just stopped serving this
+ * viewer, so offering the button would be an invitation to a failure. Same
+ * reasoning `ChatHostStartingBanner` withholds it under.
+ *
+ * A clone-offering reason must supply `messageWithoutClone` as well, and the
+ * union is what forces it: every one of those four sentences ENDS in the clone
+ * promise ("continuing here creates a new agent", "cloning creates a new agent
+ * from it"), so a viewer who cannot clone must be told the fact WITHOUT that
+ * promise rather than be handed it and have it taken back a sentence later.
+ * Adding a fifth clone-offering reason cannot silently skip the variant.
+ */
+type ChatDeadTileBannerCopy =
+  | {
+      readonly message: (hostLabel: string) => ReactNode;
+      readonly reportTitle: string;
+      readonly reportMessage: string;
+      readonly offersClone: false;
+    }
+  | {
+      readonly message: (hostLabel: string) => ReactNode;
+      /** The same fact, stated without the clone promise. */
+      readonly messageWithoutClone: (hostLabel: string) => ReactNode;
+      readonly reportTitle: string;
+      readonly reportMessage: string;
+      readonly offersClone: true;
+    };
+
 const CHAT_DEAD_TILE_BANNER_COPY: Record<
   ChatDeadTileBannerReason,
-  {
-    readonly message: (hostLabel: string) => ReactNode;
-    readonly reportTitle: string;
-    readonly reportMessage: string;
-    /**
-     * Whether this reason ends in an action the reader can actually take.
-     *
-     * Four of the five do: the transcript is readable (as a published copy or
-     * from the owner host) and cloning carries it onto a live host. `revoked`
-     * does not - the clone would have to read bytes the server just stopped
-     * serving this viewer, so offering the button would be an invitation to a
-     * failure. Same reasoning `ChatHostStartingBanner` withholds it under.
-     */
-    readonly offersClone: boolean;
-  }
+  ChatDeadTileBannerCopy
 > = {
   "host-offline": {
     message: (hostLabel) => (
@@ -415,6 +433,13 @@ const CHAT_DEAD_TILE_BANNER_COPY: Record<
         Bound host &quot;{hostLabel}&quot; is offline. Continuing here creates a
         new agent on the active host; this one stays bound to &quot;
         {hostLabel}&quot;.
+      </>
+    ),
+    messageWithoutClone: (hostLabel) => (
+      <>
+        Bound host &quot;{hostLabel}&quot; is offline, so this agent isn&apos;t
+        available right now. You have view-only access to this task, so it
+        can&apos;t be cloned onto another host.
       </>
     ),
     reportTitle: "Agent host is offline",
@@ -427,6 +452,13 @@ const CHAT_DEAD_TILE_BANNER_COPY: Record<
         Bound host &quot;{hostLabel}&quot; is local only on your current plan,
         so it can&apos;t be reached from here. Upgrade to use it remotely, or
         continue here to create a new agent on the active host.
+      </>
+    ),
+    messageWithoutClone: (hostLabel) => (
+      <>
+        Bound host &quot;{hostLabel}&quot; is local only on your current plan,
+        so it can&apos;t be reached from here. You have view-only access to this
+        task, so it can&apos;t be cloned onto another host.
       </>
     ),
     reportTitle: "Agent host is not reachable on this plan",
@@ -442,6 +474,13 @@ const CHAT_DEAD_TILE_BANNER_COPY: Record<
         stays bound to &quot;{hostLabel}&quot;.
       </>
     ),
+    messageWithoutClone: (hostLabel) => (
+      <>
+        This agent&apos;s history isn&apos;t available on &quot;{hostLabel}
+        &quot;. You have view-only access to this task, so it can&apos;t be
+        cloned onto another host.
+      </>
+    ),
     reportTitle: "Agent history unavailable",
     reportMessage: "The agent's history could not be found on its bound host.",
     offersClone: true,
@@ -455,6 +494,15 @@ const CHAT_DEAD_TILE_BANNER_COPY: Record<
       <>
         This agent&apos;s history is no longer on this host. Showing the last
         published copy; cloning creates a new agent from it.
+      </>
+    ),
+    // Drops the published-copy clause rather than restating it: this variant
+    // is reachable from mounts that do not show one, and the base sentence
+    // only gets away with the claim because it is paired with the offer.
+    messageWithoutClone: () => (
+      <>
+        This agent&apos;s history is no longer on this host. You have view-only
+        access to this task, so it can&apos;t be cloned onto another host.
       </>
     ),
     reportTitle: "Agent history missing on this host",
@@ -501,16 +549,30 @@ const CHAT_DEAD_TILE_BANNER_COPY: Record<
  *   promise does not extend to this reader instead of dangling a button the
  *   host's editor gate would refuse.
  */
+/**
+ * Whether a reachable host ANSWERED for this reason.
+ *
+ * Both are selected only after a host replied (`tab-group-view` picks them off
+ * a live response), so nothing downstream may describe them as a connectivity
+ * failure - that would invert the evidence of a host that just spoke.
+ *
+ * Shared by the foreign-owner sentence and its report metadata deliberately:
+ * they were split before, and the report went on claiming a disconnected host
+ * under a sentence that said the opposite (CodeRabbit's finding on this PR).
+ * One predicate means the two cannot disagree again.
+ */
+function hostAnsweredForReason(reason: ChatDeadTileBannerReason): boolean {
+  return reason === "chat-not-visible" || reason === "chat-not-on-this-host";
+}
+
 function foreignOwnerMessage(input: {
   readonly reason: ChatDeadTileBannerReason;
   readonly showsPublishedCopy: boolean;
   readonly cloneAllowed: boolean;
 }): string {
-  const fact =
-    input.reason === "chat-not-visible" ||
-    input.reason === "chat-not-on-this-host"
-      ? "This agent belongs to another collaborator, and its history isn't available here."
-      : "This agent belongs to another collaborator and lives on their machine, which isn't connected here.";
+  const fact = hostAnsweredForReason(input.reason)
+    ? "This agent belongs to another collaborator, and its history isn't available here."
+    : "This agent belongs to another collaborator and lives on their machine, which isn't connected here.";
   const copyClause = input.showsPublishedCopy
     ? " Showing the last published copy."
     : "";
@@ -520,11 +582,42 @@ function foreignOwnerMessage(input: {
   return `${fact}${copyClause}${cloneClause}`;
 }
 
-const FOREIGN_OWNER_REPORT = {
+const FOREIGN_OWNER_UNREACHABLE_REPORT = {
   reportTitle: "Shared agent isn't available live",
   reportMessage:
     "The agent belongs to another collaborator and its host isn't connected here.",
 };
+
+const FOREIGN_OWNER_HISTORY_REPORT = {
+  reportTitle: "Shared agent history unavailable",
+  reportMessage:
+    "The agent belongs to another collaborator and its history could not be read here.",
+};
+
+/** The report a support ticket carries, matched to the sentence on screen. */
+function foreignOwnerReport(reason: ChatDeadTileBannerReason): {
+  readonly reportTitle: string;
+  readonly reportMessage: string;
+} {
+  return hostAnsweredForReason(reason)
+    ? FOREIGN_OWNER_HISTORY_REPORT
+    : FOREIGN_OWNER_UNREACHABLE_REPORT;
+}
+
+/**
+ * The own-chat sentence, which drops the clone promise for a viewer who
+ * cannot act on it (a creator downgraded to `viewer` after opening the chat).
+ */
+function ownChatMessage(
+  copy: ChatDeadTileBannerCopy,
+  hostLabel: string,
+  cloneAllowed: boolean,
+): ReactNode {
+  if (copy.offersClone && !cloneAllowed) {
+    return copy.messageWithoutClone(hostLabel);
+  }
+  return copy.message(hostLabel);
+}
 
 export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
   const copy = CHAT_DEAD_TILE_BANNER_COPY[props.reason];
@@ -532,7 +625,7 @@ export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
   // about this viewer's entitlement, not about any host.
   const foreignOwned =
     !props.ownedByViewer && props.reason !== "chat-no-longer-shared";
-  const report = foreignOwned ? FOREIGN_OWNER_REPORT : copy;
+  const report = foreignOwned ? foreignOwnerReport(props.reason) : copy;
   return (
     // A live region, like the other two chat banners: which of the three
     // truths above is on screen is carried ONLY by this sentence, and the
@@ -556,17 +649,7 @@ export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
               showsPublishedCopy: props.showsPublishedCopy,
               cloneAllowed: props.cloneAllowed,
             })
-          : copy.message(props.hostLabel)}
-        {/* The own-chat viewer edge (role downgraded after creating the
-            chat): the reason copy still ends in "clone it and carry on", so
-            withholding the button silently would read as broken. */}
-        {!foreignOwned && copy.offersClone && !props.cloneAllowed ? (
-          <>
-            {" "}
-            You have view-only access to this task, so cloning isn&apos;t
-            available.
-          </>
-        ) : null}
+          : ownChatMessage(copy, props.hostLabel, props.cloneAllowed)}
       </span>
       {copy.offersClone && props.cloneAllowed ? (
         <Button

--- a/clients/gui-app/src/components/epic-canvas/renderers/dead-tile-banner.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/dead-tile-banner.tsx
@@ -354,6 +354,37 @@ export type ChatDeadTileBannerReason =
 export interface ChatDeadTileBannerProps {
   readonly hostLabel: string;
   readonly reason: ChatDeadTileBannerReason;
+  /**
+   * Whether the source chat belongs to the signed-in viewer. `false` is a
+   * collaborator's shared chat, and every host-naming sentence in the copy
+   * table turns false there: the owner's machine can never appear in this
+   * account's host directory, so "unreachable" is a fact about THIS viewer's
+   * fleet - not evidence the machine is off - and `hostLabel` has fallen back
+   * to a raw host id that names nothing the reader can act on. Those reasons
+   * swap to the foreign-owner sentence instead. `true` when the owner is
+   * unknown: a local chat ref is the viewer's own by construction, so only a
+   * positive mismatch may flip the copy.
+   */
+  readonly ownedByViewer: boolean;
+  /**
+   * Whether the viewer's epic role can create agents (editor/owner - the same
+   * gate `epic.createChat` enforces host-side). `false` withholds the Clone
+   * button that role's refusal would otherwise turn into a bare
+   * "You don't have permission" toast, and says why instead. Pass `true`
+   * while the role is still unknown - the host gate is the backstop, and
+   * withholding the way out of a dead tile needs evidence, not doubt.
+   */
+  readonly cloneAllowed: boolean;
+  /**
+   * Whether a readable copy (published or doc-synced) is actually mounted
+   * under this banner. The live tile mounts it above a load state or a cached
+   * live session, where "showing the last published copy" would describe
+   * content that is not on screen - so the foreign-owner copy claims it only
+   * when the mounting surface says so, rather than inferring its own
+   * presentation. The own-chat sentences carry their presentation facts in
+   * the reason copy and do not read this.
+   */
+  readonly showsPublishedCopy: boolean;
   readonly onClone: () => void;
   readonly cloning: boolean;
   readonly className: string | undefined;
@@ -450,8 +481,58 @@ const CHAT_DEAD_TILE_BANNER_COPY: Record<
   },
 };
 
+/**
+ * The sentence for a collaborator's chat, composed from three independently
+ * true clauses rather than one blanket claim (cold-review finding: the first
+ * cut collapsed presentation state and failure reason into a sentence that
+ * could describe content not on screen, or contradict a host that answered).
+ *
+ * - The FACT varies by reason: the host-unreachable reasons say the owner's
+ *   machine "isn't connected here" - deliberately not "is offline", which is
+ *   unknowable from this account (see `ownedByViewer`) - while the two
+ *   answered-host reasons (`chat-not-visible` / `chat-not-on-this-host`) keep
+ *   their missing-history fact, because "isn't connected" would invert the
+ *   evidence of a host that just spoke. Neither names a host: the label for a
+ *   foreign machine is a raw id.
+ * - The COPY clause appears only when the mounting surface actually shows one
+ *   (`showsPublishedCopy`).
+ * - The CLONE clause matches the sharing panel's promise ("Collaborators can
+ *   view and clone your agent chats"); the view-only arm says why that
+ *   promise does not extend to this reader instead of dangling a button the
+ *   host's editor gate would refuse.
+ */
+function foreignOwnerMessage(input: {
+  readonly reason: ChatDeadTileBannerReason;
+  readonly showsPublishedCopy: boolean;
+  readonly cloneAllowed: boolean;
+}): string {
+  const fact =
+    input.reason === "chat-not-visible" ||
+    input.reason === "chat-not-on-this-host"
+      ? "This agent belongs to another collaborator, and its history isn't available here."
+      : "This agent belongs to another collaborator and lives on their machine, which isn't connected here.";
+  const copyClause = input.showsPublishedCopy
+    ? " Showing the last published copy."
+    : "";
+  const cloneClause = input.cloneAllowed
+    ? " Cloning creates your own agent on the active host."
+    : " You have view-only access to this task, so it can't be cloned.";
+  return `${fact}${copyClause}${cloneClause}`;
+}
+
+const FOREIGN_OWNER_REPORT = {
+  reportTitle: "Shared agent isn't available live",
+  reportMessage:
+    "The agent belongs to another collaborator and its host isn't connected here.",
+};
+
 export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
   const copy = CHAT_DEAD_TILE_BANNER_COPY[props.reason];
+  // The revoked reason keeps its own copy for a foreign owner: it is already
+  // about this viewer's entitlement, not about any host.
+  const foreignOwned =
+    !props.ownedByViewer && props.reason !== "chat-no-longer-shared";
+  const report = foreignOwned ? FOREIGN_OWNER_REPORT : copy;
   return (
     // A live region, like the other two chat banners: which of the three
     // truths above is on screen is carried ONLY by this sentence, and the
@@ -468,8 +549,26 @@ export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
         props.className,
       )}
     >
-      <span className="min-w-0 flex-1">{copy.message(props.hostLabel)}</span>
-      {copy.offersClone ? (
+      <span className="min-w-0 flex-1">
+        {foreignOwned
+          ? foreignOwnerMessage({
+              reason: props.reason,
+              showsPublishedCopy: props.showsPublishedCopy,
+              cloneAllowed: props.cloneAllowed,
+            })
+          : copy.message(props.hostLabel)}
+        {/* The own-chat viewer edge (role downgraded after creating the
+            chat): the reason copy still ends in "clone it and carry on", so
+            withholding the button silently would read as broken. */}
+        {!foreignOwned && copy.offersClone && !props.cloneAllowed ? (
+          <>
+            {" "}
+            You have view-only access to this task, so cloning isn&apos;t
+            available.
+          </>
+        ) : null}
+      </span>
+      {copy.offersClone && props.cloneAllowed ? (
         <Button
           type="button"
           variant="outline"
@@ -482,8 +581,8 @@ export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
       ) : null}
       <ReportIssueAction
         context={createReportIssueContext({
-          title: copy.reportTitle,
-          message: copy.reportMessage,
+          title: report.reportTitle,
+          message: report.reportMessage,
           code: null,
           source: "Agent",
         })}

--- a/clients/gui-app/src/components/epic-canvas/renderers/published-chat-lock-reason.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/published-chat-lock-reason.ts
@@ -38,6 +38,16 @@ export function publishedChatLockReason(input: {
    * cross-host one.
    */
   readonly ownerIsThisHost: boolean;
+  /**
+   * Whether the chat belongs to the signed-in viewer. `false` is a
+   * collaborator's shared chat, and it outranks both reachability arms: the
+   * owner's machine can never appear in this account's host directory, so
+   * "which is offline" asserts liveness this device cannot observe,
+   * `ownerLabel` has fallen back to a raw host id, and "sending resumes"
+   * promises a composer this viewer does not get. `true` when the owner is
+   * unknown - only a positive mismatch may flip the sentence.
+   */
+  readonly ownedByViewer: boolean;
   readonly ownerLabel: string;
   readonly unreadableCount: number;
   readonly fidelityNotice: string | null;
@@ -74,6 +84,8 @@ export function replicaChatLockReason(input: {
   readonly ownerIsReachable: boolean;
   /** Same fact, same reason, as `publishedChatLockReason`'s. */
   readonly ownerIsThisHost: boolean;
+  /** Same fact, same reason, as `publishedChatLockReason`'s. */
+  readonly ownedByViewer: boolean;
   readonly ownerLabel: string;
   readonly unreadableCount: number;
 }): string {
@@ -112,8 +124,17 @@ export function replicaChatLockReason(input: {
 function publishedCopySentence(input: {
   readonly ownerIsReachable: boolean;
   readonly ownerIsThisHost: boolean;
+  readonly ownedByViewer: boolean;
   readonly ownerLabel: string;
 }): string {
+  // A collaborator's chat, checked before either reachability arm: every
+  // clause below it is written for the viewer's own fleet (see the
+  // `ownedByViewer` doc above) and turns false for a machine this account
+  // cannot observe. Aligned with the dead-tile banner's foreign-owner
+  // sentence, which sits directly above this footer.
+  if (!input.ownedByViewer) {
+    return `This agent belongs to another collaborator — showing the last published copy. It isn't available live from here.`;
+  }
   if (!input.ownerIsReachable) {
     return `This agent lives on ${input.ownerLabel}, which is offline — showing the last published copy. Sending resumes when that host is back.`;
   }
@@ -127,8 +148,13 @@ function publishedCopySentence(input: {
 function replicaCopySentence(input: {
   readonly ownerIsReachable: boolean;
   readonly ownerIsThisHost: boolean;
+  readonly ownedByViewer: boolean;
   readonly ownerLabel: string;
 }): string {
+  // Same precedence, same reason, as `publishedCopySentence`'s foreign arm.
+  if (!input.ownedByViewer) {
+    return `This agent belongs to another collaborator — showing this device's synced copy. It isn't available live from here.`;
+  }
   if (!input.ownerIsReachable) {
     return `This agent lives on ${input.ownerLabel}, which is offline — showing this device's synced copy. Sending resumes when that host is back.`;
   }

--- a/clients/gui-app/src/components/epic-canvas/renderers/published-chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/published-chat-tile.tsx
@@ -29,6 +29,7 @@ import {
   publishedChatLockReason,
   replicaChatLockReason,
 } from "@/components/epic-canvas/renderers/published-chat-lock-reason";
+import { useOwnedByViewer } from "@/hooks/chats/use-owned-by-viewer";
 
 /**
  * A chat whose owning host is out of reach, rendered through the ORDINARY chat
@@ -132,6 +133,12 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
   // `chat-not-on-this-host`, whose banner this footer sits under.
   const ownerIsThisHost =
     node.ownerHostId.length > 0 && node.ownerHostId === node.hostId;
+  // Whether this copy is the viewer's own chat, read off the ref like the
+  // owner-host equality above. A collaborator's chat swaps the lock sentence
+  // (and, in the child banner, the clone copy) for the foreign-owner arm -
+  // the offline/back-soon vocabulary below is about the viewer's own fleet
+  // and cannot be honestly said about a machine this account never sees.
+  const ownedByViewer = useOwnedByViewer(node.ownerUserId);
 
   // The same Clone offer the LIVE tile's dead-tile banner makes, on the copy.
   // Gated (inside the child) on the SAME two signals the lock sentence below
@@ -292,6 +299,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
           readOnlyNotice={replicaChatLockReason({
             ownerIsReachable: ownerReachability.status === "reachable",
             ownerIsThisHost,
+            ownedByViewer,
             ownerLabel,
             unreadableCount: replicaConversion.unreadableCount,
           })}
@@ -352,6 +360,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
           readOnlyNotice={publishedChatLockReason({
             ownerIsReachable: ownerReachability.status === "reachable",
             ownerIsThisHost,
+            ownedByViewer,
             ownerLabel,
             unreadableCount: conversion.unreadableCount,
             fidelityNotice: state.fidelityNotice,
@@ -402,6 +411,7 @@ function PublishedChatDeadTileBanner(props: {
       sourceHostId={props.node.ownerHostId}
       hostLabel={props.ownerLabel}
       reason="host-offline"
+      showsPublishedCopy
       testId={`published-chat-dead-tile-${props.node.chatId}`}
       sourceOwnerUserId={props.node.ownerUserId}
     />

--- a/clients/gui-app/src/hooks/chats/__tests__/use-clone-source-owner.test.ts
+++ b/clients/gui-app/src/hooks/chats/__tests__/use-clone-source-owner.test.ts
@@ -154,6 +154,36 @@ describe("resolveCloneSourceOwnerUserId", () => {
     ).toBeNull();
   });
 
+  // The trap the fork dialog fell into: a published copy is read through the
+  // host SERVING it, generally the viewer's own machine. Handed that host as
+  // the tie-breaker, a colliding id resolves to the viewer's own unrelated row
+  // - a wrong owner, which the host TRUSTS, rather than an absent one. Callers
+  // that cannot name the OWNING host must pass `null` and take the degrade.
+  it("resolves a collision to the viewer's own row when handed a serving host - why callers must pass the owning host or null", () => {
+    const colliding = [
+      cloudRow("chat-1", "viewer-user", "viewer-own-host"),
+      cloudRow("chat-1", "collaborator-user", "collaborator-host"),
+    ];
+    // The serving host IS the viewer's own, so this picks the wrong owner...
+    expect(
+      resolveCloneSourceOwnerUserId({
+        chatId: "chat-1",
+        localRecordOwnerUserId: null,
+        cloudChats: colliding,
+        sourceOwnerHostId: "viewer-own-host",
+      }),
+    ).toBe("viewer-user");
+    // ...whereas declining to name a host degrades honestly.
+    expect(
+      resolveCloneSourceOwnerUserId({
+        chatId: "chat-1",
+        localRecordOwnerUserId: null,
+        cloudChats: colliding,
+        sourceOwnerHostId: null,
+      }),
+    ).toBeNull();
+  });
+
   // The tie-breaker must not become a filter: one row is already unambiguous,
   // and a caller whose bound host disagrees for a reason this function cannot
   // see must not lose the owner it used to resolve.

--- a/clients/gui-app/src/hooks/chats/__tests__/use-clone-source-owner.test.ts
+++ b/clients/gui-app/src/hooks/chats/__tests__/use-clone-source-owner.test.ts
@@ -12,10 +12,14 @@ import { resolveCloneSourceOwnerUserId } from "@/hooks/chats/use-clone-source-ow
  * fabricated owner is worse than an absent one.
  */
 
-function cloudRow(chatId: string, ownerUserId: string): CloudChatSummary {
+function cloudRow(
+  chatId: string,
+  ownerUserId: string,
+  ownerHostId: string,
+): CloudChatSummary {
   return {
     identity: { taskId: "epic-1", chatId, ownerUserId },
-    ownerHostId: "owner-host",
+    ownerHostId,
     createdAt: 1,
     visibility: "task",
     title: null,
@@ -38,9 +42,10 @@ describe("resolveCloneSourceOwnerUserId", () => {
         chatId: "chat-1",
         localRecordOwnerUserId: null,
         cloudChats: [
-          cloudRow("chat-other", "owner-other"),
-          cloudRow("chat-1", "owner-9"),
+          cloudRow("chat-other", "owner-other", "owner-host"),
+          cloudRow("chat-1", "owner-9", "owner-host"),
         ],
+        sourceOwnerHostId: null,
       }),
     ).toBe("owner-9");
   });
@@ -50,7 +55,8 @@ describe("resolveCloneSourceOwnerUserId", () => {
       resolveCloneSourceOwnerUserId({
         chatId: "chat-1",
         localRecordOwnerUserId: "owner-local",
-        cloudChats: [cloudRow("chat-1", "owner-9")],
+        cloudChats: [cloudRow("chat-1", "owner-9", "owner-host")],
+        sourceOwnerHostId: null,
       }),
     ).toBe("owner-local");
   });
@@ -60,7 +66,8 @@ describe("resolveCloneSourceOwnerUserId", () => {
       resolveCloneSourceOwnerUserId({
         chatId: "chat-1",
         localRecordOwnerUserId: "",
-        cloudChats: [cloudRow("chat-1", "owner-9")],
+        cloudChats: [cloudRow("chat-1", "owner-9", "owner-host")],
+        sourceOwnerHostId: null,
       }),
     ).toBe("owner-9");
     expect(
@@ -68,6 +75,7 @@ describe("resolveCloneSourceOwnerUserId", () => {
         chatId: "chat-1",
         localRecordOwnerUserId: "",
         cloudChats: null,
+        sourceOwnerHostId: null,
       }),
     ).toBeNull();
   });
@@ -77,7 +85,8 @@ describe("resolveCloneSourceOwnerUserId", () => {
       resolveCloneSourceOwnerUserId({
         chatId: "chat-1",
         localRecordOwnerUserId: null,
-        cloudChats: [cloudRow("chat-other", "owner-other")],
+        cloudChats: [cloudRow("chat-other", "owner-other", "owner-host")],
+        sourceOwnerHostId: null,
       }),
     ).toBeNull();
   });
@@ -88,14 +97,74 @@ describe("resolveCloneSourceOwnerUserId", () => {
         chatId: "chat-1",
         localRecordOwnerUserId: null,
         cloudChats: null,
+        sourceOwnerHostId: null,
       }),
     ).toBeNull();
     expect(
       resolveCloneSourceOwnerUserId({
         chatId: null,
         localRecordOwnerUserId: "owner-local",
-        cloudChats: [cloudRow("chat-1", "owner-9")],
+        cloudChats: [cloudRow("chat-1", "owner-9", "owner-host")],
+        sourceOwnerHostId: null,
       }),
     ).toBeNull();
+  });
+
+  // `chatId` is host-minted and NOT unique under a task (`cloud-chat.ts`:
+  // identity is the triple), so a listing can carry two rows for one id. The
+  // owner drives the host's anti-squat expectation AND, since the shared-chat
+  // banner, whether the UI calls a chat the viewer's own - both are wrong to
+  // guess at.
+  it("disambiguates a colliding chat id by the source's bound host", () => {
+    expect(
+      resolveCloneSourceOwnerUserId({
+        chatId: "chat-1",
+        localRecordOwnerUserId: null,
+        cloudChats: [
+          cloudRow("chat-1", "owner-a", "host-a"),
+          cloudRow("chat-1", "owner-b", "host-b"),
+        ],
+        sourceOwnerHostId: "host-b",
+      }),
+    ).toBe("owner-b");
+  });
+
+  it("answers null for a colliding chat id it cannot disambiguate, rather than taking the first row", () => {
+    const colliding = [
+      cloudRow("chat-1", "owner-a", "host-a"),
+      cloudRow("chat-1", "owner-b", "host-b"),
+    ];
+    // No host in hand.
+    expect(
+      resolveCloneSourceOwnerUserId({
+        chatId: "chat-1",
+        localRecordOwnerUserId: null,
+        cloudChats: colliding,
+        sourceOwnerHostId: null,
+      }),
+    ).toBeNull();
+    // A host that names neither row.
+    expect(
+      resolveCloneSourceOwnerUserId({
+        chatId: "chat-1",
+        localRecordOwnerUserId: null,
+        cloudChats: colliding,
+        sourceOwnerHostId: "host-c",
+      }),
+    ).toBeNull();
+  });
+
+  // The tie-breaker must not become a filter: one row is already unambiguous,
+  // and a caller whose bound host disagrees for a reason this function cannot
+  // see must not lose the owner it used to resolve.
+  it("keeps the single matching row even when the caller's host disagrees", () => {
+    expect(
+      resolveCloneSourceOwnerUserId({
+        chatId: "chat-1",
+        localRecordOwnerUserId: null,
+        cloudChats: [cloudRow("chat-1", "owner-9", "owner-host")],
+        sourceOwnerHostId: "some-other-host",
+      }),
+    ).toBe("owner-9");
   });
 });

--- a/clients/gui-app/src/hooks/chats/use-clone-source-owner.ts
+++ b/clients/gui-app/src/hooks/chats/use-clone-source-owner.ts
@@ -54,19 +54,48 @@ export interface ResolveCloneSourceOwnerArgs {
   readonly localRecordOwnerUserId: string | null;
   /** `epic.listCloudChats`' rows, or `null` when the list has not answered. */
   readonly cloudChats: readonly CloudChatSummary[] | null;
+  /**
+   * The host the source chat is bound to, when the surface knows it - the
+   * dead tile's `sourceHostId`, the fork dialog's tab host. Used ONLY to break
+   * a tie, never to filter: see below.
+   */
+  readonly sourceOwnerHostId: string | null;
 }
 
-/** The decision itself, kept pure so both surfaces and its tests share it. */
+/**
+ * The decision itself, kept pure so both surfaces and its tests share it.
+ *
+ * `chatId` alone is NOT an identity. `cloud-chat.ts` is explicit that the id is
+ * host-minted and that two hosts can mint the same one under a single task, so
+ * identity is the triple `(taskId, chatId, ownerUserId)` - and `ownerUserId` is
+ * precisely what this function is trying to learn, which is why the list is
+ * scanned by the other two. When that scan is ambiguous the honest answer is
+ * `null`, exactly as the header says: a fabricated owner is TRUSTED by the host
+ * where an absent one merely degrades to settings-only, and (since this PR) it
+ * also decides whether the dead-tile banner calls a chat the viewer's own.
+ *
+ * `sourceOwnerHostId` breaks the tie rather than pre-filtering, so the ordinary
+ * single-row case is untouched by a caller whose bound host disagrees with the
+ * row's `ownerHostId` for any reason this function cannot see.
+ */
 export function resolveCloneSourceOwnerUserId(
   args: ResolveCloneSourceOwnerArgs,
 ): string | null {
   if (args.chatId === null) return null;
   const localOwnerUserId = usableOwnerUserId(args.localRecordOwnerUserId);
   if (localOwnerUserId !== null) return localOwnerUserId;
-  const row =
-    args.cloudChats?.find((chat) => chat.identity.chatId === args.chatId) ??
-    null;
-  return row?.identity.ownerUserId ?? null;
+  const rows = (args.cloudChats ?? []).filter(
+    (chat) => chat.identity.chatId === args.chatId,
+  );
+  if (rows.length === 1) {
+    return usableOwnerUserId(rows[0].identity.ownerUserId);
+  }
+  if (rows.length === 0 || args.sourceOwnerHostId === null) return null;
+  const onSourceHost = rows.filter(
+    (chat) => chat.ownerHostId === args.sourceOwnerHostId,
+  );
+  if (onSourceHost.length !== 1) return null;
+  return usableOwnerUserId(onSourceHost[0].identity.ownerUserId);
 }
 
 export interface UseCloneSourceOwnerUserIdArgs {
@@ -78,6 +107,8 @@ export interface UseCloneSourceOwnerUserIdArgs {
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly epicId: string;
   readonly chatId: string | null;
+  /** The source chat's bound host, when the surface knows it. */
+  readonly sourceOwnerHostId: string | null;
 }
 
 export function useCloneSourceOwnerUserId(
@@ -98,5 +129,6 @@ export function useCloneSourceOwnerUserId(
     chatId: args.chatId,
     localRecordOwnerUserId,
     cloudChats: cloudChats.data?.chats ?? null,
+    sourceOwnerHostId: args.sourceOwnerHostId,
   });
 }

--- a/clients/gui-app/src/hooks/chats/use-clone-source-owner.ts
+++ b/clients/gui-app/src/hooks/chats/use-clone-source-owner.ts
@@ -55,9 +55,15 @@ export interface ResolveCloneSourceOwnerArgs {
   /** `epic.listCloudChats`' rows, or `null` when the list has not answered. */
   readonly cloudChats: readonly CloudChatSummary[] | null;
   /**
-   * The host the source chat is bound to, when the surface knows it - the
-   * dead tile's `sourceHostId`, the fork dialog's tab host. Used ONLY to break
-   * a tie, never to filter: see below.
+   * The host that OWNS the source chat, when the surface genuinely knows it -
+   * the dead tile's `sourceHostId`, which every mount resolves from the chat's
+   * own binding or its cloud row. Used ONLY to break a tie, never to filter:
+   * see below.
+   *
+   * NOT the host a surface happens to be reading through. A published copy is
+   * served by whatever host the DEVICE runs, which is generally not the
+   * owner's, so a serving host here would resolve a colliding id to the
+   * viewer's own row. Pass `null` unless the value is the owner's host.
    */
   readonly sourceOwnerHostId: string | null;
 }

--- a/clients/gui-app/src/hooks/chats/use-owned-by-viewer.ts
+++ b/clients/gui-app/src/hooks/chats/use-owned-by-viewer.ts
@@ -1,0 +1,30 @@
+import { useAuthStore } from "@/stores/auth/auth-store";
+
+/**
+ * Whether a chat belongs to the signed-in user, given whatever owner the
+ * calling surface managed to resolve.
+ *
+ * **Only a positive mismatch flips it.** An unresolved owner (`null`, or the
+ * empty string a ref minted before `ownerUserId` was recorded carries) and an
+ * identity mid-refresh both stay on the own-chat answer, which is the
+ * vocabulary every one of these surfaces had before collaborators existed.
+ * The alternative - treating "unknown" as foreign - would tell a user their
+ * OWN agent belongs to someone else during a hydration frame, which is worse
+ * than the transient own-chat copy this returns.
+ *
+ * Shared by the dead-tile banner's container and the published tile so the
+ * banner and the footer sentence under it can never disagree about who owns
+ * the chat they are both describing.
+ */
+export function useOwnedByViewer(ownerUserId: string | null): boolean {
+  const viewerUserId = useAuthStore(
+    (state) => state.contextMetadata?.userId ?? null,
+  );
+  if (ownerUserId === null || ownerUserId.length === 0) {
+    return true;
+  }
+  if (viewerUserId === null) {
+    return true;
+  }
+  return ownerUserId === viewerUserId;
+}

--- a/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
+++ b/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
@@ -95,6 +95,41 @@ describe("toastFromHostError", () => {
     );
   });
 
+  // The host's epic role gates state the missing role in a fixed phrase
+  // (`auth-helpers.ts`: "User 'x' does not have editor|owner access to ...").
+  // Branching on it turns "You don't have permission to do that." - the toast
+  // a viewer got for clicking Clone on a shared agent, indistinguishable from
+  // a bug - into the reason. The raw ids in the host text stay out of the
+  // toast.
+  it("names view-only access when the host's editor gate refused", () => {
+    toastFromHostError(
+      makeError(
+        "FORBIDDEN",
+        "User 'user-2' does not have editor access to epic 'epic-1'",
+      ),
+      "Couldn't create agent.",
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "You have view-only access to this task, so you can't make changes to it.",
+    );
+    expect(toast.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("user-2"),
+    );
+  });
+
+  it("names the owner requirement when the host's owner gate refused", () => {
+    toastFromHostError(
+      makeError(
+        "FORBIDDEN",
+        "User 'user-2' does not have owner access to epic 'epic-1'",
+      ),
+      "fallback",
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "Only this task's owner can do that.",
+    );
+  });
+
   it("shows sign-in copy for UNAUTHORIZED", () => {
     toastFromHostError(makeError("UNAUTHORIZED", "test error"), "fallback");
     expect(toast.error).toHaveBeenCalledWith("Please sign in again.");

--- a/clients/gui-app/src/lib/commands/actions/__tests__/profile-durability-clone-host-switch-edges.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/profile-durability-clone-host-switch-edges.test.ts
@@ -367,6 +367,7 @@ describe("cloneChatOnHostSwitch: orchestration edges (previously untested)", () 
     const resolvedOwner = resolveCloneSourceOwnerUserId({
       chatId: "source-chat-1",
       localRecordOwnerUserId: null,
+      sourceOwnerHostId: "owner-host",
       cloudChats: [
         {
           identity: {

--- a/clients/gui-app/src/lib/host-error-toast.ts
+++ b/clients/gui-app/src/lib/host-error-toast.ts
@@ -295,6 +295,39 @@ function hostTerminalVerdictMessage(error: HostRpcError): string | null {
   return null;
 }
 
+/**
+ * The host's role-gate refusal phrases, verbatim.
+ *
+ * An untyped wire contract: `traycer-host`'s `auth-helpers.ts` writes these
+ * into `EpicAccessForbiddenError` messages ("User 'x' does not have editor
+ * access to epic 'y'"), and the FORBIDDEN branch below matches on them to
+ * explain the refusal. The wire carries no structured denial reason, so the
+ * phrase is the whole contract - the host repo pins both sides in
+ * `role-gate-phrase-contract.test.ts` (it reads this file), and drift there
+ * degrades gracefully here to the generic permission sentence.
+ */
+export const EDITOR_ACCESS_DENIED_PHRASE = "does not have editor access";
+export const OWNER_ACCESS_DENIED_PHRASE = "does not have owner access";
+
+/**
+ * The host's epic role gates (`defineEditorResolver` / `defineOwnerResolver`)
+ * state the missing role in a fixed phrase, so - like the AGENT_BUSY branches
+ * below - the phrase is what we branch on. The copy is rewritten rather than
+ * passed through: the raw host text names user and epic ids, which mean
+ * nothing in a toast. Without this, a viewer clicking anything editor-gated
+ * (cloning a shared agent, for one) got the bare generic, indistinguishable
+ * from a bug.
+ */
+function forbiddenToastMessage(message: string): string {
+  if (message.includes(EDITOR_ACCESS_DENIED_PHRASE)) {
+    return "You have view-only access to this task, so you can't make changes to it.";
+  }
+  if (message.includes(OWNER_ACCESS_DENIED_PHRASE)) {
+    return "Only this task's owner can do that.";
+  }
+  return "You don't have permission to do that.";
+}
+
 function hostErrorToastMessage(error: HostRpcError, fallback: string) {
   const verdict = hostTerminalVerdictMessage(error);
   if (verdict !== null) {
@@ -329,7 +362,7 @@ function hostErrorToastMessage(error: HostRpcError, fallback: string) {
     return "This needs a newer Traycer host. Update the host to continue.";
   }
   if (error.code === "FORBIDDEN") {
-    return "You don't have permission to do that.";
+    return forbiddenToastMessage(error.message);
   }
   if (error.code === "UNAUTHORIZED") {
     if (error.fatalDetails?.retryable === true) {


### PR DESCRIPTION
## Problem

Opening a chat **shared by another user** whose bound host is unreachable showed:

> Bound host `085b919a-…` is offline. Continuing here creates a new agent on the active host; this one stays bound to `085b919a-…`.

…with a **Clone agent** button that failed with the bare toast *"You don't have permission to do that."*

Two independent defects.

### 1. The banner was ownership-blind

Host reachability is computed against the **signed-in account's own host directory** (`use-host-reachability.ts`; the directory is account-scoped). Another user's host can never appear there, so a foreign-owned chat is *unconditionally* classified `unreachable → "offline"` — the banner asserted liveness about a machine the viewer has no way to observe, and `hostLabel` fell back to the raw host id, which is the UUID in the report.

All three mount sites gated purely on reachability: the live tile, the published tile, and the canvas substitution.

### 2. Clone was offered unconditionally, then refused

Clone issues `epic.createChat@1.1` with a `forkSource`, and that resolver is `defineEditorResolver` host-side — a `viewer` is refused with `FORBIDDEN`. The GUI never consulted the epic role, and the toast mapping discarded the host's message.

Note the host **already permits cross-user forks for editors** (the fork path deliberately allows a cross-user source in a shared epic, seeded from the publication tier under the caller's own bearer token). So cloning a collaborator's agent already worked end to end — only viewers needed the button withheld.

## Change

**Copy is composed from independently-true clauses instead of one blanket sentence.** For a foreign owner the banner states what is actually known — the agent belongs to another collaborator and isn't available live from here — and names no host id. The fact varies by reason: `chat-not-visible` / `chat-not-on-this-host` are selected only *after* a reachable host answered, so they keep their missing-history fact rather than asserting a connectivity claim that contradicts that evidence. "Showing the last published copy" is claimed only when the mounting surface says it is showing one, via a new explicit `showsPublishedCopy` prop — the published tile and canvas substitution pass `true`; the live tile (whose body may be a load state) and the revoked arm pass `false`.

**Clone is role-gated, and the refusal explains itself.** A known `viewer` withholds the button and says why; an unresolved role (`null`) **fails open** — the host gate is the backstop, and withholding the only way out of a dead tile needs evidence. The `FORBIDDEN` toast now names the refusal when the host message is the editor or owner gate.

**Ownership uses positive-mismatch only.** `useOwnedByViewer` (new, shared by the container and the published tile) flips to foreign only on a positive mismatch against the signed-in user; an unresolved owner or an identity mid-refresh stays on the own-chat copy, so a hydration frame never tells a user their own agent belongs to someone else.

The canvas substitution arm threads the fallback ref's `ownerUserId` into the banner so that mount doesn't depend on a second cloud lookup that can fail independently of the row that produced the copy under it; `usePublishedChatFallbackRef` is narrowed to `PublishedChatTileRef` accordingly.

`chat-no-longer-shared` keeps its entitlement-specific copy and still never offers Clone — the revoked arm outranks the foreign-owner arm.

## Contract note

The role-gate refusal phrases are an **untyped cross-package contract** — the wire carries no structured denial reason, so the phrase is the whole contract. They're now named exported constants here, and the host repo pins both sides with a cross-layer test that reads this file. Drift degrades gracefully to the generic permission sentence rather than misreporting.

## Tests

- `dead-tile-banner-container.test.tsx` (new) drives the **real** container — signed-in user A with source owner B under editor (Clone kept, no liveness claim, no raw host id), viewer (Clone withheld, view-only sentence), and null role (fail-open pinned), plus an own-chat control and the no-published-copy composition. Before this, the banner suites injected the flags directly and the published tile's suite stubbed the container, so a regression in the resolution itself would have left everything green.
- `dead-tile-banner`, `published-chat-lock-reason`, `published-chat-tile`, `tab-group-view` (pins the substitution arm's owner threading), `bounded-loading-catalog`, `host-error-toast` extended.

130 tests across the 7 touched suites; `compile` and `lint` clean; `react-doctor` clean on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
