### PR TITLE
fix(gui-app): withdraw a hosted tile's presentation claim when its writer goes

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/mobile-tile-surface-presentation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/mobile-tile-surface-presentation.test.tsx
@@ -1,0 +1,383 @@
+/**
+ * The phone canvas mounts ONE tile at a time, which makes it the only branch
+ * where a hosted chat's environment publisher can vanish while the record it
+ * published for is still a member. Every assertion here is a registry dump -
+ * which records read as presented - because that predicate is what decides
+ * whether a record paints, and two records reading presented at once means two
+ * chat transcripts stacked at the same pane rect.
+ *
+ * The desktop tab group cannot reach this state (it keeps deselected tabs
+ * mounted, so their slots republish `tabSelected: false`), so no desktop-branch
+ * test can stand in for these.
+ */
+import "../../../../__tests__/test-browser-apis";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { MobileEpicTileView } from "@/components/epic-canvas/mobile/mobile-epic-tile-view";
+import {
+  getTileSurfaceEnvironment,
+  isTileSurfacePresented,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import {
+  getTileSurfaceMembership,
+  resetTileSurfaceMembershipForTesting,
+} from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import { resetChatRemoteDeletionRegistryForTesting } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import {
+  PaneFocusProbeContext,
+  PaneSurfaceActivityContext,
+  PaneVisibilityContext,
+} from "@/components/epic-tabs/pane-visibility-context";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useTabsStore } from "@/stores/tabs/store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import type { TabRef } from "@/stores/tabs/types";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+  TilePane,
+} from "@/stores/epics/canvas/types";
+
+const HOST_ID = "host-A";
+const EPIC_A = { epicId: "epic-1", viewTabId: "view-tab-1", paneId: "pane-A" };
+const EPIC_B = { epicId: "epic-2", viewTabId: "view-tab-2", paneId: "pane-B" };
+
+// `ActiveTabBody` reads permission/snapshot/projection state through these
+// seams on every render regardless of tab type; stubbed so the chat body
+// routes through `surfaceOwnerFor` without a HostRuntimeProvider /
+// EpicSessionProvider (same seams `tab-group-view.test` stubs).
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicArtifact: (id: string) => ({ id, userId: "user-1" }),
+  useEpicChatRecordListAuthoritative: () => true,
+  useEpicChatRetraction: () => null,
+  useEpicTabDisplayTitle: (node: { readonly name: string }) => node.name,
+  useEpicLiveArtifactTitleGenerating: () => false,
+  useEpicPermissionRole: () => "owner",
+  useEpicSnapshotLoaded: () => true,
+  useMaybeEpicTuiAgentHarnessId: () => null,
+}));
+
+// A null canvas host keeps `computeIsRemoteDeleted` unauthoritative and the
+// published-copy fallback withdrawn, so every fixture chat here takes the
+// live hosted path - the one under test.
+vi.mock("@/components/epic-canvas/hooks/use-canvas-host-id", () => ({
+  useCanvasHostId: () => null,
+}));
+
+vi.mock("@/hooks/epic/use-epic-session-host-client", () => ({
+  useEpicSessionHostClient: () => null,
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: (hostId: string) => ({
+    status: "reachable",
+    hostLabel: hostId,
+  }),
+}));
+
+vi.mock("@/hooks/chats/use-cloud-chat-queries", () => ({
+  useCloudChatList: () => ({
+    data: undefined,
+    isError: false,
+    isPending: false,
+    isFetching: false,
+  }),
+  cloudChatListAuthorizesRecordSweep: () => false,
+}));
+
+vi.mock("@/lib/registries/chat-session-registry", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/registries/chat-session-registry")
+  >()),
+  useExistingChatSessionHandle: () => null,
+  useExistingChatSessionFatalClose: () => null,
+}));
+
+// `tab-group-view` imports the dead-tile banner container straight from
+// `chat-tile`, whose real module graph pulls the chat session/host runtime
+// this render-focused suite deliberately does not provide.
+vi.mock("@/components/epic-canvas/renderers/chat-tile", () => ({
+  ChatDeadTileBannerContainer: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/renderers/epic-node-tile", () => ({
+  EpicNodeTile: ({ node }: { readonly node: EpicCanvasTileRef }) => (
+    <div data-testid={`tile-${node.id}`} />
+  ),
+}));
+
+vi.mock("@/components/epic-canvas/canvas/pane-opener", () => ({
+  PaneOpener: () => <div data-testid="pane-opener" />,
+}));
+
+vi.mock("@/components/epic-canvas/mobile/mobile-current-tile-bar", () => ({
+  MobileCurrentTileBar: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/mobile/tab-switcher-sheet", () => ({
+  TabSwitcherSheet: () => null,
+}));
+
+const OPEN_EPIC_HANDLE = {} as OpenEpicStoreHandle;
+
+function chat(n: number): EpicCanvasTileRef {
+  return {
+    id: `chat-${n}`,
+    instanceId: `inst-${n}`,
+    type: "chat",
+    name: `Chat ${n}`,
+    hostId: HOST_ID,
+  };
+}
+
+function makePane(
+  id: string,
+  tiles: ReadonlyArray<EpicCanvasTileRef>,
+  activeInstanceId: string,
+): TilePane {
+  return {
+    kind: "pane",
+    id,
+    tabInstanceIds: tiles.map((tile) => tile.instanceId),
+    activeTabId: activeInstanceId,
+    previewTabId: null,
+    activationHistory: [activeInstanceId],
+  };
+}
+
+function canvasOf(
+  paneId: string,
+  tiles: ReadonlyArray<EpicCanvasTileRef>,
+  activeInstanceId: string,
+): EpicCanvasState {
+  return {
+    root: makePane(paneId, tiles, activeInstanceId),
+    activePaneId: paneId,
+    tilesByInstanceId: Object.fromEntries(
+      tiles.map((tile) => [tile.instanceId, tile]),
+    ),
+    sizesByGroupId: {},
+  };
+}
+
+function tabItem(viewTabId: string) {
+  const ref: TabRef = { kind: "epic", id: viewTabId };
+  return {
+    item: { kind: "tab" as const, id: `tab:epic:${viewTabId}`, ref },
+    ref,
+  };
+}
+
+function seedCanvases(
+  canvases: ReadonlyArray<{
+    readonly epicId: string;
+    readonly viewTabId: string;
+    readonly canvas: EpicCanvasState;
+  }>,
+  activeViewTabId: string,
+): void {
+  useEpicCanvasStore.setState({
+    tabsById: Object.fromEntries(
+      canvases.map((entry) => [
+        entry.viewTabId,
+        { tabId: entry.viewTabId, epicId: entry.epicId, name: entry.epicId },
+      ]),
+    ),
+    canvasByTabId: Object.fromEntries(
+      canvases.map((entry) => [entry.viewTabId, entry.canvas]),
+    ),
+    openTabOrder: canvases.map((entry) => entry.viewTabId),
+    activeTabId: activeViewTabId,
+  });
+  const entries = canvases.map((entry) => tabItem(entry.viewTabId));
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: entries.map((entry) => entry.item),
+    activeItemId: `tab:epic:${activeViewTabId}`,
+    stripOrder: entries.map((entry) => entry.ref),
+  }));
+}
+
+function activateTopLevel(viewTabId: string): void {
+  useTabsStore.setState((state) => ({
+    ...state,
+    activeItemId: `tab:epic:${viewTabId}`,
+  }));
+}
+
+function resetAll(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+  tabCommandCoordinator.resetReconciliationForTesting();
+  resetChatRemoteDeletionRegistryForTesting();
+  resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
+}
+
+/** The registry dump: every member that currently reads as painting. */
+function presentedInstanceIds(): ReadonlyArray<string> {
+  return [...getTileSurfaceMembership()].filter((instanceId) =>
+    isTileSurfacePresented(getTileSurfaceEnvironment(instanceId)),
+  );
+}
+
+function mobileView(view: {
+  readonly epicId: string;
+  readonly viewTabId: string;
+}): ReactNode {
+  return (
+    <EpicSessionContext.Provider value={OPEN_EPIC_HANDLE}>
+      <PaneVisibilityContext.Provider value>
+        <PaneSurfaceActivityContext.Provider
+          value={{ visible: true, focused: true }}
+        >
+          <PaneFocusProbeContext.Provider value={() => true}>
+            <MobileEpicTileView epicId={view.epicId} tabId={view.viewTabId} />
+          </PaneFocusProbeContext.Provider>
+        </PaneSurfaceActivityContext.Provider>
+      </PaneVisibilityContext.Provider>
+    </EpicSessionContext.Provider>
+  );
+}
+
+describe("mobile single-tile canvas: hosted surface presentation", () => {
+  beforeEach(() => resetAll());
+  afterEach(() => {
+    cleanup();
+    resetAll();
+  });
+
+  it("hands presentation over on a chat switch - the outgoing record stops reading as presented", () => {
+    seedCanvases(
+      [
+        {
+          ...EPIC_A,
+          canvas: canvasOf(EPIC_A.paneId, [chat(1), chat(2)], "inst-1"),
+        },
+      ],
+      EPIC_A.viewTabId,
+    );
+    render(mobileView(EPIC_A));
+
+    // Step 1: the shown chat has published and paints alone.
+    expect(presentedInstanceIds()).toEqual(["inst-1"]);
+
+    // Step 2: switch chats, through the same store transition the mobile
+    // switcher drives. Only ONE tile mounts here, so `inst-1` loses its
+    // publisher while pane retention keeps its record alive.
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .prepareSetActiveTileTabFocusTarget(
+          EPIC_A.viewTabId,
+          EPIC_A.paneId,
+          "inst-2",
+        );
+    });
+
+    // Step 3: dump. Both are members, exactly one paints.
+    expect([...getTileSurfaceMembership()].sort()).toEqual([
+      "inst-1",
+      "inst-2",
+    ]);
+    expect(presentedInstanceIds()).toEqual(["inst-2"]);
+
+    const outgoing = getTileSurfaceEnvironment("inst-1");
+    if (outgoing === null) {
+      throw new Error("the outgoing record must be RETAINED, not cleared");
+    }
+    expect(outgoing.canvasActivity.tabSelected).toBe(false);
+    expect(isTileSurfacePresented(outgoing)).toBe(false);
+    // Retention is intact - the record keeps a usable environment to re-show
+    // from; only its claim on the rect was withdrawn.
+    expect(outgoing.services.openEpicHandle).toBe(OPEN_EPIC_HANDLE);
+    expect(outgoing.placement.paneId).toBe(EPIC_A.paneId);
+  });
+
+  it("switching back and forth never leaves two records presented", () => {
+    seedCanvases(
+      [
+        {
+          ...EPIC_A,
+          canvas: canvasOf(EPIC_A.paneId, [chat(1), chat(2)], "inst-1"),
+        },
+      ],
+      EPIC_A.viewTabId,
+    );
+    render(mobileView(EPIC_A));
+
+    for (const instanceId of ["inst-2", "inst-1", "inst-2", "inst-1"]) {
+      act(() => {
+        useEpicCanvasStore
+          .getState()
+          .prepareSetActiveTileTabFocusTarget(
+            EPIC_A.viewTabId,
+            EPIC_A.paneId,
+            instanceId,
+          );
+      });
+      expect(presentedInstanceIds()).toEqual([instanceId]);
+    }
+  });
+
+  it("navigating to another epic leaves no presented record behind in the one it left", () => {
+    seedCanvases(
+      [
+        {
+          ...EPIC_A,
+          canvas: canvasOf(EPIC_A.paneId, [chat(1)], "inst-1"),
+        },
+        {
+          ...EPIC_B,
+          canvas: canvasOf(EPIC_B.paneId, [chat(2)], "inst-2"),
+        },
+      ],
+      EPIC_A.viewTabId,
+    );
+    const { rerender } = render(mobileView(EPIC_A));
+    expect(presentedInstanceIds()).toEqual(["inst-1"]);
+
+    // The record the departed epic leaves behind stays a MEMBER (its
+    // top-level surface is still retained), which is exactly why a stale
+    // presentation claim on it would paint over the epic navigated to - the
+    // two panes are different, and every record sits at its pane's rect.
+    act(() => {
+      activateTopLevel(EPIC_B.viewTabId);
+      rerender(mobileView(EPIC_B));
+    });
+
+    expect([...getTileSurfaceMembership()].sort()).toEqual([
+      "inst-1",
+      "inst-2",
+    ]);
+    expect(presentedInstanceIds()).toEqual(["inst-2"]);
+    expect(getTileSurfaceEnvironment("inst-1")).not.toBeNull();
+  });
+
+  it("tearing the epic view down withdraws its presentation claim", () => {
+    seedCanvases(
+      [
+        {
+          ...EPIC_A,
+          canvas: canvasOf(EPIC_A.paneId, [chat(1)], "inst-1"),
+        },
+      ],
+      EPIC_A.viewTabId,
+    );
+    const { unmount } = render(mobileView(EPIC_A));
+    expect(presentedInstanceIds()).toEqual(["inst-1"]);
+
+    act(() => {
+      unmount();
+    });
+
+    expect(getTileSurfaceMembership().has("inst-1")).toBe(true);
+    expect(presentedInstanceIds()).toEqual([]);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -22,8 +22,10 @@ import {
 } from "@/components/epic-canvas/surface-host/tile-surface-membership";
 import {
   getTileSurfaceEnvironment,
+  isTileSurfacePresented,
   publishTileSurfaceEnvironment,
   resetTileSurfaceEnvironmentRegistryForTesting,
+  retractTileSurfacePresentation,
   subscribeTileSurfaceEnvironment,
   type ReadyTileSurfaceEnvironment,
 } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
@@ -226,6 +228,94 @@ describe("tile surface environment registry", () => {
     });
     publishTileSurfaceEnvironment(second);
     expect(getTileSurfaceEnvironment("chat-1")).toBe(second);
+  });
+
+  it("retracting presentation lowers tabSelected without clearing the record or re-creating its services", () => {
+    seedMember("chat-1", "tab-1");
+    const published = environment({});
+    publishTileSurfaceEnvironment(published);
+    expect(isTileSurfacePresented(getTileSurfaceEnvironment("chat-1"))).toBe(
+      true,
+    );
+
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    retractTileSurfacePresentation(
+      "chat-1",
+      published.services.geometryAnchorElement,
+    );
+
+    const after = getTileSurfaceEnvironment("chat-1");
+    if (after === null) throw new Error("expected the record to be retained");
+    expect(isTileSurfacePresented(after)).toBe(false);
+    expect(notifications).toBe(1);
+    // The continuity guarantee is untouched: same identity, same placement,
+    // and the SAME services object (by reference) the source slot published.
+    expect(after.identity).toBe(published.identity);
+    expect(after.placement).toBe(published.placement);
+    expect(after.services).toBe(published.services);
+    expect(after.presentation).toBe(published.presentation);
+    // A fresh object, so a `useSyncExternalStore` reader actually re-renders
+    // rather than bailing out on an identity-equal snapshot.
+    expect(after).not.toBe(published);
+    unsubscribe();
+  });
+
+  it("a slot can only retract its OWN publish: an anchor the record no longer carries is a no-op", () => {
+    seedMember("chat-1", "tab-1");
+    const sourceAnchor = document.createElement("div");
+    publishTileSurfaceEnvironment(
+      environment({
+        services: {
+          openEpicHandle:
+            {} as ReadyTileSurfaceEnvironment["services"]["openEpicHandle"],
+          geometryAnchorElement: sourceAnchor,
+          panePortalContainer: null,
+          isPaneFocusedNow: () => false,
+        },
+      }),
+    );
+    // The destination slot publishes for the same instance BEFORE the source
+    // slot tears down - the cross-commit transfer ordering. The source's
+    // teardown must not conceal the live record.
+    const destination = environment({});
+    publishTileSurfaceEnvironment(destination);
+
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    retractTileSurfacePresentation("chat-1", sourceAnchor);
+
+    expect(getTileSurfaceEnvironment("chat-1")).toBe(destination);
+    expect(isTileSurfacePresented(getTileSurfaceEnvironment("chat-1"))).toBe(
+      true,
+    );
+    expect(notifications).toBe(0);
+    unsubscribe();
+  });
+
+  it("retracting an already-unpresented or unknown record notifies nobody", () => {
+    seedMember("chat-1", "tab-1");
+    const published = environment({});
+    publishTileSurfaceEnvironment(published);
+    const anchor = published.services.geometryAnchorElement;
+    retractTileSurfacePresentation("chat-1", anchor);
+
+    let notifications = 0;
+    const unsubscribe = subscribeTileSurfaceEnvironment("chat-1", () => {
+      notifications += 1;
+    });
+
+    retractTileSurfacePresentation("chat-1", anchor);
+    retractTileSurfacePresentation("never-a-member", anchor);
+
+    expect(notifications).toBe(0);
+    unsubscribe();
   });
 
   it("removes the record and notifies only on membership loss, never mid-transfer", () => {

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-environment-registry.test.ts
@@ -299,6 +299,38 @@ describe("tile surface environment registry", () => {
     unsubscribe();
   });
 
+  it("the source-first transfer gap is bounded by the destination publish, not by a frame", async () => {
+    seedMember("chat-1", "tab-1");
+    const source = environment({});
+    publishTileSurfaceEnvironment(source);
+
+    // Source tears down before any destination has published - the accepted
+    // gap. The record is RETAINED (still non-null, still a member) but stops
+    // claiming the rect.
+    retractTileSurfacePresentation(
+      "chat-1",
+      source.services.geometryAnchorElement,
+    );
+    expect(getTileSurfaceEnvironment("chat-1")).not.toBeNull();
+    expect(getTileSurfaceMembership().has("chat-1")).toBe(true);
+    expect(isTileSurfacePresented(getTileSurfaceEnvironment("chat-1"))).toBe(
+      false,
+    );
+
+    // Elapsed time does not end the gap: nothing in the registry schedules or
+    // bounds the recovery. Only the destination's own publish does - which is
+    // why the bound is "until the destination publishes", not "one frame".
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(isTileSurfacePresented(getTileSurfaceEnvironment("chat-1"))).toBe(
+      false,
+    );
+
+    publishTileSurfaceEnvironment(environment({}));
+    expect(isTileSurfacePresented(getTileSurfaceEnvironment("chat-1"))).toBe(
+      true,
+    );
+  });
+
   it("retracting an already-unpresented or unknown record notifies nobody", () => {
     seedMember("chat-1", "tab-1");
     const published = environment({});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
@@ -12,18 +12,27 @@
  * Two invariants the design calls out explicitly:
  *
  * - Retain last valid environment across a structural transfer. There is
- *   deliberately no "unregister"/"retract" write path: the ONLY way an
- *   environment changes is a fresh publish (source slot -> destination slot
- *   overwrites in place, never round-tripping through `null`) or membership
- *   itself removing the record. A transient gap between a source slot going
- *   quiet and a destination slot publishing must not surface as `null`.
+ *   deliberately no "unregister"/"retract" write path for the RECORD: the
+ *   only way an environment is replaced is a fresh publish (source slot ->
+ *   destination slot overwrites in place, never round-tripping through
+ *   `null`) or membership itself removing the record. A transient gap between
+ *   a source slot going quiet and a destination slot publishing must not
+ *   surface as `null`.
  * - Removal only by membership. The registry subscribes to
  *   `subscribeTileSurfaceMembership` and deletes a record (notifying its
  *   subscribers) only when the instance actually leaves membership - close,
  *   eviction past the pane's chat retention cap, or settled top-level MRU
  *   eviction. Deselecting a tab no longer removes anything (it did while
  *   decision #17 stood); it only flips the record out of
- *   `isTileSurfacePresented`. Nothing else clears it.
+ *   `isTileSurfacePresented`. Nothing else deletes a record.
+ *
+ * `retractTileSurfacePresentation` is the one narrow exception, and it is
+ * deliberately NOT an unregister: it lowers `canvasActivity.tabSelected` on a
+ * record that stays in the map with its identity, placement and `services`
+ * object references untouched, so every continuity guarantee below holds
+ * verbatim. Retention is about WHICH environment a consumer reads during a
+ * gap; presentation is about whether the record may paint right now. Only the
+ * latter may be withdrawn, and only by the slot that asserted it.
  *
  * Subscriptions are isolated per instance (`Map<instanceId, Set<listener>>`):
  * publishing or updating pane B's environment must not notify pane A's
@@ -177,6 +186,46 @@ export function publishTileSurfaceEnvironment(
   notify(instanceId);
 }
 
+/**
+ * Withdraws the PRESENTATION claim a slot made for `instanceId`, leaving the
+ * record itself - identity, placement, and every `services` handle, by
+ * reference - exactly as published. `getTileSurfaceEnvironment` keeps
+ * answering the same non-null environment; only `isTileSurfacePresented`
+ * flips, and subscribers are notified with a fresh object so a
+ * `useSyncExternalStore` reader actually re-renders.
+ *
+ * This exists because `canvasActivity.tabSelected` has exactly ONE writer -
+ * the slot that publishes it - and that writer is destroyed by the very
+ * transitions that end its claim: the slot re-pointed at a different
+ * instance, the pane torn down, the whole canvas navigated away from. A claim
+ * that outlives its writer paints forever, and because every record of a pane
+ * shares that pane's rect, "forever" means stacked on top of whatever took
+ * the rect next. There is no ancestor that survives all three transitions, so
+ * the withdrawal belongs to the writer: React runs its effect cleanup at
+ * precisely the moment the claim ends.
+ *
+ * `publishedAnchor` is that writer's own `services.geometryAnchorElement`,
+ * and the identity check on it is what makes the withdrawal safe to run
+ * unconditionally: a slot may only lower a claim that is still ITS OWN
+ * publish. Once a destination slot has published for the same instance, the
+ * source slot's later teardown is a no-op rather than a concealment of the
+ * live record.
+ */
+export function retractTileSurfacePresentation(
+  instanceId: string,
+  publishedAnchor: HTMLElement | null,
+): void {
+  const current = environments.get(instanceId);
+  if (current === undefined) return;
+  if (current.services.geometryAnchorElement !== publishedAnchor) return;
+  if (!current.canvasActivity.tabSelected) return;
+  environments.set(instanceId, {
+    ...current,
+    canvasActivity: { ...current.canvasActivity, tabSelected: false },
+  });
+  notify(instanceId);
+}
+
 /** `null` for a member with no published environment yet, or a non-member. */
 export function getTileSurfaceEnvironment(
   instanceId: string,
@@ -198,6 +247,12 @@ export function getTileSurfaceEnvironment(
  * The geometry guard in `StableTileSurfaceHost` keys off this SAME predicate
  * deliberately: a concealed layer reports a rect its body must not reflow to,
  * and "is this painting" is precisely the question that guard is asking.
+ *
+ * Both inputs are ASSERTIONS by a live slot, never facts the registry can
+ * re-derive - so each one is only as current as its writer. `tabSelected` is
+ * therefore lowered by `retractTileSurfacePresentation` when the publishing
+ * slot's claim ends, which is what keeps a record that no longer has a writer
+ * from reading as presented on a stale `true`.
  */
 export function isTileSurfacePresented(
   environment: TileSurfaceEnvironment,

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-environment-registry.ts
@@ -210,6 +210,18 @@ export function publishTileSurfaceEnvironment(
  * publish. Once a destination slot has published for the same instance, the
  * source slot's later teardown is a no-op rather than a concealment of the
  * live record.
+ *
+ * The opposite order is the accepted gap. A source slot that tears down
+ * BEFORE any destination has published leaves the record retained but
+ * unpresented, and it stays unpresented until that destination's own publish
+ * restores the claim. Nothing here schedules or bounds that interval: the
+ * bound is the destination publish, NOT a frame. It is short today only
+ * because the transfers that produce it are choreographed synchronously - a
+ * same-commit structural move republishes during the same layout phase, so
+ * the gap never reaches paint - and it would widen if that choreography ever
+ * became asynchronous. A record briefly unpainted while genuinely between
+ * owners is the deliberate trade for never painting two owners at once, which
+ * is the unrecoverable failure.
  */
 export function retractTileSurfacePresentation(
   instanceId: string,

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-slot.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-slot.tsx
@@ -30,7 +30,10 @@ import {
   usePaneVisible,
 } from "@/components/epic-tabs/pane-visibility-context";
 import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
-import { publishTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import {
+  publishTileSurfaceEnvironment,
+  retractTileSurfacePresentation,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
 import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
 import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
 
@@ -94,6 +97,30 @@ export function TileSurfaceSlot(props: TileSurfaceSlotProps): ReactNode {
     panePortalContainer,
     isPaneFocusedNow,
   ]);
+
+  // The publish above is the ONLY writer of this record's
+  // `canvasActivity.tabSelected`, so the claim has to be withdrawn by the same
+  // writer - the registry cannot re-derive it, and no ancestor outlives every
+  // transition that ends it. Three shapes end a claim, and only this cleanup
+  // sees all three: the slot re-pointed at a different instance (a canvas that
+  // mounts one tile at a time reconciles rather than remounts, so the outgoing
+  // instance loses its writer without anything unmounting), the pane torn
+  // down, and the whole canvas navigated away from while membership still
+  // retains its chats. A claim left standing after any of them keeps the
+  // record painting - and since every record of a pane is positioned at that
+  // pane's rect, it paints stacked on whatever holds the rect now, with no
+  // republish left to correct it.
+  //
+  // Scoped to the identity of the claim (`instanceId` + the anchor that
+  // carries it) rather than to the publish effect's full dependency list: a
+  // mere republish - focus, visibility, a new portal container - must not
+  // round-trip presentation through `false`.
+  const claimedInstanceId = node.instanceId;
+  useLayoutEffect(() => {
+    return () => {
+      retractTileSurfacePresentation(claimedInstanceId, slotElement);
+    };
+  }, [claimedInstanceId, slotElement]);
 
   return (
     <div


### PR DESCRIPTION
## The bug

On the phone canvas, switching between chats paints **two chat transcripts on top of each other** at the same rect, permanently — it never self-heals short of a page reload. Root-caused on the iOS Simulator against a live registry dump (1 record painted → one switch → 2 records painted on 500/500 sampled frames, with neither chat streaming).

## Mechanism

A hosted record paints when `isTileSurfacePresented` is true — `topLevelVisible && canvasActivity.tabSelected`. Both are *assertions by a live slot*, not facts the registry can re-derive, and `tabSelected` has exactly one writer: the `TileSurfaceSlot` that publishes it. The registry deliberately has no retraction path (the transfer-gap contract needs a record to keep answering its last published environment during a structural move).

So a writer that simply disappears leaves its claim asserted forever. And because every record of a pane is positioned at that pane's rect, "forever" means stacked on whatever holds the rect next.

Desktop never reaches this: `TabGroupView` keeps deselected tabs mounted and their slots republish `tabSelected: false`. Two mobile shapes do:

- **Chat switch.** `MobileEpicTileView` mounts only the selected tile, so a switch re-points the single slot at another instance. The outgoing record loses its writer without anything unmounting.
- **Epic navigation.** The whole canvas is torn down while top-level surface retention keeps its chats as members — the stranded record then belongs to a *different view tab and pane* than the one on screen.

## The fix

`retractTileSurfacePresentation(instanceId, publishedAnchor)` lowers `tabSelected`, called from the slot's own effect cleanup — which React runs at exactly the moment a claim ends, and is the only hook that sees all three teardown shapes. No ancestor does: the pane, the canvas and the epic view are each destroyed by one of them.

It is **not** an unregister. The record stays in the map with its `identity`, `placement`, `presentation` and `services` object references untouched — `getTileSurfaceEnvironment` keeps answering the same non-null environment, so the transfer-gap continuity contract holds verbatim. Only the right to paint is withdrawn, and a fresh wrapper object is stored so `useSyncExternalStore` readers actually re-render instead of bailing out on an identity-equal snapshot.

The `publishedAnchor` identity check is what makes it safe to run unconditionally: a slot may only lower a claim that is still *its own* publish. Once a destination slot has published for the same instance, the source slot's later teardown is a no-op rather than a concealment of the live record.

## Per-consumer verification

Three things read `isTileSurfacePresented`:

| Consumer | Behaviour under the new writer |
| --- | --- |
| Record concealment class (`stable-tile-surface-host.tsx`) | Re-renders — the retraction notifies with a **new** environment object, so the `useSyncExternalStore` snapshot changes identity and `invisible opacity-0` lands. Covered by the mobile suite's presented-set dumps. |
| `StableTileSurfaceHost`'s geometry guard | Reads `getTileSurfaceEnvironment(instanceId)` fresh inside the rect callback, so it sees the lowered flag immediately. A now-unpresented record with no usable rect keeps its last geometry (`!currentlyVisible && !hasUsableRect` → return), so nothing re-measures at zero width. Covered green by the permanent lifecycle matrix. |
| Retained-pane-chats membership | **Untouched** — membership never reads this predicate; it derives from `retainedPaneChatInstanceIds` + top-level retention. The tests assert the outgoing instance stays a member while ceasing to be presented, which is the invariant that keeps retention (fast re-show, no transcript re-converge) working. |

## Tests

New mobile-branch regression suite (`mobile-tile-surface-presentation.test.tsx`) — no desktop-branch test can observe this. Each assertion is a registry dump of "which members read as presented":

- chat switch → outgoing record retained, `tabSelected: false`, not presented; exactly one presented
- four back-and-forth switches → never two presented
- navigate to another epic → the departed epic's record stays a member, stops being presented
- epic view unmounted → no presented record left behind

Registry unit tests cover the retraction's continuity guarantees (same `services` reference, non-null record, fresh object identity), the own-publish-only guard under cross-commit transfer ordering, and no-op idempotence.

**Mutation-proven**: reverting only the slot's teardown turns all four mobile tests red with `expected [ 'inst-2', 'inst-1' ] to deeply equal [ 'inst-2' ]` — the bug verbatim.

## Verification

`eslint --max-warnings 0` + prettier clean on the touched files; `bun run compile` (gui-app) clean; 195/195 across the surface-host suites, `tab-group-view`, both mobile canvas suites and the permanent lifecycle matrix — including cross-pane move, the two-commit header tear-off transaction, StrictMode replay, and the retained-record-genuinely-unpainted row.

Simulator re-verify against the real WKWebView is still pending and gates release.

## Accepted tradeoff: the transfer gap

A structural transfer where the **source slot tears down before the destination publishes** now leaves the record retained-but-unpresented for that interval, instead of leaving it painted at its old rect.

Stating the bound honestly: it is **the destination publish, not one frame**. Nothing in `retractTileSurfacePresentation` schedules or bounds the recovery. The gap is short today only because structural transfers are choreographed synchronously — a same-commit move republishes during the same layout phase, so it never reaches paint — and it would widen if that choreography ever became asynchronous. The registry suite pins exactly this: elapsed time does not end the gap, only the destination's own publish does.

The reverse order is a no-op by construction (the `publishedAnchor` check), so a late source teardown can never conceal a live destination.

Weighted deliberately: a record briefly unpainted while genuinely between owners beats two owners painting at once, which never recovers. It does not affect the bug being fixed — mobile has no drag-between-panes or pane tear-off.

**Not yet pinned:** no existing transfer test asserts presentation / `aria-hidden` across frame boundaries (the tear-off coverage asserts body *retention*). A real source→destination presentation frame trace, or a simulator frame trace, is future hardening rather than something this PR claims.
