### PR TITLE
fix(updater): follow release candidate lines to stable

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/update-channel-mode.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/update-channel-mode.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSelectableCandidate,
+  modeAllowsPrerelease,
+  resolveUpdateChannelMode,
+  type DesktopUpdateChannelMode,
+} from "../update-channel-mode";
+
+// The release-line vocabulary itself (canonical `X.Y.Z-rc.N` detection, line
+// extraction, same-line equality) is owned and table-tested by
+// `@traycer-clients/shared/host-version/release-line`. What is tested here is
+// the Desktop policy layered on it: which mode a build runs in, which
+// candidates that mode may select, and what a preference change may disturb.
+// The version tables below still span the near-miss shapes, because the wiring
+// that matters is that a `2.0.0-beta.1` build does NOT acquire implicit
+// following.
+describe("resolveUpdateChannelMode", () => {
+  it.each([
+    // Explicit preference OFF: the installed version decides.
+    [false, "2.0.0", "stable-only"],
+    [false, "2.0.0-rc.1", "implicit-rc-line"],
+    [false, "2.0.0-rc.0", "implicit-rc-line"],
+    // A prerelease that is not a canonical RC never acquires implicit
+    // following - it falls back to the ordinary stable policy.
+    [false, "2.0.0-beta.1", "stable-only"],
+    [false, "2.0.0-rc.01", "stable-only"],
+    [false, "1.0.0-test", "stable-only"],
+    [false, "not-a-version", "stable-only"],
+    [false, "", "stable-only"],
+    // Explicit preference ON always wins: the opt-in is deliberately broader
+    // than implicit following.
+    [true, "2.0.0", "explicit-prerelease"],
+    [true, "2.0.0-rc.1", "explicit-prerelease"],
+    [true, "2.0.0-beta.1", "explicit-prerelease"],
+    [true, "garbage", "explicit-prerelease"],
+  ] as ReadonlyArray<readonly [boolean, string, DesktopUpdateChannelMode]>)(
+    "explicit=%s installed=%s -> %s",
+    (explicitPrerelease, installedVersion, expected) => {
+      expect(
+        resolveUpdateChannelMode(explicitPrerelease, installedVersion),
+      ).toBe(expected);
+    },
+  );
+
+  it("derives allowPrerelease for both non-stable modes", () => {
+    expect(modeAllowsPrerelease("stable-only")).toBe(false);
+    expect(modeAllowsPrerelease("implicit-rc-line")).toBe(true);
+    expect(modeAllowsPrerelease("explicit-prerelease")).toBe(true);
+  });
+
+  it("returns to stable-only once the RC's own GA is what is installed", () => {
+    // The termination guarantee, stated as a mode transition: an implicit
+    // follower that takes its line's stable release relaunches as a stable
+    // build, which derives stable-only with no preference change involved.
+    expect(resolveUpdateChannelMode(false, "2.0.0-rc.3")).toBe(
+      "implicit-rc-line",
+    );
+    expect(resolveUpdateChannelMode(false, "2.0.0")).toBe("stable-only");
+  });
+});
+
+describe("isSelectableCandidate", () => {
+  const installedVersion = "2.0.0-rc.1";
+
+  it.each([
+    // Same line, strictly newer: the two things implicit following may take.
+    ["2.0.0-rc.2", true, true],
+    ["2.0.0", true, true],
+    // Same line but not newer (the installed build itself, or an older RC).
+    ["2.0.0-rc.1", false, false],
+    ["2.0.0-rc.0", false, false],
+    // Newer, but on another line - the jump implicit following must never make,
+    // at any version distance.
+    ["2.1.0-rc.1", true, false],
+    ["2.1.0", true, false],
+    ["3.0.0-rc.1", true, false],
+    // Newer, but names no release line at all.
+    ["2.0.0-beta.9", true, false],
+  ])(
+    "implicit-rc-line: %s (newer=%s) -> %s",
+    (candidateVersion, isStrictlyNewer, expected) => {
+      expect(
+        isSelectableCandidate({
+          mode: "implicit-rc-line",
+          installedVersion,
+          candidateVersion,
+          isStrictlyNewer,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("keeps explicit opt-in broad: every candidate stays eligible", () => {
+    for (const candidateVersion of ["2.1.0-rc.1", "3.0.0", "1.0.0"]) {
+      expect(
+        isSelectableCandidate({
+          mode: "explicit-prerelease",
+          installedVersion,
+          candidateVersion,
+          // Even a not-strictly-newer candidate stays eligible here: the
+          // strictly-newer gate for the broad mode is electron-updater's, and
+          // duplicating it would be a second answer to one question.
+          isStrictlyNewer: false,
+        }),
+      ).toBe(true);
+    }
+  });
+});
+
+// A CHANGED PREFERENCE ALWAYS CHANGES THE MODE, which is what makes a
+// "persisted moved, mode did not" branch unreachable and is why neither that
+// branch nor a helper deciding it exists. Pinned here so the invariant
+// `performChannelChange` relies on fails loudly if the derivation gains a mode
+// both preference values can select.
+describe("preference-to-mode invariant", () => {
+  it.each([
+    "2.0.0",
+    "2.0.0-rc.1",
+    "2.0.0-rc.0",
+    "2.0.0-beta.1",
+    "1.0.0-test",
+    "not-a-version",
+  ])("toggling the preference on %s crosses a mode boundary", (version) => {
+    expect(resolveUpdateChannelMode(false, version)).not.toBe(
+      resolveUpdateChannelMode(true, version),
+    );
+  });
+});

--- a/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
@@ -538,7 +538,13 @@ describe("desktop app updater", () => {
     });
   });
 
-  it("treats 'no production release yet' as up-to-date (not an error) on a prerelease build", async () => {
+  it("surfaces a stable-feed 'no production release' 404 as a service error", async () => {
+    // The removed fallback (§"Compatibility recovery and dead paths"): this
+    // 404 used to be swallowed as "up to date" for any build whose version
+    // contained a `-`. A canonical RC build can no longer reach the stable
+    // feed at all - it derives `implicit-rc-line` and resolves through the
+    // namespaced selector - so the only builds that still see this error are
+    // ones for which a 404 from the release feed IS a service problem.
     const { autoUpdater, updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
     autoUpdater.checkForUpdates.mockImplementation(() => {
       const err = new Error(
@@ -551,6 +557,29 @@ describe("desktop app updater", () => {
 
     await updater.checkForUpdatesNow(false, "manual");
 
+    expect(updater.getAppUpdateSnapshot()).toMatchObject({
+      status: "error",
+      errorMessage:
+        "Traycer couldn't reach the update service right now. Please try again in a little while.",
+    });
+  });
+
+  it("never queries the stable feed from a canonical RC build", async () => {
+    // The other half of the removal: the fallback is unreachable rather than
+    // merely unused. An RC build configures `allowPrerelease` from its mode, so
+    // every check resolves through the desktop-tag selector, and "nothing
+    // selectable" is a null feed (a genuine up-to-date) rather than a 404.
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    vi.stubGlobal("fetch", fetchRouter([], {}));
+
+    await updater.installAutoUpdater(true, makeDeps(true));
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(autoUpdater.allowPrerelease).toBe(true);
+    expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
     expect(updater.getAppUpdateSnapshot()).toMatchObject({
       status: "up-to-date",
       errorMessage: null,
@@ -2021,7 +2050,7 @@ describe("compat recovery: RC probe", () => {
   });
 
   it("skips an RC that clears the floor but is not newer than the running build", async () => {
-    // The running build is `1.0.0-test` (see the electron mock). A sufficient
+    // The running build is `1.0.0` (see `STABLE_APP_VERSION`). A sufficient
     // RC that is OLDER by SemVer is a real shape - a release line predating an
     // epoch backport produces one - and this updater never sets
     // `allowDowngrade`, so electron-updater would report it as not available
@@ -2293,6 +2322,296 @@ describe("compat recovery: RC probe", () => {
   });
 });
 
+/**
+ * The three-mode channel model, exercised through the real selector.
+ *
+ * The mode derivation, the release-line vocabulary, and the
+ * persist-vs-transition split are table-tested as pure functions in
+ * `update-channel-mode.test.ts`; what these tests own is the wiring - that the
+ * derived mode actually reaches `allowPrerelease`, the namespaced selector, the
+ * channel-change choreography, and the recovery dialog.
+ */
+describe("implicit RC-line following", () => {
+  // Every release below carries the mac manifest + ZIP, so the only thing that
+  // decides selection is the channel mode's candidate filter.
+  function stubReleases(tags: readonly string[]): void {
+    const fixtures = tags.map((tag) =>
+      macReleaseFixture(tag, tag.includes("-rc.")),
+    );
+    const manifests: Record<string, string> = {};
+    for (const tag of tags) {
+      manifests[tag] = manifestYamlForTag(tag, macZipAssetName(tag));
+    }
+    vi.stubGlobal("fetch", fetchRouter(fixtures, manifests));
+  }
+
+  function selectedFeedUrl(autoUpdater: FakeAutoUpdater): unknown {
+    const calls = autoUpdater.setFeedURL.mock.calls;
+    return calls.length === 0 ? null : calls[calls.length - 1][0];
+  }
+
+  it("allows prereleases from the installed version alone, persisting nothing", async () => {
+    const { autoUpdater, preferences, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    expect(autoUpdater.allowPrerelease).toBe(true);
+    // Implicit participation is derived, never written to disk: the next stable
+    // install must return to stable-only with no preference to undo.
+    expect(preferences.allowPrerelease).toBe(false);
+    // The snapshot reports what a check EFFECTIVELY does, which is what every
+    // consumer asks it. Explicit provenance would be a distinct field.
+    expect(updater.getAppUpdateSnapshot().allowPrerelease).toBe(true);
+  });
+
+  it("selects a later RC on its own line and ignores a newer one on another", async () => {
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    stubReleases([
+      "desktop-v2.1.0-rc.1",
+      "desktop-v2.0.0-rc.2",
+      "desktop-v2.0.0-rc.1",
+    ]);
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(selectedFeedUrl(autoUpdater)).toEqual({
+      provider: "generic",
+      url: "https://github.com/traycerai/traycer/releases/download/desktop-v2.0.0-rc.2/",
+    });
+  });
+
+  it("prefers the line's stable release over a later RC on the same line", async () => {
+    // The termination guarantee: once `2.0.0` exists it outranks every
+    // `2.0.0-rc.*`, so the follower lands on stable and the next launch is a
+    // stable build in stable-only mode.
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    stubReleases([
+      "desktop-v2.1.0-rc.1",
+      "desktop-v2.0.0-rc.3",
+      "desktop-v2.0.0",
+    ]);
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(selectedFeedUrl(autoUpdater)).toEqual({
+      provider: "generic",
+      url: "https://github.com/traycerai/traycer/releases/download/desktop-v2.0.0/",
+    });
+  });
+
+  it("falls back to the highest usable later RC when the line's stable is unusable", async () => {
+    // "Prefer stable `X.Y.Z` IF USABLE, otherwise the highest later
+    // `X.Y.Z-rc.M`". Stable is still evaluated first (newest-first ordering),
+    // but a release whose manifest disagrees with its own tag is a publishing
+    // error the validate-and-skip loop rejects - and the fallback must be the
+    // NEWEST remaining same-line RC, not merely any of them.
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    vi.stubGlobal(
+      "fetch",
+      fetchRouter(
+        [
+          macReleaseFixture("desktop-v2.0.0", false),
+          macReleaseFixture("desktop-v2.0.0-rc.3", true),
+          macReleaseFixture("desktop-v2.0.0-rc.2", true),
+        ],
+        {
+          // Declares 2.0.1 under the desktop-v2.0.0 tag: rejected.
+          "desktop-v2.0.0": manifestYamlForTag(
+            "desktop-v2.0.1",
+            macZipAssetName("desktop-v2.0.0"),
+          ),
+          "desktop-v2.0.0-rc.3": manifestYamlForTag(
+            "desktop-v2.0.0-rc.3",
+            macZipAssetName("desktop-v2.0.0-rc.3"),
+          ),
+          "desktop-v2.0.0-rc.2": manifestYamlForTag(
+            "desktop-v2.0.0-rc.2",
+            macZipAssetName("desktop-v2.0.0-rc.2"),
+          ),
+        },
+      ),
+    );
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(selectedFeedUrl(autoUpdater)).toEqual({
+      provider: "generic",
+      url: "https://github.com/traycerai/traycer/releases/download/desktop-v2.0.0-rc.3/",
+    });
+  });
+
+  it("reports up-to-date rather than jumping lines when its own line has nothing newer", async () => {
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    stubReleases(["desktop-v2.1.0", "desktop-v2.1.0-rc.1", "desktop-v1.9.0"]);
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(autoUpdater.setFeedURL).not.toHaveBeenCalled();
+    expect(updater.getAppUpdateSnapshot()).toMatchObject({
+      status: "up-to-date",
+      latestVersion: RC_APP_VERSION,
+      errorMessage: null,
+    });
+  });
+
+  it("does not re-select the installed RC or an older one on its line", async () => {
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    stubReleases(["desktop-v2.0.0-rc.1", "desktop-v2.0.0-rc.0"]);
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(autoUpdater.setFeedURL).not.toHaveBeenCalled();
+    expect(updater.getAppUpdateSnapshot().status).toBe("up-to-date");
+  });
+
+  it("keeps the explicit opt-in broad: an RC build that opts in may cross lines", async () => {
+    const { autoUpdater, preferences, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    stubReleases(["desktop-v2.1.0-rc.1", "desktop-v2.0.0-rc.2"]);
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    const change = await updater.setAllowPrereleaseUpdates(true);
+    await updater.checkForUpdatesNow(false, "manual");
+
+    // Implicit → explicit IS an effective mode change (the eligible candidate
+    // set genuinely widens), so the full transition choreography runs.
+    expect(change.outcome).toBe("changed");
+    expect(preferences.allowPrerelease).toBe(true);
+    expect(selectedFeedUrl(autoUpdater)).toEqual({
+      provider: "generic",
+      url: "https://github.com/traycerai/traycer/releases/download/desktop-v2.1.0-rc.1/",
+    });
+  });
+
+  it("returns an RC build that opted out to its own line rather than to stable-only", async () => {
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    stubReleases(["desktop-v2.1.0-rc.1", "desktop-v2.0.0-rc.2"]);
+    await updater.installAutoUpdater(true, makeDeps(true));
+    await updater.setAllowPrereleaseUpdates(true);
+
+    const change = await updater.setAllowPrereleaseUpdates(false);
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(change.outcome).toBe("changed");
+    // Opting out of the broad preference does NOT put an RC build on the stable
+    // feed - implicit following is derived from the installed version and
+    // survives the opt-out.
+    expect(autoUpdater.allowPrerelease).toBe(true);
+    expect(selectedFeedUrl(autoUpdater)).toEqual({
+      provider: "generic",
+      url: "https://github.com/traycerai/traycer/releases/download/desktop-v2.0.0-rc.2/",
+    });
+  });
+
+  it("restores stable-only behavior once the line's stable build is what is installed", async () => {
+    // No preference was ever saved, so nothing has to be undone: installing
+    // `2.0.0` is by itself the exit from implicit following.
+    const { autoUpdater, preferences, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      "2.0.0",
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(autoUpdater.allowPrerelease).toBe(false);
+    expect(preferences.allowPrerelease).toBe(false);
+    // Stable-only never runs the namespaced selector: no discovery walk at all.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a non-canonical prerelease build on the stable channel", async () => {
+    const { autoUpdater, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      "2.0.0-beta.1",
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await updater.installAutoUpdater(true, makeDeps(true));
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(autoUpdater.allowPrerelease).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("never offers or persists enable-rc while following a line implicitly", async () => {
+    // The dialog's offer would change no current discovery behavior AND would
+    // write a broad prerelease preference the user never asked for - one that
+    // outlives the RC install. A sufficient RC on another line is published
+    // here precisely so a probe, if one ran, would have something to offer.
+    const { autoUpdater, preferences, updater } = await loadUpdaterForVersion(
+      NOT_LINUX_GUIDANCE,
+      RC_APP_VERSION,
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await updater.installAutoUpdater(true, makeDeps(true));
+    fetchMock.mockClear();
+    autoUpdater.setFeedURL.mockClear();
+
+    const plan = await updater.resolveCompatRecovery({
+      minimumEpoch: 2,
+      hostAllowsRcRecovery: true,
+    });
+
+    expect(plan.route).toBe("manual");
+    expect(plan.rcCandidateVersion).toBeNull();
+    // Short-circuited before the probe: no listing walk, no manifest fetches.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(preferences.allowPrerelease).toBe(false);
+    expect(autoUpdater.setFeedURL).not.toHaveBeenCalled();
+  });
+
+  it("never offers enable-rc to an explicit opt-in either", async () => {
+    const { updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await updater.installAutoUpdater(true, makeDeps(true));
+    await updater.setAllowPrereleaseUpdates(true);
+    fetchMock.mockClear();
+
+    const plan = await updater.resolveCompatRecovery({
+      minimumEpoch: 2,
+      hostAllowsRcRecovery: true,
+    });
+
+    expect(plan.route).toBe("manual");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 interface LinuxGuidanceTestConfig {
   readonly packageType: "deb" | "rpm" | null;
   readonly silentInstallSupported: boolean;
@@ -2314,6 +2633,24 @@ interface LoadedUpdater {
   readonly preferences: { allowPrerelease: boolean };
   readonly updater: UpdaterModule;
 }
+
+/**
+ * The app version every test that does not care about the channel model runs
+ * as, and it is deliberately a STABLE SemVer.
+ *
+ * The suite used to mock `1.0.0-test`. Under the three-mode model that string
+ * is not a canonical release candidate, so it still derives `stable-only` - but
+ * a fixture one character away from `1.0.0-rc.1` silently deciding whether 80
+ * tests run under implicit RC following is not a baseline anything should rest
+ * on. RC behavior is now opted into explicitly, per test, via
+ * {@link loadUpdaterForVersion}.
+ */
+const STABLE_APP_VERSION = "1.0.0";
+
+// The canonical RC build the implicit-following tests run as. Its release line
+// is `2.0.0`, so `2.0.0-rc.*` and `2.0.0` are the only implicitly selectable
+// candidates and `2.1.0-rc.*` is the near miss that must never be taken.
+const RC_APP_VERSION = "2.0.0-rc.1";
 
 // Lets a test park a `hydrateUpdatePreferences()` call and resolve it on
 // demand (finding 1's pre-init parking coverage). `resolve` is populated the
@@ -2344,14 +2681,39 @@ interface PersistPrereleaseControl {
 async function loadUpdater(
   linuxGuidance: LinuxGuidanceTestConfig,
 ): Promise<LoadedUpdater> {
-  return loadUpdaterWithControls(linuxGuidance, { kind: "immediate" }, null);
+  return loadUpdaterWithControls(
+    linuxGuidance,
+    { kind: "immediate" },
+    null,
+    STABLE_APP_VERSION,
+  );
+}
+
+// Loads the updater as a specific installed build, which is what selects the
+// channel mode: a canonical `X.Y.Z-rc.N` follows its own line, anything else
+// stays stable-only until an explicit opt-in.
+async function loadUpdaterForVersion(
+  linuxGuidance: LinuxGuidanceTestConfig,
+  appVersion: string,
+): Promise<LoadedUpdater> {
+  return loadUpdaterWithControls(
+    linuxGuidance,
+    { kind: "immediate" },
+    null,
+    appVersion,
+  );
 }
 
 async function loadUpdaterWithHydration(
   linuxGuidance: LinuxGuidanceTestConfig,
   hydration: HydrationBehavior,
 ): Promise<LoadedUpdater> {
-  return loadUpdaterWithControls(linuxGuidance, hydration, null);
+  return loadUpdaterWithControls(
+    linuxGuidance,
+    hydration,
+    null,
+    STABLE_APP_VERSION,
+  );
 }
 
 async function loadUpdaterWithPersistControl(
@@ -2362,6 +2724,7 @@ async function loadUpdaterWithPersistControl(
     linuxGuidance,
     { kind: "immediate" },
     persistControl,
+    STABLE_APP_VERSION,
   );
 }
 
@@ -2369,6 +2732,7 @@ async function loadUpdaterWithControls(
   linuxGuidance: LinuxGuidanceTestConfig,
   hydration: HydrationBehavior,
   persistControl: PersistPrereleaseControl | null,
+  appVersion: string,
 ): Promise<LoadedUpdater> {
   vi.resetModules();
   const autoUpdater = new FakeAutoUpdater();
@@ -2376,7 +2740,7 @@ async function loadUpdaterWithControls(
   const preferences = { allowPrerelease: false };
   vi.doMock("electron", () => ({
     app: {
-      getVersion: () => "1.0.0-test",
+      getVersion: () => appVersion,
     },
   }));
   vi.doMock("electron-updater", () => ({

--- a/clients/desktop/src/electron-main/app/desktop-release-feed.ts
+++ b/clients/desktop/src/electron-main/app/desktop-release-feed.ts
@@ -18,6 +18,7 @@ import type {
 } from "electron-updater/out/types";
 import { isValidCompatibilityEpoch } from "@traycer/protocol/framework/index";
 import type { LinuxPackageType } from "./linux-update-guidance";
+import { isCanonicalReleaseCandidate } from "@traycer-clients/shared/host-version/release-line";
 
 // electron-updater's HTTP executor reads a `redirect` field the node `http`
 // `RequestOptions` type doesn't declare; model that augmentation locally rather
@@ -119,7 +120,15 @@ export function projectDesktopRelease(
     return [];
   }
   const version = match[1];
-  const isReleaseCandidate = version.includes("-rc.");
+  // The same canonical predicate the channel model derives implicit RC
+  // following from, rather than a local substring test: a tag this projection
+  // accepts as an RC is one the selector may later have to place on a release
+  // line, and two definitions of "is this an RC" is how the two would drift.
+  // EQUIVALENT, not a behavior change - the tag regex above already admits only
+  // `X.Y.Z` and `X.Y.Z-rc.N` with strict SemVer numerics, so both spellings
+  // accept exactly the same set here. The point is that there is now one
+  // definition rather than two.
+  const isReleaseCandidate = isCanonicalReleaseCandidate(version);
   // Reject inconsistent metadata rather than trusting the tag: a stable tag
   // flagged `prerelease`, or an rc tag flagged stable, is a publishing mistake
   // that must not silently ship.

--- a/clients/desktop/src/electron-main/app/update-channel-mode.ts
+++ b/clients/desktop/src/electron-main/app/update-channel-mode.ts
@@ -1,0 +1,124 @@
+/**
+ * THE Desktop update channel model: which policy an update check runs under,
+ * and what a change of policy is allowed to disturb.
+ *
+ * A boolean cannot express the selection rules this app needs. `allowPrerelease`
+ * answers "may a check see prerelease tags at all", and two genuinely different
+ * policies answer it the same way:
+ *
+ *   - an RC build silently FOLLOWING ITS OWN LINE (`2.0.0-rc.1` may take
+ *     `2.0.0-rc.2` or `2.0.0`, and nothing else), which is derived from the
+ *     installed version and is never persisted; and
+ *   - a user who explicitly OPTED IN to prereleases, whose opt-in is broad by
+ *     design and may cross release lines.
+ *
+ * Collapsing those two onto one flag is what makes an implicit follower jump to
+ * `2.1.0-rc.1`, and what makes a compatibility dialog offer to "enable RC
+ * updates" to a build that is already receiving them - persisting an opt-in the
+ * user never asked for. So the mode, not the flag, is what candidate selection
+ * and channel transitions are keyed on; the flag is a derived effect of it.
+ *
+ * Pure and electron-free on purpose: `updater.ts` cannot be imported without
+ * `electron` and `electron-updater`, and these rules are exactly the part that
+ * deserves to be table-tested without either.
+ *
+ * THE RELEASE-LINE VOCABULARY IS NOT DEFINED HERE. "Is this a canonical
+ * `X.Y.Z-rc.N`" and "are these two versions on one line" are the same questions
+ * the CLI's catalog defaulting asks, and a second copy of that predicate is
+ * precisely the drift the shared module exists to prevent - so they are
+ * imported from `@traycer-clients/shared/host-version/release-line`, the same
+ * boundary `electron-main/host` already reads its comparator from. What lives
+ * here is only what is genuinely Desktop policy: which mode those facts imply,
+ * and what a mode change is allowed to disturb.
+ */
+import {
+  isCanonicalReleaseCandidate,
+  isSameReleaseLine,
+} from "@traycer-clients/shared/host-version/release-line";
+
+export type DesktopUpdateChannelMode =
+  "stable-only" | "implicit-rc-line" | "explicit-prerelease";
+
+/**
+ * The mode a check runs under, from the two inputs that decide it: the durable
+ * explicit preference, and the version this app was built as.
+ *
+ * The explicit preference wins outright - it is a broader opt-in than implicit
+ * following, and an RC user who asked for prereleases asked for all of them.
+ */
+export function resolveUpdateChannelMode(
+  explicitPrerelease: boolean,
+  installedVersion: string,
+): DesktopUpdateChannelMode {
+  if (explicitPrerelease) {
+    return "explicit-prerelease";
+  }
+  return isCanonicalReleaseCandidate(installedVersion)
+    ? "implicit-rc-line"
+    : "stable-only";
+}
+
+/**
+ * `electron-updater.allowPrerelease` as a DERIVED effect of the mode.
+ *
+ * Both non-stable modes must let prerelease tags through the feed; what they
+ * must not share is which candidate they then select. That distinction lives in
+ * the selector, which receives the mode itself.
+ */
+export function modeAllowsPrerelease(mode: DesktopUpdateChannelMode): boolean {
+  return mode !== "stable-only";
+}
+
+/**
+ * Whether a discovered release is selectable for `mode`, given the installed
+ * version and an already-decided "is it strictly newer" verdict.
+ *
+ * The newer-ness verdict is passed in rather than computed: the comparator the
+ * selector uses is the one that must decide it, and a second comparison here
+ * would be a second answer to the same question.
+ *
+ *   - `implicit-rc-line` restricts to the installed build's OWN line. Stable
+ *     `X.Y.Z` and later `X.Y.Z-rc.M` both qualify; `X.Y+1.0-rc.1` does not, at
+ *     any version distance. An ABANDONED line therefore has no implicit exit -
+ *     if `2.0.0` is never published and the work ships as `2.1.0`, a
+ *     `2.0.0-rc.1` build stops seeing updates. That is the accepted product
+ *     behavior, not an oversight: the alternative (letting the follower take a
+ *     newer stable on any line) is a cross-line jump nobody consented to, and
+ *     the remedy for an abandoned line is to publish its stable or to reinstall.
+ *   - `explicit-prerelease` keeps the existing broad behavior (the newest
+ *     usable stable or RC release, whatever its line).
+ *   - `stable-only` never reaches the namespaced selector at all - it uses the
+ *     ordinary stable feed - so it is answered here only for totality.
+ */
+export function isSelectableCandidate(input: {
+  readonly mode: DesktopUpdateChannelMode;
+  readonly installedVersion: string;
+  readonly candidateVersion: string;
+  readonly isStrictlyNewer: boolean;
+}): boolean {
+  if (input.mode !== "implicit-rc-line") {
+    return true;
+  }
+  return (
+    input.isStrictlyNewer &&
+    isSameReleaseLine(input.installedVersion, input.candidateVersion)
+  );
+}
+
+/**
+ * PERSISTED INTENT AND EFFECTIVE MODE ARE STILL TWO THINGS, and
+ * `performChannelChange` keeps them ordered as two - but under the derivation
+ * above they cannot come apart, so nothing here decides between them.
+ *
+ * `resolveUpdateChannelMode(true, …)` is always `explicit-prerelease` and
+ * `resolveUpdateChannelMode(false, …)` never is, so any request that moves the
+ * saved preference necessarily moves the mode. A helper that answered "did the
+ * effective mode change" would have exactly one possible answer, and the branch
+ * consuming it would be unreachable - which is why neither exists.
+ *
+ * The distinction still matters to a reader, and to whoever extends this: if a
+ * future mode is selectable under BOTH preference values, the persist step and
+ * the transition choreography must be split at the call site (see the note in
+ * `performChannelChange`), because the destructive half is only ever warranted
+ * by a change in which candidates the updater would select.
+ */

--- a/clients/desktop/src/electron-main/app/updater.ts
+++ b/clients/desktop/src/electron-main/app/updater.ts
@@ -32,6 +32,13 @@ import {
   type DesktopReleaseCandidate,
   type DesktopUpdateFeed,
 } from "./desktop-release-feed";
+import { isCanonicalReleaseCandidate } from "@traycer-clients/shared/host-version/release-line";
+import {
+  isSelectableCandidate,
+  modeAllowsPrerelease,
+  resolveUpdateChannelMode,
+  type DesktopUpdateChannelMode,
+} from "./update-channel-mode";
 import type {
   DesktopAppUpdateCheckIntent,
   DesktopAppUpdateChannelChange,
@@ -105,11 +112,6 @@ export interface AppUpdaterDeps {
 
 const AUTOMATIC_RESUME_CHECK_DEBOUNCE_MS = 30_000;
 const CURRENT_VERSION = app.getVersion();
-// A SemVer prerelease carries identifiers after `-` (before any `+` build
-// metadata), e.g. `1.0.0-rc.1`. When the stable channel is selected we use
-// this to treat "no GA release exists yet" as a non-error on RC builds rather
-// than logging/surfacing a failure.
-const IS_PRERELEASE_BUILD = CURRENT_VERSION.split("+")[0].includes("-");
 const PRIVATE_UPDATE_REPO = process.env.VITE_TRAYCER_DESKTOP_UPDATE_REPO ?? "";
 const PRIVATE_UPDATE_TOKEN =
   process.env.VITE_TRAYCER_DESKTOP_UPDATE_TOKEN ?? "";
@@ -173,6 +175,13 @@ let checkErrorEmitted = false;
 let downloadInProgress = false;
 let downloadIntent: DesktopAppUpdateCheckIntent | null = null;
 let lastResumeCheckAtMs = 0;
+// The channel mode the updater is CONFIGURED with right now: what
+// `autoUpdater.allowPrerelease` was derived from, and what the namespaced
+// selector is filtering candidates for. Set once at initialization and moved
+// only by a channel change that genuinely alters discovery behavior, so it can
+// be compared against a freshly requested mode to tell a real transition from a
+// preference write that changes nothing the updater does.
+let activeChannelMode: DesktopUpdateChannelMode = "stable-only";
 // Monotonic channel epoch, bumped by every `setAllowPrereleaseUpdates` call.
 // A channel change makes any discovery/candidate produced under a prior
 // generation stale: `checkForUpdatesNow` rejects a stale discovery before
@@ -322,14 +331,20 @@ async function configureAutoUpdater(deps: AppUpdaterDeps): Promise<void> {
   // update" click, where a failure is guaranteed to surface visibly (see
   // `handleUpdaterError`'s `installingUpdate` branch).
   autoUpdater.autoInstallOnAppQuit = linuxPackageType === null;
-  // electron-updater auto-enables prereleases when the running build is an RC.
-  // Replace that implicit behaviour with the explicit, persisted app setting.
-  // The default remains stable-only; prerelease checks are routed through the
-  // desktop-tag selector in `resolveDesktopReleaseFeed` below so a sibling
-  // `host-v*` / `cli-v*` prerelease in the shared repository can never be
-  // mistaken for a desktop update.
+  // electron-updater auto-enables prereleases when the running build is an RC,
+  // and then selects the newest prerelease it can see - across release lines,
+  // and across the `host-v*` / `cli-v*` tags this repository also publishes.
+  // Both halves of that are wrong here, so the flag is replaced by a mode
+  // derived from the persisted preference and the installed version, and every
+  // prerelease check is routed through the desktop-tag selector in
+  // `resolveDesktopReleaseFeed` below, which receives that mode.
   await hydrateUpdatePreferences();
-  autoUpdater.allowPrerelease = prereleaseUpdatesEnabled();
+  activeChannelMode = effectiveChannelMode();
+  autoUpdater.allowPrerelease = modeAllowsPrerelease(activeChannelMode);
+  log.debug("[updater] resolved update channel mode", {
+    mode: activeChannelMode,
+    currentVersion: CURRENT_VERSION,
+  });
   emitSnapshot({ allowPrerelease: autoUpdater.allowPrerelease });
   // Skip feed configuration entirely when the private config is invalid: the
   // startup check below is refused by the same guard, so we must not leave a
@@ -456,12 +471,22 @@ async function configureAutoUpdater(deps: AppUpdaterDeps): Promise<void> {
     notifyUpdateWhenUnfocused("ready", info.version);
   });
   autoUpdater.on("error", (err) => {
-    if (handledNoStableReleaseForPrerelease(err)) {
-      return;
-    }
     log.error("[updater] error", err);
     handleUpdaterError(err);
   });
+}
+
+/**
+ * The mode a check would run under RIGHT NOW: the durable explicit preference
+ * plus the installed version.
+ *
+ * Read from the persisted preference rather than `autoUpdater.allowPrerelease`
+ * for the same reason `getAppUpdateSnapshot` reconciles: the flag is a derived
+ * effect that a half-applied or not-yet-initialized updater can lag behind,
+ * while the preference and the app version are always authoritative.
+ */
+function effectiveChannelMode(): DesktopUpdateChannelMode {
+  return resolveUpdateChannelMode(prereleaseUpdatesEnabled(), CURRENT_VERSION);
 }
 
 export async function checkForUpdatesNow(
@@ -581,8 +606,11 @@ export async function checkForUpdatesNow(
     });
   }
   try {
-    if (autoUpdater.allowPrerelease) {
-      const feed = await resolveDesktopReleaseFeed();
+    // THE MODE decides whether the namespaced selector runs, not the flag it
+    // derived: `allowPrerelease` is now an effect of the mode, and reading the
+    // effect back to re-decide the cause is how the two drift.
+    if (modeAllowsPrerelease(activeChannelMode)) {
+      const feed = await resolveDesktopReleaseFeed(activeChannelMode);
       // Discovery is async: if the channel changed while it ran, reject this
       // stale result before touching the feed or publishing any state - the
       // superseding channel's own check (queued below via `pendingRecheck`)
@@ -605,10 +633,8 @@ export async function checkForUpdatesNow(
     }
     await autoUpdater.checkForUpdates();
   } catch (err) {
-    if (!handledNoStableReleaseForPrerelease(err)) {
-      log.warn("[updater] check failed", err);
-      emitCheckErrorFromCatch(err, checkIntent ?? intent);
-    }
+    log.warn("[updater] check failed", err);
+    emitCheckErrorFromCatch(err, checkIntent ?? intent);
   } finally {
     checkInFlight = false;
     settleCheck?.();
@@ -665,15 +691,42 @@ async function performChannelChange(
   // feed/listener set (finding 1). The barrier always settles, so this never
   // hangs; the preference persistence below is independent of updater health.
   await updaterInitialized;
-  // Idempotent set (channel unchanged): change nothing - in particular do not
-  // open a new epoch or invalidate an in-flight download for a no-op toggle. Read
-  // inside the serialized section so it reflects any preceding queued change.
+  // The mode this request asks for. Read inside the serialized section so the
+  // persisted value it is compared against reflects any preceding queued change.
+  const requestedMode = resolveUpdateChannelMode(
+    allowPrerelease,
+    CURRENT_VERSION,
+  );
+  // Idempotent set (preference unchanged): change nothing - in particular do not
+  // open a new epoch or invalidate an in-flight download for a no-op toggle.
   if (prereleaseUpdatesEnabled() === allowPrerelease) {
     return {
       outcome: "unchanged",
-      snapshot: emitSnapshot({ allowPrerelease }),
+      snapshot: emitSnapshot({
+        allowPrerelease: modeAllowsPrerelease(activeChannelMode),
+      }),
     };
   }
+  // PAST HERE THE PREFERENCE MOVES, AND SO DOES THE EFFECTIVE MODE - always,
+  // and there is deliberately no third branch for "persisted moved, mode did
+  // not".
+  //
+  // Persisting intent and transitioning the channel are still two different
+  // things, and the code below keeps them ordered accordingly. They just cannot
+  // currently come apart: `resolveUpdateChannelMode(true, …)` is always
+  // `explicit-prerelease` and `resolveUpdateChannelMode(false, …)` never is, so
+  // a changed preference always crosses that boundary. A branch guarding the
+  // other case would be unreachable defensive code, and the cold review was
+  // right that shipping one - with a test that has to construct an impossible
+  // updater state to reach it - is worse than not having it.
+  //
+  // If the derivation ever gains a mode that BOTH preference values can select,
+  // this is the point that needs the split back: persist, re-emit, and return
+  // `unchanged` WITHOUT running any of the destructive choreography below (epoch
+  // bump, candidate invalidation, staged-artifact refusal/discard, feed
+  // replacement, quit-install disarm), none of which a change that selects no
+  // different candidate can justify.
+
   // A DOWNLOAD IN PROGRESS refuses on every platform, and this half of the
   // guard is not negotiable: `startUpdateDownload` calls
   // `autoUpdater.downloadUpdate()` with no `CancellationToken`, so there is no
@@ -729,8 +782,9 @@ async function performChannelChange(
   // generation will reject its result rather than restore the old feed, and any
   // candidate/download/ready state below is invalidated.
   channelGeneration += 1;
-  autoUpdater.allowPrerelease = allowPrerelease;
-  if (!allowPrerelease) {
+  activeChannelMode = requestedMode;
+  autoUpdater.allowPrerelease = modeAllowsPrerelease(activeChannelMode);
+  if (!autoUpdater.allowPrerelease) {
     configureStableGitHubUpdateFeed();
   }
 
@@ -746,7 +800,7 @@ async function performChannelChange(
   return {
     outcome: "changed",
     snapshot: emitSnapshot({
-      allowPrerelease,
+      allowPrerelease: autoUpdater.allowPrerelease,
       status: "idle",
       latestVersion: null,
       // Cleared WITH the version. These two describe one candidate, and a null
@@ -1000,18 +1054,23 @@ export async function resolveCompatRecovery(input: {
   if (downloadInProgress || currentSnapshot.status === "downloading") {
     return manualRecoveryPlan();
   }
-  // THE PERSISTED PREFERENCE, not `currentSnapshot.allowPrerelease`. Those two
-  // can disagree - `getAppUpdateSnapshot` exists precisely to reconcile them on
-  // every read - and reading the unreconciled field here inverts this guard:
-  // with a stale `false` beside a persisted `true`, the short-circuit does not
-  // fire, the probe runs against the feed the user is ALREADY on, and the
-  // dialog offers an opt-in they already have. `setAllowPrereleaseUpdates(true)`
-  // then answers `unchanged` - a button that reports success and changes
-  // nothing, which is exactly what this guard exists to prevent.
-  if (prereleaseUpdatesEnabled()) {
-    // Already following RC, so the feed checked above WAS the RC feed. There is
-    // no second line left to look on; this is the honest corner where the
-    // manual link is the remedy.
+  // THE EFFECTIVE MODE, not the persisted preference and not
+  // `currentSnapshot.allowPrerelease`.
+  //
+  // `explicit-prerelease` is the case this guard has always covered: the feed
+  // checked above WAS the prerelease feed, so there is no second line left to
+  // look on, and `setAllowPrereleaseUpdates(true)` would answer `unchanged` -
+  // a button that reports success and changes nothing.
+  //
+  // `implicit-rc-line` is the case the mode model adds, and it is worse than a
+  // no-op. An RC build already receives its own line's candidates, so the
+  // probe would offer an opt-in that changes no current discovery behavior
+  // while PERSISTING a broad prerelease preference the user never asked for -
+  // one that outlives the RC install and keeps them on prereleases after they
+  // reach stable. Implicit participation is derived and must never be written
+  // to disk, so the `enable-rc` route stays reserved for a stable-only app
+  // giving explicit consent.
+  if (effectiveChannelMode() !== "stable-only") {
     return manualRecoveryPlan();
   }
   const candidate = await probeRcRecoveryCandidate(input.minimumEpoch);
@@ -1169,7 +1228,7 @@ async function runRcRecoveryProbe(
         channelFile,
         request.url,
       );
-      const isRc = candidate.version.includes("-rc.");
+      const isRc = isCanonicalReleaseCandidate(candidate.version);
       const isNewer =
         compareHostVersions(candidate.version, CURRENT_VERSION) > 0;
       if (!isRc || !isNewer || epoch === null || epoch < minimumEpoch) {
@@ -1260,10 +1319,8 @@ export function startUpdateDownload(): DesktopAppUpdateSnapshot {
   void (async () => {
     await autoUpdater.downloadUpdate();
   })().catch((err: unknown) => {
-    if (!handledNoStableReleaseForPrerelease(err)) {
-      log.warn("[updater] download failed", err);
-      handleUpdaterError(err);
-    }
+    log.warn("[updater] download failed", err);
+    handleUpdaterError(err);
   });
   return currentSnapshot;
 }
@@ -1325,8 +1382,20 @@ export function isInstallingUpdate(): boolean {
   return installingUpdate;
 }
 
+/**
+ * `allowPrerelease` reports whether THE CURRENT CHECK effectively allows
+ * prereleases - the derived effect of the mode, not the saved preference.
+ *
+ * An RC build following its own line reports `true` while its persisted
+ * preference is `false`, and that is the honest answer to the question every
+ * consumer is actually asking ("could this updater hand me an RC?"). If product
+ * UI ever needs to distinguish "the user asked for prereleases" from "this
+ * build follows its own line", that is a DISTINCT field - overloading this one
+ * is how the recovery dialog came to offer an opt-in to a build that already
+ * had one.
+ */
 export function getAppUpdateSnapshot(): DesktopAppUpdateSnapshot {
-  const allowPrerelease = prereleaseUpdatesEnabled();
+  const allowPrerelease = modeAllowsPrerelease(effectiveChannelMode());
   return currentSnapshot.allowPrerelease === allowPrerelease
     ? currentSnapshot
     : { ...currentSnapshot, allowPrerelease };
@@ -1437,22 +1506,24 @@ function configureStableGitHubUpdateFeed(): void {
 }
 
 /**
- * Resolves the highest compatible desktop-tagged GitHub Release (stable or
- * `rc.N`) across pagination and builds the feed that points electron-updater at
- * that exact release. The repository also hosts host and CLI releases, so
+ * Resolves the compatible desktop-tagged GitHub Release this MODE selects
+ * across pagination, and builds the feed that points electron-updater at that
+ * exact release. The repository also hosts host and CLI releases, so
  * electron-updater's built-in `allowPrerelease` GitHub path is unsafe: it
  * selects the newest prerelease without respecting the `desktop-v` namespace.
- * Returns null when no compatible desktop release exists (genuine "up to
+ * Returns null when no selectable desktop release exists (genuine "up to
  * date"); throws on a discovery error (surfaced as a check failure).
  */
-async function resolveDesktopReleaseFeed(): Promise<DesktopUpdateFeed | null> {
+async function resolveDesktopReleaseFeed(
+  mode: DesktopUpdateChannelMode,
+): Promise<DesktopUpdateFeed | null> {
   const coordinate = resolveUpdateRepo();
   if (coordinate === null) {
     throw new Error(
       "Desktop update repository is not a valid owner/repo coordinate for the configured private update token",
     );
   }
-  const release = await findNewestDesktopRelease(coordinate);
+  const release = await findNewestDesktopRelease(coordinate, mode);
   if (release === null) return null;
   const token = PRIVATE_UPDATE_TOKEN.trim();
   log.debug("[updater] configured desktop release feed", {
@@ -1477,6 +1548,7 @@ function applyDesktopReleaseFeed(feed: DesktopUpdateFeed): void {
 
 async function findNewestDesktopRelease(
   coordinate: GitHubRepoCoordinate,
+  mode: DesktopUpdateChannelMode,
 ): Promise<DesktopReleaseCandidate | null> {
   const candidates = await collectDesktopReleaseCandidates(
     coordinate,
@@ -1489,9 +1561,29 @@ async function findNewestDesktopRelease(
   // newer release is skipped so an older applicable one is chosen instead of
   // committing the feed to a candidate that only fails once electron-updater
   // parses its manifest (cold-review finding 4).
-  const ordered = [...candidates].sort((a, b) =>
-    compareHostVersions(b.version, a.version),
-  );
+  //
+  // MODE FILTERS FIRST, and newest-first ordering is what gives the implicit
+  // line its stable priority for free: the comparator ranks stable `X.Y.Z`
+  // above every `X.Y.Z-rc.M`, so once the line's stable release is published it
+  // is simply the head of the ordered list. The eligibility filter is what
+  // keeps `X.Y+1.0-rc.1` out of that list entirely.
+  const ordered = [...candidates]
+    .filter((candidate) =>
+      isSelectableCandidate({
+        mode,
+        installedVersion: CURRENT_VERSION,
+        candidateVersion: candidate.version,
+        isStrictlyNewer:
+          compareHostVersions(candidate.version, CURRENT_VERSION) > 0,
+      }),
+    )
+    .sort((a, b) => compareHostVersions(b.version, a.version));
+  if (mode === "implicit-rc-line") {
+    log.debug("[updater] implicit RC-line candidates", {
+      currentVersion: CURRENT_VERSION,
+      candidates: ordered.map((candidate) => candidate.version),
+    });
+  }
   const token = PRIVATE_UPDATE_TOKEN.trim();
   const channelFile = platformChannelFile();
   const currentOsRelease = osRelease();
@@ -1787,57 +1879,23 @@ function emitSnapshot(patch: AppUpdateSnapshotPatch): DesktopAppUpdateSnapshot {
   return currentSnapshot;
 }
 
-// Expected outcome for an RC build on the stable channel: we query
-// the stable `/releases/latest` feed, which 404s until the first GA release
-// exists (surfaced as ERR_UPDATER_LATEST_VERSION_NOT_FOUND). That is not a
-// failure for a prerelease, so we log it quietly and report "no update" instead
-// of error-logging and showing a service-unavailable message. Returns true when
-// it handled the error (callers must then treat it as non-fatal). The error
-// event fires before `checkForUpdatesAndNotify()` rejects, so both the `error`
-// listener and the check's `catch` call this; `checkErrorEmitted` makes the
-// second call a no-op.
-const NO_STABLE_RELEASE_ERROR_HINTS: readonly string[] = [
-  "err_updater_latest_version_not_found",
-  "please ensure a production release exists",
-  "no published versions",
-];
-
-function handledNoStableReleaseForPrerelease(error: unknown): boolean {
-  if (!IS_PRERELEASE_BUILD || autoUpdater.allowPrerelease) {
-    return false;
-  }
-  const rawMessage =
-    error instanceof Error && error.message.length > 0
-      ? error.message
-      : String(error);
-  if (!includesAny(rawMessage.toLowerCase(), NO_STABLE_RELEASE_ERROR_HINTS)) {
-    return false;
-  }
-  if (checkErrorEmitted) {
-    return true;
-  }
-  checkErrorEmitted = true;
-  log.debug(
-    "[updater] no production release to update to yet (prerelease build) - skipping",
-  );
-  if (currentSnapshot.status === "ready" || downloadInProgress) {
-    return true;
-  }
-  // A superseded-channel check reaching the "no stable release yet" outcome must
-  // not overwrite the current channel's snapshot with a stale up-to-date/idle;
-  // the queued re-check owns the authoritative result (finding 8).
-  if (isSupersededCheckGeneration()) {
-    return true;
-  }
-  const intent = checkIntent ?? "automatic";
-  emitSnapshot({
-    status: intent === "manual" ? "up-to-date" : "idle",
-    errorMessage: null,
-    lastCheckedAt: new Date().toISOString(),
-    lastCheckIntent: intent,
-  });
-  return true;
-}
+// REMOVED with the three-mode channel model: the "no production release exists
+// yet" fallback.
+//
+// It existed because an RC build used to check the STABLE `/releases/latest`
+// feed, which 404s until the line's first GA release is published, and
+// reporting that 404 as a service failure to every RC user was noise. Under the
+// mode model a canonical `X.Y.Z-rc.N` build is never on the stable feed - it
+// derives `implicit-rc-line`, configures `allowPrerelease: true`, and resolves
+// its candidate through the namespaced `desktop-v*` selector, which answers
+// "nothing selectable" by returning a null feed (a genuine up-to-date), not by
+// raising an updater error. The only builds still on the stable feed are stable
+// releases and non-canonical prereleases, and for both of those a 404 from the
+// release feed IS a service problem worth surfacing.
+//
+// Keeping the fallback would have meant keeping a second, contradictory
+// definition of "is this a prerelease" (`version.includes("-")`) alive purely
+// to suppress an error path that the supported builds can no longer reach.
 
 function handleUpdaterError(error: unknown): void {
   // An error after the user chose "Restart" (quitAndInstall) must NOT be

--- a/clients/desktop/src/electron-main/cli/__tests__/compare-host-versions.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/compare-host-versions.test.ts
@@ -73,3 +73,72 @@ describe("compareHostVersions", () => {
     expect(compareHostVersions("1.0.0 ", "1.0.1")).toBe(0);
   });
 });
+
+/**
+ * PARITY WITH THE CLIENT-SHARED COMPARATOR.
+ *
+ * The desktop app updater's release selector orders `desktop-v*` candidates
+ * with THIS comparator, while the host update surfaces order the same kinds of
+ * version strings with `@traycer-clients/shared`'s. Two comparators deciding
+ * "which build is newer" for one product is a drift risk, and the one that
+ * would hurt is silent: an RC-line follower and a Settings row disagreeing
+ * about whether `2.0.0` outranks `2.0.0-rc.2`.
+ *
+ * These pin agreement over the domain the selector actually sees - versions
+ * that survived `projectDesktopRelease`'s strict `X.Y.Z[-rc.N]` tag grammar -
+ * and state the one place outside that domain where the two deliberately
+ * differ. If a bump or refactor makes them disagree inside it, this fails
+ * before a release does.
+ */
+describe("compareHostVersions parity with @traycer-clients/shared", () => {
+  // Every pair the desktop selector can be asked to order: same line, across
+  // lines, RC vs its GA, and RC vs RC.
+  const SELECTOR_DOMAIN_PAIRS: ReadonlyArray<readonly [string, string]> = [
+    ["2.0.0-rc.1", "2.0.0-rc.2"],
+    ["2.0.0-rc.2", "2.0.0-rc.1"],
+    ["2.0.0-rc.1", "2.0.0-rc.1"],
+    ["2.0.0-rc.1", "2.0.0"],
+    ["2.0.0", "2.0.0-rc.9"],
+    ["2.0.0-rc.1", "2.1.0-rc.1"],
+    ["2.0.0-rc.1", "2.0.1"],
+    ["2.0.0", "2.0.0"],
+    ["2.0.0", "10.0.0"],
+    ["1.9.0", "2.0.0-rc.0"],
+    ["2.0.0-rc.0", "2.0.0-rc.10"],
+    ["0.0.0", "0.0.1-rc.1"],
+  ];
+
+  function sharedSign(ordering: "less" | "equal" | "greater"): number {
+    if (ordering === "greater") return 1;
+    return ordering === "less" ? -1 : 0;
+  }
+
+  it.each(SELECTOR_DOMAIN_PAIRS)(
+    "orders %s vs %s identically",
+    async (a, b) => {
+      const { compareHostVersions } = await import("../cli-discovery");
+      const { compareHostVersions: sharedCompare } =
+        await import("@traycer-clients/shared/host-version/compare-host-versions");
+      const shared = sharedCompare(a, b);
+      if (!shared.comparable) {
+        throw new Error(`expected ${a} vs ${b} to be comparable`);
+      }
+      expect(compareHostVersions(a, b)).toBe(sharedSign(shared.ordering));
+    },
+  );
+
+  it("differs only outside that domain, on input the selector cannot produce", async () => {
+    const { compareHostVersions } = await import("../cli-discovery");
+    const { compareHostVersions: sharedCompare } =
+      await import("@traycer-clients/shared/host-version/compare-host-versions");
+    // A leading-zero numeric identifier is not valid SemVer. The shared
+    // comparator rejects it outright; this one's looser `\d+` grammar compares
+    // it. Harmless HERE because `projectDesktopRelease` rejects
+    // `desktop-v2.0.0-rc.01` at the tag gate, so no such version ever reaches
+    // the selector - and `isCanonicalReleaseCandidate` rejects it a second time
+    // before it could name a release line. Pinned so the divergence stays a
+    // known, contained one rather than a surprise at the next bump.
+    expect(sharedCompare("2.0.0-rc.01", "2.0.0-rc.2").comparable).toBe(false);
+    expect(compareHostVersions("2.0.0-rc.01", "2.0.0-rc.2")).toBe(-1);
+  });
+});

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -2452,6 +2452,309 @@ describe("yank/apply ordering", () => {
     expect(downloads).toEqual(["host download --automatic"]);
   });
 
+  it("keeps revalidating a staged non-canonical prerelease after an opt-out", async () => {
+    // The listing question is "would this row be hidden by the default view",
+    // which covers every prerelease shape - NOT "is this a canonical RC",
+    // which is the narrower question implicit following asks. Narrowing this
+    // one would drop the staged row from the listing, read it as yanked, and
+    // purge a verified artifact.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writeStagedRecord("production", "1.8.0-beta.1", "1.8.0-beta.1");
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.7.0", ["1.7.0", "1.8.0-beta.1"]),
+    );
+    vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({ data: {} });
+
+    await controller.stageLatest();
+
+    expect(runBundledTraycerCliJson).toHaveBeenCalledWith([
+      "host",
+      "available",
+      "--json",
+      "--include-pre-releases",
+    ]);
+  });
+
+  it("follows its own RC line with no saved preference", async () => {
+    // Implicit following: derived from the installed version, nothing
+    // persisted. The listing has to be widened for the line's own RCs to be
+    // visible at all, and `2.1.0-rc.1` - newer, but another line - is not a
+    // candidate at any distance.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.9.0", ["1.9.0", "2.0.0-rc.2", "2.1.0-rc.1"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) downloads.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(runBundledTraycerCliJson).toHaveBeenCalledWith([
+      "host",
+      "available",
+      "--json",
+      "--include-pre-releases",
+    ]);
+    expect(downloads).toEqual(["host download 2.0.0-rc.2"]);
+  });
+
+  it("pins the matching stable even while the registry `latest` still lags", async () => {
+    // The case `--automatic` cannot reach: `2.0.0` is published but `latest`
+    // still points at `1.9.0`, which is a DOWNGRADE for a 2.0.0-line RC.
+    // Resolve-then-pin is what makes the line's stable reachable, and taking it
+    // is also what ends implicit participation.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.9.0", ["1.9.0", "2.0.0-rc.2", "2.0.0"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) downloads.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(downloads).toEqual(["host download 2.0.0"]);
+  });
+
+  it("stages nothing when only another RC line has moved", async () => {
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.9.0", ["1.9.0", "2.1.0-rc.1"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) downloads.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(downloads).toEqual([]);
+  });
+
+  it("does not escape an abandoned line through the --automatic stable path", async () => {
+    // The `2.0.0` line is abandoned and the work shipped as stable `2.1.0`,
+    // which `latest` now names. `--automatic` would take it - a jump to a line
+    // nobody put this host on - so the automatic path is closed while
+    // following. No candidate on the line means no download at all.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("2.1.0", ["1.9.0", "2.1.0"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) downloads.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(downloads).toEqual([]);
+    // `latest` is still reported verbatim - the pointer keeps its meaning, the
+    // follower just may not act on it.
+    expect((await controller.getStatus()).latestVersion).toBe("2.1.0");
+  });
+
+  it("does not refresh an off-line staged build through --automatic while following", async () => {
+    // A stage left behind by an earlier explicit opt-in. Its row is still in
+    // the widened listing, so it stays eligible to apply - but it must not
+    // cause a `--automatic` download that would stage another line's stable.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    writeStagedRecord("production", "2.1.0-rc.1", "2.1.0-rc.1");
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("2.1.0", ["1.9.0", "2.1.0", "2.1.0-rc.1"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) downloads.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(downloads).toEqual([]);
+  });
+
+  it("leaves an unpinned legacy stage alone while following, without attempting a purge", async () => {
+    // A legacy (fingerprint-less) stage plus a line with nothing to replace it:
+    // the repair must not run `--automatic` (that would stage another line's
+    // build), and the reconcile must stop there rather than fall into the purge
+    // branch - which needs a fingerprint this stage has never had, and would
+    // warn about "registry invalidation" that did not happen, on every pass.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    const layout = getHostFsLayout("production");
+    mkdirSync(layout.stagedDir, { recursive: true });
+    writeFileSync(
+      layout.stagedRecordFile,
+      JSON.stringify({
+        stageId: null,
+        version: "2.0.0-rc.1",
+        runtimeVersion: "2.0.0-rc.1",
+      }),
+    );
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("2.1.0", ["2.0.0-rc.1", "2.1.0"]),
+    );
+    const cliCommands: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      cliCommands.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    // No download, no purge-stage - the bytes are left exactly as they were.
+    expect(cliCommands).toEqual([]);
+    expect(
+      vi
+        .mocked(runBundledTraycerCliJson)
+        .mock.calls.filter((call) => call[0].includes("purge-stage")),
+    ).toHaveLength(0);
+    expect(readFileSync(layout.stagedRecordFile, "utf8")).toContain(
+      "2.0.0-rc.1",
+    );
+    expect((await controller.getStatus()).updateReady).toBe(false);
+  });
+
+  it("still repairs an unpinned legacy stage from its own line when one exists", async () => {
+    // The control: the same legacy state, but the line has published its
+    // stable. The repair runs, pinned to that exact version rather than to
+    // `--automatic`.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    const layout = getHostFsLayout("production");
+    mkdirSync(layout.stagedDir, { recursive: true });
+    writeFileSync(
+      layout.stagedRecordFile,
+      JSON.stringify({
+        stageId: null,
+        version: "2.0.0-rc.1",
+        runtimeVersion: "2.0.0-rc.1",
+      }),
+    );
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.9.0", ["1.9.0", "2.0.0-rc.1", "2.0.0"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) {
+        downloads.push(opts.args.join(" "));
+        writeStagedRecord("production", "2.0.0", "2.0.0");
+      }
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(downloads).toEqual(["host download 2.0.0"]);
+  });
+
+  it("keeps taking a newer stable through --automatic on a stable host", async () => {
+    // The control for the two above: closing the automatic path is scoped to
+    // implicit following. A stable install with no opt-in is unaffected.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0",
+      runtimeVersion: "2.0.0",
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("2.1.0", ["2.0.0", "2.1.0"]),
+    );
+    const downloads: string[] = [];
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) downloads.push(opts.args.join(" "));
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+
+    expect(downloads).toEqual(["host download --automatic"]);
+  });
+
+  it("drives updateReady from the verified stage alone, with no second registry probe", async () => {
+    // The landing banner reads `HostControllerStatus.updateReady` and nothing
+    // else - no React-side release lookup. Proving that here means: one
+    // `host available` call for the whole reconcile, and a canonical status
+    // that reports the pinned stage as ready straight afterwards.
+    vi.mocked(prereleaseUpdatesEnabled).mockReturnValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "2.0.0-rc.1",
+      runtimeVersion: "2.0.0-rc.1",
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.9.0", ["1.9.0", "2.0.0-rc.2", "2.0.0"]),
+    );
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) {
+        writeStagedRecord("production", "2.0.0", "2.0.0");
+      }
+      return { data: {} };
+    });
+
+    await controller.stageLatest();
+    const status = await controller.getStatus();
+
+    expect(status).toMatchObject({
+      installedVersion: "2.0.0-rc.1",
+      stagedVersion: "2.0.0",
+      updateReady: true,
+    });
+    // `latestVersion` keeps reporting the manifest pointer verbatim - this
+    // flow pins around a lagging `latest`, it never redefines it.
+    expect(status.latestVersion).toBe("1.9.0");
+    expect(
+      vi
+        .mocked(runBundledTraycerCliJson)
+        .mock.calls.filter((call) => call[0].includes("available")),
+    ).toHaveLength(1);
+  });
+
   it("purges only the yanked stage fingerprint on the download lane, never a replacement promoted during the registry probe", async () => {
     const controller = newController("production");
     writeInstallRecord("production", {

--- a/clients/desktop/src/electron-main/host/__tests__/host-stage-policy.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-stage-policy.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  requiresPreReleaseListing,
+  resolveHostChannelMode,
+  resolveHostStageTarget,
+} from "../host-stage-policy";
+import type { DesktopUpdateChannelMode } from "../../app/update-channel-mode";
+
+describe("resolveHostChannelMode", () => {
+  it.each([
+    [false, "1.8.0", "stable-only"],
+    [false, "2.0.0-rc.1", "implicit-rc-line"],
+    [false, "2.0.0-rc.0", "implicit-rc-line"],
+    // Not a canonical RC: no implicit following, whatever it calls itself.
+    [false, "2.0.0-beta.1", "stable-only"],
+    [false, "2.0.0-rc.01", "stable-only"],
+    [false, "local-host-1730000000", "stable-only"],
+    [true, "1.8.0", "explicit-prerelease"],
+    [true, "2.0.0-rc.1", "explicit-prerelease"],
+  ] as ReadonlyArray<readonly [boolean, string, DesktopUpdateChannelMode]>)(
+    "explicit=%s installed=%s -> %s",
+    (explicitPrerelease, installedVersion, expected) => {
+      expect(
+        resolveHostChannelMode({ explicitPrerelease, installedVersion }),
+      ).toBe(expected);
+    },
+  );
+
+  it("fails closed to stable-only when the install record is missing or unreadable", () => {
+    // `readDesktopHostInstallRecord` answers null for absent, malformed, and
+    // unreadable alike; none of them may switch a Host onto RC discovery.
+    expect(
+      resolveHostChannelMode({
+        explicitPrerelease: false,
+        installedVersion: null,
+      }),
+    ).toBe("stable-only");
+  });
+
+  it("still honors an explicit opt-in with no readable install record", () => {
+    // The preference is the user's standing instruction rather than something
+    // inferred from disk, so a corrupt record does not revoke it. The target
+    // resolver separately refuses to pin anything without an installed version.
+    expect(
+      resolveHostChannelMode({
+        explicitPrerelease: true,
+        installedVersion: null,
+      }),
+    ).toBe("explicit-prerelease");
+  });
+});
+
+// The catalog predicate itself is owned and table-tested by
+// `@traycer-clients/shared/host-version/release-line` - the same definition the
+// CLI's `filterHostAvailableVersions` consumes, so the two cannot drift. What
+// is tested here is only how this module USES it.
+describe("requiresPreReleaseListing", () => {
+  it("asks for the pre-release view in both non-stable modes", () => {
+    expect(
+      requiresPreReleaseListing({
+        mode: "implicit-rc-line",
+        stagedVersion: null,
+      }),
+    ).toBe(true);
+    expect(
+      requiresPreReleaseListing({
+        mode: "explicit-prerelease",
+        stagedVersion: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays stable-only for a stable-only Host with nothing staged", () => {
+    expect(
+      requiresPreReleaseListing({ mode: "stable-only", stagedVersion: null }),
+    ).toBe(false);
+    expect(
+      requiresPreReleaseListing({
+        mode: "stable-only",
+        stagedVersion: "1.9.0",
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["1.9.0-rc.1", "1.9.0-beta.1"])(
+    "widens the query to revalidate a staged %s even in stable-only mode",
+    (stagedVersion) => {
+      // Query-only: the mode and the persisted preference are untouched, so an
+      // RC staged before an opt-out is revalidated rather than purged, without
+      // putting the Host back on RC selection.
+      expect(
+        requiresPreReleaseListing({ mode: "stable-only", stagedVersion }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("resolveHostStageTarget", () => {
+  const stableOnlyInput = {
+    mode: "stable-only" as const,
+    installedVersion: "1.8.0",
+    availableVersions: ["1.8.0", "1.9.0", "2.0.0-rc.1"],
+    stableLatest: "1.9.0",
+  };
+
+  it("never pins in stable-only mode - `--automatic` already follows latest", () => {
+    expect(resolveHostStageTarget(stableOnlyInput)).toBeNull();
+  });
+
+  it("never pins without a readable installed version", () => {
+    expect(
+      resolveHostStageTarget({
+        mode: "explicit-prerelease",
+        installedVersion: null,
+        availableVersions: ["2.0.0-rc.1"],
+        stableLatest: "1.9.0",
+      }),
+    ).toBeNull();
+  });
+
+  describe("implicit-rc-line", () => {
+    const installedVersion = "2.0.0-rc.1";
+
+    function target(
+      availableVersions: readonly string[],
+      stableLatest: string | null,
+    ): string | null {
+      return resolveHostStageTarget({
+        mode: "implicit-rc-line",
+        installedVersion,
+        availableVersions,
+        stableLatest,
+      });
+    }
+
+    it("pins the matching stable even when the manifest `latest` lags behind it", () => {
+      // The plan's exact case: `2.0.0` is published, `latest` still says
+      // `1.9.0`, and `--automatic` would fetch 1.9.0 - a DOWNGRADE for an RC
+      // of the 2.0.0 line. The exact-version pin is what makes stable reachable.
+      expect(target(["1.9.0", "2.0.0-rc.2", "2.0.0"], "1.9.0")).toBe("2.0.0");
+    });
+
+    it("prefers the matching stable over every later RC on the line", () => {
+      expect(target(["2.0.0", "2.0.0-rc.9", "2.0.0-rc.2"], "2.0.0")).toBe(
+        "2.0.0",
+      );
+    });
+
+    it("falls back to the highest later RC on the line when stable is unpublished", () => {
+      expect(target(["2.0.0-rc.2", "2.0.0-rc.10", "2.0.0-rc.3"], "1.9.0")).toBe(
+        "2.0.0-rc.10",
+      );
+    });
+
+    it.each([
+      // Newer, but a different line - the jump implicit following never makes.
+      [["2.1.0-rc.1"], "2.1.0-rc.1 (another RC line)"],
+      [["2.1.0"], "2.1.0 (another line's stable)"],
+      [["3.0.0"], "3.0.0 (a much newer line)"],
+      [["2.0.1"], "2.0.1 (a patch line of its own)"],
+      // Same line, but not newer.
+      [["2.0.0-rc.1", "2.0.0-rc.0"], "only itself and an older RC"],
+      // Right core, wrong prerelease grammar: not on the 2.0.0 line at all.
+      [["2.0.0-beta.5"], "2.0.0-beta.5"],
+    ] as ReadonlyArray<readonly [readonly string[], string]>)(
+      "does not pin %s",
+      (availableVersions) => {
+        expect(target(availableVersions, "1.9.0")).toBeNull();
+      },
+    );
+
+    it("ignores a yanked/unavailable stable, since the caller filtered it out", () => {
+      // `availableVersions` is already the installable set: a withdrawn 2.0.0
+      // is simply absent, and the highest usable later RC takes over.
+      expect(target(["2.0.0-rc.2", "2.0.0-rc.3"], "1.9.0")).toBe("2.0.0-rc.3");
+    });
+  });
+
+  describe("explicit-prerelease", () => {
+    function target(
+      installedVersion: string,
+      availableVersions: readonly string[],
+      stableLatest: string | null,
+    ): string | null {
+      return resolveHostStageTarget({
+        mode: "explicit-prerelease",
+        installedVersion,
+        availableVersions,
+        stableLatest,
+      });
+    }
+
+    it("stays broad: pins the newest pre-release across release lines", () => {
+      expect(target("2.0.0-rc.1", ["2.0.0", "2.1.0-rc.1"], "2.0.0")).toBe(
+        "2.1.0-rc.1",
+      );
+    });
+
+    it("defers to `--automatic` when the newest listed build is the stable latest", () => {
+      expect(target("1.8.0", ["1.8.0", "1.9.0"], "1.9.0")).toBeNull();
+    });
+
+    it("defers to `--automatic` when the newest RC does not beat the stable latest", () => {
+      expect(target("1.8.0", ["1.9.0-rc.1", "1.9.0"], "1.9.0")).toBeNull();
+    });
+
+    it("never downgrades to an older pre-release", () => {
+      expect(target("2.0.0", ["1.9.0-rc.1"], "1.8.0")).toBeNull();
+    });
+
+    it("never downgrades onto an incomparable installed version", () => {
+      expect(target("local-host-1730000000", ["2.0.0-rc.1"], null)).toBeNull();
+    });
+  });
+});

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -22,6 +22,11 @@ import {
 } from "../cli/traycer-cli";
 import { withDesktopCliLock } from "./desktop-cli-lock";
 import {
+  requiresPreReleaseListing,
+  resolveHostChannelMode,
+  resolveHostStageTarget,
+} from "./host-stage-policy";
+import {
   getHostFsLayout,
   cliLockPath,
   type Environment,
@@ -554,49 +559,14 @@ function latestVersionFromSnapshot(
   return entry !== undefined && entry.available ? entry.version : null;
 }
 
-// Newest available version in the snapshot, INCLUDING pre-releases (unlike
-// `latestVersionFromSnapshot`, which reads the manifest's stable `latest`
-// pointer). Registry versions are always valid SemVer, so the pairwise
-// `isStrictlyNewerHostVersion` comparison never hits the incomparable arm.
-function maxAvailableVersion(snapshot: AvailableSnapshotShape): string | null {
-  const available = snapshot.versions.filter((entry) => entry.available);
-  if (available.length === 0) return null;
-  return available.reduce((max, entry) =>
-    isStrictlyNewerHostVersion(entry.version, max.version) ? entry : max,
-  ).version;
-}
-
-/**
- * Resolve-then-pin target for opt-in release-candidate auto-updates.
- *
- * `host download --automatic` follows the manifest's `latest` pointer, which
- * RC releases never move - so it is stable-only by construction, and
- * `host available --include-pre-releases` widens the version list but leaves
- * `latest` on stable too. When the user has opted into release candidates and
- * the pre-release listing carries an RC newer than BOTH the installed host
- * and the stable `latest`, return that exact version so the caller pins it via
- * `host download <version>` instead of `--automatic`. Returns null (use
- * `--automatic`, unchanged stable behavior) otherwise. `isStrictlyNewerHostVersion`
- * is the downgrade guard: an incomparable (e.g. `local-*` install) or older
- * target never pins.
- */
-function resolveRcDownloadTarget(
-  snapshot: AvailableSnapshotShape,
-  installedVersion: string | null,
-  optedIntoPreReleases: boolean,
-): string | null {
-  if (!optedIntoPreReleases || installedVersion === null) return null;
-  const rcLatest = maxAvailableVersion(snapshot);
-  if (rcLatest === null || !rcLatest.includes("-")) return null;
-  if (!isStrictlyNewerHostVersion(rcLatest, installedVersion)) return null;
-  const stableLatest = latestVersionFromSnapshot(snapshot);
-  if (
-    stableLatest !== null &&
-    !isStrictlyNewerHostVersion(rcLatest, stableLatest)
-  ) {
-    return null;
-  }
-  return rcLatest;
+// The listing rows background staging may actually choose between: installable
+// on this platform and not yanked. Every policy question in
+// `host-stage-policy.ts` is asked against this set, so a broken or withdrawn
+// release is gone before any of them run.
+function installableVersions(snapshot: AvailableSnapshotShape): string[] {
+  return snapshot.versions
+    .filter((entry) => entry.available)
+    .map((entry) => entry.version);
 }
 
 /**
@@ -2390,14 +2360,42 @@ export class HostController {
     this.eligibleStage = null;
     let staged = await readDesktopHostStagedRecord(this.layout);
     let snapshot: AvailableSnapshotShape;
-    const optedIntoPreReleases = prereleaseUpdatesEnabled();
+    // THE INSTALL RECORD IS READ BEFORE THE REGISTRY REQUEST, because it is an
+    // input to that request: an installed canonical `X.Y.Z-rc.N` follows its
+    // own line with no saved preference, and a stable-only listing would not
+    // even contain the candidates that follow implies. A missing or unreadable
+    // record fails closed to stable-only (see `resolveHostChannelMode`).
+    const installed = await readDesktopHostInstallRecord(this.layout);
+    const installedVersion = installed?.version ?? null;
+    const mode = resolveHostChannelMode({
+      explicitPrerelease: prereleaseUpdatesEnabled(),
+      installedVersion,
+    });
+    // THE ORDINARY `--automatic` PATH IS CLOSED WHILE FOLLOWING A LINE.
+    //
+    // `host download --automatic` follows the manifest's stable `latest`
+    // pointer, and for a build following its own release line that pointer is
+    // another line - so falling through to it whenever this line has nothing to
+    // offer is exactly the cross-line jump implicit participation forbids. The
+    // only builds this mode may stage are the ones `resolveHostStageTarget`
+    // returns: a later RC on the line, or the line's own stable.
+    //
+    // The consequence is deliberate and matches the Desktop app: an ABANDONED
+    // line has no automatic exit. If `2.0.0` is never published and the work
+    // ships as `2.1.0`, a `2.0.0-rc.1` host stays where it is rather than being
+    // moved to a line nobody put it on. Publishing the line's stable, or a
+    // reinstall, is the exit.
+    const automaticStablePathOpen = mode !== "implicit-rc-line";
     try {
       snapshot = parseAvailableSnapshot(
         await this.runBundled<unknown>([
           "host",
           "available",
           "--json",
-          ...(staged?.version.includes("-") === true || optedIntoPreReleases
+          ...(requiresPreReleaseListing({
+            mode,
+            stagedVersion: staged?.version ?? null,
+          })
             ? ["--include-pre-releases"]
             : []),
         ]),
@@ -2421,24 +2419,32 @@ export class HostController {
           version: staged.version,
           fingerprint: encodeStageFingerprint(staged.stageId),
         };
-        if (this.mutationStatus === null) {
+        // An unparseable manifest leaves nothing to resolve a same-line
+        // candidate from, so a follower has no admissible target here and the
+        // `--automatic` repair would stage whatever `latest` names. The stage
+        // above stays eligible either way; only the speculative refresh is
+        // skipped.
+        if (this.mutationStatus === null && automaticStablePathOpen) {
           await this.runDownloadLane(null);
-        } else {
+        } else if (this.mutationStatus !== null) {
           this.stageLatestPending = true;
         }
       }
       return;
     }
-    const installed = await readDesktopHostInstallRecord(this.layout);
-    const installedVersion = installed?.version ?? null;
-    // Opt-in RC auto-update: `--automatic` is stable-only (follows the
-    // manifest `latest` pointer, which RC releases never move), so pin the
-    // exact newer RC when the user opted in. Downgrade-guarded inside.
-    const rcTarget = resolveRcDownloadTarget(
-      snapshot,
+    // Resolve-then-pin: `--automatic` follows the manifest's stable `latest`
+    // pointer, so it can reach neither a later RC on the installed line nor a
+    // matching stable published while `latest` still lags. When this mode picks
+    // a candidate, it is pinned by exact version instead. Downgrade- and
+    // line-guarded inside; null means "nothing this mode may stage", which for
+    // `stable-only`/`explicit-prerelease` hands over to `--automatic` and for
+    // `implicit-rc-line` means no download at all.
+    const downloadTarget = resolveHostStageTarget({
+      mode,
       installedVersion,
-      optedIntoPreReleases,
-    );
+      availableVersions: installableVersions(snapshot),
+      stableLatest: this.latestVersionCache,
+    });
     let migratedLegacyStage = false;
     if (staged?.stageId === null) {
       // Legacy archives predate the stage fingerprint used by the atomic
@@ -2446,13 +2452,51 @@ export class HostController {
       // normal automatic download path to replace them with a freshly
       // verified, fingerprinted stage; otherwise this valid update remains
       // permanently deferred because Desktop can neither apply nor purge it.
-      log.info(
-        "[host-controller] replacing a legacy staged host without a handoff fingerprint",
-        { version: staged.version },
-      );
-      await this.runDownloadLane(null);
-      migratedLegacyStage = true;
-      staged = await readDesktopHostStagedRecord(this.layout);
+      //
+      // A FOLLOWER REPAIRS FROM ITS OWN LINE OR NOT AT ALL: `--automatic` here
+      // would repair the stage by fetching another line's stable, so the pinned
+      // same-line candidate is used instead. With no such candidate the legacy
+      // bytes are left alone - already unusable, and no worse for waiting -
+      // rather than replaced by a build this mode may not select.
+      //
+      // The lane overloads `null` to mean "run `--automatic`", so the two cases
+      // are spelled out rather than left to that overload: `repairWithAutomatic`
+      // says WHICH lane, `repairPin` is the exact version when the automatic
+      // lane is closed, and `null` is only ever passed when the automatic lane
+      // is genuinely the one we want.
+      const repairWithAutomatic = automaticStablePathOpen;
+      const repairPin = repairWithAutomatic ? null : downloadTarget;
+      if (repairWithAutomatic || repairPin !== null) {
+        log.info(
+          "[host-controller] replacing a legacy staged host without a handoff fingerprint",
+          {
+            version: staged.version,
+            replacement: repairWithAutomatic ? "--automatic" : repairPin,
+          },
+        );
+        await this.runDownloadLane(repairPin);
+        migratedLegacyStage = true;
+        staged = await readDesktopHostStagedRecord(this.layout);
+      } else {
+        // TERMINAL FOR THIS RECONCILE, and returning here is the point.
+        //
+        // Falling through would reach the purge branch below, which requires a
+        // fingerprint this stage does not have, and would log "cannot purge an
+        // unpinned staged host after registry invalidation" at `warn` on every
+        // single reconcile - naming a cause that did not happen. The registry
+        // is fine; the stage is fine; this build's line simply has nothing to
+        // replace it with yet. Say that once, at debug, since it is a standing
+        // condition rather than an event, and stop.
+        log.debug(
+          "[host-controller] leaving an unpinned legacy stage in place: its release line has no candidate to replace it with",
+          {
+            version: staged.version,
+            installedVersion,
+            mode,
+          },
+        );
+        return;
+      }
     }
     const stageIsEligible =
       staged !== null &&
@@ -2465,8 +2509,13 @@ export class HostController {
       const expectedStageFingerprint =
         staged.stageId === null ? null : encodeStageFingerprint(staged.stageId);
       if (expectedStageFingerprint === null) {
+        // Reached only when a replacement WAS attempted and left the stage
+        // unpinned anyway (the repair download failed). The deliberate
+        // leave-in-place case returns above, so this no longer speaks for it -
+        // and it no longer blames registry invalidation, which is one possible
+        // reason a stage is ineligible but not the reason it cannot be purged.
         log.warn(
-          "[host-controller] cannot purge an unpinned staged host after registry invalidation",
+          "[host-controller] cannot purge an ineligible staged host: it carries no handoff fingerprint",
           { version: staged.version },
         );
         return;
@@ -2501,16 +2550,23 @@ export class HostController {
       }
       staged = null;
     }
-    const needsDownload =
-      !migratedLegacyStage &&
+    // Work the `--automatic` lane would do: refresh an existing stage, or take
+    // a stable release newer than the installed build. Both are gated on the
+    // automatic path being open, so a follower whose line offers nothing simply
+    // does not download - it never reaches `runDownloadLane(null)` and so can
+    // never be handed another line's `latest`.
+    const hasAutomaticStableWork =
+      automaticStablePathOpen &&
       (staged !== null ||
-        rcTarget !== null ||
         (this.latestVersionCache !== null &&
           installedVersion !== null &&
           isStrictlyNewerHostVersion(
             this.latestVersionCache,
             installedVersion,
           )));
+    const needsDownload =
+      !migratedLegacyStage &&
+      (downloadTarget !== null || hasAutomaticStableWork);
     if (!needsDownload) {
       if (stageIsEligible && staged !== null && staged.stageId !== null) {
         this.eligibleStage = {
@@ -2530,7 +2586,7 @@ export class HostController {
       this.stageLatestPending = true;
       return;
     }
-    await this.runDownloadLane(rcTarget);
+    await this.runDownloadLane(downloadTarget);
     staged = await readDesktopHostStagedRecord(this.layout);
     const downloadedStageIsEligible =
       staged !== null &&

--- a/clients/desktop/src/electron-main/host/host-stage-policy.ts
+++ b/clients/desktop/src/electron-main/host/host-stage-policy.ts
@@ -1,0 +1,194 @@
+/**
+ * WHICH HOST VERSION BACKGROUND STAGING SHOULD FETCH, as pure functions.
+ *
+ * `HostController.reconcileEligibleStage` is orchestration - locks, lanes,
+ * fingerprints, purge choreography - and the policy questions buried in it are
+ * three small ones that deserve to be answered where they can be table-tested
+ * without a controller, a filesystem, or a spawned CLI:
+ *
+ *   1. Which channel mode is this Host install on?
+ *   2. Does the registry listing need to include pre-releases?
+ *   3. Which exact version should be downloaded, if not `--automatic`?
+ *
+ * THE MODE MODEL IS THE DESKTOP APP'S, deliberately reused rather than
+ * re-declared: the plan applies one three-mode model to both updater domains,
+ * and the only difference is which installed version feeds it - the packaged
+ * app version there, the Host install record here. Two enums with the same
+ * three members would be two things to keep in step for no benefit.
+ *
+ * NOTHING HERE RE-DECLARES A VERSION PREDICATE. The controller has to predict
+ * which rows `host available` will return - a staged build whose row is missing
+ * reads as yanked and gets purged - and that prediction is only safe while both
+ * processes read ONE definition, so `isPreReleaseVersion` comes from
+ * `@traycer-clients/shared/host-version/release-line`, which the CLI's own
+ * catalog filter now consumes too.
+ */
+import { isStrictlyNewerHostVersion } from "@traycer-clients/shared/host-version/compare-host-versions";
+import {
+  isMatchingStableRelease,
+  isPreReleaseVersion,
+  isSameReleaseLine,
+} from "@traycer-clients/shared/host-version/release-line";
+import {
+  modeAllowsPrerelease,
+  resolveUpdateChannelMode,
+  type DesktopUpdateChannelMode,
+} from "../app/update-channel-mode";
+
+/**
+ * The mode this Host install is on.
+ *
+ * FAILS CLOSED on a missing, malformed, or unreadable install record:
+ * `readDesktopHostInstallRecord` answers `null` for all three, and a Host whose
+ * version cannot be established never activates implicit RC following. The
+ * explicit preference still applies, because that one is the user's own
+ * standing instruction rather than something inferred from disk.
+ */
+export function resolveHostChannelMode(input: {
+  readonly explicitPrerelease: boolean;
+  readonly installedVersion: string | null;
+}): DesktopUpdateChannelMode {
+  if (input.installedVersion === null) {
+    return input.explicitPrerelease ? "explicit-prerelease" : "stable-only";
+  }
+  return resolveUpdateChannelMode(
+    input.explicitPrerelease,
+    input.installedVersion,
+  );
+}
+
+/**
+ * Whether `host available` must be asked for the pre-release view.
+ *
+ * Two independent reasons, and the second is NOT a mode:
+ *
+ *   - the mode allows pre-releases (implicit following or an explicit opt-in);
+ *   - a pre-release is ALREADY STAGED. Its row has to be in the listing for
+ *     `stageIsEligible` to revalidate it; asked stable-only, the row is absent,
+ *     the stage reads as yanked, and a perfectly good verified artifact is
+ *     purged. This widens the QUERY only - it changes neither the selection
+ *     mode nor the persisted preference, so an RC staged before an opt-out is
+ *     revalidated without silently putting the user back on prereleases.
+ */
+export function requiresPreReleaseListing(input: {
+  readonly mode: DesktopUpdateChannelMode;
+  readonly stagedVersion: string | null;
+}): boolean {
+  if (modeAllowsPrerelease(input.mode)) {
+    return true;
+  }
+  return (
+    input.stagedVersion !== null && isPreReleaseVersion(input.stagedVersion)
+  );
+}
+
+/**
+ * The exact version to pin with `host download <version>`, or null to use the
+ * ordinary `host download --automatic` (which follows the manifest's stable
+ * `latest` pointer).
+ *
+ * `availableVersions` is the listing already filtered to installable rows, so
+ * yanked and platform-unavailable builds are gone before any policy runs here.
+ *
+ *   - `stable-only`: null. The stable pointer is exactly the right answer and
+ *     `--automatic` already follows it.
+ *   - `implicit-rc-line`: the installed RC's OWN line only - its matching
+ *     stable first, otherwise the highest later RC on that line.
+ *   - `explicit-prerelease`: unchanged broad behavior - the newest available
+ *     pre-release, but only when it beats both the installed build and the
+ *     stable `latest` (otherwise `--automatic` is already fetching the better
+ *     one).
+ *
+ * `latest` IS NOT THE CANDIDATE SOURCE. RC releases never move that pointer,
+ * and a line's stable can be published while it still names an older release -
+ * so installed `2.0.0-rc.1` must pin `2.0.0` even while `latest` reads
+ * `1.9.0`. Nothing here reads or changes `latest` semantics; `stableLatest` is
+ * consulted only to avoid pinning a version `--automatic` would beat anyway.
+ */
+export function resolveHostStageTarget(input: {
+  readonly mode: DesktopUpdateChannelMode;
+  readonly installedVersion: string | null;
+  readonly availableVersions: readonly string[];
+  readonly stableLatest: string | null;
+}): string | null {
+  const installedVersion = input.installedVersion;
+  if (installedVersion === null || input.mode === "stable-only") {
+    return null;
+  }
+  if (input.mode === "implicit-rc-line") {
+    return resolveSameLineTarget(installedVersion, input.availableVersions);
+  }
+  return resolveBroadPreReleaseTarget(
+    installedVersion,
+    input.availableVersions,
+    input.stableLatest,
+  );
+}
+
+/**
+ * MATCHING STABLE WINS OUTRIGHT over every later RC on the line, and that
+ * priority is what makes implicit following terminate: taking `2.0.0` leaves
+ * the next launch a stable install, which derives `stable-only` with no
+ * preference to undo.
+ *
+ * No downgrade guard is needed on the stable arm - SemVer puts `X.Y.Z` above
+ * every `X.Y.Z-rc.N`, and `isMatchingStableRelease` only answers true when the
+ * installed version is a canonical RC of that exact line. The RC arm keeps its
+ * `isStrictlyNewerHostVersion` filter, which also drops the installed build
+ * itself and anything incomparable.
+ */
+function resolveSameLineTarget(
+  installedVersion: string,
+  availableVersions: readonly string[],
+): string | null {
+  const matchingStable = availableVersions.find((version) =>
+    isMatchingStableRelease(version, installedVersion),
+  );
+  if (matchingStable !== undefined) {
+    return matchingStable;
+  }
+  const laterOnLine = availableVersions.filter(
+    (version) =>
+      isSameReleaseLine(installedVersion, version) &&
+      isStrictlyNewerHostVersion(version, installedVersion),
+  );
+  if (laterOnLine.length === 0) {
+    return null;
+  }
+  return laterOnLine.reduce((newest, version) =>
+    isStrictlyNewerHostVersion(version, newest) ? version : newest,
+  );
+}
+
+function resolveBroadPreReleaseTarget(
+  installedVersion: string,
+  availableVersions: readonly string[],
+  stableLatest: string | null,
+): string | null {
+  const newest = newestVersion(availableVersions);
+  if (newest === null || !isPreReleaseVersion(newest)) {
+    return null;
+  }
+  if (!isStrictlyNewerHostVersion(newest, installedVersion)) {
+    return null;
+  }
+  if (
+    stableLatest !== null &&
+    !isStrictlyNewerHostVersion(newest, stableLatest)
+  ) {
+    return null;
+  }
+  return newest;
+}
+
+// Newest listed version INCLUDING pre-releases, unlike the manifest's stable
+// `latest` pointer. Registry versions are always valid SemVer, so the pairwise
+// comparison never hits the incomparable arm.
+function newestVersion(versions: readonly string[]): string | null {
+  if (versions.length === 0) {
+    return null;
+  }
+  return versions.reduce((newest, version) =>
+    isStrictlyNewerHostVersion(version, newest) ? version : newest,
+  );
+}

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
@@ -383,6 +383,45 @@ describe("maintenanceUpdateCheck IPC", () => {
           },
         ],
       },
+      // Reconstructed from the REQUEST, because this fixture's CLI envelope
+      // carries no inclusion metadata — the fail-closed path for a CLI that
+      // predates the fields. It never claims `installed-rc`, which asserts a
+      // derivation only a reporting CLI can have performed.
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+    });
+  });
+
+  it("preserves the CLI envelope's own resolved inclusion and provenance", async () => {
+    // The Settings explanation is keyed off `installed-rc`, and only the CLI
+    // can know it: dropping the metadata here would make the same CLI output
+    // explain itself on a remote host and stay silent on a local one.
+    installFakeCli(
+      resolveWith({
+        ...(realShapedAvailablePayload() as Record<string, unknown>),
+        includePreReleases: true,
+        includePreReleasesSource: "installed-rc",
+      }),
+    );
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+    const handler = bridge.handlers.get(
+      RunnerHostInvoke.traycerMaintenanceUpdateCheck,
+    );
+    if (handler === undefined) {
+      throw new Error("expected maintenanceUpdateCheck handler");
+    }
+
+    const result = await handler(null, {});
+
+    expect(result).toMatchObject({
+      outcome: "ok",
+      effectiveIncludePreReleases: true,
+      includePreReleasesSource: "installed-rc",
     });
   });
 
@@ -409,7 +448,11 @@ describe("maintenanceUpdateCheck IPC", () => {
     );
   });
 
-  it("shells host available --json without --include-pre-releases when the flag is false", async () => {
+  it("shells the NEGATIVE flag when the override is explicitly false", async () => {
+    // Not omission. Omission now means "derive from the installed host", and
+    // on a host running a release candidate that DERIVES inclusion — so an
+    // unchecked filter that sent nothing would keep returning the RC rows it
+    // was just asked to hide.
     installFakeCli(resolveWith(realShapedAvailablePayload()));
     const mgmt = await import("../host-management-ipc");
     mgmt.setActiveEnvironment("production");
@@ -424,6 +467,29 @@ describe("maintenanceUpdateCheck IPC", () => {
       throw new Error("expected maintenanceUpdateCheck handler");
     }
     await handler(null, { includePreReleases: false });
+    expect(bundledCliCalls).toEqual([
+      ["host", "available", "--json", "--no-include-pre-releases"],
+    ]);
+  });
+
+  it("shells NO flag when the override is absent, leaving the default to the CLI", async () => {
+    // The CLI is the catalog-default authority: it is the process that can
+    // read this environment's install record. Picking a flag here would
+    // override the derivation the absent state exists to request.
+    installFakeCli(resolveWith(realShapedAvailablePayload()));
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+    const handler = bridge.handlers.get(
+      RunnerHostInvoke.traycerMaintenanceUpdateCheck,
+    );
+    if (handler === undefined) {
+      throw new Error("expected maintenanceUpdateCheck handler");
+    }
+    await handler(null, {});
     expect(bundledCliCalls).toEqual([["host", "available", "--json"]]);
   });
 
@@ -2566,5 +2632,132 @@ describe("maintenance identity + doctorRepairIfIdle IPC", () => {
       kind: "declined",
       message: "Another process holds the host lock.",
     });
+  });
+});
+
+/**
+ * `traycerHostAvailable` resolves the DISCOVERED manifest/PATH CLI, which —
+ * unlike the bundled, version-matched CLI the maintenance projections use —
+ * can be older than the app driving it. Sending it a flag it does not have
+ * turned "untick Include release candidates" into a hard error.
+ */
+describe("traycerHostAvailable old-CLI compatibility", () => {
+  beforeEach(beginSandbox);
+  afterEach(endSandbox);
+
+  const NEGATIVE_FLAG = "--no-include-pre-releases";
+
+  function rejectUnknownOption(
+    flag: string,
+  ): (args: readonly string[], CliError: CliErrorCtor) => Promise<unknown> {
+    return (args, CliError) => {
+      if (args.includes(flag)) {
+        // The real envelope: the CLI entry's `applyRunnerErrorRouting` routes
+        // commander's parse failure into the JSON error contract under
+        // `--json`, carrying commander's own code in `details`.
+        return Promise.reject(
+          new CliError(
+            {
+              message: `unknown option '${flag}'\n(Did you mean --include-pre-releases?)`,
+              code: "E_INVALID_ARGUMENT",
+              details: { commanderCode: "commander.unknownOption" },
+              exitCode: 1,
+              stderrTail: "",
+            },
+            null,
+          ),
+        );
+      }
+      return Promise.resolve(realShapedAvailablePayload());
+    };
+  }
+
+  async function availableHandler(): Promise<
+    (event: unknown, raw: unknown) => Promise<unknown>
+  > {
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+    const handler = bridge.handlers.get(RunnerHostInvoke.traycerHostAvailable);
+    if (handler === undefined) {
+      throw new Error("expected traycerHostAvailable handler");
+    }
+    return handler;
+  }
+
+  it("retries once without the negative flag when the CLI does not know it", async () => {
+    installFakeCli(rejectUnknownOption(NEGATIVE_FLAG));
+    const handler = await availableHandler();
+
+    const result = await handler(null, { includePreReleases: false });
+
+    expect(bundledCliCalls).toEqual([
+      ["host", "available", "--json", NEGATIVE_FLAG],
+      // Dropping the flag is not a degradation: a CLI that lacks it also
+      // predates derived defaults, so its no-flag behaviour IS stable-only.
+      ["host", "available", "--json"],
+    ]);
+    expect(result).toMatchObject({ latest: "1.2.0" });
+  });
+
+  it("does NOT retry a generic CLI failure", async () => {
+    installFakeCli((_args, CliError) =>
+      Promise.reject(
+        new CliError(
+          {
+            message: "registry unreachable",
+            code: "E_REGISTRY_UNREACHABLE",
+            details: null,
+            exitCode: 1,
+            stderrTail: "",
+          },
+          null,
+        ),
+      ),
+    );
+    const handler = await availableHandler();
+
+    await expect(handler(null, { includePreReleases: false })).rejects.toThrow(
+      "registry unreachable",
+    );
+    expect(bundledCliCalls).toHaveLength(1);
+  });
+
+  it("does NOT retry when an unrelated option is the unknown one", async () => {
+    // The refusal names a DIFFERENT flag, so it is a caller bug rather than
+    // version skew and must surface rather than trigger a second run.
+    installFakeCli((_args, CliError) =>
+      Promise.reject(
+        new CliError(
+          {
+            message: "unknown option '--totally-unrelated'",
+            code: "E_INVALID_ARGUMENT",
+            details: { commanderCode: "commander.unknownOption" },
+            exitCode: 1,
+            stderrTail: "",
+          },
+          null,
+        ),
+      ),
+    );
+    const handler = await availableHandler();
+
+    await expect(handler(null, { includePreReleases: false })).rejects.toThrow(
+      "unknown option",
+    );
+    expect(bundledCliCalls).toHaveLength(1);
+  });
+
+  it("does NOT retry an include or derive request", async () => {
+    installFakeCli(rejectUnknownOption("--include-pre-releases"));
+    const handler = await availableHandler();
+
+    await expect(handler(null, { includePreReleases: true })).rejects.toThrow(
+      "unknown option",
+    );
+    expect(bundledCliCalls).toHaveLength(1);
   });
 });

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -18,7 +18,7 @@ import type {
   HostLogsTailResult,
   HostRegistryUpdateState,
   HostRemovalState,
-  HostUpdateCheckResponse,
+  HostUpdateCheckResponseV11,
   MaintenanceDoctorProjection,
   MaintenanceInstallDispatch,
   DoctorRepairDispatch,
@@ -31,6 +31,8 @@ import type {
 import {
   hostAvailableManifestSchema,
   hostDoctorIssueSchema,
+  hostIncludePreReleasesSourceSchema,
+  type HostIncludePreReleasesSource,
 } from "@traycer/protocol/host/maintenance/index";
 import {
   readHostInstallRecordAtPath,
@@ -117,6 +119,130 @@ export function optionalString(raw: unknown, key: string): string | null {
 export function optionalBoolean(raw: unknown, key: string): boolean {
   if (!isPlainObject(raw)) return false;
   return raw[key] === true;
+}
+
+/**
+ * A tri-state flag off the IPC wire: `true`, `false`, or absent.
+ *
+ * Distinct from `optionalBoolean`, which folds absent and `false` together.
+ * That fold is right for a plain switch and wrong for the catalog override,
+ * where the two are different REQUESTS: absent asks the CLI to derive
+ * inclusion from the installed host, and `false` overrides that derivation.
+ * Reading an unchecked filter as absent is what would leave an RC host still
+ * listing release candidates after the user unticked the box.
+ *
+ * Anything that is not a boolean reads as absent — the renderer omits the key
+ * for the derive state, and `structuredClone` across the context bridge drops
+ * an explicitly-undefined property anyway, so absence is the only form that
+ * state can arrive in.
+ */
+export function triStateBoolean(
+  raw: unknown,
+  key: string,
+): boolean | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const value = raw[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+/**
+ * `host available`'s catalog args for a tri-state override.
+ *
+ * Mirrors the host's own `availableArgsForOverride` resolver: absent passes NO
+ * flag so the CLI derives the default, and explicit false passes the NEGATIVE
+ * flag rather than omitting one. Both lanes below answer the same question as
+ * that resolver over the same producer, so they must spell it the same way.
+ */
+function availableArgsForOverride(
+  includePreReleases: boolean | undefined,
+): readonly string[] {
+  const base = ["host", "available", "--json"];
+  if (includePreReleases === undefined) return base;
+  return includePreReleases
+    ? [...base, "--include-pre-releases"]
+    : [...base, NO_INCLUDE_PRE_RELEASES_FLAG];
+}
+
+/** The flag only a CLI new enough to know explicit exclusion will accept. */
+const NO_INCLUDE_PRE_RELEASES_FLAG = "--no-include-pre-releases";
+
+/**
+ * Whether the CLI failed specifically because it does not KNOW that flag.
+ *
+ * Positive identification, never a generic catch: retrying an unrelated
+ * failure would mask a real fault behind a silent second run. Two signals,
+ * both naming the flag, so an unknown OTHER option (a caller bug rather than
+ * version skew) does not trigger a retry either:
+ *
+ * 1. the `--json` envelope's `details.commanderCode` — the CLI entry's
+ *    `applyRunnerErrorRouting` puts commander's own `commander.unknownOption`
+ *    there deliberately, and `TraycerCliError` carries it through as `details`;
+ * 2. failing that, commander's message text (or the stderr tail), for a CLI old
+ *    enough to predate that routing and refuse in raw stderr.
+ *
+ * Mirrors `rejectedUnknownFlag` in the host's own
+ * `host-maintenance-resolvers.ts`. The duplication is forced — separate repos,
+ * no shared module spans them — and both are keyed off the same two facts.
+ */
+function rejectedUnknownFlag(err: unknown): boolean {
+  if (!(err instanceof TraycerCliError)) return false;
+  const details = isPlainObject(err.details) ? err.details : {};
+  if (
+    details.commanderCode === "commander.unknownOption" &&
+    err.message.includes(NO_INCLUDE_PRE_RELEASES_FLAG)
+  ) {
+    return true;
+  }
+  return (
+    mentionsUnknownOption(err.message) || mentionsUnknownOption(err.stderrTail)
+  );
+}
+
+function mentionsUnknownOption(text: string): boolean {
+  return (
+    text.includes("unknown option") &&
+    text.includes(NO_INCLUDE_PRE_RELEASES_FLAG)
+  );
+}
+
+/**
+ * The CLI envelope's resolved inclusion and provenance, or a fail-closed
+ * reconstruction from the request when this CLI predates them.
+ *
+ * Same rule and same fallback as the host resolver's `parseAvailableInclusion`
+ * — including its refusal to ever synthesise `installed-rc`, which asserts a
+ * derivation only the CLI can have performed.
+ */
+function readCliInclusion(
+  payload: unknown,
+  requested: boolean | undefined,
+): {
+  readonly effectiveIncludePreReleases: boolean;
+  readonly includePreReleasesSource: HostIncludePreReleasesSource;
+} {
+  const record = isPlainObject(payload) ? payload : {};
+  const source = hostIncludePreReleasesSourceSchema.safeParse(
+    record.includePreReleasesSource,
+  );
+  const effective = record.includePreReleases;
+  if (source.success && typeof effective === "boolean") {
+    return {
+      effectiveIncludePreReleases: effective,
+      includePreReleasesSource: source.data,
+    };
+  }
+  if (requested === undefined) {
+    return {
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default",
+    };
+  }
+  return {
+    effectiveIncludePreReleases: requested,
+    includePreReleasesSource: requested
+      ? "explicit-include"
+      : "explicit-exclude",
+  };
 }
 
 function optionalNumber(raw: unknown, key: string): number | null {
@@ -1172,17 +1298,27 @@ export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
   bridge.handleInvoke(
     RunnerHostInvoke.traycerHostAvailable,
     async (_event, raw: unknown) => {
-      const includePreReleases = optionalBoolean(raw, "includePreReleases");
-      const args = [
-        "host",
-        "available",
-        "--json",
-        ...(includePreReleases ? ["--include-pre-releases"] : []),
-      ];
+      const requested = triStateBoolean(raw, "includePreReleases");
       try {
-        const result = await runTraycerCliJson<unknown>(args);
-        return projectAvailableSnapshot(result);
+        return projectAvailableSnapshot(
+          await runTraycerCliJson<unknown>(availableArgsForOverride(requested)),
+        );
       } catch (err) {
+        // ONE retry, only for an explicit exclusion this CLI is too old to
+        // spell, and only on a positively identified unknown-option refusal.
+        // Unlike the maintenance lanes below, this one resolves the DISCOVERED
+        // manifest/PATH CLI (`runTraycerCliJson`, not the bundled
+        // version-matched one), so it can be older than the app driving it.
+        // Dropping the flag is not a degradation: a CLI that does not know it
+        // also predates derived defaults, so its no-flag behaviour is already
+        // stable-only — what explicit false asked for.
+        if (requested === false && rejectedUnknownFlag(err)) {
+          return projectAvailableSnapshot(
+            await runTraycerCliJson<unknown>(
+              availableArgsForOverride(undefined),
+            ),
+          );
+        }
         // Dev builds reject this command with `E_HOST_VERIFY_FAILED`
         // because no trusted signing keys are bundled. Surface that as an
         // empty version list rather than leaking the CLI's stderr to the
@@ -1216,16 +1352,11 @@ export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
 
   bridge.handleInvoke(
     RunnerHostInvoke.traycerMaintenanceUpdateCheck,
-    async (_event, raw: unknown): Promise<HostUpdateCheckResponse> => {
+    async (_event, raw: unknown): Promise<HostUpdateCheckResponseV11> => {
       const expectedHostId = optionalString(raw, "expectedHostId") ?? "";
       return fencedLocalHostRead(bridge, expectedHostId, async () => {
-        const includePreReleases = optionalBoolean(raw, "includePreReleases");
-        const args = [
-          "host",
-          "available",
-          "--json",
-          ...(includePreReleases ? ["--include-pre-releases"] : []),
-        ];
+        const requested = triStateBoolean(raw, "includePreReleases");
+        const args = availableArgsForOverride(requested);
         let payload: unknown;
         try {
           payload = await runBundledTraycerCliJson<unknown>(args);
@@ -1254,7 +1385,16 @@ export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
           );
           return { outcome: "invalid-output" };
         }
-        return { outcome: "ok", manifest: manifest.data };
+        // The CLI envelope's own resolved inclusion and provenance, preserved
+        // rather than re-derived. This lane answers the same wire contract as
+        // the host's `host.update.check` resolver, and dropping the metadata
+        // here would make the Settings explanation appear on a remote host and
+        // vanish on a local one for identical CLI output.
+        return {
+          outcome: "ok",
+          manifest: manifest.data,
+          ...readCliInclusion(payload, requested),
+        };
       });
     },
   );

--- a/clients/desktop/src/electron-preload/host-management-bridge.ts
+++ b/clients/desktop/src/electron-preload/host-management-bridge.ts
@@ -22,7 +22,7 @@ import type {
   HostRestartRequestResult,
   HostTrayCommand,
   HostUninstallResult,
-  HostUpdateCheckResponse,
+  HostUpdateCheckResponseV11,
   InstallVersionOk,
   MaintenanceDoctorProjection,
   MaintenanceInstallDispatch,
@@ -93,7 +93,7 @@ export interface HostManagementBridgeSurface {
   // response shapes, classified in main (see `host-management-ipc.ts`).
   maintenanceUpdateCheck(
     input: HostAvailableVersionsInput & { readonly expectedHostId: string },
-  ): Promise<HostUpdateCheckResponse>;
+  ): Promise<HostUpdateCheckResponseV11>;
   maintenanceDoctor(input: {
     readonly expectedHostId: string;
   }): Promise<MaintenanceDoctorProjection>;
@@ -214,7 +214,7 @@ export function buildHostManagementBridge(): HostManagementBridgeSurface {
       ipcRenderer.invoke(RunnerHostInvoke.traycerMaintenanceUpdateCheck, {
         includePreReleases,
         expectedHostId,
-      }) as Promise<HostUpdateCheckResponse>,
+      }) as Promise<HostUpdateCheckResponseV11>,
     maintenanceDoctor: ({ expectedHostId }) =>
       ipcRenderer.invoke(RunnerHostInvoke.traycerMaintenanceDoctor, {
         expectedHostId,

--- a/clients/desktop/src/ipc-contracts/host-management-types.ts
+++ b/clients/desktop/src/ipc-contracts/host-management-types.ts
@@ -59,5 +59,5 @@ export type {
 // and the preload keep their single ipc-contracts import path.
 export type {
   HostGetInstallationInfoResponse,
-  HostUpdateCheckResponse,
+  HostUpdateCheckResponseV11,
 } from "@traycer/protocol/host/maintenance/index";

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -60,7 +60,7 @@ import type {
 } from "@traycer-clients/shared/platform/runner-host";
 import type {
   HostGetInstallationInfoResponse,
-  HostUpdateCheckResponse,
+  HostUpdateCheckResponseV11,
 } from "../ipc-contracts/host-management-types";
 import type {
   AccessibilityThemeSnapshot,
@@ -329,7 +329,7 @@ export interface DesktopHostManagementBridge {
   cliManifest(): Promise<CliInstallManifestSnapshot | null>;
   maintenanceUpdateCheck(
     input: HostAvailableVersionsInput & { readonly expectedHostId: string },
-  ): Promise<HostUpdateCheckResponse>;
+  ): Promise<HostUpdateCheckResponseV11>;
   maintenanceDoctor(input: {
     readonly expectedHostId: string;
   }): Promise<MaintenanceDoctorProjection>;

--- a/clients/gui-app/src/components/settings/host-scope/__tests__/use-host-scope-maintenance-fallback.test.tsx
+++ b/clients/gui-app/src/components/settings/host-scope/__tests__/use-host-scope-maintenance-fallback.test.tsx
@@ -102,6 +102,8 @@ function makeClient(input: {
           if (rpcCalls !== undefined) rpcCalls.push("host.update.check");
           return {
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("rpc-only-1.0.0"),
           };
         },
@@ -161,6 +163,8 @@ describe("useHostScopeFor local-maintenance fallback construction", () => {
     const maintenanceUpdateCheck = vi.fn(() =>
       Promise.resolve({
         outcome: "ok" as const,
+        effectiveIncludePreReleases: false,
+        includePreReleasesSource: "stable-default" as const,
         manifest: updateCheckManifest("bridge-1.2.0"),
       }),
     );
@@ -186,6 +190,8 @@ describe("useHostScopeFor local-maintenance fallback construction", () => {
     });
     expect(answer).toEqual({
       outcome: "ok",
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: updateCheckManifest("bridge-1.2.0"),
     });
     expect(maintenanceUpdateCheck).toHaveBeenCalledTimes(1);
@@ -198,6 +204,8 @@ describe("useHostScopeFor local-maintenance fallback construction", () => {
     const maintenanceUpdateCheck = vi.fn(() =>
       Promise.resolve({
         outcome: "ok" as const,
+        effectiveIncludePreReleases: false,
+        includePreReleasesSource: "stable-default" as const,
         manifest: updateCheckManifest("bridge-1.2.0"),
       }),
     );
@@ -221,6 +229,8 @@ describe("useHostScopeFor local-maintenance fallback construction", () => {
     });
     expect(answer).toEqual({
       outcome: "ok",
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: updateCheckManifest("rpc-only-1.0.0"),
     });
     expect(rpcCalls).toEqual(["host.update.check"]);

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-fixups.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-fixups.test.tsx
@@ -176,6 +176,8 @@ describe("<HostSettingsPanel /> Overview updates region — sticky vs transient 
               ? { outcome: "cli-unavailable" as const }
               : {
                   outcome: "ok" as const,
+                  effectiveIncludePreReleases: false,
+                  includePreReleasesSource: "stable-default" as const,
                   manifest: updateCheckManifest("1.6.0"),
                 },
           ),
@@ -212,6 +214,8 @@ describe("<HostSettingsPanel /> Overview updates region — sticky vs transient 
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.6.0"),
           }),
         "host.update.install": () =>
@@ -246,6 +250,8 @@ describe("<HostSettingsPanel /> Overview updates region — sticky vs transient 
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.6.0"),
           }),
         "host.update.install": () =>
@@ -457,6 +463,8 @@ describe("<HostSettingsPanel /> Overview arm-time capture — the remaining RPCs
           armedHostCalls += 1;
           return {
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.6.0"),
           };
         },
@@ -470,6 +478,8 @@ describe("<HostSettingsPanel /> Overview arm-time capture — the remaining RPCs
           otherHostCalls += 1;
           return Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.7.0"),
           });
         },
@@ -535,6 +545,8 @@ describe("<HostSettingsPanel /> Overview arm-time capture — the remaining RPCs
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.6.0"),
           }),
         "host.update.install": async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-maintenance-fallback.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-maintenance-fallback.test.tsx
@@ -336,6 +336,8 @@ function mountFallbackOverview(options: {
         rpcCheckCalls.count += 1;
         return {
           outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
           manifest: updateCheckManifest(RPC_CHECK_VERSION),
         };
       },
@@ -357,6 +359,8 @@ function mountFallbackOverview(options: {
     maintenanceUpdateCheck: vi.fn(() =>
       Promise.resolve({
         outcome: "ok" as const,
+        effectiveIncludePreReleases: false,
+        includePreReleasesSource: "stable-default" as const,
         manifest: updateCheckManifest(BRIDGE_CHECK_VERSION),
       }),
     ),

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-mutations.test.tsx
@@ -1323,6 +1323,8 @@ describe("<HostSettingsPanel /> Overview update-install degrade", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.6.0"),
           }),
         "host.update.install": () =>

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-test-support.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-test-support.ts
@@ -206,6 +206,8 @@ export function buildOverviewHostFixture(options: {
     }),
     "host.update.check": () => ({
       outcome: "ok" as const,
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: {
         schemaVersion: 1 as const,
         generatedAt: "2026-08-12T00:00:00Z",

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -30,6 +30,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
+import type { ReactElement } from "react";
 import {
   act,
   cleanup,
@@ -38,6 +39,7 @@ import {
   screen,
   waitFor,
   within,
+  type RenderResult,
 } from "@testing-library/react";
 import { toast } from "sonner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -120,20 +122,34 @@ async function waitForButton(name: string): Promise<HTMLElement> {
   return screen.findByRole("button", { name });
 }
 
-function renderPanel(): void {
-  render(
-    <QueryClientProvider
-      client={
-        new QueryClient({
-          defaultOptions: { queries: { retry: false, gcTime: 0 } },
-        })
-      }
-    >
+/**
+ * The panel tree, over a caller-supplied query client.
+ *
+ * Split from `renderPanel` so a test can RE-render the same element with the
+ * same client — which is what a scoped-host switch actually is. Building a
+ * fresh client would tear the subtree down instead, and a test whose subtree
+ * remounts cannot observe state that is supposed to survive a remount or be
+ * cleared without one.
+ */
+function panelElement(client: QueryClient): ReactElement {
+  return (
+    <QueryClientProvider client={client}>
       <RunnerHostProvider runnerHost={makeRunnerHost()}>
         <HostSettingsPanel />
       </RunnerHostProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+}
+
+function newQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function renderPanel(): RenderResult & { readonly queryClient: QueryClient } {
+  const queryClient = newQueryClient();
+  return { ...render(panelElement(queryClient)), queryClient };
 }
 
 /**
@@ -143,6 +159,13 @@ function renderPanel(): void {
  * cases here assemble the manifest by hand instead of growing a second
  * exported helper for a shape only this file needs.
  */
+/** The provenance an explicit override produces — never `installed-rc`. */
+function sourceForExplicit(
+  include: boolean,
+): "explicit-include" | "explicit-exclude" {
+  return include ? "explicit-include" : "explicit-exclude";
+}
+
 function multiVersionManifest(
   versions: readonly string[],
 ): HostAvailableManifest {
@@ -243,6 +266,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
           checkCalls += 1;
           return Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(["1.7.0", "1.6.0"]),
           });
         },
@@ -278,7 +303,10 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
     // available` decides what counts as a pre-release, and a client-side
     // predicate would disagree with the CLI the first time a build id stopped
     // being semver.
-    const requests: boolean[] = [];
+    // `boolean | undefined`, because ABSENT is one of the three states this
+    // records - a `boolean[]` could not tell the default apart from an
+    // explicit exclude, which is the distinction under test.
+    const requests: Array<boolean | undefined> = [];
     const fixture = buildOverviewHostFixture({
       hostId: "host-a",
       isLocalMachine: true,
@@ -288,6 +316,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
           requests.push(req.includePreReleases);
           return Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(
               req.includePreReleases ? ["1.8.0-rc.1", "1.7.0"] : ["1.7.0"],
             ),
@@ -302,19 +332,23 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
 
     // NO "Check now" click, and its removal is load-bearing rather than tidying.
     // The check fires on mount now, so a click here would race its own setup:
-    // whether it produces a SECOND `false` request or silently joins the
-    // in-flight one is a matter of timing, and `toEqual([false])` passes on only
-    // one of those. That the list arrives at all without a click is the
+    // whether it produces a SECOND default request or silently joins the
+    // in-flight one is a matter of timing, and the assertion below passes on
+    // only one of those. That the list arrives at all without a click is the
     // behaviour this line now also pins.
     await openHostOverviewAdvanced();
-    await waitFor(() => expect(requests).toEqual([false]));
+    // ABSENT, not `false`. The first load states no override at all, which is
+    // what lets the host derive inclusion from its own installed version; a
+    // `false` here would be an explicit exclusion nobody asked for, and would
+    // hide the RC line from exactly the hosts that should see it.
+    await waitFor(() => expect(requests).toEqual([undefined]));
 
     fireEvent.click(
       screen.getByRole("checkbox", { name: "Include release candidates" }),
     );
 
     // A SECOND request, carrying the flag — not the same answer re-filtered.
-    await waitFor(() => expect(requests).toEqual([false, true]));
+    await waitFor(() => expect(requests).toEqual([undefined, true]));
     await waitFor(() => {
       expect(
         within(screen.getByTestId("host-version-rows")).getByText(
@@ -343,6 +377,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(["1.7.0", "1.6.0", "1.5.0"]),
           }),
         "host.update.install": async (req) => {
@@ -415,6 +451,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(["1.7.0", "1.6.0", "1.5.0"]),
           }),
         "host.update.install": (req) => {
@@ -472,7 +510,12 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
       hostVersion: "1.0.0",
       overrideHandlers: {
         "host.update.check": () =>
-          Promise.resolve({ outcome: "ok" as const, manifest: yankedLatest }),
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: yankedLatest,
+          }),
       },
     });
     recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
@@ -512,6 +555,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: soleKeyManifest("1.7.0", "linux-x64"),
           }),
       },
@@ -550,6 +595,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: soleKeyManifest("1.7.0", "win32-x64"),
           }),
       },
@@ -589,6 +636,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(["1.6.0"]),
           }),
       },
@@ -637,6 +686,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(["1.6.0"]),
           }),
         "host.update.install": () =>
@@ -685,6 +736,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(["1.6.0"]),
           }),
       },
@@ -740,6 +793,8 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: multiVersionManifest(versions),
           }),
       },
@@ -773,5 +828,403 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
     expect(screen.getByTestId("host-version-rows-toggle").textContent).toBe(
       "Show recent",
     );
+  });
+
+  /**
+   * The v1.1 tri-state, from the checkbox down to the wire.
+   *
+   * The state under test is the one a boolean could not express: a host whose
+   * DEFAULT catalog already includes release candidates, where "unchecked" and
+   * "never touched" have to reach the host as different requests or unticking
+   * the box does nothing at all (critique finding 7).
+   */
+  it("sends an explicit exclude when the box is unticked on a host whose default includes RCs", async () => {
+    const requests: Array<boolean | undefined> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "2.0.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": (req) => {
+          requests.push(req.includePreReleases);
+          // What an RC host's CLI answers: with no flag it DERIVES inclusion
+          // from the install and says so; an explicit flag is obeyed verbatim.
+          const derived = req.includePreReleases === undefined;
+          const included = derived || req.includePreReleases === true;
+          const source = derived
+            ? ("installed-rc" as const)
+            : sourceForExplicit(req.includePreReleases === true);
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: included,
+            includePreReleasesSource: source,
+            manifest: multiVersionManifest(
+              included ? ["2.0.0-rc.2", "1.7.0"] : ["1.7.0"],
+            ),
+          });
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await openHostOverviewAdvanced();
+    await waitFor(() => expect(requests).toEqual([undefined]));
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Include release candidates",
+    });
+    // TICKED before any interaction: the box reports what the catalog did, and
+    // this catalog included RCs. Rendering it unticked beside visible RC rows
+    // would be the control contradicting the list under it.
+    await waitFor(() =>
+      expect(checkbox.getAttribute("aria-checked")).toBe("true"),
+    );
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId("host-version-rows")).getByText(
+          "v2.0.0-rc.2",
+        ),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(checkbox);
+
+    // FALSE, not absent. Absent would re-ask the same question and get the
+    // same RC rows back.
+    await waitFor(() => expect(requests).toEqual([undefined, false]));
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId("host-version-rows")).queryByText(
+          "v2.0.0-rc.2",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  it("explains an RC-derived catalog, and says nothing when provenance is not installed-rc", async () => {
+    async function renderWithSource(
+      source: "installed-rc" | "stable-default",
+      hostId: string,
+    ): Promise<void> {
+      const fixture = buildOverviewHostFixture({
+        hostId,
+        isLocalMachine: true,
+        hostVersion: "2.0.0-rc.1",
+        overrideHandlers: {
+          "host.update.check": () =>
+            Promise.resolve({
+              outcome: "ok" as const,
+              effectiveIncludePreReleases: source === "installed-rc",
+              includePreReleasesSource: source,
+              manifest: multiVersionManifest(["1.7.0"]),
+            }),
+        },
+      });
+      recordNegotiatedHostMethods(hostId, ALL_OVERVIEW_METHODS);
+      hostBindingMock.current = { hostClient: fixture.client };
+      scopeOverrides.current = scopeFrom(hostId, fixture);
+      renderPanel();
+      await openHostOverviewAdvanced();
+    }
+
+    await renderWithSource("installed-rc", "host-a");
+    const reason = await screen.findByTestId(
+      "host-overview-include-pre-releases-reason",
+    );
+    // Provenance, phrased as a fact about the host. It must not imply a saved
+    // preference, because there is none to turn off.
+    expect(reason.textContent).toContain("2.0.0-rc.1");
+
+    cleanup();
+
+    // `stable-default` is also what the v1.0->v1.1 bridge reports for an old
+    // host, which is exactly why the copy is gated on `installed-rc` alone:
+    // that value is unreachable from a peer that derived nothing, so a
+    // negotiated v1.0 response can never produce an explanation.
+    await renderWithSource("stable-default", "host-b");
+    expect(
+      screen.queryByTestId("host-overview-include-pre-releases-reason"),
+    ).toBeNull();
+  });
+
+  it("offers matching stable over a later same-line RC when latest still lags", async () => {
+    // `latest` is stable-CHANNEL metadata. On a host running 2.0.0-rc.1 it can
+    // still read 1.9.0 while 2.0.0 is published, so a summary keyed off
+    // `latest` would offer a DOWNGRADE - or, once the strictly-newer gate
+    // rejected it, claim the host was up to date with its own stable sitting
+    // in the list. Matching stable also wins over the later RC, which is what
+    // makes implicit following terminate.
+    const manifest = multiVersionManifest(["2.0.0-rc.2", "2.0.0", "1.9.0"]);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "2.0.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest: { ...manifest, latest: "1.9.0" },
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.getByText("v2.0.0 is available.")).toBeTruthy();
+    });
+  });
+
+  it("asks a newly scoped host with no override, discarding the previous host's filter", async () => {
+    // The override is a decision about ONE machine, and this pins the
+    // OBSERVABLE rule: whatever host Settings scopes to next is asked with no
+    // override, so it gets its own derived default.
+    //
+    // Two mechanisms enforce that today and this test does not distinguish
+    // them: the panel remounts under a host key, AND `useHostOverviewUpdates`
+    // clears the override when `hostId` changes. The hook-level clear is the
+    // backstop for the day the key changes — isolating it would need the
+    // condition-poll coordinator harness the panel provides, so it is covered
+    // here at the level a user would notice.
+    const requestsByHost: Array<{
+      readonly hostId: string;
+      readonly includePreReleases: boolean | undefined;
+    }> = [];
+    function fixtureFor(hostId: string): OverviewHostFixture {
+      const fixture = buildOverviewHostFixture({
+        hostId,
+        isLocalMachine: true,
+        hostVersion: "2.0.0-rc.1",
+        overrideHandlers: {
+          "host.update.check": (req) => {
+            requestsByHost.push({
+              hostId,
+              includePreReleases: req.includePreReleases,
+            });
+            return Promise.resolve({
+              outcome: "ok" as const,
+              effectiveIncludePreReleases: req.includePreReleases !== false,
+              includePreReleasesSource:
+                req.includePreReleases === undefined
+                  ? ("installed-rc" as const)
+                  : ("explicit-exclude" as const),
+              manifest: multiVersionManifest(["1.7.0"]),
+            });
+          },
+        },
+      });
+      recordNegotiatedHostMethods(hostId, ALL_OVERVIEW_METHODS);
+      return fixture;
+    }
+
+    const hostA = fixtureFor("host-a");
+    hostBindingMock.current = { hostClient: hostA.client };
+    scopeOverrides.current = scopeFrom("host-a", hostA);
+    const view = renderPanel();
+
+    await openHostOverviewAdvanced();
+    await waitFor(() =>
+      expect(requestsByHost).toEqual([
+        { hostId: "host-a", includePreReleases: undefined },
+      ]),
+    );
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Include release candidates" }),
+    );
+    await waitFor(() =>
+      expect(requestsByHost).toContainEqual({
+        hostId: "host-a",
+        includePreReleases: false,
+      }),
+    );
+
+    const hostB = fixtureFor("host-b");
+    hostBindingMock.current = { hostClient: hostB.client };
+    scopeOverrides.current = scopeFrom("host-b", hostB);
+    view.rerender(panelElement(view.queryClient));
+
+    // host-b is asked with NO override — host-a's exclusion did not follow it.
+    await waitFor(() =>
+      expect(
+        requestsByHost.filter((entry) => entry.hostId === "host-b"),
+      ).toEqual([{ hostId: "host-b", includePreReleases: undefined }]),
+    );
+  });
+
+  it("does not claim an abandoned-line RC is on the latest version while a newer row is listed", async () => {
+    // The regression this batch created: with `installed-rc` and NOTHING on
+    // the installed line, `targetCandidates` is empty, so the summary read
+    // "This host is running the latest version." — directly above an enabled,
+    // installable row for a newer version on another line.
+    //
+    // Not moving automatically is deliberate (a follower must not be pushed
+    // onto a line nobody put it on). Saying it is already latest is not.
+    const manifest = multiVersionManifest(["2.1.0", "1.9.0"]);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "2.0.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest,
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("This host is running the latest version."),
+      ).toBeNull();
+    });
+    const summary = await screen.findByText(/2\.1\.0 is available/);
+    // Names the newer version AND says it will not be taken automatically, so
+    // the sentence and the enabled row below it agree.
+    expect(summary.textContent).toContain("2.0.0-rc.1");
+    expect(summary.textContent).toContain("won't update to it automatically");
+
+    // The manual route stays open: the newer row is present and installable.
+    await openHostOverviewAdvanced();
+    const rows = within(await screen.findByTestId("host-version-rows"));
+    const row = rowFor(rows.getAllByRole("listitem"), "2.1.0");
+    expect(
+      within(row)
+        .getByRole("button", { name: "Install 2.1.0" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+  });
+
+  it("still says up to date when the abandoned line really is the newest build", async () => {
+    // The other half: no same-line candidate AND nothing newer anywhere. The
+    // original sentence is correct here and must survive.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "2.0.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest: multiVersionManifest(["1.9.0"]),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("This host is running the latest version."),
+      ).toBeTruthy();
+    });
+  });
+
+  it("falls back to the HIGHEST later same-line RC when the line's stable is unusable", async () => {
+    // Exercises the ordered candidate list end to end: matching stable first,
+    // then later RCs newest-first. The stable is yanked, so the gate loop must
+    // walk past it — and must land on rc.3 rather than rc.2, which is what the
+    // ordering (and its now-lawful comparator) is for.
+    const base = multiVersionManifest([
+      "2.0.0",
+      "2.0.0-rc.3",
+      "2.0.0-rc.2",
+      "1.9.0",
+    ]);
+    const manifest = {
+      ...base,
+      latest: "1.9.0",
+      versions: base.versions.map((entry) =>
+        entry.version === "2.0.0" ? { ...entry, yanked: true } : entry,
+      ),
+    };
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "2.0.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest,
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.getByText("v2.0.0-rc.3 is available.")).toBeTruthy();
+    });
+  });
+
+  it("does not tell a STABLE host it follows a release line when explicit include surfaces a newer RC", async () => {
+    // The stranded-line sentence explains a mechanism — "follows its own
+    // release line" — that applies only to a host whose catalog was DERIVED
+    // from an installed release candidate. This host is stable, on the newest
+    // stable, and sees an RC row only because the user ticked the box. Gating
+    // the copy on `upToDate` alone would have narrated that state with a
+    // mechanism the host is not subject to.
+    const base = multiVersionManifest(["2.0.0-rc.1", "1.9.0"]);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.9.0",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            // `latest` is the STABLE the host is already on; the RC is newer
+            // but is not what the stable channel points at.
+            manifest: { ...base, latest: "1.9.0" },
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("This host is running the latest version."),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText(/follows its own release line/)).toBeNull();
+
+    // The RC the user asked to see is still there and still installable — the
+    // gate changes the sentence, never the manual route.
+    await openHostOverviewAdvanced();
+    const rows = within(await screen.findByTestId("host-version-rows"));
+    const row = rowFor(rows.getAllByRole("listitem"), "2.0.0-rc.1");
+    expect(
+      within(row)
+        .getByRole("button", { name: "Install 2.0.0-rc.1" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/host-overview-advanced.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-advanced.tsx
@@ -94,8 +94,18 @@ export interface VersionPickerProps {
   readonly totalCount: number;
   readonly showAll: boolean;
   readonly onToggleShowAll: () => void;
+  /**
+   * What the catalog actually did — the host's resolved inclusion until the
+   * user overrides it, not a preference this checkbox owns.
+   */
   readonly includePreReleases: boolean;
   readonly onIncludePreReleasesChange: (value: boolean) => void;
+  /**
+   * Why the catalog resolved that way, when it is worth saying. Non-null only
+   * for a host that derived inclusion from its own installed release
+   * candidate; see `describeIncludePreReleasesSource`.
+   */
+  readonly includePreReleasesExplanation: string | null;
   readonly installingVersion: string | null;
   readonly disabled: boolean;
   readonly onInstall: (version: string) => void;
@@ -153,6 +163,14 @@ function VersionPicker(props: VersionPickerProps): ReactNode {
         >
           <span className="text-foreground">Include release candidates</span>
           <span>Show RC host versions when choosing a version.</span>
+          {/* Provenance, and worded as a fact about the host rather than a
+              setting: there is no stored preference behind this state, so copy
+              implying one would point at a switch that does not exist. */}
+          {props.includePreReleasesExplanation !== null ? (
+            <span data-testid="host-overview-include-pre-releases-reason">
+              {props.includePreReleasesExplanation}
+            </span>
+          ) : null}
         </label>
       </div>
       {props.awaitingFirstCheck ? (

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -583,6 +583,10 @@ export function HostOverviewPanel(props: {
   const updates = useHostOverviewUpdates({
     client,
     hostName: displayName,
+    // Identifies whose filter the RC override belongs to. `HostScopeGate` can
+    // swap the scoped host under a mounted subtree, and an override carried
+    // across that swap would apply one machine's decision to another.
+    hostId: scope.hostId,
     installedVersion: view.hostVersion,
     platformKey: host?.platform ?? null,
     // The check reads on its own now, so this gate is load-bearing rather than

--- a/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
@@ -261,22 +261,35 @@ export function useHostIdentitySet(
  * newest question rather than queueing.
  *
  * `includePreReleases` rides in `params`, which puts it in the QUERY KEY: the
- * two filters are two cache entries, so toggling the checkbox asks a genuinely
- * different question and can never show one filter's list under the other's
- * label. A host too old to know the field ignores it and answers with the stable
- * list — see the request schema for why that degrades to a filter that appears
- * not to work rather than to an error.
+ * THREE catalog states are three cache entries, so changing the filter asks a
+ * genuinely different question and can never show one filter's list under
+ * another's label. A host too old to know the field ignores it and answers with
+ * the stable list — see the request schema for why that degrades to a filter
+ * that appears not to work rather than to an error.
+ *
+ * The derive state OMITS the key rather than sending a value for it, and both
+ * halves of that matter. On the wire it is what the v1.1 request schema
+ * requires: within one major there is no request-downgrade bridge, so a v1.1
+ * client on a v1.0 host projects by parsing with the older schema, and a
+ * literal `null` would fail that parse and turn every default catalog load
+ * against an already-shipped host into `DOWNGRADE_UNSUPPORTED`. In the cache it
+ * keeps the default's key distinct from explicit-exclude's, which is the whole
+ * point of the tri-state — on an RC host those two produce different lists.
  */
 export function useHostUpdateCheckQuery(input: {
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly enabled: boolean;
-  readonly includePreReleases: boolean;
+  /** `undefined` = follow the host's derived default. */
+  readonly includePreReleases: boolean | undefined;
 }) {
   return useHostQuery<HostRpcRegistry, "host.update.check">({
     cacheKeyIdentity: undefined,
     client: input.client,
     method: "host.update.check",
-    params: { includePreReleases: input.includePreReleases },
+    params:
+      input.includePreReleases === undefined
+        ? {}
+        : { includePreReleases: input.includePreReleases },
     options: {
       enabled: input.enabled,
       // Long, deliberately. This is the one read on the page that costs a

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -1,10 +1,18 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import { compareHostVersions } from "@traycer-clients/shared/host-version/compare-host-versions";
+import {
+  compareHostVersions,
+  isStrictlyNewerHostVersion,
+} from "@traycer-clients/shared/host-version/compare-host-versions";
+import {
+  isMatchingStableRelease,
+  isSameReleaseLine,
+} from "@traycer-clients/shared/host-version/release-line";
 import type {
   HostAvailableManifest,
-  HostUpdateCheckResponse,
+  HostIncludePreReleasesSource,
+  HostUpdateCheckResponseV11,
 } from "@traycer/protocol/host/maintenance/index";
 import type { VersionPickerProps } from "@/components/settings/panels/host-overview-advanced";
 import type { HostVersionRow } from "@/components/settings/panels/host-version-rows";
@@ -62,6 +70,8 @@ import type { HostRpcRegistry } from "@/lib/host";
 export function useHostOverviewUpdates(input: {
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly hostName: string;
+  /** The scoped host this panel is showing — see the override reset below. */
+  readonly hostId: string | null;
   readonly installedVersion: string | null;
   readonly platformKey: string | null;
   /** Whether this host is worth asking at all — the page owns that gate. */
@@ -72,7 +82,25 @@ export function useHostOverviewUpdates(input: {
 }): HostOverviewUpdatesState {
   const { client, hostName, installedVersion } = input;
   const [showAllVersions, setShowAllVersions] = useState(false);
-  const [includePreReleases, setIncludePreReleases] = useState(false);
+  // `undefined` until the user touches the checkbox: the DEFAULT is the host's
+  // own derivation, not a value this component picked. Only a deliberate
+  // interaction produces `true`/`false`, which is what makes unchecking able to
+  // exclude RC rows on a host whose default includes them.
+  const [includePreReleasesOverride, setIncludePreReleasesOverride] = useState<
+    boolean | undefined
+  >(undefined);
+  // The override belongs to the host it was expressed about. Settings can swap
+  // the scoped host under a subtree `HostScopeGate` keeps mounted, and a filter
+  // carried across that swap would silently apply one machine's decision to
+  // another — worse, an explicit `false` would suppress the new host's RC rows
+  // while its checkbox rendered the reason for a host no longer on screen.
+  // Adjust-during-render on a changed input, the same shape as the discovered
+  // refusal below; an effect would render one frame under the wrong filter.
+  const [overrideHostId, setOverrideHostId] = useState(input.hostId);
+  if (overrideHostId !== input.hostId) {
+    setOverrideHostId(input.hostId);
+    setIncludePreReleasesOverride(undefined);
+  }
   // The INSTALL side's two failure lifetimes, deliberately kept apart. The
   // check's equivalents are no longer state at all — they are read straight off
   // the query's latest answer below.
@@ -105,7 +133,7 @@ export function useHostOverviewUpdates(input: {
   const checkQuery = useHostUpdateCheckQuery({
     client,
     enabled: input.enabled && input.checkDegrade === null,
-    includePreReleases,
+    includePreReleases: includePreReleasesOverride,
   });
   const installMutation = useHostUpdateInstall(client);
 
@@ -187,24 +215,46 @@ export function useHostOverviewUpdates(input: {
     );
   };
 
-  const latest = manifest?.latest ?? null;
   // While the CURRENT ask is in error, the retained manifest is display
   // history, not an actionable catalog: TanStack keeps the previous data
   // beside `isError`, and deriving install affordances from it would offer
   // versions the failed check could not confirm - under a summary that says
   // the host could not be checked.
   const actionableManifest = checkQuery.isError ? null : manifest;
+  // The best STRICTLY NEWER version this catalog offers, before the yanked and
+  // platform-asset gates - what the sentence is about, where
+  // `updatableVersion` below is what the button can act on.
+  //
   // PRECEDENCE, not equality: a host running a hotfix or RC AHEAD of the
   // stable channel is not outdated, and offering Update now there submits a
   // target the CLI short-circuits as `installed-up-to-date` - an update that
-  // announces itself and performs no work. `latest` must be STRICTLY newer to
-  // offer anything; equal precedence (build-metadata differences included)
-  // and incomparable pairs both count as up to date for the SUMMARY - the
-  // picker below stays the surface for deliberate cross-channel moves.
+  // announces itself and performs no work. Equal precedence (build-metadata
+  // differences included) and incomparable pairs both count as up to date for
+  // the SUMMARY - the picker stays the surface for deliberate cross-channel
+  // moves.
+  const targetVersion = newerTargetVersion({
+    manifest,
+    installedVersion,
+    source: check.source,
+  });
+  // Read off the resolved target rather than `manifest.latest`, which for an
+  // installed-RC catalog is the WRONG pointer: `latest` tracks the stable
+  // channel, so a host on `2.0.0-rc.1` sees `1.9.0` there and would be told it
+  // was up to date while `2.0.0` sat in the same list, offerable.
   const upToDate =
-    latest !== null &&
-    installedVersion !== null &&
-    !latestIsStrictlyNewer(installedVersion, latest);
+    manifest !== null && installedVersion !== null && targetVersion === null;
+  // The one state "up to date" would misdescribe: an `installed-rc` follower
+  // whose own line has run out, while the catalog still lists something newer
+  // on ANOTHER line. Not moving is deliberate — a follower must not be pushed
+  // to a line nobody put it on — but rendering that as "running the latest
+  // version" is a false claim about the catalog the user is looking at, with
+  // an enabled row for a newer version directly beneath it.
+  const strandedOnLine = strandedLineTarget({
+    upToDate,
+    manifest,
+    installedVersion,
+    source: check.source,
+  });
   // The summary action resolves through the SAME availability checks as the
   // picker rows: a latest with no usable asset for this host is advertised
   // nowhere rather than installable in one surface and unavailable in the
@@ -213,6 +263,7 @@ export function useHostOverviewUpdates(input: {
     manifest: actionableManifest,
     installedVersion,
     platformKey: input.platformKey,
+    source: check.source,
   });
   const installingVersion = installMutation.isPending
     ? installMutation.variables.version
@@ -230,6 +281,15 @@ export function useHostOverviewUpdates(input: {
         hostName,
         upToDate,
         offerable: updatableVersion !== null,
+        // What the BUTTON will install, when it can install anything. The two
+        // differ whenever the best candidate is unusable: with a yanked
+        // `2.0.0` on the line the offer walks down to `2.0.0-rc.3`, and a
+        // sentence still naming `2.0.0` would advertise a version Update now
+        // does not install. Falls back to the bare target so the
+        // "available, but can't install it" case still names what it means.
+        targetVersion: updatableVersion ?? targetVersion,
+        strandedOnLine,
+        installedVersion,
       }),
       transientFailure,
       checking,
@@ -254,11 +314,28 @@ export function useHostOverviewUpdates(input: {
       totalCount: manifest?.versions.length ?? 0,
       showAll: showAllVersions,
       onToggleShowAll: () => setShowAllVersions((previous) => !previous),
-      includePreReleases,
+      // What the box SHOWS is what the catalog actually did, not what this
+      // component last decided. Before any interaction the override is absent,
+      // so the host's own resolved inclusion is the honest answer — on an RC
+      // host that renders the box ticked, matching the RC rows beside it.
+      // Falls back to unticked only until the first answer arrives.
+      includePreReleases: resolveCheckboxState(
+        includePreReleasesOverride,
+        check.effectiveIncludePreReleases,
+      ),
+      // The first interaction turns the absent state into an explicit one, and
+      // never returns to absent: the user has now expressed a filter, and
+      // silently reverting to the derived default would make unticking on an
+      // RC host appear to do nothing. Scope changes reset it — see above.
+      //
       // Just moves the flag. It is part of the QUERY KEY, so changing it asks
       // the host a different question by itself — no explicit re-check, and no
       // risk of the two drifting apart the way an imperative re-ask could.
-      onIncludePreReleasesChange: setIncludePreReleases,
+      onIncludePreReleasesChange: setIncludePreReleasesOverride,
+      includePreReleasesExplanation: describeIncludePreReleasesSource(
+        check.source,
+        installedVersion,
+      ),
       installingVersion,
       disabled: input.busy,
       onInstall: install,
@@ -329,33 +406,201 @@ function visibleVersionRows(input: {
  *
  * Four gates, all of which the picker enforces per row and the summary must
  * therefore enforce for its one target: the manifest must be from a check the
- * host CONFIRMED (not error-retained data), `latest` must be strictly newer
- * than what is installed, the latest entry must not be YANKED (the row
- * disables it and the CLI's `resolveAsset` refuses it before download, so an
- * offer here would dispatch an install the host is guaranteed to reject), and
- * the entry must resolve a usable asset for this host's platform.
+ * host CONFIRMED (not error-retained data), the target must be strictly newer
+ * than what is installed, its entry must not be YANKED (the row disables it and
+ * the CLI's `resolveAsset` refuses it before download, so an offer here would
+ * dispatch an install the host is guaranteed to reject), and the entry must
+ * resolve a usable asset for this host's platform.
+ *
+ * WHICH version is the target depends on how the catalog was resolved, and
+ * that is the whole reason provenance rides on the response. For an
+ * `installed-rc` DEFAULT the answer is not `manifest.latest`: `latest` is
+ * stable-CHANNEL metadata, so on a host running `2.0.0-rc.1` it can still read
+ * `1.9.0` while `2.0.0` is published — offering `latest` there would offer a
+ * DOWNGRADE, and the strictly-newer gate would then offer nothing at all.
+ * Every other provenance keeps the plain `latest` behaviour, including an
+ * explicit include: a user who asked for the broad catalog gets the broad
+ * catalog's own pointer rather than a line restriction they did not request.
  */
 function offerableLatestVersion(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly installedVersion: string | null;
   readonly platformKey: string | null;
+  readonly source: HostIncludePreReleasesSource | null;
 }): string | null {
   const { manifest } = input;
   if (manifest === null) return null;
-  const latest = manifest.latest;
-  if (
-    input.installedVersion !== null &&
-    !latestIsStrictlyNewer(input.installedVersion, latest)
-  ) {
-    return null;
+  for (const candidate of targetCandidates({
+    manifest,
+    installedVersion: input.installedVersion,
+    source: input.source,
+  })) {
+    if (
+      input.installedVersion !== null &&
+      !latestIsStrictlyNewer(input.installedVersion, candidate)
+    ) {
+      continue;
+    }
+    const entry = manifest.versions.find(
+      (version) => version.version === candidate,
+    );
+    if (entry === undefined || entry.yanked) continue;
+    const asset = platformAssetFor(entry.platforms, input.platformKey);
+    if (assetUnavailableReason(asset) === null) return candidate;
   }
-  const entry = manifest.versions.find(
-    (candidate) => candidate.version === latest,
+  return null;
+}
+
+/**
+ * The best strictly-newer version in the catalog, ignoring installability.
+ *
+ * Separate from `offerableLatestVersion` because the summary says two
+ * different things: whether an update EXISTS (this) and whether it can be
+ * installed here (that). Collapsing them would make a yanked or
+ * wrong-platform target read as "running the latest version", which is a
+ * different — and false — claim.
+ */
+function newerTargetVersion(input: {
+  readonly manifest: HostAvailableManifest | null;
+  readonly installedVersion: string | null;
+  readonly source: HostIncludePreReleasesSource | null;
+}): string | null {
+  const { manifest, installedVersion } = input;
+  if (manifest === null) return null;
+  const candidates = targetCandidates({
+    manifest,
+    installedVersion,
+    source: input.source,
+  });
+  if (installedVersion === null) return candidates[0] ?? null;
+  return (
+    candidates.find((candidate) =>
+      latestIsStrictlyNewer(installedVersion, candidate),
+    ) ?? null
   );
-  if (entry === undefined) return null;
-  if (entry.yanked) return null;
-  const asset = platformAssetFor(entry.platforms, input.platformKey);
-  return assetUnavailableReason(asset) === null ? latest : null;
+}
+
+/**
+ * The target versions to try, best first.
+ *
+ * For an `installed-rc` default this is the plan's same-line priority, and the
+ * ORDER is the termination guarantee: matching stable `X.Y.Z` outranks every
+ * later `X.Y.Z-rc.M`, so an RC that can reach its stable takes it and the next
+ * launch derives `stable-only` with nothing to undo. Later RCs on the same line
+ * follow, newest first, for the window before that stable exists.
+ *
+ * A LIST rather than one pick, because each candidate still has to clear the
+ * yanked/asset gates above — "prefer stable IF USABLE, otherwise the highest
+ * later RC" cannot be expressed by choosing before those run.
+ *
+ * Mirrors `resolveSameLineTarget` in desktop main's `host-stage-policy.ts`,
+ * which makes the same choice for background staging. The duplication is
+ * forced — that module is Electron-main-only and this one is browser-safe —
+ * but both read the release-line vocabulary from the same shared helpers, so
+ * only the ordering is restated, never what an RC or a line IS.
+ */
+function targetCandidates(input: {
+  readonly manifest: HostAvailableManifest;
+  readonly installedVersion: string | null;
+  readonly source: HostIncludePreReleasesSource | null;
+}): readonly string[] {
+  const installed = input.installedVersion;
+  if (input.source !== "installed-rc" || installed === null) {
+    return [input.manifest.latest];
+  }
+  const versions = input.manifest.versions.map((entry) => entry.version);
+  const matchingStable = versions.filter((version) =>
+    isMatchingStableRelease(version, installed),
+  );
+  // EXCLUDING the matching stable, which also satisfies both predicates below
+  // — it is on the line and strictly newer. Without this the stable is
+  // returned twice, and `offerableLatestVersion` pays for a second yanked and
+  // platform-asset probe on a candidate it already accepted or rejected.
+  const laterOnLine = versions
+    .filter(
+      (version) =>
+        !matchingStable.includes(version) &&
+        isSameReleaseLine(installed, version) &&
+        isStrictlyNewerHostVersion(version, installed),
+    )
+    .sort(compareNewestFirst);
+  return [...matchingStable, ...laterOnLine];
+}
+
+/**
+ * The newer version this host will not take on its own, or `null`.
+ *
+ * Gated on `installed-rc` PROVENANCE, not merely on there being something
+ * newer. The copy it feeds says the host "follows its own release line", and
+ * that is only true of a host whose catalog was derived from an installed
+ * release candidate. A STABLE host with explicit inclusion is the case this
+ * gate exists for: it is on the newest stable, `latest` names that stable, and
+ * a newer RC row appears only because the user asked to see RCs — it follows
+ * no line, and telling it otherwise would explain its state with a mechanism
+ * that does not apply to it. Those RC rows stay manually installable either
+ * way; only the sentence changes.
+ *
+ * Also gated on `upToDate`, which lives here rather than at the call site
+ * where it was one more branch in an already dense hook.
+ */
+function strandedLineTarget(input: {
+  readonly upToDate: boolean;
+  readonly manifest: HostAvailableManifest | null;
+  readonly installedVersion: string | null;
+  readonly source: HostIncludePreReleasesSource | null;
+}): string | null {
+  if (!input.upToDate || input.source !== "installed-rc") return null;
+  return newestNewerVersion(input.manifest, input.installedVersion);
+}
+
+/**
+ * What the checkbox SHOWS: the user's override once expressed, otherwise the
+ * catalog's own resolved inclusion, otherwise unticked until the first answer.
+ */
+function resolveCheckboxState(
+  override: boolean | undefined,
+  effective: boolean | null,
+): boolean {
+  if (override !== undefined) return override;
+  return effective ?? false;
+}
+
+/**
+ * The newest version in the catalog that is strictly newer than what is
+ * installed, ignoring release lines entirely — or `null` when there is none.
+ *
+ * Deliberately unrestricted, unlike `targetCandidates`. This does not decide
+ * what to OFFER; it answers whether the summary may claim "running the latest
+ * version". A follower with an exhausted line is not on the newest build the
+ * catalog knows about, and saying so is what keeps the sentence honest while
+ * the automatic policy stays unchanged.
+ */
+function newestNewerVersion(
+  manifest: HostAvailableManifest | null,
+  installedVersion: string | null,
+): string | null {
+  if (manifest === null || installedVersion === null) return null;
+  const newer = manifest.versions
+    .map((entry) => entry.version)
+    .filter((version) => isStrictlyNewerHostVersion(version, installedVersion))
+    .sort(compareNewestFirst);
+  return newer[0] ?? null;
+}
+
+/**
+ * Newest first, and a LAWFUL comparator: it returns 0 for pairs that are equal
+ * or that cannot be compared at all.
+ *
+ * The obvious `isStrictlyNewer(a, b) ? -1 : 1` is not lawful — it answers `1`
+ * in both directions for such a pair, violating antisymmetry. Registry
+ * versions are unique valid SemVer so nothing misorders today, but a
+ * comparator whose correctness rests on its input never containing a tie is
+ * one duplicate away from an unstable sort.
+ */
+function compareNewestFirst(a: string, b: string): number {
+  if (isStrictlyNewerHostVersion(a, b)) return -1;
+  if (isStrictlyNewerHostVersion(b, a)) return 1;
+  return 0;
 }
 
 /**
@@ -587,6 +832,14 @@ function describeCheckState(input: {
   readonly upToDate: boolean;
   /** `updatableVersion` resolved — the summary can actually OFFER the latest. */
   readonly offerable: boolean;
+  /** The strictly-newer version this sentence is about, if there is one. */
+  readonly targetVersion: string | null;
+  /**
+   * Set only when this host's own release line has no newer candidate but the
+   * catalog does — the state "running the latest version" would misdescribe.
+   */
+  readonly strandedOnLine: string | null;
+  readonly installedVersion: string | null;
 }): string {
   // Ordered so a stale answer never outranks what is happening NOW: a refetch
   // keeps the previous manifest on screen, so "vX is available." would otherwise
@@ -604,14 +857,58 @@ function describeCheckState(input: {
   }
   // No answer yet and nothing wrong: the first load, which now starts by itself.
   if (input.manifest === null) return "Checking for updates…";
-  if (input.upToDate) return "This host is running the latest version.";
-  // A latest this host cannot act on — yanked, or no asset for its platform.
+  if (input.upToDate) {
+    // Honest about BOTH halves: the newer version exists, and this host will
+    // not take it on its own. Naming the installed version names the line, and
+    // pointing at the list is not decoration — those rows are enabled, and
+    // they are the only way across.
+    if (input.strandedOnLine !== null && input.installedVersion !== null) {
+      return `v${input.strandedOnLine} is available, but ${input.installedVersion} follows its own release line and won't update to it automatically. Pick it below to move.`;
+    }
+    return "This host is running the latest version.";
+  }
+  // Nothing strictly newer to name — an unknown installed version leaves the
+  // comparison undecidable, so the catalog is reported without a claim about
+  // whether this host is behind it.
+  const target = input.targetVersion;
+  if (target === null) return "This host is running the latest version.";
+  // A target this host cannot act on — yanked, or no asset for its platform.
   // Claiming plain availability here would put the sentence at odds with the
   // absent button; the version list carries the specific reason.
   if (!input.offerable) {
-    return `v${input.manifest.latest} is available, but ${input.hostName} can't install it.`;
+    return `v${target} is available, but ${input.hostName} can't install it.`;
   }
-  return `v${input.manifest.latest} is available.`;
+  return `v${target} is available.`;
+}
+
+/**
+ * Why this catalog includes release candidates, when that is worth saying.
+ *
+ * Gated on `installed-rc` ALONE, and that single condition is also what
+ * satisfies "omit the explanation for a negotiated v1.0 response" — no version
+ * check needed. A v1.0 host cannot produce this value: its response carries no
+ * provenance at all, and the v1.0→v1.1 bridge deliberately answers
+ * `explicit-include` or `stable-default` and never `installed-rc`, precisely
+ * because it must not assert a derivation the old peer never performed. So the
+ * one provenance that unlocks copy here is the one only a v1.1 host can send.
+ *
+ * Nothing is said for the other three. `explicit-include` and
+ * `explicit-exclude` restate the user's own click, and `stable-default` is the
+ * unremarkable case — a line of prose under each would be noise that makes the
+ * one meaningful explanation harder to notice.
+ *
+ * This is PROVENANCE, not a saved setting: the copy says the host is following
+ * its current release-candidate line, and must never imply a stored
+ * preference, because there is none to turn off.
+ */
+function describeIncludePreReleasesSource(
+  source: HostIncludePreReleasesSource | null,
+  installedVersion: string | null,
+): string | null {
+  if (source !== "installed-rc") return null;
+  return installedVersion === null
+    ? "This host is on a release candidate, so its own line is listed."
+    : `This host is on ${installedVersion}, so its own release-candidate line is listed.`;
 }
 
 /**
@@ -621,16 +918,31 @@ function describeCheckState(input: {
  * "Nothing asked yet" and an `ok` answer both mean "no failure", which is why
  * the two collapse here rather than at every use site.
  */
-function readCheckResponse(response: HostUpdateCheckResponse | null): {
+function readCheckResponse(response: HostUpdateCheckResponseV11 | null): {
   readonly manifest: HostAvailableManifest | null;
   readonly sticky: OverviewDegradeReason | null;
   readonly transient: CliShellFailure | null;
+  /** The host's resolved inclusion, or `null` when it did not answer `ok`. */
+  readonly effectiveIncludePreReleases: boolean | null;
+  readonly source: HostIncludePreReleasesSource | null;
 } {
   if (response === null) {
-    return { manifest: null, sticky: null, transient: null };
+    return {
+      manifest: null,
+      sticky: null,
+      transient: null,
+      effectiveIncludePreReleases: null,
+      source: null,
+    };
   }
   if (response.outcome === "ok") {
-    return { manifest: response.manifest, sticky: null, transient: null };
+    return {
+      manifest: response.manifest,
+      sticky: null,
+      transient: null,
+      effectiveIncludePreReleases: response.effectiveIncludePreReleases,
+      source: response.includePreReleasesSource,
+    };
   }
   // `stickyDegradeFor` owns the classification, and it is deliberately wider
   // than this response: `externally-managed` is an INSTALL outcome, which the
@@ -638,6 +950,20 @@ function readCheckResponse(response: HostUpdateCheckResponse | null): {
   // compiler rejected — the shared classifier is what keeps the two paths
   // agreeing about which refusals are structural.
   const sticky = stickyDegradeFor(response.outcome);
-  if (sticky !== null) return { manifest: null, sticky, transient: null };
-  return { manifest: null, sticky: null, transient: response.outcome };
+  if (sticky !== null) {
+    return {
+      manifest: null,
+      sticky,
+      transient: null,
+      effectiveIncludePreReleases: null,
+      source: null,
+    };
+  }
+  return {
+    manifest: null,
+    sticky: null,
+    transient: response.outcome,
+    effectiveIncludePreReleases: null,
+    source: null,
+  };
 }

--- a/clients/gui-app/src/hooks/runner/use-desktop-app-updates.ts
+++ b/clients/gui-app/src/hooks/runner/use-desktop-app-updates.ts
@@ -54,18 +54,6 @@ export function useDesktopAppUpdates(): DesktopAppUpdatesState {
   return { bridge, snapshot };
 }
 
-/**
- * The active release channel, as pushed from the Electron main process to
- * every window. This is the single per-window source of truth for the channel:
- * host-registry query identity, the Settings → Host available-versions filter,
- * and the RC toggle all read it, so they can never disagree within a window.
- *
- * `false` (stable only) in shells without the desktop update bridge.
- */
-export function useAllowPrereleaseUpdates(): boolean {
-  return useDesktopAppUpdates().snapshot.allowPrerelease;
-}
-
 function getDesktopAppUpdateStore(
   bridge: DesktopAppUpdatesBridge,
 ): DesktopAppUpdateStore {

--- a/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/local-maintenance-fallback-client.test.ts
@@ -365,11 +365,13 @@ describe("buildMaintenanceFallbackServeMap", () => {
   it("forwards includePreReleases verbatim on host.update.check", async () => {
     const maintenanceUpdateCheck = vi.fn(
       (_input: {
-        readonly includePreReleases: boolean;
+        readonly includePreReleases: boolean | undefined;
         readonly expectedHostId: string;
       }) =>
         Promise.resolve({
           outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
           manifest: updateCheckManifest("1.2.0"),
         }),
     );
@@ -393,6 +395,8 @@ describe("buildMaintenanceFallbackServeMap", () => {
     const maintenanceUpdateCheck = vi.fn(() =>
       Promise.resolve({
         outcome: "ok" as const,
+        effectiveIncludePreReleases: false,
+        includePreReleasesSource: "stable-default" as const,
         manifest: updateCheckManifest("1.2.0"),
       }),
     );
@@ -490,6 +494,8 @@ describe("createLocalMaintenanceFallbackClient", () => {
           rpcCalls.push("host.update.check");
           return {
             outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
             manifest: updateCheckManifest("1.2.0"),
           };
         },
@@ -575,7 +581,7 @@ describe("createLocalMaintenanceFallbackClient", () => {
   function servingManagement(): {
     readonly management: IHostManagement;
     readonly checkCalls: Array<{
-      readonly includePreReleases: boolean;
+      readonly includePreReleases: boolean | undefined;
       readonly expectedHostId: string;
     }>;
     readonly installCalls: Array<{
@@ -587,7 +593,7 @@ describe("createLocalMaintenanceFallbackClient", () => {
     readonly installInfoCalls: Array<{ readonly expectedHostId: string }>;
   } {
     const checkCalls: Array<{
-      readonly includePreReleases: boolean;
+      readonly includePreReleases: boolean | undefined;
       readonly expectedHostId: string;
     }> = [];
     const installCalls: Array<{
@@ -602,6 +608,8 @@ describe("createLocalMaintenanceFallbackClient", () => {
         checkCalls.push(input);
         return Promise.resolve({
           outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
           manifest: updateCheckManifest("1.2.0"),
         });
       },
@@ -818,6 +826,8 @@ describe("createLocalMaintenanceFallbackClient", () => {
 
     expect(answer).toEqual({
       outcome: "ok",
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: updateCheckManifest("1.2.0"),
     });
     expect(rpcCalls).toEqual(["host.update.check"]);
@@ -943,6 +953,8 @@ describe("createLocalMaintenanceFallbackClient", () => {
 
     expect(answer).toEqual({
       outcome: "ok",
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: updateCheckManifest("1.2.0"),
     });
     expect(rpcCalls).toEqual([]);
@@ -1032,6 +1044,8 @@ describe("createLocalMaintenanceFallbackClient", () => {
     );
     expect(answer).toEqual({
       outcome: "ok",
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: updateCheckManifest("1.2.0"),
     });
     controller.abort();
@@ -1053,6 +1067,8 @@ describe("createLocalMaintenanceFallbackClient", () => {
       client.request("host.update.check", { includePreReleases: false }),
     ).resolves.toEqual({
       outcome: "ok",
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default" as const,
       manifest: updateCheckManifest("1.2.0"),
     });
     await expect(

--- a/clients/gui-app/src/lib/host/local-maintenance-fallback-client.ts
+++ b/clients/gui-app/src/lib/host/local-maintenance-fallback-client.ts
@@ -15,8 +15,8 @@ import type {
 import {
   type HostDoctorResponse,
   type HostGetInstallationInfoResponse,
-  type HostUpdateCheckRequest,
-  type HostUpdateCheckResponse,
+  type HostUpdateCheckRequestV11,
+  type HostUpdateCheckResponseV11,
   type HostUpdateInstallRequest,
   type HostUpdateInstallResponse,
 } from "@traycer/protocol/host/maintenance/index";
@@ -206,8 +206,8 @@ export function localWsDoctorResponse(
  */
 export interface MaintenanceFallbackServeMap {
   readonly "host.update.check": (
-    params: HostUpdateCheckRequest,
-  ) => Promise<HostUpdateCheckResponse>;
+    params: HostUpdateCheckRequestV11,
+  ) => Promise<HostUpdateCheckResponseV11>;
   readonly "host.update.install": (
     params: HostUpdateInstallRequest,
   ) => Promise<HostUpdateInstallResponse>;
@@ -314,14 +314,14 @@ function serveFallbackRequest<Method extends keyof HostRpcRegistry & string>(
 ): Promise<ResponseOfMethod<HostRpcRegistry, Method>> {
   const request: unknown = params;
   const answer = ((): Promise<
-    | HostUpdateCheckResponse
+    | HostUpdateCheckResponseV11
     | HostUpdateInstallResponse
     | HostDoctorResponse
     | HostGetInstallationInfoResponse
   > => {
     switch (method) {
       case "host.update.check":
-        return serve[method](request as HostUpdateCheckRequest);
+        return serve[method](request as HostUpdateCheckRequestV11);
       case "host.update.install":
         return serve[method](request as HostUpdateInstallRequest);
       case "host.doctor":

--- a/clients/shared/__tests__/host-update-check-negotiation.test.ts
+++ b/clients/shared/__tests__/host-update-check-negotiation.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
+import type { HostAvailableManifest } from "@traycer/protocol/host/maintenance/schemas";
+import {
+  decodeResponsePayloadWithContext,
+  prepareRequestPayload,
+} from "../host-transport/ws-rpc-client";
+
+/**
+ * Two-sided negotiation for `host.update.check`, through the REAL transport
+ * helpers rather than the schemas alone.
+ *
+ * This is the case the v1.1 wire shape was chosen for. Within one major there
+ * is no request-downgrade bridge, so a v1.1 client talking to an already
+ * shipped v1.0 host projects its params by PARSING them with the v1.0 request
+ * schema. Any tri-state encoding whose third state is a VALUE the v1.0 schema
+ * refuses (an explicit `null`, say) turns every default catalog load against
+ * an old host into `DOWNGRADE_UNSUPPORTED`. Encoding it as an absent key makes
+ * that same load arrive as v1.0's stable-only default, which is what the
+ * rollout promises.
+ */
+const REGISTRY = hostRpcRegistry["host.update.check"];
+const CLIENT_V11 = { major: 1, minor: 1 } as const;
+const HOST_V10 = { major: 1, minor: 0 } as const;
+const HOST_V11 = { major: 1, minor: 1 } as const;
+
+const MANIFEST: HostAvailableManifest = {
+  schemaVersion: 1,
+  generatedAt: "2026-06-22T01:00:00.000Z",
+  latest: "1.2.0",
+  versions: [],
+};
+
+function prepare(params: { includePreReleases?: boolean }): {
+  readonly onWireVersion: { readonly major: number; readonly minor: number };
+  readonly onWirePayload: unknown;
+} {
+  return prepareRequestPayload(
+    REGISTRY,
+    CLIENT_V11,
+    HOST_V10,
+    params,
+    "req-1",
+    "host.update.check",
+  );
+}
+
+describe("a v1.1 client negotiating v1.0", () => {
+  it("sends a derive request as the old stable-only default, not an error", () => {
+    const prepared = prepare({});
+    expect(prepared.onWireVersion).toEqual(HOST_V10);
+    expect(prepared.onWirePayload).toEqual({ includePreReleases: false });
+  });
+
+  it("sends an explicit include as the old include", () => {
+    expect(prepare({ includePreReleases: true }).onWirePayload).toEqual({
+      includePreReleases: true,
+    });
+  });
+
+  it("sends an explicit exclude as the old stable-only ask", () => {
+    // The v1.1-only distinction between "excluded" and "not stated" simply is
+    // not expressible to that peer; both mean stable-only there.
+    expect(prepare({ includePreReleases: false }).onWirePayload).toEqual({
+      includePreReleases: false,
+    });
+  });
+
+  it("upgrades the old host's answer with provenance derived from the wire request", () => {
+    const prepared = prepare({});
+    const decoded = decodeResponsePayloadWithContext(
+      REGISTRY,
+      CLIENT_V11,
+      HOST_V10,
+      { outcome: "ok", manifest: MANIFEST },
+      "req-1",
+      "host.update.check",
+      prepared.onWirePayload,
+      "host-1",
+    );
+
+    // Stable-default, never installed-rc: the old host derived nothing, and a
+    // fabricated provenance would drive Settings copy that is simply untrue.
+    expect(decoded).toEqual({
+      outcome: "ok",
+      manifest: MANIFEST,
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default",
+    });
+  });
+
+  it("reports an explicit include against an old host as explicit-include", () => {
+    const prepared = prepare({ includePreReleases: true });
+    expect(
+      decodeResponsePayloadWithContext(
+        REGISTRY,
+        CLIENT_V11,
+        HOST_V10,
+        { outcome: "ok", manifest: MANIFEST },
+        "req-1",
+        "host.update.check",
+        prepared.onWirePayload,
+        "host-1",
+      ),
+    ).toEqual({
+      outcome: "ok",
+      manifest: MANIFEST,
+      effectiveIncludePreReleases: true,
+      includePreReleasesSource: "explicit-include",
+    });
+  });
+});
+
+describe("a v1.1 client negotiating v1.1", () => {
+  it("passes the tri-state through untouched in both directions", () => {
+    const prepared = prepareRequestPayload(
+      REGISTRY,
+      CLIENT_V11,
+      HOST_V11,
+      {},
+      "req-1",
+      "host.update.check",
+    );
+    expect(prepared.onWireVersion).toEqual(HOST_V11);
+    // Absent stays absent - the host, not the client, resolves it.
+    expect(prepared.onWirePayload).toEqual({});
+
+    const answer = {
+      outcome: "ok",
+      manifest: MANIFEST,
+      effectiveIncludePreReleases: true,
+      includePreReleasesSource: "installed-rc",
+    };
+    expect(
+      decodeResponsePayloadWithContext(
+        REGISTRY,
+        CLIENT_V11,
+        HOST_V11,
+        answer,
+        "req-1",
+        "host.update.check",
+        prepared.onWirePayload,
+        "host-1",
+      ),
+    ).toEqual(answer);
+  });
+});

--- a/clients/shared/host-version/__tests__/release-line.test.ts
+++ b/clients/shared/host-version/__tests__/release-line.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCanonicalReleaseCandidate,
+  isMatchingStableRelease,
+  isPreReleaseVersion,
+  isSameReleaseLine,
+} from "../release-line";
+
+/**
+ * The whole updater rests on this predicate answering "no" for everything that
+ * is not one of our release candidates. A false positive does not merely
+ * mislabel a version - it silently enrols that install into automatic updates
+ * it never asked for, so the negative table is the load-bearing half.
+ */
+describe("isCanonicalReleaseCandidate", () => {
+  it("accepts canonical X.Y.Z-rc.N", () => {
+    for (const version of [
+      "2.0.0-rc.0",
+      "2.0.0-rc.1",
+      "2.0.0-rc.42",
+      "0.0.1-rc.1",
+      "10.20.30-rc.999",
+    ]) {
+      expect(isCanonicalReleaseCandidate(version)).toBe(true);
+    }
+  });
+
+  it("rejects every other prerelease shape", () => {
+    for (const version of [
+      // Other prerelease words - the ones `includes("-")` cannot tell apart.
+      "2.0.0-beta.1",
+      "2.0.0-alpha",
+      "2.0.0-alpha.1",
+      "2.0.0-nightly.3",
+      "2.0.0-test",
+      "2.0.0-rc1",
+      // `rc` with no ordinal, a non-numeric ordinal, or extra identifiers.
+      "2.0.0-rc",
+      "2.0.0-rc.x",
+      "2.0.0-rc.1.2",
+      "2.0.0-rc.1-hotfix",
+      // Leading zeros are legal digits and illegal SemVer.
+      "2.0.0-rc.01",
+      "02.0.0-rc.1",
+      // Build metadata: SemVer-valid, but no published RC of ours carries it.
+      "2.0.0-rc.1+build.7",
+      // Not a version at all - including the local-file install pin.
+      "local-traycer-host-1730000000",
+      "1.0.0-test",
+      "2.0",
+      "v2.0.0-rc.1",
+      "",
+      "  2.0.0-rc.1  ",
+    ]) {
+      expect(isCanonicalReleaseCandidate(version)).toBe(false);
+    }
+  });
+
+  it("rejects a stable release - stable never follows a line implicitly", () => {
+    expect(isCanonicalReleaseCandidate("2.0.0")).toBe(false);
+  });
+
+  it("scopes an RC to the line its core names", () => {
+    // Asserted through the public surface: `2.3.4-rc.7` shares a line with the
+    // `2.3.4` core and with nothing else, while `2.3.4-beta.7` has no line to
+    // share at all.
+    expect(isSameReleaseLine("2.3.4-rc.7", "2.3.4")).toBe(true);
+    expect(isSameReleaseLine("2.3.4-rc.7", "2.3.5")).toBe(false);
+    expect(isSameReleaseLine("2.3.4-beta.7", "2.3.4")).toBe(false);
+  });
+});
+
+// Line membership itself is module-private (`hostReleaseLine`): callers ask
+// these two questions, never "what line is this". Both halves of the rule are
+// pinned here through them - which versions DO share a line, and which shapes
+// have no line to share despite carrying the same core.
+describe("release-line membership", () => {
+  it("gives a canonical RC and its stable the same line", () => {
+    expect(isSameReleaseLine("2.0.0-rc.1", "2.0.0")).toBe(true);
+    expect(isSameReleaseLine("2.0.0", "2.0.0")).toBe(true);
+    expect(isMatchingStableRelease("2.0.0", "2.0.0-rc.1")).toBe(true);
+  });
+
+  it("refuses a line for a non-canonical prerelease that shares the core", () => {
+    // `2.0.0-beta.1` does have core `2.0.0`. Treating that as the 2.0.0 line
+    // would let the beta follow the line's RCs and stable, which is exactly
+    // what the canonical predicate exists to prevent - so it matches neither
+    // the line's stable nor the line's other members.
+    for (const version of [
+      "2.0.0-beta.1",
+      "2.0.0-rc.01",
+      "local-traycer-host-1730000000",
+      "2.0.0+build.4",
+    ]) {
+      expect(isSameReleaseLine(version, "2.0.0")).toBe(false);
+      expect(isSameReleaseLine(version, "2.0.0-rc.1")).toBe(false);
+      expect(isMatchingStableRelease("2.0.0", version)).toBe(false);
+    }
+  });
+
+  it("is reflexive only for versions it can classify", () => {
+    // The one asymmetry worth stating: a classifiable version shares a line
+    // with itself, an unclassifiable one does not even do that.
+    expect(isSameReleaseLine("2.0.0-rc.1", "2.0.0-rc.1")).toBe(true);
+    expect(isSameReleaseLine("2.0.0-beta.1", "2.0.0-beta.1")).toBe(false);
+  });
+});
+
+describe("isSameReleaseLine", () => {
+  it("keeps an RC on its own line", () => {
+    expect(isSameReleaseLine("2.0.0-rc.1", "2.0.0-rc.2")).toBe(true);
+    expect(isSameReleaseLine("2.0.0-rc.1", "2.0.0")).toBe(true);
+  });
+
+  it("never crosses to another release line", () => {
+    // The termination guarantee: implicit following can only ever end at the
+    // stable for ITS line, so `2.1.0-rc.1` must be out of reach.
+    expect(isSameReleaseLine("2.0.0-rc.1", "2.1.0-rc.1")).toBe(false);
+    expect(isSameReleaseLine("2.0.0-rc.1", "2.0.1-rc.1")).toBe(false);
+    expect(isSameReleaseLine("2.0.0-rc.1", "3.0.0")).toBe(false);
+  });
+
+  it("is never true for input it cannot classify", () => {
+    expect(isSameReleaseLine("2.0.0-beta.1", "2.0.0")).toBe(false);
+    expect(isSameReleaseLine("garbage", "garbage")).toBe(false);
+  });
+});
+
+/**
+ * The CATALOG predicate, and the one two processes must agree on to the letter:
+ * the CLI filters `host available` rows with it, and Desktop's `HostController`
+ * predicts that filter with it to decide whether a staged build would still
+ * appear in the default listing. Disagreement is not cosmetic - a staged build
+ * whose row goes missing reads as yanked and is purged.
+ */
+describe("isPreReleaseVersion", () => {
+  it("accepts every pre-release shape, not just canonical RCs", () => {
+    for (const version of [
+      "2.0.0-rc.1",
+      "2.0.0-rc.01",
+      "2.0.0-beta.1",
+      "2.0.0-alpha",
+      "2.0.0-nightly.3",
+      "2.0.0-test",
+      "2.0.0-rc",
+      "2.0.0-rc.1+build.7",
+      "0.0.1-x",
+      "10.20.30-anything.at.all",
+    ]) {
+      expect(isPreReleaseVersion(version)).toBe(true);
+    }
+  });
+
+  it("rejects stable releases, including ones carrying build metadata", () => {
+    // SemVer: build metadata is not a pre-release. `1.8.0+build.4` is a stable
+    // release and must stay in the default catalog.
+    for (const version of ["2.0.0", "0.0.0", "10.20.30", "1.8.0+build.4"]) {
+      expect(isPreReleaseVersion(version)).toBe(false);
+    }
+  });
+
+  it("rejects values that are not registry versions at all", () => {
+    // The local-file install pin is the one a bare `includes("-")` used to
+    // match; the anchored triplet does not, and it is not a catalog row anyway.
+    for (const version of [
+      "local-traycer-host-1730000000",
+      "v2.0.0-rc.1",
+      "2.0-rc.1",
+      "not-a-version",
+      "",
+      "  2.0.0-rc.1  ",
+    ]) {
+      expect(isPreReleaseVersion(version)).toBe(false);
+    }
+  });
+
+  it("stays strictly broader than the canonical predicate", () => {
+    // The invariant that keeps the two questions apart: everything that may
+    // follow a line is a pre-release, but not every pre-release may follow one.
+    for (const version of ["2.0.0-rc.1", "2.0.0-beta.1", "2.0.0-rc.01"]) {
+      expect(isPreReleaseVersion(version)).toBe(true);
+    }
+    expect(isCanonicalReleaseCandidate("2.0.0-beta.1")).toBe(false);
+    expect(isCanonicalReleaseCandidate("2.0.0-rc.01")).toBe(false);
+    expect(isCanonicalReleaseCandidate("2.0.0-rc.1")).toBe(true);
+  });
+});
+
+describe("isMatchingStableRelease", () => {
+  it("identifies the stable that terminates an RC's line", () => {
+    expect(isMatchingStableRelease("2.0.0", "2.0.0-rc.1")).toBe(true);
+  });
+
+  it("rejects a later RC, another line's stable, and a non-canonical install", () => {
+    expect(isMatchingStableRelease("2.0.0-rc.2", "2.0.0-rc.1")).toBe(false);
+    expect(isMatchingStableRelease("2.1.0", "2.0.0-rc.1")).toBe(false);
+    expect(isMatchingStableRelease("2.0.0", "2.0.0-beta.1")).toBe(false);
+  });
+});

--- a/clients/shared/host-version/release-line.ts
+++ b/clients/shared/host-version/release-line.ts
@@ -1,0 +1,174 @@
+// Canonical release-candidate identity for the host/app update domain.
+//
+// The RC-to-stable updater lets an installed release candidate follow its OWN
+// release line without any saved preference: `2.0.0-rc.1` may select
+// `2.0.0-rc.2` or stable `2.0.0`, and nothing else. Two decisions hang off
+// this file, in both the CLI and desktop main, so they must not diverge:
+//
+//   1. Does the installed version activate implicit following at all?
+//   2. Is a candidate on the SAME release line as the installed version?
+//
+// `includes("-")` cannot answer either one. Only a CANONICAL release
+// candidate activates implicit following: valid SemVer whose core is exactly
+// `X.Y.Z` and whose pre-release is exactly `rc.<non-negative integer>`.
+// `beta`, `alpha`, `nightly`, `test`, arbitrary hyphenated strings, the
+// `local-<basename>-<timestamp>` pin a local-file install records, and
+// malformed versions all fail closed to stable-only discovery — which is the
+// conservative answer, since a stable-only user never receives an RC
+// automatically.
+//
+// Build metadata (`+…`) is deliberately NOT accepted on a canonical RC.
+// SemVer ignores it for precedence, but no published Traycer RC carries it,
+// so a version that does is not one of ours to follow; refusing it fails
+// closed rather than opening implicit following to an unknown build.
+//
+// A THIRD, BROADER question also lives here — `isPreReleaseVersion`, "is this
+// version a pre-release at all", which the `host available` catalog filter
+// asks and which legitimately covers every pre-release shape. It shares this
+// file so the contrast is impossible to miss, and it must stay a SEPARATE
+// export: widening canonical RC detection to answer it would silently let
+// `2.0.0-beta.1` start following a release line, and narrowing it to the
+// canonical predicate would make the catalog filter and the Desktop
+// staged-artifact revalidation disagree about which rows the default listing
+// returns — which purges a perfectly good staged `2.0.0-beta.1`.
+
+import { isValidHostVersion } from "./compare-host-versions";
+
+/**
+ * A version's `X.Y.Z` core — the identity an implicit follow is scoped to.
+ *
+ * Module-private, like {@link hostReleaseLine} below: no caller outside this
+ * file has ever needed a line in the hand. They ask questions ABOUT lines —
+ * "same line?", "is this the stable that ends this line?" — and those are the
+ * exported surface.
+ */
+type HostReleaseLine = string;
+
+const CANONICAL_RC_PATTERN = /^(\d+\.\d+\.\d+)-rc\.(\d+)$/;
+const STABLE_PATTERN = /^\d+\.\d+\.\d+$/;
+
+/**
+ * The release line of a canonical `X.Y.Z-rc.N`, or `null` for every other
+ * shape.
+ *
+ * Module-private, and the RC ordinal it matches is deliberately discarded.
+ * Nothing needs it: ordering two RCs on one line is `compareHostVersions`'s
+ * job (it handles arbitrary-precision numeric identifiers, which a caller
+ * comparing ordinals by hand would get wrong past 2^53), and identity is the
+ * full version string. An exported ordinal would be an invitation to order by
+ * it.
+ *
+ * `isValidHostVersion` runs alongside the pattern rather than being replaced
+ * by it: the pattern proves the SHAPE, the validator proves the SemVer
+ * grammar the shape does not encode — notably leading zeros, which are legal
+ * digit strings (`1.02.0`, `1.0.0-rc.01`) and illegal SemVer.
+ */
+function canonicalReleaseCandidateLine(
+  version: string,
+): HostReleaseLine | null {
+  const match = CANONICAL_RC_PATTERN.exec(version);
+  if (match === null) return null;
+  if (!isValidHostVersion(version)) return null;
+  return match[1];
+}
+
+/** Whether `version` activates implicit same-line following. */
+export function isCanonicalReleaseCandidate(version: string): boolean {
+  return canonicalReleaseCandidateLine(version) !== null;
+}
+
+/**
+ * THE BROAD one: would the default `host available` catalog hide this version
+ * behind `--include-pre-releases`?
+ *
+ * Deliberately not {@link isCanonicalReleaseCandidate}, and the two are not
+ * interchangeable in either direction. This one answers a CATALOG question and
+ * covers every pre-release shape — `rc`, `beta`, `alpha`, `nightly`, a
+ * leading-zero `-rc.01`, anything after the `-`. The canonical predicate
+ * answers a POLICY question ("may this build follow a release line") and is
+ * narrow on purpose.
+ *
+ * Two processes ask this, which is why it is here rather than in either of
+ * them: the CLI's `filterHostAvailableVersions` decides which rows to return,
+ * and Desktop's `HostController` has to PREDICT that decision — a staged build
+ * whose row is missing from the listing reads as yanked and gets purged. A
+ * second copy in either place is a purge waiting for the day the two spellings
+ * diverge.
+ *
+ * Anchored on a full `X.Y.Z-` triplet rather than a bare `includes("-")`: the
+ * substring test also matched the `local-<basename>-<timestamp>` version a
+ * local-file install records, which is not a registry row at all. Build
+ * metadata alone (`1.8.0+build.4`) is not a pre-release, per SemVer.
+ */
+export function isPreReleaseVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+-/.test(version);
+}
+
+/**
+ * The release line a version belongs to, for the versions implicit following
+ * can reason about: a canonical RC and the stable release it leads to share
+ * one line, which is what makes `2.0.0` the terminating candidate for
+ * `2.0.0-rc.1`.
+ *
+ * Every other pre-release shape returns `null` rather than its bare core. A
+ * `2.0.0-beta.1` DOES have core `2.0.0`, but treating that as "the 2.0.0
+ * line" would let the beta follow the line's RCs and stable — exactly the
+ * broadening the canonical predicate exists to prevent.
+ *
+ * MODULE-PRIVATE. It was exported for a caller that never materialized: every
+ * consumer across the CLI, Desktop main, and the GUI asks `isSameReleaseLine`
+ * or `isMatchingStableRelease` instead. Keeping it public would publish a bare
+ * string whose only correct use is equality against another line from this same
+ * function — an invitation to compare cores by hand, which is how
+ * `2.0.0-beta.1` ends up on the `2.0.0` line. Export it again only alongside a
+ * real caller that genuinely needs to tell "different line" from "cannot
+ * classify".
+ */
+function hostReleaseLine(version: string): HostReleaseLine | null {
+  const canonical = canonicalReleaseCandidateLine(version);
+  if (canonical !== null) return canonical;
+  if (!STABLE_PATTERN.test(version)) return null;
+  if (!isValidHostVersion(version)) return null;
+  return version;
+}
+
+/**
+ * Whether two versions sit on one release line. Incomparable or non-canonical
+ * input is never "same line", which fails closed: a version this module cannot
+ * classify never joins anyone's line.
+ *
+ * That does collapse "different line" and "cannot classify" into one `false`.
+ * No caller has needed to tell them apart — both mean "not a candidate for this
+ * install" at every call site — and the pair is far easier to get wrong than to
+ * use, so the distinction stays unexported until something genuinely needs it.
+ */
+export function isSameReleaseLine(a: string, b: string): boolean {
+  const lineA = hostReleaseLine(a);
+  if (lineA === null) return false;
+  return lineA === hostReleaseLine(b);
+}
+
+/**
+ * Whether `candidate` is the stable release that terminates `installedRc`'s
+ * line — the candidate implicit following must prefer over every later RC on
+ * that line, since it is what ends implicit participation.
+ *
+ * Exported ahead of its caller, deliberately. `HostController`'s candidate
+ * resolver (the generalization of `resolveRcDownloadTarget`) has to answer
+ * exactly this question to pin matching stable with `host download <version>`
+ * even when the registry's `latest` pointer still lags on the stable channel —
+ * installed `2.0.0-rc.1` must take published `2.0.0` while `latest` says
+ * `1.9.0`. That resolver is a Desktop-side consumer, so it cannot own the
+ * predicate: this module is the single definition both processes read, and a
+ * second copy over there is precisely the RC-detection drift this file exists
+ * to prevent. `isSameReleaseLine` alone is not enough — it cannot express
+ * "prefer the stable one", which is what guarantees the follow terminates.
+ */
+export function isMatchingStableRelease(
+  candidate: string,
+  installedRc: string,
+): boolean {
+  const line = canonicalReleaseCandidateLine(installedRc);
+  if (line === null) return false;
+  return STABLE_PATTERN.test(candidate) && candidate === line;
+}

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -27,7 +27,7 @@ import type { StoredCredentials } from "@traycer/protocol/config/credentials";
 import type {
   HostDoctorIssue as MaintenanceDoctorIssue,
   HostGetInstallationInfoResponse,
-  HostUpdateCheckResponse,
+  HostUpdateCheckResponseV11,
 } from "@traycer/protocol/host/maintenance/index";
 
 export type { StoredCredentials } from "@traycer/protocol/config/credentials";
@@ -1441,7 +1441,18 @@ export interface HostAvailableSnapshot {
 }
 
 export interface HostAvailableVersionsInput {
-  readonly includePreReleases: boolean;
+  /**
+   * The catalog override, tri-state: `true` explicitly includes release
+   * candidates, `false` explicitly excludes them, and `undefined` asks the CLI
+   * to derive inclusion from the installed host.
+   *
+   * `boolean | undefined` rather than an optional property, so a caller must
+   * state which of the three it means. Read it with `=== undefined`; the
+   * absent state is a real request, not a missing argument, and collapsing it
+   * to `false` is what would make an RC host's default catalog silently
+   * stable-only again.
+   */
+  readonly includePreReleases: boolean | undefined;
 }
 
 export type HostDoctorSeverity = "info" | "warning" | "error" | "fatal";
@@ -1931,7 +1942,7 @@ export interface IHostManagement {
   /** `host.update.check`'s answer from this machine's bundled CLI. */
   readonly maintenanceUpdateCheck: (
     input: HostAvailableVersionsInput & { readonly expectedHostId: string },
-  ) => Promise<HostUpdateCheckResponse>;
+  ) => Promise<HostUpdateCheckResponseV11>;
   /** `host.doctor`'s answer, minus the caller-owned transport vantage. */
   readonly maintenanceDoctor: (input: {
     readonly expectedHostId: string;

--- a/clients/traycer-cli/src/commands/__tests__/host-available-entrypoint.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available-entrypoint.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Command } from "commander";
+import type { ProgressInfo } from "../../runner/output";
+import type {
+  CommandContext,
+  CommandFn,
+  CommandResult,
+} from "../../runner/runner";
+import type {
+  HostPlatformAsset,
+  HostVersionsManifest,
+  RegistryClient,
+} from "../../registry";
+import type { HostInstallRecord } from "../../manifest/host-install";
+
+/**
+ * `host available`'s three flag states, driven through the REAL commander
+ * tree.
+ *
+ * The derive state is spelled as an ABSENT commander option, which makes it
+ * the one state no source line asserts: it exists only because commander
+ * leaves `includePreReleases` unset when a command declares both `--x` and
+ * `--no-x` and neither is passed. That is a library rule, and it has not been
+ * stable across majors - commander 9.5.0 lets a `--no-x` declared FIRST
+ * install an implicit `true` default, so on that version the declaration order
+ * in `index.ts` is load-bearing. The CLI resolves 15.0.0, where neither order
+ * does that (verified both ways). A dependency bump is therefore the live
+ * risk, not a source edit: if the 9.x rule ever returns, "neither flag"
+ * silently becomes `true` and every default listing on every host starts
+ * including release candidates.
+ *
+ * So these assert BEHAVIOUR, not registration. The structural suite next door
+ * only checks the flag exists; these parse real argv and pin the value that
+ * comes out the far end, so a regression anywhere along commander ->
+ * `index.ts`'s mapping -> `resolveIncludePreReleases` lands here. Confirmed by
+ * mutation: collapsing the mapping back to a plain boolean fails two of them.
+ *
+ * Deliberately its own file: it has to mock the registry client and the
+ * install-record reader to keep the command off the network and off disk, and
+ * `cli-entrypoint-registration.test.ts` walks the whole command tree - those
+ * mocks have no business being in scope there.
+ */
+const mocks = vi.hoisted(() => ({
+  results: [] as CommandResult[],
+  fetchManifestMock: vi.fn(),
+  readHostInstallRecordMock: vi.fn(),
+}));
+
+vi.mock("../../registry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../registry")>();
+  return {
+    ...actual,
+    createDefaultRegistryClient: async (): Promise<RegistryClient> => ({
+      fetchManifest: mocks.fetchManifestMock,
+      resolveAsset: vi.fn(),
+      downloadAndVerify: vi.fn(),
+    }),
+    currentHostPlatformKey: () => "darwin-arm64",
+  };
+});
+
+vi.mock("../../manifest/host-install", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../manifest/host-install")>();
+  return {
+    ...actual,
+    readHostInstallRecord: mocks.readHostInstallRecordMock,
+  };
+});
+
+// Same shape as `cli-entrypoint-registration.test.ts`: replace only
+// `runCommand`, which owns `process.exit`, so `parseAsync` can drive the real
+// command wiring to completion inside the test process.
+vi.mock("../../runner/runner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../runner/runner")>();
+  return {
+    ...actual,
+    runCommand: async (fn: CommandFn) => {
+      const ctx: CommandContext = {
+        runtime: {
+          json: true,
+          quiet: false,
+          noProgress: true,
+          noBootstrap: false,
+          nonInteractive: true,
+          environment: "production",
+          logger: {
+            debug: () => undefined,
+            info: () => undefined,
+            warn: () => undefined,
+            error: () => undefined,
+          },
+        },
+        output: {
+          progress: () => undefined,
+          human: () => undefined,
+          humanRequired: () => undefined,
+          emitResult: () => undefined,
+          emitError: () => undefined,
+        },
+        progress: (_info: ProgressInfo) => undefined,
+      };
+      mocks.results.push(await fn(ctx));
+    },
+  };
+});
+
+import { buildProgram } from "../../index";
+
+const AVAILABLE_ASSET: HostPlatformAsset = {
+  available: true,
+  unavailableReason: null,
+  url: "https://example.com/traycer-host-macos-arm64.tar.gz",
+  sizeBytes: 123,
+  sha256: "a".repeat(64),
+  signatureUrl: "https://example.com/traycer-host-macos-arm64.tar.gz.minisig",
+  signatureAlgorithm: "minisign",
+  publicKeyId: "test-key",
+};
+
+const MANIFEST: HostVersionsManifest = {
+  schemaVersion: 1,
+  generatedAt: "2026-06-22T01:00:00.000Z",
+  latest: "1.2.0",
+  versions: ["2.0.0-rc.2", "1.2.0"].map((version) => ({
+    version,
+    releasedAt: "2026-06-22T00:00:00.000Z",
+    releaseNotesUrl: `https://example.com/${version}`,
+    yanked: false,
+    deprecationReason: null,
+    requiredCliVersion: null,
+    minimumEpoch: null,
+    platforms: { "darwin-arm64": AVAILABLE_ASSET },
+  })),
+};
+
+function rcInstallRecord(): HostInstallRecord {
+  return {
+    installId: "install-1",
+    version: "2.0.0-rc.1",
+    runtimeVersion: null,
+    platform: "darwin",
+    arch: "arm64",
+    installedAt: "2026-06-22T00:00:00.000Z",
+    source: { kind: "registry", value: "https://example.com/host.tar.gz" },
+    archiveSha256: null,
+    signatureVerifiedAt: "2026-06-22T00:00:00.000Z",
+    signatureKeyId: "test-key",
+    sizeBytes: 1,
+    executablePath: "/opt/traycer/host",
+  };
+}
+
+function findHostAvailable(program: Command): Command {
+  const host = program.commands.find((child) => child.name() === "host");
+  expect(host, "'host' command is not registered").toBeDefined();
+  const available = host?.commands.find(
+    (child) => child.name() === "available",
+  );
+  expect(available, "'host available' is not registered").toBeDefined();
+  if (available === undefined) throw new Error("unreachable");
+  return available;
+}
+
+/** Runs `host available` with the given extra argv and returns what it emitted. */
+async function runHostAvailable(argv: readonly string[]): Promise<{
+  readonly parsedOption: unknown;
+  readonly data: Record<string, unknown>;
+}> {
+  mocks.results.length = 0;
+  const program = buildProgram();
+  program.exitOverride();
+  await program.parseAsync(["host", "available", ...argv], { from: "user" });
+  expect(mocks.results).toHaveLength(1);
+  const data = mocks.results[0].data;
+  expect(data).toBeTypeOf("object");
+  return {
+    parsedOption: findHostAvailable(program).opts().includePreReleases,
+    data: data as Record<string, unknown>,
+  };
+}
+
+function listedVersions(data: Record<string, unknown>): readonly string[] {
+  const manifest = data.manifest as HostVersionsManifest;
+  return manifest.versions.map((entry) => entry.version);
+}
+
+describe("host available flag states through the real commander tree", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchManifestMock.mockResolvedValue(MANIFEST);
+    mocks.readHostInstallRecordMock.mockResolvedValue(rcInstallRecord());
+  });
+
+  it("leaves the option undefined with neither flag, and derives from the RC install", async () => {
+    // The load-bearing assertion. If commander ever defaults this to `true`,
+    // `parsedOption` catches it before the provenance does - and the
+    // provenance proves the CLI did not merely guess right by accident.
+    const { parsedOption, data } = await runHostAvailable([]);
+
+    expect(parsedOption).toBe(undefined);
+    expect(data.includePreReleases).toBe(true);
+    expect(data.includePreReleasesSource).toBe("installed-rc");
+    expect(listedVersions(data)).toEqual(["2.0.0-rc.2", "1.2.0"]);
+  });
+
+  it("parses the positive flag as an explicit include", async () => {
+    const { parsedOption, data } = await runHostAvailable([
+      "--include-pre-releases",
+    ]);
+
+    expect(parsedOption).toBe(true);
+    expect(data.includePreReleases).toBe(true);
+    expect(data.includePreReleasesSource).toBe("explicit-include");
+    expect(mocks.readHostInstallRecordMock).not.toHaveBeenCalled();
+  });
+
+  it("parses the negative flag as an explicit exclude that beats the RC install", async () => {
+    // Critique finding 7's remedy, end to end: on an RC host, whose derived
+    // default includes RCs, the negative flag must still produce a
+    // stable-only listing.
+    const { parsedOption, data } = await runHostAvailable([
+      "--no-include-pre-releases",
+    ]);
+
+    expect(parsedOption).toBe(false);
+    expect(data.includePreReleases).toBe(false);
+    expect(data.includePreReleasesSource).toBe("explicit-exclude");
+    expect(listedVersions(data)).toEqual(["1.2.0"]);
+    expect(mocks.readHostInstallRecordMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps all three states distinct - none collapses into another", async () => {
+    // The regression this file exists for is a COLLAPSE: two of the three
+    // states quietly becoming one. Asserted together so a reorder that makes
+    // "neither" behave like "--include-pre-releases" cannot pass by fixing
+    // each case's expectation in isolation.
+    const neither = await runHostAvailable([]);
+    const positive = await runHostAvailable(["--include-pre-releases"]);
+    const negative = await runHostAvailable(["--no-include-pre-releases"]);
+
+    expect([
+      neither.parsedOption,
+      positive.parsedOption,
+      negative.parsedOption,
+    ]).toEqual([undefined, true, false]);
+    expect([
+      neither.data.includePreReleasesSource,
+      positive.data.includePreReleasesSource,
+      negative.data.includePreReleasesSource,
+    ]).toEqual(["installed-rc", "explicit-include", "explicit-exclude"]);
+  });
+
+  it("exposes both flags in help so the negative one is discoverable", () => {
+    const help = findHostAvailable(buildProgram()).helpInformation();
+    expect(help).toContain("--include-pre-releases");
+    expect(help).toContain("--no-include-pre-releases");
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
@@ -18,6 +18,7 @@ import type {
 // first.
 const mocks = vi.hoisted(() => ({
   fetchManifestMock: vi.fn(),
+  readHostInstallRecordMock: vi.fn(),
 }));
 
 vi.mock("../../registry", async (importOriginal) => {
@@ -36,10 +37,25 @@ vi.mock("../../registry", async (importOriginal) => {
   };
 });
 
+// The derived default is the one thing this command reads off local disk, so
+// the install record is mocked rather than materialized: these cases are about
+// what the CLI CONCLUDES from a version string (and from a read that fails),
+// not about `install.json` parsing, which `manifest/host-install` owns.
+vi.mock("../../manifest/host-install", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../manifest/host-install")>();
+  return {
+    ...actual,
+    readHostInstallRecord: mocks.readHostInstallRecordMock,
+  };
+});
+
 import {
   buildHostAvailableCommand,
   buildHostAvailableListing,
+  resolveIncludePreReleases,
 } from "../host-available";
+import type { HostInstallRecord } from "../../manifest/host-install";
 import type { CommandContext } from "../../runner/runner";
 
 const AVAILABLE_ASSET: HostPlatformAsset = {
@@ -100,6 +116,7 @@ describe("buildHostAvailableListing", () => {
       manifestUrl: "https://example.com/versions.json",
       platformKey: "darwin-arm64",
       includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
       cliVersion: "9.9.9",
     });
 
@@ -124,6 +141,7 @@ describe("buildHostAvailableListing", () => {
         "https://github.com/traycerai/traycer/releases/download/released-host-versions/versions.json",
       platformKey: "darwin-arm64",
       includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
       cliVersion: "9.9.9",
     });
 
@@ -148,6 +166,7 @@ describe("buildHostAvailableListing", () => {
         "https://github.com/traycerai/traycer/releases/download/released-host-versions/versions.json",
       platformKey: "darwin-arm64",
       includePreReleases: true,
+      includePreReleasesSource: "explicit-include",
       cliVersion: "9.9.9",
     });
 
@@ -235,6 +254,201 @@ function parseAvailableSnapshotLikeDesktop(raw: unknown): {
   });
   return { latest: manifest.latest, versions };
 }
+
+// The catalog default is derived, not stored, and the CLI is the only process
+// that can derive it - it is the one that can read this environment's install
+// record. These cases pin all four provenances plus the fail-closed rule that
+// keeps a corrupt record from breaking the listing.
+describe("resolveIncludePreReleases", () => {
+  it("honours an explicit include regardless of what is installed", () => {
+    expect(
+      resolveIncludePreReleases({
+        override: true,
+        installedHostVersion: "1.2.0",
+      }),
+    ).toEqual({ includePreReleases: true, source: "explicit-include" });
+  });
+
+  it("honours an explicit exclude even on an RC host - the whole point of the negative flag", () => {
+    // Without a negative flag an RC host could never be shown a stable-only
+    // catalog: its derived default includes RCs, and "unchecked" would be
+    // indistinguishable from "never touched".
+    expect(
+      resolveIncludePreReleases({
+        override: false,
+        installedHostVersion: "2.0.0-rc.1",
+      }),
+    ).toEqual({ includePreReleases: false, source: "explicit-exclude" });
+  });
+
+  it("derives inclusion from a canonical RC install", () => {
+    expect(
+      resolveIncludePreReleases({
+        override: null,
+        installedHostVersion: "2.0.0-rc.1",
+      }),
+    ).toEqual({ includePreReleases: true, source: "installed-rc" });
+  });
+
+  it("derives stable-default for every non-canonical installed version", () => {
+    // Canonical `X.Y.Z-rc.N` is the ONLY prerelease shape that activates
+    // implicit following; everything else - including a version that merely
+    // contains a hyphen - fails closed to the stable catalog.
+    for (const installedHostVersion of [
+      "1.2.0",
+      "2.0.0-beta.1",
+      "2.0.0-alpha",
+      "2.0.0-nightly.3",
+      "2.0.0-rc",
+      "2.0.0-rc.01",
+      "2.0.0-rc.1.2",
+      "2.0.0-rc.1+build.7",
+      "local-traycer-host-1730000000",
+      "not-a-version",
+      "",
+    ]) {
+      expect(
+        resolveIncludePreReleases({ override: null, installedHostVersion }),
+      ).toEqual({ includePreReleases: false, source: "stable-default" });
+    }
+  });
+
+  it("derives stable-default when nothing is installed or the record was unreadable", () => {
+    expect(
+      resolveIncludePreReleases({ override: null, installedHostVersion: null }),
+    ).toEqual({ includePreReleases: false, source: "stable-default" });
+  });
+});
+
+function installRecord(version: string): HostInstallRecord {
+  return {
+    installId: "install-1",
+    version,
+    runtimeVersion: null,
+    platform: "darwin",
+    arch: "arm64",
+    installedAt: "2026-06-22T00:00:00.000Z",
+    source: { kind: "registry", value: "https://example.com/host.tar.gz" },
+    archiveSha256: null,
+    signatureVerifiedAt: "2026-06-22T00:00:00.000Z",
+    signatureKeyId: "test-key",
+    sizeBytes: 1,
+    executablePath: "/opt/traycer/host",
+  };
+}
+
+describe("buildHostAvailableCommand's derived catalog default", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("lists an RC host's own line with no flag passed, and says why", async () => {
+    mocks.fetchManifestMock.mockResolvedValue(
+      createManifest(["2.0.0-rc.2", "1.2.0"]),
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      installRecord("2.0.0-rc.1"),
+    );
+
+    const command = buildHostAvailableCommand({ includePreReleases: null });
+    const result = await command(fakeCtx());
+
+    expect(result.data).toMatchObject({
+      includePreReleases: true,
+      includePreReleasesSource: "installed-rc",
+    });
+    expect(parseAvailableSnapshotLikeDesktop(result.data).versions).toEqual([
+      { version: "2.0.0-rc.2", available: true },
+      { version: "1.2.0", available: true },
+    ]);
+    expect(result.human).toContain(
+      "pre-releases: included (following the installed release candidate's line)",
+    );
+  });
+
+  it("keeps a stable host on the stable catalog with no flag passed", async () => {
+    mocks.fetchManifestMock.mockResolvedValue(
+      createManifest(["2.0.0-rc.2", "1.2.0"]),
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(installRecord("1.2.0"));
+
+    const command = buildHostAvailableCommand({ includePreReleases: null });
+    const result = await command(fakeCtx());
+
+    expect(result.data).toMatchObject({
+      includePreReleases: false,
+      includePreReleasesSource: "stable-default",
+    });
+    expect(parseAvailableSnapshotLikeDesktop(result.data).versions).toEqual([
+      { version: "1.2.0", available: true },
+    ]);
+  });
+
+  it("still lists the registry when the install record is corrupt", async () => {
+    // A corrupt `install.json` is exactly when someone needs to see which
+    // versions exist. `readHostInstallRecord` throws rather than overwrite a
+    // suspect record - right for the install path, wrong for a listing - so
+    // this must fail closed to stable-default, not propagate.
+    mocks.fetchManifestMock.mockResolvedValue(
+      createManifest(["2.0.0-rc.2", "1.2.0"]),
+    );
+    mocks.readHostInstallRecordMock.mockRejectedValue(
+      Object.assign(new Error("host install record is invalid"), {
+        code: "E_HOST_INSTALL_RECORD_INVALID",
+      }),
+    );
+
+    const command = buildHostAvailableCommand({ includePreReleases: null });
+    const result = await command(fakeCtx());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toMatchObject({
+      includePreReleases: false,
+      includePreReleasesSource: "stable-default",
+    });
+    expect(parseAvailableSnapshotLikeDesktop(result.data).versions).toEqual([
+      { version: "1.2.0", available: true },
+    ]);
+  });
+
+  it("filters RC rows off an RC host when the negative flag is passed, without reading the record", async () => {
+    mocks.fetchManifestMock.mockResolvedValue(
+      createManifest(["2.0.0-rc.2", "1.2.0"]),
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      installRecord("2.0.0-rc.1"),
+    );
+
+    const command = buildHostAvailableCommand({ includePreReleases: false });
+    const result = await command(fakeCtx());
+
+    expect(result.data).toMatchObject({
+      includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+    });
+    expect(parseAvailableSnapshotLikeDesktop(result.data).versions).toEqual([
+      { version: "1.2.0", available: true },
+    ]);
+    // An explicit answer must not depend on a disk read that can fail.
+    expect(mocks.readHostInstallRecordMock).not.toHaveBeenCalled();
+  });
+
+  it("includes RCs on a stable host when the positive flag is passed", async () => {
+    mocks.fetchManifestMock.mockResolvedValue(
+      createManifest(["2.0.0-rc.2", "1.2.0"]),
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(installRecord("1.2.0"));
+
+    const command = buildHostAvailableCommand({ includePreReleases: true });
+    const result = await command(fakeCtx());
+
+    expect(result.data).toMatchObject({
+      includePreReleases: true,
+      includePreReleasesSource: "explicit-include",
+    });
+    expect(mocks.readHostInstallRecordMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("buildHostAvailableCommand's real data envelope against desktop's parse contract", () => {
   afterEach(() => {
@@ -344,6 +558,7 @@ describe("buildHostAvailableListing platform scoping", () => {
       manifestUrl: "https://example.com/versions.json",
       platformKey: "darwin-arm64",
       includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
       cliVersion: "9.9.9",
     });
 
@@ -362,6 +577,7 @@ describe("buildHostAvailableListing platform scoping", () => {
       manifestUrl: "https://example.com/versions.json",
       platformKey: "darwin-arm64",
       includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
       cliVersion: "9.9.9",
     });
 

--- a/clients/traycer-cli/src/commands/host-available.ts
+++ b/clients/traycer-cli/src/commands/host-available.ts
@@ -1,4 +1,9 @@
 import {
+  isCanonicalReleaseCandidate,
+  isPreReleaseVersion,
+} from "@traycer-clients/shared/host-version/release-line";
+import type { HostIncludePreReleasesSource } from "@traycer/protocol/host/maintenance/schemas";
+import {
   createDefaultRegistryClient,
   currentHostPlatformKey,
   resolveManifestUrl,
@@ -8,15 +13,31 @@ import {
   isHostClientFloorRefusal,
 } from "../registry/client-floor";
 import { resolveCliVersion } from "../cli-version";
+import { readHostInstallRecord } from "../manifest/host-install";
 import type {
   HostPlatformKey,
   HostVersionEntry,
   HostVersionsManifest,
 } from "../registry";
-import type { CommandFn, CommandResult } from "../runner/runner";
+import type { Environment } from "../runner/environment";
+import type {
+  CommandContext,
+  CommandFn,
+  CommandResult,
+} from "../runner/runner";
 
 interface HostAvailableArgs {
-  readonly includePreReleases: boolean;
+  /**
+   * The catalog override: `true` explicitly includes release candidates,
+   * `false` explicitly filters them out, and `null` means the caller stated
+   * nothing and wants the default derived from the installed host.
+   *
+   * Three states, not two, because "unchecked" and "never touched" are
+   * different requests once an RC host includes its own line by default:
+   * collapsing them would leave a user on an RC host with no way to get a
+   * stable-only listing.
+   */
+  readonly includePreReleases: boolean | null;
 }
 
 interface HostAvailableListingArgs {
@@ -24,6 +45,7 @@ interface HostAvailableListingArgs {
   readonly manifestUrl: string;
   readonly platformKey: HostPlatformKey;
   readonly includePreReleases: boolean;
+  readonly includePreReleasesSource: HostIncludePreReleasesSource;
   /** THIS CLI's version - the floor is about the runner, not the archive. */
   readonly cliVersion: string;
 }
@@ -33,8 +55,77 @@ interface HostAvailableListing {
   readonly human: string;
 }
 
-// `traycer host available` - explicit registry probe per Flow 6. By default it
-// lists stable host versions only; pass --include-pre-releases to inspect RCs.
+export interface ResolvedIncludePreReleases {
+  readonly includePreReleases: boolean;
+  readonly source: HostIncludePreReleasesSource;
+}
+
+/**
+ * The CLI is the catalog-default authority: it is the only process that reads
+ * this environment's install record, so it - not the GUI, and not the host
+ * resolver - decides what an unstated override means.
+ *
+ * An installed canonical `X.Y.Z-rc.N` includes pre-releases so the RC can see
+ * its own line. EVERY other installed state resolves stable-only: a stable
+ * host, a non-canonical pre-release (`beta`, `nightly`, a `local-*` pin), no
+ * install at all, and an install record that could not be read. That last one
+ * is the point of `installedHostVersion: null` collapsing absent and
+ * unreadable together - see `readInstalledHostVersionFailingClosed`.
+ */
+export function resolveIncludePreReleases(args: {
+  readonly override: boolean | null;
+  readonly installedHostVersion: string | null;
+}): ResolvedIncludePreReleases {
+  if (args.override === true) {
+    return { includePreReleases: true, source: "explicit-include" };
+  }
+  if (args.override === false) {
+    return { includePreReleases: false, source: "explicit-exclude" };
+  }
+  if (
+    args.installedHostVersion !== null &&
+    isCanonicalReleaseCandidate(args.installedHostVersion)
+  ) {
+    return { includePreReleases: true, source: "installed-rc" };
+  }
+  return { includePreReleases: false, source: "stable-default" };
+}
+
+/**
+ * Reads the installed host's version for the derivation above, failing closed.
+ *
+ * Every failure mode collapses to `null` (stable-default), deliberately. This
+ * read exists only to pick a DEFAULT FILTER for a listing; a corrupt or
+ * unreadable `install.json` is not a reason to refuse to tell someone which
+ * host versions exist - that is exactly the moment they are most likely to be
+ * reinstalling. `readHostInstallRecord` is the strict reader used by the
+ * install/start paths, and it throws `HOST_INSTALL_RECORD_INVALID` rather than
+ * overwrite a suspect record; that strictness is right there and wrong here,
+ * so this catches it along with permission and I/O errors.
+ */
+async function readInstalledHostVersionFailingClosed(
+  environment: Environment,
+  ctx: CommandContext,
+): Promise<string | null> {
+  try {
+    const record = await readHostInstallRecord(environment);
+    return record === null ? null : record.version;
+  } catch (err) {
+    ctx.runtime.logger.debug(
+      "Host install record unreadable; defaulting catalog to stable-only",
+      {
+        environment,
+        errorName: err instanceof Error ? err.name : typeof err,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return null;
+  }
+}
+
+// `traycer host available` - explicit registry probe per Flow 6. With neither
+// flag it derives RC inclusion from the installed host; `--include-pre-releases`
+// and `--no-include-pre-releases` override that in either direction.
 export function buildHostAvailableCommand(args: HostAvailableArgs): CommandFn {
   return async (ctx): Promise<CommandResult> => {
     const urlInfo = resolveManifestUrl();
@@ -44,11 +135,25 @@ export function buildHostAvailableCommand(args: HostAvailableArgs): CommandFn {
     );
     const manifest = await client.fetchManifest();
     const platformKey = currentHostPlatformKey();
+    // Only consulted when the caller stated nothing - an explicit flag must
+    // not pay for a disk read, and must not be able to fail on one.
+    const installedHostVersion =
+      args.includePreReleases === null
+        ? await readInstalledHostVersionFailingClosed(
+            ctx.runtime.environment,
+            ctx,
+          )
+        : null;
+    const resolved = resolveIncludePreReleases({
+      override: args.includePreReleases,
+      installedHostVersion,
+    });
     const listing = buildHostAvailableListing({
       manifest,
       manifestUrl: urlInfo.url,
       platformKey,
-      includePreReleases: args.includePreReleases,
+      includePreReleases: resolved.includePreReleases,
+      includePreReleasesSource: resolved.source,
       cliVersion: resolveCliVersion(process.env),
     });
     return {
@@ -56,17 +161,18 @@ export function buildHostAvailableCommand(args: HostAvailableArgs): CommandFn {
         manifest: listing.manifest,
         manifestUrl: urlInfo.url,
         platformKey,
-        includePreReleases: args.includePreReleases,
+        // Both, not one: the resolved inclusion says what the rows were
+        // filtered by, and the provenance says why - which is what lets a
+        // caller explain an RC-inclusive default without claiming the user
+        // saved a preference.
+        includePreReleases: resolved.includePreReleases,
+        includePreReleasesSource: resolved.source,
       },
       human: listing.human,
       exitCode: 0,
     };
   };
 }
-
-export const hostAvailableCommand: CommandFn = buildHostAvailableCommand({
-  includePreReleases: false,
-});
 
 export function buildHostAvailableListing(
   args: HostAvailableListingArgs,
@@ -90,6 +196,9 @@ export function buildHostAvailableListing(
   lines.push(`generatedAt: ${args.manifest.generatedAt}`);
   lines.push(`latest: ${args.manifest.latest}`);
   lines.push(`platform: ${args.platformKey}`);
+  lines.push(
+    `pre-releases: ${describeIncludePreReleases(args.includePreReleasesSource)}`,
+  );
   lines.push("");
   lines.push(
     ...versions.map((entry) => {
@@ -115,6 +224,24 @@ export function buildHostAvailableListing(
     manifest,
     human: lines.join("\n"),
   };
+}
+
+// The human listing states the provenance too, not just the filter. An RC
+// host lists RC rows with no flag passed, and without this line that reads as
+// the CLI ignoring its own documented default.
+function describeIncludePreReleases(
+  source: HostIncludePreReleasesSource,
+): string {
+  switch (source) {
+    case "explicit-include":
+      return "included (--include-pre-releases)";
+    case "explicit-exclude":
+      return "excluded (--no-include-pre-releases)";
+    case "installed-rc":
+      return "included (following the installed release candidate's line)";
+    case "stable-default":
+      return "excluded (stable default)";
+  }
 }
 
 // Emit only the asset for the platform this CLI is running on.
@@ -184,14 +311,14 @@ function projectClientFloor(
   };
 }
 
+// `isPreReleaseVersion` is the shared catalog predicate rather than a local
+// one: Desktop's `HostController` predicts this exact filter to decide whether
+// a staged build would still appear in the default listing, and a second copy
+// of the rule here is what would eventually purge one.
 function filterHostAvailableVersions(
   versions: readonly HostVersionEntry[],
   includePreReleases: boolean,
 ): readonly HostVersionEntry[] {
   if (includePreReleases) return versions;
   return versions.filter((entry) => !isPreReleaseVersion(entry.version));
-}
-
-function isPreReleaseVersion(version: string): boolean {
-  return /^\d+\.\d+\.\d+-/.test(version);
 }

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1114,10 +1114,29 @@ function registerHostCommands(program: Command): void {
       .option(
         "--include-pre-releases",
         "Include release-candidate and other prerelease host versions",
+      )
+      .option(
+        "--no-include-pre-releases",
+        "Exclude prerelease host versions even when the installed host is a release candidate",
       ),
+    // Three states, and commander gives all three: `--include-…` yields true,
+    // `--no-include-…` yields false, and NEITHER leaves the option unset,
+    // which becomes the `null` the command derives from.
+    //
+    // That third state rests on commander declining to install a default when
+    // a command declares both forms - a library rule, not something this file
+    // states. It has moved across majors (on 9.5.0, a `--no-` declared FIRST
+    // installs an implicit `true`; on the 15.x this package resolves, neither
+    // order does), and if it ever moves back, "neither flag" silently starts
+    // including release candidates on every host. Keep the positive flag
+    // declared first, and see `host-available-entrypoint.test.ts`, which pins
+    // all three parsed values so a dependency bump cannot change this quietly.
     (opts) =>
       buildHostAvailableCommand({
-        includePreReleases: opts.includePreReleases === true,
+        includePreReleases:
+          opts.includePreReleases === undefined
+            ? null
+            : opts.includePreReleases === true,
       }),
   );
 

--- a/protocol/src/host/maintenance/__tests__/host-update-check.test.ts
+++ b/protocol/src/host/maintenance/__tests__/host-update-check.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import {
+  upgradeRequestToVersion,
+  upgradeResponseToVersion,
+  upgradeResponseToVersionWithContext,
+} from "@traycer/protocol/framework/index";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
+import {
+  hostUpdateCheckV10,
+  hostUpdateCheckV11,
+} from "@traycer/protocol/host/maintenance/contracts";
+import {
+  hostUpdateCheckRequestSchema,
+  hostUpdateCheckRequestSchemaV11,
+  hostUpdateCheckResponseSchemaV11,
+  type HostAvailableManifest,
+} from "@traycer/protocol/host/maintenance/schemas";
+
+const MANIFEST: HostAvailableManifest = {
+  schemaVersion: 1,
+  generatedAt: "2026-06-22T01:00:00.000Z",
+  latest: "1.2.0",
+  versions: [],
+};
+
+const V10 = hostUpdateCheckV10.schemaVersion;
+const V11 = hostUpdateCheckV11.schemaVersion;
+const REGISTRY = hostRpcRegistry["host.update.check"];
+
+describe("host.update.check v1.1 request", () => {
+  it("carries all three catalog states", () => {
+    expect(
+      hostUpdateCheckRequestSchemaV11.parse({ includePreReleases: true }),
+    ).toEqual({ includePreReleases: true });
+    expect(
+      hostUpdateCheckRequestSchemaV11.parse({ includePreReleases: false }),
+    ).toEqual({ includePreReleases: false });
+    // Absent is the third state - derive from the installed host - and it
+    // stays absent rather than being defaulted into one of the other two.
+    expect(hostUpdateCheckRequestSchemaV11.parse({})).toStrictEqual({});
+  });
+
+  it("rejects null, the shape that cannot cross to a v1.0 peer", () => {
+    // The third state is an omitted key precisely because `null` fails the
+    // v1.0 projection below; accepting it here would let a client build a
+    // request that dies at `prepareRequestPayload` against a shipped host.
+    expect(
+      hostUpdateCheckRequestSchemaV11.safeParse({ includePreReleases: null })
+        .success,
+    ).toBe(false);
+  });
+});
+
+/**
+ * What `prepareRequestPayload` does when a v1.1 client negotiates v1.0: it
+ * PARSES the v1.1 params with the v1.0 request schema and sends the result.
+ * These three cases are the whole documented old-host contract.
+ */
+describe("v1.1 request projected onto a negotiated v1.0 peer", () => {
+  it("sends the stable-only default for a derive request", () => {
+    const derive = hostUpdateCheckRequestSchemaV11.parse({});
+    const projected = hostUpdateCheckRequestSchema.safeParse(derive);
+    expect(projected.success).toBe(true);
+    expect(projected.success && projected.data).toEqual({
+      includePreReleases: false,
+    });
+  });
+
+  it("preserves an explicit include", () => {
+    expect(
+      hostUpdateCheckRequestSchema.parse({ includePreReleases: true }),
+    ).toEqual({ includePreReleases: true });
+  });
+
+  it("collapses explicit exclude onto the same stable-only ask", () => {
+    // The v1.1-only distinction between "excluded" and "not stated" is not
+    // sent to an old peer; both mean stable-only there, which is what that
+    // peer has always done.
+    expect(
+      hostUpdateCheckRequestSchema.parse({ includePreReleases: false }),
+    ).toEqual({ includePreReleases: false });
+  });
+});
+
+describe("host.update.check v1.1 response", () => {
+  it("requires resolved inclusion and provenance on the ok arm", () => {
+    expect(
+      hostUpdateCheckResponseSchemaV11.safeParse({
+        outcome: "ok",
+        manifest: MANIFEST,
+      }).success,
+    ).toBe(false);
+    const resolved = {
+      outcome: "ok",
+      manifest: MANIFEST,
+      effectiveIncludePreReleases: true,
+      includePreReleasesSource: "installed-rc",
+    };
+    expect(hostUpdateCheckResponseSchemaV11.parse(resolved)).toEqual(resolved);
+  });
+
+  it("rejects a provenance outside the declared set", () => {
+    expect(
+      hostUpdateCheckResponseSchemaV11.safeParse({
+        outcome: "ok",
+        manifest: MANIFEST,
+        effectiveIncludePreReleases: true,
+        includePreReleasesSource: "implicit-rc-line",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("leaves the failure arms untouched - nothing was resolved to report", () => {
+    for (const outcome of ["cli-unavailable", "cli-failed", "invalid-output"]) {
+      expect(hostUpdateCheckResponseSchemaV11.parse({ outcome })).toEqual({
+        outcome,
+      });
+    }
+  });
+});
+
+describe("v1.0 -> v1.1 upgrade", () => {
+  it("maps a v1.0 true to an explicit include", () => {
+    expect(
+      upgradeRequestToVersion(REGISTRY, V10, V11, {
+        includePreReleases: true,
+      }),
+    ).toEqual({ includePreReleases: true });
+  });
+
+  it("maps a v1.0 false to derive, not to explicit exclude", () => {
+    // An old client's `false` was the stable-only DEFAULT, not a deliberate
+    // filter - it had no way to express one. Reading it as explicit exclude
+    // would pin every old client to stable-only even on an RC host.
+    //
+    // `toStrictEqual`, NOT `toEqual`: `toEqual` ignores undefined-valued keys,
+    // so it passes for `{ includePreReleases: undefined }` too and cannot see
+    // the distinction this whole assertion is about.
+    expect(
+      upgradeRequestToVersion(REGISTRY, V10, V11, {
+        includePreReleases: false,
+      }),
+    ).toStrictEqual({});
+  });
+
+  it("reports an old host's true response as an explicit include", () => {
+    expect(
+      upgradeResponseToVersionWithContext(
+        REGISTRY,
+        V10,
+        V11,
+        { outcome: "ok", manifest: MANIFEST },
+        { request: { includePreReleases: true }, hostId: "host-1" },
+      ),
+    ).toEqual({
+      outcome: "ok",
+      manifest: MANIFEST,
+      effectiveIncludePreReleases: true,
+      includePreReleasesSource: "explicit-include",
+    });
+  });
+
+  it("never claims installed-rc provenance from an old host", () => {
+    // The old peer derived nothing. `stable-default` is what its contract
+    // actually meant; `installed-rc` would fabricate the Settings copy that
+    // keys off it.
+    expect(
+      upgradeResponseToVersionWithContext(
+        REGISTRY,
+        V10,
+        V11,
+        { outcome: "ok", manifest: MANIFEST },
+        { request: { includePreReleases: false }, hostId: "host-1" },
+      ),
+    ).toEqual({
+      outcome: "ok",
+      manifest: MANIFEST,
+      effectiveIncludePreReleases: false,
+      includePreReleasesSource: "stable-default",
+    });
+  });
+
+  it("passes a failure outcome through without inventing provenance", () => {
+    expect(
+      upgradeResponseToVersionWithContext(
+        REGISTRY,
+        V10,
+        V11,
+        { outcome: "cli-unavailable" },
+        { request: { includePreReleases: true }, hostId: "host-1" },
+      ),
+    ).toEqual({ outcome: "cli-unavailable" });
+  });
+
+  it("refuses to upgrade an ok response with no request context", () => {
+    // Provenance is a fact about the REQUEST. Without it the only options are
+    // to guess or to fail, and a guessed provenance is worse than an error.
+    expect(() =>
+      upgradeResponseToVersion(REGISTRY, V10, V11, {
+        outcome: "ok",
+        manifest: MANIFEST,
+      }),
+    ).toThrow(/request context/);
+  });
+});
+
+/**
+ * The representation a resolver actually receives for the derive state.
+ *
+ * A resolver has to distinguish three requests, and the third is spelled by an
+ * absence - so HOW that absence is represented is part of the contract, not an
+ * implementation detail. Two paths deliver it: a v1.1 client's request parsed
+ * off the wire, and a v1.0 request bridged up. If they disagreed on key
+ * presence, `"includePreReleases" in params` would classify one logical state
+ * two different ways depending on the peer, and only against an old client -
+ * the worst possible place to find out.
+ */
+describe("the derive state as a resolver sees it", () => {
+  it("has no own key when parsed from a v1.1 client's request", () => {
+    const parsed = hostUpdateCheckRequestSchemaV11.parse({});
+    expect(Object.hasOwn(parsed, "includePreReleases")).toBe(false);
+    expect(Object.keys(parsed)).toStrictEqual([]);
+  });
+
+  it("has no own key when bridged up from a v1.0 peer either", () => {
+    const bridged = upgradeRequestToVersion(REGISTRY, V10, V11, {
+      includePreReleases: false,
+    });
+    expect(Object.hasOwn(bridged, "includePreReleases")).toBe(false);
+    expect(Object.keys(bridged)).toStrictEqual([]);
+  });
+
+  it("reads as undefined under the documented value test, from either path", () => {
+    // `=== undefined` is the rule resolvers must use: it is correct whether or
+    // not the own key is present, so it survives a future bridge that spells
+    // the absence the other way.
+    const fromWire = hostUpdateCheckRequestSchemaV11.parse({});
+    const fromBridge = upgradeRequestToVersion(REGISTRY, V10, V11, {
+      includePreReleases: false,
+    });
+    expect(fromWire.includePreReleases).toBe(undefined);
+    expect(fromBridge.includePreReleases).toBe(undefined);
+  });
+
+  it("keeps the two explicit states distinguishable from it and from each other", () => {
+    const include = hostUpdateCheckRequestSchemaV11.parse({
+      includePreReleases: true,
+    });
+    const exclude = hostUpdateCheckRequestSchemaV11.parse({
+      includePreReleases: false,
+    });
+    expect(include).toStrictEqual({ includePreReleases: true });
+    expect(exclude).toStrictEqual({ includePreReleases: false });
+    // The one that a boolean-only contract could not express: explicit
+    // exclude must not read as the derive state.
+    expect(exclude.includePreReleases).not.toBe(undefined);
+  });
+});
+
+describe("host.update.check registry line", () => {
+  it("makes v1.1 the current minor of major 1", () => {
+    expect(REGISTRY[1].latestMinor).toBe(1);
+    expect(REGISTRY[1].versions[1].contract).toBe(hostUpdateCheckV11);
+    expect(REGISTRY[1].versions[1].upgradeFromPreviousVersion).not.toBe(null);
+  });
+
+  it("adds no cross-major downgrade bridge - v1.0 and v1.1 share major 1", () => {
+    expect(REGISTRY[1].downgradePathsFromLatest).toEqual({});
+  });
+
+  it("stays an optional method with a declared missing-peer behaviour", () => {
+    // A host predating this method has no `host.update.check` at all; the
+    // handshake must degrade rather than treat the name-set as incompatible.
+    expect(REGISTRY.degrade).toEqual({ kind: "unsupported" });
+  });
+});

--- a/protocol/src/host/maintenance/contracts.ts
+++ b/protocol/src/host/maintenance/contracts.ts
@@ -1,4 +1,7 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineContextualUpgradePath,
+  defineRpcContract,
+} from "@traycer/protocol/framework/index";
 import {
   hostDoctorRequestSchema,
   hostDoctorResponseSchema,
@@ -11,7 +14,9 @@ import {
   hostServiceStatusRequestSchema,
   hostServiceStatusResponseSchema,
   hostUpdateCheckRequestSchema,
+  hostUpdateCheckRequestSchemaV11,
   hostUpdateCheckResponseSchema,
+  hostUpdateCheckResponseSchemaV11,
   hostUpdateInstallRequestSchema,
   hostUpdateInstallResponseSchema,
 } from "./schemas";
@@ -30,6 +35,75 @@ export const hostUpdateCheckV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: hostUpdateCheckRequestSchema,
   responseSchema: hostUpdateCheckResponseSchema,
+});
+
+/**
+ * v1.1: tri-state catalog override in, resolved inclusion + provenance out.
+ *
+ * The same registry listing as v1.0, asked and answered precisely enough for
+ * an installed release candidate to have its own line included by DEFAULT
+ * while an explicit "uncheck" can still filter RC rows off that same host.
+ */
+export const hostUpdateCheckV11 = defineRpcContract({
+  method: "host.update.check",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: hostUpdateCheckRequestSchemaV11,
+  responseSchema: hostUpdateCheckResponseSchemaV11,
+});
+
+/**
+ * The within-major bridge from v1.0. Contextual because the v1.0 RESPONSE
+ * cannot answer the new questions on its own — provenance is a fact about the
+ * REQUEST, and the framework's response-upgrade context is the only place the
+ * originating v1.0 request is still in hand.
+ *
+ * Request: v1.0 `true` was an explicit ask for RCs and stays `true`. v1.0
+ * `false`/omitted becomes the ABSENT (derive) state, NOT `false`: those
+ * clients had no way to express explicit exclusion, and their `false` was the
+ * old stable-only DEFAULT rather than a deliberate filter. Mapping it to
+ * `false` would pin every old client to stable-only even on an RC host,
+ * defeating the feature for exactly the peers it most helps.
+ *
+ * That derive state is spelled by OMITTING the key, not by writing
+ * `includePreReleases: undefined`. Both satisfy the contract's type and both
+ * read the same under the documented `=== undefined` test, but they are
+ * different objects: `{ includePreReleases: undefined }` has an own key, and a
+ * v1.1 request parsed off the wire does not. Constructing the same shape both
+ * ways keeps `"includePreReleases" in params` from answering differently for
+ * one logical request depending on which peer it came from - a divergence a
+ * resolver could only discover in production, against an old client.
+ *
+ * Response: an old host derived nothing, so the bridge reports what the old
+ * contract actually meant — `true` becomes `explicit-include`, `false`/omitted
+ * becomes stable-only under `stable-default`. It never claims `installed-rc`:
+ * that provenance asserts a derivation the old peer did not perform, and the
+ * Settings copy keyed off it would be a fabricated explanation.
+ */
+export const hostUpdateCheckUpgradeV10ToV11 = defineContextualUpgradePath<
+  typeof hostUpdateCheckV10,
+  typeof hostUpdateCheckV11
+>({
+  from: hostUpdateCheckV10.schemaVersion,
+  to: hostUpdateCheckV11.schemaVersion,
+  upgradeRequest: (request) =>
+    request.includePreReleases ? { includePreReleases: true } : {},
+  upgradeResponse: (response, context) => {
+    if (response.outcome !== "ok") return response;
+    if (context === undefined) {
+      throw new Error(
+        "host.update.check v1.0 responses require request context when upgraded to v1.1",
+      );
+    }
+    const requested = context.request.includePreReleases;
+    return {
+      outcome: "ok",
+      manifest: response.manifest,
+      effectiveIncludePreReleases: requested,
+      includePreReleasesSource: requested
+        ? "explicit-include"
+        : "stable-default",
+    };
+  },
 });
 
 /** Starts the CLI-owned, detached update swap for an explicitly chosen version. */

--- a/protocol/src/host/maintenance/index.ts
+++ b/protocol/src/host/maintenance/index.ts
@@ -4,7 +4,9 @@ export {
   hostServiceDeregisterV10,
   hostServiceRegisterV10,
   hostServiceStatusV10,
+  hostUpdateCheckUpgradeV10ToV11,
   hostUpdateCheckV10,
+  hostUpdateCheckV11,
   hostUpdateInstallV10,
 } from "./contracts";
 
@@ -25,8 +27,11 @@ export {
   hostServiceStateSchema,
   hostServiceStatusRequestSchema,
   hostServiceStatusResponseSchema,
+  hostIncludePreReleasesSourceSchema,
   hostUpdateCheckRequestSchema,
+  hostUpdateCheckRequestSchemaV11,
   hostUpdateCheckResponseSchema,
+  hostUpdateCheckResponseSchemaV11,
   hostUpdateInstallRequestSchema,
   hostUpdateInstallResponseSchema,
   type HostAvailableManifest,
@@ -43,8 +48,11 @@ export {
   type HostServiceState,
   type HostServiceStatusRequest,
   type HostServiceStatusResponse,
+  type HostIncludePreReleasesSource,
   type HostUpdateCheckRequest,
+  type HostUpdateCheckRequestV11,
   type HostUpdateCheckResponse,
+  type HostUpdateCheckResponseV11,
   type HostUpdateInstallRequest,
   type HostUpdateInstallResponse,
 } from "./schemas";

--- a/protocol/src/host/maintenance/schemas.ts
+++ b/protocol/src/host/maintenance/schemas.ts
@@ -181,6 +181,104 @@ export type HostUpdateCheckResponse = z.infer<
   typeof hostUpdateCheckResponseSchema
 >;
 
+/**
+ * Where the catalog's effective RC inclusion came from.
+ *
+ * This is PROVENANCE, not a saved preference — nothing in it is persisted.
+ * `installed-rc` says the CLI derived inclusion from an installed canonical
+ * `X.Y.Z-rc.N` host, which is what lets Settings explain that the host is
+ * following its current RC line instead of implying the user checked a box.
+ * `stable-default` is the fail-closed answer, and covers a stable install, a
+ * non-canonical pre-release, no install at all, and an install record the CLI
+ * could not read — a corrupt record must not break registry listing, so it is
+ * reported as the ordinary default rather than as an error.
+ *
+ * The two explicit values mirror the CLI's positive and negative flags. They
+ * exist because "unchecked" and "never touched" are genuinely different
+ * requests: only an explicit false can filter RC rows off an RC host.
+ */
+export const hostIncludePreReleasesSourceSchema = z.enum([
+  "explicit-include",
+  "explicit-exclude",
+  "installed-rc",
+  "stable-default",
+]);
+export type HostIncludePreReleasesSource = z.infer<
+  typeof hostIncludePreReleasesSourceSchema
+>;
+
+/**
+ * v1.1 replaces v1.0's defaulted boolean with a tri-state catalog override:
+ * `true` explicitly includes, `false` explicitly excludes, and ABSENT asks
+ * the host to derive inclusion from its own installed version.
+ *
+ * The third state is an omitted key rather than an explicit `null`, and that
+ * is a wire-projection requirement, not a style choice. Within one major there
+ * is no request-downgrade bridge - `downgradePathsFromLatest` is reserved for
+ * crossing majors - so a v1.1 client talking to a v1.0 host projects its
+ * params by PARSING them with the v1.0 request schema
+ * (`prepareRequestPayload`). `{ includePreReleases: null }` fails that parse,
+ * which would turn every default catalog load against an already-shipped host
+ * into `DOWNGRADE_UNSUPPORTED`. An omitted key parses to v1.0's `false`, which
+ * is precisely the documented old-host fallback: stable-only.
+ *
+ * `.optional()` and never `.default()`, for the reason
+ * `epicSubscribeOpenRequestSchema` gives: a default materializes a key the
+ * caller never wrote, splitting the GUI's query cache between the caller's
+ * params and the parsed params for one logical request - and here it would
+ * also re-collapse "excluded" into "not stated", the exact ambiguity this
+ * minor exists to remove.
+ *
+ * READING THE DERIVE STATE: test `params.includePreReleases === undefined`,
+ * never `"includePreReleases" in params` and never `Object.hasOwn(...)`. The
+ * two ways a derive request reaches a resolver do not agree on key PRESENCE,
+ * only on VALUE:
+ *
+ * - parsed from the wire, a v1.1 client's `{}` yields an object with no such
+ *   own key at all;
+ * - bridged from a v1.0 peer, `hostUpdateCheckUpgradeV10ToV11` yields whatever
+ *   that bridge constructs.
+ *
+ * The bridge deliberately omits the key so the two coincide today, and
+ * `host-update-check.test.ts` pins that with `toStrictEqual` rather than
+ * `toEqual` (which cannot see the difference). An identity check on the VALUE
+ * is correct under either representation, so it is the rule that survives.
+ */
+export const hostUpdateCheckRequestSchemaV11 = z.object({
+  includePreReleases: z.boolean().optional(),
+});
+export type HostUpdateCheckRequestV11 = z.infer<
+  typeof hostUpdateCheckRequestSchemaV11
+>;
+
+/**
+ * v1.1's `ok` arm reports what the catalog actually did.
+ *
+ * `effectiveIncludePreReleases` is the resolved inclusion — the answer the
+ * rows were filtered by — and is NOT a restatement of the request: for a
+ * derive request (the absent third state) it is the host's own derivation,
+ * which is the only way a caller can learn what an unstated override became.
+ * The other three outcomes are unchanged; a CLI that never ran resolved
+ * nothing to report.
+ */
+export const hostUpdateCheckResponseSchemaV11 = z.discriminatedUnion(
+  "outcome",
+  [
+    z.object({
+      outcome: z.literal("ok"),
+      manifest: hostAvailableManifestSchema,
+      effectiveIncludePreReleases: z.boolean(),
+      includePreReleasesSource: hostIncludePreReleasesSourceSchema,
+    }),
+    z.object({ outcome: z.literal("cli-unavailable") }),
+    z.object({ outcome: z.literal("cli-failed") }),
+    z.object({ outcome: z.literal("invalid-output") }),
+  ],
+);
+export type HostUpdateCheckResponseV11 = z.infer<
+  typeof hostUpdateCheckResponseSchemaV11
+>;
+
 export const hostUpdateInstallRequestSchema = z.object({
   version: z.string().min(1),
   force: z.boolean(),

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -223,7 +223,9 @@ import {
   hostServiceDeregisterV10,
   hostServiceRegisterV10,
   hostServiceStatusV10,
+  hostUpdateCheckUpgradeV10ToV11,
   hostUpdateCheckV10,
+  hostUpdateCheckV11,
   hostUpdateInstallV10,
 } from "@traycer/protocol/host/maintenance/contracts";
 import {
@@ -3660,8 +3662,7 @@ export const workspacePrepareFoldersUpgradeV11ToV12 = defineUpgradePath<
   to: workspacePrepareFoldersV12.schemaVersion,
   upgradeRequest: (request) => ({
     ...request,
-    bumpRecency:
-      request.operation === "recordRecentWorkspace" ? true : null,
+    bumpRecency: request.operation === "recordRecentWorkspace" ? true : null,
   }),
   upgradeResponse: (response) => response,
 });
@@ -3971,14 +3972,25 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
+  // v1.1 adds the tri-state catalog override and the resolved-inclusion +
+  // provenance the Settings copy reads. A minor, not a major: the request
+  // only grows a third (absent) state on an already-optional key and the `ok`
+  // response only gains fields, so `upgradeFromPreviousVersion` is the whole
+  // bridge and no `downgradePathsFromLatest` entry is warranted - those cross
+  // majors. A v1.0 peer keeps stable-only default semantics; provenance is
+  // reported only where v1.1 is negotiated.
   "host.update.check": {
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: hostUpdateCheckV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: hostUpdateCheckV11,
+          upgradeFromPreviousVersion: hostUpdateCheckUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},
@@ -6536,8 +6548,7 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
       versions: {
         1: {
           contract: terminalPlainEnsureRunningV21,
-          upgradeFromPreviousVersion:
-            terminalPlainEnsureRunningUpgradeV10ToV21,
+          upgradeFromPreviousVersion: terminalPlainEnsureRunningUpgradeV10ToV21,
           semanticMajorBreakFromPreviousMajor: true,
         },
       },
@@ -6587,8 +6598,7 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
       versions: {
         1: {
           contract: terminalPlainImportLegacyV21,
-          upgradeFromPreviousVersion:
-            terminalPlainImportLegacyUpgradeV10ToV21,
+          upgradeFromPreviousVersion: terminalPlainImportLegacyUpgradeV10ToV21,
           semanticMajorBreakFromPreviousMajor: true,
         },
       },


### PR DESCRIPTION
## Summary
- let Desktop and Host RC installs implicitly follow later RCs on the same release line
- prioritize the matching stable release, then return to stable-only behavior after installation
- add Host update-check v1.1 tri-state filtering and provenance across CLI, protocol, Desktop, and Settings
- preserve compatibility with v1.0 peers and older CLIs

## Verification
- affected compile, lint, and formatting checks pass
- focused Desktop, GUI, CLI, shared, and protocol suites pass
- three cold review passes completed with no remaining findings

Supersedes #1400 with a DCO-signed commit rebased onto current main.