### PR TITLE
fix(gui-app): keep the landing surface's focus restoration off the mobile app

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -36,6 +36,7 @@ import {
   resetTerminalFocusRegistryForTests,
 } from "@/lib/terminals/terminal-focus-registry";
 import { resetPrimaryFocusCoordinatorForTests } from "@/lib/focus/primary-focus-coordinator";
+import { isMobileApp, setMobileApp } from "@/lib/mobile-app";
 import { PrimaryFocusCoordinatorProvider } from "@/lib/focus/primary-focus-coordinator-provider";
 import { useLandingTerminalStore } from "@/stores/home/landing-terminal-store";
 import { useTabsStore } from "@/stores/tabs/store";
@@ -231,6 +232,11 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
           : composer.closest("[data-primary-focus-scope='true']");
       if (
         activityEnabled &&
+        // Mirrors the real editor's own gate: becoming active is not a user
+        // gesture, so the installed mobile app never takes focus from it. The
+        // mock carries it so a surface-driven focus is the only thing left that
+        // could raise the keyboard here.
+        !isMobileApp() &&
         !paneActivationFocusIntent.shouldYieldAutoFocus() &&
         (focusScope === null ||
           document.activeElement === null ||
@@ -462,6 +468,7 @@ describe("<HomePage />", () => {
     });
     useWorkspaceFoldersStore.setState({ byHost: {} });
     useMobileNavStore.setState({ open: false });
+    setMobileApp(false);
     useAuthStore.setState({
       status: "signed-out",
       profile: null,
@@ -907,6 +914,34 @@ describe("<HomePage />", () => {
 
       unregisterInactive();
       inactiveComposer.remove();
+      queryClient.clear();
+    });
+
+    // The installed mobile app's rule: only a gesture may raise the software
+    // keyboard. The landing surface reaches both endpoints through their focus
+    // registries, so neither endpoint's own guard is on this path - the guard
+    // has to be here, and these two cases are what hold it.
+    it("takes no focus on the mobile app when the landing surface becomes focused", async () => {
+      setMobileApp(true);
+      useLandingDraftStore.getState().createDraftWithId("draft-a", null);
+      useLandingDraftStore.getState().setActiveDraft("draft-a");
+      const { queryClient } = renderLandingFocusHarness(noPaneFocusIntent);
+
+      // The composer IS registered and active - without that this would pass on
+      // a surface that simply had no endpoint to focus.
+      const submit = await screen.findByTestId("landing-submit");
+      expect(document.activeElement).not.toBe(submit);
+      expect(document.body.contains(submit)).toBe(true);
+      queryClient.clear();
+    });
+
+    it("leaves a maximized landing terminal unfocused on the mobile app", async () => {
+      setMobileApp(true);
+      seedFocusedLandingTerminal(true);
+      const { queryClient } = renderLandingFocusHarness(noPaneFocusIntent);
+
+      const terminal = await screen.findByTestId("landing-terminal-panel-slot");
+      expect(document.activeElement).not.toBe(terminal);
       queryClient.clear();
     });
 

--- a/clients/gui-app/src/components/home/landing-draft-surface.tsx
+++ b/clients/gui-app/src/components/home/landing-draft-surface.tsx
@@ -16,6 +16,7 @@ import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
 import "./home-touch-targets.css";
 import { focusRegisteredActiveComposer } from "@/lib/composer/composer-focus-registry";
+import { isMobileApp } from "@/lib/mobile-app";
 import { focusTerminalInstance } from "@/lib/terminals/terminal-focus-registry";
 import {
   landingTerminalLayoutFor,
@@ -109,42 +110,18 @@ export function LandingDraftSurface() {
     if (!newlyFocused || paneActivationFocusIntent.shouldYieldAutoFocus()) {
       return;
     }
-
-    const terminalState = useLandingTerminalStore.getState();
-    const layout = landingTerminalLayoutFor(
-      terminalState,
-      draftId ?? "unbound-landing-page",
+    // The surface becoming focused is not a user gesture, and on the installed
+    // mobile app that alone must not raise the software keyboard - the same
+    // rule the composer's own autofocus obeys, restated here because this path
+    // reaches the composer and the terminal through their focus REGISTRIES and
+    // therefore never runs their guards. Explicit focus (tapping the composer,
+    // tapping the terminal) is unaffected: it is the gesture the rule asks for.
+    if (isMobileApp()) return;
+    restoreLandingSurfaceFocus(
+      draftId,
+      surfaceRef.current,
+      focusRestorationTargetRef.current,
     );
-    if (layout.panelOpen && layout.maximized) {
-      const instanceId = terminalState.activeInstanceId;
-      if (instanceId !== null) {
-        focusTerminalInstance(instanceId);
-        return;
-      }
-    }
-
-    const surface = surfaceRef.current;
-    const previous = focusRestorationTargetRef.current;
-    if (
-      surface !== null &&
-      previous !== null &&
-      previous.isConnected &&
-      surface.contains(previous)
-    ) {
-      previous.focus({ preventScroll: true });
-      if (
-        document.activeElement === previous ||
-        (document.activeElement !== null &&
-          previous.contains(document.activeElement))
-      ) {
-        return;
-      }
-    }
-    // The local Tiptap editor may not have registered yet
-    // (`immediatelyRender: false`). Never fall back to a retained inactive
-    // split partner here; if no active endpoint exists, the local editor's own
-    // autofocus effect will run as soon as it registers.
-    focusRegisteredActiveComposer();
   }, [draftId, paneActivationFocusIntent, surfaceEffectivelyFocused]);
 
   return (
@@ -234,6 +211,55 @@ export function LandingDraftSurface() {
       )}
     </div>
   );
+}
+
+/**
+ * Puts the caret back where this surface last had it, in the order the surface
+ * itself ranks its endpoints: a maximized terminal owns the pane outright, then
+ * the element that actually held focus, then the active composer.
+ *
+ * A module function rather than an inline effect body so the effect above stays
+ * a list of GUARDS - who may restore, and when - with the ranking read on its
+ * own.
+ */
+function restoreLandingSurfaceFocus(
+  draftId: string | null,
+  surface: HTMLDivElement | null,
+  previous: HTMLElement | null,
+): void {
+  const terminalState = useLandingTerminalStore.getState();
+  const layout = landingTerminalLayoutFor(
+    terminalState,
+    draftId ?? "unbound-landing-page",
+  );
+  if (layout.panelOpen && layout.maximized) {
+    const instanceId = terminalState.activeInstanceId;
+    if (instanceId !== null) {
+      focusTerminalInstance(instanceId);
+      return;
+    }
+  }
+
+  if (
+    surface !== null &&
+    previous !== null &&
+    previous.isConnected &&
+    surface.contains(previous)
+  ) {
+    previous.focus({ preventScroll: true });
+    if (
+      document.activeElement === previous ||
+      (document.activeElement !== null &&
+        previous.contains(document.activeElement))
+    ) {
+      return;
+    }
+  }
+  // The local Tiptap editor may not have registered yet
+  // (`immediatelyRender: false`). Never fall back to a retained inactive split
+  // partner here; if no active endpoint exists, the local editor's own
+  // autofocus effect will run as soon as it registers.
+  focusRegisteredActiveComposer();
 }
 
 function renderLandingWorkspaceControls(


### PR DESCRIPTION
## What

On the installed mobile app, Home becoming the focused surface programmatically focuses the composer (or a maximized landing terminal) and raises the software keyboard with no user gesture. This restores the rule that already governs the composer's own autofocus.

## Why it slipped through

The composer states the rule itself:

```ts
// Becoming the active composer is not a user gesture. On the installed
// mobile app that alone must not raise the software keyboard; the explicit
// focus paths (tapping the composer, restoring a draft, editing a message)
// still do.
if (isMobileApp()) return;
```

`LandingDraftSurface`'s focus-restoration effect reaches the composer and the landing terminal through their focus **registries** (`focusRegisteredActiveComposer()`, `focusTerminalInstance()`), whose endpoints are a raw `editor.commands.focus()` and the terminal's focus call. The registry path never runs the endpoint's own guard, so the surface could do what the endpoint had just refused to do.

Rule stated in one place, decision made in another. The fix states it where the decision is made.

Explicit focus is untouched — tapping the composer or the terminal is the gesture the rule asks for.

## Changes

- `landing-draft-surface.tsx` — guard the restoration arm on `isMobileApp()`; move the endpoint ranking (maximized terminal → last focused element → active composer) into a module function, so the effect reads as the list of guards it now is and stays under the complexity gate.
- `home-page.test.tsx` — two cases against the existing live-`LandingDraftSurface` harness, plus the same `isMobileApp()` gate on the harness's mock composer so it mirrors the real editor and the surface-driven focus is the only thing the cases can be observing.

## Verification

Both new cases are mutation-proven — they fail on `mobile-app` without the guard:

```
× takes no focus on the mobile app when the landing surface becomes focused
× leaves a maximized landing terminal unfocused on the mobile app
AssertionError: expected <button type="button" …(1)></button> not to be <button type="button" …(1)></button>
Tests  2 failed | 16 passed (18)
```

With the guard: 18/18 in `home-page.test.tsx`, 33/33 across `home-page` + `home-hero` + `composer-render-isolation`. `eslint --max-warnings 0`, prettier, and `compile` clean; the full `build · compile · lint · format (nx affected)` pre-commit gate passed.

## Scope note

This was found while investigating the v1.0.18 edge-swipe report. It is **not** claimed as that regression's root cause — the gesture stack itself (`use-edge-nav-swipe.ts`, `shell-gestures.ts`, `use-mobile-history-swipes.ts`, `blocking-layer-claim.ts`, the safe-area reads, the window-narrator arm) has a zero-byte diff across `mobile-staging-v1.0.17..v1.0.18`, and all 92 existing gesture/edge-swipe assertions are green on `mobile-app`. This is shipped on its own merits: the keyboard must not raise itself on the phone's Home.
