### PR TITLE
fix(terminals): preserve RC protocol compatibility

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -17,6 +17,10 @@ const mocks = vi.hoisted(() => ({
   chatBackupStatus: null as EpicChatBackupStatus | null,
   terminalCoverage: null as
     "partial-serving-host" | "complete-fleet" | "complete-local" | null,
+  terminalCapability: {
+    status: "capable",
+    schemaVersion: { major: 2, minor: 1 },
+  },
   commGraphFeedHealth: null as CommGraphFeedHealth | null,
 }));
 
@@ -54,6 +58,7 @@ vi.mock("@/hooks/terminal/use-plain-terminal-authority", () => ({
   useHostPlainTerminalAuthority: () => ({
     hostId: "host-a",
     coverage: mocks.terminalCoverage,
+    capability: mocks.terminalCapability,
   }),
 }));
 
@@ -100,6 +105,10 @@ describe("<EpicConnectionPill />", () => {
     vi.useRealTimers();
     mocks.chatBackupStatus = null;
     mocks.terminalCoverage = null;
+    mocks.terminalCapability = {
+      status: "capable",
+      schemaVersion: { major: 2, minor: 1 },
+    };
     mocks.commGraphFeedHealth = null;
   });
 
@@ -366,6 +375,24 @@ describe("<EpicConnectionPill />", () => {
     expect(screen.getByRole("status").textContent).toBe(
       "Remote terminal discovery is unavailable. Showing terminals from this host only. It will recover automatically.",
     );
+  });
+
+  it("does not report a fleet outage for a local-only RC host", () => {
+    vi.useFakeTimers();
+    mocks.terminalCoverage = "partial-serving-host";
+    mocks.terminalCapability = {
+      status: "capable",
+      schemaVersion: { major: 1, minor: 0 },
+    };
+    renderPill("hostPending");
+
+    act(() => {
+      vi.advanceTimersByTime(750);
+    });
+
+    const pill = screen.getByRole<HTMLButtonElement>("button");
+    expect(pill.dataset.source).toBe("artifact");
+    expect(pill.textContent).not.toContain("Remote terminals unavailable");
   });
 
   it("shows the highest severity across artifact sync and chat backup", async () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -20,6 +20,7 @@ import { useCanvasHostId } from "@/components/epic-canvas/hooks/use-canvas-host-
 import { cn } from "@/lib/utils";
 import { useHostPlainTerminalAuthority } from "@/hooks/terminal/use-plain-terminal-authority";
 import { useDelayedTerminalFleetWarning } from "@/hooks/terminal/use-delayed-terminal-fleet-warning";
+import { plainTerminalCapabilityTopology } from "@/lib/terminals/plain-terminal-authority";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 
 /**
@@ -66,7 +67,8 @@ export function EpicConnectionPill(props: EpicConnectionPillProps) {
     scope: { kind: "epic", epicId: props.epicId },
   });
   const terminalCatalogUnavailable = useDelayedTerminalFleetWarning(
-    terminalAuthority.coverage === "partial-serving-host",
+    plainTerminalCapabilityTopology(terminalAuthority.capability) === "fleet" &&
+      terminalAuthority.coverage === "partial-serving-host",
     JSON.stringify([terminalAuthority.hostId, props.epicId]),
   );
   // Visuals use the settled state to avoid strobing; the tooltip uses the raw

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -158,7 +158,13 @@ vi.mock("@/hooks/terminal/use-plain-terminal-authority", () => ({
   useHostPlainTerminalAuthority: () => ({
     hostId: "host-1",
     scope: { kind: "epic", epicId: "epic-1" },
-    capability: { status: durableAuthority.capability },
+    capability:
+      durableAuthority.capability === "capable"
+        ? {
+            status: "capable",
+            schemaVersion: { major: 2, minor: 1 },
+          }
+        : { status: durableAuthority.capability },
     canMutate: durableAuthority.canMutate,
     collection: {
       terminalsByIdentity: durableAuthority.collectionIncludesSession

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-durable-projection.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-durable-projection.test.tsx
@@ -109,7 +109,10 @@ vi.mock("@/hooks/terminal/use-plain-terminal-authority", () => ({
   useHostPlainTerminalAuthority: () => ({
     hostId: "host-1",
     scope: { kind: "epic", epicId: "epic-1" },
-    capability: { status: "capable" },
+    capability: {
+      status: "capable",
+      schemaVersion: { major: 2, minor: 1 },
+    },
     canMutate: true,
     collection: durableCollection.value,
     coverage: durableCollection.value?.coverage ?? null,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-fleet-identity.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-fleet-identity.test.tsx
@@ -168,7 +168,10 @@ vi.mock("@/hooks/terminal/use-plain-terminal-authority", () => ({
   useHostPlainTerminalAuthority: () => ({
     hostId: HOST_A,
     scope: { kind: "epic", epicId: EPIC_ID },
-    capability: { status: "capable" },
+    capability: {
+      status: "capable",
+      schemaVersion: { major: 2, minor: 1 },
+    },
     canMutate: true,
     collection: durableCollection.value,
   }),

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-source-reconciliation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-source-reconciliation.test.tsx
@@ -187,7 +187,13 @@ vi.mock("@/hooks/terminal/use-plain-terminal-authority", () => ({
   useHostPlainTerminalAuthority: () => ({
     hostId: HOST_A,
     scope: { kind: "epic", epicId: EPIC_ID },
-    capability: { status: authority.capability },
+    capability:
+      authority.capability === "capable"
+        ? {
+            status: "capable",
+            schemaVersion: { major: 2, minor: 1 },
+          }
+        : { status: authority.capability },
     canMutate: authority.canMutate,
     collection: durableCollection.value,
     coverage: durableCollection.value?.coverage ?? null,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -104,6 +104,7 @@ import {
 } from "@/lib/terminals/pending-create-identity";
 import {
   getPlainTerminal,
+  plainTerminalCapabilityTopology,
   plainTerminalCollectionIdentityKey,
   plainTerminalCollectionValues,
   type PlainTerminalCollection,
@@ -270,13 +271,16 @@ function TerminalsPanelBodyLive(props: {
         epicId,
         servingHostId: activeHostId,
         capability: durableAuthority.capability.status,
+        topology:
+          plainTerminalCapabilityTopology(durableAuthority.capability) ??
+          "fleet",
         coverage: durableAuthority.coverage ?? null,
         listed: list.data?.sessions ?? [],
         durableCollection: durableAuthority.collection,
       }),
     [
       activeHostId,
-      durableAuthority.capability.status,
+      durableAuthority.capability,
       durableAuthority.collection,
       durableAuthority.coverage,
       epicId,

--- a/clients/gui-app/src/hooks/terminal/__tests__/use-plain-terminal-authority.test.tsx
+++ b/clients/gui-app/src/hooks/terminal/__tests__/use-plain-terminal-authority.test.tsx
@@ -36,7 +36,10 @@ import {
   type HostStreamRpcRegistry,
 } from "@traycer/protocol/host/registry";
 import type { PlainTerminalProjection } from "@traycer/protocol/host/terminal/plain-schemas";
-import type { TerminalPlainSubscribeListServerFrame } from "@traycer/protocol/host/terminal/plain-subscribe-list";
+import type {
+  TerminalPlainSubscribeListServerFrame,
+  TerminalPlainSubscribeListServerFrameV10,
+} from "@traycer/protocol/host/terminal/plain-subscribe-list";
 import type { HostStreamClientBinding } from "@/hooks/host/use-host-stream-client-for";
 import { useLandingTerminalDurableLifecycle } from "@/components/home/terminal-panel/landing-terminal-durable-bootstrap";
 import { reconcileCapableLandingTerminals } from "@/components/home/terminal-panel/use-landing-terminal-reconciliation";
@@ -143,6 +146,8 @@ class ControlledSession implements IStreamSession {
   private statusHandler: StatusChangeHandler | null = null;
   closeCount = 0;
 
+  constructor(private readonly negotiatedVersion: SchemaVersion) {}
+
   sendClientFrame(
     _envelope: StreamFrameEnvelope,
     _binaryPayload: Uint8Array | null,
@@ -159,7 +164,7 @@ class ControlledSession implements IStreamSession {
   requestReconnect(): void {}
 
   getNegotiatedSchemaVersion(): SchemaVersion | null {
-    return { major: 2, minor: 1 };
+    return this.negotiatedVersion;
   }
 
   close(): void {
@@ -174,7 +179,11 @@ class ControlledSession implements IStreamSession {
     this.statusHandler?.(status, reason);
   }
 
-  emitFrame(frame: TerminalPlainSubscribeListServerFrame): void {
+  emitFrame(
+    frame:
+      | TerminalPlainSubscribeListServerFrame
+      | TerminalPlainSubscribeListServerFrameV10,
+  ): void {
     this.frameHandler?.(frame, null);
   }
 
@@ -183,7 +192,7 @@ class ControlledSession implements IStreamSession {
 
 class ControlledStreamClient extends WsStreamClient<HostStreamRpcRegistry> {
   readonly sessions: ControlledSession[] = [];
-  private readonly negotiatedVersion: SchemaVersion = { major: 2, minor: 1 };
+  private negotiatedVersion: SchemaVersion = { major: 2, minor: 1 };
   private readonly supportListeners = new Set<() => void>();
   subscribeCount = 0;
 
@@ -217,7 +226,7 @@ class ControlledStreamClient extends WsStreamClient<HostStreamRpcRegistry> {
     _params: ParamsOf<HostStreamRpcRegistry, Method>,
   ): IStreamSession {
     this.subscribeCount += 1;
-    const session = new ControlledSession();
+    const session = new ControlledSession(this.negotiatedVersion);
     this.sessions.push(session);
     return session;
   }
@@ -242,6 +251,10 @@ class ControlledStreamClient extends WsStreamClient<HostStreamRpcRegistry> {
   setSupport(support: StreamMethodSupport): void {
     this.support = support;
     for (const listener of this.supportListeners) listener();
+  }
+
+  setNegotiatedVersion(version: SchemaVersion): void {
+    this.negotiatedVersion = version;
   }
 
   get session(): ControlledSession {
@@ -377,6 +390,16 @@ function recordCapableManifest(): void {
   };
   for (const method of PLAIN_TERMINAL_RPC_METHODS) {
     manifest[method] = { major: 2, minor: 1 };
+  }
+  recordNegotiatedHostManifest(HOST_ID, manifest);
+}
+
+function recordLocalCapableManifest(): void {
+  const manifest: Record<string, SchemaVersion> = {
+    "host.status": { major: 1, minor: 0 },
+  };
+  for (const method of PLAIN_TERMINAL_RPC_METHODS) {
+    manifest[method] = { major: 1, minor: 0 };
   }
   recordNegotiatedHostManifest(HOST_ID, manifest);
 }
@@ -1258,6 +1281,51 @@ describe("usePlainTerminalAuthority integration", () => {
     expect(rendered.result.current.capability).toEqual({ status: "legacy" });
     expect(rendered.result.current.query.fetchStatus).toBe("idle");
     expect(stream.subscribeCount).toBe(0);
+  });
+
+  it("uses the frozen local authority when a new client connects to an RC host", async () => {
+    recordLocalCapableManifest();
+    const test = fixture([terminal(1, null)]);
+    const stream = new ControlledStreamClient("supported");
+    stream.setNegotiatedVersion({ major: 1, minor: 0 });
+    const rendered = renderHook(
+      () =>
+        usePlainTerminalAuthority({
+          hostId: HOST_ID,
+          scope: SCOPE,
+          client: test.client,
+          streamClient: stream,
+          capabilityIncarnation: "rc-host",
+        }),
+      { wrapper: test.Wrapper },
+    );
+
+    await waitFor(() => expect(stream.subscribeCount).toBe(1));
+    act(() => {
+      stream.session.emitStatus("open", null);
+      stream.session.emitFrame({
+        kind: "snapshot",
+        hasBinaryPayload: false,
+        terminals: [
+          {
+            ...terminal(1, null),
+            runtime: { status: "dormant" },
+          },
+        ],
+      });
+      stream.session.emitFrame({
+        kind: "initialized",
+        hasBinaryPayload: false,
+      });
+    });
+
+    await waitFor(() => expect(rendered.result.current.canMutate).toBe(true));
+    expect(rendered.result.current.capability).toEqual({
+      status: "capable",
+      schemaVersion: { major: 1, minor: 0 },
+    });
+    expect(rendered.result.current.coverage).toBe("partial-serving-host");
+    expect(rendered.result.current.terminals).toEqual([terminal(1, null)]);
   });
 
   it("starts when support becomes available without replacing the established session", async () => {

--- a/clients/gui-app/src/hooks/terminal/use-plain-terminal-authority.ts
+++ b/clients/gui-app/src/hooks/terminal/use-plain-terminal-authority.ts
@@ -20,7 +20,7 @@ import type {
   PlainTerminalProjection,
   PlainTerminalScope,
 } from "@traycer/protocol/host/terminal/plain-schemas";
-import { PLAIN_TERMINAL_FAMILY_VERSION } from "@traycer/protocol/host/terminal/plain-contracts";
+import { PLAIN_TERMINAL_LOCAL_FAMILY_VERSION } from "@traycer/protocol/host/terminal/plain-contracts";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
 import { useHostCapabilityProbe } from "@/hooks/host/use-host-capability-probe";
 import { useHostClientFor } from "@/hooks/host/use-host-client-for";
@@ -326,11 +326,13 @@ export interface PlainTerminalAuthorityResult {
 
 function plainTerminalStreamVersionCompatible(
   version: SchemaVersion | null,
+  capability: PlainTerminalCapability,
 ): boolean {
+  if (version === null) return true;
   return (
-    version === null ||
-    (version.major === PLAIN_TERMINAL_FAMILY_VERSION.major &&
-      version.minor === PLAIN_TERMINAL_FAMILY_VERSION.minor)
+    capability.status === "capable" &&
+    version.major === capability.schemaVersion.major &&
+    version.minor === capability.schemaVersion.minor
   );
 }
 
@@ -411,8 +413,10 @@ export function usePlainTerminalAuthority(args: {
     args.streamClient,
     PLAIN_TERMINAL_STREAM_METHOD,
   );
-  const streamVersionCompatible =
-    plainTerminalStreamVersionCompatible(streamVersion);
+  const streamVersionCompatible = plainTerminalStreamVersionCompatible(
+    streamVersion,
+    unaryCapability,
+  );
   const queryKey = useMemo(
     () => hostQueryKeys.plainTerminals(args.hostId, stableScope),
     [args.hostId, stableScope],
@@ -444,12 +448,34 @@ export function usePlainTerminalAuthority(args: {
       queryClient: cache,
       queryKey: mappedKey,
       requestContext,
-    }) =>
-      seedPlainTerminalList(
+    }) => {
+      let normalizedResponse = response;
+      if (
+        unaryCapability.status === "capable" &&
+        unaryCapability.schemaVersion.major ===
+          PLAIN_TERMINAL_LOCAL_FAMILY_VERSION.major
+      ) {
+        normalizedResponse =
+          stableScope.kind === "independent"
+            ? {
+                ...response,
+                coverage: "complete-local",
+                scope: stableScope,
+              }
+            : {
+                ...response,
+                coverage: "partial-serving-host",
+                scope: stableScope,
+                servingHostId: args.hostId,
+              };
+      }
+
+      return seedPlainTerminalList(
         cache.getQueryData<PlainTerminalCollection>(mappedKey),
-        response,
+        normalizedResponse,
         requestContext ?? capturePlainTerminalProjectionBarrier(undefined),
-      ),
+      );
+    },
   });
 
   // Base transport identity owns unmount/host/client/scope teardown.
@@ -567,6 +593,7 @@ export function usePlainTerminalAuthority(args: {
         };
         return new PlainTerminalListStreamClient({
           wsStreamClient: streamClient,
+          servingHostId: args.hostId,
           scope: stableScope,
           callbacks: {
             onState: (frame) => {

--- a/clients/gui-app/src/lib/terminals/__tests__/plain-terminal-authority.test.ts
+++ b/clients/gui-app/src/lib/terminals/__tests__/plain-terminal-authority.test.ts
@@ -152,12 +152,15 @@ const V2_DRAFT_FAMILY = Object.fromEntries(
 );
 
 describe("plain terminal capability negotiation", () => {
-  it("distinguishes unknown, partial/old, and complete v2 families", () => {
+  it("recognizes frozen local v1 and fleet v2 only as complete families", () => {
     expect(capability({}, false)).toEqual({ status: "unknown" });
     expect(
       capability({ "terminal.plain.list": { major: 2, minor: 0 } }, true),
     ).toEqual({ status: "legacy" });
-    expect(capability(V1_FAMILY, true)).toEqual({ status: "legacy" });
+    expect(capability(V1_FAMILY, true)).toEqual({
+      status: "capable",
+      schemaVersion: { major: 1, minor: 0 },
+    });
     expect(capability(V2_DRAFT_FAMILY, true)).toEqual({ status: "legacy" });
     expect(
       capability(
@@ -174,7 +177,7 @@ describe("plain terminal capability negotiation", () => {
     });
   });
 
-  it("keeps old hosts on local authority and makes a stale capable host view-only", () => {
+  it("keeps hosts without a durable family on legacy authority and makes a stale capable host view-only", () => {
     const oldHost = capability({}, true);
     const stale = seedPlainTerminalList(
       undefined,

--- a/clients/gui-app/src/lib/terminals/__tests__/reconcile-terminal-sidebar-sessions.test.ts
+++ b/clients/gui-app/src/lib/terminals/__tests__/reconcile-terminal-sidebar-sessions.test.ts
@@ -107,6 +107,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: [listedSession(SHARED_ID, { lifecycleOwner: "registry" })],
       durableCollection: completeFleet([
@@ -127,6 +128,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: [
         listedSession("term-a", { lifecycleOwner: "registry" }),
@@ -150,6 +152,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: [listedSession("gone", { lifecycleOwner: "registry" })],
       durableCollection: collection,
@@ -162,6 +165,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: [
         listedSession("setup-term", { lifecycleOwner: "manager" }),
@@ -185,6 +189,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "legacy",
+      topology: "local",
       coverage: null,
       listed: [listedSession("legacy-a", {}), listedSession("legacy-b", {})],
       durableCollection: completeFleet([
@@ -217,6 +222,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "partial-serving-host",
       listed,
       durableCollection: partial,
@@ -232,6 +238,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed,
       durableCollection: complete,
@@ -242,6 +249,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed,
       durableCollection: recovered,
@@ -254,11 +262,29 @@ describe("reconcileTerminalSidebarSessions", () => {
     ]);
   });
 
+  it("does not report a fleet outage for a local-only v1 authority", () => {
+    const result = reconcileTerminalSidebarSessions({
+      epicId: EPIC_ID,
+      servingHostId: HOST_A,
+      capability: "capable",
+      topology: "local",
+      coverage: "partial-serving-host",
+      listed: [listedSession("local", { lifecycleOwner: "registry" })],
+      durableCollection: partialServing(HOST_A, [
+        durableTerminal(HOST_A, "local", "running"),
+      ]),
+    });
+
+    expect(result.incompleteFleet).toBe(false);
+    expect(rowIds(result)).toEqual([`${HOST_A}:local`]);
+  });
+
   it("keeps dormant persistent terminals visible", () => {
     const result = reconcileTerminalSidebarSessions({
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: [],
       durableCollection: completeFleet([
@@ -275,6 +301,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "unknown",
+      topology: "local",
       coverage: null,
       listed: [
         listedSession("cached", { lifecycleOwner: "manager" }),
@@ -293,6 +320,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: [
         listedSession("fresh-client-missing", {}),
@@ -320,6 +348,7 @@ describe("reconcileTerminalSidebarSessions", () => {
       epicId: EPIC_ID,
       servingHostId: HOST_A,
       capability: "capable",
+      topology: "fleet",
       coverage: "complete-fleet",
       listed: managerIds.map((sessionId) =>
         listedSession(sessionId, { lifecycleOwner: "manager" }),

--- a/clients/gui-app/src/lib/terminals/plain-terminal-authority.ts
+++ b/clients/gui-app/src/lib/terminals/plain-terminal-authority.ts
@@ -39,6 +39,18 @@ export type PlainTerminalCapability =
       readonly schemaVersion: SchemaVersion;
     };
 
+export type PlainTerminalTopology = "local" | "fleet";
+
+export function plainTerminalCapabilityTopology(
+  capability: PlainTerminalCapability,
+): PlainTerminalTopology | null {
+  if (capability.status !== "capable") return null;
+  return capability.schemaVersion.major ===
+    PLAIN_TERMINAL_LOCAL_FAMILY_VERSION.major
+    ? "local"
+    : "fleet";
+}
+
 /**
  * Resolves the optional family as a unit. The frozen v1 family is local-only
  * durable authority; v2.1 is fleet authority. A partial mix is legacy.

--- a/clients/gui-app/src/lib/terminals/plain-terminal-authority.ts
+++ b/clients/gui-app/src/lib/terminals/plain-terminal-authority.ts
@@ -1,5 +1,8 @@
 import type { SchemaVersion } from "@traycer/protocol/framework/index";
-import { PLAIN_TERMINAL_FAMILY_VERSION } from "@traycer/protocol/host/terminal/plain-contracts";
+import {
+  PLAIN_TERMINAL_FAMILY_VERSION,
+  PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+} from "@traycer/protocol/host/terminal/plain-contracts";
 import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type {
   ImportLegacyPlainTerminalRequest,
@@ -37,29 +40,35 @@ export type PlainTerminalCapability =
     };
 
 /**
- * Resolves the optional family as a unit. Clients require the complete v2
- * family; a partial v1/v2 mix is legacy behavior, never a license to compose
- * incompatible method semantics.
+ * Resolves the optional family as a unit. The frozen v1 family is local-only
+ * durable authority; v2.1 is fleet authority. A partial mix is legacy.
  */
 export function resolvePlainTerminalCapability(input: {
   readonly manifestKnown: boolean;
   readonly versionFor: (method: PlainTerminalRpcMethod) => SchemaVersion | null;
 }): PlainTerminalCapability {
   if (!input.manifestKnown) return { status: "unknown" };
-  for (const method of PLAIN_TERMINAL_RPC_METHODS) {
-    const version = input.versionFor(method);
-    if (
-      version === null ||
-      version.major !== PLAIN_TERMINAL_FAMILY_VERSION.major ||
-      version.minor !== PLAIN_TERMINAL_FAMILY_VERSION.minor
-    ) {
-      return { status: "legacy" };
+  for (const candidate of [
+    PLAIN_TERMINAL_FAMILY_VERSION,
+    PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  ]) {
+    let matches = true;
+    for (const method of PLAIN_TERMINAL_RPC_METHODS) {
+      const version = input.versionFor(method);
+      if (
+        version === null ||
+        version.major !== candidate.major ||
+        version.minor !== candidate.minor
+      ) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return { status: "capable", schemaVersion: candidate };
     }
   }
-  return {
-    status: "capable",
-    schemaVersion: PLAIN_TERMINAL_FAMILY_VERSION,
-  };
+  return { status: "legacy" };
 }
 
 export function plainTerminalCollectionIdentityKey(

--- a/clients/gui-app/src/lib/terminals/reconcile-terminal-sidebar-sessions.ts
+++ b/clients/gui-app/src/lib/terminals/reconcile-terminal-sidebar-sessions.ts
@@ -36,6 +36,7 @@ export interface ReconcileTerminalSidebarSessionsArgs {
   readonly epicId: string;
   readonly servingHostId: string;
   readonly capability: "unknown" | "legacy" | "capable";
+  readonly topology: "local" | "fleet";
   readonly coverage: PlainTerminalListCoverage | null;
   readonly listed: readonly ListedTerminalSidebarSession[];
   readonly durableCollection: PlainTerminalCollection | undefined;
@@ -106,7 +107,9 @@ export function reconcileTerminalSidebarSessions(
     return { incompleteFleet: false, rows: [] };
   }
   const incompleteFleet =
-    args.capability === "capable" && args.coverage === "partial-serving-host";
+    args.capability === "capable" &&
+    args.topology === "fleet" &&
+    args.coverage === "partial-serving-host";
   const listed = args.listed.filter((session) =>
     isVisibleEpicTerminalSession(session, args.epicId),
   );

--- a/clients/shared/host-transport/__tests__/plain-terminal-list-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/plain-terminal-list-stream-client.test.ts
@@ -117,6 +117,7 @@ function harness() {
   const onConnectionStatus = vi.fn();
   const client = new PlainTerminalListStreamClient({
     wsStreamClient,
+    servingHostId: "host-1",
     scope: { kind: "epic", epicId: "epic-1" },
     callbacks: {
       onState,
@@ -171,6 +172,53 @@ describe("PlainTerminalListStreamClient", () => {
     expect(h.onState).toHaveBeenCalledTimes(2);
     expect(h.onState).toHaveBeenNthCalledWith(1, complete);
     expect(h.onState).toHaveBeenNthCalledWith(2, partial);
+    h.client.close();
+  });
+
+  it("adapts frozen v1 incremental frames into local replacement states", () => {
+    const h = harness();
+    h.session.negotiatedSchemaVersion = { major: 1, minor: 0 };
+
+    h.session.emitFrame({
+      kind: "snapshot",
+      hasBinaryPayload: false,
+      terminals: [dormant],
+    });
+    h.session.emitFrame({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      terminal: running,
+    });
+    expect(h.onState).not.toHaveBeenCalled();
+
+    h.session.emitFrame({ kind: "initialized", hasBinaryPayload: false });
+    expect(h.onState).toHaveBeenLastCalledWith({
+      kind: "state",
+      hasBinaryPayload: false,
+      state: {
+        coverage: "partial-serving-host",
+        scope: { kind: "epic", epicId: "epic-1" },
+        servingHostId: "host-1",
+        terminals: [running],
+      },
+    });
+
+    h.session.emitFrame({
+      kind: "deleted",
+      hasBinaryPayload: false,
+      terminalId: "terminal-1",
+      revision: 8,
+    });
+    expect(h.onState).toHaveBeenLastCalledWith({
+      kind: "state",
+      hasBinaryPayload: false,
+      state: {
+        coverage: "partial-serving-host",
+        scope: { kind: "epic", epicId: "epic-1" },
+        servingHostId: "host-1",
+        terminals: [],
+      },
+    });
     h.client.close();
   });
 

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -630,6 +630,93 @@ describe("WsStreamClient", () => {
     session.close();
   });
 
+  it("selects an installed older major before subscribing to an RC host", async () => {
+    const openRequestSchema = z.object({ id: z.string() });
+    const clientFrameSchema = z.discriminatedUnion("kind", [
+      z.object({
+        kind: z.literal("noop"),
+        hasBinaryPayload: z.literal(false),
+      }),
+    ]);
+    const registry = defineVersionedStreamRpcRegistry({
+      "dual-major.subscribe": {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: {
+              contract: defineStreamRpcContract({
+                method: "dual-major.subscribe",
+                schemaVersion: { major: 1, minor: 0 } as const,
+                openRequestSchema,
+                serverFrameSchema: z.object({
+                  kind: z.literal("snapshot"),
+                  hasBinaryPayload: z.literal(false),
+                  id: z.string(),
+                }),
+                clientFrameSchema,
+              }),
+            },
+          },
+        },
+        2: {
+          latestMinor: 1,
+          versions: {
+            1: {
+              contract: defineStreamRpcContract({
+                method: "dual-major.subscribe",
+                schemaVersion: { major: 2, minor: 1 } as const,
+                openRequestSchema,
+                serverFrameSchema: z.object({
+                  kind: z.literal("state"),
+                  hasBinaryPayload: z.literal(false),
+                  id: z.string(),
+                }),
+                clientFrameSchema,
+              }),
+            },
+          },
+        },
+      },
+    });
+    const { factory, sockets } = makeFactory();
+    const client = new WsStreamClient({
+      registry,
+      endpoint: () => mockLocalHostEntry,
+      bearer: () => makeRequestContext("t")?.credentials ?? null,
+      auth: null,
+      hostCredentialMint: null,
+      onHostCredentialState: null,
+      evidence: NO_TRANSPORT_EVIDENCE,
+      webSocketFactory: factory,
+      dialTimeoutMs: 1000,
+      openAckTimeoutMs: 1000,
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+
+    const session = client.subscribe("dual-major.subscribe", { id: "item-1" });
+    await flush();
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+    stub.fireText(
+      streamOpenAck(
+        { "dual-major.subscribe": { major: 1, minor: 0 } },
+        undefined,
+      ),
+    );
+
+    expect(parseText(stub.textSent[1])).toEqual({
+      kind: "subscribe",
+      method: "dual-major.subscribe",
+      schemaVersion: { major: 1, minor: 0 },
+      params: { id: "item-1" },
+    });
+
+    session.close();
+  });
+
   it("pushes a credentialUpdate frame on bearer rotation when the host advertises support", async () => {
     const { factory, sockets } = makeFactory();
     const { client, ctx } = makeRotatableClient(factory, "token-1");

--- a/clients/shared/host-transport/plain-terminal-list-stream-client.ts
+++ b/clients/shared/host-transport/plain-terminal-list-stream-client.ts
@@ -1,8 +1,14 @@
 import {
+  terminalPlainSubscribeListServerFrameSchemaV10,
   terminalPlainSubscribeListServerFrameSchema,
   type TerminalPlainSubscribeListServerFrame,
+  type TerminalPlainSubscribeListServerFrameV10,
 } from "@traycer/protocol/host/terminal/plain-subscribe-list";
-import type { PlainTerminalScope } from "@traycer/protocol/host/terminal/plain-schemas";
+import {
+  plainTerminalFleetIdentityKey,
+  type PlainTerminalProjection,
+  type PlainTerminalScope,
+} from "@traycer/protocol/host/terminal/plain-schemas";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type {
   IStreamSession,
@@ -27,6 +33,7 @@ export interface PlainTerminalListStreamCallbacks {
 
 export interface PlainTerminalListStreamClientOptions {
   readonly wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>;
+  readonly servingHostId: string;
   readonly scope: PlainTerminalScope;
   readonly callbacks: PlainTerminalListStreamCallbacks;
 }
@@ -35,10 +42,18 @@ export interface PlainTerminalListStreamClientOptions {
 export class PlainTerminalListStreamClient {
   private readonly session: IStreamSession;
   private readonly callbacks: PlainTerminalListStreamCallbacks;
+  private readonly servingHostId: string;
+  private readonly scope: PlainTerminalScope;
+  private readonly v1TerminalsByIdentity: Map<string, PlainTerminalProjection>;
+  private v1Initialized: boolean;
   private closed: boolean;
 
   constructor(options: PlainTerminalListStreamClientOptions) {
     this.callbacks = options.callbacks;
+    this.servingHostId = options.servingHostId;
+    this.scope = options.scope;
+    this.v1TerminalsByIdentity = new Map();
+    this.v1Initialized = false;
     this.closed = false;
     this.session = options.wsStreamClient.subscribe(
       "terminal.plain.subscribeList",
@@ -48,6 +63,14 @@ export class PlainTerminalListStreamClient {
       this.handleServerFrame(envelope, binaryPayload);
     });
     this.session.onStatusChange((status, reason) => {
+      if (
+        status === "connecting" ||
+        status === "reconnecting" ||
+        status === "closed"
+      ) {
+        this.v1TerminalsByIdentity.clear();
+        this.v1Initialized = false;
+      }
       this.callbacks.onConnectionStatus(status, reason);
     });
   }
@@ -62,17 +85,22 @@ export class PlainTerminalListStreamClient {
     envelope: StreamFrameEnvelope,
     _binaryPayload: Uint8Array | null,
   ): void {
+    const negotiatedVersion = this.session.getNegotiatedSchemaVersion();
+    if (negotiatedVersion?.major === 1) {
+      const parsedV1 =
+        terminalPlainSubscribeListServerFrameSchemaV10.safeParse(envelope);
+      if (parsedV1.success) {
+        this.handleV1ServerFrame(parsedV1.data);
+        return;
+      }
+      this.warnMalformedFrame(envelope, parsedV1.error.issues);
+      return;
+    }
+
     const parsed =
       terminalPlainSubscribeListServerFrameSchema.safeParse(envelope);
     if (!parsed.success) {
-      const issuePaths = parsed.error.issues
-        .map((issue) =>
-          issue.path.length > 0 ? issue.path.join(".") : "(root)",
-        )
-        .join(", ");
-      console.warn(
-        `[stream] terminal.plain.subscribeList frame failed schema validation (kind=${envelope.kind}, issues=[${issuePaths}]); dropping frame`,
-      );
+      this.warnMalformedFrame(envelope, parsed.error.issues);
       return;
     }
 
@@ -94,5 +122,95 @@ export class PlainTerminalListStreamClient {
         return;
       }
     }
+  }
+
+  private handleV1ServerFrame(
+    frame: TerminalPlainSubscribeListServerFrameV10,
+  ): void {
+    switch (frame.kind) {
+      case "snapshot": {
+        this.v1TerminalsByIdentity.clear();
+        for (const terminal of frame.terminals) {
+          this.v1TerminalsByIdentity.set(
+            plainTerminalFleetIdentityKey({
+              hostId: terminal.record.hostId,
+              terminalId: terminal.record.terminalId,
+            }),
+            terminal,
+          );
+        }
+        this.v1Initialized = false;
+        return;
+      }
+      case "initialized": {
+        this.v1Initialized = true;
+        this.emitV1ReplacementState();
+        return;
+      }
+      case "upsert": {
+        this.v1TerminalsByIdentity.set(
+          plainTerminalFleetIdentityKey({
+            hostId: frame.terminal.record.hostId,
+            terminalId: frame.terminal.record.terminalId,
+          }),
+          frame.terminal,
+        );
+        if (this.v1Initialized) this.emitV1ReplacementState();
+        return;
+      }
+      case "deleted": {
+        this.v1TerminalsByIdentity.delete(
+          plainTerminalFleetIdentityKey({
+            hostId: this.servingHostId,
+            terminalId: frame.terminalId,
+          }),
+        );
+        if (this.v1Initialized) this.emitV1ReplacementState();
+        return;
+      }
+      case "pong": {
+        return;
+      }
+      default: {
+        const unhandled: never = frame;
+        console.warn(
+          "[stream] terminal.plain.subscribeList unhandled v1 frame kind; dropping frame",
+          unhandled,
+        );
+      }
+    }
+  }
+
+  private emitV1ReplacementState(): void {
+    const terminals = [...this.v1TerminalsByIdentity.values()];
+    this.callbacks.onState({
+      kind: "state",
+      hasBinaryPayload: false,
+      state:
+        this.scope.kind === "independent"
+          ? {
+              coverage: "complete-local",
+              scope: this.scope,
+              terminals,
+            }
+          : {
+              coverage: "partial-serving-host",
+              scope: this.scope,
+              servingHostId: this.servingHostId,
+              terminals,
+            },
+    });
+  }
+
+  private warnMalformedFrame(
+    envelope: StreamFrameEnvelope,
+    issues: readonly { readonly path: PropertyKey[] }[],
+  ): void {
+    const issuePaths = issues
+      .map((issue) => (issue.path.length > 0 ? issue.path.join(".") : "(root)"))
+      .join(", ");
+    console.warn(
+      `[stream] terminal.plain.subscribeList frame failed schema validation (kind=${envelope.kind}, issues=[${issuePaths}]); dropping frame`,
+    );
   }
 }

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -137,6 +137,50 @@ const cursorStreamRegistry = defineVersionedStreamRpcRegistry({
     },
   },
 });
+const dualMajorCursorStreamRegistry = defineVersionedStreamRpcRegistry({
+  "cursor.subscribe": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: defineStreamRpcContract({
+            method: "cursor.subscribe",
+            schemaVersion: { major: 1, minor: 0 },
+            openRequestSchema: z.object({ cursor: z.number().nullable() }),
+            serverFrameSchema: z.object({
+              kind: z.literal("snapshot"),
+              hasBinaryPayload: z.literal(false),
+            }),
+            clientFrameSchema: z.object({
+              kind: z.literal("noop"),
+              hasBinaryPayload: z.literal(false),
+            }),
+          }),
+        },
+      },
+    },
+    2: {
+      latestMinor: 1,
+      versions: {
+        1: {
+          contract: defineStreamRpcContract({
+            method: "cursor.subscribe",
+            schemaVersion: { major: 2, minor: 1 },
+            openRequestSchema: z.object({ cursor: z.number().nullable() }),
+            serverFrameSchema: z.object({
+              kind: z.literal("state"),
+              hasBinaryPayload: z.literal(false),
+            }),
+            clientFrameSchema: z.object({
+              kind: z.literal("noop"),
+              hasBinaryPayload: z.literal(false),
+            }),
+          }),
+        },
+      },
+    },
+  },
+});
 
 type OpenDecision =
   | { readonly kind: "ack" }
@@ -211,6 +255,8 @@ class FakeRelayHost {
   readonly openBearers: string[] = [];
   /** Params carried by every logical subscribe, including reconnect replay. */
   readonly subscribeParams: unknown[] = [];
+  /** Schema version carried beside each logical subscribe. */
+  readonly subscribeSchemaVersions: unknown[] = [];
   /** streamId of every logical subscribe, index-aligned with `subscribeParams`. */
   readonly subscribeStreamIds: number[] = [];
   /** Every `credits` value from a CREDIT control frame the client sent. */
@@ -531,6 +577,7 @@ class FakeRelayHost {
   ): Promise<void> {
     if (message.type === MuxFrameType.SUBSCRIBE) {
       this.subscribeParams.push(message.json?.params);
+      this.subscribeSchemaVersions.push(message.json?.schemaVersion);
       this.subscribeStreamIds.push(message.streamId);
       return;
     }
@@ -1705,6 +1752,43 @@ describe("RemoteSession host_detached readiness evidence", () => {
 });
 
 describe("RemoteStreamClient dynamic subscribe params", () => {
+  it(
+    "selects an installed older stream major advertised by an RC host",
+    async () => {
+      const relay = new FakeRelayHost();
+      relay.streamManifest = {
+        "cursor.subscribe": { major: 1, minor: 0 },
+      };
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        streamRegistry: dualMajorCursorStreamRegistry,
+      });
+      const streamClient = new RemoteStreamClient<
+        VersionedRpcRegistry,
+        typeof dualMajorCursorStreamRegistry
+      >(session);
+      const stream = streamClient.subscribe("cursor.subscribe", {
+        cursor: null,
+      });
+      try {
+        await vi.waitFor(
+          () => expect(relay.subscribeParams).toHaveLength(1),
+          WAIT,
+        );
+        expect(relay.subscribeSchemaVersions[0]).toEqual({
+          major: 1,
+          minor: 0,
+        });
+        expect(relay.errors).toEqual([]);
+      } finally {
+        stream.close();
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+
   it(
     "re-reads the current params before a reconnect re-subscribes",
     async () => {

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -9,6 +9,7 @@ import {
 } from "@traycer/protocol/framework/index";
 import {
   mergeConnectionManifests,
+  selectConnectionManifestForPeer,
   splitConnectionManifest,
 } from "@traycer/protocol/framework/capability-manifest";
 import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
@@ -42,7 +43,7 @@ import {
 import {
   extractBearerForOpenFrame,
   prepareRequestPayload,
-  decodeResponsePayload,
+  decodeResponsePayloadWithContext,
 } from "../ws-rpc-client";
 import {
   prepareStreamSubscribeRequest,
@@ -406,6 +407,7 @@ interface PendingUnary {
   readonly clientCanonical: SchemaVersion;
   readonly hostCanonical: SchemaVersion;
   readonly methodRegistry: MethodVersionRegistry;
+  readonly onWireRequest: unknown;
   readonly resolve: (result: unknown) => void;
   readonly reject: (error: HostRpcError) => void;
   timer: TimerHandle | null;
@@ -1013,6 +1015,7 @@ export class RemoteSession<
           clientCanonical,
           hostCanonical,
           methodRegistry,
+          onWireRequest: prepared.onWirePayload,
           resolve,
           reject,
           timer,
@@ -1996,11 +1999,16 @@ export class RemoteSession<
     if (hostManifest === null) {
       return;
     }
-    const clientCanonical = this.clientManifests.stream[stream.method];
+    const selectedClientManifest = selectConnectionManifestForPeer(
+      this.options.streamRegistry,
+      this.clientManifests.stream,
+      hostManifest.stream,
+    );
+    const clientCanonical = selectedClientManifest[stream.method];
     const hostCanonical = hostManifest.stream[stream.method];
     const compat = checkStreamMethodCompatibility(
       this.options.streamRegistry,
-      this.clientManifests.stream,
+      selectedClientManifest,
       hostManifest.stream,
       "client",
       stream.method,
@@ -2072,13 +2080,15 @@ export class RemoteSession<
       return;
     }
     try {
-      const decoded = decodeResponsePayload(
+      const decoded = decodeResponsePayloadWithContext(
         entry.methodRegistry,
         entry.clientCanonical,
         entry.hostCanonical,
         parsed.data.result,
         entry.requestId,
         entry.method,
+        entry.onWireRequest,
+        this.options.hostId,
       );
       entry.resolve(decoded);
     } catch (cause) {

--- a/clients/shared/host-transport/ws-rpc-client.ts
+++ b/clients/shared/host-transport/ws-rpc-client.ts
@@ -10,6 +10,7 @@ import {
   mergeConnectionManifests,
   splitConnectionManifest,
   upgradeResponseToVersion,
+  upgradeResponseToVersionWithContext,
 } from "@traycer/protocol/framework/index";
 import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
 import { CredentialLeaseReleasedError } from "@traycer/protocol/auth/request-context";
@@ -416,6 +417,7 @@ export class WsRpcClient<
           params,
           requestId,
           responseTimeoutMs,
+          selected.hostId,
         );
       }
 
@@ -431,6 +433,7 @@ export class WsRpcClient<
         params,
         requestId,
         responseTimeoutMs,
+        selected.hostId,
       );
     } finally {
       authority.abortSignal.removeEventListener("abort", onAbort);
@@ -452,6 +455,7 @@ async function executeAvailableMethodRequest<Payload, Response>(
   params: Payload,
   requestId: string,
   responseTimeoutMs: number,
+  hostId: string,
 ): Promise<Response> {
   const preparedRequest = prepareRequestPayload<Payload>(
     methodRegistry,
@@ -487,13 +491,15 @@ async function executeAvailableMethodRequest<Payload, Response>(
 
   const decodedResult = decodeResponseFrame(responseFrame, requestId, method);
 
-  return decodeResponsePayload<Response>(
+  return decodeResponsePayloadWithContext<Response>(
     methodRegistry,
     clientCanonical,
     hostCanonical,
     decodedResult,
     requestId,
     method,
+    preparedRequest.onWirePayload,
+    hostId,
   );
 }
 
@@ -511,6 +517,7 @@ async function executeUnavailableMethodDegrade<
   params: RequestOfMethod<Registry, Method>,
   requestId: string,
   responseTimeoutMs: number,
+  hostId: string,
 ): Promise<ResponseOfMethod<Registry, Method>> {
   // Degrade POLICY is shared with the remote mux transport (see
   // `unavailable-method-degrade.ts`); only the dispatch below is ws-specific.
@@ -533,6 +540,7 @@ async function executeUnavailableMethodDegrade<
         input.params,
         requestId,
         responseTimeoutMs,
+        hostId,
       ),
   })) as ResponseOfMethod<Registry, Method>;
 }
@@ -638,6 +646,47 @@ export function decodeResponsePayload<Payload>(
   requestId: string,
   method: string,
 ): Payload {
+  return decodeResponsePayloadInternal(
+    methodRegistry,
+    clientCanonical,
+    hostCanonical,
+    result,
+    requestId,
+    method,
+    null,
+  );
+}
+
+export function decodeResponsePayloadWithContext<Payload>(
+  methodRegistry: MethodVersionRegistry,
+  clientCanonical: SchemaVersion,
+  hostCanonical: SchemaVersion,
+  result: unknown,
+  requestId: string,
+  method: string,
+  onWireRequest: unknown,
+  hostId: string,
+): Payload {
+  return decodeResponsePayloadInternal(
+    methodRegistry,
+    clientCanonical,
+    hostCanonical,
+    result,
+    requestId,
+    method,
+    { request: onWireRequest, hostId },
+  );
+}
+
+function decodeResponsePayloadInternal<Payload>(
+  methodRegistry: MethodVersionRegistry,
+  clientCanonical: SchemaVersion,
+  hostCanonical: SchemaVersion,
+  result: unknown,
+  requestId: string,
+  method: string,
+  context: { readonly request: unknown; readonly hostId: string } | null,
+): Payload {
   if (clientCanonical.major === hostCanonical.major) {
     if (clientCanonical.minor <= hostCanonical.minor) {
       return result as Payload;
@@ -649,6 +698,7 @@ export function decodeResponsePayload<Payload>(
       result,
       requestId,
       method,
+      context,
     );
   }
   if (clientCanonical.major < hostCanonical.major) {
@@ -661,6 +711,7 @@ export function decodeResponsePayload<Payload>(
     result,
     requestId,
     method,
+    context,
   );
 }
 
@@ -671,6 +722,7 @@ function upgradeResponseAlongChain<Payload>(
   result: unknown,
   requestId: string,
   method: string,
+  context: { readonly request: unknown; readonly hostId: string } | null,
 ): Payload {
   try {
     // The host is the older side here, so `result` is raw wire data framed at
@@ -694,12 +746,21 @@ function upgradeResponseAlongChain<Payload>(
       }
       chainInput = parsed.data;
     }
-    const upgraded = upgradeResponseToVersion(
-      methodRegistry,
-      fromVersion,
-      toVersion,
-      chainInput as never,
-    );
+    const upgraded =
+      context === null
+        ? upgradeResponseToVersion(
+            methodRegistry,
+            fromVersion,
+            toVersion,
+            chainInput as never,
+          )
+        : upgradeResponseToVersionWithContext(
+            methodRegistry,
+            fromVersion,
+            toVersion,
+            chainInput as never,
+            { request: context.request as never, hostId: context.hostId },
+          );
     return upgraded as Payload;
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -7,6 +7,7 @@ import {
   buildStreamManifest,
   checkStreamMethodCompatibility,
 } from "@traycer/protocol/framework/stream-compat";
+import { selectConnectionManifestForPeer } from "@traycer/protocol/framework/capability-manifest";
 import {
   extractBearerForOpenFrame,
   MissingBearerTokenForOpenFrameError,
@@ -686,7 +687,11 @@ export class WsStreamClient<
     subscribedMethod: string,
     subscribedMethodSupport: "supported" | "unsupported",
   ): void {
-    const myManifest = buildStreamManifest(this.options.registry);
+    const myManifest = selectConnectionManifestForPeer(
+      this.options.registry,
+      buildStreamManifest(this.options.registry),
+      theirManifest,
+    );
     let changed = false;
     for (const method of Object.keys(myManifest)) {
       if (method === subscribedMethod) {
@@ -1589,8 +1594,12 @@ class StreamSession<
     );
     const hostCredentialState = ackParse.data.hostCredentialState;
 
-    const myManifest = buildStreamManifest(this.config.registry);
     const theirManifest = ackParse.data.manifest;
+    const myManifest = selectConnectionManifestForPeer(
+      this.config.registry,
+      buildStreamManifest(this.config.registry),
+      theirManifest,
+    );
     const compat = checkStreamMethodCompatibility(
       this.config.registry,
       myManifest,

--- a/protocol/src/framework/__tests__/capability-manifest.test.ts
+++ b/protocol/src/framework/__tests__/capability-manifest.test.ts
@@ -8,6 +8,7 @@ import {
   defineRpcContract,
   defineVersionedRpcRegistry,
   mergeConnectionManifests,
+  selectConnectionManifestForPeer,
   splitConnectionManifest,
   validateVersionedRpcRegistryDegrades,
 } from "@traycer/protocol/framework/index";
@@ -58,6 +59,13 @@ const REGISTRY_WITH_UNSUPPORTED_OPTIONAL = defineFloorAwareVersionedRpcRegistry(
     },
   },
 );
+
+const MULTI_MAJOR_MANIFEST_REGISTRY = {
+  echo: {
+    1: { latestMinor: 1 },
+    2: { latestMinor: 0 },
+  },
+} as const;
 
 describe("capability manifest helpers", () => {
   it("keeps the host legacy manifest exactly the released floor set", () => {
@@ -130,6 +138,35 @@ describe("capability manifest helpers", () => {
       "floor.method": { major: 1, minor: 0 },
       "optional.method": { major: 1, minor: 0 },
     });
+  });
+
+  it("selects the latest installed minor on the peer's offered major", () => {
+    const hostManifest = buildConnectionManifest(MULTI_MAJOR_MANIFEST_REGISTRY);
+
+    expect(
+      selectConnectionManifestForPeer(
+        MULTI_MAJOR_MANIFEST_REGISTRY,
+        hostManifest,
+        {
+        echo: { major: 1, minor: 0 },
+        },
+      ),
+    ).toEqual({ echo: { major: 1, minor: 1 } });
+  });
+
+  it("retains the host canonical when the peer's major is not installed", () => {
+    const hostManifest = buildConnectionManifest(MULTI_MAJOR_MANIFEST_REGISTRY);
+
+    expect(
+      selectConnectionManifestForPeer(
+        MULTI_MAJOR_MANIFEST_REGISTRY,
+        hostManifest,
+        {
+          echo: { major: 3, minor: 0 },
+          "peer.only": { major: 1, minor: 0 },
+        },
+      ),
+    ).toEqual({ echo: { major: 2, minor: 0 } });
   });
 });
 

--- a/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
@@ -583,6 +583,85 @@ describe("validateVersionedRpcRegistry (Zod-level compatibility)", () => {
     expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
   });
 
+  it("rejects a semantic-major annotation on the first installed major", () => {
+    const registry = {
+      semanticAuthority: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: {
+              contract: defineRpcContract({
+                method: "semanticAuthority",
+                schemaVersion: { major: 1, minor: 0 } as const,
+                requestSchema: z.object({ terminalId: z.string() }),
+                responseSchema: z.object({ ok: z.boolean() }),
+              }),
+              upgradeFromPreviousVersion: null,
+              semanticMajorBreakFromPreviousMajor: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "there is no previous installed major",
+    );
+  });
+
+  it("rejects a semantic-major annotation when the schemas already break structurally", () => {
+    const localV10 = defineRpcContract({
+      method: "structuralAuthority",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const fleetV20 = defineRpcContract({
+      method: "structuralAuthority",
+      schemaVersion: { major: 2, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string(), hostId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean(), revision: z.number() }),
+    });
+    const registry = {
+      structuralAuthority: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: localV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+        2: {
+          latestMinor: 0,
+          versions: {
+            0: {
+              contract: fleetV20,
+              upgradeFromPreviousVersion: defineUpgradePath<
+                typeof localV10,
+                typeof fleetV20
+              >({
+                from: localV10.schemaVersion,
+                to: fleetV20.schemaVersion,
+                upgradeRequest: (request) => ({
+                  ...request,
+                  hostId: "host-1",
+                }),
+                upgradeResponse: (response) => ({ ...response, revision: 0 }),
+              }),
+              semanticMajorBreakFromPreviousMajor: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "already has a structural breaking change",
+    );
+  });
+
   it("does not let the discriminator STAMP alone justify a major bump", () => {
     // `x-traycer-discriminator` is metadata this framework writes onto the
     // emitted schema so arm identity can be resolved; it constrains no value.

--- a/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
@@ -583,6 +583,154 @@ describe("validateVersionedRpcRegistry (Zod-level compatibility)", () => {
     expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
   });
 
+  it("reads a semantic-major annotation from the first installed minor", () => {
+    const localV10 = defineRpcContract({
+      method: "evolvingSemanticAuthority",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const fleetV20 = defineRpcContract({
+      method: "evolvingSemanticAuthority",
+      schemaVersion: { major: 2, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const fleetV21 = defineRpcContract({
+      method: "evolvingSemanticAuthority",
+      schemaVersion: { major: 2, minor: 1 } as const,
+      requestSchema: z.object({
+        terminalId: z.string(),
+        includeRuntime: z.boolean().optional(),
+      }),
+      responseSchema: z.object({
+        ok: z.boolean(),
+        runtimeKnown: z.boolean().optional(),
+      }),
+    });
+    const upgradeToV20 = defineUpgradePath<
+      typeof localV10,
+      typeof fleetV20
+    >({
+      from: localV10.schemaVersion,
+      to: fleetV20.schemaVersion,
+      upgradeRequest: (request) => request,
+      upgradeResponse: (response) => response,
+    });
+    const upgradeToV21 = defineUpgradePath<
+      typeof fleetV20,
+      typeof fleetV21
+    >({
+      from: fleetV20.schemaVersion,
+      to: fleetV21.schemaVersion,
+      upgradeRequest: (request) => request,
+      upgradeResponse: (response) => response,
+    });
+
+    const registry = {
+      evolvingSemanticAuthority: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: localV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+        2: {
+          latestMinor: 1,
+          versions: {
+            0: {
+              contract: fleetV20,
+              upgradeFromPreviousVersion: upgradeToV20,
+              semanticMajorBreakFromPreviousMajor: true,
+            },
+            1: {
+              contract: fleetV21,
+              upgradeFromPreviousVersion: upgradeToV21,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
+  });
+
+  it("rejects a semantic-major annotation on a later minor", () => {
+    const localV10 = defineRpcContract({
+      method: "misplacedSemanticAuthority",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const fleetV20 = defineRpcContract({
+      method: "misplacedSemanticAuthority",
+      schemaVersion: { major: 2, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const fleetV21 = defineRpcContract({
+      method: "misplacedSemanticAuthority",
+      schemaVersion: { major: 2, minor: 1 } as const,
+      requestSchema: z.object({
+        terminalId: z.string(),
+        includeRuntime: z.boolean().optional(),
+      }),
+      responseSchema: z.object({
+        ok: z.boolean(),
+        runtimeKnown: z.boolean().optional(),
+      }),
+    });
+
+    const registry = {
+      misplacedSemanticAuthority: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: localV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+        2: {
+          latestMinor: 1,
+          versions: {
+            0: {
+              contract: fleetV20,
+              upgradeFromPreviousVersion: defineUpgradePath<
+                typeof localV10,
+                typeof fleetV20
+              >({
+                from: localV10.schemaVersion,
+                to: fleetV20.schemaVersion,
+                upgradeRequest: (request) => request,
+                upgradeResponse: (response) => response,
+              }),
+            },
+            1: {
+              contract: fleetV21,
+              upgradeFromPreviousVersion: defineUpgradePath<
+                typeof fleetV20,
+                typeof fleetV21
+              >({
+                from: fleetV20.schemaVersion,
+                to: fleetV21.schemaVersion,
+                upgradeRequest: (request) => request,
+                upgradeResponse: (response) => response,
+              }),
+              semanticMajorBreakFromPreviousMajor: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).toThrow(
+      "the annotation must be on the first installed minor 2.0",
+    );
+  });
+
   it("rejects a semantic-major annotation on the first installed major", () => {
     const registry = {
       semanticAuthority: {

--- a/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-json-schema.test.ts
@@ -537,6 +537,52 @@ describe("validateVersionedRpcRegistry (Zod-level compatibility)", () => {
     );
   });
 
+  it("allows a schema-compatible major when the registry declares a semantic break", () => {
+    const localV10 = defineRpcContract({
+      method: "semanticAuthority",
+      schemaVersion: { major: 1, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const fleetV20 = defineRpcContract({
+      method: "semanticAuthority",
+      schemaVersion: { major: 2, minor: 0 } as const,
+      requestSchema: z.object({ terminalId: z.string() }),
+      responseSchema: z.object({ ok: z.boolean() }),
+    });
+    const upgrade = defineUpgradePath<typeof localV10, typeof fleetV20>({
+      from: localV10.schemaVersion,
+      to: fleetV20.schemaVersion,
+      upgradeRequest: (request) => request,
+      upgradeResponse: (response) => response,
+    });
+
+    const registry = {
+      semanticAuthority: {
+        1: {
+          latestMinor: 0,
+          versions: {
+            0: { contract: localV10, upgradeFromPreviousVersion: null },
+          },
+          downgradePathsFromLatest: {},
+        },
+        2: {
+          latestMinor: 0,
+          versions: {
+            0: {
+              contract: fleetV20,
+              upgradeFromPreviousVersion: upgrade,
+              semanticMajorBreakFromPreviousMajor: true,
+            },
+          },
+          downgradePathsFromLatest: {},
+        },
+      },
+    } as const;
+
+    expect(() => validateVersionedRpcRegistry(registry)).not.toThrow();
+  });
+
   it("does not let the discriminator STAMP alone justify a major bump", () => {
     // `x-traycer-discriminator` is metadata this framework writes onto the
     // emitted schema so arm identity can be resolved; it constrains no value.

--- a/protocol/src/framework/__tests__/versioned-rpc-types.test.ts
+++ b/protocol/src/framework/__tests__/versioned-rpc-types.test.ts
@@ -16,6 +16,7 @@ import {
   type RequestOf,
   type ResponseOf,
   type RpcErrorFor,
+  type RpcResponseUpgradeContext,
   type RpcRequestFor,
   type RpcSuccessFor,
   type UncheckedVersionedRpcRegistry,

--- a/protocol/src/framework/capability-manifest.ts
+++ b/protocol/src/framework/capability-manifest.ts
@@ -47,3 +47,34 @@ export function mergeConnectionManifests(
   }
   return { ...manifest, ...optionalManifest };
 }
+
+/**
+ * Selects the newest installed minor on the major offered by this peer.
+ *
+ * Connection manifests expose one canonical version per method, so a host
+ * that installs multiple majors must tailor its open acknowledgement to the
+ * connecting peer. When the offered major is not installed we retain the
+ * host's canonical version and let the ordinary compatibility checker report
+ * the missing bridge. Methods outside `hostManifest` are never added.
+ */
+export function selectConnectionManifestForPeer(
+  registry: ManifestRegistry,
+  hostManifest: ConnectionManifest,
+  peerManifest: ConnectionManifest,
+): ConnectionManifest {
+  const selected: Record<string, SchemaVersion> = {};
+
+  for (const [method, hostCanonical] of Object.entries(hostManifest)) {
+    const peerCanonical = peerManifest[method];
+    const line =
+      peerCanonical === undefined
+        ? undefined
+        : registry[method]?.[peerCanonical.major];
+    selected[method] =
+      line === undefined
+        ? hostCanonical
+        : { major: peerCanonical.major, minor: line.latestMinor };
+  }
+
+  return selected;
+}

--- a/protocol/src/framework/index.ts
+++ b/protocol/src/framework/index.ts
@@ -21,6 +21,8 @@ export type {
   AnyRpcContract,
   AnyUpgradePath,
   AnyVersionEntry,
+  ContextlessUpgradePath,
+  ContextualUpgradePath,
   ContractForInstalledVersion,
   DowngradePath,
   DowngradeResult,
@@ -38,6 +40,7 @@ export type {
   RpcErrorFor,
   RpcRequestFor,
   RpcResultFor,
+  RpcResponseUpgradeContext,
   RpcSuccessFor,
   SchemaVersion,
   UncheckedMethodVersionRegistry,
@@ -61,6 +64,7 @@ export type {
 } from "./versioned-rpc";
 
 export {
+  defineContextualUpgradePath,
   defineDowngradePath,
   defineFallbackMethodDegrade,
   defineFloorAwareVersionedRpcRegistry,
@@ -73,6 +77,7 @@ export {
   toJsonSchemas,
   upgradeRequestToVersion,
   upgradeResponseToVersion,
+  upgradeResponseToVersionWithContext,
   validateVersionedRpcRegistryDegrades,
   validateVersionedRpcRegistry,
 } from "./versioned-rpc";

--- a/protocol/src/framework/index.ts
+++ b/protocol/src/framework/index.ts
@@ -176,6 +176,7 @@ export type {
 export {
   buildConnectionManifest,
   mergeConnectionManifests,
+  selectConnectionManifestForPeer,
   splitConnectionManifest,
 } from "./capability-manifest";
 

--- a/protocol/src/framework/versioned-rpc-types.ts
+++ b/protocol/src/framework/versioned-rpc-types.ts
@@ -136,6 +136,11 @@ export type RpcErrorFor<Contract> = Contract extends AnyRpcContract
 export type RpcResultFor<Contract> =
   RpcSuccessFor<Contract> | RpcErrorFor<Contract>;
 
+export type RpcResponseUpgradeContext<Request> = {
+  readonly request: Request;
+  readonly hostId: string;
+};
+
 type SameMethodPair<
   From extends AnyRpcContract,
   To extends AnyRpcContract,
@@ -145,18 +150,42 @@ type SameMethodPair<
     : false
   : false;
 
+type UpgradePathBase<
+  From extends AnyRpcContract,
+  To extends AnyRpcContract,
+> = {
+  from: From["schemaVersion"];
+  to: To["schemaVersion"];
+  upgradeRequest: (request: RequestOf<From>) => RequestOf<To>;
+};
+
+export type ContextlessUpgradePath<
+  From extends AnyRpcContract,
+  To extends AnyRpcContract,
+> = SameMethodPair<From, To> extends true
+  ? UpgradePathBase<From, To> & {
+      upgradeResponse: (response: ResponseOf<From>) => ResponseOf<To>;
+    }
+  : never;
+
+export type ContextualUpgradePath<
+  From extends AnyRpcContract,
+  To extends AnyRpcContract,
+> = SameMethodPair<From, To> extends true
+  ? UpgradePathBase<From, To> & {
+      upgradeResponse: (
+        response: ResponseOf<From>,
+        context: RpcResponseUpgradeContext<RequestOf<From>> | undefined,
+      ) => ResponseOf<To>;
+    }
+  : never;
+
 export type UpgradePath<
   From extends AnyRpcContract,
   To extends AnyRpcContract,
 > =
-  SameMethodPair<From, To> extends true
-    ? {
-        from: From["schemaVersion"];
-        to: To["schemaVersion"];
-        upgradeRequest: (request: RequestOf<From>) => RequestOf<To>;
-        upgradeResponse: (response: ResponseOf<From>) => ResponseOf<To>;
-      }
-    : never;
+  | ContextlessUpgradePath<From, To>
+  | ContextualUpgradePath<From, To>;
 
 export type DowngradeResult<Value> =
   { ok: true; value: Value } | { ok: false; error: RpcErrorDetails };
@@ -239,7 +268,10 @@ export type AnyUpgradePath = {
   from: SchemaVersion;
   to: SchemaVersion;
   upgradeRequest: (request: never) => object;
-  upgradeResponse: (response: never) => object;
+  upgradeResponse: (
+    response: never,
+    context: RpcResponseUpgradeContext<never> | undefined,
+  ) => object;
 };
 
 /**
@@ -714,6 +746,9 @@ export type RuntimeUpgradePath<Registry extends MethodVersionRegistry> = {
   ) => RegistryRequestValue<Registry>;
   upgradeResponse: (
     response: RegistryResponseValue<Registry>,
+    context:
+      | RpcResponseUpgradeContext<RegistryRequestValue<Registry>>
+      | undefined,
   ) => RegistryResponseValue<Registry>;
 };
 

--- a/protocol/src/framework/versioned-rpc-types.ts
+++ b/protocol/src/framework/versioned-rpc-types.ts
@@ -276,6 +276,13 @@ export type VersionEntry<
    * cannot check; other structural reductions remain forbidden.
    */
   readonly responseGrowthProjectionGated?: true;
+  /**
+   * Declares that the first contract in a new major changes semantics even
+   * when its isolated request/response schemas remain structurally
+   * compatible. Use only when the method belongs to a coherently negotiated
+   * family whose authority or topology changed across the major boundary.
+   */
+  readonly semanticMajorBreakFromPreviousMajor?: true;
 };
 
 export type AnyVersionEntry = VersionEntry<

--- a/protocol/src/framework/versioned-rpc.ts
+++ b/protocol/src/framework/versioned-rpc.ts
@@ -450,6 +450,19 @@ function assertSchemaCompatibility(
             );
           }
         }
+      } else {
+        const firstMinor = getLowestInstalledNumber(line.versions);
+
+        for (const minor of minors) {
+          if (
+            minor !== firstMinor &&
+            line.versions[minor].semanticMajorBreakFromPreviousMajor === true
+          ) {
+            throw new Error(
+              `Version ${major}.${minor} for method '${method}' declares \`semanticMajorBreakFromPreviousMajor\` but the annotation must be on the first installed minor ${major}.${firstMinor}`,
+            );
+          }
+        }
       }
 
       for (let index = 1; index < minors.length; index += 1) {
@@ -564,11 +577,11 @@ function assertSchemaCompatibility(
         toUnknownKeyTree(currentLatestContract.responseSchema),
       );
 
-      const currentLatestEntry =
-        currentLine.versions[currentLine.latestMinor];
+      const currentFirstMinor = getLowestInstalledNumber(currentLine.versions);
+      const currentFirstEntry = currentLine.versions[currentFirstMinor];
       if (
         (requestBreak !== null || responseBreak !== null) &&
-        currentLatestEntry.semanticMajorBreakFromPreviousMajor === true
+        currentFirstEntry.semanticMajorBreakFromPreviousMajor === true
       ) {
         throw new Error(
           `Major bump ${previousMajor} -> ${currentMajor} for method '${method}' declares \`semanticMajorBreakFromPreviousMajor\` but already has a structural breaking change; remove the annotation`,
@@ -577,7 +590,7 @@ function assertSchemaCompatibility(
       if (
         requestBreak === null &&
         responseBreak === null &&
-        currentLatestEntry.semanticMajorBreakFromPreviousMajor !== true
+        currentFirstEntry.semanticMajorBreakFromPreviousMajor !== true
       ) {
         throw new Error(
           `Major bump ${previousMajor} -> ${currentMajor} for method '${method}' is not a breaking change (could have shipped as a minor)`,
@@ -995,6 +1008,19 @@ function getHighestInstalledNumber<Value>(
   }
 
   return latest;
+}
+
+function getLowestInstalledNumber<Value>(
+  values: Readonly<Record<number, Value>>,
+): number {
+  const keys = getSortedNumberKeys(values);
+  const earliest = keys[0];
+
+  if (earliest === undefined) {
+    throw new Error("Registry line must define at least one installed version");
+  }
+
+  return earliest;
 }
 
 function getMajorLine<

--- a/protocol/src/framework/versioned-rpc.ts
+++ b/protocol/src/framework/versioned-rpc.ts
@@ -16,6 +16,8 @@ import {
 } from "./json-schema-fingerprint";
 import type {
   AnyRpcContract,
+  ContextlessUpgradePath,
+  ContextualUpgradePath,
   ContractForInstalledVersion,
   DowngradePath,
   DowngradeResult,
@@ -26,11 +28,11 @@ import type {
   MethodDegradeDeclaration,
   RequestOf,
   ResponseOf,
+  RpcResponseUpgradeContext,
   RuntimeDowngradePath,
   RuntimeUpgradePath,
   SchemaVersion,
   UncheckedVersionedRpcRegistry,
-  UpgradePath,
   ValidateVersionedRpcRegistryDegrades,
   ValidateVersionedRpcRegistry,
   VersionedRpcRegistry,
@@ -41,6 +43,8 @@ export type {
   AnyRpcContract,
   AnyUpgradePath,
   AnyVersionEntry,
+  ContextlessUpgradePath,
+  ContextualUpgradePath,
   ContractForInstalledVersion,
   DowngradePath,
   DowngradeResult,
@@ -104,7 +108,14 @@ export function defineRpcContract<
 export function defineUpgradePath<
   From extends AnyRpcContract,
   To extends AnyRpcContract,
->(path: UpgradePath<From, To>): UpgradePath<From, To> {
+>(path: ContextlessUpgradePath<From, To>): ContextlessUpgradePath<From, To> {
+  return path;
+}
+
+export function defineContextualUpgradePath<
+  From extends AnyRpcContract,
+  To extends AnyRpcContract,
+>(path: ContextualUpgradePath<From, To>): ContextualUpgradePath<From, To> {
   return path;
 }
 
@@ -429,6 +440,18 @@ function assertSchemaCompatibility(
       const line = methodRegistry[major];
       const minors = getSortedNumberKeys(line.versions);
 
+      if (major === majors[0]) {
+        for (const minor of minors) {
+          if (
+            line.versions[minor].semanticMajorBreakFromPreviousMajor === true
+          ) {
+            throw new Error(
+              `Version ${major}.${minor} for method '${method}' declares \`semanticMajorBreakFromPreviousMajor\` but there is no previous installed major`,
+            );
+          }
+        }
+      }
+
       for (let index = 1; index < minors.length; index += 1) {
         const previousMinor = minors[index - 1];
         const currentMinor = minors[index];
@@ -543,6 +566,14 @@ function assertSchemaCompatibility(
 
       const currentLatestEntry =
         currentLine.versions[currentLine.latestMinor];
+      if (
+        (requestBreak !== null || responseBreak !== null) &&
+        currentLatestEntry.semanticMajorBreakFromPreviousMajor === true
+      ) {
+        throw new Error(
+          `Major bump ${previousMajor} -> ${currentMajor} for method '${method}' declares \`semanticMajorBreakFromPreviousMajor\` but already has a structural breaking change; remove the annotation`,
+        );
+      }
       if (
         requestBreak === null &&
         responseBreak === null &&
@@ -736,6 +767,52 @@ export function upgradeResponseToVersion<
   toVersion: ToVersion,
   response: ResponseOf<ContractForInstalledVersion<Registry, FromVersion>>,
 ): ResponseOf<ContractForInstalledVersion<Registry, ToVersion>> {
+  return upgradeResponseToVersionInternal(
+    registry,
+    fromVersion,
+    toVersion,
+    response,
+    undefined,
+  );
+}
+
+export function upgradeResponseToVersionWithContext<
+  Registry extends MethodVersionRegistry,
+  const FromVersion extends InstalledSchemaVersion<Registry>,
+  const ToVersion extends InstalledSchemaVersion<Registry>,
+>(
+  registry: Registry,
+  fromVersion: FromVersion,
+  toVersion: ToVersion,
+  response: ResponseOf<ContractForInstalledVersion<Registry, FromVersion>>,
+  context: RpcResponseUpgradeContext<
+    RequestOf<ContractForInstalledVersion<Registry, FromVersion>>
+  >,
+): ResponseOf<ContractForInstalledVersion<Registry, ToVersion>> {
+  return upgradeResponseToVersionInternal(
+    registry,
+    fromVersion,
+    toVersion,
+    response,
+    context,
+  );
+}
+
+function upgradeResponseToVersionInternal<
+  Registry extends MethodVersionRegistry,
+  const FromVersion extends InstalledSchemaVersion<Registry>,
+  const ToVersion extends InstalledSchemaVersion<Registry>,
+>(
+  registry: Registry,
+  fromVersion: FromVersion,
+  toVersion: ToVersion,
+  response: ResponseOf<ContractForInstalledVersion<Registry, FromVersion>>,
+  context:
+    | RpcResponseUpgradeContext<
+        RequestOf<ContractForInstalledVersion<Registry, FromVersion>>
+      >
+    | undefined,
+): ResponseOf<ContractForInstalledVersion<Registry, ToVersion>> {
   assertUpgradeOrder(fromVersion, toVersion);
 
   if (isSameSchemaVersion(fromVersion, toVersion)) {
@@ -750,6 +827,9 @@ export function upgradeResponseToVersion<
   let currentResponse: Parameters<
     RuntimeUpgradePath<Registry>["upgradeResponse"]
   >[0] = response;
+  let currentRequest: Parameters<
+    RuntimeUpgradePath<Registry>["upgradeRequest"]
+  >[0] | null = context?.request ?? null;
 
   for (let index = fromIndex + 1; index <= toIndex; index += 1) {
     const nextVersion = installedVersions[index];
@@ -767,7 +847,15 @@ export function upgradeResponseToVersion<
 
     const runtimeUpgradePath =
       versionEntry.upgradeFromPreviousVersion as RuntimeUpgradePath<Registry>;
-    currentResponse = runtimeUpgradePath.upgradeResponse(currentResponse);
+    currentResponse = runtimeUpgradePath.upgradeResponse(
+      currentResponse,
+      currentRequest === null || context === undefined
+        ? undefined
+        : { request: currentRequest, hostId: context.hostId },
+    );
+    if (currentRequest !== null) {
+      currentRequest = runtimeUpgradePath.upgradeRequest(currentRequest);
+    }
   }
 
   return currentResponse as ResponseOf<

--- a/protocol/src/framework/versioned-rpc.ts
+++ b/protocol/src/framework/versioned-rpc.ts
@@ -541,7 +541,13 @@ function assertSchemaCompatibility(
         toUnknownKeyTree(currentLatestContract.responseSchema),
       );
 
-      if (requestBreak === null && responseBreak === null) {
+      const currentLatestEntry =
+        currentLine.versions[currentLine.latestMinor];
+      if (
+        requestBreak === null &&
+        responseBreak === null &&
+        currentLatestEntry.semanticMajorBreakFromPreviousMajor !== true
+      ) {
         throw new Error(
           `Major bump ${previousMajor} -> ${currentMajor} for method '${method}' is not a breaking change (could have shipped as a minor)`,
         );

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -401,14 +401,35 @@ import {
   terminalSubscribeV15,
 } from "@traycer/protocol/host/terminal/contracts";
 import {
+  terminalPlainCloseDowngradeV21ToV10,
+  terminalPlainCloseUpgradeV10ToV21,
+  terminalPlainCloseV10,
   terminalPlainCloseV21,
+  terminalPlainCreateDowngradeV21ToV10,
+  terminalPlainCreateUpgradeV10ToV21,
+  terminalPlainCreateV10,
   terminalPlainCreateV21,
+  terminalPlainEnsureRunningDowngradeV21ToV10,
+  terminalPlainEnsureRunningUpgradeV10ToV21,
+  terminalPlainEnsureRunningV10,
   terminalPlainEnsureRunningV21,
+  terminalPlainImportLegacyDowngradeV21ToV10,
+  terminalPlainImportLegacyUpgradeV10ToV21,
+  terminalPlainImportLegacyV10,
   terminalPlainImportLegacyV21,
+  terminalPlainListDowngradeV21ToV10,
+  terminalPlainListUpgradeV10ToV21,
+  terminalPlainListV10,
   terminalPlainListV21,
+  terminalPlainRenameDowngradeV21ToV10,
+  terminalPlainRenameUpgradeV10ToV21,
+  terminalPlainRenameV10,
   terminalPlainRenameV21,
 } from "@traycer/protocol/host/terminal/plain-contracts";
-import { terminalPlainSubscribeListV21 } from "@traycer/protocol/host/terminal/plain-subscribe-list";
+import {
+  terminalPlainSubscribeListV10,
+  terminalPlainSubscribeListV21,
+} from "@traycer/protocol/host/terminal/plain-subscribe-list";
 import {
   hostNotificationHooksSave,
   hostNotificationHooksStatus,
@@ -6229,86 +6250,156 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
-  // Durable plain terminals use their own optional v2.1 family. The released
-  // generic terminal methods also carry terminal-agent sessions and remain
-  // frozen; a peer without this family continues on the legacy client-owned
-  // lifecycle. Mixed v1/v2 is unsupported; the family moves together.
+  // v1.0 is the frozen local-only RC family; v2.1 is the fleet family. They
+  // negotiate as a whole so callers never compose incompatible topologies.
   "terminal.plain.create": {
     degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainCreateV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
     2: {
       latestMinor: 1,
       versions: {
         1: {
           contract: terminalPlainCreateV21,
+          upgradeFromPreviousVersion: terminalPlainCreateUpgradeV10ToV21,
+          semanticMajorBreakFromPreviousMajor: true,
+        },
+      },
+      downgradePathsFromLatest: { 1: terminalPlainCreateDowngradeV21ToV10 },
+    },
+  },
+  "terminal.plain.list": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainListV10,
           upgradeFromPreviousVersion: null,
         },
       },
       downgradePathsFromLatest: {},
     },
-  },
-  "terminal.plain.list": {
-    degrade: { kind: "unsupported" },
     2: {
       latestMinor: 1,
       versions: {
         1: {
           contract: terminalPlainListV21,
+          upgradeFromPreviousVersion: terminalPlainListUpgradeV10ToV21,
+          semanticMajorBreakFromPreviousMajor: true,
+        },
+      },
+      downgradePathsFromLatest: { 1: terminalPlainListDowngradeV21ToV10 },
+    },
+  },
+  "terminal.plain.rename": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainRenameV10,
           upgradeFromPreviousVersion: null,
         },
       },
       downgradePathsFromLatest: {},
     },
-  },
-  "terminal.plain.rename": {
-    degrade: { kind: "unsupported" },
     2: {
       latestMinor: 1,
       versions: {
         1: {
           contract: terminalPlainRenameV21,
+          upgradeFromPreviousVersion: terminalPlainRenameUpgradeV10ToV21,
+          semanticMajorBreakFromPreviousMajor: true,
+        },
+      },
+      downgradePathsFromLatest: { 1: terminalPlainRenameDowngradeV21ToV10 },
+    },
+  },
+  "terminal.plain.ensureRunning": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainEnsureRunningV10,
           upgradeFromPreviousVersion: null,
         },
       },
       downgradePathsFromLatest: {},
     },
-  },
-  "terminal.plain.ensureRunning": {
-    degrade: { kind: "unsupported" },
     2: {
       latestMinor: 1,
       versions: {
         1: {
           contract: terminalPlainEnsureRunningV21,
+          upgradeFromPreviousVersion:
+            terminalPlainEnsureRunningUpgradeV10ToV21,
+          semanticMajorBreakFromPreviousMajor: true,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: terminalPlainEnsureRunningDowngradeV21ToV10,
+      },
+    },
+  },
+  "terminal.plain.close": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainCloseV10,
           upgradeFromPreviousVersion: null,
         },
       },
       downgradePathsFromLatest: {},
     },
-  },
-  "terminal.plain.close": {
-    degrade: { kind: "unsupported" },
     2: {
       latestMinor: 1,
       versions: {
         1: {
           contract: terminalPlainCloseV21,
+          upgradeFromPreviousVersion: terminalPlainCloseUpgradeV10ToV21,
+          semanticMajorBreakFromPreviousMajor: true,
+        },
+      },
+      downgradePathsFromLatest: { 1: terminalPlainCloseDowngradeV21ToV10 },
+    },
+  },
+  "terminal.plain.importLegacy": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainImportLegacyV10,
           upgradeFromPreviousVersion: null,
         },
       },
       downgradePathsFromLatest: {},
     },
-  },
-  "terminal.plain.importLegacy": {
-    degrade: { kind: "unsupported" },
     2: {
       latestMinor: 1,
       versions: {
         1: {
           contract: terminalPlainImportLegacyV21,
-          upgradeFromPreviousVersion: null,
+          upgradeFromPreviousVersion:
+            terminalPlainImportLegacyUpgradeV10ToV21,
+          semanticMajorBreakFromPreviousMajor: true,
         },
       },
-      downgradePathsFromLatest: {},
+      downgradePathsFromLatest: {
+        1: terminalPlainImportLegacyDowngradeV21ToV10,
+      },
     },
   },
   "worktree.listByWorkspacePaths": {
@@ -7722,9 +7813,16 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
       },
     },
   },
-  // Replacement-state durable plain-terminal collection. Unsupported on older
-  // hosts, where the capability-gated client keeps its legacy local model.
+  // Frozen v1 snapshot/increment stream and v2 replacement-state fleet stream.
   "terminal.plain.subscribeList": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: terminalPlainSubscribeListV10,
+        },
+      },
+    },
     2: {
       latestMinor: 1,
       versions: {

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -6294,7 +6294,6 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         1: {
           contract: terminalPlainListV21,
           upgradeFromPreviousVersion: terminalPlainListUpgradeV10ToV21,
-          semanticMajorBreakFromPreviousMajor: true,
         },
       },
       downgradePathsFromLatest: { 1: terminalPlainListDowngradeV21ToV10 },
@@ -6318,7 +6317,6 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         1: {
           contract: terminalPlainRenameV21,
           upgradeFromPreviousVersion: terminalPlainRenameUpgradeV10ToV21,
-          semanticMajorBreakFromPreviousMajor: true,
         },
       },
       downgradePathsFromLatest: { 1: terminalPlainRenameDowngradeV21ToV10 },

--- a/protocol/src/host/terminal/__tests__/plain-terminal-contracts.test.ts
+++ b/protocol/src/host/terminal/__tests__/plain-terminal-contracts.test.ts
@@ -6,12 +6,19 @@ import {
 import {
   PLAIN_TERMINAL_FAMILY_METHODS,
   PLAIN_TERMINAL_FAMILY_VERSION,
+  PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
   resolvePlainTerminalFamilyCapability,
+  terminalPlainCloseV10,
   terminalPlainCloseV21,
+  terminalPlainCreateV10,
   terminalPlainCreateV21,
+  terminalPlainEnsureRunningV10,
   terminalPlainEnsureRunningV21,
+  terminalPlainImportLegacyV10,
   terminalPlainImportLegacyV21,
+  terminalPlainListV10,
   terminalPlainListV21,
+  terminalPlainRenameV10,
   terminalPlainRenameV21,
   type PlainTerminalFamilyMethod,
 } from "@traycer/protocol/host/terminal/plain-contracts";
@@ -36,6 +43,8 @@ import {
   type PlainTerminalProjection,
 } from "@traycer/protocol/host/terminal/plain-schemas";
 import {
+  terminalPlainSubscribeListServerFrameSchemaV10,
+  terminalPlainSubscribeListV10,
   terminalPlainSubscribeListClientFrameSchema,
   terminalPlainSubscribeListOpenRequestSchema,
   terminalPlainSubscribeListServerFrameSchema,
@@ -151,6 +160,12 @@ const V2_FAMILY = Object.fromEntries(
   PLAIN_TERMINAL_FAMILY_METHODS.map((method) => [
     method,
     { major: 2, minor: 1 },
+  ]),
+) as Record<PlainTerminalFamilyMethod, FrameworkSchemaVersion>;
+const V1_FAMILY = Object.fromEntries(
+  PLAIN_TERMINAL_FAMILY_METHODS.map((method) => [
+    method,
+    { major: 1, minor: 0 },
   ]),
 ) as Record<PlainTerminalFamilyMethod, FrameworkSchemaVersion>;
 
@@ -790,7 +805,7 @@ describe("lifetime-delete revision", () => {
 });
 
 describe("plain-terminal family capability", () => {
-  it("requires the complete v2 family and reports anything else unsupported", () => {
+  it("recognizes only complete v1-local or v2-fleet families", () => {
     expect(familyCapability({}, false)).toEqual({ status: "unknown" });
     expect(familyCapability({}, true)).toEqual({ status: "unsupported" });
     expect(
@@ -805,51 +820,64 @@ describe("plain-terminal family capability", () => {
         true,
       ),
     ).toEqual({ status: "unsupported" });
-    expect(
-      familyCapability(
-        Object.fromEntries(
-          PLAIN_TERMINAL_FAMILY_METHODS.map((method) => [
-            method,
-            { major: 1, minor: 0 },
-          ]),
-        ),
-        true,
-      ),
-    ).toEqual({ status: "unsupported" });
+    expect(familyCapability(V1_FAMILY, true)).toEqual({
+      status: "capable",
+      schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+      topology: "local",
+    });
     expect(familyCapability(V2_FAMILY, true)).toEqual({
       status: "capable",
       schemaVersion: PLAIN_TERMINAL_FAMILY_VERSION,
+      topology: "fleet",
     });
   });
 });
 
 describe("protocol registration and released compatibility", () => {
-  it("registers every unary contract as optional v2 with no v1 line", () => {
+  it("registers the frozen v1 and fleet v2 unary lines", () => {
     const expected = {
-      "terminal.plain.create": terminalPlainCreateV21,
-      "terminal.plain.list": terminalPlainListV21,
-      "terminal.plain.rename": terminalPlainRenameV21,
-      "terminal.plain.ensureRunning": terminalPlainEnsureRunningV21,
-      "terminal.plain.close": terminalPlainCloseV21,
-      "terminal.plain.importLegacy": terminalPlainImportLegacyV21,
+      "terminal.plain.create": [terminalPlainCreateV10, terminalPlainCreateV21],
+      "terminal.plain.list": [terminalPlainListV10, terminalPlainListV21],
+      "terminal.plain.rename": [terminalPlainRenameV10, terminalPlainRenameV21],
+      "terminal.plain.ensureRunning": [
+        terminalPlainEnsureRunningV10,
+        terminalPlainEnsureRunningV21,
+      ],
+      "terminal.plain.close": [terminalPlainCloseV10, terminalPlainCloseV21],
+      "terminal.plain.importLegacy": [
+        terminalPlainImportLegacyV10,
+        terminalPlainImportLegacyV21,
+      ],
     } as const;
 
-    for (const [method, contract] of Object.entries(expected)) {
+    for (const [method, contracts] of Object.entries(expected)) {
       const entry = hostRpcRegistry[method as keyof typeof expected];
       expect(entry.degrade).toEqual({ kind: "unsupported" });
+      expect(entry[1].latestMinor).toBe(0);
+      expect(entry[1].versions[0].contract).toBe(contracts[0]);
       expect(entry[2].latestMinor).toBe(1);
-      expect(entry[2].versions[1].contract).toBe(contract);
+      expect(entry[2].versions[1].contract).toBe(contracts[1]);
       expect(0 in entry[2].versions).toBe(false);
-      expect("1" in entry).toBe(false);
     }
   });
 
-  it("registers the replacement-state list stream at v2", () => {
+  it("registers the v1 incremental and v2 replacement-state streams", () => {
     const entry = hostStreamRpcRegistry["terminal.plain.subscribeList"];
+    expect(entry[1].latestMinor).toBe(0);
+    expect(entry[1].versions[0].contract).toBe(terminalPlainSubscribeListV10);
     expect(entry[2].latestMinor).toBe(1);
     expect(entry[2].versions[1].contract).toBe(terminalPlainSubscribeListV21);
     expect(0 in entry[2].versions).toBe(false);
-    expect("1" in entry).toBe(false);
+  });
+
+  it("keeps unknown runtime outside the frozen v1 stream", () => {
+    expect(
+      terminalPlainSubscribeListServerFrameSchemaV10.safeParse({
+        kind: "upsert",
+        hasBinaryPayload: false,
+        terminal: unknown,
+      }).success,
+    ).toBe(false);
   });
 
   it("leaves all released generic terminal version lines frozen", () => {

--- a/protocol/src/host/terminal/__tests__/plain-terminal-contracts.test.ts
+++ b/protocol/src/host/terminal/__tests__/plain-terminal-contracts.test.ts
@@ -43,6 +43,7 @@ import {
   type PlainTerminalProjection,
 } from "@traycer/protocol/host/terminal/plain-schemas";
 import {
+  terminalPlainSubscribeListClientFrameSchemaV10,
   terminalPlainSubscribeListServerFrameSchemaV10,
   terminalPlainSubscribeListV10,
   terminalPlainSubscribeListClientFrameSchema,
@@ -60,7 +61,11 @@ import {
   terminalListV23,
   terminalRenameV10,
 } from "@traycer/protocol/host/terminal/contracts";
-import type { SchemaVersion as FrameworkSchemaVersion } from "@traycer/protocol/framework/index";
+import {
+  downgradeResponseAcrossMajors,
+  upgradeResponseToVersionWithContext,
+  type SchemaVersion as FrameworkSchemaVersion,
+} from "@traycer/protocol/framework/index";
 
 function terminal(
   runtime: PlainTerminalProjection["runtime"],
@@ -877,6 +882,66 @@ describe("protocol registration and released compatibility", () => {
         hasBinaryPayload: false,
         terminal: unknown,
       }).success,
+    ).toBe(false);
+  });
+
+  it("keeps the frozen v1 client frame schema independent from v2", () => {
+    const ping = { kind: "ping", hasBinaryPayload: false } as const;
+    expect(terminalPlainSubscribeListClientFrameSchemaV10.parse(ping)).toEqual(
+      ping,
+    );
+    expect(terminalPlainSubscribeListClientFrameSchemaV10).not.toBe(
+      terminalPlainSubscribeListClientFrameSchema,
+    );
+  });
+
+  it("upgrades an empty v1 Epic list with its request scope and serving host", () => {
+    const upgraded = upgradeResponseToVersionWithContext(
+      hostRpcRegistry["terminal.plain.list"],
+      PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+      PLAIN_TERMINAL_FAMILY_VERSION,
+      { terminals: [] },
+      {
+        request: { scope: epicScope },
+        hostId: "host-1",
+      },
+    );
+
+    expect(upgraded).toEqual({
+      coverage: "partial-serving-host",
+      scope: epicScope,
+      servingHostId: "host-1",
+      terminals: [],
+    });
+  });
+
+  it("upgrades an empty v1 independent list as complete local authority", () => {
+    const upgraded = upgradeResponseToVersionWithContext(
+      hostRpcRegistry["terminal.plain.list"],
+      PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+      PLAIN_TERMINAL_FAMILY_VERSION,
+      { terminals: [] },
+      {
+        request: { scope: independentScope },
+        hostId: "host-1",
+      },
+    );
+
+    expect(upgraded).toEqual({
+      coverage: "complete-local",
+      scope: independentScope,
+      terminals: [],
+    });
+  });
+
+  it("refuses to down-project a fleet list onto the frozen v1 line", () => {
+    expect(
+      downgradeResponseAcrossMajors(
+        hostRpcRegistry["terminal.plain.list"],
+        PLAIN_TERMINAL_FAMILY_VERSION.major,
+        PLAIN_TERMINAL_LOCAL_FAMILY_VERSION.major,
+        completeFleet,
+      ).ok,
     ).toBe(false);
   });
 

--- a/protocol/src/host/terminal/plain-contracts.ts
+++ b/protocol/src/host/terminal/plain-contracts.ts
@@ -1,7 +1,23 @@
 import {
+  defineDowngradePath,
   defineRpcContract,
+  defineUpgradePath,
   type SchemaVersion,
 } from "@traycer/protocol/framework/index";
+import {
+  closePlainTerminalRequestSchemaV10,
+  closePlainTerminalResponseSchemaV10,
+  createPlainTerminalRequestSchemaV10,
+  createPlainTerminalResponseSchemaV10,
+  ensurePlainTerminalRunningRequestSchemaV10,
+  ensurePlainTerminalRunningResponseSchemaV10,
+  importLegacyPlainTerminalRequestSchemaV10,
+  importLegacyPlainTerminalResponseSchemaV10,
+  listPlainTerminalsRequestSchemaV10,
+  listPlainTerminalsResponseSchemaV10,
+  renamePlainTerminalRequestSchemaV10,
+  renamePlainTerminalResponseSchemaV10,
+} from "@traycer/protocol/host/terminal/plain-v1-schemas";
 import {
   closePlainTerminalRequestSchema,
   closePlainTerminalResponseSchema,
@@ -48,17 +64,24 @@ export const PLAIN_TERMINAL_FAMILY_VERSION = {
   major: 2,
   minor: 1,
 } as const satisfies SchemaVersion;
+export const PLAIN_TERMINAL_LOCAL_FAMILY_VERSION = {
+  major: 1,
+  minor: 0,
+} as const satisfies SchemaVersion;
 
 export type PlainTerminalFamilyCapability =
   | { readonly status: "unknown" }
   | { readonly status: "unsupported" }
   | {
       readonly status: "capable";
-      readonly schemaVersion: typeof PLAIN_TERMINAL_FAMILY_VERSION;
+      readonly schemaVersion:
+        | typeof PLAIN_TERMINAL_LOCAL_FAMILY_VERSION
+        | typeof PLAIN_TERMINAL_FAMILY_VERSION;
+      readonly topology: "local" | "fleet";
     };
 
 /**
- * Resolves the optional family as a unit. A partial, v1, or mixed v1/v2
+ * Resolves the optional family as a unit. A partial or mixed v1/v2
  * family is unsupported rather than a license to compose incompatible
  * semantics method by method.
  */
@@ -71,26 +94,75 @@ export function resolvePlainTerminalFamilyCapability(input: {
   if (!input.manifestKnown) {
     return { status: "unknown" };
   }
-  for (const method of PLAIN_TERMINAL_FAMILY_METHODS) {
-    const version = input.versionFor(method);
-    if (
-      version === null ||
-      version.major !== PLAIN_TERMINAL_FAMILY_VERSION.major ||
-      version.minor !== PLAIN_TERMINAL_FAMILY_VERSION.minor
-    ) {
-      return { status: "unsupported" };
+  for (const candidate of [
+    { version: PLAIN_TERMINAL_FAMILY_VERSION, topology: "fleet" as const },
+    {
+      version: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+      topology: "local" as const,
+    },
+  ]) {
+    let matches = true;
+    for (const method of PLAIN_TERMINAL_FAMILY_METHODS) {
+      const version = input.versionFor(method);
+      if (
+        version === null ||
+        version.major !== candidate.version.major ||
+        version.minor !== candidate.version.minor
+      ) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return {
+        status: "capable",
+        schemaVersion: candidate.version,
+        topology: candidate.topology,
+      };
     }
   }
-  return {
-    status: "capable",
-    schemaVersion: PLAIN_TERMINAL_FAMILY_VERSION,
-  };
+  return { status: "unsupported" };
 }
 
-// Unreleased family: staging app and hosts move together onto v2.1. The
-// runtime `unknown` state was added before release, so the incomplete 2.0
-// draft is deliberately not registered or bridged. There is no mixed-family
-// line and no downgrade into either 2.0 or the superseded 1.0 shapes.
+// v1.0 shipped in desktop/host v1.2.0-rc.1 and remains frozen as the local-only
+// durable line. v2.1 adds fleet replacement state and `unknown` runtime.
+export const terminalPlainCreateV10 = defineRpcContract({
+  method: "terminal.plain.create",
+  schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  requestSchema: createPlainTerminalRequestSchemaV10,
+  responseSchema: createPlainTerminalResponseSchemaV10,
+});
+export const terminalPlainListV10 = defineRpcContract({
+  method: "terminal.plain.list",
+  schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  requestSchema: listPlainTerminalsRequestSchemaV10,
+  responseSchema: listPlainTerminalsResponseSchemaV10,
+});
+export const terminalPlainRenameV10 = defineRpcContract({
+  method: "terminal.plain.rename",
+  schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  requestSchema: renamePlainTerminalRequestSchemaV10,
+  responseSchema: renamePlainTerminalResponseSchemaV10,
+});
+export const terminalPlainEnsureRunningV10 = defineRpcContract({
+  method: "terminal.plain.ensureRunning",
+  schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  requestSchema: ensurePlainTerminalRunningRequestSchemaV10,
+  responseSchema: ensurePlainTerminalRunningResponseSchemaV10,
+});
+export const terminalPlainCloseV10 = defineRpcContract({
+  method: "terminal.plain.close",
+  schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  requestSchema: closePlainTerminalRequestSchemaV10,
+  responseSchema: closePlainTerminalResponseSchemaV10,
+});
+export const terminalPlainImportLegacyV10 = defineRpcContract({
+  method: "terminal.plain.importLegacy",
+  schemaVersion: PLAIN_TERMINAL_LOCAL_FAMILY_VERSION,
+  requestSchema: importLegacyPlainTerminalRequestSchemaV10,
+  responseSchema: importLegacyPlainTerminalResponseSchemaV10,
+});
+
 export const terminalPlainCreateV21 = defineRpcContract({
   method: "terminal.plain.create",
   schemaVersion: { major: 2, minor: 1 } as const,
@@ -131,4 +203,166 @@ export const terminalPlainImportLegacyV21 = defineRpcContract({
   schemaVersion: { major: 2, minor: 1 } as const,
   requestSchema: importLegacyPlainTerminalRequestSchema,
   responseSchema: importLegacyPlainTerminalResponseSchema,
+});
+
+const runtimeUnavailableDowngrade = {
+  code: "DOWNGRADE_UNSUPPORTED",
+  message: "The terminal runtime is unavailable to this older app.",
+} as const;
+
+export const terminalPlainCreateUpgradeV10ToV21 = defineUpgradePath<
+  typeof terminalPlainCreateV10,
+  typeof terminalPlainCreateV21
+>({
+  from: terminalPlainCreateV10.schemaVersion,
+  to: terminalPlainCreateV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+export const terminalPlainCreateDowngradeV21ToV10 = defineDowngradePath<
+  typeof terminalPlainCreateV21,
+  typeof terminalPlainCreateV10
+>({
+  from: terminalPlainCreateV21.schemaVersion,
+  to: terminalPlainCreateV10.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = createPlainTerminalResponseSchemaV10.safeParse(response);
+    return parsed.success
+      ? { ok: true, value: parsed.data }
+      : { ok: false, error: runtimeUnavailableDowngrade };
+  },
+});
+
+export const terminalPlainListUpgradeV10ToV21 = defineUpgradePath<
+  typeof terminalPlainListV10,
+  typeof terminalPlainListV21
+>({
+  from: terminalPlainListV10.schemaVersion,
+  to: terminalPlainListV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => {
+    const first = response.terminals[0];
+    if (first?.record.scope.kind === "epic") {
+      return {
+        coverage: "complete-fleet",
+        scope: first.record.scope,
+        terminals: response.terminals,
+      };
+    }
+    return {
+      coverage: "complete-local",
+      scope: { kind: "independent" },
+      terminals: response.terminals,
+    };
+  },
+});
+export const terminalPlainListDowngradeV21ToV10 = defineDowngradePath<
+  typeof terminalPlainListV21,
+  typeof terminalPlainListV10
+>({
+  from: terminalPlainListV21.schemaVersion,
+  to: terminalPlainListV10.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = listPlainTerminalsResponseSchemaV10.safeParse({
+      terminals: response.terminals,
+    });
+    return parsed.success
+      ? { ok: true, value: parsed.data }
+      : { ok: false, error: runtimeUnavailableDowngrade };
+  },
+});
+
+export const terminalPlainRenameUpgradeV10ToV21 = defineUpgradePath<
+  typeof terminalPlainRenameV10,
+  typeof terminalPlainRenameV21
+>({
+  from: terminalPlainRenameV10.schemaVersion,
+  to: terminalPlainRenameV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+export const terminalPlainRenameDowngradeV21ToV10 = defineDowngradePath<
+  typeof terminalPlainRenameV21,
+  typeof terminalPlainRenameV10
+>({
+  from: terminalPlainRenameV21.schemaVersion,
+  to: terminalPlainRenameV10.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = renamePlainTerminalResponseSchemaV10.safeParse(response);
+    return parsed.success
+      ? { ok: true, value: parsed.data }
+      : { ok: false, error: runtimeUnavailableDowngrade };
+  },
+});
+export const terminalPlainEnsureRunningUpgradeV10ToV21 = defineUpgradePath<
+  typeof terminalPlainEnsureRunningV10,
+  typeof terminalPlainEnsureRunningV21
+>({
+  from: terminalPlainEnsureRunningV10.schemaVersion,
+  to: terminalPlainEnsureRunningV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+export const terminalPlainEnsureRunningDowngradeV21ToV10 =
+  defineDowngradePath<
+    typeof terminalPlainEnsureRunningV21,
+    typeof terminalPlainEnsureRunningV10
+  >({
+    from: terminalPlainEnsureRunningV21.schemaVersion,
+    to: terminalPlainEnsureRunningV10.schemaVersion,
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      const parsed =
+        ensurePlainTerminalRunningResponseSchemaV10.safeParse(response);
+      return parsed.success
+        ? { ok: true, value: parsed.data }
+        : { ok: false, error: runtimeUnavailableDowngrade };
+    },
+  });
+export const terminalPlainCloseUpgradeV10ToV21 = defineUpgradePath<
+  typeof terminalPlainCloseV10,
+  typeof terminalPlainCloseV21
+>({
+  from: terminalPlainCloseV10.schemaVersion,
+  to: terminalPlainCloseV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+export const terminalPlainCloseDowngradeV21ToV10 = defineDowngradePath<
+  typeof terminalPlainCloseV21,
+  typeof terminalPlainCloseV10
+>({
+  from: terminalPlainCloseV21.schemaVersion,
+  to: terminalPlainCloseV10.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({ ok: true, value: response }),
+});
+export const terminalPlainImportLegacyUpgradeV10ToV21 = defineUpgradePath<
+  typeof terminalPlainImportLegacyV10,
+  typeof terminalPlainImportLegacyV21
+>({
+  from: terminalPlainImportLegacyV10.schemaVersion,
+  to: terminalPlainImportLegacyV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+export const terminalPlainImportLegacyDowngradeV21ToV10 = defineDowngradePath<
+  typeof terminalPlainImportLegacyV21,
+  typeof terminalPlainImportLegacyV10
+>({
+  from: terminalPlainImportLegacyV21.schemaVersion,
+  to: terminalPlainImportLegacyV10.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    if (response.status === "deleted") {
+      return { ok: true, value: response };
+    }
+    const parsed = importLegacyPlainTerminalResponseSchemaV10.safeParse(response);
+    return parsed.success
+      ? { ok: true, value: parsed.data }
+      : { ok: false, error: runtimeUnavailableDowngrade };
+  },
 });

--- a/protocol/src/host/terminal/plain-contracts.ts
+++ b/protocol/src/host/terminal/plain-contracts.ts
@@ -1,4 +1,5 @@
 import {
+  defineContextualUpgradePath,
   defineDowngradePath,
   defineRpcContract,
   defineUpgradePath,
@@ -234,19 +235,24 @@ export const terminalPlainCreateDowngradeV21ToV10 = defineDowngradePath<
   },
 });
 
-export const terminalPlainListUpgradeV10ToV21 = defineUpgradePath<
+export const terminalPlainListUpgradeV10ToV21 = defineContextualUpgradePath<
   typeof terminalPlainListV10,
   typeof terminalPlainListV21
 >({
   from: terminalPlainListV10.schemaVersion,
   to: terminalPlainListV21.schemaVersion,
   upgradeRequest: (request) => request,
-  upgradeResponse: (response) => {
-    const first = response.terminals[0];
-    if (first?.record.scope.kind === "epic") {
+  upgradeResponse: (response, context) => {
+    if (context === undefined) {
+      throw new Error(
+        "terminal.plain.list v1 responses require request context when upgraded to v2",
+      );
+    }
+    if (context.request.scope.kind === "epic") {
       return {
-        coverage: "complete-fleet",
-        scope: first.record.scope,
+        coverage: "partial-serving-host",
+        scope: context.request.scope,
+        servingHostId: context.hostId,
         terminals: response.terminals,
       };
     }
@@ -265,6 +271,9 @@ export const terminalPlainListDowngradeV21ToV10 = defineDowngradePath<
   to: terminalPlainListV10.schemaVersion,
   downgradeRequest: (request) => ({ ok: true, value: request }),
   downgradeResponse: (response) => {
+    if (response.coverage === "complete-fleet") {
+      return { ok: false, error: runtimeUnavailableDowngrade };
+    }
     const parsed = listPlainTerminalsResponseSchemaV10.safeParse({
       terminals: response.terminals,
     });

--- a/protocol/src/host/terminal/plain-subscribe-list.ts
+++ b/protocol/src/host/terminal/plain-subscribe-list.ts
@@ -57,6 +57,14 @@ export type TerminalPlainSubscribeListServerFrameV10 = z.infer<
   typeof terminalPlainSubscribeListServerFrameSchemaV10
 >;
 
+export const terminalPlainSubscribeListClientFrameSchemaV10 =
+  z.discriminatedUnion("kind", [
+    z.strictObject({
+      kind: z.literal("ping"),
+      ...textFrameFields,
+    }),
+  ]);
+
 /**
  * Server frames are replacement `state` plus the transport keepalive.
  * Each accepted `state` frame replaces the collection described by its
@@ -99,7 +107,7 @@ export const terminalPlainSubscribeListV10 = defineStreamRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   openRequestSchema: terminalPlainSubscribeListOpenRequestSchemaV10,
   serverFrameSchema: terminalPlainSubscribeListServerFrameSchemaV10,
-  clientFrameSchema: terminalPlainSubscribeListClientFrameSchema,
+  clientFrameSchema: terminalPlainSubscribeListClientFrameSchemaV10,
 });
 
 export const terminalPlainSubscribeListV21 = defineStreamRpcContract({

--- a/protocol/src/host/terminal/plain-subscribe-list.ts
+++ b/protocol/src/host/terminal/plain-subscribe-list.ts
@@ -2,6 +2,10 @@
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 import {
+  plainTerminalProjectionSchemaV10,
+  plainTerminalScopeSchemaV10,
+} from "@traycer/protocol/host/terminal/plain-v1-schemas";
+import {
   plainTerminalListStateSchema,
   plainTerminalScopeSchema,
 } from "@traycer/protocol/host/terminal/plain-schemas";
@@ -15,6 +19,42 @@ export const terminalPlainSubscribeListOpenRequestSchema = z.strictObject({
 });
 export type TerminalPlainSubscribeListOpenRequest = z.infer<
   typeof terminalPlainSubscribeListOpenRequestSchema
+>;
+
+export const terminalPlainSubscribeListOpenRequestSchemaV10 = z.strictObject({
+  scope: plainTerminalScopeSchemaV10,
+});
+
+/** Frozen snapshot-first server frames shipped in desktop/host v1.2.0-rc.1. */
+export const terminalPlainSubscribeListServerFrameSchemaV10 =
+  z.discriminatedUnion("kind", [
+    z.strictObject({
+      kind: z.literal("snapshot"),
+      ...textFrameFields,
+      terminals: z.array(plainTerminalProjectionSchemaV10),
+    }),
+    z.strictObject({
+      kind: z.literal("initialized"),
+      ...textFrameFields,
+    }),
+    z.strictObject({
+      kind: z.literal("upsert"),
+      ...textFrameFields,
+      terminal: plainTerminalProjectionSchemaV10,
+    }),
+    z.strictObject({
+      kind: z.literal("deleted"),
+      ...textFrameFields,
+      terminalId: z.string().min(1),
+      revision: z.number().int().nonnegative(),
+    }),
+    z.strictObject({
+      kind: z.literal("pong"),
+      ...textFrameFields,
+    }),
+  ]);
+export type TerminalPlainSubscribeListServerFrameV10 = z.infer<
+  typeof terminalPlainSubscribeListServerFrameSchemaV10
 >;
 
 /**
@@ -53,6 +93,14 @@ export const terminalPlainSubscribeListClientFrameSchema = z.discriminatedUnion(
 export type TerminalPlainSubscribeListClientFrame = z.infer<
   typeof terminalPlainSubscribeListClientFrameSchema
 >;
+
+export const terminalPlainSubscribeListV10 = defineStreamRpcContract({
+  method: "terminal.plain.subscribeList",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: terminalPlainSubscribeListOpenRequestSchemaV10,
+  serverFrameSchema: terminalPlainSubscribeListServerFrameSchemaV10,
+  clientFrameSchema: terminalPlainSubscribeListClientFrameSchema,
+});
 
 export const terminalPlainSubscribeListV21 = defineStreamRpcContract({
   method: "terminal.plain.subscribeList",

--- a/protocol/src/host/terminal/plain-v1-schemas.ts
+++ b/protocol/src/host/terminal/plain-v1-schemas.ts
@@ -1,0 +1,148 @@
+/** Frozen durable plain-terminal schemas shipped in desktop/host v1.2.0-rc.1. */
+import { z } from "zod";
+import { isoMillisecondTimestampSchema } from "@traycer/protocol/common/schemas";
+
+export const plainTerminalScopeSchemaV10 = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("epic"), epicId: z.string().min(1) }),
+  z.strictObject({ kind: z.literal("independent") }),
+]);
+
+export const plainTerminalLaunchSchemaV10 = z.strictObject({
+  cwd: z.string().min(1),
+  shellCommand: z.string().min(1),
+  shellArgs: z.array(z.string()),
+});
+
+export const plainTerminalRecordSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+  hostId: z.string().min(1),
+  scope: plainTerminalScopeSchemaV10,
+  launch: plainTerminalLaunchSchemaV10,
+  manualTitle: z.string().nullable(),
+  revision: z.number().int().nonnegative(),
+  createdAt: isoMillisecondTimestampSchema,
+  updatedAt: isoMillisecondTimestampSchema,
+});
+
+export const dormantPlainTerminalRuntimeSchemaV10 = z.strictObject({
+  status: z.literal("dormant"),
+});
+
+export const runningPlainTerminalRuntimeSchemaV10 = z.strictObject({
+  status: z.literal("running"),
+  sessionId: z.string().min(1),
+  currentCwd: z.string().min(1),
+  activeProcessName: z.string().nullable(),
+  cols: z.number().int().positive(),
+  rows: z.number().int().positive(),
+});
+
+export const plainTerminalRuntimeSchemaV10 = z.discriminatedUnion("status", [
+  dormantPlainTerminalRuntimeSchemaV10,
+  runningPlainTerminalRuntimeSchemaV10,
+]);
+
+export const plainTerminalProjectionSchemaV10 = z
+  .strictObject({
+    record: plainTerminalRecordSchemaV10,
+    runtime: plainTerminalRuntimeSchemaV10,
+  })
+  .superRefine((projection, ctx) => {
+    if (
+      projection.runtime.status === "running" &&
+      projection.runtime.sessionId !== projection.record.terminalId
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["runtime", "sessionId"],
+        message: "sessionId must equal the logical terminalId",
+      });
+    }
+  });
+export type PlainTerminalProjectionV10 = z.infer<
+  typeof plainTerminalProjectionSchemaV10
+>;
+
+export const runningPlainTerminalProjectionSchemaV10 = z
+  .strictObject({
+    record: plainTerminalRecordSchemaV10,
+    runtime: runningPlainTerminalRuntimeSchemaV10,
+  })
+  .superRefine((projection, ctx) => {
+    if (projection.runtime.sessionId !== projection.record.terminalId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["runtime", "sessionId"],
+        message: "sessionId must equal the logical terminalId",
+      });
+    }
+  });
+
+const gridFieldsV10 = {
+  cols: z.number().int().positive(),
+  rows: z.number().int().positive(),
+} as const;
+
+export const createPlainTerminalRequestSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+  scope: plainTerminalScopeSchemaV10,
+  cwd: z.string().min(1),
+  ...gridFieldsV10,
+});
+export const createPlainTerminalResponseSchemaV10 = z.strictObject({
+  terminal: runningPlainTerminalProjectionSchemaV10,
+});
+export const listPlainTerminalsRequestSchemaV10 = z.strictObject({
+  scope: plainTerminalScopeSchemaV10,
+});
+export const listPlainTerminalsResponseSchemaV10 = z.strictObject({
+  terminals: z.array(plainTerminalProjectionSchemaV10),
+});
+export const renamePlainTerminalRequestSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+  manualTitle: z.string().nullable(),
+});
+export const renamePlainTerminalResponseSchemaV10 = z.strictObject({
+  terminal: plainTerminalProjectionSchemaV10,
+});
+export const ensurePlainTerminalRunningRequestSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+  ...gridFieldsV10,
+});
+export const ensurePlainTerminalRunningResponseSchemaV10 = z.strictObject({
+  terminal: runningPlainTerminalProjectionSchemaV10,
+});
+export const closePlainTerminalRequestSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+});
+export const closePlainTerminalResponseSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+  revision: z.number().int().nonnegative(),
+});
+export const importLegacyPlainTerminalRequestSchemaV10 = z.strictObject({
+  terminalId: z.string().min(1),
+  hostId: z.string().min(1),
+  scope: plainTerminalScopeSchemaV10,
+  cwd: z.string().min(1),
+  name: z.string(),
+  titleSource: z.enum(["default", "manual"]),
+  sourceStoreVersion: z.number().int().nonnegative(),
+});
+export const importLegacyPlainTerminalResponseSchemaV10 = z.discriminatedUnion(
+  "status",
+  [
+    z.strictObject({
+      status: z.literal("imported"),
+      terminal: plainTerminalProjectionSchemaV10,
+    }),
+    z.strictObject({
+      status: z.literal("existing"),
+      terminal: plainTerminalProjectionSchemaV10,
+    }),
+    z.strictObject({
+      status: z.literal("deleted"),
+      terminalId: z.string().min(1),
+      revision: z.number().int().nonnegative(),
+    }),
+  ],
+);


### PR DESCRIPTION
## Summary
- restore the frozen terminal.plain v1.0 family alongside the v2.1 fleet family
- select connection manifests per peer so RC clients receive the complete v1 unary and stream family
- adapt v1 list and stream data into the new GUI local-authority model so new apps work with RC hosts
- keep v1 local semantics isolated from v2 multi-host fleet semantics

## Compatibility matrix
- RC app + new host: host advertises and serves frozen v1 local durable terminal semantics
- new app + RC host: app recognizes v1 as capable local durable authority
- new app + new host: v2.1 fleet semantics unchanged

## Verification
- repository pre-commit affected compile, lint, format, and build checks passed
- protocol terminal contract and capability tests passed
- shared terminal stream adapter tests passed
- GUI terminal authority tests passed

## Dependency
The internal host PR will consume this commit and add the direct/relay handshake and frozen v1 resolver branches.