### PR TITLE
feat(gui-app): reach task history from the command palette's Tasks group

### DIFF
--- a/clients/gui-app/src/lib/commands/__tests__/epics.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/epics.source.test.tsx
@@ -74,6 +74,7 @@ interface HistoryItemOverrides {
   readonly pullRequestNumbers?: ReadonlyArray<string>;
   readonly worktreeBranches?: ReadonlyArray<string>;
   readonly linkedRepos?: ReadonlyArray<string>;
+  readonly worktreePaths?: ReadonlyArray<string>;
 }
 
 function historyItem(overrides: HistoryItemOverrides): HistoryItem {
@@ -91,7 +92,7 @@ function historyItem(overrides: HistoryItemOverrides): HistoryItem {
     chatHostIds: null,
     pullRequestNumbers: overrides.pullRequestNumbers ?? [],
     worktreeBranches: overrides.worktreeBranches ?? [],
-    worktreePaths: [],
+    worktreePaths: overrides.worktreePaths ?? [],
     ownership: "mine",
     permissionRole: null,
     isPinned: false,
@@ -236,6 +237,36 @@ describe("epicsSource", () => {
     expect(paletteFilter(value, "#5186", keywords)).toBeGreaterThan(0);
     expect(paletteFilter(value, "5186", keywords)).toBeGreaterThan(0);
     expect(paletteFilter(value, "clever-elk", keywords)).toBeGreaterThan(0);
+  });
+
+  it("keeps a row history matched only by its worktree path visible", () => {
+    // A Traycer worktree directory is not the branch name - it carries a hash
+    // suffix - so this query reaches the row through `worktreePaths` alone.
+    // Without that keyword the task is fetched by the local arm and then
+    // hidden by cmdk.
+    const row = historyItem({
+      epicId: "epic-path-row",
+      title: "Some unrelated title",
+      worktreeBranches: ["traycer/clever-elk"],
+      worktreePaths: [
+        "/Users/dev/.traycer/worktrees/traycer-clever-elk-7a9d867d6d1d",
+      ],
+    });
+    mockState.result = historyResult([row]);
+
+    const items = captureEpicsItems("7a9d867d6d1d");
+    const item = items.find(
+      (candidate) => candidate.id === "epic:epic-path-row",
+    );
+    expect(item).toBeDefined();
+    if (item === undefined) throw new Error("item missing");
+
+    expect(item.keywords).toContain(
+      "/Users/dev/.traycer/worktrees/traycer-clever-elk-7a9d867d6d1d",
+    );
+    expect(
+      paletteFilter(buildCmdkValue(item), "7a9d867d6d1d", [...item.keywords]),
+    ).toBeGreaterThan(0);
   });
 
   it("ablation: a row without the match keywords scores 0 against the same query", () => {

--- a/clients/gui-app/src/lib/commands/__tests__/epics.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/epics.source.test.tsx
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import {
+  buildCmdkValue,
+  paletteFilter,
+} from "@/components/command-palette/palette-cmdk-controller";
+import type { HistoryItem } from "@/components/home/data/home-page.data";
+import type {
+  HistoryFetchResult,
+  UseHistoryQueryParams,
+  UseHistoryQueryResult,
+} from "@/hooks/home/use-history-query";
+import {
+  epicsSource,
+  taskSearchQuery,
+} from "@/lib/commands/sources/epics.source";
+import { PaletteQueryProvider } from "@/lib/commands/palette-query-context";
+import type { CommandContext, CommandItem } from "@/lib/commands/types";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicViewTab } from "@/stores/epics/canvas/types";
+import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
+
+const mockState = vi.hoisted(() => {
+  return {
+    recordedParams: [] as Array<UseHistoryQueryParams>,
+    result: null as UseHistoryQueryResult | null,
+  };
+});
+
+vi.mock("@/hooks/home/use-history-query", () => ({
+  useHistoryQuery: (params: UseHistoryQueryParams): UseHistoryQueryResult => {
+    mockState.recordedParams.push(params);
+    const result = mockState.result;
+    if (result === null) {
+      throw new Error("mockState.result must be set before rendering");
+    }
+    return result;
+  },
+}));
+
+function historyResult(
+  items: ReadonlyArray<HistoryItem>,
+): UseHistoryQueryResult {
+  const data: HistoryFetchResult = {
+    items,
+    availableRepos: [],
+    availableWorkspaces: [],
+    totalCount: items.length,
+    facets: {
+      repos: [],
+      workspaces: [],
+      chatHosts: null,
+      ownershipScopes: [],
+    },
+    worktreesByEpicId: new Map<string, readonly WorktreeHostEntryV12[]>(),
+    chatHostFilterUnsupported: false,
+  };
+  return {
+    data,
+    isPending: false,
+    isFetching: false,
+    error: null,
+    hostId: "host-1",
+    refetch: () => Promise.resolve(),
+    fetchNextPage: () => undefined,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  };
+}
+
+interface HistoryItemOverrides {
+  readonly epicId: string;
+  readonly title?: string;
+  readonly pullRequestNumbers?: ReadonlyArray<string>;
+  readonly worktreeBranches?: ReadonlyArray<string>;
+  readonly linkedRepos?: ReadonlyArray<string>;
+}
+
+function historyItem(overrides: HistoryItemOverrides): HistoryItem {
+  return {
+    id: `row:${overrides.epicId}`,
+    epicId: overrides.epicId,
+    taskType: "epic",
+    title: overrides.title ?? "Untitled row",
+    initialUserPrompt: "",
+    updatedAtMs: 0,
+    updatedLabel: "",
+    updatedBucket: "today",
+    linkedRepos: overrides.linkedRepos ?? [],
+    linkedWorkspaces: [],
+    chatHostIds: null,
+    pullRequestNumbers: overrides.pullRequestNumbers ?? [],
+    worktreeBranches: overrides.worktreeBranches ?? [],
+    worktreePaths: [],
+    ownership: "mine",
+    permissionRole: null,
+    isPinned: false,
+  };
+}
+
+function ctx(): CommandContext {
+  return {
+    pathname: "/",
+    router: {
+      getPathname: () => "/",
+      navigateHome: () => undefined,
+      navigateSettings: () => undefined,
+      navigateToEpic: () => undefined,
+      navigateToEpicTab: () => undefined,
+      navigateToEpicList: () => undefined,
+      navigateSettingsSection: () => undefined,
+      navigateToTabIntent: () => undefined,
+      goBack: () => undefined,
+      goForward: () => undefined,
+      isHistoryNavAvailable: () => false,
+      canGoBack: () => false,
+      canGoForward: () => false,
+    },
+    activeTabId: null,
+    activeEpicId: null,
+    focusedComposerKind: null,
+    targetGroupId: null,
+  };
+}
+
+function captureEpicsItems(query: string): ReadonlyArray<CommandItem> {
+  let captured: ReadonlyArray<CommandItem> = [];
+  function Probe() {
+    captured = epicsSource.useItems(ctx());
+    return null;
+  }
+  render(
+    <PaletteQueryProvider value={query}>
+      <Probe />
+    </PaletteQueryProvider>,
+  );
+  return captured;
+}
+
+describe("taskSearchQuery", () => {
+  it("passes a plain digit query through unchanged", () => {
+    expect(taskSearchQuery("5186")).toBe("5186");
+  });
+
+  it("strips a leading Tasks scope prefix", () => {
+    expect(taskSearchQuery("#5186")).toBe("5186");
+  });
+
+  it("strips the Tasks scope prefix and one following space", () => {
+    expect(taskSearchQuery("# 5186")).toBe("5186");
+  });
+
+  it("hides the group for the Actions scope prefix", () => {
+    expect(taskSearchQuery(">foo")).toBe("");
+  });
+
+  it("hides the group for the Workspaces scope prefix", () => {
+    expect(taskSearchQuery("@ws")).toBe("");
+  });
+
+  it("trims a whitespace-only query to empty", () => {
+    expect(taskSearchQuery("  ")).toBe("");
+  });
+});
+
+describe("epicsSource", () => {
+  beforeEach(() => {
+    mockState.recordedParams.length = 0;
+    mockState.result = historyResult([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState({ tabsById: {}, openTabOrder: [] });
+  });
+
+  it("forwards a Tasks-scoped live query as relevance-sorted search text", () => {
+    captureEpicsItems("#5186");
+    const lastParams = mockState.recordedParams.at(-1);
+    expect(lastParams).toBeDefined();
+    expect(lastParams?.search.query).toBe("5186");
+    expect(lastParams?.search.sort).toBe("relevance");
+  });
+
+  it("falls back to the default recents search when the live query is empty", () => {
+    captureEpicsItems("");
+    const lastParams = mockState.recordedParams.at(-1);
+    expect(lastParams).toBeDefined();
+    expect(lastParams?.search.query).toBe("");
+    expect(lastParams?.search.sort).toBe("recent");
+  });
+
+  it("carries PR number / branch / repo match keywords on the emitted item", () => {
+    const row = historyItem({
+      epicId: "epic-pr-row",
+      title: "Some unrelated title",
+      pullRequestNumbers: ["5186", "#5186", "PR #5186"],
+      worktreeBranches: ["traycer/clever-elk"],
+      linkedRepos: ["traycerai/traycer-internal"],
+    });
+    mockState.result = historyResult([row]);
+
+    const items = captureEpicsItems("#5186");
+    const item = items.find((candidate) => candidate.id === "epic:epic-pr-row");
+    expect(item).toBeDefined();
+    if (item === undefined) throw new Error("item missing");
+
+    for (const keyword of [
+      "5186",
+      "#5186",
+      "PR #5186",
+      "traycer/clever-elk",
+      "traycerai/traycer-internal",
+    ]) {
+      expect(item.keywords).toContain(keyword);
+    }
+  });
+
+  it("keeps the PR/branch-matched item alive under the palette's cmdk filter", () => {
+    const row = historyItem({
+      epicId: "epic-pr-row",
+      title: "Some unrelated title",
+      pullRequestNumbers: ["5186", "#5186", "PR #5186"],
+      worktreeBranches: ["traycer/clever-elk"],
+      linkedRepos: ["traycerai/traycer-internal"],
+    });
+    mockState.result = historyResult([row]);
+
+    const items = captureEpicsItems("#5186");
+    const item = items.find((candidate) => candidate.id === "epic:epic-pr-row");
+    expect(item).toBeDefined();
+    if (item === undefined) throw new Error("item missing");
+
+    const value = buildCmdkValue(item);
+    const keywords = [...item.keywords];
+    expect(paletteFilter(value, "#5186", keywords)).toBeGreaterThan(0);
+    expect(paletteFilter(value, "5186", keywords)).toBeGreaterThan(0);
+    expect(paletteFilter(value, "clever-elk", keywords)).toBeGreaterThan(0);
+  });
+
+  it("ablation: a row without the match keywords scores 0 against the same query", () => {
+    const row = historyItem({
+      epicId: "epic-no-match",
+      title: "Nothing related to the query at all",
+    });
+    mockState.result = historyResult([row]);
+
+    const items = captureEpicsItems("#5186");
+    const item = items.find(
+      (candidate) => candidate.id === "epic:epic-no-match",
+    );
+    expect(item).toBeDefined();
+    if (item === undefined) throw new Error("item missing");
+
+    const value = buildCmdkValue(item);
+    const keywords = [...item.keywords];
+    expect(paletteFilter(value, "5186", keywords)).toBe(0);
+  });
+
+  it("open tab wins over its matching history row but inherits its match keywords", () => {
+    const tab: EpicViewTab = { tabId: "tab-1", epicId: "e1", name: "Tab name" };
+    useEpicCanvasStore.setState({
+      tabsById: { "tab-1": tab },
+      openTabOrder: ["tab-1"],
+    });
+    const row = historyItem({
+      epicId: "e1",
+      pullRequestNumbers: ["#5186", "5186", "PR #5186"],
+    });
+    mockState.result = historyResult([row]);
+
+    const items = captureEpicsItems("#5186");
+    const matches = items.filter((candidate) => candidate.id === "epic:e1");
+    expect(matches).toHaveLength(1);
+    const item = matches[0];
+    expect(item.description).toBe("Open");
+    expect(item.keywords).toContain("#5186");
+  });
+
+  it("an open tab with no matching history row still emits an Open item", () => {
+    const tab: EpicViewTab = { tabId: "tab-2", epicId: "e2", name: "Solo tab" };
+    useEpicCanvasStore.setState({
+      tabsById: { "tab-2": tab },
+      openTabOrder: ["tab-2"],
+    });
+    mockState.result = historyResult([]);
+
+    const items = captureEpicsItems("");
+    const item = items.find((candidate) => candidate.id === "epic:e2");
+    expect(item).toBeDefined();
+    if (item === undefined) throw new Error("item missing");
+    expect(item.description).toBe("Open");
+    expect(item.keywords).toEqual(["task", "epic", "open"]);
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/epics.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/epics.source.ts
@@ -1,9 +1,22 @@
 /**
  * React-aware source: open epic tabs (from
- * `useEpicCanvasStore.tabsById` / `openTabOrder`) + recent epics from the same
+ * `useEpicCanvasStore.tabsById` / `openTabOrder`) + epics from the same
  * TanStack Query that powers `/epics` (via `useHistoryQuery`). The
  * two lists dedupe by id with the open-tab copy winning so open
  * epics render with an `"Open"` pill without a second row.
+ *
+ * The palette's live query is forwarded to the history search (scope prefix
+ * stripped), so the rows are the SAME rows the History page would show for
+ * that text: the cloud title/repo match plus the local worktree arm that
+ * resolves branch names and PR numbers (`84`, `#84`, `PR #84`) to tasks and
+ * fetches them by id. With an empty query the source falls back to the
+ * default recents page, exactly as before.
+ *
+ * cmdk still runs its own filter over the pool, so every local-only match
+ * key the history search can hit (PR number forms, branch names, repo
+ * identifiers) is also carried on the row as a keyword - otherwise a task
+ * found BY its PR number would be fetched and then hidden, since neither its
+ * id nor its title contains the number.
  *
  * Rendered inside a single "Tasks" group, alphabetical by label.
  *
@@ -12,8 +25,15 @@
  */
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { DEFAULT_HISTORY_SEARCH } from "@/lib/history-search";
+import type { HistoryItem } from "@/components/home/data/home-page.data";
+import {
+  DEFAULT_HISTORY_SEARCH,
+  patchHistorySearch,
+  type HistorySearchState,
+} from "@/lib/history-search";
 import { displayTitle, epicDisplayTitle } from "@/lib/display-title";
+import { usePaletteLiveQuery } from "@/lib/commands/palette-query-context";
+import { parseScopePrefix } from "@/lib/commands/scopes";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useHistoryQuery } from "@/hooks/home/use-history-query";
 import type {
@@ -21,6 +41,18 @@ import type {
   CommandItem,
   ReactCommandSource,
 } from "@/lib/commands/types";
+
+/**
+ * The text to search task history for, derived from the raw palette query.
+ * A leading Tasks prefix (`#`) is stripped so `#84` searches for `84`; any
+ * OTHER scope prefix (`>`, `@`, `?`) hides this group entirely, so its text
+ * is not worth a cloud round-trip and the default recents are kept instead.
+ */
+export function taskSearchQuery(paletteQuery: string): string {
+  const parsed = parseScopePrefix(paletteQuery);
+  if (parsed === null) return paletteQuery.trim();
+  return parsed.scope === "epics" ? parsed.restQuery.trim() : "";
+}
 
 function useEpicsItems(_ctx: CommandContext): ReadonlyArray<CommandItem> {
   const openTabs = useEpicCanvasStore(
@@ -31,27 +63,40 @@ function useEpicsItems(_ctx: CommandContext): ReadonlyArray<CommandItem> {
       }),
     ),
   );
-  const history = useHistoryQuery({
-    search: DEFAULT_HISTORY_SEARCH,
-    nowMs: null,
-  });
+  const query = taskSearchQuery(usePaletteLiveQuery());
+  // `useHistoryQuery` owns the debounce; this only has to hand it the text.
+  const search = useMemo<HistorySearchState>(
+    () =>
+      query.length === 0
+        ? DEFAULT_HISTORY_SEARCH
+        : patchHistorySearch(DEFAULT_HISTORY_SEARCH, { query }),
+    [query],
+  );
+  const history = useHistoryQuery({ search, nowMs: null });
 
   const historyItems = history.data?.items;
 
   return useMemo<ReadonlyArray<CommandItem>>(() => {
-    const recentRows = historyItems ?? [];
+    const rows = historyItems ?? [];
+    const rowsByEpicId = new Map<string, HistoryItem>();
+    for (const row of rows) {
+      if (!rowsByEpicId.has(row.epicId)) rowsByEpicId.set(row.epicId, row);
+    }
     const seen = new Set<string>();
     const items: Array<CommandItem> = [];
 
     for (const tab of openTabs) {
+      if (seen.has(tab.epicId)) continue;
       seen.add(tab.epicId);
-      items.push(buildOpenItem(tab.epicId, tab.name));
+      items.push(
+        buildOpenItem(tab.epicId, tab.name, rowsByEpicId.get(tab.epicId)),
+      );
     }
 
-    for (const row of recentRows) {
+    for (const row of rows) {
       if (seen.has(row.epicId)) continue;
       seen.add(row.epicId);
-      items.push(buildRecentItem(row.epicId, row.title, row.initialUserPrompt));
+      items.push(buildRecentItem(row));
     }
 
     return items;
@@ -63,12 +108,33 @@ export const epicsSource: ReactCommandSource = {
   useItems: useEpicsItems,
 };
 
-function buildOpenItem(epicId: string, name: string): CommandItem {
+/**
+ * The search keys the history query can match a row on that are NOT part of
+ * the label. Mirrors `LOCAL_FUSE_OPTIONS` in `use-history-query.ts`.
+ */
+function historyMatchKeywords(row: HistoryItem): ReadonlyArray<string> {
+  return [
+    ...row.pullRequestNumbers,
+    ...row.worktreeBranches,
+    ...row.linkedRepos,
+  ];
+}
+
+function buildOpenItem(
+  epicId: string,
+  name: string,
+  row: HistoryItem | undefined,
+): CommandItem {
   return {
     id: `epic:${epicId}`,
     label: displayTitle(name, "epic"),
     description: "Open",
-    keywords: ["task", "epic", "open"],
+    keywords: [
+      "task",
+      "epic",
+      "open",
+      ...(row === undefined ? [] : historyMatchKeywords(row)),
+    ],
     group: "epics",
     scope: "epics",
     shortcut: null,
@@ -78,16 +144,16 @@ function buildOpenItem(epicId: string, name: string): CommandItem {
   };
 }
 
-function buildRecentItem(
-  epicId: string,
-  title: string,
-  initialUserPrompt: string,
-): CommandItem {
+function buildRecentItem(row: HistoryItem): CommandItem {
+  const { epicId } = row;
   return {
     id: `epic:${epicId}`,
-    label: epicDisplayTitle({ title, initialUserPrompt }),
+    label: epicDisplayTitle({
+      title: row.title,
+      initialUserPrompt: row.initialUserPrompt,
+    }),
     description: null,
-    keywords: ["task", "epic", "recent"],
+    keywords: ["task", "epic", "recent", ...historyMatchKeywords(row)],
     group: "epics",
     scope: "epics",
     shortcut: null,

--- a/clients/gui-app/src/lib/commands/sources/epics.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/epics.source.ts
@@ -110,13 +110,25 @@ export const epicsSource: ReactCommandSource = {
 
 /**
  * The search keys the history query can match a row on that are NOT part of
- * the label. Mirrors `LOCAL_FUSE_OPTIONS` in `use-history-query.ts`.
+ * the label. Mirrors `LOCAL_FUSE_OPTIONS` in `use-history-query.ts` - every
+ * key there except `title`, which is already the row's label.
+ *
+ * `worktreePaths` earns its place even though the local epic-id resolution
+ * deliberately matches paths NARROWLY (basename, or the full path only for a
+ * `/`-shaped query, so a common ancestor like the home directory cannot union
+ * unrelated tasks into an ordinary search). That narrowness governs which
+ * tasks ENTER the pool; this list only governs which pooled rows cmdk is
+ * allowed to show, and can never add a task history did not already match. A
+ * worktree directory name is not the branch name - a Traycer worktree carries
+ * a hash suffix - so a query that matched only by path would otherwise be
+ * fetched and then hidden.
  */
 function historyMatchKeywords(row: HistoryItem): ReadonlyArray<string> {
   return [
     ...row.pullRequestNumbers,
     ...row.worktreeBranches,
     ...row.linkedRepos,
+    ...row.worktreePaths,
   ];
 }
 


### PR DESCRIPTION
## What

The command palette's **Tasks** group now searches task history instead of filtering the default recents page. Typing a PR number in ⌘K finds the task that owns it.

## Why

`epicsSource` called `useHistoryQuery` with `DEFAULT_HISTORY_SEARCH`, so the typed query never reached it. The pool was always open tabs + the 20 most recent tasks, fuzzy-filtered client-side — a task whose *title* didn't contain the query was unreachable from the palette, even though the History page finds it. A PR number is the sharpest case: it is never in the title at all.

## How

- Forward the palette's live query (Tasks `#` prefix stripped) to the **same** `useHistoryQuery` the History page uses, so the pool is whatever History search would return for that text: the cloud title/repo match plus the local worktree arm that resolves branch names and PR numbers (`84`, `#84`, `PR #84`) to owning epics and fetches them by id. Empty query → default recents, unchanged. A query under another scope prefix (`>`, `@`, `?`) hides the group anyway, so it deliberately doesn't spend a round-trip.
- Carry the row's PR numbers, branch names and repo identifiers as cmdk **keywords**. cmdk filters the pool independently, scoring only `id + label + keywords` — so without them a task found *by* its PR number would be fetched and then hidden. Open-tab rows win the dedupe as before and inherit the keywords of the history row they shadow, so an already-open task stays findable by its PR number.

No new fetch path, no new index: the debounce, the cloud query, the worktree/PR arm and the Fuse re-rank all stay inside `useHistoryQuery`.

## Notes for review

- **Two filters in series** is the shape to keep in mind: History decides which rows are in the pool, cmdk decides which are visible. The keyword mirror exists solely to stop the second from discarding what the first matched; it mirrors the key list in `LOCAL_FUSE_OPTIONS`.
- **PR numbers are local facts** — they come from the host's worktree metadata (`worktree.listAllForHost` with `includeActivity: true`), not the cloud task index, so a PR number only matches tasks whose worktree exists on the serving host. Same limit the History page already has.
- Group order stays alphabetical (`bucketItems`); History's relevance order is not carried into the palette.

## Testing

New `src/lib/commands/__tests__/epics.source.test.tsx` (13 cases): query forwarding (`#5186` → `"5186"`, sort `relevance`; empty → `recent`), keyword carriage, open-tab-wins-and-inherits, and the `paletteFilter` behaviour itself — including the ablation that a row *without* those keywords scores `0` for the same query.

Also verified locally: `bun run compile`, `eslint --max-warnings 0`, `prettier --check` clean on the touched files.
