### PR TITLE
feat(protocol): export the upgrade-channel contract as runtime values

### DIFF
--- a/protocol/src/framework/__tests__/client-identity.test.ts
+++ b/protocol/src/framework/__tests__/client-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
+  CLIENT_UPGRADE_CHANNELS,
   CURRENT_CLIENT_COMPATIBILITY_EPOCH,
   LEGACY_CLIENT_COMPATIBILITY_EPOCH,
   MAX_DIAGNOSTIC_APP_VERSION_LENGTH,
@@ -8,6 +9,7 @@ import {
   isStrictSemVer,
   clientCompatibilityRequirementSchema,
   clientHandshakeIdentitySchema,
+  isClientUpgradeChannel,
   isValidCompatibilityEpoch,
   toClientHandshakeIdentity,
   type ClientCompatibilityRequirement,
@@ -374,5 +376,48 @@ describe("clientCompatibilityRequirement on the fatal envelope", () => {
         minimumCompatibilityEpoch: 2.5,
       }).success,
     ).toBe(false);
+  });
+});
+
+describe("the upgrade-channel contract as runtime values", () => {
+  /**
+   * The channel had a type-only export, so every RUNTIME reader outside this
+   * package - a host validating its own baked config at startup, the release
+   * tooling validating what it is about to stamp - had to hand-write the pair
+   * of literals. These assertions are what make the exported values the single
+   * definition rather than a second one that happens to agree today.
+   */
+
+  it("is the same set the wire schema accepts", () => {
+    for (const channel of CLIENT_UPGRADE_CHANNELS) {
+      expect(
+        clientCompatibilityRequirementSchema.safeParse({
+          ...REQUIREMENT,
+          upgradeChannel: channel,
+        }).success,
+      ).toBe(true);
+    }
+  });
+
+  it("rejects a channel the wire schema also rejects", () => {
+    // Both directions on one value: a spelling no channel carries must fail the
+    // guard AND the schema, or a host would admit a config the wire cannot
+    // describe.
+    expect(isClientUpgradeChannel("beta")).toBe(false);
+    expect(
+      clientCompatibilityRequirementSchema.safeParse({
+        ...REQUIREMENT,
+        upgradeChannel: "beta",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("guards every declared channel and nothing else", () => {
+    for (const channel of CLIENT_UPGRADE_CHANNELS) {
+      expect(isClientUpgradeChannel(channel)).toBe(true);
+    }
+    for (const notAChannel of [null, undefined, 2, "", "STABLE", ["rc"]]) {
+      expect(isClientUpgradeChannel(notAChannel)).toBe(false);
+    }
   });
 });

--- a/protocol/src/framework/client-identity.ts
+++ b/protocol/src/framework/client-identity.ts
@@ -167,8 +167,27 @@ export type ClientCompatibilityFailure =
   | "invalid-epoch"
   | "below-minimum";
 
-/** Which release line the remedy lives on. */
-export type ClientUpgradeChannel = "stable" | "rc";
+/**
+ * Which release line the remedy lives on.
+ *
+ * Exported as VALUES, not only as a type, because the channel has runtime
+ * readers outside this package: a host validates the channel baked into its own
+ * config at startup, and the release tooling validates the one it is about to
+ * stamp. A type-only export leaves each of those hand-writing `"stable"` and
+ * `"rc"`, which is how a third channel gets added here and silently rejected
+ * there.
+ */
+export const CLIENT_UPGRADE_CHANNELS = ["stable", "rc"] as const;
+export type ClientUpgradeChannel = (typeof CLIENT_UPGRADE_CHANNELS)[number];
+
+export function isClientUpgradeChannel(
+  value: unknown,
+): value is ClientUpgradeChannel {
+  return (
+    typeof value === "string" &&
+    (CLIENT_UPGRADE_CHANNELS as readonly string[]).includes(value)
+  );
+}
 
 /**
  * The structured half of an epoch rejection, carried additively on
@@ -198,7 +217,7 @@ export const clientCompatibilityRequirementSchema = z.object({
   observedClientAppVersion: z.string().nullable(),
   observedClientAppVersionStatus: z.enum(["valid", "missing", "invalid"]),
   minimumKnownClientAppVersion: z.string().nullable(),
-  upgradeChannel: z.enum(["stable", "rc"]).nullable(),
+  upgradeChannel: z.enum(CLIENT_UPGRADE_CHANNELS).nullable(),
 });
 
 /**

--- a/protocol/src/framework/index.ts
+++ b/protocol/src/framework/index.ts
@@ -185,12 +185,14 @@ export type {
 } from "./client-identity";
 
 export {
+  CLIENT_UPGRADE_CHANNELS,
   CURRENT_CLIENT_COMPATIBILITY_EPOCH,
   LEGACY_CLIENT_COMPATIBILITY_EPOCH,
   MAX_DIAGNOSTIC_APP_VERSION_LENGTH,
   STRICT_SEMVER_PATTERN,
   clientCompatibilityRequirementSchema,
   clientHandshakeIdentitySchema,
+  isClientUpgradeChannel,
   isStrictSemVer,
   isValidCompatibilityEpoch,
   toClientHandshakeIdentity,


### PR DESCRIPTION
Follow-up to the [client compatibility epoch handshake](https://github.com/traycerai/traycer/pull/1364), from a CodeRabbit review comment on the internal host-side PR that was resolved without being handled.

## The problem

`ClientUpgradeChannel` is exported **type-only**, while the runtime definition lives inline in `clientCompatibilityRequirementSchema` as `z.enum(["stable", "rc"])`. Nothing exports the values.

So every runtime reader outside this package hand-writes the literal pair:

- the **host** validates the channel baked into its own config at startup (`resolveClientCompatibilityPolicy` — `channel !== "stable" && channel !== "rc"`)
- the **release tooling** validates the channel it is about to stamp into an artifact

That is one contract with three independent copies. Adding a third channel here would leave a host rejecting, at startup, a value the wire happily describes — on an artifact that is already signed and published. The floor exists precisely because a host in the field cannot be reached to fix that.

## The change

- `CLIENT_UPGRADE_CHANNELS` — the values, `as const`
- `isClientUpgradeChannel` — a runtime guard
- `ClientUpgradeChannel` is now derived from the constant
- `clientCompatibilityRequirementSchema` builds its enum from the same constant

Same `LOG_LEVELS` / `RPC_ERROR_CODES` idiom already used across this package.

**Purely additive — no wire shape changes.** The type keeps its exact meaning and the schema accepts exactly what it accepted before.

## Tests

Three cases pin the schema and the guard to one definition rather than two that agree today: every declared channel parses on the wire *and* passes the guard, a value neither accepts is rejected by both, and the guard rejects non-string shapes. 41 tests pass in `client-identity.test.ts`.

## Consumer note

The host-side cleanup (dropping its duplicated literals in favour of this export) lands separately in the internal repo, after this merges and the submodule pin moves forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)