### PR TITLE
Prevent delayed package-manager latest regressions

### DIFF
--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -220,7 +220,7 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Refuse an npm latest regression
-        if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'
+        if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true' && env.DIST_TAG == 'latest'
         shell: bash
         run: |
           set -euo pipefail
@@ -347,14 +347,17 @@ jobs:
               exit 1
             fi
             EXISTING_ARGS=(--existing="Homebrew main=$current")
-            while IFS= read -r open_branch; do
+            STALE_PRS=()
+            while IFS=$'\t' read -r open_number open_branch; do
+              [ -n "$open_number" ] || continue
               [ -n "$open_branch" ] || continue
               [ "$open_branch" = "$branch" ] && continue
               open_version="${open_branch#traycer-formula-}"
               EXISTING_ARGS+=(--existing="open Homebrew PR ${open_branch}=$open_version")
+              STALE_PRS+=("$open_number")
             done < <(gh pr list --repo "$TAP_REPO" --state open --limit 100 \
-              --json headRefName,body \
-              --jq '.[] | select(.body | contains("Updates the rolling Formula/traycer.rb")) | .headRefName | select(startswith("traycer-formula-"))')
+              --json number,headRefName,body \
+              --jq '.[] | select(.body | contains("Updates the rolling Formula/traycer.rb")) | select(.headRefName | startswith("traycer-formula-")) | [.number, .headRefName] | @tsv')
             node ../scripts/native-packaging/assert-rolling-package-version.cjs \
               --candidate="$VERSION" \
               "${EXISTING_ARGS[@]}"
@@ -362,13 +365,10 @@ jobs:
             # other rolling formula PR. Retire those older mutation intents so
             # a human cannot merge one after this version becomes the proven
             # remedy.
-            while IFS= read -r stale_pr; do
-              [ -n "$stale_pr" ] || continue
+            for stale_pr in "${STALE_PRS[@]}"; do
               gh pr close "$stale_pr" --repo "$TAP_REPO" \
                 --comment "Superseded by the monotonic rolling formula update for Traycer ${VERSION}. The older PR is closed so it cannot regress Formula/traycer.rb after a compatibility floor is activated."
-            done < <(gh pr list --repo "$TAP_REPO" --state open --limit 100 \
-              --json number,headRefName,body \
-              --jq ".[] | select(.body | contains(\"Updates the rolling Formula/traycer.rb\")) | select(.headRefName | startswith(\"traycer-formula-\")) | select(.headRefName != \"$branch\") | .number")
+            done
           fi
           git commit -m "traycer ${VERSION}"
           git push --force origin "$branch"

--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -183,6 +183,14 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.oss_ref }}
           persist-credentials: false
+      - name: Check out the workflow-owned publication guard
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-guard
+          persist-credentials: false
+          sparse-checkout: scripts/native-packaging/assert-rolling-package-version.cjs
+          sparse-checkout-cone-mode: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.12"
@@ -225,7 +233,7 @@ jobs:
         run: |
           set -euo pipefail
           current="$(npm view "@traycerai/cli" dist-tags.latest --registry "https://registry.npmjs.org")"
-          node scripts/native-packaging/assert-rolling-package-version.cjs \
+          node workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs \
             --candidate="$VERSION" \
             --existing="npm latest=$current"
       - name: Publish npm package (with provenance)
@@ -248,6 +256,7 @@ jobs:
     env:
       VERSION: ${{ needs.resolve.outputs.version }}
       RELEASE_REPO: ${{ github.repository }}
+      ROLLING_HOMEBREW: ${{ inputs.homebrew_versioned_only != true && needs.resolve.outputs.dist_tag == 'latest' }}
     steps:
       - name: Check tap repo secrets
         if: ${{ inputs.dry_run != true }}
@@ -265,6 +274,14 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.oss_ref }}
           persist-credentials: false
+      - name: Check out the workflow-owned publication guard
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-guard
+          persist-credentials: false
+          sparse-checkout: scripts/native-packaging/assert-rolling-package-version.cjs
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.15.0"
@@ -293,8 +310,6 @@ jobs:
           done
           ls -la descriptors/
       - name: Render Homebrew formula
-        env:
-          HOMEBREW_VERSIONED_ONLY: ${{ inputs.homebrew_versioned_only }}
         shell: bash
         run: |
           set -euo pipefail
@@ -304,7 +319,7 @@ jobs:
             DESCRIPTOR_ARGS+=(--descriptor "$f")
           done
           VERSIONED_ONLY_ARGS=()
-          if [ "$HOMEBREW_VERSIONED_ONLY" = "true" ]; then
+          if [ "$ROLLING_HOMEBREW" != "true" ]; then
             VERSIONED_ONLY_ARGS+=(--homebrew-versioned-only)
           fi
           node scripts/native-packaging/publish-cli-package-managers.cjs \
@@ -323,7 +338,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TRAYCER_TAP_PUSH_TOKEN }}
           TAP_REPO: ${{ secrets.TRAYCER_HOMEBREW_TAP_REPO }}
-          HOMEBREW_VERSIONED_ONLY: ${{ inputs.homebrew_versioned_only }}
         shell: bash
         run: |
           set -euo pipefail
@@ -340,7 +354,7 @@ jobs:
             echo "::notice::Formula already up to date for ${VERSION}; nothing to PR."
             exit 0
           fi
-          if [ "$HOMEBREW_VERSIONED_ONLY" != "true" ]; then
+          if [ "$ROLLING_HOMEBREW" = "true" ]; then
             current="$(git show origin/main:Formula/traycer.rb | sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p')"
             if [ -z "$current" ]; then
               echo "::error::Formula/traycer.rb on ${TAP_REPO}@main has no readable version; refusing to replace a rolling selector whose current value is unknown."
@@ -348,6 +362,14 @@ jobs:
             fi
             EXISTING_ARGS=(--existing="Homebrew main=$current")
             STALE_PRS=()
