### PR TITLE
fix(gui-app): restore landing surface focus

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
@@ -1,6 +1,12 @@
-import { Profiler, useState, type ProfilerOnRenderCallback } from "react";
+import {
+  Profiler,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ProfilerOnRenderCallback,
+} from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
@@ -16,10 +22,67 @@ import {
   PaneActivationFocusIntentContext,
   type PaneActivationFocusIntent,
 } from "@/components/epic-canvas/pane-activation";
+import {
+  focusTerminalInstance,
+  registerTerminalFocus,
+  resetTerminalFocusRegistryForTests,
+} from "@/lib/terminals/terminal-focus-registry";
+import { PrimaryFocusCoordinatorProvider } from "@/lib/focus/primary-focus-coordinator-provider";
+import { resetPrimaryFocusCoordinatorForTests } from "@/lib/focus/primary-focus-coordinator";
 
 afterEach(() => {
   cleanup();
+  resetTerminalFocusRegistryForTests();
+  resetPrimaryFocusCoordinatorForTests();
 });
+
+function MaximizedTerminalFocusProbe() {
+  const terminalRef = useRef<HTMLButtonElement | null>(null);
+  const pickerStore = useState<ComposerPickerStore>(() =>
+    createComposerPickerStore(),
+  )[0];
+  useLayoutEffect(() => {
+    const terminal = terminalRef.current;
+    if (terminal === null) return;
+    const unregister = registerTerminalFocus(
+      "delayed-composer-terminal",
+      () => terminal.focus(),
+      (activeElement) => activeElement === terminal,
+      () => terminal.isConnected,
+    );
+    focusTerminalInstance("delayed-composer-terminal");
+    return unregister;
+  }, []);
+  return (
+    <div data-primary-focus-scope="true">
+      <button ref={terminalRef} type="button" aria-label="Terminal input" />
+      <ComposerPromptEditor
+        ref={null}
+        initialContent={emptyContent()}
+        initialSelection={null}
+        pickerStore={pickerStore}
+        placeholder="test"
+        editorClassName={undefined}
+        isActive
+        disabled={false}
+        slashProviderId="claude"
+        hasPastedImageBytes={null}
+        ingestPastedComposerImages={null}
+        stabilizeImageAttachmentCaret={false}
+        onDocumentChange={() => undefined}
+        onSelectionChange={() => undefined}
+        onSubmit={() => undefined}
+        onPaste={() => undefined}
+        onDragOver={() => undefined}
+        onDrop={() => undefined}
+        onKeyDown={undefined}
+        onFocus={() => undefined}
+        onBlur={() => undefined}
+        onEditorReady={null}
+      />
+    </div>
+  );
+}
 
 interface HarnessProps {
   readonly profileRender: ProfilerOnRenderCallback;
@@ -77,17 +140,39 @@ function Harness({
 }
 
 describe("ComposerPromptEditor render isolation", () => {
+  it("does not overwrite restored terminal focus after its delayed editor mount", async () => {
+    const view = render(
+      <PrimaryFocusCoordinatorProvider>
+        <MaximizedTerminalFocusProbe />
+      </PrimaryFocusCoordinatorProvider>,
+    );
+    const terminal = view.getByRole("button", { name: "Terminal input" });
+    expect(document.activeElement).toBe(terminal);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await waitFor(() => {
+      expect(
+        view.container.querySelector("[data-composer-editor]"),
+      ).not.toBeNull();
+    });
+    expect(document.activeElement).toBe(terminal);
+  });
+
   it("does not steal focus from the control that activated its pane", async () => {
     const handleRef: { current: ComposerPromptEditorHandle | null } = {
       current: null,
     };
     const pickerStore = createComposerPickerStore();
     let yieldCheckCount = 0;
+    let shouldYield = true;
     const focusIntent: PaneActivationFocusIntent = {
       mark: () => undefined,
       shouldYieldAutoFocus: () => {
         yieldCheckCount += 1;
-        return true;
+        return shouldYield;
       },
     };
     const initialContent = emptyContent();
@@ -148,6 +233,23 @@ describe("ComposerPromptEditor render isolation", () => {
     });
 
     expect(yieldCheckCount).toBe(2);
+    expect(document.activeElement).toBe(control);
+
+    // Once the bounded activation intent expires, a landing-surface focus
+    // restoration may already have put the keyboard back in its terminal or
+    // another remembered control before this passive composer effect runs.
+    // The composer must not overwrite focus that is already inside its own
+    // primary-focus scope.
+    shouldYield = false;
+    view.container.dataset.primaryFocusScope = "true";
+    view.rerender(renderEditor(false));
+    control.focus();
+    view.rerender(renderEditor(true));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(yieldCheckCount).toBe(3);
     expect(document.activeElement).toBe(control);
   });
 

--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -313,6 +313,7 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
   const onSelectionChangeRef = useRef(onSelectionChange);
   const onEditorReadyRef = useRef(onEditorReady);
   const initialSelectionRef = useRef(normalizedInitial.selection);
+  const initialAutofocusSelectionPreparedRef = useRef(false);
   useEffect(() => {
     onSubmitRef.current = onSubmit;
     onDocumentChangeRef.current = onDocumentChange;
@@ -364,7 +365,10 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     {
       extensions,
       content: normalizedInitial.content,
-      autofocus: isActive ? "end" : false,
+      // Initial focus is coordinated by the guarded effect below. Tiptap's
+      // intrinsic autofocus runs after its deferred mount and bypasses pane
+      // activation / restored-terminal ownership checks.
+      autofocus: false,
       immediatelyRender: false,
       editable: !disabled,
       editorProps: {
@@ -441,6 +445,23 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     if (!isActive) return;
     if (editor.isFocused) return;
     if (paneActivationFocusIntent.shouldYieldAutoFocus()) return;
+    const focusScope = editor.view.dom.closest(
+      "[data-primary-focus-scope='true']",
+    );
+    if (
+      focusScope !== null &&
+      document.activeElement !== null &&
+      focusScope.contains(document.activeElement)
+    ) {
+      return;
+    }
+    if (
+      !initialAutofocusSelectionPreparedRef.current &&
+      initialSelectionRef.current === null
+    ) {
+      editor.commands.setTextSelection(editor.state.doc.content.size);
+    }
+    initialAutofocusSelectionPreparedRef.current = true;
     focusActiveComposer();
   }, [editor, isActive, paneActivationFocusIntent]);
 

--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   act,
@@ -26,6 +26,24 @@ import {
   type WorkspaceFolderInfo,
 } from "@/stores/workspace/workspace-folders-store";
 import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  focusActiveComposer,
+  registerComposerFocus,
+} from "@/lib/composer/composer-focus-registry";
+import {
+  registerTerminalFocus,
+  resetTerminalFocusRegistryForTests,
+} from "@/lib/terminals/terminal-focus-registry";
+import { resetPrimaryFocusCoordinatorForTests } from "@/lib/focus/primary-focus-coordinator";
+import { PrimaryFocusCoordinatorProvider } from "@/lib/focus/primary-focus-coordinator-provider";
+import { useLandingTerminalStore } from "@/stores/home/landing-terminal-store";
+import { useTabsStore } from "@/stores/tabs/store";
+import { LandingTerminalHost } from "@/components/home/terminal-panel/landing-terminal-host";
+import {
+  PaneActivationFocusIntentContext,
+  type PaneActivationFocusIntent,
+  usePaneActivationFocusIntent,
+} from "@/components/epic-canvas/pane-activation";
 
 /**
  * Commit-level observation of the mocked LandingComposer's mount identity.
@@ -65,6 +83,12 @@ const homeMocks = vi.hoisted(() => ({
   })),
   composerCommits: [] as ComposerCommit[],
   nextInstanceId: 0,
+  tabActivity: { visible: true, focused: true },
+  delayComposerRegistration: false,
+}));
+
+vi.mock("@/components/layout/tab-surface-activity-hooks", () => ({
+  useTabSurfaceActivity: () => homeMocks.tabActivity,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -161,6 +185,9 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
     // The real composer reads surface activity from context (provided by
     // HomePage); the mock mirrors that so the gating stays observable.
     const activityEnabled = useSurfaceActivity();
+    const paneActivationFocusIntent = usePaneActivationFocusIntent();
+    const composerRef = useRef<HTMLButtonElement | null>(null);
+    const delayComposerRegistration = homeMocks.delayComposerRegistration;
     const actions = useLandingComposerActions(useTestPlacementTarget());
     const draftId = props.draftId;
     const pendingCreateId = props.pendingCreateId;
@@ -171,6 +198,38 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
       instanceIdRef.current = homeMocks.nextInstanceId;
     }
     const instanceId = instanceIdRef.current;
+
+    useLayoutEffect(() => {
+      if (delayComposerRegistration) return;
+      const composer = composerRef.current;
+      if (composer === null) return;
+      return registerComposerFocus(
+        `landing-test-${instanceId}`,
+        {
+          focus: () => composer.focus(),
+          containsActiveElement: (activeElement) => activeElement === composer,
+          isEligible: () => composer.isConnected,
+        },
+        activityEnabled,
+      );
+    }, [activityEnabled, delayComposerRegistration, instanceId]);
+    useEffect(() => {
+      if (delayComposerRegistration) return;
+      const composer = composerRef.current;
+      const focusScope =
+        composer === null
+          ? null
+          : composer.closest("[data-primary-focus-scope='true']");
+      if (
+        activityEnabled &&
+        !paneActivationFocusIntent.shouldYieldAutoFocus() &&
+        (focusScope === null ||
+          document.activeElement === null ||
+          !focusScope.contains(document.activeElement))
+      ) {
+        focusActiveComposer();
+      }
+    }, [activityEnabled, delayComposerRegistration, paneActivationFocusIntent]);
 
     // Instance lifetime (keyed remounts). `instanceId` is allocated once per
     // React key identity; depend only on it so prop updates do not fake unmounts.
@@ -241,6 +300,7 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
         data-instance-id={String(instanceId)}
       >
         <button
+          ref={composerRef}
           type="button"
           data-testid="landing-submit"
           onClick={handleClick}
@@ -280,14 +340,47 @@ vi.mock("@/components/epics/epics-list-panel", () => ({
 }));
 
 vi.mock("@/components/home/terminal-panel/landing-terminal-panel", () => ({
-  LandingTerminalPanel: () => <div data-testid="landing-terminal-panel-slot" />,
+  LandingTerminalPanel: () => {
+    const terminalRef = useRef<HTMLButtonElement | null>(null);
+    useLayoutEffect(() => {
+      const terminal = terminalRef.current;
+      if (terminal === null) return;
+      return registerTerminalFocus(
+        "landing-terminal-focus-test",
+        () => terminal.focus(),
+        (activeElement) => activeElement === terminal,
+        () => terminal.isConnected,
+      );
+    }, []);
+    return (
+      <button
+        ref={terminalRef}
+        type="button"
+        data-testid="landing-terminal-panel-slot"
+      >
+        Terminal input
+      </button>
+    );
+  },
 }));
+
+vi.mock(
+  "@/components/home/terminal-panel/landing-terminal-gesture-provider",
+  () => ({
+    LandingTerminalGestureProvider: (props: { readonly children: ReactNode }) =>
+      props.children,
+  }),
+);
 import { HomePage } from "@/components/home/home-page";
 
 // The workspace-folders store buckets by host; every fixture in this suite
 // resolves the active host through `homeMocks.getActiveHostId()`, so seed and
 // read that same host's bucket.
 const TEST_HOST_ID = "host-home";
+const INITIAL_TAB_LAYOUT = {
+  items: useTabsStore.getState().items,
+  activeItemId: useTabsStore.getState().activeItemId,
+};
 
 function setGlobalWorkspaceFolders(
   folders: ReadonlyArray<string>,
@@ -302,6 +395,8 @@ function setGlobalWorkspaceFolders(
 
 describe("<HomePage />", () => {
   beforeEach(() => {
+    homeMocks.tabActivity = { visible: true, focused: true };
+    homeMocks.delayComposerRegistration = false;
     __resetTabNavigationControllerForTesting();
     window.localStorage.clear();
     homeMocks.systemModalOpen = false;
@@ -320,6 +415,8 @@ describe("<HomePage />", () => {
     });
     homeMocks.composerCommits.length = 0;
     homeMocks.nextInstanceId = 0;
+    useLandingTerminalStore.getState().resetForTests();
+    useTabsStore.setState(INITIAL_TAB_LAYOUT);
     useAuthStore.setState({
       status: "signed-in",
       profile: {
@@ -342,6 +439,10 @@ describe("<HomePage />", () => {
 
   afterEach(() => {
     cleanup();
+    resetTerminalFocusRegistryForTests();
+    resetPrimaryFocusCoordinatorForTests();
+    useLandingTerminalStore.getState().resetForTests();
+    useTabsStore.setState(INITIAL_TAB_LAYOUT);
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     useEpicCanvasStore.setState({
       tabsById: {},
@@ -624,6 +725,163 @@ describe("<HomePage />", () => {
     function mounts(): ReadonlyArray<ComposerCommit> {
       return homeMocks.composerCommits.filter((c) => c.phase === "mount");
     }
+
+    const noPaneFocusIntent: PaneActivationFocusIntent = {
+      mark: () => undefined,
+      shouldYieldAutoFocus: () => false,
+    };
+
+    function seedFocusedLandingTerminal(maximized: boolean): void {
+      useLandingDraftStore.getState().createDraftWithId("draft-a", null);
+      useLandingDraftStore.getState().setActiveDraft("draft-a");
+      useTabsStore.setState({
+        items: [
+          {
+            kind: "tab",
+            id: "item-draft-a",
+            ref: { kind: "draft", id: "draft-a" },
+          },
+        ],
+        activeItemId: "item-draft-a",
+      });
+      const terminalStore = useLandingTerminalStore.getState();
+      terminalStore.addTab({
+        instanceId: "landing-terminal-focus-test",
+        sessionId: "terminal-session-test",
+        hostId: TEST_HOST_ID,
+        cwd: "/tmp",
+        name: "Terminal",
+        titleSource: "default",
+      });
+      terminalStore.setPanelOpen("draft-a", true);
+      terminalStore.setPanelMaximized("draft-a", maximized);
+    }
+
+    function renderLandingFocusHarness(focusIntent: PaneActivationFocusIntent) {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const tree = () => (
+        <PrimaryFocusCoordinatorProvider>
+          <QueryClientProvider client={queryClient}>
+            <button type="button" data-testid="other-tab-control">
+              Other tab
+            </button>
+            <PaneActivationFocusIntentContext.Provider value={focusIntent}>
+              <HomePage />
+            </PaneActivationFocusIntentContext.Provider>
+            <LandingTerminalHost />
+          </QueryClientProvider>
+        </PrimaryFocusCoordinatorProvider>
+      );
+      const view = render(tree());
+      return { queryClient, tree, view };
+    }
+
+    it("restores terminal focus through the real landing portal after tab reactivation", async () => {
+      seedFocusedLandingTerminal(false);
+      const { queryClient, tree, view } =
+        renderLandingFocusHarness(noPaneFocusIntent);
+      const terminal = await screen.findByTestId("landing-terminal-panel-slot");
+      expect(
+        screen.getByTestId("landing-draft-surface").contains(terminal),
+      ).toBe(true);
+      terminal.focus();
+      expect(document.activeElement).toBe(terminal);
+
+      homeMocks.tabActivity = { visible: false, focused: false };
+      view.rerender(tree());
+      screen.getByTestId("other-tab-control").focus();
+
+      homeMocks.tabActivity = { visible: true, focused: true };
+      view.rerender(tree());
+
+      expect(document.activeElement).toBe(terminal);
+      queryClient.clear();
+    });
+
+    it("focuses the active terminal when a maximized landing surface mounts already focused", async () => {
+      seedFocusedLandingTerminal(true);
+      const { queryClient } = renderLandingFocusHarness(noPaneFocusIntent);
+
+      expect(document.activeElement).toBe(
+        await screen.findByTestId("landing-terminal-panel-slot"),
+      );
+      queryClient.clear();
+    });
+
+    it("does not focus a retained inactive composer while the focused editor registers asynchronously", async () => {
+      useLandingDraftStore.getState().createDraftWithId("draft-a", null);
+      useLandingDraftStore.getState().setActiveDraft("draft-a");
+      homeMocks.delayComposerRegistration = true;
+      const inactiveComposer = document.createElement("button");
+      inactiveComposer.type = "button";
+      document.body.append(inactiveComposer);
+      const unregisterInactive = registerComposerFocus(
+        "retained-inactive-split-partner",
+        {
+          focus: () => inactiveComposer.focus(),
+          containsActiveElement: (activeElement) =>
+            activeElement === inactiveComposer,
+          isEligible: () => inactiveComposer.isConnected,
+        },
+        false,
+      );
+
+      const { queryClient, tree, view } =
+        renderLandingFocusHarness(noPaneFocusIntent);
+
+      expect(document.activeElement).not.toBe(inactiveComposer);
+
+      homeMocks.delayComposerRegistration = false;
+      view.rerender(tree());
+      await waitFor(() => {
+        expect(document.activeElement).toBe(
+          screen.getByTestId("landing-submit"),
+        );
+      });
+
+      unregisterInactive();
+      inactiveComposer.remove();
+      queryClient.clear();
+    });
+
+    it("restores the maximized terminal after a system modal closes", async () => {
+      seedFocusedLandingTerminal(true);
+      const { queryClient, tree, view } =
+        renderLandingFocusHarness(noPaneFocusIntent);
+      const terminal = await screen.findByTestId("landing-terminal-panel-slot");
+      expect(document.activeElement).toBe(terminal);
+
+      homeMocks.systemModalOpen = true;
+      view.rerender(tree());
+      screen.getByTestId("other-tab-control").focus();
+
+      homeMocks.systemModalOpen = false;
+      view.rerender(tree());
+
+      expect(document.activeElement).toBe(terminal);
+      queryClient.clear();
+    });
+
+    it("yields restoration to the control that activates an unfocused draft pane", () => {
+      seedFocusedLandingTerminal(false);
+      const focusIntent: PaneActivationFocusIntent = {
+        mark: () => undefined,
+        shouldYieldAutoFocus: () => true,
+      };
+      homeMocks.tabActivity = { visible: true, focused: false };
+      const { queryClient, tree, view } =
+        renderLandingFocusHarness(focusIntent);
+      const activatingControl = screen.getByTestId("landing-change-twice");
+      activatingControl.focus();
+
+      homeMocks.tabActivity = { visible: true, focused: true };
+      view.rerender(tree());
+
+      expect(document.activeElement).toBe(activatingControl);
+      queryClient.clear();
+    });
 
     it("never commits a null-draft frame still keyed by a pending-created draft id", () => {
       const queryClient = renderHome();

--- a/clients/gui-app/src/components/home/landing-draft-surface.tsx
+++ b/clients/gui-app/src/components/home/landing-draft-surface.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouterState } from "@tanstack/react-router";
 import { v4 as uuidv4 } from "uuid";
 import { HomeHero } from "@/components/home/home-hero";
@@ -12,6 +12,13 @@ import { parseSystemTabOverlayView } from "@/lib/system-tab-overlay-search";
 import { useDraftSurfaceId } from "@/providers/draft-surface-hooks";
 import { useLandingDraftShell } from "@/stores/home/landing-draft-store";
 import { LandingTerminalPaneAnchor } from "@/components/home/terminal-panel/landing-terminal-host";
+import { focusRegisteredActiveComposer } from "@/lib/composer/composer-focus-registry";
+import { focusTerminalInstance } from "@/lib/terminals/terminal-focus-registry";
+import {
+  landingTerminalLayoutFor,
+  useLandingTerminalStore,
+} from "@/stores/home/landing-terminal-store";
+import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
 
 /**
  * Route-independent landing body. Its exact draft runtime remains the T6
@@ -21,6 +28,7 @@ export function LandingDraftSurface() {
   const draftId = useDraftSurfaceId();
   const { workspaceFolders, settings } = useLandingDraftShell(draftId);
   const activity = useTabSurfaceActivity();
+  const paneActivationFocusIntent = usePaneActivationFocusIntent();
 
   // Pre-mint the mount identity for the null-draft landing so the first
   // substantive edit (which creates a draft and flips this surface's id
@@ -56,9 +64,88 @@ export function LandingDraftSurface() {
     () => renderLandingWorkspaceControls.bind(null, workspaceSurface),
     [workspaceSurface],
   );
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  const focusRestorationTargetRef = useRef<HTMLElement | null>(null);
+  const surfaceEffectivelyFocused = activity.focused && !systemModalOpen;
+  const previouslyEffectivelyFocusedRef = useRef(false);
+
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    if (surface === null) return;
+    const rememberFocusedElement = (event: globalThis.FocusEvent): void => {
+      if (
+        event.target instanceof HTMLElement &&
+        surface.contains(event.target)
+      ) {
+        lastFocusedElementRef.current = event.target;
+      }
+    };
+    // Native focus events follow the DOM tree. The landing terminal is owned
+    // by a sibling React root and portaled into this surface's anchor, so a
+    // React onFocusCapture here cannot observe it even though its DOM lives
+    // below this node.
+    document.addEventListener("focusin", rememberFocusedElement);
+    return () =>
+      document.removeEventListener("focusin", rememberFocusedElement);
+  }, []);
+
+  useEffect(() => {
+    const newlyFocused =
+      surfaceEffectivelyFocused && !previouslyEffectivelyFocusedRef.current;
+    previouslyEffectivelyFocusedRef.current = surfaceEffectivelyFocused;
+    if (!surfaceEffectivelyFocused) {
+      focusRestorationTargetRef.current = lastFocusedElementRef.current;
+      return;
+    }
+    if (!newlyFocused || paneActivationFocusIntent.shouldYieldAutoFocus()) {
+      return;
+    }
+
+    const terminalState = useLandingTerminalStore.getState();
+    const layout = landingTerminalLayoutFor(
+      terminalState,
+      draftId ?? "unbound-landing-page",
+    );
+    if (layout.panelOpen && layout.maximized) {
+      const instanceId = terminalState.activeInstanceId;
+      if (instanceId !== null) {
+        focusTerminalInstance(instanceId);
+        return;
+      }
+    }
+
+    const surface = surfaceRef.current;
+    const previous = focusRestorationTargetRef.current;
+    if (
+      surface !== null &&
+      previous !== null &&
+      previous.isConnected &&
+      surface.contains(previous)
+    ) {
+      previous.focus({ preventScroll: true });
+      if (
+        document.activeElement === previous ||
+        (document.activeElement !== null &&
+          previous.contains(document.activeElement))
+      ) {
+        return;
+      }
+    }
+    // The local Tiptap editor may not have registered yet
+    // (`immediatelyRender: false`). Never fall back to a retained inactive
+    // split partner here; if no active endpoint exists, the local editor's own
+    // autofocus effect will run as soon as it registers.
+    focusRegisteredActiveComposer();
+  }, [draftId, paneActivationFocusIntent, surfaceEffectivelyFocused]);
 
   return (
-    <div className="relative flex min-h-0 flex-1 overflow-hidden bg-background text-foreground">
+    <div
+      ref={surfaceRef}
+      className="relative flex min-h-0 flex-1 overflow-hidden bg-background text-foreground"
+      data-primary-focus-scope="true"
+      data-testid="landing-draft-surface"
+    >
       <div className="grid min-h-0 min-w-0 flex-1 grid-rows-[auto_minmax(0,1fr)_minmax(0,1fr)] overflow-hidden">
         <div className="mx-auto w-full max-w-3xl px-6 pt-3">
           <HostUpdateBanner className={undefined} />

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   act,
@@ -47,13 +47,32 @@ import {
 } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
 import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
 import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+import { useSurfaceActivity } from "@/components/home/composer/surface-activity-hooks";
+import { registerComposerFocus } from "@/lib/composer/composer-focus-registry";
+import {
+  registerTerminalFocus,
+  resetTerminalFocusRegistryForTests,
+} from "@/lib/terminals/terminal-focus-registry";
+import { resetPrimaryFocusCoordinatorForTests } from "@/lib/focus/primary-focus-coordinator";
+import { PrimaryFocusCoordinatorProvider } from "@/lib/focus/primary-focus-coordinator-provider";
+import { useLandingTerminalStore } from "@/stores/home/landing-terminal-store";
 
 const stableTileSurfaceHostTestState = vi.hoisted(() => ({ enabled: false }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@tanstack/react-router")>();
-  return { ...actual, useRouterState: () => "/" };
+  return {
+    ...actual,
+    useRouterState: (options: {
+      readonly select?: (state: {
+        readonly location: {
+          readonly pathname: string;
+          readonly search: Record<string, unknown>;
+        };
+      }) => unknown;
+    }) => options.select?.({ location: { pathname: "/", search: {} } }) ?? "/",
+  };
 });
 
 vi.mock(
@@ -120,8 +139,44 @@ vi.mock("@/components/epic-tabs/epic-surface", async () => {
   return { EpicSurface: MockEpicSurface };
 });
 
-vi.mock("@/components/home/landing-draft-surface", () => ({
-  LandingDraftSurface: () => <div data-testid="draft-surface-body" />,
+vi.mock("@/components/home/home-hero", () => ({
+  HomeHero: () => <div />,
+}));
+vi.mock("@/components/home/host-update-banner", () => ({
+  HostUpdateBanner: () => null,
+}));
+vi.mock("@/components/epics/epics-list-panel", () => ({
+  EpicsListPanel: () => null,
+}));
+vi.mock(
+  "@/components/home/host-workspace-selector/host-workspace-selector",
+  () => ({ HostWorkspaceSelector: () => null }),
+);
+vi.mock("@/components/home/composer/landing-composer", () => ({
+  LandingComposer: (props: { readonly draftId: string | null }) => {
+    const active = useSurfaceActivity();
+    const ref = useRef<HTMLButtonElement | null>(null);
+    useLayoutEffect(() => {
+      const element = ref.current;
+      if (element === null) return;
+      return registerComposerFocus(
+        `integrated-${props.draftId ?? "unbound"}`,
+        {
+          focus: () => element.focus(),
+          containsActiveElement: (activeElement) => activeElement === element,
+          isEligible: () => element.isConnected,
+        },
+        active,
+      );
+    }, [active, props.draftId]);
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={`Composer ${props.draftId}`}
+      />
+    );
+  },
 }));
 
 vi.mock("@/components/epics/history-surface", () => ({
@@ -149,7 +204,26 @@ vi.mock(
   }),
 );
 vi.mock("@/components/home/terminal-panel/landing-terminal-panel", () => ({
-  LandingTerminalPanel: () => <div data-testid="landing-terminal-panel-body" />,
+  LandingTerminalPanel: () => {
+    const ref = useRef<HTMLButtonElement | null>(null);
+    useLayoutEffect(() => {
+      const element = ref.current;
+      if (element === null) return;
+      return registerTerminalFocus(
+        "integrated-terminal",
+        () => element.focus(),
+        (activeElement) => activeElement === element,
+        () => element.isConnected,
+      );
+    }, []);
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-testid="landing-terminal-panel-body"
+      />
+    );
+  },
 }));
 
 const EPIC_A: TabRef = { kind: "epic", id: "epic-a" };
@@ -307,6 +381,7 @@ describe("<TopLevelTabHost />", () => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
     useAuthStore.setState(useAuthStore.getInitialState(), true);
+    useLandingTerminalStore.getState().resetForTests();
   });
 
   afterEach(() => {
@@ -315,6 +390,9 @@ describe("<TopLevelTabHost />", () => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
     useAuthStore.setState(useAuthStore.getInitialState(), true);
+    useLandingTerminalStore.getState().resetForTests();
+    resetTerminalFocusRegistryForTests();
+    resetPrimaryFocusCoordinatorForTests();
   });
 
   it.each([
@@ -393,6 +471,29 @@ describe("<TopLevelTabHost />", () => {
 
     expect(surfaceRef(EPIC_B).dataset.focused).toBe("true");
     expect(document.activeElement).toBe(action);
+  });
+
+  it("keeps the activating composer focused in a real draft/draft split", async () => {
+    seedSources([DRAFT_A, DRAFT_B]);
+    setSplit(DRAFT_A, DRAFT_B, "left");
+    render(
+      <PrimaryFocusCoordinatorProvider>
+        {activatingHost(DRAFT_A, DRAFT_B)}
+      </PrimaryFocusCoordinatorProvider>,
+    );
+
+    const rightComposer = await screen.findByRole("button", {
+      name: `Composer ${DRAFT_B.id}`,
+    });
+    act(() => {
+      rightComposer.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, composed: true }),
+      );
+      rightComposer.focus();
+    });
+
+    expect(surfaceRef(DRAFT_B).dataset.focused).toBe("true");
+    expect(document.activeElement).toBe(rightComposer);
   });
 
   it("retains primary autofocus for blank top-level surface activation", () => {
@@ -512,6 +613,54 @@ describe("<TopLevelTabHost />", () => {
 
     expect(screen.getByTestId("top-level-fillable-slot-right")).not.toBeNull();
     expect(screen.getAllByTestId(/^top-level-surface-/)).toHaveLength(5);
+  });
+
+  it("focuses a maximized terminal when its draft is reconstructed after MRU eviction", async () => {
+    const refs = Array.from({ length: 6 }, (_value, index) => ({
+      kind: "draft" as const,
+      id: `draft-${index}`,
+    }));
+    seedSources(refs);
+    setSingle(refs[0], refs);
+    const terminalStore = useLandingTerminalStore.getState();
+    terminalStore.addTab({
+      instanceId: "integrated-terminal",
+      sessionId: "integrated-terminal-session",
+      hostId: TEST_HOST_ID,
+      cwd: "/tmp",
+      name: "Terminal",
+      titleSource: "default",
+    });
+    terminalStore.setPanelOpen(refs[0].id, true);
+    terminalStore.setPanelMaximized(refs[0].id, true);
+
+    render(
+      <PrimaryFocusCoordinatorProvider>
+        <TopLevelTabHost />
+        <LandingTerminalHost />
+      </PrimaryFocusCoordinatorProvider>,
+    );
+    const firstSurface = surfaceRef(refs[0]);
+    const terminal = await screen.findByTestId("landing-terminal-panel-body");
+    expect(document.activeElement).toBe(terminal);
+
+    for (const ref of refs.slice(1)) {
+      act(() => setSingle(ref, refs));
+    }
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(`top-level-surface-draft-${refs[0].id}`),
+      ).toBeNull();
+    });
+
+    act(() => setSingle(refs[0], refs));
+
+    await waitFor(() => {
+      expect(surfaceRef(refs[0])).not.toBe(firstSurface);
+      expect(document.activeElement).toBe(
+        screen.getByTestId("landing-terminal-panel-body"),
+      );
+    });
   });
 
   it("mounts exactly one landing terminal panel for a draft/draft split", () => {

--- a/clients/gui-app/src/lib/composer/composer-focus-registry.ts
+++ b/clients/gui-app/src/lib/composer/composer-focus-registry.ts
@@ -42,3 +42,19 @@ export function focusActiveComposer(): boolean {
   requestPrimaryFocus(fallback.target);
   return true;
 }
+
+/**
+ * Focuses a composer only when one has explicitly registered as active.
+ *
+ * Mount-time autofocus must not use `focusActiveComposer`'s inactive fallback:
+ * the newly active Tiptap editor registers asynchronously, so a retained split
+ * partner may temporarily be the only endpoint in the registry.
+ */
+export function focusRegisteredActiveComposer(): boolean {
+  for (const entry of entries) {
+    if (!entry.isActive) continue;
+    requestPrimaryFocus(entry.target);
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- restore the last focused control when returning to a landing draft surface
- prioritize maximized landing terminals and respect split-pane activation and modal focus transitions
- coordinate delayed Tiptap autofocus and cover real terminal portals, split activation, and MRU reconstruction

## Validation
- pre-commit affected lint, format, compile, and build checks
- focused GUI tests: 47 passed plus 10 React Compiler tests
- React Doctor: no issues
