### PR TITLE
build(protocol): type-check with the native compiler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@typescript-eslint/eslint-plugin": "catalog:",
         "@typescript-eslint/parser": "catalog:",
+        "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "concurrently": "^10.0.5",
         "esbuild": "catalog:",
         "eslint": "catalog:",
@@ -1540,6 +1541,22 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.65.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260707.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "arm" }, "sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "x64" }, "sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ=="],
 
     "@uiw/codemirror-extensions-basic-setup": ["@uiw/codemirror-extensions-basic-setup@4.25.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw=="],
 

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "concurrently": "^10.0.5",
     "esbuild": "catalog:",
     "eslint": "catalog:",

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -123,7 +123,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/patch-dist-esm-imports.cjs",
-    "compile": "tsc --noEmit",
+    "compile": "tsgo --noEmit --singleThreaded",
     "prepack": "bun run build",
     "test": "vitest run",
     "lint": "eslint . --cache --fix --max-warnings 0"


### PR DESCRIPTION
## Summary

Type-checking `@traycer/protocol` with `tsc` peaks at **1.58 GB for 5.6 s**. Every workspace check on every machine pays that, and the peaks stack when several agents or worktrees compile at once.

This switches the `compile` target to the native (Go) TypeScript compiler. Same 909-file program, same clean result:

| command | time | max RSS |
| --- | --- | --- |
| `tsc --noEmit` (today) | 5.6 s | 1.58 GB |
| `tsgo --noEmit` | 1.9 s | 2.47 GB |
| **`tsgo --noEmit --singleThreaded`** | **2.5 s** | **1.08 GB** |

`--singleThreaded` is deliberate. The parallel checker allocates per worker, so it buys 0.6 s for 0.9 GB — a bad trade on a small machine, and a worse one when N compiles already saturate the cores. Single-threaded beats `tsc` on **both** axes: 2.2× faster and 32% lighter.

## Scope

- `compile` only. **`build` stays on `tsc`** — it emits declarations, and this change is about the type-check.
- **TypeScript stays pinned at 6.x.** TS 7.0 shipped without the programmatic compiler API, so `typescript-eslint` cannot run on it yet ([typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)); support is expected with TS 7.1. The native compiler arrives as `@typescript/native-preview`, pinned exactly at the final preview build (`7.0.0-dev.20260707.2`), whose `tsgo` bin does not collide with the `tsc` from typescript 6.
- When TS 7.1 lands with the stable API, this collapses: bump `typescript`, drop `@typescript/native-preview`, and `tsgo` becomes `tsc` again.

## Verification

- `bun install` — lockfile updated, `tsgo` bin linked.
- `bun run --filter '@traycer/protocol' compile` — exit 0, no diagnostics; 1.08 GB max RSS measured with `/usr/bin/time -l`.
- Diagnostic parity against `tsc --noEmit` confirmed before switching (both clean, identical program).
- Full pre-commit suite passed, including the affected `build · compile · lint · format` checks.