+            OPEN_PR_LIMIT=1000
+            open_prs="$(gh pr list --repo "$TAP_REPO" --state open --limit "$OPEN_PR_LIMIT" \
+              --json number,headRefName,body)"
+            open_pr_count="$(jq 'length' <<<"$open_prs")"
+            if [ "$open_pr_count" -ge "$OPEN_PR_LIMIT" ]; then
+              echo "::error::Found ${open_pr_count} open Homebrew pull requests, reaching the ${OPEN_PR_LIMIT}-PR inspection bound; refusing to publish without proving the complete rolling-selector set."
+              exit 1
+            fi
             while IFS=$'\t' read -r open_number open_branch; do
               [ -n "$open_number" ] || continue
               [ -n "$open_branch" ] || continue
@@ -355,10 +377,8 @@ jobs:
               open_version="${open_branch#traycer-formula-}"
               EXISTING_ARGS+=(--existing="open Homebrew PR ${open_branch}=$open_version")
               STALE_PRS+=("$open_number")
-            done < <(gh pr list --repo "$TAP_REPO" --state open --limit 100 \
-              --json number,headRefName,body \
-              --jq '.[] | select(.body | contains("Updates the rolling Formula/traycer.rb")) | select(.headRefName | startswith("traycer-formula-")) | [.number, .headRefName] | @tsv')
-            node ../scripts/native-packaging/assert-rolling-package-version.cjs \
+            done < <(jq -r '.[] | select(.body | contains("Updates the rolling Formula/traycer.rb")) | select(.headRefName | startswith("traycer-formula-")) | [.number, .headRefName] | @tsv' <<<"$open_prs")
+            node ../workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs \
               --candidate="$VERSION" \
               "${EXISTING_ARGS[@]}"
             # The serialized job has proved this candidate outranks every
@@ -373,7 +393,7 @@ jobs:
           git commit -m "traycer ${VERSION}"
           git push --force origin "$branch"
           existing="$(gh pr list --repo "$TAP_REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')"
-          if [ "$HOMEBREW_VERSIONED_ONLY" = "true" ]; then
+          if [ "$ROLLING_HOMEBREW" != "true" ]; then
             body="Automated Homebrew formula backfill for Traycer CLI ${VERSION}. Adds/updates only Formula/traycer@${VERSION}.rb; the rolling Formula/traycer.rb is intentionally left untouched. Generated by publish-cli-package-managers.yml. Review and merge to publish."
           else
             body="Automated Homebrew formula update for Traycer CLI ${VERSION}. Updates the rolling Formula/traycer.rb and the exact-version Formula/traycer@${VERSION}.rb formula generated by publish-cli-package-managers.yml. Review and merge to publish."

--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -156,6 +156,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      # The guard immediately before npm publish reads the current `latest`
+      # selector. Serializing every writer makes that read + mutation one
+      # ordered decision: a delayed older workflow cannot pass against an old
+      # value and then overwrite a newer publication.
+      group: traycer-cli-npm-latest-publish
+      cancel-in-progress: false
     env:
       VERSION: ${{ needs.resolve.outputs.version }}
       DIST_TAG: ${{ needs.resolve.outputs.dist_tag }}
@@ -212,6 +219,15 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Refuse an npm latest regression
+        if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(npm view "@traycerai/cli" dist-tags.latest --registry "https://registry.npmjs.org")"
+          node scripts/native-packaging/assert-rolling-package-version.cjs \
+            --candidate="$VERSION" \
+            --existing="npm latest=$current"
       - name: Publish npm package (with provenance)
         if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'
         run: npm publish clients/traycer-cli/dist-npm --provenance --access public --tag "$DIST_TAG" --registry "https://registry.npmjs.org"
@@ -247,6 +263,7 @@ jobs:
           fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.resolve.outputs.oss_ref }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -322,6 +339,36 @@ jobs:
           if git diff --cached --quiet; then
             echo "::notice::Formula already up to date for ${VERSION}; nothing to PR."
             exit 0
+          fi
+          if [ "$HOMEBREW_VERSIONED_ONLY" != "true" ]; then
+            current="$(git show origin/main:Formula/traycer.rb | sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p')"
+            if [ -z "$current" ]; then
+              echo "::error::Formula/traycer.rb on ${TAP_REPO}@main has no readable version; refusing to replace a rolling selector whose current value is unknown."
+              exit 1
+            fi
+            EXISTING_ARGS=(--existing="Homebrew main=$current")
+            while IFS= read -r open_branch; do
+              [ -n "$open_branch" ] || continue
+              [ "$open_branch" = "$branch" ] && continue
+              open_version="${open_branch#traycer-formula-}"
+              EXISTING_ARGS+=(--existing="open Homebrew PR ${open_branch}=$open_version")
+            done < <(gh pr list --repo "$TAP_REPO" --state open --limit 100 \
+              --json headRefName,body \
+              --jq '.[] | select(.body | contains("Updates the rolling Formula/traycer.rb")) | .headRefName | select(startswith("traycer-formula-"))')
+            node ../scripts/native-packaging/assert-rolling-package-version.cjs \
+              --candidate="$VERSION" \
+              "${EXISTING_ARGS[@]}"
+            # The serialized job has proved this candidate outranks every
+            # other rolling formula PR. Retire those older mutation intents so
+            # a human cannot merge one after this version becomes the proven
+            # remedy.
+            while IFS= read -r stale_pr; do
+              [ -n "$stale_pr" ] || continue
+              gh pr close "$stale_pr" --repo "$TAP_REPO" \
+                --comment "Superseded by the monotonic rolling formula update for Traycer ${VERSION}. The older PR is closed so it cannot regress Formula/traycer.rb after a compatibility floor is activated."
+            done < <(gh pr list --repo "$TAP_REPO" --state open --limit 100 \
+              --json number,headRefName,body \
+              --jq ".[] | select(.body | contains(\"Updates the rolling Formula/traycer.rb\")) | select(.headRefName | startswith(\"traycer-formula-\")) | select(.headRefName != \"$branch\") | .number")
           fi
           git commit -m "traycer ${VERSION}"
           git push --force origin "$branch"

