### PR TITLE
fix(gui-app): make the File tree panel usable on a touch viewport

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -205,6 +205,10 @@ const modelListeners = new Set<() => void>();
 // invoke it directly, the same way Pierre invokes it on a real row click.
 let capturedOnSelectionChange: ((paths: ReadonlyArray<string>) => void) | null =
   null;
+// Row geometry the panel asked Pierre for. Only observable here: `useFileTree`
+// reads its options once, at construction, and the model exposes no getter the
+// panel could be asked afterwards.
+let capturedItemHeight: number | undefined = undefined;
 
 function notifyModel(): void {
   for (const listener of modelListeners) listener();
@@ -350,8 +354,10 @@ vi.mock("@pierre/trees/react", () => ({
     useSyncExternalStore(subscribeToSearchSnapshot, getSearchSnapshot),
   useFileTree: (options: {
     readonly onSelectionChange: (paths: ReadonlyArray<string>) => void;
+    readonly itemHeight: number | undefined;
   }) => {
     capturedOnSelectionChange = options.onSelectionChange;
+    capturedItemHeight = options.itemHeight;
     return { model: mockModel };
   },
 }));
@@ -1351,5 +1357,109 @@ describe("reveal in sidebar", () => {
         { path: "a.ts", options: { offset: "nearest" } },
       ]);
     });
