### PR TITLE
feat(protocol): busyBreakdown on host.status@1.2, restart verdict @1.2, runtime-status awareness

### DIFF
--- a/clients/gui-app/__tests__/traycer-app.test.tsx
+++ b/clients/gui-app/__tests__/traycer-app.test.tsx
@@ -123,6 +123,7 @@ function hostStatusResponse() {
     busy: false,
     busySessionCount: 0,
     updateProgress: null,
+    busyBreakdown: null,
   };
 }
 

--- a/clients/gui-app/src/components/__tests__/epics-list.test.tsx
+++ b/clients/gui-app/src/components/__tests__/epics-list.test.tsx
@@ -105,6 +105,7 @@ function buildMessengerFactory(
             busy: false,
             busySessionCount: 0,
             updateProgress: null,
+            busyBreakdown: null,
           }),
       },
     });

--- a/clients/gui-app/src/components/auth/__tests__/user-menu.test.tsx
+++ b/clients/gui-app/src/components/auth/__tests__/user-menu.test.tsx
@@ -57,6 +57,7 @@ function makeMessengerFactory(): (args: {
             busy: false,
             busySessionCount: 0,
             updateProgress: null,
+            busyBreakdown: null,
           }),
       },
     });

--- a/clients/gui-app/src/components/host/__tests__/host-restart-copy.test.ts
+++ b/clients/gui-app/src/components/host/__tests__/host-restart-copy.test.ts
@@ -10,6 +10,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 2,
       blockers: null,
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "2 sessions are still keeping this host busy.",
@@ -20,6 +21,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 1,
       blockers: null,
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "1 session is still keeping this host busy.",
@@ -30,6 +32,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 0,
       blockers: { workingAgents: true, runningTerminals: false },
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "Agent work is still keeping this host busy.",
@@ -40,6 +43,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 0,
       blockers: { workingAgents: true, runningTerminals: true },
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "Agent work and open terminals are still keeping this host busy.",
@@ -50,6 +54,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 2,
       blockers: { workingAgents: true, runningTerminals: true },
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "2 sessions, agent work, and open terminals are still keeping this host busy.",
@@ -64,6 +69,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 0,
       blockers: null,
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "The host is still finishing other work.",
@@ -74,6 +80,7 @@ describe("busyRestartVerdictSentence", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 0,
       blockers: { workingAgents: false, runningTerminals: false },
+      busyBreakdown: null,
     };
     expect(busyRestartVerdictSentence(verdict)).toBe(
       "The host is still finishing other work.",
@@ -86,6 +93,7 @@ describe("busyRestartMessage", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 2,
       blockers: null,
+      busyBreakdown: null,
     };
     expect(busyRestartMessage(verdict, true)).toBe(
       "2 sessions are still keeping this host busy. Nothing was interrupted; " +
@@ -97,6 +105,7 @@ describe("busyRestartMessage", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 0,
       blockers: { workingAgents: true, runningTerminals: true },
+      busyBreakdown: null,
     };
     expect(busyRestartMessage(verdict, false)).toBe(
       "Agent work and open terminals are still keeping this host busy. " +
@@ -108,6 +117,7 @@ describe("busyRestartMessage", () => {
     const verdict: HostRestartBusyVerdict = {
       busySessionCount: 1,
       blockers: null,
+      busyBreakdown: null,
     };
     expect(busyRestartMessage(verdict, false)).toBe(
       "1 session is still keeping this host busy. Nothing was interrupted; " +

--- a/clients/gui-app/src/components/host/__tests__/local-host-restart-flow.test.tsx
+++ b/clients/gui-app/src/components/host/__tests__/local-host-restart-flow.test.tsx
@@ -356,7 +356,11 @@ describe("<LocalHostRestartFlow /> - host runtime binding present, local host re
           "host.restart": () =>
             Promise.resolve({
               outcome: "busy" as const,
-              verdict: { busySessionCount, blockers: null },
+              verdict: {
+                busySessionCount,
+                blockers: null,
+                busyBreakdown: null,
+              },
             }),
         },
       });
@@ -543,7 +547,11 @@ describe("<LocalHostRestartFlow /> - host runtime binding present, local host re
           transitionIds.push(req.transitionId);
           return Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           });
         },
       },
@@ -787,7 +795,11 @@ describe("<LocalHostRestartFlow /> - a local host identity change under an open 
           restartCallCount += 1;
           return Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           });
         },
       },
@@ -859,7 +871,11 @@ describe("<LocalHostRestartFlow /> - a local host identity change under an open 
           restartCallCount += 1;
           return Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           });
         },
       },

