### PR TITLE
fix(gui-app): keep the live-delivered exit reason so a reaped setup terminal is not reported as a crash

### DIFF
--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
@@ -9,6 +9,7 @@ import {
   createTerminalSessionStore,
   type TerminalWrite,
 } from "@/stores/terminals/terminal-session-store";
+import { isTerminalCrashExit } from "@/hooks/terminal/use-terminal-crash-notification";
 
 type TerminalSnapshotFrame = Extract<
   TerminalSubscribeServerFrame,
@@ -602,6 +603,74 @@ describe("createTerminalSessionStore", () => {
       exitCode: 0,
       activeProcessName: null,
     });
+  });
+
+  it("keeps a live-delivered reaped exit reason so the kill is not a crash", () => {
+    const harness = createHarness();
+
+    emitSnapshot(harness.callbacks(), snapshot(""));
+    // The host's setup-terminal reap kills a session its canvas tile is
+    // actively subscribed to: `handlePtyExit` broadcasts a `sessionUpdated`
+    // frame carrying the reason, then a reasonless `exit` frame. The store
+    // must keep the reason across both, or the tile reports the reap as
+    // "exited unexpectedly".
+    harness.callbacks().onSessionUpdated({
+      kind: "sessionUpdated",
+      hasBinaryPayload: false,
+      sessionId: "terminal-1",
+      session: {
+        ...terminalInfoWithSize(80, 24),
+        status: "exited",
+        exitCode: -1,
+        exitReason: "reaped",
+      },
+    });
+    harness.callbacks().onExit(exit(-1));
+
+    const state = harness.handle.store.getState();
+    expect(state).toMatchObject({
+      status: "exited",
+      exitCode: -1,
+      exitReason: "reaped",
+    });
+    expect(
+      isTerminalCrashExit({
+        status: state.status,
+        exitCode: state.exitCode,
+        exitReason: state.exitReason,
+        isExitSuppressed: () => false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not clobber a learned exit reason with a reason-less session update", () => {
+    const harness = createHarness();
+
+    emitSnapshot(harness.callbacks(), snapshot(""));
+    harness.callbacks().onSessionUpdated({
+      kind: "sessionUpdated",
+      hasBinaryPayload: false,
+      sessionId: "terminal-1",
+      session: {
+        ...terminalInfoWithSize(80, 24),
+        status: "exited",
+        exitCode: -1,
+        exitReason: "killed",
+      },
+    });
+    // e.g. from a host predating the field, or a frame built without it.
+    harness.callbacks().onSessionUpdated({
+      kind: "sessionUpdated",
+      hasBinaryPayload: false,
+      sessionId: "terminal-1",
+      session: {
+        ...terminalInfoWithSize(80, 24),
+        status: "exited",
+        exitCode: -1,
+      },
+    });
+
+    expect(harness.handle.store.getState().exitReason).toBe("killed");
   });
 
   describe("ack-credit (terminal.subscribe@1.1)", () => {

--- a/clients/gui-app/src/stores/terminals/terminal-session-store.ts
+++ b/clients/gui-app/src/stores/terminals/terminal-session-store.ts
@@ -638,11 +638,12 @@ export function createTerminalSessionStore(
       },
       onExit: (frame) => {
         if (disposed || frame.sessionId !== options.sessionId) return;
-        // A live exit frame carries no reason - it is only ever a genuine
-        // process exit or an explicit kill to an attached viewer (a reaped
-        // idle session has no viewer, so it is observed via the reattach
-        // snapshot's `session.exitReason` instead). Leave `exitReason`
-        // untouched here; the snapshot path is authoritative for it.
+        // A live exit frame carries no reason. It is NOT only ever a genuine
+        // process exit to an attached viewer: the host's setup-terminal reap
+        // kills sessions whose canvas tiles are live subscribers. The reason
+        // for such a kill arrives on the `sessionUpdated` frame the host
+        // broadcasts immediately before this exit frame (handled below), so
+        // leave `exitReason` untouched here rather than clearing it.
         set({
           status: "exited",
           exitCode: frame.exitCode,
@@ -664,6 +665,13 @@ export function createTerminalSessionStore(
         set({
           status: frame.session.status === "exited" ? "exited" : "running",
           exitCode: frame.session.exitCode,
+          // The one live carrier of the exit reason for an attached viewer.
+          // The host kills setup terminals whose tiles are subscribed (the
+          // reap keys on typed input, not viewers), and its `handlePtyExit`
+          // broadcasts this frame - reason included - before the reasonless
+          // `exit` frame. Dropping it here classified every reaped setup
+          // shell as a crash ("exited unexpectedly" notifications).
+          exitReason: frame.session.exitReason ?? get().exitReason,
           title: frame.session.title,
           activeProcessName: activeProcessNameFromSession(frame.session),
           currentCwd: currentCwd === undefined ? get().currentCwd : currentCwd,


### PR DESCRIPTION
## Problem

Since the host's setup-terminal reap landed (traycer-internal#5186), every reaped task-created setup shell produces a needs-attention notification:

> **Setup: … exited unexpectedly.**
> The terminal process ended with an error.

## Root cause

The reap keys on **typed input**, not viewer presence — deliberately, because the epic canvas auto-mounts a live `terminal.subscribe` tile for every terminal in an open epic. That means the kill now happens **with viewers attached**, which the old exit-reason plumbing never had to handle:

- The host's `handlePtyExit` keeps the exit *reason* off the live `exit` frame (frozen stream contract); the frame carries only the synthetic `exitCode: -1`.
- The reason **is** already on the wire, though: `handlePtyExit` broadcasts a `sessionUpdated` frame carrying the full session info — `exitReason: "reaped"` included (`canonicalTerminalSessionInfoSchema` has the field) — immediately **before** the exit frame.
- But the renderer store's `onSessionUpdated` handler never copied `exitReason` into state. So an attached tile saw `status: "exited", exitCode: -1, exitReason: null`, and `isTerminalCrashExit` — which already treats `"reaped"`/`"killed"` as benign lifecycle — classified the reap as a crash and emitted the notification.

## Fix

Copy `exitReason` from the `sessionUpdated` frame in the store (falling back to the already-learned value when a host predating the field omits it), and correct the `onExit` comment that claimed a reaped session can have no attached viewer. No protocol change: the field has always been on the frame schema.

## Tests

- `keeps a live-delivered reaped exit reason so the kill is not a crash` — replays the host's exact frame sequence (`sessionUpdated` with `exitReason: "reaped"` → reasonless `exit`) and asserts the store keeps the reason and `isTerminalCrashExit` returns false.
- `does not clobber a learned exit reason with a reason-less session update` — guards the fallback branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)