### PR TITLE
fix(gui-app): pluralize the epic-sharing invite toast

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/use-controller.ts
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/use-controller.ts
@@ -203,7 +203,11 @@ export function useEpicSharingPanelController(
     });
 
     if (result.succeededNewInvites.length > 0) {
-      toast.success(`Invited ${result.succeededNewInvites.length} people`);
+      const invitedNoun =
+        result.succeededNewInvites.length === 1 ? "person" : "people";
+      toast.success(
+        `Invited ${result.succeededNewInvites.length} ${invitedNoun}`,
+      );
     }
 
     result.succeededReInvites.forEach((invite) => {


### PR DESCRIPTION
## Summary

The Epic sharing panel's success toast was hard-coded to the plural noun,
so inviting a single collaborator read **"Invited 1 people"**.

### What changes

`handleSendInvites` now selects `person` / `people` from
`succeededNewInvites.length`, using the same inline-ternary pluralization
idiom the rest of the app uses (there is no shared pluralize helper).

Copy only — no behavioral change to the invite flow itself.