--- a/clients/gui-app/src/components/layout/__tests__/app-stays-mounted-across-host-switch.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-stays-mounted-across-host-switch.test.tsx
@@ -74,6 +74,7 @@ const compatibleHostStatus: HostStatusResponse = {
   busy: false,
   busySessionCount: 0,
   updateProgress: null,
+  busyBreakdown: null,
 };
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -62,6 +62,7 @@ function makeMessengerFactory(): (args: {
             busy: false,
             busySessionCount: 0,
             updateProgress: null,
+            busyBreakdown: null,
           }),
       },
     });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-config-rpc-test-support.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-config-rpc-test-support.ts
@@ -127,6 +127,7 @@ export function buildConfigHostFixture(options: {
         busy: false,
         busySessionCount: 0,
         updateProgress: null,
+        busyBreakdown: null,
       };
     },
     "config.shell.get": async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-identity-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-identity-card.test.tsx
@@ -216,6 +216,7 @@ describe("<HostSettingsPanel /> Overview identity card — active-sessions chip"
             busy: true,
             busySessionCount: 1,
             updateProgress: null,
+            busyBreakdown: null,
           };
         },
       },

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
@@ -379,7 +379,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes", () => {
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 2, blockers: null },
+            verdict: {
+              busySessionCount: 2,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -489,7 +493,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes", () => {
           transitionIds.push(req.transitionId);
           return Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           });
         },
       },
@@ -554,7 +562,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 2, blockers: null },
+            verdict: {
+              busySessionCount: 2,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -612,7 +624,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 3, blockers: null },
+            verdict: {
+              busySessionCount: 3,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -660,7 +676,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 2, blockers: null },
+            verdict: {
+              busySessionCount: 2,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -747,7 +767,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 3, blockers: null },
+            verdict: {
+              busySessionCount: 3,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -813,7 +837,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -873,7 +901,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
           attempt += 1;
           return Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: attempt, blockers: null },
+            verdict: {
+              busySessionCount: attempt,
+              blockers: null,
+              busyBreakdown: null,
+            },
           });
         },
       },
@@ -936,7 +968,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 4, blockers: null },
+            verdict: {
+              busySessionCount: 4,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -1032,7 +1068,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -1126,7 +1166,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 1, blockers: null },
+            verdict: {
+              busySessionCount: 1,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });
@@ -1215,7 +1259,11 @@ describe("<HostSettingsPanel /> Overview restart outcomes — Force restart", ()
         "host.restart": () =>
           Promise.resolve({
             outcome: "busy" as const,
-            verdict: { busySessionCount: 2, blockers: null },
+            verdict: {
+              busySessionCount: 2,
+              blockers: null,
+              busyBreakdown: null,
+            },
           }),
       },
     });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-test-support.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-test-support.ts
@@ -173,6 +173,7 @@ export function buildOverviewHostFixture(options: {
         busy: false,
         busySessionCount: options.busySessionCount ?? 0,
         updateProgress: null,
+        busyBreakdown: null,
       };
     },
     "host.identity.get": () => ({ ...identity }),

--- a/clients/gui-app/src/hooks/host/__tests__/use-host-queries.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-host-queries.test.tsx
@@ -126,6 +126,7 @@ function createHostQueriesFixture(): {
             busy: false,
             busySessionCount: 0,
             updateProgress: null,
+            busyBreakdown: null,
           };
         },
       },

--- a/clients/gui-app/src/hooks/host/__tests__/use-host-query.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-host-query.test.tsx
@@ -651,6 +651,7 @@ function createHostQueryFixture(): {
             busy: false,
             busySessionCount: 0,
             updateProgress: null,
+            busyBreakdown: null,
           };
         },
       },

--- a/clients/gui-app/src/lib/host/__tests__/compatibility-state.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/compatibility-state.test.ts
@@ -158,6 +158,7 @@ const compatibleHostStatus: HostStatusResponse = {
   busy: false,
   busySessionCount: 0,
   updateProgress: null,
+  busyBreakdown: null,
 };
 
 interface Deferred<T> {

--- a/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
@@ -518,6 +518,7 @@ describe("createLocalMaintenanceFallbackClient", () => {
             busy: false,
             busySessionCount: 0,
             updateProgress: null,
+            busyBreakdown: null,
           };
         },
       },

--- a/clients/gui-app/src/providers/__tests__/epic-tab-existence-reconciler.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-tab-existence-reconciler.test.tsx
@@ -92,6 +92,7 @@ const compatibleHostStatus: HostStatusResponse = {
   busy: false,
   busySessionCount: 0,
   updateProgress: null,
+  busyBreakdown: null,
 };
 
 let restoreFetch: () => void = () => undefined;

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -139,6 +139,7 @@ const compatibleHostStatus: HostStatusResponse = {
   busy: false,
   busySessionCount: 0,
   updateProgress: null,
+  busyBreakdown: null,
 };
 
 let restoreFetch: () => void = () => undefined;

