### PR TITLE
fix(gui-app): make Add Host success flow actionable

### DIFF
--- a/clients/gui-app/src/components/settings/host-scope/__tests__/add-host-dialog.test.tsx
+++ b/clients/gui-app/src/components/settings/host-scope/__tests__/add-host-dialog.test.tsx
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { HostScope } from "@/components/settings/host-scope/use-host-scope";
 import { AddHostDialog } from "@/components/settings/host-scope/add-host-dialog";
 import { useAddHostDialogStore } from "@/stores/settings/add-host-dialog-store";
@@ -20,6 +27,9 @@ import { useAddHostDialogStore } from "@/stores/settings/add-host-dialog-store";
 const scopeMocks: { scope: Partial<HostScope> } = vi.hoisted(() => ({
   scope: {},
 }));
+const navigationMocks = vi.hoisted(() => ({
+  navigateToSettingsSection: vi.fn(),
+}));
 
 vi.mock("@/components/settings/host-scope/use-host-scope", async () => {
   const { hostScopeFixture } =
@@ -29,7 +39,10 @@ vi.mock("@/components/settings/host-scope/use-host-scope", async () => {
   };
 });
 
+vi.mock("@/lib/settings-navigation", () => navigationMocks);
+
 beforeEach(() => {
+  navigationMocks.navigateToSettingsSection.mockClear();
   useAddHostDialogStore.getState().closeDialog();
 });
 
@@ -73,7 +86,7 @@ describe("<AddHostDialog /> arrival", () => {
     expect(screen.getByTestId("add-host-arrived")).not.toBeNull();
     // ...and the copy claims registration, not a connection that is not there.
     expect(
-      screen.getByRole("heading", { name: "Office Linux is registered" }),
+      screen.getByRole("heading", { name: "Host registered" }),
     ).not.toBeNull();
     expect(screen.queryByText(/ready to run agents/)).toBeNull();
   });
@@ -95,7 +108,7 @@ describe("<AddHostDialog /> arrival", () => {
     render(<AddHostDialog />);
 
     expect(
-      screen.getByRole("heading", { name: "Office Linux is connected" }),
+      screen.getByRole("heading", { name: "Host connected" }),
     ).not.toBeNull();
     expect(screen.getByText(/ready to run agents/)).not.toBeNull();
   });
@@ -145,7 +158,7 @@ describe("<AddHostDialog /> arrival", () => {
 
     expect(screen.getByTestId("add-host-arrived")).not.toBeNull();
     expect(
-      screen.getByRole("heading", { name: "Office Linux is connected" }),
+      screen.getByRole("heading", { name: "Host connected" }),
     ).not.toBeNull();
   });
 
@@ -204,8 +217,59 @@ describe("<AddHostDialog /> arrival", () => {
 
     expect(screen.getByTestId("add-host-arrived")).not.toBeNull();
     expect(
-      screen.getByRole("heading", { name: "Office Linux is connected" }),
+      screen.getByRole("heading", { name: "Host connected" }),
     ).not.toBeNull();
+  });
+
+  it("contains a long unbroken host name inside the identity card", async () => {
+    const longName = `host-${"a".repeat(160)}.internal`;
+    const newcomer = await hostOption({
+      hostId: "host-long",
+      name: longName,
+      registered: true,
+      connectable: true,
+    });
+    scopeMocks.scope = {
+      hosts: [newcomer],
+      isLoading: false,
+      listsFailed: false,
+    };
+    useAddHostDialogStore.getState().openDialog([]);
+
+    render(<AddHostDialog />);
+
+    const card = screen.getByTestId("add-host-arrived");
+    const name = within(card).getByLabelText(longName);
+    expect(name.className).toContain("[overflow-wrap:anywhere]");
+    expect(
+      screen.getByRole("heading", { name: "Host connected" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Set up host" })).not.toBeNull();
+  });
+
+  it("opens the arrived host's Overview page", async () => {
+    const setHostId = vi.fn();
+    const newcomer = await hostOption({
+      hostId: "host-new",
+      name: "Office Linux",
+      registered: true,
+      connectable: true,
+    });
+    scopeMocks.scope = {
+      hosts: [newcomer],
+      isLoading: false,
+      listsFailed: false,
+      setHostId,
+    };
+    useAddHostDialogStore.getState().openDialog([]);
+
+    render(<AddHostDialog />);
+    fireEvent.click(screen.getByRole("button", { name: "Set up host" }));
+
+    expect(setHostId).toHaveBeenCalledWith("host-new");
+    expect(navigationMocks.navigateToSettingsSection).toHaveBeenCalledWith(
+      "host",
+    );
   });
 
   it("does not announce a directory-only row that never registered", async () => {
@@ -261,6 +325,29 @@ describe("<AddHostDialog /> setup instructions", () => {
     expect(steps[1].textContent).toContain("traycer login");
     // The step whose absence made the whole dialog unreachable.
     expect(steps[2].textContent).toContain("traycer host ensure");
+  });
+
+  it("shows one installer command and switches it in place", async () => {
+    const user = userEvent.setup();
+    render(<AddHostDialog />);
+    const npmTab = screen.getByRole("tab", { name: "npm" });
+    const homebrewTab = screen.getByRole("tab", { name: "Homebrew" });
+
+    expect(npmTab.getAttribute("data-state")).toBe("active");
+    expect(npmTab.className).toContain("data-[state=active]:bg-background");
+    expect(screen.getByText("npm install -g @traycerai/cli")).not.toBeNull();
+    expect(
+      screen.queryByText("brew install traycerai/traycer/traycer"),
+    ).toBeNull();
+
+    await user.click(homebrewTab);
+
+    expect(homebrewTab.getAttribute("data-state")).toBe("active");
+    expect(
+      screen.getByText("brew install traycerai/traycer/traycer"),
+    ).not.toBeNull();
+    expect(screen.queryByText("npm install -g @traycerai/cli")).toBeNull();
+    expect(screen.getByText("Available on macOS and Linux.")).not.toBeNull();
   });
 
   it("no longer prints the curl installer", () => {

--- a/clients/gui-app/src/components/settings/host-scope/add-host-dialog.tsx
+++ b/clients/gui-app/src/components/settings/host-scope/add-host-dialog.tsx
@@ -8,6 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   HostGlyph,
   HostPresenceDot,
@@ -16,6 +18,7 @@ import { formatPlatform } from "@/components/settings/host-scope/host-scope-mode
 import { useHostScope } from "@/components/settings/host-scope/use-host-scope";
 import { useAddHostDialogStore } from "@/stores/settings/add-host-dialog-store";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
+import { navigateToSettingsSection } from "@/lib/settings-navigation";
 import { toast } from "sonner";
 
 // The commands that actually stand a host up, and nothing else.
@@ -167,9 +170,7 @@ function AddHostDialogBody(): ReactNode {
       <>
         <DialogHeader>
           <DialogTitle>
-            {arrived.connectable
-              ? `${arrived.name} is connected`
-              : `${arrived.name} is registered`}
+            {arrived.connectable ? "Host connected" : "Host registered"}
           </DialogTitle>
           <DialogDescription>
             {arrived.connectable
@@ -185,9 +186,19 @@ function AddHostDialogBody(): ReactNode {
             <HostGlyph host={arrived} className="size-4.5" />
           </span>
           <span className="min-w-0 flex-1">
-            <span className="block truncate text-ui-sm font-medium">
-              {arrived.name}
-            </span>
+            <TooltipWrapper
+              label={arrived.name}
+              side="top"
+              sideOffset={undefined}
+              align="start"
+            >
+              <span
+                aria-label={arrived.name}
+                className="line-clamp-2 text-ui-sm font-medium [overflow-wrap:anywhere]"
+              >
+                {arrived.name}
+              </span>
+            </TooltipWrapper>
             <span className="flex min-w-0 items-center gap-1.5 text-ui-xs text-muted-foreground">
               <HostPresenceDot
                 tone={arrived.health.tone}
@@ -203,19 +214,26 @@ function AddHostDialogBody(): ReactNode {
           </span>
           <Check className="size-4 shrink-0 text-emerald-500" aria-hidden />
         </div>
-        <div className="flex justify-end gap-2">
-          <Button type="button" variant="outline" onClick={closeDialog}>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full sm:w-auto"
+            onClick={closeDialog}
+          >
             Close
           </Button>
           <Button
             type="button"
+            className="w-full sm:w-auto"
             onClick={() => {
               scope.setHostId(arrived.hostId);
               closeDialog();
+              navigateToSettingsSection("host");
             }}
             data-testid="add-host-manage-arrived"
           >
-            Set up {arrived.name}
+            Set up host
           </Button>
         </div>
       </>
@@ -226,33 +244,53 @@ function AddHostDialogBody(): ReactNode {
     <>
       <DialogHeader>
         <DialogTitle>Add host</DialogTitle>
-        <DialogDescription>
-          A host is Traycer running on the computer you want to reach. Run these
-          over there — this window notices the moment it joins your account.
+        <DialogDescription className="text-pretty">
+          Run these commands on the computer you want to reach. This window
+          detects it when it connects.
         </DialogDescription>
       </DialogHeader>
 
       <ol className="flex min-w-0 flex-col" data-testid="add-host-steps">
         <Step index={1} title="Install the Traycer CLI">
-          <CommandBlock command={CLI_NPM_COMMAND} label="npm" />
-          <CommandBlock command={CLI_HOMEBREW_COMMAND} label="brew" />
-          <StepNote>
-            Pick one — npm (needs Node 20.18 or newer) or Homebrew (macOS and
-            Linux). Running both installs two competing copies.
-          </StepNote>
+          <Tabs defaultValue="npm" className="gap-1.5">
+            <TabsList
+              variant="line"
+              aria-label="Install method"
+              className="justify-start border-b border-border group-data-[orientation=horizontal]/tabs:h-7"
+            >
+              <TabsTrigger
+                value="npm"
+                className="flex-none px-2.5 py-0 text-ui-xs"
+              >
+                npm
+              </TabsTrigger>
+              <TabsTrigger
+                value="homebrew"
+                className="flex-none px-2.5 py-0 text-ui-xs"
+              >
+                Homebrew
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="npm" className="grid gap-1.5">
+              <CommandBlock command={CLI_NPM_COMMAND} />
+              <StepNote>Requires Node 20.18 or newer.</StepNote>
+            </TabsContent>
+            <TabsContent value="homebrew" className="grid gap-1.5">
+              <CommandBlock command={CLI_HOMEBREW_COMMAND} />
+              <StepNote>Available on macOS and Linux.</StepNote>
+            </TabsContent>
+          </Tabs>
         </Step>
         <Step index={2} title="Sign in">
-          <CommandBlock command={LOGIN_COMMAND} label={null} />
+          <CommandBlock command={LOGIN_COMMAND} />
           <StepNote>
-            Prints a link and a code — open the link on any device, enter the
-            code, approve. This only signs in.
+            Open the link on any device, enter the code, and approve sign-in.
           </StepNote>
         </Step>
         <Step index={3} title="Install and start the host">
-          <CommandBlock command={HOST_ENSURE_COMMAND} label={null} />
+          <CommandBlock command={HOST_ENSURE_COMMAND} />
           <StepNote>
-            Installs the host, registers it as a background service, and starts
-            it. Safe to run again if anything looks wrong.
+            Installs, registers, and starts the host. Safe to run again.
           </StepNote>
         </Step>
       </ol>
@@ -291,14 +329,13 @@ function Step(props: {
 
 function StepNote(props: { readonly children: ReactNode }): ReactNode {
   return (
-    <span className="text-ui-xs text-muted-foreground">{props.children}</span>
+    <span className="text-pretty text-ui-xs text-muted-foreground">
+      {props.children}
+    </span>
   );
 }
 
-function CommandBlock(props: {
-  readonly command: string;
-  readonly label: string | null;
-}): ReactNode {
+function CommandBlock(props: { readonly command: string }): ReactNode {
   // The hook, not a hand-rolled writeText + timeout: it withholds the success
   // check when the write rejects (denied permission, insecure context) and
   // clears its reset timer on unmount, both of which the inline version got
@@ -310,11 +347,6 @@ function CommandBlock(props: {
   });
   return (
     <div className="group flex min-w-0 items-center gap-2 rounded-lg border border-border bg-foreground/5 px-2.5 py-1.5 transition-colors hover:bg-foreground/6">
-      {props.label === null ? null : (
-        <span className="shrink-0 font-mono text-code-xs text-muted-foreground/70 select-none">
-          {props.label}
-        </span>
-      )}
       <code className="min-w-0 flex-1 overflow-x-auto font-mono text-code-xs whitespace-pre text-foreground">
         {props.command}
       </code>

--- a/clients/gui-app/src/components/ui/tabs.tsx
+++ b/clients/gui-app/src/components/ui/tabs.tsx
@@ -13,8 +13,9 @@ function Tabs({
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
+      orientation={orientation}
       className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
         className,
       )}
       {...props}
@@ -23,7 +24,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-8 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -61,10 +62,10 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-ui-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-ui-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Make the Add Host success card responsive to arbitrarily long host names, with stable status copy and a Settings Overview CTA.
- Add compact npm/Homebrew installer tabs with npm as the default and only one command/note visible at a time.
- Correct the shared Radix Tabs wrapper to pass orientation and use official state/orientation selectors.

## Validation

- `bun run --filter @traycer-clients/gui-app test src/components/settings/host-scope/__tests__/add-host-dialog.test.tsx` (11 normal, 10 React compiler, 1 config)
- Changed-file React Doctor: no issues
- Pre-commit affected checks: hygiene, lint, format, compile, build
- Commit signed off with DCO

## Related issue

None.