### PR TITLE
feat(gui-app): give the installed mobile app its own back stack

### DIFF
--- a/clients/gui-app/src/components/layout/shell/__tests__/mobile-history-swipe-navigation.test.tsx
+++ b/clients/gui-app/src/components/layout/shell/__tests__/mobile-history-swipe-navigation.test.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/lib/tab-navigation";
 import { goBack, goForward } from "@/lib/commands/actions/history-navigation";
 import { useTabsStore } from "@/stores/tabs/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { selectHostFocusedRef } from "@/stores/tabs/selectors";
 import * as DesktopTabsPersistence from "@/stores/tabs/desktop-tabs-persistence";
 
@@ -147,6 +148,7 @@ const activeUnmounts: Array<() => void> = [];
 
 beforeEach(() => {
   navigateProbe.current = null;
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
   useTabsStore.setState({
     version: 2,
     items: [],
@@ -187,6 +189,96 @@ describe("mobile back navigation over a plain history", () => {
     await waitFor(() => {
       expect(focusedKind()).toBe("settings");
     });
+  });
+
+  // The step every phone journey ends with and no case above takes: back to
+  // HOME. The suites here hop between two tabs, so they never land on the
+  // landing path - which is resolved by a different branch entirely, and is the
+  // one a user reaches by opening one thing from Home and swiping back.
+  it("returns to the landing surface on a back step out of the first tab", async () => {
+    const { history, router } = buildRouter();
+    render(<RouterProvider router={router} />);
+    await waitFor(() => {
+      expect(navigateProbe.current).not.toBeNull();
+    });
+    const navigate = navigateProbe.current;
+    if (navigate === null) throw new Error("router never published navigate");
+
+    expect(router.state.location.pathname).toBe("/");
+    await act(async () => {
+      activateTabIntent(navigate, settingsTabIntent("general"), undefined);
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("settings");
+    });
+
+    await act(async () => {
+      goBack({ history });
+      await Promise.resolve();
+    });
+
+    // The route is back at the landing; the SURFACE has to follow it. A
+    // resolver that moves the location and leaves Settings active is the frozen
+    // screen the device reports.
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/");
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("draft");
+    });
+    // Home is not the absence of a tab: a populated strip always has exactly
+    // one active item, and on this shell Home IS the landing draft surface.
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+  });
+
+  // The hazard of activating on every step: each press could stack another
+  // Home. The landing draft is named rather than minted, so the second press
+  // re-activates the one that exists.
+  it("re-activates the one Home rather than stacking a draft per step", async () => {
+    const { history, router } = buildRouter();
+    render(<RouterProvider router={router} />);
+    await waitFor(() => {
+      expect(navigateProbe.current).not.toBeNull();
+    });
+    const navigate = navigateProbe.current;
+    if (navigate === null) throw new Error("router never published navigate");
+
+    await act(async () => {
+      activateTabIntent(navigate, settingsTabIntent("general"), undefined);
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("settings");
+    });
+    await act(async () => {
+      goBack({ history });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("draft");
+    });
+    const firstHome = selectHostFocusedRef(useTabsStore.getState())?.id ?? null;
+    expect(firstHome).not.toBeNull();
+
+    // Forward into Settings, then back to Home a second time.
+    await act(async () => {
+      goForward({ history });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("settings");
+    });
+    await act(async () => {
+      goBack({ history });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("draft");
+    });
+
+    expect(selectHostFocusedRef(useTabsStore.getState())?.id).toBe(firstHome);
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
   });
 
   it("returns to the later surface on a forward step", async () => {

--- a/clients/gui-app/src/components/layout/shell/__tests__/mobile-history-swipe-navigation.test.tsx
+++ b/clients/gui-app/src/components/layout/shell/__tests__/mobile-history-swipe-navigation.test.tsx
@@ -1,14 +1,15 @@
-// The whole chain the mobile back swipe rides, end to end on the history a
-// phone actually gets: a PLAIN memory history with no persistent-history
-// controller brand, which is what the Capacitor bundle boots with. The pieces
-// are all real - the tab-navigation controller, its route bridge, the tabs
-// store and the shared `goBack` action - because the claim under test is that
-// they compose, not that any one of them works.
+// The whole chain the mobile back swipe rides, end to end. The pieces are all
+// real - the tab-navigation controller, its route bridge, the tabs store and
+// the shared `goBack` action - because the claim under test is that they
+// compose, not that any one of them works.
 //
-// What makes this worth pinning: `goBack` refused outright on an unbranded
-// history until the fallback existed, so every assertion here would have held
-// against a shell where the swipe did nothing at all. The activations before
-// the back are what make it a real re-activation rather than a no-op.
+// TWO HISTORIES, and the split is the point. The suites below build a PLAIN
+// history to pin the unbranded fallback, which is still what a browser tab
+// gets and what `goBack` must keep answering on. The last suite asks the
+// question none of them can: which history the installed mobile app actually
+// BOOTS with. Every fixture here constructs its own, so all of them would hold
+// against a shell whose real history nothing ever writes to - and that is the
+// shape this feature shipped in, recognizing perfectly and navigating nowhere.
 import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -32,7 +33,11 @@ import {
   type UseNavigateResult,
 } from "@tanstack/react-router";
 import { routeTree } from "@/routeTree.gen";
-import type { AppRouter } from "@/router";
+import { createAppRouter, type AppRouter } from "@/router";
+import {
+  getHistoryController,
+  historyNavChromeAvailable,
+} from "@/lib/history-navigation";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { setMobileApp } from "@/lib/mobile-app";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
@@ -99,6 +104,30 @@ function focusedKind(): string | null {
 }
 
 /**
+ * Two CROSS-ITEM activations, which is what makes them pushes rather than
+ * focus-replaces - the same shape as a phone leaving one top-level surface for
+ * another.
+ */
+async function activateSettingsThenHistory(): Promise<void> {
+  const navigate = navigateProbe.current;
+  if (navigate === null) throw new Error("router never published navigate");
+  await act(async () => {
+    activateTabIntent(navigate, settingsTabIntent("general"), undefined);
+    await Promise.resolve();
+  });
+  await waitFor(() => {
+    expect(focusedKind()).toBe("settings");
+  });
+  await act(async () => {
+    activateTabIntent(navigate, historyTabIntent(), undefined);
+    await Promise.resolve();
+  });
+  await waitFor(() => {
+    expect(focusedKind()).toBe("history");
+  });
+}
+
+/**
  * The app's real route tree, for the suite that only needs router CONTEXT -
  * the swipe hook reads `useRouter().history` and never renders a route.
  */
@@ -135,29 +164,11 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  setMobileApp(false);
   __resetTabNavigationControllerForTesting();
 });
 
 describe("mobile back navigation over a plain history", () => {
-  async function activateSettingsThenHistory(): Promise<void> {
-    const navigate = navigateProbe.current;
-    if (navigate === null) throw new Error("router never published navigate");
-    await act(async () => {
-      activateTabIntent(navigate, settingsTabIntent("general"), undefined);
-      await Promise.resolve();
-    });
-    await waitFor(() => {
-      expect(focusedKind()).toBe("settings");
-    });
-    await act(async () => {
-      activateTabIntent(navigate, historyTabIntent(), undefined);
-      await Promise.resolve();
-    });
-    await waitFor(() => {
-      expect(focusedKind()).toBe("history");
-    });
-  }
-
   it("re-activates the previous surface on a back step", async () => {
     const { history, router } = buildRouter();
     render(<RouterProvider router={router} />);
@@ -395,5 +406,81 @@ describe("useMobileHistorySwipes", () => {
 
       expect(backSpy).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// The half every suite above was handed for free: a stack with something in it.
+// Each one CONSTRUCTS its history, so all of them would pass unchanged on a
+// shell whose real history nothing ever writes to - which is exactly the shape
+// the feature shipped in. What is pinned here is the boot decision itself:
+// which history the installed mobile app gets, and that ordinary surface
+// changes make it grow.
+describe("the history the mobile app actually boots with", () => {
+  function mobileAppHistory(): RouterHistory {
+    setMobileApp(true);
+    return createAppRouter(null, null).history;
+  }
+
+  /** The lightweight tree from this file's other suites, over a given history. */
+  function renderShellOver(history: RouterHistory) {
+    const rootRoute = createRootRoute({ component: ShellLike });
+    const anyRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "$",
+      component: () => <div data-testid="surface" />,
+    });
+    return createRouter({
+      routeTree: rootRoute.addChildren([anyRoute]),
+      history,
+    });
+  }
+
+  it("owns its back stack, which the browser build still does not", () => {
+    const mobile = mobileAppHistory();
+    expect(getHistoryController(mobile)).not.toBeNull();
+
+    setMobileApp(false);
+    expect(
+      getHistoryController(createAppRouter(null, null).history),
+    ).toBeNull();
+  });
+
+  // The stack is the phone's, the CHROME is not: the same brand that lights up
+  // the desktop's arrows, mouse buttons and palette rows must stay dark on a
+  // header with no room for them.
+  it("carries the stack without carrying the desktop's chrome", () => {
+    const mobile = mobileAppHistory();
+    expect(historyNavChromeAvailable(mobile)).toBe(false);
+  });
+
+  it("grows an entry when the user changes surface", async () => {
+    const history = mobileAppHistory();
+    const controller = getHistoryController(history);
+    if (controller === null) throw new Error("mobile history lost its brand");
+    // A cold launch starts at the landing with nothing behind it - the state
+    // every one of these surfaces is reached FROM, and the state that makes a
+    // seeded fixture unable to see this bug.
+    expect(controller.getIndex()).toBe(0);
+    expect(history.canGoBack()).toBe(false);
+
+    render(<RouterProvider router={renderShellOver(history)} />);
+    await waitFor(() => {
+      expect(navigateProbe.current).not.toBeNull();
+    });
+    await activateSettingsThenHistory();
+
+    // Two cross-item activations, two entries. Without them the recognizer
+    // fires, every gate passes, and `goBack` lands on an index that cannot move.
+    expect(controller.getIndex()).toBe(2);
+    expect(history.canGoBack()).toBe(true);
+
+    await act(async () => {
+      goBack({ history });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(focusedKind()).toBe("settings");
+    });
+    expect(controller.getIndex()).toBe(1);
   });
 });

--- a/clients/gui-app/src/components/layout/shell/__tests__/mobile-history-swipe-navigation.test.tsx
+++ b/clients/gui-app/src/components/layout/shell/__tests__/mobile-history-swipe-navigation.test.tsx
@@ -482,5 +482,13 @@ describe("the history the mobile app actually boots with", () => {
       expect(focusedKind()).toBe("settings");
     });
     expect(controller.getIndex()).toBe(1);
+
+    // The next COLD LAUNCH, through the same boot path that produced the stack
+    // above: a second router, same arguments, and none of it carried over. The
+    // stack is the session's, and the session ends with the process.
+    const relaunched = getHistoryController(mobileAppHistory());
+    if (relaunched === null) throw new Error("mobile history lost its brand");
+    expect(relaunched.getIndex()).toBe(0);
+    expect(relaunched.getEntries()).toEqual(["/"]);
   });
 });

--- a/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
+++ b/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
@@ -306,6 +306,63 @@ describe("createPersistentMemoryHistory", () => {
     expect(controller.getEntries()).toEqual(["/epics/epic-a/tab-a"]);
     expect(controller.getIndex()).toBe(0);
   });
+
+  // The mobile app's whole persistence contract, stated as behavior rather than
+  // as trust in the two null-window early returns that implement it. A refusal
+  // is easy to relax by accident - a default window id, a "harmless" per-install
+  // key - and nothing else in this file would notice.
+  describe("a null window is the session-scoped mobile stack", () => {
+    it("writes nothing while the session navigates", () => {
+      const history = createPersistentMemoryHistory(null, null);
+      history.push("/epics/epic-a/tab-a");
+      history.push("/settings/general");
+      history.push("/history");
+
+      const controller = controllerOf(history);
+      // The stack is REAL - this is not passing because nothing happened.
+      expect(controller.getIndex()).toBe(3);
+      expect(controller.getEntries()).toEqual([
+        "/",
+        "/epics/epic-a/tab-a",
+        "/settings/general",
+        "/history",
+      ]);
+      // Not "no last-route key" - NO key. A write under any name is a write
+      // that a later cold start could learn to read.
+      expect(window.localStorage.length).toBe(0);
+      expect(window.sessionStorage.length).toBe(0);
+    });
+
+    it("starts the next launch with nothing behind it", () => {
+      const first = createPersistentMemoryHistory(null, null);
+      first.push("/epics/epic-a/tab-a");
+      first.push("/settings/general");
+      expect(controllerOf(first).getIndex()).toBe(2);
+
+      // A cold launch: the shell builds a second history from the same
+      // arguments. It must not inherit the first one's stack - a restored one
+      // would hand the launch's first back swipe a surface from the last
+      // sitting.
+      const next = createPersistentMemoryHistory(null, null);
+      const controller = controllerOf(next);
+
+      expect(next.location.pathname).toBe("/");
+      expect(controller.getEntries()).toEqual(["/"]);
+      expect(controller.getIndex()).toBe(0);
+      expect(next.canGoBack()).toBe(false);
+    });
+
+    // The contrast that makes the two cases above mean something: the SAME
+    // constructor, one argument different, does remember.
+    it("still restores a window that has an id", () => {
+      const first = createPersistentMemoryHistory(null, "window-a");
+      first.push("/epics/epic-a/tab-a");
+
+      const next = createPersistentMemoryHistory(null, "window-a");
+
+      expect(next.location.pathname).toBe("/epics/epic-a/tab-a");
+    });
+  });
 });
 
 describe("getHistoryController", () => {

--- a/clients/gui-app/src/lib/history-navigation/index.ts
+++ b/clients/gui-app/src/lib/history-navigation/index.ts
@@ -13,7 +13,10 @@ export {
   type PersistentHistoryController,
 } from "@/lib/persistent-history";
 
-export { useHistoryNavAvailable } from "@/lib/history-navigation/use-history-nav-available";
+export {
+  historyNavChromeAvailable,
+  useHistoryNavAvailable,
+} from "@/lib/history-navigation/use-history-nav-available";
 export {
   useHistoryNavState,
   type HistoryNavState,

--- a/clients/gui-app/src/lib/history-navigation/use-history-nav-available.ts
+++ b/clients/gui-app/src/lib/history-navigation/use-history-nav-available.ts
@@ -1,19 +1,43 @@
 import { useRouter } from "@tanstack/react-router";
+import type { RouterHistory } from "@tanstack/react-router";
 import { getHistoryController } from "@/lib/persistent-history";
+import { isMobileApp } from "@/lib/mobile-app";
 
 /**
- * The single feature-availability signal for in-app back/forward navigation:
- * `true` when the CURRENT router's history carries the persistent-history
- * controller brand (the Electron renderer), `false` under browser/memory
- * history (the web app).
+ * Whether in-app back/forward may show CHROME on this shell - the header
+ * arrows, the mouse-button reservation, the palette rows.
  *
- * Every input surface — header arrows, mouse listener, keybind reservation,
- * palette emission — reads this same flag so the feature is wholly inert
- * outside Electron (tech plan §3.6). Reads `useRouter().history`, never a
- * module-level singleton, so multi-window routers each resolve their own
- * history.
+ * TWO FACTS, and they are deliberately not the same question. The first is
+ * capability: the current router's history carries the persistent-history
+ * controller brand, so there is a stack to walk at all. The second is
+ * presentation: the installed mobile app HAS that stack and must not grow any
+ * of that chrome for it. The phone's affordance is the edge swipe, and it is
+ * the whole affordance - a header with no room for arrows, a palette a thumb
+ * does not open, and mouse buttons that do not exist. Chrome added here would
+ * be chrome nobody on that shell can use.
+ *
+ * So the gesture asks nothing of this predicate. It walks the same stack
+ * through the same `goBack` / `goForward`, and those already no-op on a history
+ * with no controller - which is what keeps the phone's swipe and the desktop's
+ * arrows one implementation rather than two answers to "go back".
+ *
+ * Stated once, here, because the predicate has three call sites that cannot see
+ * each other: this hook, the keybinding router adapter (which the palette reads
+ * through, since it mounts above `<RouterProvider>` where router context is
+ * null), and the mouse listener. A copy of the rule in each is how one of them
+ * ends up disagreeing.
+ */
+export function historyNavChromeAvailable(history: RouterHistory): boolean {
+  if (getHistoryController(history) === null) return false;
+  return !isMobileApp();
+}
+
+/**
+ * {@link historyNavChromeAvailable} for a component, off the CURRENT router's
+ * history - never a module-level singleton, so multi-window routers each
+ * resolve their own.
  */
 export function useHistoryNavAvailable(): boolean {
   const router = useRouter();
-  return getHistoryController(router.history) !== null;
+  return historyNavChromeAvailable(router.history);
 }

--- a/clients/gui-app/src/lib/keybindings/router-adapter.ts
+++ b/clients/gui-app/src/lib/keybindings/router-adapter.ts
@@ -17,6 +17,7 @@ import {
   goForward as goForwardAction,
 } from "@/lib/commands/actions";
 import { getHistoryController } from "@/lib/persistent-history";
+import { historyNavChromeAvailable } from "@/lib/history-navigation/use-history-nav-available";
 import { LANDING_ROUTE } from "@/lib/routes";
 import {
   existingEpicTabIntent,
@@ -133,7 +134,7 @@ export function routerAdapterFor(
     // History-navigation availability + boundary state off the live router's
     // controller brand. The palette source reads these through `ctx.router`
     // (it mounts above `<RouterProvider>`, where TanStack router context is null).
-    isHistoryNavAvailable: () => getHistoryController(router.history) !== null,
+    isHistoryNavAvailable: () => historyNavChromeAvailable(router.history),
     canGoBack: () => {
       const controller = getHistoryController(router.history);
       return controller !== null && controller.canGoBack();

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -455,10 +455,27 @@ function computeSeededStack(
 }
 
 /**
- * Creates a router history seeded from the explicit `initialRoute` override
- * merged into this window's `localStorage` history, or from that history alone
- * when the shell provides no route. Intended for the Electron renderer only -
- * the browser web app should use TanStack's default browser history.
+ * Creates a router history the app OWNS - entries, index, and the controller
+ * brand that lets `goBack` / `goForward` step it semantically - for the two
+ * shells that have no browser to own one for them.
+ *
+ * `windowId` selects between them, and it is the only switch:
+ *
+ * - **A window id (Electron renderer)** - seeded from the explicit
+ *   `initialRoute` override merged into that window's `localStorage` history,
+ *   or from that history alone when the shell provides no route, and written
+ *   back on every navigation. The renderer's scheme drops the path on relaunch,
+ *   so this is what boots it at the last visited route with no async gate.
+ * - **`null` (the installed mobile app)** - in-memory and SESSION-scoped.
+ *   `loadPersistedState` and `persistState` both refuse a null window, so
+ *   nothing is read at boot and nothing is written. That is deliberate, not an
+ *   oversight to tidy up: a phone's process outlives every navigation in one
+ *   sitting, so the stack already survives a resume, while a stack restored
+ *   across a COLD launch would hand the first back swipe a surface from
+ *   yesterday.
+ *
+ * The browser web app uses neither - it has a URL bar and its own back button,
+ * so TanStack's default browser history is correct there.
  */
 export function createPersistentMemoryHistory(
   initialRoute: string | null,

--- a/clients/gui-app/src/lib/tab-navigation.ts
+++ b/clients/gui-app/src/lib/tab-navigation.ts
@@ -32,7 +32,10 @@ import {
   resolveTabIdForEpic,
   useEpicCanvasStore,
 } from "@/stores/epics/canvas/store";
-import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import {
+  newestLandingDraftId,
+  useLandingDraftStore,
+} from "@/stores/home/landing-draft-store";
 import { tabRouteOptions } from "@/stores/tabs/registry";
 import {
   tabCommandCoordinator,
@@ -629,14 +632,19 @@ export class TabNavigationController {
 
     if (action === "BACK" || action === "FORWARD" || action === "GO") {
       this.establishExternalAuthority();
-      this.resolveExternalLocation(location, false, navigate);
+      // The one caller that is a STEP: the user moved through their own
+      // history. Every other path into the resolver is the app arriving
+      // somewhere (a launch, a synchronization, an external commit), and the
+      // difference decides what the landing means - see the resolver's landing
+      // branch.
+      this.resolveExternalLocation(location, false, true, navigate);
       return;
     }
 
     const envelope = envelopeFromState(location.state);
     if (envelope === null || envelope.sessionId !== this.sessionId) {
       this.establishExternalAuthority();
-      this.resolveExternalLocation(location, false, navigate);
+      this.resolveExternalLocation(location, false, false, navigate);
       return;
     }
 
@@ -647,7 +655,7 @@ export class TabNavigationController {
         return;
       }
       this.establishExternalAuthority();
-      this.resolveExternalLocation(location, false, navigate);
+      this.resolveExternalLocation(location, false, false, navigate);
       return;
     }
 
@@ -664,12 +672,12 @@ export class TabNavigationController {
         return;
       }
       this.establishExternalAuthority();
-      this.resolveExternalLocation(location, false, navigate);
+      this.resolveExternalLocation(location, false, false, navigate);
       return;
     }
 
     this.establishExternalAuthority();
-    this.resolveExternalLocation(location, false, navigate);
+    this.resolveExternalLocation(location, false, false, navigate);
   }
 
   synchronizeInitialLocation(): void {
@@ -698,7 +706,7 @@ export class TabNavigationController {
       synchronizationOnly &&
       (envelope === null || envelope.sessionId !== this.sessionId)
     ) {
-      this.resolveExternalLocation(location, true, navigate);
+      this.resolveExternalLocation(location, true, false, navigate);
       return;
     }
     this.classifySynchronizedLocation(location, preserveStartupFocus, navigate);
@@ -716,11 +724,12 @@ export class TabNavigationController {
         this.resolveExternalLocation(
           current,
           queuedExternal.preserveStartupFocus,
+          false,
           navigate,
         );
       } else {
         this.establishExternalAuthority();
-        this.resolveExternalLocation(current, false, navigate);
+        this.resolveExternalLocation(current, false, false, navigate);
       }
     }
     const queuedActivation = this.queuedActivation;
@@ -1097,7 +1106,12 @@ export class TabNavigationController {
       return;
     }
     this.establishExternalAuthority();
-    this.resolveExternalLocation(location, preserveStartupFocus, navigate);
+    this.resolveExternalLocation(
+      location,
+      preserveStartupFocus,
+      false,
+      navigate,
+    );
   }
 
   private acknowledge(
@@ -1367,9 +1381,17 @@ export class TabNavigationController {
     this.notifyFailureListeners();
   }
 
+  /**
+   * @param historyStep - whether this location was reached by the user STEPPING
+   * through their own history (back, forward, or a controller `go`), as opposed
+   * to the app arriving somewhere: a launch, a synchronization, or an external
+   * commit. Only the landing branch reads it, and only because those two cases
+   * want opposite things from the same pathname.
+   */
   private resolveExternalLocation(
     location: TabNavigationLocation,
     preserveStartupFocus: boolean,
+    historyStep: boolean,
     navigate: NavigateFn,
   ): void {
     if (location.pathname === "/draft/new") {
@@ -1378,7 +1400,10 @@ export class TabNavigationController {
     }
     const routed = routedTabTarget(location.pathname);
     if (routed === null) {
-      if (isLandingPath(location.pathname)) return;
+      if (isLandingPath(location.pathname)) {
+        if (historyStep) this.resolveSteppedLanding();
+        return;
+      }
       this.issueLandingCorrection(location, navigate);
       return;
     }
@@ -1503,6 +1528,34 @@ export class TabNavigationController {
     }
     this.rememberRoute(ref, systemIntent, location.search);
     useTabsStore.getState().rememberSystemTabPath(kind, location.pathname);
+  }
+
+  /**
+   * The landing, reached because the user STEPPED here rather than because the
+   * app arrived here.
+   *
+   * Home on this shell is the landing DRAFT surface, so "show me Home" is an
+   * activation like any other, not the absence of one - a populated strip
+   * always has exactly one active item (`repairLayout` restores that invariant
+   * after every commit), and a step that activated nothing left the previous
+   * tab on screen while the route moved underneath it.
+   *
+   * IDEMPOTENT, which is what makes it safe to run on every step. The existing
+   * landing draft is named explicitly, so repeated steps back to `/` re-activate
+   * the one Home instead of stacking a new draft per press; only a session that
+   * has never had one mints, through the same activation `/draft/new` runs.
+   */
+  private resolveSteppedLanding(): void {
+    this.activateExternalTarget({
+      kind: "draft",
+      draftId: newestLandingDraftId(),
+      // Same seed as `/draft/new`: the landing composer opens on the app-wide
+      // active host, so it inherits that host's last-run bucket.
+      settings: useComposerRunSettingsStore
+        .getState()
+        .getGlobalRunSettings(activeHostIdOrNull()),
+      create: true,
+    });
   }
 
   private resolveDraftEntry(

--- a/clients/gui-app/src/providers/keybinding-provider.tsx
+++ b/clients/gui-app/src/providers/keybinding-provider.tsx
@@ -15,7 +15,7 @@ import {
   resolveLeaderOwner,
 } from "@/lib/keybindings/dispatch";
 import { subscribeLeaderScopes } from "@/lib/keybindings/leader-scope";
-import { getHistoryController } from "@/lib/history-navigation";
+import { historyNavChromeAvailable } from "@/lib/history-navigation";
 import type { ActionId } from "@/lib/keybindings/actions";
 import {
   routerAdapterFor,
@@ -354,15 +354,16 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       dispatchAction(actionId, adapter);
     };
 
-    // Mouse back/forward (buttons 3/4). Desktop-only: gated on the current
-    // router carrying a persistent-history controller, so the browser/web build
-    // never intercepts these. `preventDefault()` runs only when handled, so the
-    // shell's native back/forward stays intact off-desktop.
+    // Mouse back/forward (buttons 3/4). Desktop-only, on the shared chrome
+    // predicate rather than the controller brand alone: the mobile app carries
+    // the brand too, and these buttons are chrome for a device that has them.
+    // `preventDefault()` runs only when handled, so the shell's native
+    // back/forward stays intact everywhere else.
     // NOTE: Windows may instead surface these as a main-process `app-command`
     // (`browser-backward`/`browser-forward`); that path is a verify-and-extend
     // follow-up tracked in the tech plan (§4.4).
     const handleMouseNav = (event: MouseEvent) => {
-      if (getHistoryController(router.history) === null) return;
+      if (!historyNavChromeAvailable(router.history)) return;
       if (event.button === 3) {
         event.preventDefault();
         adapter.goBack();

--- a/clients/gui-app/src/router.tsx
+++ b/clients/gui-app/src/router.tsx
@@ -7,6 +7,7 @@ import {
 import { queryClient } from "@/lib/query-client";
 import { getAppHostClientSnapshot } from "@/lib/host/runtime";
 import { createPersistentMemoryHistory } from "@/lib/persistent-history";
+import { isMobileApp } from "@/lib/mobile-app";
 import { RoutePendingScreen } from "@/components/loading/route-pending-screen";
 import { RouteErrorComponent } from "@/components/errors/route-error-component";
 import { warmRouteChunks } from "@/lib/warm-route-chunks";
@@ -155,6 +156,23 @@ function createAppHistory(
   // work natively, and reload survives via the browser. A shell-injected
   // `initialRoute` still overrides via memory history below.
   if (!isElectronContext()) {
+    // The installed mobile app owns its back stack, because it is the one
+    // non-Electron shell whose ONLY history affordance is in-app: the phone has
+    // no URL bar, no back button, and no room in its header for the desktop's
+    // arrows - the edge swipe is the whole of back and forward there. TanStack's
+    // own history would leave that gesture reading a stack nothing in this app
+    // fills, which is a gesture that recognizes perfectly and then navigates
+    // nowhere.
+    //
+    // `windowId` is deliberately `null`, which is what makes the stack
+    // SESSION-scoped: both halves of the persistence layer no-op on a null
+    // window, so nothing is read at boot and nothing is written. A phone's
+    // process outlives every navigation the user makes inside one sitting, so
+    // the in-memory stack already survives everything a resume can do to it; a
+    // stack restored across a COLD launch would instead hand the first swipe
+    // after opening the app a surface from yesterday, which reads as the app
+    // going somewhere the user never was.
+    if (isMobileApp()) return createPersistentMemoryHistory(initialRoute, null);
     if (initialRoute === null) return undefined;
     return createMemoryHistory({
       initialEntries: [normalizeInitialRoute(initialRoute)],


### PR DESCRIPTION
## What

The mobile edge swipe recognizes, every gate passes, `onNavigate` runs — and then the step lands on a history nothing in this app ever wrote to. Simulator forensics measured it directly: `getHistoryController(router.history)` is null on the phone, and `__TSR_index` sits at 0 on the surfaces users swipe from. A gesture that works perfectly and navigates nowhere.

This gives the installed mobile app its own back stack.

## Why the phone, specifically

`createAppHistory` handed `createPersistentMemoryHistory` to the Electron renderer only; every other shell fell through to TanStack's own history. That is right for a browser tab — the URL bar drives navigation and the browser owns back. It is wrong for the installed app, which is the one non-Electron shell whose *only* history affordance is in-app: no URL bar, no back button, and no room in its header for the desktop's arrows. The edge swipe is the whole of back and forward there.

With the controller, `goBack` / `goForward` also take the **semantic** branch instead of the plain fallback: eligibility honored, the landing entry's tile restored before the step, and a step with no eligible entry refused outright rather than issuing a `go(0)` that re-runs the current route for nothing.

## Session-scoped, deliberately

`windowId` is passed as `null`, and that is the entire scoping mechanism — no new key, no new code. Both halves of the persistence layer already refuse a null window (`loadPersistedState` at `persistent-history.ts:157`, `persistState` at `:230`), so nothing is read at boot and nothing is written.

A phone's process outlives every navigation the user makes in one sitting, so the in-memory stack already survives anything a resume does to it. A stack restored across a **cold** launch would instead hand the first swipe after opening the app a surface from yesterday — the app going somewhere the user has never been.

## The chrome split

The controller brand was doing double duty: "there is a stack to walk" *and* "show the back/forward chrome". The mobile app now carries the brand, so those had to come apart.

`historyNavChromeAvailable(history)` is the one predicate for the second question. It had **three** call sites that could not see each other, each open-coding it:

- `useHistoryNavAvailable` — header arrows, and the resource-monitor popover's nested-focus gate
- the keybinding router adapter's `isHistoryNavAvailable` — which the palette reads through, since it mounts above `<RouterProvider>` where router context is null
- the mouse-nav listener's inline `getHistoryController(...) !== null`

All three now call it. Without that, the brand flip would have leaked arrows, a mouse reservation, and palette rows onto a phone through whichever copy got missed.

The gesture asks nothing of this predicate. `useMobileHistorySwipes` → `goBack` was already unconditional; it just has a stack to walk now.

## Tests — closing the gap that let this ship green

Every existing fixture **constructs** its history, so all of them would hold against a shell whose real history nothing ever feeds. That is exactly the shape this shipped in.

The new suite takes the history from a real `createAppRouter(null, null)` under `setMobileApp(true)`, drives two cross-item activations through the real `TabNavigationRouteBridge`, and asserts the stack **grew**: `getIndex()` 0 → 2, `canGoBack()` false → true, then `goBack` → index 1 with the surface re-activated.

All three cases are mutation-proven:

| Mutation | Fails |
| --- | --- |
| revert the `router.tsx` mobile branch | "owns its back stack" + "grows an entry" (`expected null not to be null`) |
| neuter `!isMobileApp()` in the chrome predicate | "carries the stack without carrying the desktop's chrome" (`expected true to be false`) |

11/11 in that file; 37/37 across the five neighbours that read the brand (`history-nav-buttons`, `keybinding-provider-history-nav`, `history-prune-provider`, `use-system-tab-modal`, `system-overlay-promotion-back-nav`). eslint `--max-warnings 0`, prettier, and gui-app `compile` clean; the full `build · compile · lint · format (nx affected)` pre-commit gate passed.

That file's header comment asserted the Capacitor bundle boots a plain unbranded history — true before this commit, false after — so it is rewritten rather than left as the next reader's wrong premise.

## Known and deliberate

A cold launch still starts at index 0, so the very first swipe of a fresh session — before the user has gone anywhere — does nothing. That is a settled product decision, not a gap: back steps real history only, with no "up" fallback to a parent surface. Once the stack fills on the first surface change, the silent case narrows to the first screen of a fresh launch, which is where doing nothing is the defensible answer.

Device re-verification on the simulator is booked separately and is not claimed by this PR.

---

## Follow-up in this PR: the screen now moves

The stack above was necessary and not sufficient. Simulator verification found the history stepping correctly — controller present, index advancing, `history.go` running, route changing both directions — while the visible surface stayed frozen.

**Cause:** a step onto the landing (`/`) resolves to no tab, and `resolveExternalLocation`'s landing branch returned without touching the layout. The location moved; the previously active tab stayed active. On a phone that is every journey's last step — open one thing from Home, swipe back.

**Home is not the absence of a tab.** `repairLayout` runs after every transaction commit and restores the invariant that a populated strip has exactly one active item, so "deactivate everything" is not a state this layout can hold — it comes straight back as the first tab. Home on this shell is the landing *draft* surface, so returning to it is an activation like any other, through the same `activateExternalTarget` the `/draft/new` route already runs, seeded from the same run settings.

**Idempotent by naming.** The existing landing draft is passed explicitly (`newestLandingDraftId()`) rather than as `null`, so repeated steps re-activate the one Home instead of stacking a draft per press. `resolveDraftActivation` already had a mobile-only stable-composer rule that masked this — on **desktop** an id-less create would have minted a draft on every back-press.

**Scoped to steps.** A `historyStep` flag is threaded explicitly through all nine `resolveExternalLocation` call sites; only the BACK/FORWARD/GO branch passes `true`. A cold launch REPLACEs to `/` on its own while stored tokens validate, so acting on every arrival would strand a restoring window on the landing and undo the startup focus the branch above protects.

**Desktop consequence, deliberate:** the desktop back arrow reaching a `/` entry now lands Home instead of freezing. Same bug, quieter, fixed once rather than carved out per shell.

Mutation-proven in both directions:

| Mutation | Fails |
| --- | --- |
| drop the call (no fix) | both landing cases |
| `newestLandingDraftId()` → `null` | the idempotence case (two steps, one draft) |
| ignore the step flag | *"leaves a fresh session untouched when there is nothing behind it"* — an existing test, which is what proves the gate load-bearing |

324/324 across the 20 suites touching history, tabs, and the shell; compile clean. Rebased onto the rewritten `mobile-app` (clean replay, no conflicts) so CI runs against the current base.