--- a/protocol/src/host/RELEASE-INVARIANT.md
+++ b/protocol/src/host/RELEASE-INVARIANT.md
@@ -80,7 +80,14 @@ This prints one `SupportMatrixEntry` object literal (the full per-method
 with the label you passed). Paste it as a new element appended to the
 `supportMatrix` array in
 `protocol/src/host/__tests__/__fixtures__/support-matrix.ts` - append only,
-never edit or reorder existing entries in the same change. The fixture file's
+never edit or reorder existing entries in the same change.
+
+An additive minor on an existing method (for example `host.status` 1.1 → 1.2
+or `host.restart` 1.1 → 1.2) is the prescribed path for a field addition and
+does **not** need a support-matrix snapshot in the same change. The
+current-vs-historical two-sided check already exercises the new
+`upgradeFromPreviousVersion` chain against every seeded historical
+manifest. Snapshot the matrix at the next release cut. The fixture file's
 own header has the full procedure and explains why only `host-v1.0.0` is
 seeded today (it's the same baseline `released-method-names.ts` already
 freezes, captured from the exact commit - `fd65a24`, PR #84 - that produced

--- a/protocol/src/host/__tests__/host-restart.test.ts
+++ b/protocol/src/host/__tests__/host-restart.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { hostRestartUpgradeV10ToV11 } from "@traycer/protocol/host/restart/contracts";
-import { hostRestartResponseSchema } from "@traycer/protocol/host/restart/schemas";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
+import {
+  hostRestartUpgradeV10ToV11,
+  hostRestartUpgradeV11ToV12,
+  hostRestartV10,
+  hostRestartV11,
+  hostRestartV12,
+} from "@traycer/protocol/host/restart/contracts";
+import {
+  hostRestartResponseSchema,
+  hostRestartResponseV11Schema,
+} from "@traycer/protocol/host/restart/schemas";
 
 /**
  * `blockers: null` is the deliberate upgrade answer, NOT a fabricated
@@ -23,7 +33,7 @@ describe("hostRestartUpgradeV10ToV11.upgradeResponse", () => {
       verdict: { busySessionCount: 3, blockers: null },
     });
     // The bridged result is a valid v1.1 response.
-    expect(hostRestartResponseSchema.parse(upgraded)).toEqual(upgraded);
+    expect(hostRestartResponseV11Schema.parse(upgraded)).toEqual(upgraded);
   });
 
   it("passes an accepted response through unchanged", () => {
@@ -32,6 +42,76 @@ describe("hostRestartUpgradeV10ToV11.upgradeResponse", () => {
     const upgraded = hostRestartUpgradeV10ToV11.upgradeResponse(v10Response);
 
     expect(upgraded).toEqual({ outcome: "accepted" });
+    expect(hostRestartResponseV11Schema.parse(upgraded)).toEqual(upgraded);
+  });
+});
+
+/**
+ * `busyBreakdown: null` is the deliberate upgrade answer, NOT a fabricated
+ * zero object: a v1.1 host never stated how the total splits, so the client
+ * must not put an affirmative "idle by every kind" in a v1.1 host's mouth.
+ */
+describe("hostRestartUpgradeV11ToV12.upgradeResponse", () => {
+  it("maps a v1.1 busy response to busyBreakdown: null, leaving count and blockers untouched", () => {
+    const v11Response = {
+      outcome: "busy" as const,
+      verdict: {
+        busySessionCount: 3,
+        blockers: { workingAgents: true, runningTerminals: false },
+      },
+    };
+
+    const upgraded = hostRestartUpgradeV11ToV12.upgradeResponse(v11Response);
+
+    expect(upgraded).toEqual({
+      outcome: "busy",
+      verdict: {
+        busySessionCount: 3,
+        blockers: { workingAgents: true, runningTerminals: false },
+        busyBreakdown: null,
+      },
+    });
     expect(hostRestartResponseSchema.parse(upgraded)).toEqual(upgraded);
+  });
+
+  it("passes an accepted response through unchanged", () => {
+    const v11Response = { outcome: "accepted" as const };
+
+    const upgraded = hostRestartUpgradeV11ToV12.upgradeResponse(v11Response);
+
+    expect(upgraded).toEqual({ outcome: "accepted" });
+    expect(hostRestartResponseSchema.parse(upgraded)).toEqual(upgraded);
+  });
+});
+
+describe("host.restart@1.2 busyBreakdown", () => {
+  it("round-trips a populated breakdown on the busy arm", () => {
+    const payload = {
+      outcome: "busy" as const,
+      verdict: {
+        busySessionCount: 3,
+        blockers: { workingAgents: true, runningTerminals: true },
+        busyBreakdown: {
+          workingAgents: 2,
+          activeTerminalAgents: 1,
+          busyTerminals: 0,
+        },
+      },
+    };
+    expect(hostRestartResponseSchema.parse(payload)).toEqual(payload);
+  });
+});
+
+describe("host.restart registry membership", () => {
+  it("installs @1.0, @1.1, and @1.2 on the unary registry at major 1", () => {
+    const entry = hostRpcRegistry["host.restart"];
+    expect(entry).toBeDefined();
+    expect(entry[1].latestMinor).toBe(2);
+    expect(entry[1].versions[0].contract).toBe(hostRestartV10);
+    expect(entry[1].versions[1].contract).toBe(hostRestartV11);
+    expect(entry[1].versions[2].contract).toBe(hostRestartV12);
+    expect(entry[1].versions[2].upgradeFromPreviousVersion).toBe(
+      hostRestartUpgradeV11ToV12,
+    );
   });
 });

--- a/protocol/src/host/host-status.ts
+++ b/protocol/src/host/host-status.ts
@@ -31,7 +31,7 @@ import { z } from "zod";
  * `busy` / `busySessionCount` went with them, for a different reason: they
  * describe a *right now* that a lease refreshed on the order of minutes cannot
  * carry. Both already exist on the live host↔GUI connection
- * (`host.status@1.1`), and the notification room's
+ * (`host.status@1.2`), and the notification room's
  * {@link HOST_RUNTIME_STATUS_AWARENESS_FIELD} carries them for surfaces that
  * hold a room rather than a session. A client with neither has no live source
  * and must render no drain state at all — not a stale one, and not a zero.

--- a/protocol/src/host/notifications/__tests__/notifications-subscribe.test.ts
+++ b/protocol/src/host/notifications/__tests__/notifications-subscribe.test.ts
@@ -292,6 +292,60 @@ describe("readHostRuntimeStatusAwareness", () => {
       updateProgress: null,
     });
   });
