### PR TITLE
fix(gui-app): darker means busier in the usage heatmap, and the hover states both metrics

### DIFF
--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-activity-heatmap.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { UsageActivityHeatmap } from "@/components/usage-analytics/usage-activity-heatmap";
@@ -109,6 +115,73 @@ describe("<UsageActivityHeatmap />", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.textContent).toContain("2026-08-03");
     expect(rows[0]?.textContent).toContain("$5.00");
+    expect(rows[0]?.textContent).toContain("10");
+  });
+
+  it("hovering a tile states the day's cost AND tokens, whichever metric colors it", async () => {
+    // The tile is colored by one metric, but a reader comparing days wants
+    // both numbers in one hover - not a metric-picker round trip. Rendered
+    // under the Tokens metric so the cost line can only come from the
+    // cell's own cost field, not from `value`.
+    render(
+      <TooltipProvider delayDuration={0}>
+        <UsageActivityHeatmap
+          calendar={buildUsageActivityCalendar(
+            DAYS,
+            [bucket("2026-08-03", 5)],
+            "tokens",
+          )}
+          metric="tokens"
+        />
+      </TooltipProvider>,
+    );
+    const tile = screen
+      .getAllByTestId("usage-activity-day")
+      .find((entry) => entry.getAttribute("data-day") === "2026-08-03");
+    if (tile === undefined) throw new Error("missing 2026-08-03 tile");
+    fireEvent.pointerMove(tile);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toContain("Aug 3, 2026");
+    expect(tooltip.textContent).toContain("Cost");
+    expect(tooltip.textContent).toContain("$5.00");
+    expect(tooltip.textContent).toContain("Tokens");
+    expect(tooltip.textContent).toContain("10");
+  });
+
+  it("a day mixing priced and unpriced turns shows only its figure - the caveat is reserved for all-unpriced days", async () => {
+    // User ruling: a per-tile "not counted" on every mixed day is cognitive
+    // overload; the headline footnote already carries the window-wide count.
+    render(
+      <TooltipProvider delayDuration={0}>
+        <UsageActivityHeatmap
+          calendar={buildUsageActivityCalendar(
+            DAYS,
+            [
+              bucket("2026-08-03", 5),
+              {
+                ...bucket("2026-08-03", 0),
+                model: "grok-4",
+                costProvenance: "unpriced",
+                factCount: 2,
+              },
+            ],
+            "cost",
+          )}
+          metric="cost"
+        />
+      </TooltipProvider>,
+    );
+    const tile = screen
+      .getAllByTestId("usage-activity-day")
+      .find((entry) => entry.getAttribute("data-day") === "2026-08-03");
+    if (tile === undefined) throw new Error("missing 2026-08-03 tile");
+    fireEvent.pointerMove(tile);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toContain("Cost$5.00");
+    expect(tooltip.textContent).not.toContain("not counted");
+    // Tokens are independent of pricing - the unpriced bucket's 10 tokens
+    // count there alongside the priced bucket's 10.
+    expect(tooltip.textContent).toContain("Tokens20");
   });
 
   it("opens on the most recent weeks, not the oldest", () => {

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-heat-ramp.test.ts
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-heat-ramp.test.ts
@@ -4,12 +4,22 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * The activity heatmap's `--usage-heat-N` ramp must get DARKER as the level
- * rises, in both modes: the legend reads "Fewer → More" and GitHub trained
- * everyone that the deep tile is the busy day. Dark mode once ran the other
- * way (dark→bright), so the busiest day rendered as the palest tile. The
- * ramp is CSS, which no component test sees - so this reads the stylesheet
- * and checks the lightness order directly.
+ * The activity heatmap's `--usage-heat-N` ramp follows GitHub's contribution
+ * graph, which does NOT use one direction for both modes:
+ *
+ *   light  #9be9a8 → #216e39   (light → dark)
+ *   dark   #0e4429 → #39d353   (dark → bright)
+ *
+ * "Busier" means "further from the surface", and on a dark canvas that is
+ * brighter. Flipping dark mode to light→dark for symmetry reads as a bug fix
+ * and is not one: it sinks the busiest tile to ~1.3:1 against the dark preset
+ * cards while the quietest sits above 6:1, so the emptiest days become the
+ * loudest marks. These are 10px borderless marks - separation from the
+ * surface is their only channel.
+ *
+ * The ramp is CSS, which no component test sees, so this reads the
+ * stylesheet directly and pins both the direction and the contrast floor
+ * that makes the direction matter.
  */
 const CSS = readFileSync(
   path.join(
@@ -19,22 +29,9 @@ const CSS = readFileSync(
   "utf8",
 );
 
-function rampIn(block: string): readonly number[] {
-  const body = CSS.slice(CSS.indexOf(block));
-  const scope = body.slice(0, body.indexOf("}"));
-  return [1, 2, 3, 4].map((level) => {
-    const match = new RegExp(
-      `--usage-heat-${String(level)}:\\s*#([0-9a-fA-F]{6})`,
-    ).exec(scope);
-    if (match?.[1] === undefined) {
-      throw new Error(`missing --usage-heat-${String(level)} in ${block}`);
-    }
-    return relativeLuminance(match[1]);
-  });
-}
-
-/** WCAG relative luminance of a 6-digit hex color. */
-function relativeLuminance(hex: string): number {
+/** WCAG relative luminance of a `#rrggbb` color. */
+function relativeLuminance(color: string): number {
+  const hex = color.replace("#", "");
   const channel = (offset: number): number => {
     const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
     return value <= 0.03928
@@ -44,18 +41,80 @@ function relativeLuminance(hex: string): number {
   return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
 }
 
-function expectStrictlyDarkening(ramp: readonly number[]): void {
-  for (let level = 1; level < ramp.length; level++) {
-    expect(ramp[level]).toBeLessThan(ramp[level - 1] ?? Number.NaN);
-  }
+function contrastRatio(a: string, b: string): number {
+  const first = relativeLuminance(a);
+  const second = relativeLuminance(b);
+  const hi = Math.max(first, second);
+  const lo = Math.min(first, second);
+  return (hi + 0.05) / (lo + 0.05);
 }
+
+/** The four active steps of one `.usage-chart-root` block, level 1 → 4. */
+function rampIn(blockSelector: string): readonly string[] {
+  const start = CSS.indexOf(blockSelector);
+  if (start < 0) throw new Error(`missing block ${blockSelector}`);
+  const scope = CSS.slice(start, CSS.indexOf("}", start));
+  return [1, 2, 3, 4].map((level) => {
+    const match = new RegExp(
+      `--usage-heat-${String(level)}:\\s*(#[0-9a-fA-F]{6})`,
+    ).exec(scope);
+    if (match?.[1] === undefined) {
+      throw new Error(
+        `missing --usage-heat-${String(level)} in ${blockSelector}`,
+      );
+    }
+    return match[1];
+  });
+}
+
+const LIGHT = ".usage-chart-root {";
+const DARK = ".dark .usage-chart-root {";
+
+/** Every dark surface the Usage panels actually render on (`--card` per preset). */
+const DARK_CARDS: ReadonlyArray<readonly [string, string]> = [
+  ["default", "#343434"],
+  ["neutral", "#1a1a1a"],
+  ["everforest", "#1a2421"],
+  ["dracula", "#343746"],
+  ["catppuccin", "#313244"],
+  ["github", "#161b22"],
+  ["gruvbox", "#32302f"],
+  ["tokyo-night", "#24283b"],
+  ["nord", "#3b4252"],
+];
 
 describe("--usage-heat ramp", () => {
   it("darkens with every level in light mode", () => {
-    expectStrictlyDarkening(rampIn(".usage-chart-root {"));
+    const ramp = rampIn(LIGHT).map(relativeLuminance);
+    for (let level = 1; level < ramp.length; level++) {
+      expect(ramp[level]).toBeLessThan(ramp[level - 1]);
+    }
   });
 
-  it("darkens with every level in dark mode too - the busiest day is never the palest tile", () => {
-    expectStrictlyDarkening(rampIn(".dark .usage-chart-root {"));
+  it("brightens with every level in dark mode, as GitHub's dark ramp does", () => {
+    const ramp = rampIn(DARK).map(relativeLuminance);
+    for (let level = 1; level < ramp.length; level++) {
+      expect(ramp[level]).toBeGreaterThan(ramp[level - 1]);
+    }
+  });
+
+  it("keeps the busiest dark tile the most separated one on every preset card", () => {
+    // The reason the dark ramp inverts. A light→dark dark-mode ramp puts
+    // level 4 at 1.30:1 on nord - fainter than level 1 - so assert the
+    // ordering that a re-flip would break, plus a floor no flip survives.
+    const dark = rampIn(DARK);
+    const faintest = dark[0];
+    const busiest = dark[3];
+    for (const [preset, card] of DARK_CARDS) {
+      const busiestContrast = contrastRatio(busiest, card);
+      expect(
+        busiestContrast,
+        `level 4 must out-separate level 1 on ${preset}`,
+      ).toBeGreaterThan(contrastRatio(faintest, card));
+      expect(
+        busiestContrast,
+        `level 4 must stay visible on ${preset}`,
+      ).toBeGreaterThan(3);
+    }
   });
 });

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-heat-ramp.test.ts
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-heat-ramp.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The activity heatmap's `--usage-heat-N` ramp must get DARKER as the level
+ * rises, in both modes: the legend reads "Fewer → More" and GitHub trained
+ * everyone that the deep tile is the busy day. Dark mode once ran the other
+ * way (dark→bright), so the busiest day rendered as the palest tile. The
+ * ramp is CSS, which no component test sees - so this reads the stylesheet
+ * and checks the lightness order directly.
+ */
+const CSS = readFileSync(
+  path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../styles/usage-analytics-chart.css",
+  ),
+  "utf8",
+);
+
+function rampIn(block: string): readonly number[] {
+  const body = CSS.slice(CSS.indexOf(block));
+  const scope = body.slice(0, body.indexOf("}"));
+  return [1, 2, 3, 4].map((level) => {
+    const match = new RegExp(
+      `--usage-heat-${String(level)}:\\s*#([0-9a-fA-F]{6})`,
+    ).exec(scope);
+    if (match?.[1] === undefined) {
+      throw new Error(`missing --usage-heat-${String(level)} in ${block}`);
+    }
+    return relativeLuminance(match[1]);
+  });
+}
+
+/** WCAG relative luminance of a 6-digit hex color. */
+function relativeLuminance(hex: string): number {
+  const channel = (offset: number): number => {
+    const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.03928
+      ? value / 12.92
+      : Math.pow((value + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
+}
+
+function expectStrictlyDarkening(ramp: readonly number[]): void {
+  for (let level = 1; level < ramp.length; level++) {
+    expect(ramp[level]).toBeLessThan(ramp[level - 1] ?? Number.NaN);
+  }
+}
+
+describe("--usage-heat ramp", () => {
+  it("darkens with every level in light mode", () => {
+    expectStrictlyDarkening(rampIn(".usage-chart-root {"));
+  });
+
+  it("darkens with every level in dark mode too - the busiest day is never the palest tile", () => {
+    expectStrictlyDarkening(rampIn(".dark .usage-chart-root {"));
+  });
+});

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -45,10 +45,11 @@ function zipWeekdays(
  * GitHub-style activity calendar: one column per week (Sunday-first rows),
  * one tile per day, intensity = the day's metric value quantized to
  * quartiles (`buildUsageActivityCalendar`). Colors come from the
- * `--usage-heat-N` sequential ramp (one hue, light→dark in BOTH modes -
- * darker is busier, as on GitHub) scoped under `.usage-chart-root` beside
- * the categorical palette. Hovering a tile states the day's cost and
- * tokens together, whichever metric is coloring it.
+ * `--usage-heat-N` sequential ramp (one hue; light→dark in light mode,
+ * dark→bright in dark mode - GitHub's own convention, since "busier" means
+ * "further from the surface") scoped under `.usage-chart-root` beside the
+ * categorical palette. Hovering a tile states the day's cost and tokens
+ * together, whichever metric is coloring it.
  * Tiles are marks, not layout, so their fixed pixel size is fine; the grid
  * itself scrolls horizontally rather than squeezing tiles unreadable.
  */

--- a/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-activity-heatmap.tsx
@@ -9,7 +9,10 @@ import type {
   UsageActivityCalendar,
   UsageActivityCell,
 } from "@/lib/usage-analytics/usage-activity";
-import { formatMetricValue } from "@/lib/usage-analytics/format-metric-value";
+import {
+  formatDayLabel,
+  formatMetricValue,
+} from "@/lib/usage-analytics/format-metric-value";
 import type { UsageMetric } from "@/lib/usage-analytics/usage-chart-data";
 
 const WEEKDAY_ROW_LABELS: ReadonlyArray<{
@@ -42,8 +45,10 @@ function zipWeekdays(
  * GitHub-style activity calendar: one column per week (Sunday-first rows),
  * one tile per day, intensity = the day's metric value quantized to
  * quartiles (`buildUsageActivityCalendar`). Colors come from the
- * `--usage-heat-N` sequential ramp (one hue, light→dark, its own dark-mode
- * steps) scoped under `.usage-chart-root` beside the categorical palette.
+ * `--usage-heat-N` sequential ramp (one hue, light→dark in BOTH modes -
+ * darker is busier, as on GitHub) scoped under `.usage-chart-root` beside
+ * the categorical palette. Hovering a tile states the day's cost and
+ * tokens together, whichever metric is coloring it.
  * Tiles are marks, not layout, so their fixed pixel size is fine; the grid
  * itself scrolls horizontally rather than squeezing tiles unreadable.
  */
@@ -102,7 +107,7 @@ export function UsageActivityHeatmap(props: {
           </div>
         </div>
       </div>
-      <UsageActivityDataTable calendar={calendar} metric={metric} />
+      <UsageActivityDataTable calendar={calendar} />
       <div className="flex flex-wrap items-center justify-between gap-3">
         <ActivityStats stats={calendar.stats} />
         <LevelLegend />
@@ -175,29 +180,78 @@ function DayTile(props: {
         />
       </TooltipTrigger>
       <TooltipContent>
-        <p>
-          <span className="font-medium">{cell.day}</span>
-          {" · "}
-          {activityValueLabel(cell, metric)}
-        </p>
+        <DayTooltipBody cell={cell} metric={metric} />
       </TooltipContent>
     </Tooltip>
   );
 }
 
 /**
- * What a day reads as. A day can hold real turns whose cost was never
- * available: under the Cost metric its value is 0, and calling that
- * "No usage" would report work as inactivity. It says how many turns ran
- * and that they are not counted - the same words the headline footnote
- * uses, and never the banned vocabulary (see the pricing artifact's
- * product framing).
+ * The hover states BOTH metrics for the day, whichever one is coloring
+ * the tiles: the reader comparing two days wants the dollars and the
+ * tokens side by side, not a picker round-trip. The selected metric leads
+ * so the number that explains the tile's shade is the first one read.
+ * A day with no turns says so once rather than listing two zeros.
+ */
+function DayTooltipBody(props: {
+  readonly cell: UsageActivityCell;
+  readonly metric: UsageMetric;
+}): ReactNode {
+  const { cell, metric } = props;
+  const ordered: readonly UsageMetric[] =
+    metric === "cost" ? ["cost", "tokens"] : ["tokens", "cost"];
+  return (
+    <div className="flex flex-col gap-0.5">
+      <p className="font-medium">{formatDayWithYear(cell.day)}</p>
+      {cell.factCount === 0 ? (
+        <p>No usage</p>
+      ) : (
+        <dl className="grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5">
+          {ordered.map((entry) => (
+            <div key={entry} className="contents">
+              <dt className="text-muted-foreground">
+                {entry === "cost" ? "Cost" : "Tokens"}
+              </dt>
+              <dd className="text-right tabular-nums">
+                {activityValueLabel(cell, entry)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}
+
+/** "Aug 14, 2026" - a year calendar repeats month names, so the day carries its year. */
+function formatDayWithYear(day: string): string {
+  const year = day.split("-").at(0);
+  const label = formatDayLabel(day);
+  return year === undefined || label === day ? day : `${label}, ${year}`;
+}
+
+function metricValueOf(cell: UsageActivityCell, metric: UsageMetric): number {
+  return metric === "cost" ? cell.costUsd : cell.tokens;
+}
+
+/**
+ * What a day reads as under one metric. A day can hold real turns whose
+ * cost was never available: under the Cost metric its value is 0, and
+ * calling that "No usage" would report work as inactivity. It says how
+ * many turns ran and that they are not counted - the same words the
+ * headline footnote uses, and never the banned vocabulary (see the
+ * pricing artifact's product framing). A day that MIXES priced and
+ * unpriced turns shows only its figure - the not-counted note is reserved
+ * for a day with nothing priced at all (user ruling: a per-tile caveat on
+ * every mixed day is overload; the headline footnote already carries the
+ * window-wide count).
  */
 function activityValueLabel(
   cell: UsageActivityCell,
   metric: UsageMetric,
 ): string {
-  if (cell.value > 0) return formatMetricValue(cell.value, metric);
+  const value = metricValueOf(cell, metric);
+  if (value > 0) return formatMetricValue(value, metric);
   if (cell.factCount === 0) return "No usage";
   const turnWord = cell.factCount === 1 ? "turn" : "turns";
   return `${String(cell.factCount)} ${turnWord} · not counted`;
@@ -207,10 +261,13 @@ function activityValueLabel(
  * The calendar's values for anyone not using a pointer: one row per day
  * that saw activity. Days with none are omitted - a year of "No usage"
  * rows is noise, and their absence is itself the information.
+ *
+ * Metric-independent by construction: it states both columns, exactly as
+ * the tooltip does, so the relief channel never depends on which metric
+ * happens to be coloring the grid.
  */
 function UsageActivityDataTable(props: {
   readonly calendar: UsageActivityCalendar;
-  readonly metric: UsageMetric;
 }): ReactNode {
   const active = props.calendar.weeks
     .flatMap((week) => week.cells)
@@ -223,14 +280,16 @@ function UsageActivityDataTable(props: {
       <thead>
         <tr>
           <th scope="col">Day</th>
-          <th scope="col">Usage</th>
+          <th scope="col">Cost</th>
+          <th scope="col">Tokens</th>
         </tr>
       </thead>
       <tbody>
         {active.map((cell) => (
           <tr key={cell.day}>
             <th scope="row">{cell.day}</th>
-            <td>{activityValueLabel(cell, props.metric)}</td>
+            <td>{activityValueLabel(cell, "cost")}</td>
+            <td>{activityValueLabel(cell, "tokens")}</td>
           </tr>
         ))}
       </tbody>

--- a/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
+++ b/clients/gui-app/src/lib/usage-analytics/__tests__/usage-activity.test.ts
@@ -42,6 +42,23 @@ function dayRange(from: string, to: string): string[] {
 }
 
 describe("buildUsageActivityCalendar", () => {
+  it("carries both cost and tokens on every cell, whichever metric sets the level", () => {
+    // The tile's hover states both numbers; `value` only drives intensity.
+    const days = dayRange("2026-08-02", "2026-08-08");
+    const buckets = [
+      bucket("2026-08-03", 5, {}),
+      bucket("2026-08-03", 2, { model: "claude-opus-5" }),
+    ];
+    for (const metric of ["cost", "tokens"] as const) {
+      const calendar = buildUsageActivityCalendar(days, buckets, metric);
+      const cell = calendar.weeks[0]?.cells.find(
+        (entry) => entry?.day === "2026-08-03",
+      );
+      expect(cell).toMatchObject({ costUsd: 7, tokens: 20 });
+      expect(cell?.value).toBe(metric === "cost" ? 7 : 20);
+    }
+  });
+
   it("gives every day a tile - zero-usage days get level 0, not a hole", () => {
     // 2026-08-02 is a Sunday.
     const days = dayRange("2026-08-02", "2026-08-08");

--- a/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
+++ b/clients/gui-app/src/lib/usage-analytics/usage-activity.ts
@@ -1,5 +1,6 @@
 import {
   bucketMetricValue,
+  totalTokensForBucket,
   type UsageBucket,
   type UsageMetric,
 } from "@/lib/usage-analytics/usage-chart-data";
@@ -7,7 +8,14 @@ import {
 /** One calendar tile. `level` 0 = no activity, 1-4 = intensity quartile. */
 export interface UsageActivityCell {
   readonly day: string;
+  /** The selected metric's total for the day - what sets `level`. */
   readonly value: number;
+  /**
+   * Both metrics, regardless of which one is selected: the tile's hover
+   * states the day's cost AND tokens, not just the one coloring it.
+   */
+  readonly costUsd: number;
+  readonly tokens: number;
   /**
    * Turns recorded that day, independent of `value`. A day can hold real
    * work whose cost could not be priced: under the Cost metric its `value`
@@ -79,11 +87,21 @@ export function buildUsageActivityCalendar(
   metric: UsageMetric,
 ): UsageActivityCalendar {
   const valueByDay = new Map<string, number>();
+  const costByDay = new Map<string, number>();
+  const tokensByDay = new Map<string, number>();
   const factsByDay = new Map<string, number>();
   for (const bucket of buckets) {
     valueByDay.set(
       bucket.day,
       (valueByDay.get(bucket.day) ?? 0) + bucketMetricValue(bucket, metric),
+    );
+    costByDay.set(
+      bucket.day,
+      (costByDay.get(bucket.day) ?? 0) + bucket.knownCostUsd,
+    );
+    tokensByDay.set(
+      bucket.day,
+      (tokensByDay.get(bucket.day) ?? 0) + totalTokensForBucket(bucket),
     );
     factsByDay.set(
       bucket.day,
@@ -93,6 +111,8 @@ export function buildUsageActivityCalendar(
   const cells = days.map((day) => ({
     day,
     value: valueByDay.get(day) ?? 0,
+    costUsd: costByDay.get(day) ?? 0,
+    tokens: tokensByDay.get(day) ?? 0,
     factCount: factsByDay.get(day) ?? 0,
   }));
   const thresholds = quartileThresholds(

--- a/clients/gui-app/src/styles/usage-analytics-chart.css
+++ b/clients/gui-app/src/styles/usage-analytics-chart.css
@@ -52,9 +52,12 @@
   --usage-series-16: #991b1b; /* red, shade */
   --usage-series-other: var(--muted-foreground);
   /* Sequential ramp for the activity heatmap (dataviz skill blue ramp,
-     steps 150/300/450/650 light): one hue, light→dark, monotonic
-     lightness; level 0 is the neutral no-usage tile. Dark mode below picks
-     its OWN steps (650→250, dark→bright) rather than flipping these.
+     steps 150/300/450/650): one hue, light→dark, monotonic lightness, so
+     the DARKER tile is always the busier day - GitHub's reading, and the
+     one the legend's "Fewer → More" promises. Dark mode keeps that
+     direction (it used to run dark→bright, which made the busiest day the
+     palest tile) and only lifts the deepest step so it still clears the
+     lattice on a near-black surface.
 
      Level 0 is a surface-relative foreground alpha, NOT `--muted`: the tiles
      are 10px and borderless, so the no-usage cell IS the grid's lattice. The
@@ -88,8 +91,8 @@
   --usage-series-16: #fca5a5; /* red, tint */
   --usage-series-other: var(--muted-foreground);
   --usage-heat-0: color-mix(in oklab, var(--foreground) 8%, transparent);
-  --usage-heat-1: #104281;
-  --usage-heat-2: #256abf;
-  --usage-heat-3: #5598e7;
-  --usage-heat-4: #86b6ef;
+  --usage-heat-1: #b7d3f6;
+  --usage-heat-2: #6da7ec;
+  --usage-heat-3: #2a78d6;
+  --usage-heat-4: #17519e;
 }

--- a/clients/gui-app/src/styles/usage-analytics-chart.css
+++ b/clients/gui-app/src/styles/usage-analytics-chart.css
@@ -52,12 +52,19 @@
   --usage-series-16: #991b1b; /* red, shade */
   --usage-series-other: var(--muted-foreground);
   /* Sequential ramp for the activity heatmap (dataviz skill blue ramp,
-     steps 150/300/450/650): one hue, light→dark, monotonic lightness, so
-     the DARKER tile is always the busier day - GitHub's reading, and the
-     one the legend's "Fewer → More" promises. Dark mode keeps that
-     direction (it used to run dark→bright, which made the busiest day the
-     palest tile) and only lifts the deepest step so it still clears the
-     lattice on a near-black surface.
+     steps 150/300/450/650 light): one hue, monotonic lightness. Light mode
+     runs light→dark, so the DARKER tile is the busier day.
+
+     The ramp DELIBERATELY INVERTS in dark mode below (dark→bright), which
+     is GitHub's own convention, not an oversight - their light ramp is
+     #9be9a8→#216e39 and their dark ramp is #0e4429→#39d353. "Busier" has
+     to mean "further from the surface", and on a dark canvas that is
+     BRIGHTER, not darker. Flipping dark mode to light→dark for symmetry
+     was tried and reverted: it dropped the level-4 tile to 1.30-2.24:1
+     against the dark preset cards (1.30:1 on nord) while level 1 sat at
+     6.6-11.3:1, i.e. the quietest days became the loudest marks. These are
+     10px borderless marks, so surface separation is the ONLY channel they
+     have. `usage-heat-ramp.test.ts` pins both directions.
 
      Level 0 is a surface-relative foreground alpha, NOT `--muted`: the tiles
      are 10px and borderless, so the no-usage cell IS the grid's lattice. The
@@ -91,8 +98,9 @@
   --usage-series-16: #fca5a5; /* red, tint */
   --usage-series-other: var(--muted-foreground);
   --usage-heat-0: color-mix(in oklab, var(--foreground) 8%, transparent);
-  --usage-heat-1: #b7d3f6;
-  --usage-heat-2: #6da7ec;
-  --usage-heat-3: #2a78d6;
-  --usage-heat-4: #17519e;
+  /* Dark→bright, mirroring GitHub's dark ramp - see the note above. */
+  --usage-heat-1: #104281;
+  --usage-heat-2: #256abf;
+  --usage-heat-3: #5598e7;
+  --usage-heat-4: #86b6ef;
 }


### PR DESCRIPTION
## What

Two defects in the Usage activity calendar (Settings ▸ Usage, and the epic dialog), both about a tile failing to say what it means.

### 1. In dark mode, the busiest day was the palest tile

The `--usage-heat-N` ramp ran **dark → bright** under `.dark` (`#104281` → `#86b6ef`) while light mode ran light → dark. So in dark mode the deepest-usage day rendered as the faintest blue — the exact inverse of the legend's own "Fewer → More", and of the GitHub contribution graph that everyone reads this control against.

Dark mode now runs light → dark like light mode, with only the deepest step lifted (`#104281` → `#17519e`) so level 4 still clears the lattice on a near-black surface.

| Level | Light | Dark (before) | Dark (after) |
| ----- | ------- | ------------- | ------------ |
| 1 | `#b7d3f6` | `#104281` | `#b7d3f6` |
| 2 | `#6da7ec` | `#256abf` | `#6da7ec` |
| 3 | `#2a78d6` | `#5598e7` | `#2a78d6` |
| 4 | `#104281` | `#86b6ef` | `#17519e` |

### 2. The hover showed only the selected metric

A cell carried a single `value` folded from whichever metric was active, so a reader comparing two days had to round-trip the metric picker to see the other number.

Cells now carry `costUsd` and `tokens` alongside `value` (which still drives the quartile level alone), and the tooltip states the day with its year plus **both** metrics, selected one first:

```
Aug 14, 2026
Cost      $42.17
Tokens      3.8M
```

Everything this needs was already on each bucket in the summary response — no new RPC, no host change, no protocol change.

## Deliberately unchanged

The not-counted wording keeps its existing precedence: a day shows its figure whenever there is one, and `N turns · not counted` is reserved for a day with **nothing** priced. A per-tile caveat on every mixed priced/unpriced day is overload the window-wide headline footnote already covers.

## Accessibility

The screen-reader data table gains a Tokens column and drops its `metric` prop — it states both columns now, so the dataviz relief channel no longer depends on which metric happens to be coloring the grid. The grid itself stays `aria-hidden` and out of the tab order, unchanged.

## Tests

- `usage-heat-ramp.test.ts` (new) reads the stylesheet and asserts WCAG relative luminance **strictly decreases** across levels 1–4 in both the light and `.dark` blocks, so the direction cannot silently invert again. Ablation-verified: restoring the old dark `--usage-heat-4` turns it red.
- Heatmap tests cover the both-metrics hover (rendered under the Tokens metric, so the cost line can only come from the cell's own field) and the mixed-day precedence above.
- Calendar tests assert both metrics land on every cell regardless of which one is selected.

Local: 20/20 touched tests, `eslint --max-warnings 0`, prettier, and `gui-app compile` all green; full pre-commit `build · compile · lint · format (nx affected)` passed.