--- a/scripts/__tests__/assert-rolling-package-version.test.mjs
+++ b/scripts/__tests__/assert-rolling-package-version.test.mjs
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertRollingVersionAdvances,
+  compareStableVersions,
+  parseArgs,
+} from "../native-packaging/assert-rolling-package-version.cjs";
+
+// `assert-rolling-package-version.cjs` is the shared guard both
+// publish-cli-package-managers.yml jobs (npm + Homebrew) shell out to
+// immediately before mutating their respective rolling "latest" selector.
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "native-packaging",
+  "assert-rolling-package-version.cjs",
+);
+
+function runCli(args) {
+  return execFileSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+  });
+}
+
+// execFileSync throws on a non-zero exit; the thrown error carries
+// .status/.stdout/.stderr, which is exactly the contract the workflow's
+// `set -euo pipefail` steps rely on to stop the job.
+function runCliExpectFailure(args) {
+  try {
+    const stdout = runCli(args);
+    throw new Error(
+      `expected the CLI to exit non-zero, got status 0 with stdout: ${stdout}`,
+    );
+  } catch (error) {
+    if (error.status === undefined) throw error;
+    return error;
+  }
+}
+
+describe("compareStableVersions: strict stable SemVer only, numeric ordering", () => {
+  it("orders numerically, not lexically (double digits, ties)", () => {
+    expect(compareStableVersions("1.10.0", "1.9.0")).toBe(1);
+    expect(compareStableVersions("1.9.0", "1.10.0")).toBe(-1);
+    expect(compareStableVersions("2.0.0", "2.0.0")).toBe(0);
+    expect(compareStableVersions("1.2.10", "1.2.9")).toBe(1);
+  });
+
+  it("compares major/minor/patch in that precedence order", () => {
+    expect(compareStableVersions("2.0.0", "1.9.9")).toBe(1);
+    expect(compareStableVersions("1.3.0", "1.2.9")).toBe(1);
+    expect(compareStableVersions("1.2.4", "1.2.3")).toBe(1);
+  });
+
+  it("rejects every non-strict-stable form on either side", () => {
+    for (const bad of [
+      "1.2.3-rc.1",
+      "1.2.3+build.5",
+      "1.2",
+      "1.2.3.4",
+      "v1.2.3",
+      "1.2.x",
+      "01.2.3",
+      "1.02.3",
+      "",
+      "1.2.3 ",
+      " 1.2.3",
+    ]) {
+      expect(
+        () => compareStableVersions(bad, "1.0.0"),
+        `expected ${JSON.stringify(bad)} to be rejected as candidate`,
+      ).toThrow(/must be strict stable SemVer/u);
+      expect(
+        () => compareStableVersions("1.0.0", bad),
+        `expected ${JSON.stringify(bad)} to be rejected as published`,
+      ).toThrow(/must be strict stable SemVer/u);
+    }
+  });
+
+  it("labels which side is malformed (candidate vs published) in the error", () => {
+    expect(() => compareStableVersions("bad", "1.0.0")).toThrow(
+      /candidate version must be strict stable SemVer/u,
+    );
+    expect(() => compareStableVersions("1.0.0", "bad")).toThrow(
+      /published version must be strict stable SemVer/u,
+    );
+  });
+});
+
+describe("assertRollingVersionAdvances: refuses equal/older, accepts strictly-newer", () => {
+  it("accepts a candidate strictly newer than every existing observation", () => {
+    expect(() =>
+      assertRollingVersionAdvances({
+        candidate: "1.3.0",
+        existing: [
+          { label: "npm latest", version: "1.2.0" },
+          { label: "Homebrew main", version: "1.1.0" },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("refuses when the candidate equals an existing observation", () => {
+    expect(() =>
+      assertRollingVersionAdvances({
+        candidate: "1.2.0",
+        existing: [{ label: "npm latest", version: "1.2.0" }],
+      }),
+    ).toThrow(/1\.2\.0 cannot replace npm latest at 1\.2\.0/u);
+  });
+
+  it("refuses when the candidate is older than an existing observation", () => {
+    expect(() =>
+      assertRollingVersionAdvances({
+        candidate: "1.1.0",
+        existing: [{ label: "npm latest", version: "1.2.0" }],
+      }),
+    ).toThrow(/1\.1\.0 cannot replace npm latest at 1\.2\.0/u);
+  });
+
+  it("refuses if ANY one of several observations is not strictly behind, even when the rest are", () => {
+    expect(() =>
+      assertRollingVersionAdvances({
+        candidate: "1.3.0",
+        existing: [
+          { label: "npm latest", version: "1.2.0" },
+          {
+            label: "open Homebrew PR traycer-formula-1.3.0",
+            version: "1.3.0",
+          },
+        ],
+      }),
+    ).toThrow(
+      /1\.3\.0 cannot replace open Homebrew PR traycer-formula-1\.3\.0 at 1\.3\.0/u,
+    );
+  });
+
+  it("explains why in the error: a delayed older publisher could regress users below an active compatibility floor", () => {
+    expect(() =>
+      assertRollingVersionAdvances({
+        candidate: "1.0.0",
+        existing: [{ label: "npm latest", version: "1.1.0" }],
+      }),
+    ).toThrow(/compatibility floor/u);
+  });
+});
+
+describe("parseArgs: the workflow-facing CLI surface", () => {
+  it("parses a candidate plus one or more --existing=<label>=<version> observations", () => {
+    expect(
+      parseArgs([
+        "--candidate=1.3.0",
+        "--existing=npm latest=1.2.0",
+        "--existing=Homebrew main=1.1.0",
+      ]),
+    ).toEqual({
+      candidate: "1.3.0",
+      existing: [
+        { label: "npm latest", version: "1.2.0" },
+        { label: "Homebrew main", version: "1.1.0" },
+      ],
+    });
+  });
+
+  it("--existing splits on the FIRST '=' only, so a label may itself contain '='-free branch names", () => {
+    expect(
+      parseArgs([
+        "--candidate=1.3.0",
+        "--existing=open Homebrew PR traycer-formula-1.2.0=1.2.0",
+      ]),
+    ).toEqual({
+      candidate: "1.3.0",
+      existing: [
+        {
+          label: "open Homebrew PR traycer-formula-1.2.0",
+          version: "1.2.0",
+        },
+      ],
+    });
+  });
+
+  it("requires --candidate", () => {
+    expect(() => parseArgs(["--existing=npm latest=1.2.0"])).toThrow(
+      /--candidate=<stable-version> is required/u,
+    );
+  });
+
+  it("requires at least one --existing observation (publishing blind would permit a regression)", () => {
+    expect(() => parseArgs(["--candidate=1.3.0"])).toThrow(
+      /at least one --existing=<label>=<version> is required/u,
+    );
+  });
+
+  it("rejects a malformed candidate at parse time, before any --existing is consulted", () => {
+    expect(() =>
+      parseArgs(["--candidate=not-a-version", "--existing=npm latest=1.2.0"]),
+    ).toThrow(/candidate version must be strict stable SemVer/u);
+  });
+
+  it("rejects a malformed --existing pair with no '=' between label and version", () => {
+    expect(() =>
+      parseArgs(["--candidate=1.3.0", "--existing=npm-latest-1.2.0"]),
+    ).toThrow(/--existing must be --existing=<label>=<version>/u);
+  });
+
+  it("rejects a malformed --existing pair with an empty label or an empty version", () => {
+    expect(() =>
+      parseArgs(["--candidate=1.3.0", "--existing==1.2.0"]),
+    ).toThrow(/--existing must be --existing=<label>=<version>/u);
+    expect(() =>
+      parseArgs(["--candidate=1.3.0", "--existing=npm latest="]),
+    ).toThrow(/--existing must be --existing=<label>=<version>/u);
+  });
+
+  it("rejects any unrecognized argument", () => {
+    expect(() => parseArgs(["--bogus=1"])).toThrow(
+      /unrecognized argument "--bogus=1"/u,
+    );
+  });
+});
+
+describe("CLI entrypoint: exit-code contract the `set -euo pipefail` workflow steps rely on", () => {
+  it("exits 0 and prints a confirming line naming every observation advanced", () => {
+    const stdout = runCli([
+      "--candidate=1.3.0",
+      "--existing=npm latest=1.2.0",
+      "--existing=Homebrew main=1.1.0",
+    ]);
+    expect(stdout).toContain(
+      "Rolling package version guard: 1.3.0 advances npm latest (1.2.0), Homebrew main (1.1.0).",
+    );
+  });
+
+  it("exits non-zero with a FAILED message on stderr when the candidate does not advance", () => {
+    const error = runCliExpectFailure([
+      "--candidate=1.2.0",
+      "--existing=npm latest=1.2.0",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr.toString()).toContain(
+      "Rolling package version guard FAILED",
+    );
+    expect(error.stderr.toString()).toContain("cannot replace npm latest");
+  });
+
+  it("exits non-zero when --existing is missing entirely", () => {
+    const error = runCliExpectFailure(["--candidate=1.3.0"]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr.toString()).toContain(
+      "at least one --existing=<label>=<version> is required",
+    );
+  });
+
+  it("exits non-zero on a malformed observation, e.g. an unreadable Homebrew formula version reaching --existing", () => {
+    const error = runCliExpectFailure([
+      "--candidate=1.3.0",
+      "--existing=Homebrew main=not-a-version",
+    ]);
+    expect(error.status).not.toBe(0);
+    expect(error.stderr.toString()).toContain(
+      "must be strict stable SemVer",
+    );
+  });
+});

--- a/scripts/__tests__/publish-cli-package-managers-rolling-guard.test.mjs
+++ b/scripts/__tests__/publish-cli-package-managers-rolling-guard.test.mjs
@@ -80,16 +80,22 @@ describe("publish-npm: the rolling-version guard sits immediately before the mut
     expect(publishIdx).toBeLessThan(dryRunIdx);
   });
 
-  it("gates the guard step with the exact same `if:` as the publish step it protects", () => {
+  it("gates the guard step with the publish step's condition PLUS env.DIST_TAG == 'latest', while publish keeps the broader condition", () => {
+    // The rolling guard only makes sense against npm's `latest` dist-tag: a
+    // prerelease/backfill publish under a non-"latest" dist-tag never moves
+    // the rolling selector, so it must not be blocked by (or compared
+    // against) it. The "Publish npm package" step still runs for those
+    // dist-tags, so it deliberately keeps the broader, un-narrowed condition.
     const guardStep = stepBlock(npmJob, "Refuse an npm latest regression");
     const publishStep = stepBlock(
       npmJob,
       "Publish npm package (with provenance)",
     );
-    const expectedIf =
-      "if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'";
-    expect(guardStep).toContain(expectedIf);
-    expect(publishStep).toContain(expectedIf);
+    const sharedIf =
+      "steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'";
+    expect(guardStep).toContain(`if: ${sharedIf} && env.DIST_TAG == 'latest'`);
+    expect(publishStep).toContain(`if: ${sharedIf}`);
+    expect(publishStep).not.toContain("env.DIST_TAG == 'latest'");
   });
 
   it("re-reads the live npm dist-tags.latest and feeds it as the sole --existing observation", () => {
@@ -127,17 +133,33 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
     expect(prStep).toContain("exit 1");
   });
 
-  it("collects every OPEN rolling-formula PR (excluding its own branch) as additional --existing observations", () => {
+  it("collects every OPEN rolling-formula PR (excluding its own branch) as additional --existing observations, from a single gh pr list query", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    // Exactly one `gh pr list` call within the guarded block feeds both
+    // EXISTING_ARGS and STALE_PRS - there must be no second query re-deriving
+    // the close list separately. (A THIRD, unrelated `gh pr list` call later
+    // in this step finds this run's OWN branch's PR number for the
+    // create-vs-update decision - that one is out of scope here.)
+    const guardedBlock = /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
+      prStep,
+    )[1];
+    const listCalls = guardedBlock.match(/gh pr list --repo "\$TAP_REPO"/gu) ?? [];
+    expect(listCalls).toHaveLength(1);
     expect(prStep).toContain('gh pr list --repo "$TAP_REPO" --state open --limit 100');
     expect(prStep).toContain(
       'select(.body | contains("Updates the rolling Formula/traycer.rb"))',
     );
-    expect(prStep).toContain('select(startswith("traycer-formula-"))');
+    expect(prStep).toContain('select(.headRefName | startswith("traycer-formula-"))');
+    // The single query emits number+branch pairs as TSV; the read loop
+    // parses both, skips its own branch, and records the validated PR
+    // number for later closure alongside the --existing observation.
+    expect(prStep).toContain('[.number, .headRefName] | @tsv');
+    expect(prStep).toMatch(/while IFS=\$'\\t' read -r open_number open_branch; do/u);
     expect(prStep).toMatch(/\[ "\$open_branch" = "\$branch" \] && continue/u);
     expect(prStep).toContain(
       '--existing="open Homebrew PR ${open_branch}=$open_version"',
     );
+    expect(prStep).toMatch(/STALE_PRS\+=\("\$open_number"\)/u);
   });
 
   it("invokes the shared guard with the candidate and every gathered --existing observation", () => {
@@ -154,7 +176,7 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
     const guardIdx = prStep.indexOf(
       "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
     );
-    const closeIdx = prStep.indexOf('gh pr close "$stale_pr"');
+    const closeIdx = prStep.indexOf('for stale_pr in "${STALE_PRS[@]}"; do');
     const commitIdx = prStep.indexOf('git commit -m "traycer ${VERSION}"');
     expect(guardIdx).toBeGreaterThan(-1);
     expect(closeIdx).toBeGreaterThan(-1);
@@ -163,13 +185,19 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
     expect(closeIdx).toBeLessThan(commitIdx);
   });
 
-  it("only closes OTHER open rolling-formula PRs (excludes this run's own branch)", () => {
+  it("closes exactly the PR numbers recorded in STALE_PRS during the earlier loop, with no second gh pr list query", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
-    // This jq filter is embedded in a double-quoted bash string (so `$branch`
-    // interpolates), so its inner quotes are backslash-escaped.
-    expect(prStep).toContain(
-      '--jq ".[] | select(.body | contains(\\"Updates the rolling Formula/traycer.rb\\")) | select(.headRefName | startswith(\\"traycer-formula-\\")) | select(.headRefName != \\"$branch\\") | .number")',
+    expect(prStep).toMatch(
+      /for stale_pr in "\$\{STALE_PRS\[@\]\}"; do\n\s+gh pr close "\$stale_pr" --repo "\$TAP_REPO"/u,
     );
+    // Confirms (again, scoped to the guarded block) there is no independent
+    // second query deriving the close list - STALE_PRS from the single
+    // earlier read loop is the only source `gh pr close` iterates.
+    const guardedBlock = /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
+      prStep,
+    )[1];
+    const listCalls = guardedBlock.match(/gh pr list --repo "\$TAP_REPO"/gu) ?? [];
+    expect(listCalls).toHaveLength(1);
   });
 });
 

--- a/scripts/__tests__/publish-cli-package-managers-rolling-guard.test.mjs
+++ b/scripts/__tests__/publish-cli-package-managers-rolling-guard.test.mjs
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Parses publish-cli-package-managers.yml as raw text rather than through a
+// YAML parser: the property under test is the literal shell wiring (step
+// order, `if:` conditions, concurrency groups) that GitHub Actions executes,
+// not an abstract YAML structure.
+const WORKFLOW_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "publish-cli-package-managers.yml",
+);
+
+const workflowText = fs.readFileSync(WORKFLOW_PATH, "utf8");
+const jobsText = workflowText.slice(workflowText.indexOf("\njobs:\n"));
+
+function jobBlock(name) {
+  const header = new RegExp(`\\n {2}${name}:\\n`, "u");
+  const match = header.exec(jobsText);
+  if (match === null) {
+    throw new Error(`job "${name}" not found in ${WORKFLOW_PATH}`);
+  }
+  const start = match.index + match[0].length;
+  const rest = jobsText.slice(start);
+  const nextJob = /\n {2}[A-Za-z0-9_-]+:\n/u.exec(rest);
+  return nextJob === null ? rest : rest.slice(0, nextJob.index + 1);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function stepIndex(source, stepName) {
+  const header = new RegExp(`- name: ${escapeRegExp(stepName)}\\n`, "u");
+  const match = header.exec(source);
+  if (match === null) {
+    throw new Error(`step "${stepName}" not found`);
+  }
+  return match.index;
+}
+
+function stepBlock(source, stepName) {
+  const start = stepIndex(source, stepName);
+  const rest = source.slice(start);
+  const nextStep = /\n {6}- name: /u.exec(rest.slice(1));
+  const end = nextStep === null ? rest.length : nextStep.index + 1;
+  return rest.slice(0, end);
+}
+
+const npmJob = jobBlock("publish-npm");
+const homebrewJob = jobBlock("publish-homebrew-formula");
+
+describe("publish-npm: concurrency serializes every writer around the guard", () => {
+  it("carries a job-level concurrency group with cancel-in-progress: false", () => {
+    const concurrencyIndex = npmJob.indexOf("concurrency:");
+    const envIndex = npmJob.indexOf("\n    env:\n");
+    expect(concurrencyIndex).toBeGreaterThan(-1);
+    // The concurrency block must precede the steps (and env), not be some
+    // unrelated later mention of the word.
+    expect(concurrencyIndex).toBeLessThan(envIndex);
+    const concurrencyBlock = npmJob.slice(concurrencyIndex, envIndex);
+    expect(concurrencyBlock).toContain("group: traycer-cli-npm-latest-publish");
+    expect(concurrencyBlock).toContain("cancel-in-progress: false");
+  });
+});
+
+describe("publish-npm: the rolling-version guard sits immediately before the mutation", () => {
+  it("orders Skip existing -> Refuse regression -> Publish -> dry run, guard directly before publish", () => {
+    const existingIdx = stepIndex(npmJob, "Skip existing npm version");
+    const refuseIdx = stepIndex(npmJob, "Refuse an npm latest regression");
+    const publishIdx = stepIndex(npmJob, "Publish npm package (with provenance)");
+    const dryRunIdx = stepIndex(npmJob, "npm dry run");
+    expect(existingIdx).toBeLessThan(refuseIdx);
+    expect(refuseIdx).toBeLessThan(publishIdx);
+    expect(publishIdx).toBeLessThan(dryRunIdx);
+  });
+
+  it("gates the guard step with the exact same `if:` as the publish step it protects", () => {
+    const guardStep = stepBlock(npmJob, "Refuse an npm latest regression");
+    const publishStep = stepBlock(
+      npmJob,
+      "Publish npm package (with provenance)",
+    );
+    const expectedIf =
+      "if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'";
+    expect(guardStep).toContain(expectedIf);
+    expect(publishStep).toContain(expectedIf);
+  });
+
+  it("re-reads the live npm dist-tags.latest and feeds it as the sole --existing observation", () => {
+    const guardStep = stepBlock(npmJob, "Refuse an npm latest regression");
+    expect(guardStep).toMatch(
+      /current="\$\(npm view "@traycerai\/cli" dist-tags\.latest --registry "https:\/\/registry\.npmjs\.org"\)"/u,
+    );
+    expect(guardStep).toContain(
+      "node scripts/native-packaging/assert-rolling-package-version.cjs",
+    );
+    expect(guardStep).toContain('--candidate="$VERSION"');
+    expect(guardStep).toContain('--existing="npm latest=$current"');
+    // Guarded by `set -euo pipefail`, so a non-zero exit from the guard
+    // script stops the job before "Publish npm package" runs.
+    expect(guardStep).toContain("set -euo pipefail");
+  });
+});
+
+describe("publish-homebrew-formula: the rolling-version guard reads origin/main + open rolling PRs", () => {
+  it("reads the pre-existing rolling version from the git ref, not the working tree the release PR is about to overwrite", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    // `cp` overwrites Formula/traycer.rb with the CANDIDATE content before
+    // this line runs; reading the "current" (pre-mutation) version must
+    // therefore come from git history (origin/main), not the working tree,
+    // or the guard would compare the candidate against itself.
+    expect(prStep).toMatch(
+      /current="\$\(git show origin\/main:Formula\/traycer\.rb \| sed -nE 's\/\^\[\[:space:\]\]\*version "\(\[\^"\]\+\)"\.\*\/\\1\/p'\)"/u,
+    );
+  });
+
+  it("refuses when the rolling formula's current version is unreadable", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    expect(prStep).toMatch(/if \[ -z "\$current" \]; then/u);
+    expect(prStep).toContain("has no readable version");
+    expect(prStep).toContain("exit 1");
+  });
+
+  it("collects every OPEN rolling-formula PR (excluding its own branch) as additional --existing observations", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    expect(prStep).toContain('gh pr list --repo "$TAP_REPO" --state open --limit 100');
+    expect(prStep).toContain(
+      'select(.body | contains("Updates the rolling Formula/traycer.rb"))',
+    );
+    expect(prStep).toContain('select(startswith("traycer-formula-"))');
+    expect(prStep).toMatch(/\[ "\$open_branch" = "\$branch" \] && continue/u);
+    expect(prStep).toContain(
+      '--existing="open Homebrew PR ${open_branch}=$open_version"',
+    );
+  });
+
+  it("invokes the shared guard with the candidate and every gathered --existing observation", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    expect(prStep).toContain(
+      "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
+    );
+    expect(prStep).toContain('--candidate="$VERSION"');
+    expect(prStep).toContain('"${EXISTING_ARGS[@]}"');
+  });
+
+  it("closes stale rolling-formula PRs only AFTER the guard proves this candidate outranks them, before commit/push", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    const guardIdx = prStep.indexOf(
+      "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
+    );
+    const closeIdx = prStep.indexOf('gh pr close "$stale_pr"');
+    const commitIdx = prStep.indexOf('git commit -m "traycer ${VERSION}"');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(closeIdx).toBeGreaterThan(-1);
+    expect(commitIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(closeIdx);
+    expect(closeIdx).toBeLessThan(commitIdx);
+  });
+
+  it("only closes OTHER open rolling-formula PRs (excludes this run's own branch)", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    // This jq filter is embedded in a double-quoted bash string (so `$branch`
+    // interpolates), so its inner quotes are backslash-escaped.
+    expect(prStep).toContain(
+      '--jq ".[] | select(.body | contains(\\"Updates the rolling Formula/traycer.rb\\")) | select(.headRefName | startswith(\\"traycer-formula-\\")) | select(.headRefName != \\"$branch\\") | .number")',
+    );
+  });
+});
+
+describe("publish-homebrew-formula: homebrew_versioned_only bypasses both the rolling guard and stale-PR closure", () => {
+  it("wraps the entire guard + stale-PR-closure block in `if [ \"$HOMEBREW_VERSIONED_ONLY\" != \"true\" ]`", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    // Outer if/fi at 10-space indent; the nested `if [ -z "$current" ]`
+    // guard inside it sits at 12-space indent, so this anchor does not
+    // false-match the inner block's `fi`.
+    const outer =
+      /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
+        prStep,
+      );
+    expect(outer).not.toBeNull();
+    const body = outer[1];
+    expect(body).toContain(
+      "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
+    );
+    expect(body).toContain('gh pr close "$stale_pr"');
+  });
+
+  it("commits and pushes unconditionally, outside the versioned-only-gated block", () => {
+    const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
+    const outer =
+      /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n[\s\S]*?\n {10}fi\n/u.exec(
+        prStep,
+      );
+    expect(outer).not.toBeNull();
+    const afterGuardBlock = prStep.slice(outer.index + outer[0].length);
+    expect(afterGuardBlock).toMatch(/^\s*git commit -m "traycer \$\{VERSION\}"/u);
+  });
+
+  it("the render step also skips the rolling Formula/traycer.rb output when homebrew_versioned_only is set (backfill leaves it untouched)", () => {
+    const renderStep = stepBlock(homebrewJob, "Render Homebrew formula");
+    expect(renderStep).toContain("HOMEBREW_VERSIONED_ONLY");
+    expect(renderStep).toMatch(/if \[ "\$HOMEBREW_VERSIONED_ONLY" = "true" \]; then/u);
+    expect(renderStep).toContain("--homebrew-versioned-only");
+  });
+});

--- a/scripts/__tests__/publish-cli-package-managers-rolling-guard.test.mjs
+++ b/scripts/__tests__/publish-cli-package-managers-rolling-guard.test.mjs
@@ -104,7 +104,7 @@ describe("publish-npm: the rolling-version guard sits immediately before the mut
       /current="\$\(npm view "@traycerai\/cli" dist-tags\.latest --registry "https:\/\/registry\.npmjs\.org"\)"/u,
     );
     expect(guardStep).toContain(
-      "node scripts/native-packaging/assert-rolling-package-version.cjs",
+      "node workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs",
     );
     expect(guardStep).toContain('--candidate="$VERSION"');
     expect(guardStep).toContain('--existing="npm latest=$current"');
@@ -115,6 +115,22 @@ describe("publish-npm: the rolling-version guard sits immediately before the mut
 });
 
 describe("publish-homebrew-formula: the rolling-version guard reads origin/main + open rolling PRs", () => {
+  it("runs both guards from the workflow revision, not the historical release checkout", () => {
+    for (const job of [npmJob, homebrewJob]) {
+      expect(job).toContain("ref: ${{ github.workflow_sha }}");
+      expect(job).toContain("path: workflow-guard");
+      expect(job).toContain(
+        "sparse-checkout: scripts/native-packaging/assert-rolling-package-version.cjs",
+      );
+    }
+    expect(npmJob).toContain(
+      "node workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs",
+    );
+    expect(homebrewJob).toContain(
+      "node ../workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs",
+    );
+  });
+
   it("reads the pre-existing rolling version from the git ref, not the working tree the release PR is about to overwrite", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
     // `cp` overwrites Formula/traycer.rb with the CANDIDATE content before
@@ -133,19 +149,26 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
     expect(prStep).toContain("exit 1");
   });
 
-  it("collects every OPEN rolling-formula PR (excluding its own branch) as additional --existing observations, from a single gh pr list query", () => {
+  it("collects every inspected open rolling-formula PR from one query and refuses at the explicit completeness bound", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
     // Exactly one `gh pr list` call within the guarded block feeds both
     // EXISTING_ARGS and STALE_PRS - there must be no second query re-deriving
     // the close list separately. (A THIRD, unrelated `gh pr list` call later
     // in this step finds this run's OWN branch's PR number for the
     // create-vs-update decision - that one is out of scope here.)
-    const guardedBlock = /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
-      prStep,
-    )[1];
+    const guardedBlock = /\n {10}if \[ "\$ROLLING_HOMEBREW" = "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(prStep)[1];
     const listCalls = guardedBlock.match(/gh pr list --repo "\$TAP_REPO"/gu) ?? [];
     expect(listCalls).toHaveLength(1);
-    expect(prStep).toContain('gh pr list --repo "$TAP_REPO" --state open --limit 100');
+    expect(prStep).toContain("OPEN_PR_LIMIT=1000");
+    expect(prStep).toContain(
+      'gh pr list --repo "$TAP_REPO" --state open --limit "$OPEN_PR_LIMIT"',
+    );
+    expect(prStep).toContain(
+      'if [ "$open_pr_count" -ge "$OPEN_PR_LIMIT" ]; then',
+    );
+    expect(prStep).toContain(
+      "refusing to publish without proving the complete rolling-selector set",
+    );
     expect(prStep).toContain(
       'select(.body | contains("Updates the rolling Formula/traycer.rb"))',
     );
@@ -165,7 +188,7 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
   it("invokes the shared guard with the candidate and every gathered --existing observation", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
     expect(prStep).toContain(
-      "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
+      "node ../workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs",
     );
     expect(prStep).toContain('--candidate="$VERSION"');
     expect(prStep).toContain('"${EXISTING_ARGS[@]}"');
@@ -174,7 +197,7 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
   it("closes stale rolling-formula PRs only AFTER the guard proves this candidate outranks them, before commit/push", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
     const guardIdx = prStep.indexOf(
-      "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
+      "node ../workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs",
     );
     const closeIdx = prStep.indexOf('for stale_pr in "${STALE_PRS[@]}"; do');
     const commitIdx = prStep.indexOf('git commit -m "traycer ${VERSION}"');
@@ -193,28 +216,32 @@ describe("publish-homebrew-formula: the rolling-version guard reads origin/main 
     // Confirms (again, scoped to the guarded block) there is no independent
     // second query deriving the close list - STALE_PRS from the single
     // earlier read loop is the only source `gh pr close` iterates.
-    const guardedBlock = /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
-      prStep,
-    )[1];
+    const guardedBlock = /\n {10}if \[ "\$ROLLING_HOMEBREW" = "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(prStep)[1];
     const listCalls = guardedBlock.match(/gh pr list --repo "\$TAP_REPO"/gu) ?? [];
     expect(listCalls).toHaveLength(1);
   });
 });
 
-describe("publish-homebrew-formula: homebrew_versioned_only bypasses both the rolling guard and stale-PR closure", () => {
-  it("wraps the entire guard + stale-PR-closure block in `if [ \"$HOMEBREW_VERSIONED_ONLY\" != \"true\" ]`", () => {
+describe("publish-homebrew-formula: only stable rolling releases enter the guard and closure", () => {
+  it("derives rolling eligibility from both the input and the resolved dist-tag", () => {
+    expect(homebrewJob).toContain(
+      "ROLLING_HOMEBREW: ${{ inputs.homebrew_versioned_only != true && needs.resolve.outputs.dist_tag == 'latest' }}",
+    );
+  });
+
+  it("wraps the entire guard + stale-PR-closure block in the rolling eligibility check", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
     // Outer if/fi at 10-space indent; the nested `if [ -z "$current" ]`
     // guard inside it sits at 12-space indent, so this anchor does not
     // false-match the inner block's `fi`.
     const outer =
-      /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
+      /\n {10}if \[ "\$ROLLING_HOMEBREW" = "true" \]; then\n([\s\S]*?)\n {10}fi\n/u.exec(
         prStep,
       );
     expect(outer).not.toBeNull();
     const body = outer[1];
     expect(body).toContain(
-      "node ../scripts/native-packaging/assert-rolling-package-version.cjs",
+      "node ../workflow-guard/scripts/native-packaging/assert-rolling-package-version.cjs",
     );
     expect(body).toContain('gh pr close "$stale_pr"');
   });
@@ -222,7 +249,7 @@ describe("publish-homebrew-formula: homebrew_versioned_only bypasses both the ro
   it("commits and pushes unconditionally, outside the versioned-only-gated block", () => {
     const prStep = stepBlock(homebrewJob, "Open Homebrew formula PR");
     const outer =
-      /\n {10}if \[ "\$HOMEBREW_VERSIONED_ONLY" != "true" \]; then\n[\s\S]*?\n {10}fi\n/u.exec(
+      /\n {10}if \[ "\$ROLLING_HOMEBREW" = "true" \]; then\n[\s\S]*?\n {10}fi\n/u.exec(
         prStep,
       );
     expect(outer).not.toBeNull();
@@ -230,10 +257,10 @@ describe("publish-homebrew-formula: homebrew_versioned_only bypasses both the ro
     expect(afterGuardBlock).toMatch(/^\s*git commit -m "traycer \$\{VERSION\}"/u);
   });
 
-  it("the render step also skips the rolling Formula/traycer.rb output when homebrew_versioned_only is set (backfill leaves it untouched)", () => {
+  it("the render step skips the rolling formula for versioned-only and prerelease publications", () => {
     const renderStep = stepBlock(homebrewJob, "Render Homebrew formula");
-    expect(renderStep).toContain("HOMEBREW_VERSIONED_ONLY");
-    expect(renderStep).toMatch(/if \[ "\$HOMEBREW_VERSIONED_ONLY" = "true" \]; then/u);
+    expect(renderStep).toContain("ROLLING_HOMEBREW");
+    expect(renderStep).toMatch(/if \[ "\$ROLLING_HOMEBREW" != "true" \]; then/u);
     expect(renderStep).toContain("--homebrew-versioned-only");
   });
 });

--- a/scripts/native-packaging/assert-rolling-package-version.cjs
+++ b/scripts/native-packaging/assert-rolling-package-version.cjs
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+"use strict";
+
+/**
+ * Refuses a rolling package-manager mutation that would move a stable
+ * "latest" pointer backwards.
+ *
+ * This deliberately handles stable x.y.z versions only. The workflow that
+ * calls it runs on stable cli-v* releases; accepting prerelease syntax here
+ * would broaden the selector beyond the npm `latest` tag and Homebrew's
+ * rolling Formula/traycer.rb surface.
+ */
+
+const STABLE_VERSION = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
+
+function parseStableVersion(value, label) {
+  const match = STABLE_VERSION.exec(value);
+  if (match === null) {
+    throw new Error(
+      `${label} must be strict stable SemVer (x.y.z), got ${JSON.stringify(value)}`,
+    );
+  }
+  return match.slice(1).map((part) => BigInt(part));
+}
+
+function compareStableVersions(left, right) {
+  const leftParts = parseStableVersion(left, "candidate version");
+  const rightParts = parseStableVersion(right, "published version");
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] > rightParts[index]) return 1;
+    if (leftParts[index] < rightParts[index]) return -1;
+  }
+  return 0;
+}
+
+function parseArgs(argv) {
+  let candidate = null;
+  const existing = [];
+  for (const arg of argv) {
+    if (arg.startsWith("--candidate=")) {
+      candidate = arg.slice("--candidate=".length);
+      continue;
+    }
+    if (arg.startsWith("--existing=")) {
+      const pair = arg.slice("--existing=".length);
+      const separator = pair.indexOf("=");
+      if (separator <= 0 || separator === pair.length - 1) {
+        throw new Error(
+          `--existing must be --existing=<label>=<version>, got ${JSON.stringify(arg)}`,
+        );
+      }
+      existing.push({
+        label: pair.slice(0, separator),
+        version: pair.slice(separator + 1),
+      });
+      continue;
+    }
+    throw new Error(`unrecognized argument ${JSON.stringify(arg)}`);
+  }
+  if (candidate === null || candidate.length === 0) {
+    throw new Error("--candidate=<stable-version> is required");
+  }
+  parseStableVersion(candidate, "candidate version");
+  if (existing.length === 0) {
+    throw new Error(
+      "at least one --existing=<label>=<version> is required; publishing without observing the current rolling selector would permit a regression",
+    );
+  }
+  return { candidate, existing };
+}
+
+function assertRollingVersionAdvances(args) {
+  const { candidate, existing } = args;
+  for (const entry of existing) {
+    if (compareStableVersions(candidate, entry.version) <= 0) {
+      throw new Error(
+        `${candidate} cannot replace ${entry.label} at ${entry.version}: a rolling package-manager selector must advance strictly, or a delayed older publisher could move users back to a client below an already-active compatibility floor`,
+      );
+    }
+  }
+}
+
+module.exports = {
+  assertRollingVersionAdvances,
+  compareStableVersions,
+  parseArgs,
+};
+
+if (require.main === module) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    assertRollingVersionAdvances(args);
+    console.log(
+      `Rolling package version guard: ${args.candidate} advances ${args.existing.map((entry) => `${entry.label} (${entry.version})`).join(", ")}.`,
+    );
+  } catch (error) {
+    console.error(
+      `Rolling package version guard FAILED: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- serialize npm `latest` writers and refuse candidates that do not strictly advance the live dist-tag
- guard Homebrew's rolling formula against both current `main` and newer open rolling PRs
- close superseded rolling formula PRs so they cannot be merged after a compatibility floor is activated
- pin formula generation to the release provenance commit

## Why

A host compatibility floor is safe only while every advertised recovery carrier remains at or above that floor. The internal coordinator proves npm and Homebrew immediately before host promotion, but an older delayed OSS publisher could previously mutate those external rolling selectors afterward. These mutation-time monotonic guards close that race.

## Validation

- pre-commit hook passed, including affected build/compile/lint/format
- focused guard/workflow contract tests: 34 passed
