### PR TITLE
fix(gui-app): standardize refresh controls

### DIFF
--- a/clients/gui-app/src/components/chat/composer/menu/mention-step-chrome-bar.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/mention-step-chrome-bar.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
-import { RefreshCwIcon } from "lucide-react";
-
+import { RefreshIcon } from "@/components/refresh-icon";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -132,15 +131,7 @@ function RefreshButton(props: {
           }}
           onClick={spinner.trigger}
         >
-          {spinner.refreshing ? (
-            <AgentSpinningDots
-              testId={undefined}
-              variant="orbit"
-              className="text-muted-foreground/70"
-            />
-          ) : (
-            <RefreshCwIcon className="size-3.5" />
-          )}
+          <RefreshIcon refreshing={spinner.refreshing} className="size-3.5" />
         </Button>
       </span>
     </TooltipWrapper>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-actions.test.tsx
@@ -81,7 +81,8 @@ describe("<GitDiffPanelActions />", () => {
     expect(
       screen.getByRole("menuitem", { name: "Switch to tree view" }),
     ).toBeDefined();
-    expect(screen.getByRole("menuitem", { name: "Refresh" })).toBeDefined();
+    const refresh = screen.getByRole("menuitem", { name: "Refresh" });
+    expect(refresh.querySelector(".lucide-refresh-cw")).not.toBeNull();
   });
 
   it("toggles list layout from the header action", () => {

--- a/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
@@ -7,9 +7,9 @@ import {
   ExternalLink,
   EyeOff,
   type LucideIcon,
-  RotateCcw,
   Settings2,
 } from "lucide-react";
+import { RefreshIcon } from "@/components/refresh-icon";
 import { DiffSplitIcon, DiffUnifiedIcon } from "./diff-mode-icons";
 import type { GitDiffTileViewState } from "@/stores/epics/canvas/types";
 import type {
@@ -179,9 +179,7 @@ export function DiffTabToolbar(props: DiffTabToolbarProps) {
               aria-label="Refresh diff"
               className="text-muted-foreground hover:text-foreground"
             >
-              <RotateCcw
-                className={cn("size-4", props.refreshing && "animate-spin")}
-              />
+              <RefreshIcon refreshing={props.refreshing} />
             </Button>
           </span>
         </TooltipWrapper>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
@@ -4,7 +4,7 @@ import type { LeftPanelHeaderSlotProps } from "@/components/epic-canvas/sidebar/
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
-import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { RefreshIcon } from "@/components/refresh-icon";
 import {
   selectGitPanelEpicState,
   useGitPanelStore,
@@ -120,13 +120,7 @@ export function GitDiffPanelActions(props: LeftPanelHeaderSlotProps) {
           disabled={selectedRepo === null || refresh.refreshing}
           data-testid="git-diff-panel-refresh"
         >
-          {refresh.refreshing ? (
-            <AgentSpinningDots
-              className={undefined}
-              testId={undefined}
-              variant={undefined}
-            />
-          ) : null}
+          <RefreshIcon refreshing={refresh.refreshing} />
           Refresh
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/__tests__/panel.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/__tests__/panel.test.tsx
@@ -511,7 +511,7 @@ describe("<SharingPanel />", () => {
     expect(testState.collaboratorsQuery.refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("spins the refresh icon while collaborators are refreshing", () => {
+  it("shows the standard agent spinner while collaborators are refreshing", () => {
     testState.collaboratorsQuery = {
       isFetching: true,
       dataUpdatedAt: Date.now(),
@@ -526,8 +526,8 @@ describe("<SharingPanel />", () => {
         .hasAttribute("disabled"),
     ).toBe(true);
     expect(
-      screen.getByTestId("epic-sharing-refresh-spinner").getAttribute("class"),
-    ).toContain("animate-spin");
+      screen.getByTestId("epic-sharing-refresh-spinner").className,
+    ).toContain("font-mono");
   });
 
   it("keeps role triggers visible for teams and direct collaborators", () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/panel.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/panel.tsx
@@ -1,10 +1,11 @@
-import { RefreshCw } from "lucide-react";
 import { useCallback, type ReactNode } from "react";
+import { RefreshIcon } from "@/components/refresh-icon";
 import { Button } from "@/components/ui/button";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useRelativeTimestamp } from "@/lib/relative-time";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { cn } from "@/lib/utils";
 import { TeamsAccess, PeopleWithAccess } from "./access-lists";
 import { InviteCard } from "./invite-card";
 import { MyAgentsSharingSection } from "./my-agents-section";
@@ -13,7 +14,6 @@ import {
   type SharingPanelController,
   type SharingRefreshProps,
 } from "./use-controller";
-import { cn } from "@/lib/utils";
 
 const SHARING_REFRESH_TIMEOUT_MS = 10_000;
 
@@ -115,9 +115,9 @@ function SharingPanelHeader(props: SharingRefreshProps) {
           aria-label="Refresh collaborators"
           data-testid="epic-sharing-refresh-button"
         >
-          <RefreshCw
-            className={cn("size-4", refresh.refreshing && "animate-spin")}
-            data-testid={
+          <RefreshIcon
+            refreshing={refresh.refreshing}
+            testId={
               refresh.refreshing ? "epic-sharing-refresh-spinner" : undefined
             }
           />

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-detail-header.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-detail-header.tsx
@@ -6,9 +6,9 @@ import {
   GitPullRequestArrow,
   GitPullRequestClosed,
   GitPullRequestDraft,
-  RotateCcw,
   type LucideIcon,
 } from "lucide-react";
+import { RefreshIcon } from "@/components/refresh-icon";
 import type {
   PrDetailCore,
   PrSourceNotice,
@@ -136,15 +136,10 @@ export function PrDetailHeader(props: {
           data-testid="pr-detail-refresh"
           className="text-muted-foreground hover:text-foreground"
         >
-          {props.refreshing ? (
-            <AgentSpinningDots
-              testId="pr-detail-refresh-dots"
-              variant="dots"
-              className="size-4"
-            />
-          ) : (
-            <RotateCcw className="size-4" />
-          )}
+          <RefreshIcon
+            refreshing={props.refreshing}
+            testId={props.refreshing ? "pr-detail-refresh-dots" : undefined}
+          />
         </Button>
       </div>
     </div>

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-panel-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-panel-actions.tsx
@@ -1,5 +1,5 @@
 import { useCallback, type ReactNode } from "react";
-import { RotateCcw } from "lucide-react";
+import { RefreshIcon } from "@/components/refresh-icon";
 import { useCanvasHostId } from "@/components/epic-canvas/hooks/use-canvas-host-id";
 import type { LeftPanelSlotProps } from "@/components/epic-canvas/sidebar/left-panel-registry";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,6 @@ import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
 import { useStreamMethodSupport } from "@/lib/host/stream-runtime-context";
 import { newestObservedAt } from "@/lib/pr/pr-list-projection";
 import { useRelativeTimestamp } from "@/lib/relative-time";
-import { cn } from "@/lib/utils";
 import {
   useLeftPanelSectionCollapsed,
   useMainPanelCollapsed,
@@ -92,9 +91,7 @@ function PrPanelActionsLive(props: {
         data-testid="pr-panel-refresh"
         className="text-muted-foreground hover:text-foreground"
       >
-        <RotateCcw
-          className={cn("size-4", refresh.refreshing && "animate-spin")}
-        />
+        <RefreshIcon refreshing={refresh.refreshing} />
       </Button>
     </div>
   );

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -19,11 +19,11 @@ import {
   Paintbrush,
   Pencil,
   Pin,
-  RefreshCwIcon,
   Search,
   Trash2,
   X,
 } from "lucide-react";
+import { RefreshIcon } from "@/components/refresh-icon";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import {
   ContextMenu,
@@ -947,9 +947,7 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
               disabled={refresh.refreshing || hostId === null}
               onClick={refresh.trigger}
             >
-              <RefreshCwIcon
-                className={cn("size-4", refresh.refreshing && "animate-spin")}
-              />
+              <RefreshIcon refreshing={refresh.refreshing} />
             </Button>
           </>
         )}

--- a/clients/gui-app/src/components/layout/dialogs/desktop/open-epic-in-new-window-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/open-epic-in-new-window-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, type ReactNode } from "react";
-import { ExternalLink, RefreshCw } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import { Button } from "@/components/ui/button";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
@@ -17,7 +17,7 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { epicDisplayTitle } from "@/lib/display-title";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
-import { cn } from "@/lib/utils";
+import { RefreshIcon } from "@/components/refresh-icon";
 import type { OpenEpicInNewWindowDialogProps } from "./types";
 
 const OPEN_EPIC_REFRESH_TIMEOUT_MS = 10_000;
@@ -66,9 +66,7 @@ export function OpenEpicInNewWindowDialog(
               disabled={refresh.refreshing || hostId === null}
               onClick={refresh.trigger}
             >
-              <RefreshCw
-                className={cn("size-4", refresh.refreshing && "animate-spin")}
-              />
+              <RefreshIcon refreshing={refresh.refreshing} />
             </Button>
           </div>
           <OpenEpicPickerBody

--- a/clients/gui-app/src/components/refresh-icon-button.tsx
+++ b/clients/gui-app/src/components/refresh-icon-button.tsx
@@ -1,6 +1,6 @@
-import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { RefreshIcon } from "@/components/refresh-icon";
 
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 // Hard cap on the spinning/disabled state so a hung refetch can't wedge the
@@ -51,7 +51,7 @@ export function RefreshIconButton(props: RefreshIconButtonProps) {
             className,
           )}
         >
-          <RefreshCw className={cn("size-4", refreshing && "animate-spin")} />
+          <RefreshIcon refreshing={refreshing} />
         </button>
       </span>
     </TooltipWrapper>

--- a/clients/gui-app/src/components/refresh-icon.tsx
+++ b/clients/gui-app/src/components/refresh-icon.tsx
@@ -1,0 +1,20 @@
+import { RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function RefreshIcon(props: {
+  readonly refreshing: boolean;
+  readonly className?: string;
+  readonly testId?: string;
+}) {
+  return (
+    <RefreshCw
+      aria-hidden
+      className={cn(
+        "size-4",
+        props.refreshing && "animate-spin",
+        props.className,
+      )}
+      data-testid={props.testId}
+    />
+  );
+}

--- a/clients/gui-app/src/components/refresh-icon.tsx
+++ b/clients/gui-app/src/components/refresh-icon.tsx
@@ -1,4 +1,5 @@
 import { RefreshCw } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { cn } from "@/lib/utils";
 
 export function RefreshIcon(props: {
@@ -6,14 +7,19 @@ export function RefreshIcon(props: {
   readonly className?: string;
   readonly testId?: string;
 }) {
+  if (props.refreshing) {
+    return (
+      <AgentSpinningDots
+        className={props.className}
+        testId={props.testId}
+        variant={undefined}
+      />
+    );
+  }
   return (
     <RefreshCw
       aria-hidden
-      className={cn(
-        "size-4",
-        props.refreshing && "animate-spin",
-        props.className,
-      )}
+      className={cn("size-4", props.className)}
       data-testid={props.testId}
     />
   );


### PR DESCRIPTION
## Summary
- add one shared clockwise-spinning refresh icon based on the model-picker rail treatment
- use it across standalone refresh controls in Git Diff, PR, sharing, task history, open-Epic, and mention surfaces
- give the Git Diff overflow Refresh item a persistent icon

## Testing
- focused Vitest suites for Git Diff actions, sharing, PR actions, mention refresh, and task history
- React Doctor changed-file scan
- pre-commit affected lint, format, compile, and build checks