### PR TITLE
fix(gui-app): one quiet light for remote-terminal coverage, every degraded plane on hover

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -104,6 +104,20 @@ async function expectTooltip(text: string) {
   expect((await screen.findByRole("tooltip")).textContent).toBe(text);
 }
 
+/**
+ * The hover, one entry per degraded plane: the selected plane's sentence
+ * first, then every other degraded plane in source order. A single-plane
+ * hover is a bare string, which reads here as one line.
+ */
+async function tooltipLines(): Promise<ReadonlyArray<string | null>> {
+  fireEvent.focus(screen.getByTestId("epic-connection-pill"));
+  const tooltip = await screen.findByRole("tooltip");
+  const paragraphs = Array.from(tooltip.querySelectorAll("p"));
+  return paragraphs.length === 0
+    ? [tooltip.textContent]
+    : paragraphs.map((line) => line.textContent);
+}
+
 describe("<EpicConnectionPill />", () => {
   afterEach(() => {
     cleanup();
@@ -374,14 +388,73 @@ describe("<EpicConnectionPill />", () => {
 
     const pill = screen.getByRole<HTMLButtonElement>("button");
     expect(pill.dataset.source).toBe("terminal-catalog");
-    expect(pill.textContent).toContain("Remote terminals unavailable");
-    expect(pill.className).toContain("bg-amber-500/10");
+    // Dot-only, like the other read-only degradations: the sentence is on
+    // hover and in the accessible name, never a permanent label in the row.
+    expect(pill.textContent).toBe("");
+    expect(screen.getByTestId("epic-connection-pill-dot").className).toContain(
+      "bg-amber-500",
+    );
+    expect(pill.className).not.toContain("bg-amber-500/10");
     expect(pill.getAttribute("aria-label")).toBe(
       "Remote terminal discovery is unavailable. Showing terminals from this host only. It will recover automatically.",
     );
     expect(screen.getByRole("status").textContent).toBe(
       "Remote terminal discovery is unavailable. Showing terminals from this host only. It will recover automatically.",
     );
+  });
+
+  it("shows one plane's copy and lists every other degraded plane on hover", async () => {
+    // Two warnings at once: the catalog gap (earlier source, so it wins the
+    // tie) and degraded presence, which carries a label of its own. The row
+    // must not concatenate them - one light, the selected plane's copy only -
+    // while the hover and the accessible name carry both, selected first, so
+    // the second outage is not hidden behind the first.
+    vi.useFakeTimers();
+    mocks.terminalCoverage = "partial-serving-host";
+    mocks.presenceDegraded = "cloud-down";
+    renderPill("hostPending");
+    act(() => {
+      vi.advanceTimersByTime(750);
+    });
+
+    const pill = screen.getByRole<HTMLButtonElement>("button");
+    expect(pill.dataset.source).toBe("terminal-catalog");
+    expect(pill.textContent).toBe("");
+    const catalogCopy =
+      "Remote terminal discovery is unavailable. Showing terminals from this host only. It will recover automatically.";
+    const presenceCopy =
+      "This device can’t reach the cloud right now, so agents on other devices may show as idle. Agents on this device are live.";
+    expect(pill.getAttribute("aria-label")).toBe(
+      `${catalogCopy} ${presenceCopy}`,
+    );
+    expect(screen.getByRole("status").textContent).toBe(
+      `${catalogCopy} ${presenceCopy}`,
+    );
+    vi.useRealTimers();
+    expect(await tooltipLines()).toEqual([catalogCopy, presenceCopy]);
+  });
+
+  it("does not list a merely busy plane beside a degraded one on hover", async () => {
+    // "Backing up chats" is activity, not an outage: when the graph feed is
+    // the one degraded plane, the hover stays a single sentence.
+    mocks.chatBackupStatus = {
+      severity: "activity",
+      tooltip: "Backing up chats",
+      ariaLabel: "Backing up chats",
+    };
+    mocks.commGraphFeedHealth = {
+      severity: "warning",
+      tooltip: "Communication graph feed: reconnecting…",
+      ariaLabel: "Communication graph feed: reconnecting…",
+    };
+    renderPill("synced");
+
+    const pill = screen.getByRole<HTMLButtonElement>("button");
+    expect(pill.dataset.source).toBe("comm-graph");
+    expect(pill.getAttribute("aria-label")).toBe(
+      "Communication graph feed: reconnecting…",
+    );
+    await expectTooltip("Communication graph feed: reconnecting…");
   });
 
   it("does not report a fleet outage for a local-only RC host", () => {
@@ -415,7 +488,12 @@ describe("<EpicConnectionPill />", () => {
     expect(screen.getByTestId("epic-connection-pill-dot").className).toContain(
       "bg-red-500",
     );
-    await expectTooltip(OFFLINE_COPY);
+    // The row shows the winner alone; the loser is not dropped, it follows
+    // on hover.
+    expect(await tooltipLines()).toEqual([
+      OFFLINE_COPY,
+      "Chat backup failing · 1 chat not backed up",
+    ]);
   });
 
   it("keeps artifact status when warning severities tie", async () => {
@@ -429,7 +507,10 @@ describe("<EpicConnectionPill />", () => {
     const pill = screen.getByRole<HTMLButtonElement>("button");
     expect(pill.dataset.source).toBe("artifact");
     expect(pill.textContent).toContain("Connecting…");
-    await expectTooltip("Connecting to server");
+    expect(await tooltipLines()).toEqual([
+      "Connecting to server",
+      "Chat backup failing · 1 chat not backed up",
+    ]);
   });
 
   const COMM_GRAPH_HEALTH: CommGraphFeedHealth = {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
 } from "@testing-library/react";
 import { EpicConnectionPill } from "@/components/epic-canvas/panels/epic-connection-pill";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -112,10 +113,10 @@ async function expectTooltip(text: string) {
 async function tooltipLines(): Promise<ReadonlyArray<string | null>> {
   fireEvent.focus(screen.getByTestId("epic-connection-pill"));
   const tooltip = await screen.findByRole("tooltip");
-  const paragraphs = Array.from(tooltip.querySelectorAll("p"));
-  return paragraphs.length === 0
+  const entries = within(tooltip).queryAllByRole("listitem");
+  return entries.length === 0
     ? [tooltip.textContent]
-    : paragraphs.map((line) => line.textContent);
+    : entries.map((entry) => entry.textContent);
 }
 
 describe("<EpicConnectionPill />", () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { LivePulse } from "@/components/ui/live-pulse";
 import {
@@ -98,7 +98,7 @@ export function EpicConnectionPill(props: EpicConnectionPillProps) {
   return (
     <>
       <TooltipWrapper
-        label={rawSelected.indicator.tooltip}
+        label={tooltipFor(rawSelected)}
         side="top"
         sideOffset={undefined}
         align={undefined}
@@ -108,7 +108,7 @@ export function EpicConnectionPill(props: EpicConnectionPillProps) {
           data-testid="epic-connection-pill"
           data-status={state}
           data-source={selected.source}
-          aria-label={rawSelected.indicator.ariaLabel}
+          aria-label={accessibleNameFor(rawSelected)}
           className={cn(
             "inline-flex items-center gap-1 text-ui-xs font-medium text-current focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
             indicator.containerClassName,
@@ -134,21 +134,21 @@ function warningAnnouncement(
     selected.source !== "artifact" &&
     selected.indicator.severity === "warning"
   ) {
-    return selected.indicator.ariaLabel;
+    return accessibleNameFor(selected);
   }
   switch (state) {
     case "offlineWithUnsavedChanges":
     case "offlineWithHostPending":
     case "offlineChangesSavedLocally":
     case "offline":
-      return selected.indicator.ariaLabel;
+      return accessibleNameFor(selected);
     // A routine reconnect stays silent - it announces nothing a sighted user
     // would be interrupted by either. Once it has been down long enough to
     // escalate, it is worth saying: the copy tells the user their unsent work
     // depends on this window staying open.
     case "connecting":
     case "reconnecting":
-      return linkDownTooLong ? selected.indicator.ariaLabel : null;
+      return linkDownTooLong ? accessibleNameFor(selected) : null;
     default:
       return null;
   }
@@ -215,14 +215,48 @@ interface PillIndicator {
   readonly ariaLabel: string;
 }
 
+type PillSource =
+  | "artifact"
+  | "chat-backup"
+  | "terminal-catalog"
+  | "comm-graph"
+  | "agent-activity";
+
 interface SelectedIndicator {
-  readonly source:
-    | "artifact"
-    | "chat-backup"
-    | "terminal-catalog"
-    | "comm-graph"
-    | "agent-activity";
+  readonly source: PillSource;
   readonly indicator: PillIndicator;
+  /**
+   * Every OTHER plane that is degraded (warning or worse) right now, in
+   * source order. The visible row stays the selected plane's alone - one
+   * light, at most one label - and these ride the hover and the accessible
+   * name, so a second outage is never hidden behind the first.
+   */
+  readonly alsoDegraded: ReadonlyArray<PillIndicator>;
+}
+
+/**
+ * The hover copy: the selected plane's sentence, then one line per other
+ * degraded plane. A single-plane case stays a plain string so the tooltip
+ * reads exactly as it always has.
+ */
+function tooltipFor(selected: SelectedIndicator): ReactNode {
+  if (selected.alsoDegraded.length === 0) return selected.indicator.tooltip;
+  return (
+    <div className="flex flex-col gap-1">
+      <p>{selected.indicator.tooltip ?? selected.indicator.ariaLabel}</p>
+      {selected.alsoDegraded.map((other) => (
+        <p key={other.ariaLabel}>{other.tooltip ?? other.ariaLabel}</p>
+      ))}
+    </div>
+  );
+}
+
+/** The accessible name and live announcement: every degraded plane, selected first. */
+function accessibleNameFor(selected: SelectedIndicator): string {
+  return [
+    selected.indicator.ariaLabel,
+    ...selected.alsoDegraded.map((other) => other.ariaLabel),
+  ].join(" ");
 }
 
 function ConnectionPillDot(props: { indicator: PillIndicator }) {
@@ -332,74 +366,85 @@ interface PillSignals {
   readonly presenceDegraded: AgentActivityPresenceDegradedReason | null;
 }
 
-function highestSeverityIndicator(signals: PillSignals): SelectedIndicator {
-  const {
-    artifactIndicator,
-    chatBackupStatus,
-    terminalCatalogUnavailable,
-    commGraphFeedHealth,
-    presenceDegraded,
-  } = signals;
-  let selected: SelectedIndicator = {
-    source: "artifact",
-    indicator: artifactIndicator,
-  };
-  if (chatBackupStatus !== null) {
-    const chatIndicator = indicatorForChatBackup(chatBackupStatus);
-    if (
-      SEVERITY_RANK[chatIndicator.severity] >
-      SEVERITY_RANK[selected.indicator.severity]
-    ) {
-      selected = { source: "chat-backup", indicator: chatIndicator };
-    }
-  }
-  if (terminalCatalogUnavailable) {
-    const terminalIndicator = indicatorForTerminalCatalogUnavailable();
-    if (
-      SEVERITY_RANK[terminalIndicator.severity] >
-      SEVERITY_RANK[selected.indicator.severity]
-    ) {
-      selected = {
-        source: "terminal-catalog",
-        indicator: terminalIndicator,
-      };
-    }
-  }
-  if (commGraphFeedHealth !== null) {
-    const feedIndicator = indicatorForCommGraphFeed(commGraphFeedHealth);
-    if (
-      SEVERITY_RANK[feedIndicator.severity] >
-      SEVERITY_RANK[selected.indicator.severity]
-    ) {
-      selected = { source: "comm-graph", indicator: feedIndicator };
-    }
-  }
-  if (presenceDegraded !== null) {
-    const presenceIndicator = indicatorForPresenceDegraded(presenceDegraded);
-    if (
-      SEVERITY_RANK[presenceIndicator.severity] >
-      SEVERITY_RANK[selected.indicator.severity]
-    ) {
-      selected = { source: "agent-activity", indicator: presenceIndicator };
-    }
-  }
-  // Ties stay with the earlier source. Artifact/Yjs warnings can mean the
-  // newest bytes exist only in this renderer; chat backup, catalog health,
-  // graph-feed health and presence health remain secondary when an equally
-  // severe durability warning is active. The read-only ones are checked last:
-  // the graph feed costs the canvas new rows and presence costs only the
-  // freshness of a spinner, not the user's data.
-  return selected;
+interface PillCandidate {
+  readonly source: PillSource;
+  readonly indicator: PillIndicator;
 }
 
+function highestSeverityIndicator(signals: PillSignals): SelectedIndicator {
+  // Source order IS the tie-break order: ties stay with the earlier source.
+  // Artifact/Yjs warnings can mean the newest bytes exist only in this
+  // renderer; chat backup, catalog health, graph-feed health and presence
+  // health remain secondary when an equally severe durability warning is
+  // active. The read-only ones come last: the graph feed costs the canvas new
+  // rows and presence costs only the freshness of a spinner, not the user's
+  // data.
+  const artifact: PillCandidate = {
+    source: "artifact",
+    indicator: signals.artifactIndicator,
+  };
+  const secondary: PillCandidate[] = [];
+  if (signals.chatBackupStatus !== null) {
+    secondary.push({
+      source: "chat-backup",
+      indicator: indicatorForChatBackup(signals.chatBackupStatus),
+    });
+  }
+  if (signals.terminalCatalogUnavailable) {
+    secondary.push({
+      source: "terminal-catalog",
+      indicator: indicatorForTerminalCatalogUnavailable(),
+    });
+  }
+  if (signals.commGraphFeedHealth !== null) {
+    secondary.push({
+      source: "comm-graph",
+      indicator: indicatorForCommGraphFeed(signals.commGraphFeedHealth),
+    });
+  }
+  if (signals.presenceDegraded !== null) {
+    secondary.push({
+      source: "agent-activity",
+      indicator: indicatorForPresenceDegraded(signals.presenceDegraded),
+    });
+  }
+  let selected = artifact;
+  for (const candidate of secondary) {
+    if (
+      SEVERITY_RANK[candidate.indicator.severity] >
+      SEVERITY_RANK[selected.indicator.severity]
+    ) {
+      selected = candidate;
+    }
+  }
+  // One light, at most one label: the others are not dropped, they move to
+  // the hover and the accessible name (see `SelectedIndicator.alsoDegraded`).
+  // Only degraded planes ride along - a plane that is merely busy ("Saving
+  // changes", "Backing up chats") is not a second outage to report.
+  const alsoDegraded = [artifact, ...secondary]
+    .filter(
+      (candidate) =>
+        candidate !== selected &&
+        SEVERITY_RANK[candidate.indicator.severity] >= SEVERITY_RANK.warning,
+    )
+    .map((candidate) => candidate.indicator);
+  return { ...selected, alsoDegraded };
+}
+
+/**
+ * Dot-only, like chat backup and the graph feed: remote discovery dropping out
+ * is worth an amber light and a sentence on hover, not a permanent label in
+ * the status row - the terminals this host serves stay fully usable, and the
+ * coverage gap heals by itself.
+ */
 function indicatorForTerminalCatalogUnavailable(): PillIndicator {
   const message =
     "Remote terminal discovery is unavailable. Showing terminals from this host only. It will recover automatically.";
   return {
     severity: "warning",
-    containerClassName: AMBER_CONTAINER_CLASS,
+    containerClassName: QUIET_CONTAINER_CLASS,
     dotClassName: "bg-amber-500",
-    label: "Remote terminals unavailable",
+    label: null,
     showAgentSpinner: false,
     pulse: null,
     tooltip: message,

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -241,13 +241,15 @@ interface SelectedIndicator {
  */
 function tooltipFor(selected: SelectedIndicator): ReactNode {
   if (selected.alsoDegraded.length === 0) return selected.indicator.tooltip;
+  // A real list, winner first: one entry per degraded plane, in the order
+  // the accessible name reads them.
   return (
-    <div className="flex flex-col gap-1">
-      <p>{selected.indicator.tooltip ?? selected.indicator.ariaLabel}</p>
+    <ul className="flex flex-col gap-1">
+      <li>{selected.indicator.tooltip ?? selected.indicator.ariaLabel}</li>
       {selected.alsoDegraded.map((other) => (
-        <p key={other.ariaLabel}>{other.tooltip ?? other.ariaLabel}</p>
+        <li key={other.ariaLabel}>{other.tooltip ?? other.ariaLabel}</li>
       ))}
-    </div>
+    </ul>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-source-reconciliation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-source-reconciliation.test.tsx
@@ -332,7 +332,7 @@ describe("terminal sidebar source reconciliation", () => {
       durableTerminal(HOST_A, "shared"),
       durableTerminal(HOST_B, "shared"),
     ]);
-    const { getAllByTestId, queryByTestId } = render(
+    const { getAllByTestId } = render(
       wrapper(<TerminalsPanelBody epicId={EPIC_ID} tabId={TAB_ID} />),
     );
     const rows = getAllByTestId("epic-terminal-sidebar-item-shared");
@@ -340,7 +340,6 @@ describe("terminal sidebar source reconciliation", () => {
     expect(
       rows.map((row) => row.getAttribute("data-terminal-host-id")),
     ).toEqual([HOST_A, HOST_B]);
-    expect(queryByTestId("epic-terminal-sidebar-incomplete-fleet")).toBeNull();
   });
 
   it("keeps manager-owned listed rows and suppresses an ordinary stale shadow", () => {
@@ -417,18 +416,15 @@ describe("terminal sidebar source reconciliation", () => {
     view.rerender(
       wrapper(<TerminalsPanelBody epicId={EPIC_ID} tabId={TAB_ID} />),
     );
-    expect(
-      view.queryByTestId("epic-terminal-sidebar-incomplete-fleet"),
-    ).toBeNull();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(750);
     });
-    expect(
-      view.getByTestId("epic-terminal-sidebar-incomplete-fleet"),
-    ).not.toBeNull();
     expect(view.getByTestId("epic-terminal-sidebar-item-local")).not.toBeNull();
     expect(view.queryByTestId("epic-terminal-sidebar-item-remote")).toBeNull();
-    expect(view.getByText(/Showing this host only/)).not.toBeNull();
+    // The coverage gap is the status pill's to report, not the sidebar's:
+    // no caption row, the serving host's rows alone.
+    expect(view.queryByText(/Showing this host only/)).toBeNull();
+    expect(view.queryByText(/Remote terminal/)).toBeNull();
 
     durableCollection.value = completeFleet([
       durableTerminal(HOST_A, "local"),
@@ -438,27 +434,28 @@ describe("terminal sidebar source reconciliation", () => {
       wrapper(<TerminalsPanelBody epicId={EPIC_ID} tabId={TAB_ID} />),
     );
     expect(
-      view.queryByTestId("epic-terminal-sidebar-incomplete-fleet"),
-    ).toBeNull();
-    expect(
       view.getByTestId("epic-terminal-sidebar-item-remote-restored"),
     ).not.toBeNull();
     vi.useRealTimers();
   });
 
-  it("does not flash the incomplete-fleet notice when catalog hydration recovers within the grace", async () => {
+  it("holds the loading state rather than flashing the empty state while catalog hydration recovers within the grace", async () => {
+    // A partial fleet with no serving-host rows is, for the first 750ms, most
+    // likely a catalog still hydrating. Claiming "No terminals yet." in that
+    // window would be wrong the moment the remote rows arrive, so the body
+    // keeps loading until the grace elapses or coverage recovers.
     vi.useFakeTimers();
     durableCollection.value = partialFleet(HOST_A, []);
     const view = render(
       wrapper(<TerminalsPanelBody epicId={EPIC_ID} tabId={TAB_ID} />),
     );
-    expect(
-      view.queryByTestId("epic-terminal-sidebar-incomplete-fleet"),
-    ).toBeNull();
+    expect(view.queryByTestId("epic-terminal-sidebar-empty")).toBeNull();
+    expect(view.getByText("Loading terminals…")).not.toBeNull();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(500);
     });
+    expect(view.queryByTestId("epic-terminal-sidebar-empty")).toBeNull();
     durableCollection.value = completeFleet([
       durableTerminal(HOST_B, "remote-before-notice"),
     ]);
@@ -469,9 +466,7 @@ describe("terminal sidebar source reconciliation", () => {
       await vi.advanceTimersByTimeAsync(500);
     });
 
-    expect(
-      view.queryByTestId("epic-terminal-sidebar-incomplete-fleet"),
-    ).toBeNull();
+    expect(view.queryByTestId("epic-terminal-sidebar-empty")).toBeNull();
     expect(
       view.getByTestId("epic-terminal-sidebar-item-remote-before-notice"),
     ).not.toBeNull();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -289,7 +289,11 @@ function TerminalsPanelBodyLive(props: {
   );
   const sessions = reconciled.rows;
   const incompleteFleet = reconciled.incompleteFleet;
-  const showIncompleteFleet = useDelayedTerminalFleetWarning(
+  // The sidebar no longer captions partial fleet coverage - the epic status
+  // pill owns that signal (one amber light, the sentence on hover). The grace
+  // still matters here: until it elapses a catalog that is merely hydrating
+  // must not read as "No terminals yet.", so the loading state holds instead.
+  const fleetGapSettled = useDelayedTerminalFleetWarning(
     incompleteFleet,
     JSON.stringify([activeHostId, epicId]),
   );
@@ -344,7 +348,7 @@ function TerminalsPanelBodyLive(props: {
               failedCreates.length === 0 &&
               (durableAuthority.capability.status === "unknown" ||
                 (incompleteFleet &&
-                  !showIncompleteFleet &&
+                  !fleetGapSettled &&
                   sessions.length === 0) ||
                 (sessions.length === 0 &&
                   (list.isPending ||
@@ -360,7 +364,6 @@ function TerminalsPanelBodyLive(props: {
             isRetrying={list.isFetching}
             onRetry={retryList}
             sessions={sessions}
-            incompleteFleet={showIncompleteFleet}
             failedCreates={failedCreates}
             epicId={epicId}
             tabId={tabId}
@@ -421,7 +424,6 @@ interface TerminalSidebarBodyProps {
   readonly isRetrying: boolean;
   readonly onRetry: () => void;
   readonly sessions: ReadonlyArray<TerminalSidebarSessionRow>;
-  readonly incompleteFleet: boolean;
   readonly failedCreates: ReadonlyArray<EpicTerminalDurableCreateJobView>;
   readonly epicId: string;
   readonly tabId: string;
@@ -517,17 +519,6 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
     );
   }
   if (props.sessions.length === 0 && props.failedCreates.length === 0) {
-    if (props.incompleteFleet) {
-      return (
-        <div
-          className="px-2 py-1.5 text-ui-sm text-muted-foreground"
-          data-testid="epic-terminal-sidebar-incomplete-fleet"
-        >
-          Remote terminal coverage is unavailable. This host has no terminals to
-          show.
-        </div>
-      );
-    }
     return (
       <SidebarPanelEmptyState
         icon={TerminalIcon}
@@ -543,14 +534,6 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
       className="space-y-0.5"
       data-testid="epic-terminal-sidebar-list"
     >
-      {props.incompleteFleet ? (
-        <li
-          className="px-2 py-1.5 text-ui-sm text-muted-foreground"
-          data-testid="epic-terminal-sidebar-incomplete-fleet"
-        >
-          Remote terminals are unavailable. Showing this host only.
-        </li>
-      ) : null}
       {props.sessions.map((row) => (
         <TerminalRow
           key={epicTerminalUiIdentityKey(


### PR DESCRIPTION
## What

Partial remote-terminal coverage was narrated twice — a caption in the Terminals sidebar **and** a permanent amber label in the epic status pill. One rule now: the pill owns the signal; the row shows one light and at most one label; everything else is on hover.

| Surface | Before | After |
| --- | --- | --- |
| Terminals sidebar (list) | "Remote terminals are unavailable. Showing this host only." caption above the rows | No caption |
| Terminals sidebar (no rows) | "Remote terminal coverage is unavailable…" in place of the empty state | Ordinary empty state — after the 750ms grace; until then the **loading** state holds so a catalog that is merely hydrating never flashes "No terminals yet." |
| Pill, terminal-catalog plane | Amber container + label "Remote terminals unavailable" | Amber **dot only**, sentence on hover — same shape as chat backup and the comm-graph feed |
| Pill, several degraded planes | Only the winner's tooltip/aria; the rest invisible | Visible row unchanged (single winner, same tie-break). Hover lists the winner's sentence then one line per other degraded plane; aria-label and the live announcement carry all of them. Busy-but-healthy planes ("Saving changes", "Backing up chats") are not outages and are not listed |

## Not changed

- Presence-degraded indicators keep their labels (their copy names a user-facing consequence). One-line change each if they should go dot-only too.
- Severity ranking / tie-break order.

## Tests

`epic-connection-pill.test.tsx`: dot-only catalog case; a two-plane case pinning "one visible copy, both on hover"; a busy-plane-not-listed case; the two existing multi-signal cases now assert both hover lines. `terminal-sidebar-source-reconciliation.test.tsx`: no caption after the grace; loading held instead of the empty state during it. No protocol or host change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)