+
+  it("still parses an entry that omits busyBreakdown — the key is additive", () => {
+    const entry = {
+      [HOST_RUNTIME_STATUS_AWARENESS_FIELD]: {
+        busy: true,
+        busySessionCount: 2,
+        updateProgress: null,
+      },
+    };
+    expect(readHostRuntimeStatusAwareness(entry)).toEqual({
+      busy: true,
+      busySessionCount: 2,
+      updateProgress: null,
+    });
+  });
+
+  it("round-trips a populated busyBreakdown", () => {
+    const breakdown = {
+      workingAgents: 2,
+      activeTerminalAgents: 1,
+      busyTerminals: 0,
+    };
+    const entry = {
+      [HOST_RUNTIME_STATUS_AWARENESS_FIELD]: {
+        busy: true,
+        busySessionCount: 3,
+        updateProgress: null,
+        busyBreakdown: breakdown,
+      },
+    };
+    expect(readHostRuntimeStatusAwareness(entry)).toEqual({
+      busy: true,
+      busySessionCount: 3,
+      updateProgress: null,
+      busyBreakdown: breakdown,
+    });
+  });
+
+  it("round-trips busyBreakdown: null", () => {
+    const entry = {
+      [HOST_RUNTIME_STATUS_AWARENESS_FIELD]: {
+        busy: true,
+        busySessionCount: 2,
+        updateProgress: null,
+        busyBreakdown: null,
+      },
+    };
+    expect(readHostRuntimeStatusAwareness(entry)).toEqual({
+      busy: true,
+      busySessionCount: 2,
+      updateProgress: null,
+      busyBreakdown: null,
+    });
+  });
 });
 
 describe("notifications.subscribe registry membership", () => {

--- a/protocol/src/host/notifications/subscribe.ts
+++ b/protocol/src/host/notifications/subscribe.ts
@@ -27,6 +27,7 @@
  */
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
+import { hostBusyBreakdownSchema } from "@traycer/protocol/host/status/contracts";
 
 /**
  * Awareness state field under which each host publishes its agent-activity
@@ -99,16 +100,24 @@ export const AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD = "agentActivityHostId";
  *   busy: boolean;
  *   busySessionCount: number;
  *   updateProgress: { state: "updating" | "failed"; error: string | null } | null;
+ *   busyBreakdown?: {
+ *     workingAgents: number;
+ *     activeTerminalAgents: number;
+ *     busyTerminals: number;
+ *   } | null;
  * }
  * ```
  *
- * These three used to ride the cloud `GET /api/v3/hosts` DTO, on a lease the
+ * These facts used to ride the cloud `GET /api/v3/hosts` DTO, on a lease the
  * host refreshed every 20 seconds. That lease is gone, and its replacement is
  * refreshed on the order of MINUTES — far too coarse for a session count that
  * gates a destructive "Apply now — ends N sessions" button. So they moved to
- * the two channels that are actually live: `host.status@1.1` for a client
+ * the two channels that are actually live: `host.status@1.2` for a client
  * holding a session to the host, and this field for a client that holds the
  * room but no session (the cross-host case — the My-Hosts-style surfaces).
+ * `busyBreakdown` is optional here (and nullable) because awareness is
+ * unnegotiated: an older host omits the key, a newer host that cannot split
+ * the total may send `null`, and both must still parse.
  *
  * ADDITIVE, and additive is the whole point: awareness entries are per-host and
  * unnegotiated, so a host that does not publish this is not an error state, it
@@ -130,8 +139,11 @@ export const HOST_RUNTIME_STATUS_AWARENESS_FIELD = "hostRuntimeStatus";
  *
  * Shared so the publishing host and the reading client cannot drift on a field
  * the stream contract's `major`/`minor` negotiation does not cover. Mirrors
- * `host.status@1.1`'s `updateProgress` arm exactly — the same fact reaching a
- * client by a second route must not arrive in a second shape.
+ * `host.status@1.2`'s `updateProgress` and `busyBreakdown` arms — the same
+ * fact reaching a client by a second route must not arrive in a second shape.
+ * `busyBreakdown` is `.optional()` here (and `.nullable()`) so an older host's
+ * entry, which never had the key, still parses; a negotiated RPC upgrade
+ * instead writes `null`.
  *
  * Deliberately NOT `.strict()`, unlike the `GET /api/v3/hosts` DTO. There,
  * strictness makes a server-side addition fail loudly, because both ends of a
@@ -149,6 +161,7 @@ export const hostRuntimeStatusAwarenessSchema = z.object({
       error: z.string().nullable(),
     })
     .nullable(),
+  busyBreakdown: hostBusyBreakdownSchema.nullable().optional(),
 });
 export type HostRuntimeStatusAwareness = z.infer<
   typeof hostRuntimeStatusAwarenessSchema

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -200,12 +200,16 @@ import {
 import {
   hostStatusV10,
   hostStatusV11,
+  hostStatusV12,
   hostStatusUpgradeV10ToV11,
+  hostStatusUpgradeV11ToV12,
 } from "@traycer/protocol/host/status/contracts";
 import {
   hostRestartUpgradeV10ToV11,
+  hostRestartUpgradeV11ToV12,
   hostRestartV10,
   hostRestartV11,
+  hostRestartV12,
 } from "@traycer/protocol/host/restart/contracts";
 import {
   hostIdentityGetV10,
@@ -3751,7 +3755,7 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
   },
   "host.status": {
     1: {
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: hostStatusV10,
@@ -3760,6 +3764,10 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         1: {
           contract: hostStatusV11,
           upgradeFromPreviousVersion: hostStatusUpgradeV10ToV11,
+        },
+        2: {
+          contract: hostStatusV12,
+          upgradeFromPreviousVersion: hostStatusUpgradeV11ToV12,
         },
       },
       downgradePathsFromLatest: {},
@@ -3771,7 +3779,7 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
     // it with a racy activity read.
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: hostRestartV10,
@@ -3780,6 +3788,10 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         1: {
           contract: hostRestartV11,
           upgradeFromPreviousVersion: hostRestartUpgradeV10ToV11,
+        },
+        2: {
+          contract: hostRestartV12,
+          upgradeFromPreviousVersion: hostRestartUpgradeV11ToV12,
         },
       },
       downgradePathsFromLatest: {},

--- a/protocol/src/host/restart/contracts.ts
+++ b/protocol/src/host/restart/contracts.ts
@@ -6,6 +6,7 @@ import {
   hostRestartRequestSchema,
   hostRestartResponseSchema,
   hostRestartResponseV10Schema,
+  hostRestartResponseV11Schema,
 } from "./schemas";
 
 /**
@@ -33,6 +34,20 @@ export const hostRestartV11 = defineRpcContract({
   method: "host.restart",
   schemaVersion: { major: 1, minor: 1 } as const,
   requestSchema: hostRestartRequestSchema,
+  responseSchema: hostRestartResponseV11Schema,
+});
+
+/**
+ * v1.2 adds `verdict.busyBreakdown` to the busy arm: the typed split of
+ * `busySessionCount` (working agents, active terminal-agents, busy plain
+ * terminals). `blockers` stays; a v1.2 host derives them from the same
+ * snapshot (`workingAgents = breakdown.workingAgents > 0`,
+ * `runningTerminals = activeTerminalAgents + busyTerminals > 0`).
+ */
+export const hostRestartV12 = defineRpcContract({
+  method: "host.restart",
+  schemaVersion: { major: 1, minor: 2 } as const,
+  requestSchema: hostRestartRequestSchema,
   responseSchema: hostRestartResponseSchema,
 });
 
@@ -51,5 +66,26 @@ export const hostRestartUpgradeV10ToV11 = defineUpgradePath<
   upgradeResponse: (response) =>
     response.outcome === "busy"
       ? { ...response, verdict: { ...response.verdict, blockers: null } }
+      : response,
+});
+
+// A v1.1 host refuses without a typed split. `busyBreakdown` upgrades to
+// `null`, NOT to a zero object: a fabricated idle-by-kind claim would put
+// an affirmative "nothing of any kind is blocking" in a v1.1 host's mouth
+// under a verdict that already said it was busy — the same distinction
+// `host.status`'s 1.1→1.2 `busyBreakdown: null` upgrade preserves.
+export const hostRestartUpgradeV11ToV12 = defineUpgradePath<
+  typeof hostRestartV11,
+  typeof hostRestartV12
+>({
+  from: hostRestartV11.schemaVersion,
+  to: hostRestartV12.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) =>
+    response.outcome === "busy"
+      ? {
+          ...response,
+          verdict: { ...response.verdict, busyBreakdown: null },
+        }
       : response,
 });

