### PR TITLE
fix(gui-app): keep transcript row positions coherent while a reply streams

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-stable-rows.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-stable-rows.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "@/stores/composer/chat-store";
 import {
+  chatTimelineKeySequence,
   computeStableChatTimelineRows,
+  didChatTimelineKeySequenceChange,
   EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE,
   type StableChatTimelineRowsState,
 } from "@/components/chat/chat-stable-rows";
@@ -199,5 +201,57 @@ describe("computeStableChatTimelineRows", () => {
 
     const next = computeStableChatTimelineRows([], empty);
     expect(next).toBe(empty);
+  });
+});
+
+describe("didChatTimelineKeySequenceChange", () => {
+  const rowsFor = (...ids: ReadonlyArray<string>): ReadonlyArray<ChatMessage> =>
+    ids.map((id, index) => ({ ...makeMessage(index, "user"), id }));
+
+  it("reports no move for a first population", () => {
+    expect(didChatTimelineKeySequenceChange(undefined, rowsFor("a", "b"))).toBe(
+      false,
+    );
+    expect(didChatTimelineKeySequenceChange([], rowsFor("a", "b"))).toBe(false);
+  });
+
+  it("reports no move when a row changes content in place", () => {
+    expect(
+      didChatTimelineKeySequenceChange(["a", "b"], rowsFor("a", "b")),
+    ).toBe(false);
+  });
+
+  it("reports a move for an insert, a removal, and a reorder", () => {
+    expect(
+      didChatTimelineKeySequenceChange(["a", "b"], rowsFor("a", "b", "c")),
+    ).toBe(true);
+    expect(didChatTimelineKeySequenceChange(["a", "b"], rowsFor("b"))).toBe(
+      true,
+    );
+    // Same ids, different order - a setup card reaching its anchor.
+    expect(
+      didChatTimelineKeySequenceChange(["a", "b", "c"], rowsFor("a", "c", "b")),
+    ).toBe(true);
+  });
+
+  /**
+   * The baseline is what the list last RENDERED, so a render React discarded
+   * must not move it. Deriving it from a render-time cache would: a discarded
+   * [a,b,c] would leave the next real render comparing three keys against
+   * three and calling a genuine insertion settled content.
+   */
+  it("still reports the insertion when a discarded render already saw it", () => {
+    const committed = chatTimelineKeySequence(rowsFor("a", "b"));
+
+    // The render React throws away. It computes a verdict; it publishes no
+    // committed sequence, because only a commit does that.
+    expect(
+      didChatTimelineKeySequenceChange(committed, rowsFor("a", "b", "c")),
+    ).toBe(true);
+
+    // The real render that replaces it: same new keys, one further token.
+    expect(
+      didChatTimelineKeySequenceChange(committed, rowsFor("a", "b", "c")),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -1211,13 +1211,53 @@ describe("ChatTimeline LegendList strict-edge policy config", () => {
     await settleLegendList();
     expect(legendListPolicyProps.last).not.toBeNull();
     expect(legendListPolicyProps.last?.maintainScrollAtEndThreshold).toBe(0);
-    // MVCP's size channel only. The data channel arms an anchor lock that
-    // defers position recalculation to an animation frame, and a streaming
-    // transcript re-arms it on every token - see the prop's own comment.
+    // MVCP's size channel is unconditional; the data channel rides the key
+    // sequence and is off for a settled transcript - see the prop's own
+    // comment, and the two cases below for each arm.
     expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toEqual({
       data: false,
       size: true,
     });
     expect(legendListPolicyProps.last?.maintainScrollAtEnd).toBeUndefined();
+  });
+
+  it("keeps the MVCP data channel off while a streaming row changes in place", async () => {
+    const messages = makeMessages(6);
+    const { rerenderMessages } = renderTimeline({ messages });
+    await settleLegendList();
+
+    // A token: same rows in the same order, one row's content replaced. Fresh
+    // objects throughout, which is what the store hands over on every update.
+    const streamed = messages.map((message, index) =>
+      index === messages.length - 1
+        ? { ...message, content: `${message.content} more` }
+        : { ...message },
+    );
+    act(() => {
+      rerenderMessages(streamed, undefined);
+    });
+
+    expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toEqual({
+      data: false,
+      size: true,
+    });
+  });
+
+  it("turns the MVCP data channel on for the commit that changes the key sequence", async () => {
+    const messages = makeMessages(6);
+    const { rerenderMessages } = renderTimeline({ messages });
+    await settleLegendList();
+
+    // A row above the tail disappears - the shape a settled-row deletion, a
+    // steer nesting into its assistant turn, or a moved setup card produces.
+    const withRowRemoved = messages.filter((_, index) => index !== 1);
+    act(() => {
+      rerenderMessages(withRowRemoved, undefined);
+    });
+
+    expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toEqual({
+      data: true,
+      size: true,
+    });
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -1211,9 +1211,13 @@ describe("ChatTimeline LegendList strict-edge policy config", () => {
     await settleLegendList();
     expect(legendListPolicyProps.last).not.toBeNull();
     expect(legendListPolicyProps.last?.maintainScrollAtEndThreshold).toBe(0);
-    expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toBe(
-      true,
-    );
+    // MVCP's size channel only. The data channel arms an anchor lock that
+    // defers position recalculation to an animation frame, and a streaming
+    // transcript re-arms it on every token - see the prop's own comment.
+    expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toEqual({
+      data: false,
+      size: true,
+    });
     expect(legendListPolicyProps.last?.maintainScrollAtEnd).toBeUndefined();
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline.test.tsx
@@ -1260,4 +1260,35 @@ describe("ChatTimeline LegendList strict-edge policy config", () => {
       size: true,
     });
   });
+
+  it("retires the data channel once the moved sequence has been rendered", async () => {
+    const messages = makeMessages(6);
+    const { rerenderMessages } = renderTimeline({ messages });
+    await settleLegendList();
+
+    const withRowRemoved = messages.filter((_, index) => index !== 1);
+    act(() => {
+      rerenderMessages(withRowRemoved, undefined);
+    });
+    expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toEqual({
+      data: true,
+      size: true,
+    });
+
+    // A token on top of the new sequence. The baseline advanced when the
+    // removal COMMITTED, so this is content-only and needs no anchor.
+    const streamed = withRowRemoved.map((message, index) =>
+      index === withRowRemoved.length - 1
+        ? { ...message, content: `${message.content} more` }
+        : { ...message },
+    );
+    act(() => {
+      rerenderMessages(streamed, undefined);
+    });
+
+    expect(legendListPolicyProps.last?.maintainVisibleContentPosition).toEqual({
+      data: false,
+      size: true,
+    });
+  });
 });

--- a/clients/gui-app/src/components/chat/__tests__/legend-list-estimate-recovery.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/legend-list-estimate-recovery.test.tsx
@@ -1,8 +1,13 @@
 import { createRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
-import { LegendList, type LegendListRef } from "@legendapp/list/react";
+import {
+  LegendList,
+  type LegendListRef,
+  type MaintainVisibleContentPositionConfig,
+} from "@legendapp/list/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  advanceLegendListFrames,
   advanceLegendListTime,
   installLegendListTestClock,
   installLegendListViewportMetrics,
@@ -79,6 +84,46 @@ function createTestList(
       renderItem={({ item }) => <div data-index={item.id}>{item.id}</div>}
     />
   );
+}
+
+/** `ChatTimeline`'s own maintain configuration, on a bare list. The transcript
+ *  never passes the library's `maintainScrollAtEnd` (it owns bottom-follow
+ *  itself), so the only maintain behavior under test is MVCP. */
+function createTranscriptList(
+  data: readonly Row[],
+  listRef: React.RefObject<LegendListRef | null>,
+  maintainVisibleContentPosition: MaintainVisibleContentPositionConfig<Row>,
+) {
+  return (
+    <LegendList
+      ref={listRef}
+      data={data}
+      estimatedItemSize={90}
+      getItemType={() => "assistant"}
+      keyExtractor={(item) => item.id}
+      maintainScrollAtEndThreshold={0}
+      maintainVisibleContentPosition={maintainVisibleContentPosition}
+      recycleItems={false}
+      renderItem={({ item }) => <div data-index={item.id}>{item.id}</div>}
+    />
+  );
+}
+
+/** Every row starts exactly where the previous one ends. A row whose offset
+ *  was computed from a size a sibling has already invalidated paints on top of
+ *  that sibling. */
+function positionGapsAndSizes(list: LegendListRef): {
+  readonly gaps: number[];
+  readonly sizes: number[];
+} {
+  const state = list.getState();
+  const gaps: number[] = [];
+  const sizes: number[] = [];
+  for (let index = 0; index < 11; index += 1) {
+    gaps.push(state.positionAtIndex(index + 1) - state.positionAtIndex(index));
+    sizes.push(state.sizeAtIndex(index));
+  }
+  return { gaps, sizes };
 }
 
 describe("LegendList estimate recovery", () => {
@@ -241,15 +286,72 @@ describe("LegendList estimate recovery", () => {
       }
     });
 
-    const state = list.getState();
-    const gaps: number[] = [];
-    const sizes: number[] = [];
-    for (let index = 0; index < 11; index += 1) {
-      gaps.push(
-        state.positionAtIndex(index + 1) - state.positionAtIndex(index),
-      );
-      sizes.push(state.sizeAtIndex(index));
-    }
+    const { gaps, sizes } = positionGapsAndSizes(list);
     expect(gaps).toEqual(sizes);
+  });
+
+  /**
+   * A streaming reply hands the list a structurally-changed array on every
+   * token while the row it is appending to keeps growing. Both halves land in
+   * the same commit, so the offsets of the rows after the growing one have to
+   * be rewritten before the browser paints - the browser has already laid that
+   * row out at its new height, and any row still carrying its previous offset
+   * paints inside the grown row's band.
+   *
+   * The two cases below are the same sequence under the two MVCP
+   * configurations. They pin the transcript's `data: false` and, in the second
+   * case, hold the reproduction that made it necessary - so this stays a
+   * regression suite rather than a description of current behavior.
+   */
+  describe("streaming growth after a data change", () => {
+    async function streamTokenThenGrowRow(
+      maintainVisibleContentPosition: MaintainVisibleContentPositionConfig<Row>,
+    ): Promise<LegendListRef> {
+      const listRef = createRef<LegendListRef | null>();
+      const { rerender } = render(
+        createTranscriptList(rows(12), listRef, maintainVisibleContentPosition),
+      );
+      await settleLegendList();
+
+      const list = listRef.current;
+      if (list === null) throw new Error("LegendList ref did not mount");
+
+      const measuredSize = list.getState().getAverageItemSizes()
+        .assistant.average;
+
+      // One token: same keys, fresh row objects. With no `itemsAreEqual` the
+      // library reads that as a structural data change, exactly as a live
+      // transcript does on every token.
+      rerender(
+        createTranscriptList(rows(12), listRef, maintainVisibleContentPosition),
+      );
+      act(() => {
+        list.setItemSize("row-3", { height: measuredSize * 3, width: 800 });
+      });
+      return list;
+    }
+
+    it("rewrites positions in the same commit under the transcript's config", async () => {
+      const list = await streamTokenThenGrowRow({ data: false, size: true });
+
+      const { gaps, sizes } = positionGapsAndSizes(list);
+      expect(gaps).toEqual(sizes);
+    });
+
+    it("leaves positions a frame stale once the data channel arms the MVCP anchor lock", async () => {
+      const list = await streamTokenThenGrowRow({ data: true, size: true });
+
+      // The lock is armed by the data change and holds for 300ms, re-armed by
+      // every further token. While it is held the library stops recalculating
+      // positions inline and defers the pass to an animation frame, so the row
+      // after the grown one still carries its previous offset.
+      const stale = positionGapsAndSizes(list);
+      expect(stale.gaps).not.toEqual(stale.sizes);
+
+      await advanceLegendListFrames(1);
+
+      const settled = positionGapsAndSizes(list);
+      expect(settled.gaps).toEqual(settled.sizes);
+    });
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/legend-list-estimate-recovery.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/legend-list-estimate-recovery.test.tsx
@@ -299,9 +299,12 @@ describe("LegendList estimate recovery", () => {
    * paints inside the grown row's band.
    *
    * The two cases below are the same sequence under the two MVCP
-   * configurations. They pin the transcript's `data: false` and, in the second
-   * case, hold the reproduction that made it necessary - so this stays a
-   * regression suite rather than a description of current behavior.
+   * configurations. They pin the channel the transcript selects for a
+   * same-key token and, in the second case, hold the reproduction that made
+   * it necessary - so this stays a regression suite rather than a description
+   * of current behavior. The parked-anchor describe that follows pins the
+   * other arm, and the two together are why the channel is chosen per commit
+   * instead of being turned off outright.
    */
   describe("streaming growth after a data change", () => {
     async function streamTokenThenGrowRow(
@@ -352,6 +355,84 @@ describe("LegendList estimate recovery", () => {
 
       const settled = positionGapsAndSizes(list);
       expect(settled.gaps).toEqual(settled.sizes);
+    });
+  });
+
+  /**
+   * The other half of the contract. A transcript is not append-only: rows are
+   * removed when a settled turn's last segment is suppressed, moved when a
+   * setup card reaches its anchor, and dropped when a steer nests into its
+   * assistant turn or a branch edit lands. A reader parked below one of those
+   * has nothing else holding their place - the scroller sets
+   * `overflow-anchor: none`, so the browser's own anchoring is off - which is
+   * what the data channel is for, and why it is selected rather than removed.
+   */
+  describe("a row removed above a parked reader", () => {
+    const ANCHOR_KEY = "row-22";
+
+    async function viewportOffsetAcrossRemoval(
+      maintainVisibleContentPosition: MaintainVisibleContentPositionConfig<Row>,
+    ): Promise<{ readonly before: number; readonly after: number }> {
+      const listRef = createRef<LegendListRef | null>();
+      const data = rows(40);
+      const { rerender } = render(
+        createTranscriptList(data, listRef, maintainVisibleContentPosition),
+      );
+      await settleLegendList();
+
+      const list = listRef.current;
+      if (list === null) throw new Error("LegendList ref did not mount");
+
+      // Park the reader well down the list, detached from both edges. The
+      // scroll promise settles on the virtual clock, so it is fired here and
+      // awaited by the settle below rather than directly.
+      act(() => {
+        void list.scrollToIndex({ animated: false, index: 20 });
+      });
+      await settleLegendList();
+
+      const offsetOf = (): number => {
+        const state = list.getState();
+        const position = state.positionByKey(ANCHOR_KEY);
+        if (position === undefined) {
+          throw new Error(`${ANCHOR_KEY} left the list`);
+        }
+        return position - state.scroll;
+      };
+      const before = offsetOf();
+
+      // A row ABOVE the parked one disappears. Everything below it shifts up
+      // by that row's height unless the scroll offset is corrected to match.
+      rerender(
+        createTranscriptList(
+          data.filter((row) => row.id !== "row-5"),
+          listRef,
+          maintainVisibleContentPosition,
+        ),
+      );
+      await settleLegendList();
+
+      return { after: offsetOf(), before };
+    }
+
+    it("holds the parked row at the same viewport offset with the data channel on", async () => {
+      const { before, after } = await viewportOffsetAcrossRemoval({
+        data: true,
+        size: true,
+      });
+
+      expect(after).toBeCloseTo(before, 0);
+    });
+
+    it("shifts the parked row when the data channel is off", async () => {
+      const { before, after } = await viewportOffsetAcrossRemoval({
+        data: false,
+        size: true,
+      });
+
+      // The regression a blanket `data: false` would have shipped: the reader
+      // is moved by the height of the row that vanished above them.
+      expect(after).not.toBeCloseTo(before, 0);
     });
   });
 });

--- a/clients/gui-app/src/components/chat/chat-stable-rows.ts
+++ b/clients/gui-app/src/components/chat/chat-stable-rows.ts
@@ -9,12 +9,25 @@ import type { ChatMessage } from "@/stores/composer/chat-store";
 export interface StableChatTimelineRowsState {
   readonly byId: ReadonlyMap<string, ChatMessage>;
   readonly result: ReadonlyArray<ChatMessage>;
+  /**
+   * Whether this state's row KEYS differ, in order or in count, from the ones
+   * it superseded - a row inserted, removed, or moved, as opposed to a row
+   * whose content changed in place. A streaming reply produces a continuous
+   * run of the latter and must not be mistaken for the former; see
+   * `ChatTimeline`'s `maintainVisibleContentPosition` for what reads this.
+   *
+   * A pass that changes nothing returns the previous state untouched, so
+   * re-running this computation on rows it has already seen answers exactly
+   * as it did the first time rather than reporting the move as settled.
+   */
+  readonly keySequenceChanged: boolean;
 }
 
 export const EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE: StableChatTimelineRowsState =
   {
     byId: new Map(),
     result: [],
+    keySequenceChanged: false,
   };
 
 /**
@@ -31,6 +44,11 @@ export function computeStableChatTimelineRows(
 ): StableChatTimelineRowsState {
   const next = new Map<string, ChatMessage>();
   let anyChanged = rows.length !== previous.byId.size;
+  // A first population is not a move: there is no rendered row set the new one
+  // could have shifted, so nothing downstream has a position to preserve.
+  const isFirstPopulation = previous.result.length === 0;
+  let keySequenceChanged =
+    !isFirstPopulation && rows.length !== previous.result.length;
 
   const result = rows.map((row, index) => {
     const prevRow = previous.byId.get(row.id);
@@ -42,10 +60,19 @@ export function computeStableChatTimelineRows(
     if (!anyChanged && previous.result[index] !== nextRow) {
       anyChanged = true;
     }
+    // Compared by INDEX, so a reorder counts even when the set of ids is
+    // identical - the timeline moves rows as well as adding and dropping them.
+    if (
+      !keySequenceChanged &&
+      !isFirstPopulation &&
+      previous.result[index]?.id !== row.id
+    ) {
+      keySequenceChanged = true;
+    }
     return nextRow;
   });
 
-  return anyChanged ? { byId: next, result } : previous;
+  return anyChanged ? { byId: next, result, keySequenceChanged } : previous;
 }
 
 type ChatMessageComparableField = Exclude<keyof ChatMessage, "id">;

--- a/clients/gui-app/src/components/chat/chat-stable-rows.ts
+++ b/clients/gui-app/src/components/chat/chat-stable-rows.ts
@@ -9,26 +9,44 @@ import type { ChatMessage } from "@/stores/composer/chat-store";
 export interface StableChatTimelineRowsState {
   readonly byId: ReadonlyMap<string, ChatMessage>;
   readonly result: ReadonlyArray<ChatMessage>;
-  /**
-   * Whether this state's row KEYS differ, in order or in count, from the ones
-   * it superseded - a row inserted, removed, or moved, as opposed to a row
-   * whose content changed in place. A streaming reply produces a continuous
-   * run of the latter and must not be mistaken for the former; see
-   * `ChatTimeline`'s `maintainVisibleContentPosition` for what reads this.
-   *
-   * A pass that changes nothing returns the previous state untouched, so
-   * re-running this computation on rows it has already seen answers exactly
-   * as it did the first time rather than reporting the move as settled.
-   */
-  readonly keySequenceChanged: boolean;
 }
 
 export const EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE: StableChatTimelineRowsState =
   {
     byId: new Map(),
     result: [],
-    keySequenceChanged: false,
   };
+
+/** The row keys in order, as the list will see them. */
+export function chatTimelineKeySequence(
+  rows: ReadonlyArray<ChatMessage>,
+): ReadonlyArray<string> {
+  return rows.map((row) => row.id);
+}
+
+/**
+ * Whether `rows` presents a different sequence of row KEYS than `committed` -
+ * a row inserted, removed, or moved, as opposed to a row whose content changed
+ * in place. A streaming reply produces a continuous run of the latter, and
+ * `ChatTimeline` reads this to decide whether that commit needs MVCP's data
+ * channel.
+ *
+ * `committed` must be the sequence the list last actually RENDERED, never one
+ * a render merely computed: React discards renders, and a baseline advanced by
+ * a discarded one makes a real insertion that follows it look like settled
+ * content. `undefined` is a first population, which no reader is positioned
+ * within and so cannot have shifted.
+ */
+export function didChatTimelineKeySequenceChange(
+  committed: ReadonlyArray<string> | undefined,
+  rows: ReadonlyArray<ChatMessage>,
+): boolean {
+  if (committed === undefined || committed.length === 0) return false;
+  if (committed.length !== rows.length) return true;
+  // By INDEX, so a reorder counts even when the set of ids is identical - the
+  // timeline moves rows as well as adding and dropping them.
+  return rows.some((row, index) => committed[index] !== row.id);
+}
 
 /**
  * Reuses the previous message object reference wherever a message is
@@ -44,11 +62,6 @@ export function computeStableChatTimelineRows(
 ): StableChatTimelineRowsState {
   const next = new Map<string, ChatMessage>();
   let anyChanged = rows.length !== previous.byId.size;
-  // A first population is not a move: there is no rendered row set the new one
-  // could have shifted, so nothing downstream has a position to preserve.
-  const isFirstPopulation = previous.result.length === 0;
-  let keySequenceChanged =
-    !isFirstPopulation && rows.length !== previous.result.length;
 
   const result = rows.map((row, index) => {
     const prevRow = previous.byId.get(row.id);
@@ -60,19 +73,10 @@ export function computeStableChatTimelineRows(
     if (!anyChanged && previous.result[index] !== nextRow) {
       anyChanged = true;
     }
-    // Compared by INDEX, so a reorder counts even when the set of ids is
-    // identical - the timeline moves rows as well as adding and dropping them.
-    if (
-      !keySequenceChanged &&
-      !isFirstPopulation &&
-      previous.result[index]?.id !== row.id
-    ) {
-      keySequenceChanged = true;
-    }
     return nextRow;
   });
 
-  return anyChanged ? { byId: next, result, keySequenceChanged } : previous;
+  return anyChanged ? { byId: next, result } : previous;
 }
 
 type ChatMessageComparableField = Exclude<keyof ChatMessage, "id">;

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -9,7 +9,11 @@ import {
   useSyncExternalStore,
   type RefObject,
 } from "react";
-import { LegendList, type LegendListRef } from "@legendapp/list/react";
+import {
+  LegendList,
+  type LegendListRef,
+  type MaintainVisibleContentPositionConfig,
+} from "@legendapp/list/react";
 import { cn } from "@/lib/utils";
 import { ChatEmptyState } from "@/components/chat/chat-empty-state";
 import {
@@ -139,6 +143,12 @@ const ChatTimelineRowCtx = createContext<ChatTimelineRowSharedState | null>(
 /** decision #5: "isNearEnd (library default 10% threshold)". */
 const CHAT_TIMELINE_NEAR_END_THRESHOLD = 0.1;
 
+/** Module scope so the config keeps one identity for the list's lifetime.
+ *  `size` on, `data` off - see the prop's own comment for why. `data` is the
+ *  library's own default-off channel; the boolean shorthand would opt in. */
+const CHAT_TIMELINE_MVCP: MaintainVisibleContentPositionConfig<ChatMessageModel> =
+  { data: false, size: true };
+
 // M4 (ticket 16 spacer alignment): the old 40px header/footer were
 // unsanctioned drift (decision log #30).
 // Consumers read the live measured size via `onListMetricsChange`, so they
@@ -222,9 +232,11 @@ export interface ChatTimelineProps {
  * unchanged. Bottom-follow is a strict 1px edge, owned by
  * `useChatTimelineFollowLatch` (see that module) rather than LegendList's
  * own `maintainScrollAtEnd`, which this component never enables.
- * `maintainVisibleContentPosition` stays on unconditionally - it keeps an
- * already-detached reader's view pixel-stable against unrelated growth,
- * which never pulls toward the tail. There is no app-owned scroll mode here.
+ * `maintainVisibleContentPosition` stays on unconditionally, but only on its
+ * SIZE channel - it keeps an already-detached reader's view pixel-stable
+ * against unrelated growth, which never pulls toward the tail. See the prop
+ * itself for why the data channel is off. There is no app-owned scroll mode
+ * here.
  */
 export const ChatTimeline = memo(function ChatTimeline({
   messages,
@@ -396,7 +408,24 @@ export const ChatTimeline = memo(function ChatTimeline({
         // to `distanceFromEnd <= 0` rather than its 10%-of-viewport default.
         // The separate `isAtEnd` calculation owns the 1px edge tolerance.
         maintainScrollAtEndThreshold={0}
-        maintainVisibleContentPosition
+        // SIZE keeps a detached reader pixel-stable when content above the
+        // viewport changes height - the only channel anything here depends on
+        // (a nested chain-open in find, a row remeasuring above the reader).
+        //
+        // DATA is off because it is not free: the library arms an MVCP anchor
+        // lock on every pass where the data array changed structurally, and
+        // while that lock is held it stops recalculating item positions inline
+        // and defers the recalculation to an animation frame. A transcript
+        // streaming a reply hands the library a structurally-changed array on
+        // every token, which re-arms the lock faster than its 300ms TTL can
+        // retire it, so the lock is held for the whole stream. Each row that
+        // grows is laid out by the browser immediately while the offsets of
+        // the rows after it are only rewritten a frame later - so the frame in
+        // between paints those rows inside the grown row's band and they
+        // overlap until the deferred pass lands. The channel buys anchoring
+        // across inserts and removals mid-list, which an append-only
+        // transcript never needs.
+        maintainVisibleContentPosition={CHAT_TIMELINE_MVCP}
         onItemSizeChanged={handleItemSizeChanged}
         onScroll={handleScroll}
         onMetricsChange={handleMetricsChange}

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -143,11 +143,23 @@ const ChatTimelineRowCtx = createContext<ChatTimelineRowSharedState | null>(
 /** decision #5: "isNearEnd (library default 10% threshold)". */
 const CHAT_TIMELINE_NEAR_END_THRESHOLD = 0.1;
 
-/** Module scope so the config keeps one identity for the list's lifetime.
- *  `size` on, `data` off - see the prop's own comment for why. `data` is the
- *  library's own default-off channel; the boolean shorthand would opt in. */
-const CHAT_TIMELINE_MVCP: MaintainVisibleContentPositionConfig<ChatMessageModel> =
+/** The two configurations the timeline alternates between, at module scope so
+ *  each keeps one identity and a commit that does not move between them hands
+ *  the list the same object. See the prop itself for what selects which. */
+const CHAT_TIMELINE_MVCP_SIZE_ONLY: MaintainVisibleContentPositionConfig<ChatMessageModel> =
   { data: false, size: true };
+const CHAT_TIMELINE_MVCP_WITH_DATA: MaintainVisibleContentPositionConfig<ChatMessageModel> =
+  { data: true, size: true };
+
+/** Both arms are pinned by the prop-capture cases in `chat-timeline.test.tsx`,
+ *  which observe what the list actually received rather than calling this. */
+function resolveChatTimelineMvcp(
+  keySequenceChanged: boolean,
+): MaintainVisibleContentPositionConfig<ChatMessageModel> {
+  return keySequenceChanged
+    ? CHAT_TIMELINE_MVCP_WITH_DATA
+    : CHAT_TIMELINE_MVCP_SIZE_ONLY;
+}
 
 // M4 (ticket 16 spacer alignment): the old 40px header/footer were
 // unsanctioned drift (decision log #30).
@@ -260,7 +272,10 @@ export const ChatTimeline = memo(function ChatTimeline({
   onListMetricsChange,
   ...rest
 }: ChatTimelineProps) {
-  const rows = useStableChatTimelineRows(listRef, messages);
+  const { result: rows, keySequenceChanged } = useStableChatTimelineRows(
+    listRef,
+    messages,
+  );
 
   // Fixup (fix-detached-streaming-yank/callback-synchronous-follow): see the
   // hook's own doc comment. Bottom-follow is owned entirely here now -
@@ -408,24 +423,37 @@ export const ChatTimeline = memo(function ChatTimeline({
         // to `distanceFromEnd <= 0` rather than its 10%-of-viewport default.
         // The separate `isAtEnd` calculation owns the 1px edge tolerance.
         maintainScrollAtEndThreshold={0}
-        // SIZE keeps a detached reader pixel-stable when content above the
-        // viewport changes height - the only channel anything here depends on
-        // (a nested chain-open in find, a row remeasuring above the reader).
+        // SIZE is always on: it keeps a detached reader pixel-stable when
+        // content above the viewport changes HEIGHT - a nested chain-open in
+        // find, a row remeasuring above the reader.
         //
-        // DATA is off because it is not free: the library arms an MVCP anchor
-        // lock on every pass where the data array changed structurally, and
-        // while that lock is held it stops recalculating item positions inline
-        // and defers the recalculation to an animation frame. A transcript
-        // streaming a reply hands the library a structurally-changed array on
-        // every token, which re-arms the lock faster than its 300ms TTL can
-        // retire it, so the lock is held for the whole stream. Each row that
-        // grows is laid out by the browser immediately while the offsets of
-        // the rows after it are only rewritten a frame later - so the frame in
-        // between paints those rows inside the grown row's band and they
-        // overlap until the deferred pass lands. The channel buys anchoring
-        // across inserts and removals mid-list, which an append-only
-        // transcript never needs.
-        maintainVisibleContentPosition={CHAT_TIMELINE_MVCP}
+        // DATA rides the key sequence, because the two things it is asked to
+        // tell apart arrive on the same signal. The library treats any row
+        // object it cannot prove equal as a structural data change, and while
+        // that channel is on it arms an MVCP anchor lock on every such pass.
+        // A held lock stops the library recalculating item positions inline
+        // and defers them to an animation frame; a row that grows is laid out
+        // by the browser immediately while the offsets of the rows after it
+        // are only rewritten a frame later, so the frame in between paints
+        // those rows inside the grown row's band. A streaming reply hands over
+        // a changed array on every token, well inside the lock's 300ms expiry,
+        // so leaving DATA on holds that lock - and that overlap - for the
+        // whole stream.
+        //
+        // The rows themselves distinguish the two: a streaming token changes a
+        // row's CONTENT in place, while an insert, a removal, or a move
+        // changes the sequence of row KEYS. Only the latter can shift what a
+        // detached reader is looking at, and only the latter needs the anchor,
+        // so the channel is on for exactly those commits. Off, positions are
+        // recalculated inline and stay coherent before the browser paints.
+        //
+        // Deliberately NOT `itemsAreEqual`: the library reuses that same
+        // comparator to decide whether a mounted container refreshes its item
+        // data, so calling same-key rows equal would freeze a streaming row's
+        // rendered content in place.
+        maintainVisibleContentPosition={resolveChatTimelineMvcp(
+          keySequenceChanged,
+        )}
         onItemSizeChanged={handleItemSizeChanged}
         onScroll={handleScroll}
         onMetricsChange={handleMetricsChange}
@@ -505,18 +533,25 @@ const stableChatTimelineRowsCache = new WeakMap<
  *  -style adjust-state-during-render retry would cost a genuine extra render
  *  pass on that hot path, not just a Strict Mode dev artifact. See
  *  `stableChatTimelineRowsCache`'s own doc comment for the cache shape and
- *  why it stays correct under a discarded speculative render. */
+ *  why it stays correct under a discarded speculative render.
+ *
+ *  The state's `keySequenceChanged` survives that same scenario for a reason
+ *  of its own: a pass that changes nothing returns `previous` by identity, so
+ *  re-running this on rows a discarded render has already cached answers as it
+ *  did the first time instead of reporting the move as already settled. A
+ *  stale `true` is inert - the library only consults the data channel on a
+ *  pass where it saw the array change. */
 function useStableChatTimelineRows(
   listRef: RefObject<LegendListRef | null>,
   rows: ReadonlyArray<ChatMessageModel>,
-): ReadonlyArray<ChatMessageModel> {
+): StableChatTimelineRowsState {
   return useMemo(() => {
     const previous =
       stableChatTimelineRowsCache.get(listRef) ??
       EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE;
     const next = computeStableChatTimelineRows(rows, previous);
     stableChatTimelineRowsCache.set(listRef, next);
-    return next.result;
+    return next;
   }, [rows, listRef]);
 }
 

--- a/clients/gui-app/src/components/chat/chat-timeline.tsx
+++ b/clients/gui-app/src/components/chat/chat-timeline.tsx
@@ -29,7 +29,9 @@ import {
   clearChatTimelineVisibleRows,
 } from "@/components/chat/chat-timeline-panel-resize-snapshot";
 import {
+  chatTimelineKeySequence,
   computeStableChatTimelineRows,
+  didChatTimelineKeySequenceChange,
   EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE,
   type StableChatTimelineRowsState,
 } from "./chat-stable-rows";
@@ -272,10 +274,9 @@ export const ChatTimeline = memo(function ChatTimeline({
   onListMetricsChange,
   ...rest
 }: ChatTimelineProps) {
-  const { result: rows, keySequenceChanged } = useStableChatTimelineRows(
-    listRef,
-    messages,
-  );
+  const rows = useStableChatTimelineRows(listRef, messages);
+
+  const keySequenceChanged = useCommittedKeySequenceChanged(listRef, rows);
 
   // Fixup (fix-detached-streaming-yank/callback-synchronous-follow): see the
   // hook's own doc comment. Bottom-follow is owned entirely here now -
@@ -526,6 +527,18 @@ const stableChatTimelineRowsCache = new WeakMap<
   StableChatTimelineRowsState
 >();
 
+/**
+ * The row key sequence each mounted timeline last RENDERED, keyed by that
+ * mount's `listRef` exactly as `stableChatTimelineRowsCache` is. Written only
+ * from a layout effect, so a render React discards never advances it - which
+ * is the whole point of keeping it separate from the row-reuse cache above,
+ * whose entry is published during render by design.
+ */
+const committedChatTimelineKeysCache = new WeakMap<
+  RefObject<LegendListRef | null>,
+  ReadonlyArray<string>
+>();
+
 /** Returns a structurally-shared copy of `rows`: for each row whose content
  *  hasn't changed since last call, the previous object reference is reused.
  *  `messages` is rebuilt wholesale on every store update (every streaming
@@ -535,24 +548,58 @@ const stableChatTimelineRowsCache = new WeakMap<
  *  `stableChatTimelineRowsCache`'s own doc comment for the cache shape and
  *  why it stays correct under a discarded speculative render.
  *
- *  The state's `keySequenceChanged` survives that same scenario for a reason
- *  of its own: a pass that changes nothing returns `previous` by identity, so
- *  re-running this on rows a discarded render has already cached answers as it
- *  did the first time instead of reporting the move as already settled. A
- *  stale `true` is inert - the library only consults the data channel on a
- *  pass where it saw the array change. */
+ *  Row reuse is all this decides. Anything that has to reason about what the
+ *  list last RENDERED - the key sequence the MVCP data channel rides - reads
+ *  `committedChatTimelineKeysCache` instead, precisely because this entry is
+ *  published during render and a discarded render can move it. */
 function useStableChatTimelineRows(
   listRef: RefObject<LegendListRef | null>,
   rows: ReadonlyArray<ChatMessageModel>,
-): StableChatTimelineRowsState {
+): ReadonlyArray<ChatMessageModel> {
   return useMemo(() => {
     const previous =
       stableChatTimelineRowsCache.get(listRef) ??
       EMPTY_STABLE_CHAT_TIMELINE_ROWS_STATE;
     const next = computeStableChatTimelineRows(rows, previous);
     stableChatTimelineRowsCache.set(listRef, next);
-    return next;
+    return next.result;
   }, [rows, listRef]);
+}
+
+/**
+ * Whether `rows` moves rows relative to the sequence this timeline last
+ * actually RENDERED - the signal `maintainVisibleContentPosition` rides.
+ *
+ * The baseline is published from a layout effect, never from render, and that
+ * is the whole design: React discards renders, and a baseline a discarded one
+ * advanced makes the real render that replaces it compare against a sequence
+ * nothing ever rendered. Concretely - committed `[A,B]`, a discarded render of
+ * `[A,B,C]`, then a real `[A,B,C']` - a render-time baseline would compare
+ * three keys against three, call the genuine insertion settled content, and
+ * hand it to the library with its anchor off. A discarded render runs no
+ * layout effect, so it cannot move this.
+ *
+ * `listRef` is used only as the per-mount map key, exactly as
+ * `stableChatTimelineRowsCache` uses it; its `current` is never read here.
+ */
+function useCommittedKeySequenceChanged(
+  listRef: RefObject<LegendListRef | null>,
+  rows: ReadonlyArray<ChatMessageModel>,
+): boolean {
+  const keySequenceChanged = useMemo(
+    () =>
+      didChatTimelineKeySequenceChange(
+        committedChatTimelineKeysCache.get(listRef),
+        rows,
+      ),
+    [listRef, rows],
+  );
+
+  useLayoutEffect(() => {
+    committedChatTimelineKeysCache.set(listRef, chatTimelineKeySequence(rows));
+  }, [listRef, rows]);
+
+  return keySequenceChanged;
 }
 
 /**


### PR DESCRIPTION
## The bug

While a reply streams, transcript rows paint on top of each other — two
messages in the same vertical band, doubled/interleaved text. It clears itself
a moment later rather than sticking, so it reads as a flicker.

It is not a measurement bug. It is a **position-application** bug: the sizes
the library records are correct, they are just applied to the rows after the
growing one a frame too late.

## Root cause

`ChatTimeline` passed `maintainVisibleContentPosition` with the boolean
shorthand. That normalizes to `{ data: true, size: true }` — the `data`
channel is the library's own default-**off** setting, and only the shorthand
opted us in, unconditionally and for every commit.

The `data` channel is not free. On every pass where the data array changed
structurally, the library arms an MVCP **anchor lock**. While that lock is
held, `runOrScheduleMVCPRecalculate` stops recalculating item positions inline
and defers the recalculation to a `requestAnimationFrame`:

```js
if (!state.mvcpAnchorLock) {
  calculateItemsInView(ctx, { doMVCP: true });          // inline
} else if (!state.scheduledWork.has("mvcpRecalculate")) {
  state.scheduledWork.frame(                            // a frame later
    () => calculateItemsInView(ctx, { doMVCP: true }), "mvcpRecalculate");
}
```

A streaming transcript hands the list a structurally-changed array on **every
token** (we pass no `itemsAreEqual`, so any changed row object counts). Each
token re-arms the lock well inside its 300ms expiry, and release needs two
consecutive passes with no data change — so the lock is held continuously for
the whole stream.

The consequence: a row grows, the browser lays it out at its new height
immediately, and the offsets of every row after it are only rewritten in the
next frame. The frame in between paints those rows inside the grown row's
band. The deferred pass then lands and the overlap disappears — the flicker.

## Why the 3.3.4 bump was insufficient

That bump (and its two local patch guards) is about *sizes* — rejecting a
zero cross-axis measurement and a grossly stale cached estimate. Neither
touches *when* positions are applied. The anchor-lock deferral is byte-for-byte
the same code in **3.2.0, 3.3.4 and 3.3.8**, so no version on the registry
fixes this, and the 3.3.6/3.3.8 upgrade would not have either. (3.3.8's new
`experimental_hideItemsUntilMeasured` is a *recycling* guard — it hides an item
a container was newly assigned until measured. It does nothing for a row that
is already measured and growing.)

The phone-minimap decoupling that preceded this was also a real fix for a real
problem, but a different one; it removed forced layout from the transcript's
path and left this deferral untouched.

## The fix

**Select the data channel per commit, on the key sequence.**

A first pass turned `data` off outright. Review caught that as a real regression: the timeline is **not** append-only. A settled assistant row is dropped when projection suppresses its last segment (`chat-pinned-todos.ts`), a setup card moves once its anchor is available and a top-level user row disappears when a steer nests into its assistant turn (`rendered-messages.ts`), and branch edits and snapshot replacement rewrite the sequence outright. For a reader parked below any of those, the data channel is the only thing holding their row in place — the scroller sets `overflow-anchor: none`, so the browser's own anchoring is off.

The two cases share one signal only because the library cannot tell them apart. The rows themselves can: a token changes a row's **content** in place, while an insert, a removal, or a move changes the sequence of row **keys**. That is derived in `computeStableChatTimelineRows` — the structural-sharing pass that already walks every row — and selects `{data, size: true}` per commit. Streaming commits get `data: false` and inline positions; the one commit that moves rows gets `data: true` and its anchor.

The baseline is **the sequence the list last committed**, published from a layout effect and never from render. That distinction is load-bearing: React discards renders, and a baseline a discarded render advanced makes the real render that replaces it compare against a sequence nothing ever rendered. With `[A,B]` on screen, a discarded `[A,B,C]` followed by a real `[A,B,C']` would compare three keys against three, call a genuine insertion settled content, and ship it unanchored. A discarded render runs no layout effect, so it cannot move the baseline.

The row-reuse `WeakMap` keeps its original job. The two caches are keyed identically and differ only in *when* they are written — one is published during render by design, the other must not be.

A first population reports no move; no reader is positioned within it. A stale `true` is inert — the library only consults the channel on a pass where it saw the array change.

**Not `itemsAreEqual`** — the shorter route, and unavailable. Installed `react.js:3289-3317` reuses that same comparator to decide whether a mounted container refreshes its item data, so reporting same-key rows equal freezes a streaming row's rendered content.

## Tests

`legend-list-estimate-recovery.test.tsx` drives a **real** LegendList through both halves of the contract:

| case | assertion |
| --- | --- |
| token (same keys) + row grows, `data: false` | positions coherent, **no frame advanced** |
| token (same keys) + row grows, `data: true` | positions **stale**; correct one frame later |
| row removed above a parked reader, `data: true` | parked row holds the same viewport offset |
| row removed above a parked reader, `data: false` | parked row **shifts** |

Rows 2 and 4 are genuine reproductions of the two failure modes, not guards — row 2 is the shipped overlap, row 4 is the regression the first pass would have introduced. Earlier attempts at this class failed because they chased *paint*, which jsdom has none of; both defects here are observable as scheduling and scroll state.

`chat-timeline.test.tsx` pins the arms end-to-end on the real component: a same-key streaming rerender keeps `{data: false, size: true}`, a rerender that removes a row yields `{data: true, size: true}`, and a token *after* that removal returns to `data: false` — proving the baseline advanced on the commit rather than on the render.

`chat-stable-rows.test.ts` covers the pure comparison directly, including the discarded-render sequence: baseline `[A,B]`, a computation for `[A,B,C]` that never commits, then the real `[A,B,C']` — which must still report the move.

**Green locally** — every suite that mounts a real LegendList: estimate-recovery 8/8 · chat-timeline + chat-stable-rows 32/32 · chat-messages + follow-latch-integration + follow-latch + scroll-restoration + scrollbar-composer-overlay + panel-resize-snapshot 206/206 (292/292 including the epic-canvas set) · stable-tile-lifecycle-matrix + chat-tile-queue-edit-steer + chat-tile 86/86. `gui-app` compile clean; eslint `--max-warnings 0` and prettier clean on all four touched files.

## Manual retest

Stream a reply in a chat on the phone build and watch the rows as the reply
grows, including with the transcript scrolled up mid-stream. jsdom can prove
the deferral is gone; only a device can confirm nothing else paints stacked.

Worth pairing with the other half now that the channel is selected rather than
removed: park the transcript mid-history and delete a message above the
viewport, confirming the row you were reading does not move.