+  });
+});
+
+/**
+ * The same panel body under the phone tab switcher, where it is the File tree
+ * category rather than a sidebar column. `useIsMobileViewport` reads
+ * `window.innerWidth` directly, so overriding it before render is what forces
+ * the touch presentation - same pattern as the composer-menu and providers
+ * panel mobile suites.
+ */
+describe("file tree on a touch viewport", () => {
+  const TAB_ID = "tab-1";
+  let openPermanentSpy: Mock<
+    (tabId: string, node: EpicCanvasTileRef) => NestedFocusTarget | null
+  >;
+  let openPreviewSpy: Mock<
+    (tabId: string, node: EpicCanvasTileRef) => NestedFocusTarget | null
+  >;
+
+  beforeEach(() => {
+    useSettingsStore.setState({
+      diffViewerPreferences: {
+        ...DEFAULT_DIFF_VIEWER_PREFERENCES,
+        ignoreWhitespace: false,
+      },
+    });
+    mockListedPaths = [];
+    mockSearchValue = "";
+    mockSearchSnapshot = { isOpen: false, value: "", matchingPaths: [] };
+    searchSnapshotListeners.clear();
+    listFileTreeCalls.length = 0;
+    resetPathsCalls.length = 0;
+    setSearchCalls.length = 0;
+    searchCalls.length = 0;
+    expandedInModel.clear();
+    expandedAtLastReset.clear();
+    selectedInModel.clear();
+    scrollToPathCalls.length = 0;
+    modelListeners.clear();
+    capturedOnSelectionChange = null;
+    capturedItemHeight = undefined;
+    installSearchHost({});
+    __resetWorkspaceFileListSubscriptionsForTesting();
+    useFileTreeStore.setState({ expandedPathsByScope: {} });
+    openPermanentSpy = vi.fn(() => null);
+    openPreviewSpy = vi.fn(() => null);
+    useEpicCanvasStore.setState({
+      prepareOpenTileInTabFocusTarget: openPermanentSpy,
+      prepareOpenTilePreviewInTabFocusTarget: openPreviewSpy,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetWorkspaceFileListSubscriptionsForTesting();
+    useFileTreeStore.setState({ expandedPathsByScope: {} });
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    pinnedStreamBindingRef.value = null;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
+  });
+
+  it("asks for touch-sized rows instead of the sidebar's compact ones", () => {
+    renderPanel(new MockWsStreamClient("unknown"));
+
+    expect(capturedItemHeight).toBe(44);
+  });
+
+  it("opens a tapped row permanently, because there is no tab strip to promote it from", () => {
+    const client = new MockWsStreamClient("unknown");
+    renderPanel(client);
+    act(() => {
+      client.sessions[0].emitFrame({
+        kind: "listing",
+        directoryPath: "",
+        entries: [
+          {
+            path: "readme.md",
+            name: "readme.md",
+            kind: "file",
+            ignored: false,
+          },
+        ],
+        truncated: false,
+        hasBinaryPayload: false,
+      });
+    });
+
+    act(() => {
+      capturedOnSelectionChange?.(["readme.md"]);
+    });
+
+    expect(openPreviewSpy).not.toHaveBeenCalled();
+    expect(openPermanentSpy).toHaveBeenCalledTimes(1);
+    expect(openPermanentSpy).toHaveBeenCalledWith(
+      TAB_ID,
+      expect.objectContaining({ filePath: "readme.md" }),
+    );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -17,7 +17,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useSyncExternalStore, type ReactNode } from "react";
+import { useState, useSyncExternalStore, type ReactNode } from "react";
 import type {
   IStreamSession,
   ServerFrameHandler,
@@ -357,7 +357,12 @@ vi.mock("@pierre/trees/react", () => ({
     readonly itemHeight: number | undefined;
   }) => {
     capturedOnSelectionChange = options.onSelectionChange;
-    capturedItemHeight = options.itemHeight;
+    // Mount-captured, exactly like the real hook's `useState(() => new
+    // FileTree(options))`. Recording it per RENDER instead would make the row
+    // geometry look reactive here when it is not, and the viewport-transition
+    // case below would pass without the body ever having been rebuilt.
+    const [itemHeightAtConstruction] = useState(() => options.itemHeight);
+    capturedItemHeight = itemHeightAtConstruction;
     return { model: mockModel };
   },
 }));
@@ -1369,6 +1374,58 @@ describe("reveal in sidebar", () => {
  */
 describe("file tree on a touch viewport", () => {
   const TAB_ID = "tab-1";
+  const MOBILE_WIDTH = 390;
+  const DESKTOP_WIDTH = 1024;
+
+  // The shared setup's `matchMedia` never notifies, which is right for suites
+  // that only need one width. Crossing the breakpoint mid-test needs a real
+  // one: `useIsMobileViewport` is a `useSyncExternalStore` over this event, so
+  // without it a width change reaches no render at all.
+  const breakpointListeners = new Set<() => void>();
+  function installLiveMatchMedia(): void {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: window.innerWidth < 768,
+        media: query,
+        onchange: null,
+        addEventListener: (_type: string, listener: () => void) => {
+          breakpointListeners.add(listener);
+        },
+        removeEventListener: (_type: string, listener: () => void) => {
+          breakpointListeners.delete(listener);
+        },
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+  function restoreInertMatchMedia(): void {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+  function setViewportWidth(width: number): void {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+    for (const listener of [...breakpointListeners]) listener();
+  }
+
   let openPermanentSpy: Mock<
     (tabId: string, node: EpicCanvasTileRef) => NestedFocusTarget | null
   >;
@@ -1407,10 +1464,9 @@ describe("file tree on a touch viewport", () => {
       prepareOpenTileInTabFocusTarget: openPermanentSpy,
       prepareOpenTilePreviewInTabFocusTarget: openPreviewSpy,
     });
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      value: 390,
-    });
+    breakpointListeners.clear();
+    installLiveMatchMedia();
+    setViewportWidth(MOBILE_WIDTH);
   });
 
   afterEach(() => {
@@ -1419,9 +1475,11 @@ describe("file tree on a touch viewport", () => {
     useFileTreeStore.setState({ expandedPathsByScope: {} });
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     pinnedStreamBindingRef.value = null;
+    breakpointListeners.clear();
+    restoreInertMatchMedia();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
-      value: 1024,
+      value: DESKTOP_WIDTH,
     });
   });
 
@@ -1461,5 +1519,19 @@ describe("file tree on a touch viewport", () => {
       TAB_ID,
       expect.objectContaining({ filePath: "readme.md" }),
     );
+  });
+
+  it("rebuilds the tree when the window crosses the breakpoint, rather than leaving the other class's rows", () => {
+    setViewportWidth(DESKTOP_WIDTH);
+    renderPanel(new MockWsStreamClient("unknown"));
+    expect(capturedItemHeight).toBeUndefined();
+
+    act(() => {
+      setViewportWidth(MOBILE_WIDTH);
+    });
+
+    // Only a rebuilt model can report this: the mocked hook, like the real
+    // one, reads `itemHeight` once at construction.
+    expect(capturedItemHeight).toBe(44);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -1431,7 +1431,7 @@ describe("file tree on a touch viewport", () => {
     expect(capturedItemHeight).toBe(44);
   });
 
-  it("opens a tapped row permanently, because there is no tab strip to promote it from", () => {
+  it("recycles the single preview tile for a tapped row rather than accumulating one per file", () => {
     const client = new MockWsStreamClient("unknown");
     renderPanel(client);
     act(() => {
@@ -1455,9 +1455,9 @@ describe("file tree on a touch viewport", () => {
       capturedOnSelectionChange?.(["readme.md"]);
     });
 
-    expect(openPreviewSpy).not.toHaveBeenCalled();
-    expect(openPermanentSpy).toHaveBeenCalledTimes(1);
-    expect(openPermanentSpy).toHaveBeenCalledWith(
+    expect(openPermanentSpy).not.toHaveBeenCalled();
+    expect(openPreviewSpy).toHaveBeenCalledTimes(1);
+    expect(openPreviewSpy).toHaveBeenCalledWith(
       TAB_ID,
       expect.objectContaining({ filePath: "readme.md" }),
     );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -81,6 +81,7 @@ import {
   useWorkspaceSearchPaths,
 } from "@/hooks/workspace/use-workspace-search-paths-query";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
 import { gitChangedFileToPierreStatusEntry } from "@/lib/git/panel-file-rendering";
 import {
   StreamRuntimeContext,
@@ -115,6 +116,19 @@ const WORKSPACE_FILE_LIST_METHOD = "workspace.subscribeFileList";
 
 /** Filter-box pause before either filter source runs. */
 const SEARCH_DEBOUNCE_MS = 200;
+
+/**
+ * Tree row height (px) under a touch viewport, where the panel is the phone tab
+ * switcher's File tree category rather than a sidebar column. Pierre's
+ * `compact` preset is 24px, and its rows live in a shadow root that the mobile
+ * shell's hit-area stylesheet cannot reach - so the row itself has to be the
+ * 44px target the rest of the phone surfaces use (`min-h-11`).
+ *
+ * Read once: `useFileTree` constructs the model from its options on first
+ * render and exposes no height setter, so a viewport that flips mid-session
+ * keeps the height it mounted with until the panel remounts.
+ */
+const TOUCH_TREE_ROW_HEIGHT_PX = 44;
 
 const EMPTY_TREE_PATHS: ReadonlyArray<string> = Object.freeze([]);
 const EMPTY_GIT_STATUS: ReadonlyArray<GitStatusEntry> = Object.freeze([]);
@@ -509,6 +523,7 @@ function FileTreeBodyForResolvedHost(
   // so they keep resolving against the same host after a later swap
   // (CLAUDE.md: tabs are bound to a host for life).
   const { hostId, onLatchHost } = props;
+  const isMobileViewport = useIsMobileViewport();
   // The box is a filter, not a search field: the query is applied on a pause,
   // and the same debounced value gates both the host RPC and the local row
   // filter so the two can never disagree about what is being filtered for.
@@ -571,13 +586,27 @@ function FileTreeBodyForResolvedHost(
       onLatchHost();
       navigateNested(props.epicId, props.tabId, () => open(props.tabId, ref));
     };
+    // Preview-vs-permanent is a tab-strip concept, and a touch viewport has no
+    // tab strip: it shows one tile at a time and navigates through the switcher.
+    // There a preview tile is silently replaced by the next row tapped, and the
+    // double-click that promotes it to permanent has no touch equivalent - so
+    // the file tree would be the one surface a phone can never open two of.
+    // Tapping a row opens permanently instead, which is also what every other
+    // switcher category's row does (`useSwitcherActivate`). `openTile` dedupes
+    // on the ref either way, so a re-tap focuses the tile already open.
     handlersRef.current.onSelect = (treePath) => {
-      openInTab(treePath, prepareOpenTilePreviewInTabFocusTarget);
+      openInTab(
+        treePath,
+        isMobileViewport
+          ? prepareOpenTileInTabFocusTarget
+          : prepareOpenTilePreviewInTabFocusTarget,
+      );
     };
     handlersRef.current.onOpen = (treePath) => {
       openInTab(treePath, prepareOpenTileInTabFocusTarget);
     };
   }, [
+    isMobileViewport,
     navigateNested,
     workspaceFileRefForTreePath,
     props.epicId,
@@ -600,7 +629,8 @@ function FileTreeBodyForResolvedHost(
   const { model } = useFileTree({
     paths: treePaths,
     initialExpansion: "closed",
-    density: "compact",
+    density: isMobileViewport ? "default" : "compact",
+    itemHeight: isMobileViewport ? TOUCH_TREE_ROW_HEIGHT_PX : undefined,
     icons: "complete",
     stickyFolders: true,
     gitStatus,
@@ -743,7 +773,12 @@ function FileTreeBodyForResolvedHost(
       className="relative flex min-h-0 flex-1 flex-col px-2 pb-2"
       onDoubleClickCapture={handleDoubleClick}
     >
-      <InputGroup className="mb-1.5 h-7 shrink-0">
+      {/* The sidebar's 28px filter row is below the touch target every other
+          phone control meets, and this one is a text field the user has to hit
+          precisely rather than a control with room for invisible hit-slop. */}
+      <InputGroup
+        className={cn("mb-1.5 shrink-0", isMobileViewport ? "h-11" : "h-7")}
+      >
         <InputGroupAddon align="inline-start">
           <Search className="size-3.5" aria-hidden />
         </InputGroupAddon>

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -124,9 +124,9 @@ const SEARCH_DEBOUNCE_MS = 200;
  * shell's hit-area stylesheet cannot reach - so the row itself has to be the
  * 44px target the rest of the phone surfaces use (`min-h-11`).
  *
- * Read once: `useFileTree` constructs the model from its options on first
- * render and exposes no height setter, so a viewport that flips mid-session
- * keeps the height it mounted with until the panel remounts.
+ * `useFileTree` constructs its model from these options once and exposes no
+ * height setter, so the body is keyed on the viewport class to rebuild it -
+ * see {@link FileTreePanelBodyForWorkspace}.
  */
 const TOUCH_TREE_ROW_HEIGHT_PX = 44;
 
@@ -508,9 +508,23 @@ export function FileTreePanelBodyForWorkspace(
   // The value to PROVIDE: ambient while following, the pin's own binding once
   // built, null while pending - never the ambient socket for a pinned host.
   const pinnedStreamBinding = useSurfaceHostStreamBinding(props.hostId);
+  // Keyed on the viewport CLASS, which is the one remount this body wants.
+  // Pierre reads `density` / `itemHeight` when it constructs the model and
+  // offers no setter for either, and its row height is not merely painted -
+  // it is the virtualizer's arithmetic (total height, sticky-row tops, scroll
+  // offsets), so re-painting the CSS variables alone would leave the layout
+  // disagreeing with the positions. Without the key a window crossing the
+  // breakpoint gets the other class's filter box over rows that kept their
+  // original geometry. Expansion survives the rebuild - it is persisted per
+  // (epic, host, workspace) and re-seeded on the next reset; the filter query
+  // does not, which is the right answer for a layout change.
+  const isTouchViewport = useIsMobileViewport();
   return (
     <StreamRuntimeContext.Provider value={pinnedStreamBinding}>
-      <FileTreeBodyForResolvedHost {...props} />
+      <FileTreeBodyForResolvedHost
+        key={isTouchViewport ? "touch" : "pointer"}
+        {...props}
+      />
     </StreamRuntimeContext.Provider>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -586,27 +586,20 @@ function FileTreeBodyForResolvedHost(
       onLatchHost();
       navigateNested(props.epicId, props.tabId, () => open(props.tabId, ref));
     };
-    // Preview-vs-permanent is a tab-strip concept, and a touch viewport has no
-    // tab strip: it shows one tile at a time and navigates through the switcher.
-    // There a preview tile is silently replaced by the next row tapped, and the
-    // double-click that promotes it to permanent has no touch equivalent - so
-    // the file tree would be the one surface a phone can never open two of.
-    // Tapping a row opens permanently instead, which is also what every other
-    // switcher category's row does (`useSwitcherActivate`). `openTile` dedupes
-    // on the ref either way, so a re-tap focuses the tile already open.
+    // Preview is right on a touch viewport too, even though the double-click
+    // that promotes it there has no touch equivalent: that viewport shows ONE
+    // tile at a time, none of its lists surfaces an open workspace-file tile,
+    // and nothing there can close one - so a permanent open buys nothing
+    // visible and leaves an unreachable tile behind. Recycling the single
+    // preview is what browsing a tree by tap wants, and the row itself is the
+    // way back to a file already visited.
     handlersRef.current.onSelect = (treePath) => {
-      openInTab(
-        treePath,
-        isMobileViewport
-          ? prepareOpenTileInTabFocusTarget
-          : prepareOpenTilePreviewInTabFocusTarget,
-      );
+      openInTab(treePath, prepareOpenTilePreviewInTabFocusTarget);
     };
     handlersRef.current.onOpen = (treePath) => {
       openInTab(treePath, prepareOpenTileInTabFocusTarget);
     };
   }, [
-    isMobileViewport,
     navigateNested,
     workspaceFileRefForTreePath,
     props.epicId,


### PR DESCRIPTION
## Summary

Mobile-vs-desktop parity sweep for the **File tree** category of the phone tab switcher.

The good news first: this category does **not** fork the desktop panel. `SwitcherPanelEmbed` mounts `FileTreePanelBody` verbatim, so header naming, the workspace picker, the filter box, per-row metadata (icon / name / git badge / ignored dimming / sticky folders) and every empty state are literally the desktop component. Desktop's file tree has no per-row `···` menu and no header actions (`Actions: null` in the panel registry), so there is nothing missing there either.

What was missing is touch ergonomics.

### Rows were a 24px touch target

`@pierre/trees` renders rows inside a shadow root, so `mobile-shell-touch-targets.css` — which enlarges hit areas for `[data-slot="button"]` under the sheet — can never reach them. The `compact` density preset (24px) was the panel's real touch target on a phone. Structurally, `itemHeight` is the only lever.

Below `md` the tree now asks for 44px rows, the same target `min-h-11` gives every other switcher row. Pierre takes `itemHeight` as a public option, but reads it once when it constructs the model and offers no setter — and the number is not merely painted, it is the virtualizer's arithmetic (total height, sticky-row tops, scroll offsets), so overriding the CSS variables the React wrapper exposes would leave the layout disagreeing with the positions. The body is therefore keyed on the viewport class, so a window crossing the breakpoint rebuilds the model instead of keeping the other class's row geometry under the other class's filter box. Expansion survives that rebuild: it is persisted per (epic, host, workspace) and re-seeded on the next reset.

The filter box moves to the same 44px target on a phone — it is a text field, so it cannot borrow the invisible vertical hit-slop the stylesheet gives buttons.

Both branches use `useIsMobileViewport()`, the viewport signal `docs/mobile/AGENTS.md` prescribes for layout and touch-appropriate interaction. Desktop is untouched.

### Row opening: deliberately left as preview

Worth recording, because it was investigated and reversed rather than overlooked.

A row click opens a **preview** tile; only a double-click promotes it to permanent, and a phone has neither the double-click nor a tab strip to show the distinction. That reads like a gap — a phone can never pin a file — but opening permanently instead is worse, for reasons specific to this surface:

- `MobileEpicTileView` shows **exactly one tile**, so a second open file tile is never visible.
- No mobile list surfaces an open workspace-file tile. `MobileCurrentTileBar` carries no between-tile navigation by design, and the switcher's categories list *content*, never open tiles.
- Nothing on a phone can close a canvas tile.

So a permanent open displays nothing extra and strands a tile the user can neither reach nor dismiss. Preview-recycle loses no reachability either — the tree row is itself the way back to a file already visited — and it is what browsing a tree by tap wants. The Git diff panel independently reached the same call, so the two browsing surfaces agree.

### Deliberately not closed

- **Row drag → canvas / composer mention** has no touch analogue.
- **A per-row `···` menu** is not viable through Pierre today: its floating trigger follows hover/keyboard focus, and `buttonVisibility: "always"` paints a *decorative* glyph inside the row button rather than a second tap target — so on touch the trigger would only appear after a tap that has already opened the file and closed the sheet. Desktop has no such menu either, so this is a gap only against touch, not against desktop.
- **"Reveal in Sidebar" is inert on a phone.** `requestFileTreeReveal` is dispatched from the desktop tab-strip context menu, which the phone replaces with `MobileCurrentTileBar`; nothing there offers the item and nothing opens the switcher sheet. This panel already serves such a request correctly — the missing half is the tile-bar chrome, tracked separately.
- **A phone cannot close a canvas tile at all.** Same tile-bar-chrome gap; out of scope for this panel.

## Testing

- `bunx vitest run src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx` — 23 passed, including three new touch-viewport cases (44px row height requested; a tapped row recycles the preview rather than accumulating a tile per file; crossing the breakpoint rebuilds the model). The last one was checked against a build with the key removed, where it fails `expected undefined to be 44`.
- `eslint --max-warnings 0` + `prettier` clean on both touched files.
- Simulator verification is pending as part of the batch pass over this sweep — specifically the 44px rows inside the 70dvh sheet, and that finger-scrolling the tree does not trip the root dnd sensor (`distance: 5`, no delay).