--- a/protocol/src/host/restart/index.ts
+++ b/protocol/src/host/restart/index.ts
@@ -1,16 +1,20 @@
 export {
   hostRestartUpgradeV10ToV11,
+  hostRestartUpgradeV11ToV12,
   hostRestartV10,
   hostRestartV11,
+  hostRestartV12,
 } from "./contracts";
 
 export {
   hostRestartBusyBlockersSchema,
   hostRestartBusyVerdictSchema,
   hostRestartBusyVerdictV10Schema,
+  hostRestartBusyVerdictV11Schema,
   hostRestartRequestSchema,
   hostRestartResponseSchema,
   hostRestartResponseV10Schema,
+  hostRestartResponseV11Schema,
   type HostRestartBusyBlockers,
   type HostRestartBusyVerdict,
   type HostRestartRequest,

--- a/protocol/src/host/restart/schemas.ts
+++ b/protocol/src/host/restart/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { hostBusyBreakdownSchema } from "@traycer/protocol/host/status/contracts";
 
 /**
  * Caller-generated identity for one logical restart action. Retries must keep
@@ -45,9 +46,23 @@ export const hostRestartBusyBlockersSchema = z.object({
  * case would put an affirmative "nothing is blocking" in the host's mouth
  * under a verdict that says the opposite.
  */
+export const hostRestartBusyVerdictV11Schema = z.object({
+  busySessionCount: z.number().int().nonnegative(),
+  blockers: hostRestartBusyBlockersSchema.nullable(),
+});
+
+/**
+ * v1.2 verdict: the v1.1 count + blockers, plus a typed `busyBreakdown`.
+ *
+ * `busyBreakdown: null` means the host did not say how the total splits —
+ * NOT that every component is zero. `blockers` is unchanged: a v1.2 host
+ * still names the boolean deny signals, and a v1.1 host still upgrades them
+ * to `null`.
+ */
 export const hostRestartBusyVerdictSchema = z.object({
   busySessionCount: z.number().int().nonnegative(),
   blockers: hostRestartBusyBlockersSchema.nullable(),
+  busyBreakdown: hostBusyBreakdownSchema.nullable(),
 });
 
 export const hostRestartResponseV10Schema = z.discriminatedUnion("outcome", [
@@ -55,6 +70,14 @@ export const hostRestartResponseV10Schema = z.discriminatedUnion("outcome", [
   z.object({
     outcome: z.literal("busy"),
     verdict: hostRestartBusyVerdictV10Schema,
+  }),
+]);
+
+export const hostRestartResponseV11Schema = z.discriminatedUnion("outcome", [
+  z.object({ outcome: z.literal("accepted") }),
+  z.object({
+    outcome: z.literal("busy"),
+    verdict: hostRestartBusyVerdictV11Schema,
   }),
 ]);
 

--- a/protocol/src/host/status/__tests__/contracts.test.ts
+++ b/protocol/src/host/status/__tests__/contracts.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
+  hostBusyBreakdownSchema,
   hostStatusUpgradeV10ToV11,
+  hostStatusUpgradeV11ToV12,
   hostStatusV10,
   hostStatusV11,
+  hostStatusV12,
 } from "../contracts";
 
 const V10_RESPONSE = {
@@ -64,9 +68,9 @@ describe("hostStatusUpgradeV10ToV11", () => {
         updateProgress: null,
       });
       expect(upgraded).not.toEqual(genuineZero);
-      expect(Object.is(upgraded.busySessionCount, genuineZero.busySessionCount)).toBe(
-        false,
-      );
+      expect(
+        Object.is(upgraded.busySessionCount, genuineZero.busySessionCount),
+      ).toBe(false);
     });
   });
 
@@ -80,5 +84,110 @@ describe("hostStatusUpgradeV10ToV11", () => {
     const parsed = hostStatusV10.responseSchema.parse(V10_RESPONSE);
     const upgraded = hostStatusUpgradeV10ToV11.upgradeResponse(parsed);
     expect(upgraded.busySessionCount).not.toBe(0);
+  });
+});
+
+const V11_RESPONSE = {
+  ...V10_RESPONSE,
+  busy: true,
+  busySessionCount: 3,
+  updateProgress: null,
+};
+
+const BUSY_BREAKDOWN = {
+  workingAgents: 2,
+  activeTerminalAgents: 1,
+  busyTerminals: 0,
+};
+
+describe("hostStatusUpgradeV11ToV12", () => {
+  it("upgrades a v1.1 response with busyBreakdown: null, NOT a fabricated zero object", () => {
+    const parsed = hostStatusV11.responseSchema.parse(V11_RESPONSE);
+    const upgraded = hostStatusUpgradeV11ToV12.upgradeResponse(parsed);
+    expect(upgraded.busyBreakdown).toBeNull();
+    expect(upgraded.busySessionCount).toBe(3);
+    expect(upgraded.busy).toBe(true);
+    expect(() => hostStatusV12.responseSchema.parse(upgraded)).not.toThrow();
+  });
+
+  it("leaves the request identity-mapped", () => {
+    expect(hostStatusUpgradeV11ToV12.upgradeRequest({})).toEqual({});
+  });
+
+  describe("null vs a genuine zero breakdown — different claims", () => {
+    it("an upgraded v1.1 host's breakdown is null (never reported), not zeros", () => {
+      const parsed = hostStatusV11.responseSchema.parse(V11_RESPONSE);
+      const upgraded = hostStatusUpgradeV11ToV12.upgradeResponse(parsed);
+      expect(upgraded.busyBreakdown).toBeNull();
+      expect(upgraded.busyBreakdown).not.toEqual({
+        workingAgents: 0,
+        activeTerminalAgents: 0,
+        busyTerminals: 0,
+      });
+    });
+
+    it("a real v1.2 host reporting a zero breakdown parses as zeros, not null", () => {
+      const genuineZero = hostStatusV12.responseSchema.parse({
+        ...V11_RESPONSE,
+        busy: false,
+        busySessionCount: 0,
+        busyBreakdown: {
+          workingAgents: 0,
+          activeTerminalAgents: 0,
+          busyTerminals: 0,
+        },
+      });
+      expect(genuineZero.busyBreakdown).toEqual({
+        workingAgents: 0,
+        activeTerminalAgents: 0,
+        busyTerminals: 0,
+      });
+      expect(genuineZero.busyBreakdown).not.toBeNull();
+    });
+  });
+});
+
+describe("host.status@1.2 busyBreakdown", () => {
+  it("round-trips a populated breakdown", () => {
+    const payload = {
+      ...V11_RESPONSE,
+      busyBreakdown: BUSY_BREAKDOWN,
+    };
+    const parsed = hostStatusV12.responseSchema.parse(payload);
+    expect(parsed.busyBreakdown).toEqual(BUSY_BREAKDOWN);
+    expect(hostBusyBreakdownSchema.parse(BUSY_BREAKDOWN)).toEqual(
+      BUSY_BREAKDOWN,
+    );
+  });
+
+  it("round-trips busyBreakdown: null", () => {
+    const parsed = hostStatusV12.responseSchema.parse({
+      ...V11_RESPONSE,
+      busyBreakdown: null,
+    });
+    expect(parsed.busyBreakdown).toBeNull();
+  });
+
+  it("rejects a negative component", () => {
+    expect(
+      hostStatusV12.responseSchema.safeParse({
+        ...V11_RESPONSE,
+        busyBreakdown: { ...BUSY_BREAKDOWN, busyTerminals: -1 },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("host.status registry membership", () => {
+  it("installs @1.0, @1.1, and @1.2 on the unary registry at major 1", () => {
+    const entry = hostRpcRegistry["host.status"];
+    expect(entry).toBeDefined();
+    expect(entry[1].latestMinor).toBe(2);
+    expect(entry[1].versions[0].contract).toBe(hostStatusV10);
+    expect(entry[1].versions[1].contract).toBe(hostStatusV11);
+    expect(entry[1].versions[2].contract).toBe(hostStatusV12);
+    expect(entry[1].versions[2].upgradeFromPreviousVersion).toBe(
+      hostStatusUpgradeV11ToV12,
+    );
   });
 });

--- a/protocol/src/host/status/contracts.ts
+++ b/protocol/src/host/status/contracts.ts
@@ -39,6 +39,19 @@ export type HostStatusUpdateProgress = z.infer<
 >;
 
 /**
+ * Typed breakdown of {@link hostStatusV12}'s `busySessionCount` total, reused
+ * by `host.restart` @1.2 and the unnegotiated `hostRuntimeStatus` awareness
+ * field. Counts are non-negative; a missing breakdown is `null` (unknown),
+ * never a fabricated zero object.
+ */
+export const hostBusyBreakdownSchema = z.object({
+  workingAgents: z.number().int().nonnegative(),
+  activeTerminalAgents: z.number().int().nonnegative(),
+  busyTerminals: z.number().int().nonnegative(),
+});
+export type HostBusyBreakdown = z.infer<typeof hostBusyBreakdownSchema>;
+
+/**
  * v1.1 folds in the T16 busy/drain signal (`host.drainStatus`, since removed
  * - see the RPC backward-compat decision log) as additive `host.status`
  * fields instead of a standalone method name, so the wire method-set stays
@@ -65,6 +78,40 @@ export const hostStatusV11 = defineRpcContract({
      */
     busySessionCount: z.number().int().nonnegative().nullable(),
     updateProgress: hostStatusUpdateProgressSchema.nullable(),
+  }),
+});
+
+/**
+ * v1.2 adds a typed `busyBreakdown` beside the existing total.
+ *
+ * `busySessionCount` is now the breakdown total (`workingAgents` +
+ * `activeTerminalAgents` + `busyTerminals`) when the host reports both; old
+ * clients keep rendering the single number. `busyBreakdown: null` means the
+ * host did not say how the total splits — NOT that every component is zero.
+ * The v1.1→v1.2 upgrade therefore writes `null`, following the v1.0→v1.1
+ * `busySessionCount: null` precedent: manufacturing `{ workingAgents: 0, ... }`
+ * would put an affirmative idle-by-kind claim in an old host's mouth.
+ */
+export const hostStatusV12 = defineRpcContract({
+  method: "host.status",
+  schemaVersion: { major: 1, minor: 2 } as const,
+  requestSchema: z.object({}),
+  responseSchema: z.object({
+    ready: z.boolean(),
+    hostVersion: z.string(),
+    protocolVersion: z.object({
+      major: z.number().int().nonnegative(),
+      minor: z.number().int().nonnegative(),
+    }),
+    busy: z.boolean(),
+    /**
+     * Total busy items blocking an update drain (the sum of
+     * `busyBreakdown` when that is present). `null` means the host did not
+     * report a count — NOT that it reported zero.
+     */
+    busySessionCount: z.number().int().nonnegative().nullable(),
+    updateProgress: hostStatusUpdateProgressSchema.nullable(),
+    busyBreakdown: hostBusyBreakdownSchema.nullable(),
   }),
 });
 
@@ -95,5 +142,24 @@ export const hostStatusUpgradeV10ToV11 = defineUpgradePath<
     busy: false,
     busySessionCount: null,
     updateProgress: null,
+  }),
+});
+
+// A v1.1 peer reports a total and never a typed split. `busyBreakdown`
+// upgrades to `null`, NOT to a zero object: a real `{ workingAgents: 0,
+// activeTerminalAgents: 0, busyTerminals: 0 }` is an affirmative "idle by
+// every kind", while `null` is "did not say". The drain UI that starts to
+// name kinds depends on that difference the same way the count UI depends
+// on `busySessionCount: null` vs `0`.
+export const hostStatusUpgradeV11ToV12 = defineUpgradePath<
+  typeof hostStatusV11,
+  typeof hostStatusV12
+>({
+  from: hostStatusV11.schemaVersion,
+  to: hostStatusV12.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => ({
+    ...response,
+    busyBreakdown: null,
   }),
 });


### PR DESCRIPTION
## Why

The host is getting one process-tree-aware "busy" rule shared by `lifecycle.claimShutdown`, the update-drain gate, `GET /activity`, `host.status`, the restart verdict, the room's runtime-status awareness entry, and every GUI indicator. Clients should be able to say *what* is working ("2 agents · 1 terminal") instead of an ambiguous session count. This PR adds the wire shape; the host/GUI halves follow in the internal repo.

## What

- Shared `hostBusyBreakdownSchema` / `HostBusyBreakdown` = `{ workingAgents, activeTerminalAgents, busyTerminals }` (non-negative ints), exported once from `host/status/contracts.ts`.
- `host.status@1.2`: @1.1 + `busyBreakdown: … .nullable()`. `busySessionCount` is documented as the breakdown total. Upgrade 1.1→1.2 sets `busyBreakdown: null` (unknown, not zero — same rule as the existing `busySessionCount: null` upgrade).
- `host.restart@1.2`: the busy verdict adds the same nullable `busyBreakdown`; `blockers` kept; v1.1 schemas frozen; upgrade sets `null`.
- `hostRuntimeStatusAwarenessSchema`: optional nullable `busyBreakdown`; the schema stays non-strict so entries from older hosts still parse and older clients drop the key.
- `RELEASE-INVARIANT.md` and contract tests updated; mechanical `busyBreakdown: null` on gui-app fixtures so typed lint stays green (no GUI behavior change here).
- No change to `GET /activity` or `lifecycle.claimShutdown`.

## Tests

`protocol`: `host-status`, `host-restart`, `notifications-subscribe`, `status/contracts`, `two-sided-release-invariant` — 5 files, 57 passed. Protocol compile+lint and gui-app compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
