### PR TITLE
feat(mobile): bring the Terminals tab to desktop parity

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-agents-list";
 import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
 import { STATUS_DOT_CLASSES } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
-import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
 
 interface FixtureRecord {
   readonly id: string;
@@ -12,12 +11,6 @@ interface FixtureRecord {
   readonly type: string;
   readonly status: number | null;
   readonly hostId: string;
-}
-interface FixtureSession {
-  readonly sessionId: string;
-  readonly title: string | null;
-  readonly activeProcessName: string | null;
-  readonly cwd: string;
 }
 /**
  * The whole ref, not just its `type`. The ref's `hostId` is what the opened
@@ -34,7 +27,6 @@ interface ActivateCall {
 }
 interface Holder {
   records: ReadonlyArray<FixtureRecord>;
-  sessions: ReadonlyArray<FixtureSession>;
   activeId: string | null;
   role: "owner" | "viewer";
   activateCalls: ActivateCall[];
@@ -64,7 +56,6 @@ interface IndicatorFixture extends IndicatorResponseFixture {
 
 const holder = vi.hoisted((): Holder => ({
   records: [],
-  sessions: [],
   activeId: null,
   role: "owner",
   activateCalls: [],
@@ -119,15 +110,9 @@ vi.mock("@/components/epic-canvas/mobile/use-switcher-activate", () => ({
       holder.activateCalls.push({ id, ref: buildRef() });
     },
 }));
-vi.mock("@/hooks/terminal/use-terminal-list-query", () => ({
-  useTerminalList: () => ({ data: { sessions: holder.sessions } }),
-}));
 vi.mock("@/lib/host", () => ({ useHostClient: () => null }));
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({
   useAddressableHostId: () => "host-A",
-}));
-vi.mock("@/lib/terminals/terminal-session-filters", () => ({
-  isVisibleEpicTerminalSession: () => true,
 }));
 // Keep the row menu's mutation + focus hooks inert so it mounts without a
 // QueryClient / host client (the menu's editor gating is what we assert).
@@ -190,7 +175,6 @@ const PROPS = { epicId: "epic-1", tabId: "tab-1", onClose: () => {} };
 
 beforeEach(() => {
   holder.records = [];
-  holder.sessions = [];
   holder.activeId = null;
   holder.role = "owner";
   holder.activateCalls = [];
@@ -431,31 +415,6 @@ describe("<SwitcherAgentsList />", () => {
   });
 });
 
-describe("<SwitcherTerminalsList />", () => {
-  it("renders a row per visible PTY session and taps open a terminal ref", () => {
-    holder.sessions = [
-      {
-        sessionId: "term-1",
-        title: "Build",
-        activeProcessName: null,
-        cwd: "/repo",
-      },
-    ];
-    render(<SwitcherTerminalsList {...PROPS} />);
-    const row = screen.getByTestId("switcher-terminal-row-term-1");
-    expect(row.textContent).toContain("Build");
-    fireEvent.click(row);
-    expect(holder.activateCalls).toHaveLength(1);
-    expect(holder.activateCalls[0].id).toBe("term-1");
-    expect(holder.activateCalls[0].ref.type).toBe("terminal");
-  });
-
-  it("shows an empty state when there are no terminals", () => {
-    render(<SwitcherTerminalsList {...PROPS} />);
-    expect(screen.getByText("No terminals yet.")).toBeTruthy();
-  });
-});
-
 describe("<SwitcherArtifactsList />", () => {
   it("renders artifact rows with a status dot for a ticket", () => {
     holder.records = [
@@ -522,35 +481,6 @@ describe("switcher create affordances (editor-gated)", () => {
     render(<SwitcherAgentsList {...PROPS} />);
     expect(screen.getByTestId("switcher-new-chat")).toBeTruthy();
     expect(screen.getByText("No agents yet.")).toBeTruthy();
-  });
-
-  it("shows the New terminal row as the first row for an editor and hides it for a viewer", () => {
-    holder.sessions = [
-      {
-        sessionId: "term-1",
-        title: "Build",
-        activeProcessName: null,
-        cwd: "/repo",
-      },
-    ];
-    const editor = render(<SwitcherTerminalsList {...PROPS} />);
-    const newTerminalRow = screen.getByTestId("switcher-new-terminal");
-    const firstItemRow = screen.getByTestId("switcher-terminal-row-term-1");
-    expect(
-      newTerminalRow.compareDocumentPosition(firstItemRow) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    editor.unmount();
-
-    holder.role = "viewer";
-    render(<SwitcherTerminalsList {...PROPS} />);
-    expect(screen.queryByTestId("switcher-new-terminal")).toBeNull();
-  });
-
-  it("keeps the New terminal row above the empty-state message when there are no terminals", () => {
-    render(<SwitcherTerminalsList {...PROPS} />);
-    expect(screen.getByTestId("switcher-new-terminal")).toBeTruthy();
-    expect(screen.getByText("No terminals yet.")).toBeTruthy();
   });
 
   it("shows New artifact for an editor and hides it for a viewer", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
@@ -1,0 +1,363 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
+import { terminalRowMenuEntries } from "@/components/epic-canvas/sidebar/terminal-row-menu-entries";
+import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
+import type { TerminalSidebarSessionRow } from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
+import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+
+/**
+ * The phone Terminals category against the SHARED panel layer: everything the
+ * desktop panel says about a terminal list - it is still loading, it failed
+ * and here is the way back, this row's runtime status is unknown, this create
+ * failed - has to survive the trip to a phone. The panel itself is faked here;
+ * what is under test is that this surface renders every one of its states and
+ * routes a tap through the ref the panel handed it.
+ */
+
+interface Holder {
+  rows: ReadonlyArray<TerminalSidebarSessionRow>;
+  failedCreates: ReadonlyArray<{
+    readonly status: string;
+    readonly request: { readonly hostId: string; readonly terminalId: string };
+    readonly error: { readonly message: string } | null;
+  }>;
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string | null;
+  role: "owner" | "viewer";
+  activeSessionId: string | null;
+  /** null models an owner host the client cannot currently reach. */
+  openRefBySessionId: Record<string, EpicTerminalRef | null>;
+  openedTiles: EpicTerminalRef[];
+  selectedTiles: { paneId: string; instanceId: string }[];
+  closeCalls: number;
+  retryCalls: number;
+  canRename: boolean;
+  closeDisabled: boolean;
+  showResourceStats: boolean;
+}
+
+const holder = vi.hoisted((): Holder => ({
+  rows: [],
+  failedCreates: [],
+  isLoading: false,
+  isError: false,
+  errorMessage: null,
+  role: "owner",
+  activeSessionId: null,
+  openRefBySessionId: {},
+  openedTiles: [],
+  selectedTiles: [],
+  closeCalls: 0,
+  retryCalls: 0,
+  canRename: true,
+  closeDisabled: false,
+  showResourceStats: false,
+}));
+
+vi.mock("@/components/epic-canvas/sidebar/use-epic-terminals-panel", () => ({
+  useEpicTerminalsPanel: () => ({
+    rows: holder.rows,
+    failedCreates: holder.failedCreates,
+    isLoading: holder.isLoading,
+    isError: holder.isError,
+    errorMessage: holder.errorMessage,
+    isRetrying: false,
+    retry: () => {
+      holder.retryCalls += 1;
+    },
+    hostId: "host-A",
+    closeCapability: "capable",
+    closeCanMutate: true,
+    closePending: false,
+    onDurableClose: vi.fn(),
+    durableRenameIdentityKeys: new Set<string>(),
+    durableRenamePending: false,
+    onDurableRename: vi.fn(),
+    prepareOpenRow: (row: TerminalSidebarSessionRow) =>
+      holder.openRefBySessionId[row.session.sessionId] ?? null,
+  }),
+  useEpicTerminalRowActions: (args: {
+    readonly session: { readonly sessionId: string };
+  }) => ({
+    label: `label-${args.session.sessionId}`,
+    canRename: holder.canRename,
+    renamePending: false,
+    submitRename: vi.fn(),
+    closeDisabled: holder.closeDisabled,
+    requestClose: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicPermissionRole: () => holder.role,
+}));
+vi.mock("@/components/epic-canvas/mobile/switcher-create-actions", () => ({
+  SwitcherNewTerminalRow: () => (
+    <button type="button" data-testid="switcher-new-terminal" />
+  ),
+}));
+vi.mock("@/components/epic-canvas/mobile/use-mobile-epic-tiles", () => ({
+  useMobileEpicTiles: () => ({
+    tiles: [],
+    currentInstanceId: null,
+    selectTile: (paneId: string, instanceId: string) => {
+      holder.selectedTiles.push({ paneId, instanceId });
+    },
+  }),
+}));
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation:
+    () => (_epicId: string, _tabId: string, prepare: () => void) =>
+      prepare(),
+}));
+vi.mock("@/stores/epics/canvas/store", () => ({
+  findOpenTileInTab: () => null,
+  useIsActiveTile: (_tabId: string, tileId: string) =>
+    holder.activeSessionId === tileId,
+  useEpicCanvasStore: (
+    selector: (state: {
+      prepareOpenTileInTabFocusTarget: (
+        tabId: string,
+        tile: EpicTerminalRef,
+      ) => void;
+      unmarkTerminalPendingCreate: (hostId: string, terminalId: string) => void;
+    }) => unknown,
+  ) =>
+    selector({
+      prepareOpenTileInTabFocusTarget: (_tabId, tile) => {
+        holder.openedTiles.push(tile);
+      },
+      unmarkTerminalPendingCreate: vi.fn(),
+    }),
+}));
+vi.mock("@/stores/settings/settings-store", () => ({
+  useSettingsStore: (
+    selector: (state: { showNavigatorResourceStats: boolean }) => unknown,
+  ) => selector({ showNavigatorResourceStats: holder.showResourceStats }),
+}));
+vi.mock("@/components/resources/resource-usage-chip", () => ({
+  OwnerResourceChip: () => <span data-testid="owner-resource-chip" />,
+}));
+
+function sessionRow(args: {
+  readonly sessionId: string;
+  readonly durable: boolean;
+  readonly runtimeStatus: "running" | "dormant" | "unknown";
+}): TerminalSidebarSessionRow {
+  return {
+    hostId: "host-A",
+    durable: args.durable,
+    runtimeStatus: args.runtimeStatus,
+    session: {
+      sessionId: args.sessionId,
+      scope: { kind: "epic", epicId: "epic-1" },
+      sessionKind: "terminal",
+      cwd: "/repo",
+      shellCommand: "/bin/zsh",
+      shellArgs: [],
+      cols: 80,
+      rows: 24,
+      status: "running",
+      exitCode: null,
+      exitReason: null,
+      createdAt: 0,
+      title: `Term ${args.sessionId}`,
+      activeProcessName: null,
+    },
+  };
+}
+
+const TILE: EpicTerminalRef = {
+  id: "term-1",
+  instanceId: "inst-1",
+  type: "terminal",
+  name: "Term term-1",
+  hostId: "host-A",
+  authority: "host",
+  legacyFallback: { name: "Term term-1", titleSource: "manual", cwd: "/repo" },
+};
+
+const PROPS = {
+  epicId: "epic-1",
+  tabId: "tab-1",
+  onClose: () => {
+    holder.closeCalls += 1;
+  },
+};
+
+beforeEach(() => {
+  holder.rows = [];
+  holder.failedCreates = [];
+  holder.isLoading = false;
+  holder.isError = false;
+  holder.errorMessage = null;
+  holder.role = "owner";
+  holder.activeSessionId = null;
+  holder.openRefBySessionId = {};
+  holder.openedTiles = [];
+  holder.selectedTiles = [];
+  holder.closeCalls = 0;
+  holder.retryCalls = 0;
+  holder.canRename = true;
+  holder.closeDisabled = false;
+  holder.showResourceStats = false;
+});
+afterEach(cleanup);
+
+describe("<SwitcherTerminalsList /> states", () => {
+  it("holds the loading state instead of claiming there are no terminals", () => {
+    holder.isLoading = true;
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-terminal-loading")).toBeTruthy();
+    expect(screen.queryByText("No terminals yet.")).toBeNull();
+  });
+
+  it("surfaces a load failure with the host's message and a retry", () => {
+    holder.isError = true;
+    holder.errorMessage = "host unreachable";
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-terminal-error").textContent).toContain(
+      "host unreachable",
+    );
+    fireEvent.click(screen.getByTestId("switcher-terminal-retry"));
+    expect(holder.retryCalls).toBe(1);
+  });
+
+  it("shows the empty state only when the list is genuinely empty", () => {
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-terminal-empty")).toBeTruthy();
+    expect(screen.getByText("No terminals yet.")).toBeTruthy();
+    // The create row stays above it either way.
+    expect(screen.getByTestId("switcher-new-terminal")).toBeTruthy();
+  });
+
+  it("offers retry and discard for a durable create that failed", () => {
+    holder.failedCreates = [
+      {
+        status: "failed",
+        request: { hostId: "host-A", terminalId: "term-9" },
+        error: { message: "spawn refused" },
+      },
+    ];
+    render(<SwitcherTerminalsList {...PROPS} />);
+    const key = epicTerminalUiIdentityKey("failed", "host-A", "term-9");
+    const row = screen.getByTestId(`switcher-terminal-failed-create-${key}`);
+    expect(row.textContent).toContain("spawn refused");
+    expect(
+      screen.getByTestId(`switcher-terminal-failed-retry-${key}`),
+    ).toBeTruthy();
+    expect(
+      screen.getByTestId(`switcher-terminal-failed-discard-${key}`),
+    ).toBeTruthy();
+  });
+});
+
+describe("<SwitcherTerminalsList /> rows", () => {
+  it("lists durable rows the raw session list cannot see, with their status", () => {
+    holder.rows = [
+      sessionRow({
+        sessionId: "term-1",
+        durable: true,
+        runtimeStatus: "unknown",
+      }),
+      sessionRow({
+        sessionId: "term-2",
+        durable: false,
+        runtimeStatus: "running",
+      }),
+    ];
+    render(<SwitcherTerminalsList {...PROPS} />);
+    const durable = screen.getByTestId("switcher-terminal-row-term-1");
+    expect(durable.textContent).toContain("Term term-1");
+    // Desktop's per-row status line, which the phone used to drop entirely.
+    expect(durable.textContent).toContain("Runtime status unavailable");
+    const running = screen.getByTestId("switcher-terminal-row-term-2");
+    expect(running.textContent).not.toContain("Runtime status unavailable");
+  });
+
+  it("carries the resource chip when the navigator stats setting is on", () => {
+    holder.showResourceStats = true;
+    holder.rows = [
+      sessionRow({
+        sessionId: "term-1",
+        durable: true,
+        runtimeStatus: "running",
+      }),
+    ];
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByTestId("owner-resource-chip")).toBeTruthy();
+  });
+
+  it("opens the panel's ref - authority and all - and closes the sheet", () => {
+    holder.rows = [
+      sessionRow({
+        sessionId: "term-1",
+        durable: true,
+        runtimeStatus: "running",
+      }),
+    ];
+    holder.openRefBySessionId = { "term-1": TILE };
+    render(<SwitcherTerminalsList {...PROPS} />);
+    fireEvent.click(screen.getByTestId("switcher-terminal-row-term-1"));
+    expect(holder.openedTiles).toHaveLength(1);
+    expect(holder.openedTiles[0]).toBe(TILE);
+    expect(holder.closeCalls).toBe(1);
+  });
+
+  it("opens nothing and stays put when the row's owner host is unreachable", () => {
+    holder.rows = [
+      sessionRow({
+        sessionId: "term-1",
+        durable: true,
+        runtimeStatus: "running",
+      }),
+    ];
+    holder.openRefBySessionId = { "term-1": null };
+    render(<SwitcherTerminalsList {...PROPS} />);
+    fireEvent.click(screen.getByTestId("switcher-terminal-row-term-1"));
+    expect(holder.openedTiles).toHaveLength(0);
+    expect(holder.closeCalls).toBe(0);
+  });
+
+  it("gives an editor the row menu and a viewer none at all", () => {
+    holder.rows = [
+      sessionRow({
+        sessionId: "term-1",
+        durable: true,
+        runtimeStatus: "running",
+      }),
+    ];
+    const editor = render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-more-term-1")).toBeTruthy();
+    editor.unmount();
+
+    holder.role = "viewer";
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.queryByTestId("switcher-more-term-1")).toBeNull();
+  });
+});
+
+describe("terminal row menu entries", () => {
+  it("is the same Rename-then-Close menu wherever it is mounted", () => {
+    const entries = terminalRowMenuEntries({
+      closeDisabled: true,
+      renameDisabled: false,
+      onStartRename: vi.fn(),
+      onRequestClose: vi.fn(),
+      testIds: {
+        rename: { dropdown: "r-d", context: "r-c" },
+        close: { dropdown: "c-d", context: "c-c" },
+      },
+    });
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "rename",
+      "before-close",
+      "close",
+    ]);
+    const close = entries[2];
+    expect(close.kind === "item" && close.label).toBe("Close");
+    expect(close.kind === "item" && close.disabled).toBe(true);
+    expect(close.kind === "item" && close.variant).toBe("destructive");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
@@ -278,7 +278,9 @@ describe("<SwitcherTerminalsList /> rows", () => {
       }),
     ]);
     renderList(openEpicTab());
-    const row = screen.getByTestId("switcher-terminal-row-durable-term");
+    // Anchored: the row and its "…" trigger are both buttons, and the trigger
+    // is named "Actions for Durable shell".
+    const row = screen.getByRole("button", { name: /^Durable shell/ });
     expect(row.textContent).toContain("Durable shell");
     // Desktop's per-row status line, which the phone used to drop.
     expect(row.textContent).toContain("Runtime status unavailable");
@@ -317,10 +319,10 @@ describe("<SwitcherTerminalsList /> rows", () => {
 
     // Two rows share a terminalId across hosts: matching on the id alone lights
     // both up, which is exactly what the id-only mobile selector did.
-    const hostA = screen.getByText("Host A shell").closest("button");
-    const hostB = screen.getByText("Host B shell").closest("button");
-    expect(hostA?.getAttribute("aria-current")).toBe("true");
-    expect(hostB?.getAttribute("aria-current")).toBeNull();
+    const hostA = screen.getByRole("button", { name: /^Host A shell/ });
+    const hostB = screen.getByRole("button", { name: /^Host B shell/ });
+    expect(hostA.getAttribute("aria-current")).toBe("true");
+    expect(hostB.getAttribute("aria-current")).toBeNull();
   });
 
   it("opens a durable row as a host-authority tile and closes the sheet", () => {
@@ -334,7 +336,7 @@ describe("<SwitcherTerminalsList /> rows", () => {
     ]);
     const tabId = openEpicTab();
     renderList(tabId);
-    fireEvent.click(screen.getByTestId("switcher-terminal-row-durable-term"));
+    fireEvent.click(screen.getByRole("button", { name: /^Durable shell/ }));
 
     const tiles = Object.values(
       useEpicCanvasStore.getState().canvasByTabId[tabId]?.tilesByInstanceId ??
@@ -378,17 +380,15 @@ describe("<SwitcherTerminalsList /> rows", () => {
       }),
     ]);
     const editor = renderList(openEpicTab());
-    expect(
-      screen.getByTestId("switcher-terminal-rename-durable-term").textContent,
-    ).toContain("Rename");
-    expect(
-      screen.getByTestId("switcher-terminal-close-durable-term").textContent,
-    ).toContain("Close");
+    expect(screen.getByRole("button", { name: "Rename" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
     editor.unmount();
 
     role.value = "viewer";
     renderList(openEpicTab());
-    expect(screen.queryByTestId("switcher-more-durable-term")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Actions for Durable shell" }),
+    ).toBeNull();
   });
 
   it("disables close for a durable row the client may not mutate", () => {
@@ -402,11 +402,10 @@ describe("<SwitcherTerminalsList /> rows", () => {
       }),
     ]);
     renderList(openEpicTab());
-    expect(
-      screen
-        .getByTestId("switcher-terminal-close-durable-term")
-        .hasAttribute("disabled"),
-    ).toBe(true);
+    const close = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Close",
+    });
+    expect(close.disabled).toBe(true);
   });
 });
 
@@ -425,7 +424,7 @@ describe("<SwitcherTerminalsList /> states", () => {
     expect(screen.getByTestId("switcher-terminal-error").textContent).toContain(
       "host unreachable",
     );
-    fireEvent.click(screen.getByTestId("switcher-terminal-retry"));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(listQuery.refetchCalls).toBe(1);
   });
 
@@ -466,12 +465,8 @@ describe("<SwitcherTerminalsList /> states", () => {
     expect(
       screen.getByTestId(`switcher-terminal-failed-create-${key}`).textContent,
     ).toContain("host offline");
-    expect(
-      screen.getByTestId(`switcher-terminal-failed-retry-${key}`),
-    ).toBeTruthy();
-    expect(
-      screen.getByTestId(`switcher-terminal-failed-discard-${key}`),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Discard" })).toBeTruthy();
     // A failed create is not an empty list.
     expect(screen.queryByTestId("switcher-terminal-empty")).toBeNull();
   });

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
@@ -1,363 +1,478 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
-import { terminalRowMenuEntries } from "@/components/epic-canvas/sidebar/terminal-row-menu-entries";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { CanonicalTerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
+import type { PlainTerminalProjection } from "@traycer/protocol/host/terminal/plain-schemas";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  replacePlainTerminalState,
+  settlePlainTerminalSnapshot,
+  type PlainTerminalCollection,
+} from "@/lib/terminals/plain-terminal-authority";
+import {
+  acceptEpicTerminalDurableCreate,
+  requestEpicTerminalDurableCreate,
+  resetEpicTerminalDurableCreatesForTests,
+} from "@/lib/terminals/epic-terminal-durable-create-coordinator";
 import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
-import type { TerminalSidebarSessionRow } from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
-import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 
 /**
- * The phone Terminals category against the SHARED panel layer: everything the
- * desktop panel says about a terminal list - it is still loading, it failed
- * and here is the way back, this row's runtime status is unknown, this create
- * failed - has to survive the trip to a phone. The panel itself is faked here;
- * what is under test is that this surface renders every one of its states and
- * routes a tap through the ref the panel handed it.
+ * The phone Terminals category over the SHARED panel layer, against the real
+ * canvas store: what a phone lists, and what a tap binds a tile to, are the two
+ * things that drifted while this surface read `terminal.list` on its own, so
+ * both are exercised end to end here. Only host transport, the plain-terminal
+ * authority and the sibling create row are faked.
  */
 
-interface Holder {
-  rows: ReadonlyArray<TerminalSidebarSessionRow>;
-  failedCreates: ReadonlyArray<{
-    readonly status: string;
-    readonly request: { readonly hostId: string; readonly terminalId: string };
-    readonly error: { readonly message: string } | null;
-  }>;
-  isLoading: boolean;
+const EPIC_ID = "epic-1";
+const HOST_A = "host-a";
+const HOST_B = "host-b";
+const SHARED_ID = "shared-term";
+
+interface DurableCollectionHolder {
+  value: PlainTerminalCollection | null;
+}
+interface ListedSessionsHolder {
+  value: CanonicalTerminalSessionInfo[];
+}
+interface ListQueryHolder {
+  isPending: boolean;
   isError: boolean;
   errorMessage: string | null;
-  role: "owner" | "viewer";
-  activeSessionId: string | null;
-  /** null models an owner host the client cannot currently reach. */
-  openRefBySessionId: Record<string, EpicTerminalRef | null>;
-  openedTiles: EpicTerminalRef[];
-  selectedTiles: { paneId: string; instanceId: string }[];
-  closeCalls: number;
-  retryCalls: number;
-  canRename: boolean;
-  closeDisabled: boolean;
-  showResourceStats: boolean;
+  refetchCalls: number;
+}
+interface AuthorityHolder {
+  capability: "unknown" | "legacy" | "capable";
+  canMutate: boolean;
+}
+interface RoleHolder {
+  value: "owner" | "viewer";
 }
 
-const holder = vi.hoisted((): Holder => ({
-  rows: [],
-  failedCreates: [],
-  isLoading: false,
+const durableCollection = vi.hoisted((): DurableCollectionHolder => ({
+  value: null,
+}));
+const listedSessions = vi.hoisted((): ListedSessionsHolder => ({ value: [] }));
+const listQuery = vi.hoisted((): ListQueryHolder => ({
+  isPending: false,
   isError: false,
   errorMessage: null,
-  role: "owner",
-  activeSessionId: null,
-  openRefBySessionId: {},
-  openedTiles: [],
-  selectedTiles: [],
-  closeCalls: 0,
-  retryCalls: 0,
-  canRename: true,
-  closeDisabled: false,
-  showResourceStats: false,
+  refetchCalls: 0,
 }));
+const authority = vi.hoisted((): AuthorityHolder => ({
+  capability: "capable",
+  canMutate: true,
+}));
+const role = vi.hoisted((): RoleHolder => ({ value: "owner" }));
 
-vi.mock("@/components/epic-canvas/sidebar/use-epic-terminals-panel", () => ({
-  useEpicTerminalsPanel: () => ({
-    rows: holder.rows,
-    failedCreates: holder.failedCreates,
-    isLoading: holder.isLoading,
-    isError: holder.isError,
-    errorMessage: holder.errorMessage,
-    isRetrying: false,
-    retry: () => {
-      holder.retryCalls += 1;
+vi.mock("@/hooks/epic/use-epic-session-host-id", () => ({
+  useEpicSessionHostId: () => HOST_A,
+}));
+vi.mock("@/hooks/epic/use-epic-session-host-client", () => ({
+  useEpicSessionHostClient: () => ({ request: vi.fn() }),
+}));
+vi.mock("@/lib/terminals/resolve-plain-terminal-owner-client", () => ({
+  useResolvePlainTerminalOwnerHostClient: () => () => ({ request: vi.fn() }),
+}));
+vi.mock("@/hooks/terminal/use-terminal-list-query", () => ({
+  useTerminalList: () => ({
+    data: { sessions: listedSessions.value },
+    isPending: listQuery.isPending,
+    isError: listQuery.isError,
+    error:
+      listQuery.errorMessage === null
+        ? null
+        : { message: listQuery.errorMessage },
+    isFetching: false,
+    refetch: () => {
+      listQuery.refetchCalls += 1;
     },
-    hostId: "host-A",
-    closeCapability: "capable",
-    closeCanMutate: true,
-    closePending: false,
-    onDurableClose: vi.fn(),
-    durableRenameIdentityKeys: new Set<string>(),
-    durableRenamePending: false,
-    onDurableRename: vi.fn(),
-    prepareOpenRow: (row: TerminalSidebarSessionRow) =>
-      holder.openRefBySessionId[row.session.sessionId] ?? null,
   }),
-  useEpicTerminalRowActions: (args: {
-    readonly session: { readonly sessionId: string };
-  }) => ({
-    label: `label-${args.session.sessionId}`,
-    canRename: holder.canRename,
-    renamePending: false,
-    submitRename: vi.fn(),
-    closeDisabled: holder.closeDisabled,
-    requestClose: vi.fn(),
+}));
+vi.mock("@/hooks/terminal/use-terminal-kill-for-mutation", () => ({
+  useTerminalKillFor: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/terminal/use-terminal-rename-for-mutation", () => ({
+  useTerminalRenameFor: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/terminal/use-plain-terminal-authority", () => ({
+  useHostPlainTerminalAuthority: () => ({
+    hostId: HOST_A,
+    scope: { kind: "epic", epicId: EPIC_ID },
+    capability:
+      authority.capability === "capable"
+        ? { status: "capable", schemaVersion: { major: 2, minor: 1 } }
+        : { status: authority.capability },
+    canMutate: authority.canMutate,
+    collection: durableCollection.value,
+    coverage: durableCollection.value?.coverage ?? null,
   }),
+}));
+vi.mock("@/hooks/terminal/use-plain-terminal-mutations", () => ({
+  useHostPlainTerminalMutations: () => ({
+    close: { mutateAsync: vi.fn(), isPending: false },
+    rename: { mutate: vi.fn(), isPending: false },
+  }),
+}));
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation:
+    () => (_epicId: string, _tabId: string, prepare: () => unknown) =>
+      prepare(),
 }));
 vi.mock("@/lib/epic-selectors", () => ({
-  useEpicPermissionRole: () => holder.role,
+  useEpicPermissionRole: () => role.value,
 }));
+// The create row opens the host + folder picker, a sibling surface with its own
+// coverage; this file is about the list below it.
 vi.mock("@/components/epic-canvas/mobile/switcher-create-actions", () => ({
   SwitcherNewTerminalRow: () => (
     <button type="button" data-testid="switcher-new-terminal" />
   ),
 }));
-vi.mock("@/components/epic-canvas/mobile/use-mobile-epic-tiles", () => ({
-  useMobileEpicTiles: () => ({
-    tiles: [],
-    currentInstanceId: null,
-    selectTile: (paneId: string, instanceId: string) => {
-      holder.selectedTiles.push({ paneId, instanceId });
-    },
-  }),
-}));
-vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
-  useEpicNestedFocusNavigation:
-    () => (_epicId: string, _tabId: string, prepare: () => void) =>
-      prepare(),
-}));
-vi.mock("@/stores/epics/canvas/store", () => ({
-  findOpenTileInTab: () => null,
-  useIsActiveTile: (_tabId: string, tileId: string) =>
-    holder.activeSessionId === tileId,
-  useEpicCanvasStore: (
-    selector: (state: {
-      prepareOpenTileInTabFocusTarget: (
-        tabId: string,
-        tile: EpicTerminalRef,
-      ) => void;
-      unmarkTerminalPendingCreate: (hostId: string, terminalId: string) => void;
-    }) => unknown,
-  ) =>
-    selector({
-      prepareOpenTileInTabFocusTarget: (_tabId, tile) => {
-        holder.openedTiles.push(tile);
-      },
-      unmarkTerminalPendingCreate: vi.fn(),
-    }),
-}));
-vi.mock("@/stores/settings/settings-store", () => ({
-  useSettingsStore: (
-    selector: (state: { showNavigatorResourceStats: boolean }) => unknown,
-  ) => selector({ showNavigatorResourceStats: holder.showResourceStats }),
-}));
 vi.mock("@/components/resources/resource-usage-chip", () => ({
-  OwnerResourceChip: () => <span data-testid="owner-resource-chip" />,
+  OwnerResourceChip: (props: {
+    readonly ownerId: string;
+    readonly hostId: string | null;
+  }) => (
+    <span
+      data-testid={`owner-resource-chip-${props.hostId}-${props.ownerId}`}
+    />
+  ),
+}));
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: (props: { readonly children: ReactNode }) => props.children,
+  DropdownMenuTrigger: (props: { readonly children: ReactNode }) =>
+    props.children,
+  DropdownMenuContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DropdownMenuItem: (props: {
+    readonly children: ReactNode;
+    readonly onSelect: () => void;
+    readonly "data-testid": string;
+    readonly disabled: boolean | undefined;
+  }) => (
+    <button
+      type="button"
+      data-testid={props["data-testid"]}
+      disabled={props.disabled}
+      onClick={props.onSelect}
+    >
+      {props.children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => null,
 }));
 
-function sessionRow(args: {
-  readonly sessionId: string;
-  readonly durable: boolean;
-  readonly runtimeStatus: "running" | "dormant" | "unknown";
-}): TerminalSidebarSessionRow {
+import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
+
+function durableTerminal(args: {
+  readonly hostId: string;
+  readonly terminalId: string;
+  readonly title: string;
+  readonly runtime: PlainTerminalProjection["runtime"];
+}): PlainTerminalProjection {
   return {
-    hostId: "host-A",
-    durable: args.durable,
-    runtimeStatus: args.runtimeStatus,
-    session: {
-      sessionId: args.sessionId,
-      scope: { kind: "epic", epicId: "epic-1" },
-      sessionKind: "terminal",
-      cwd: "/repo",
-      shellCommand: "/bin/zsh",
-      shellArgs: [],
-      cols: 80,
-      rows: 24,
-      status: "running",
-      exitCode: null,
-      exitReason: null,
-      createdAt: 0,
-      title: `Term ${args.sessionId}`,
-      activeProcessName: null,
+    record: {
+      terminalId: args.terminalId,
+      hostId: args.hostId,
+      scope: { kind: "epic", epicId: EPIC_ID },
+      launch: { cwd: "/tmp/work", shellCommand: "/bin/zsh", shellArgs: [] },
+      manualTitle: args.title,
+      revision: 1,
+      createdAt: "2026-08-17T10:00:00.000Z",
+      updatedAt: "2026-08-17T10:00:00.000Z",
     },
+    runtime: args.runtime,
   };
 }
 
-const TILE: EpicTerminalRef = {
-  id: "term-1",
-  instanceId: "inst-1",
-  type: "terminal",
-  name: "Term term-1",
-  hostId: "host-A",
-  authority: "host",
-  legacyFallback: { name: "Term term-1", titleSource: "manual", cwd: "/repo" },
-};
+function runningRuntime(
+  terminalId: string,
+): PlainTerminalProjection["runtime"] {
+  return {
+    status: "running",
+    sessionId: terminalId,
+    currentCwd: "/tmp/work",
+    activeProcessName: null,
+    cols: 80,
+    rows: 24,
+  };
+}
 
-const PROPS = {
-  epicId: "epic-1",
-  tabId: "tab-1",
-  onClose: () => {
-    holder.closeCalls += 1;
-  },
-};
+function completeFleet(
+  terminals: readonly PlainTerminalProjection[],
+): PlainTerminalCollection {
+  return settlePlainTerminalSnapshot(
+    replacePlainTerminalState(undefined, {
+      coverage: "complete-fleet",
+      scope: { kind: "epic", epicId: EPIC_ID },
+      terminals: [...terminals],
+    }),
+  );
+}
+
+function wrapper(node: ReactNode): ReactNode {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{node}</TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+const onClose = vi.fn();
+
+function openEpicTab(): string {
+  return useEpicCanvasStore.getState().openEpicTab(EPIC_ID, "Epic");
+}
+
+function renderList(tabId: string) {
+  return render(
+    wrapper(
+      <SwitcherTerminalsList
+        epicId={EPIC_ID}
+        tabId={tabId}
+        onClose={onClose}
+      />,
+    ),
+  );
+}
 
 beforeEach(() => {
-  holder.rows = [];
-  holder.failedCreates = [];
-  holder.isLoading = false;
-  holder.isError = false;
-  holder.errorMessage = null;
-  holder.role = "owner";
-  holder.activeSessionId = null;
-  holder.openRefBySessionId = {};
-  holder.openedTiles = [];
-  holder.selectedTiles = [];
-  holder.closeCalls = 0;
-  holder.retryCalls = 0;
-  holder.canRename = true;
-  holder.closeDisabled = false;
-  holder.showResourceStats = false;
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useSettingsStore.setState({ showNavigatorResourceStats: false });
+  resetEpicTerminalDurableCreatesForTests();
+  durableCollection.value = null;
+  listedSessions.value = [];
+  listQuery.isPending = false;
+  listQuery.isError = false;
+  listQuery.errorMessage = null;
+  listQuery.refetchCalls = 0;
+  authority.capability = "capable";
+  authority.canMutate = true;
+  role.value = "owner";
+  onClose.mockClear();
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  useSettingsStore.setState({ showNavigatorResourceStats: false });
+  resetEpicTerminalDurableCreatesForTests();
+});
+
+describe("<SwitcherTerminalsList /> rows", () => {
+  it("lists durable projections a raw terminal.list read cannot see", () => {
+    // Capable host, no live PTY in `terminal.list`: before the shared panel
+    // layer this list was empty on a phone and populated on desktop.
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_A,
+        terminalId: "durable-term",
+        title: "Durable shell",
+        runtime: { status: "unknown" },
+      }),
+    ]);
+    renderList(openEpicTab());
+    const row = screen.getByTestId("switcher-terminal-row-durable-term");
+    expect(row.textContent).toContain("Durable shell");
+    // Desktop's per-row status line, which the phone used to drop.
+    expect(row.textContent).toContain("Runtime status unavailable");
+  });
+
+  it("marks only the row whose owner host holds the open tile", () => {
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_A,
+        terminalId: SHARED_ID,
+        title: "Host A shell",
+        runtime: runningRuntime(SHARED_ID),
+      }),
+      durableTerminal({
+        hostId: HOST_B,
+        terminalId: SHARED_ID,
+        title: "Host B shell",
+        runtime: runningRuntime(SHARED_ID),
+      }),
+    ]);
+    const tabId = openEpicTab();
+    useEpicCanvasStore.getState().openTileInTab(tabId, {
+      id: SHARED_ID,
+      instanceId: "inst-host-a",
+      type: "terminal",
+      name: "Host A shell",
+      hostId: HOST_A,
+      authority: "host",
+      legacyFallback: {
+        name: "Host A shell",
+        titleSource: "manual",
+        cwd: "/tmp/work",
+      },
+    });
+    renderList(tabId);
+
+    // Two rows share a terminalId across hosts: matching on the id alone lights
+    // both up, which is exactly what the id-only mobile selector did.
+    const hostA = screen.getByText("Host A shell").closest("button");
+    const hostB = screen.getByText("Host B shell").closest("button");
+    expect(hostA?.getAttribute("aria-current")).toBe("true");
+    expect(hostB?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("opens a durable row as a host-authority tile and closes the sheet", () => {
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_B,
+        terminalId: "durable-term",
+        title: "Durable shell",
+        runtime: runningRuntime("durable-term"),
+      }),
+    ]);
+    const tabId = openEpicTab();
+    renderList(tabId);
+    fireEvent.click(screen.getByTestId("switcher-terminal-row-durable-term"));
+
+    const tiles = Object.values(
+      useEpicCanvasStore.getState().canvasByTabId[tabId]?.tilesByInstanceId ??
+        {},
+    );
+    expect(tiles).toHaveLength(1);
+    const tile = tiles[0];
+    if (tile === undefined || tile.type !== "terminal") {
+      throw new Error("expected a terminal tile");
+    }
+    // The row's OWNER host, and the host lifetime authority - the two fields
+    // the hand-built mobile ref got wrong.
+    expect(tile.hostId).toBe(HOST_B);
+    expect("authority" in tile && tile.authority === "host").toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the resource chip for the row's owner host when stats are on", () => {
+    useSettingsStore.setState({ showNavigatorResourceStats: true });
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_B,
+        terminalId: "durable-term",
+        title: "Durable shell",
+        runtime: runningRuntime("durable-term"),
+      }),
+    ]);
+    renderList(openEpicTab());
+    expect(
+      screen.getByTestId(`owner-resource-chip-${HOST_B}-durable-term`),
+    ).toBeTruthy();
+  });
+
+  it("gives an editor Rename and Close, and a viewer no menu at all", () => {
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_A,
+        terminalId: "durable-term",
+        title: "Durable shell",
+        runtime: runningRuntime("durable-term"),
+      }),
+    ]);
+    const editor = renderList(openEpicTab());
+    expect(
+      screen.getByTestId("switcher-terminal-rename-durable-term").textContent,
+    ).toContain("Rename");
+    expect(
+      screen.getByTestId("switcher-terminal-close-durable-term").textContent,
+    ).toContain("Close");
+    editor.unmount();
+
+    role.value = "viewer";
+    renderList(openEpicTab());
+    expect(screen.queryByTestId("switcher-more-durable-term")).toBeNull();
+  });
+
+  it("disables close for a durable row the client may not mutate", () => {
+    authority.canMutate = false;
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_A,
+        terminalId: "durable-term",
+        title: "Durable shell",
+        runtime: runningRuntime("durable-term"),
+      }),
+    ]);
+    renderList(openEpicTab());
+    expect(
+      screen
+        .getByTestId("switcher-terminal-close-durable-term")
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+});
 
 describe("<SwitcherTerminalsList /> states", () => {
   it("holds the loading state instead of claiming there are no terminals", () => {
-    holder.isLoading = true;
-    render(<SwitcherTerminalsList {...PROPS} />);
+    authority.capability = "unknown";
+    renderList(openEpicTab());
     expect(screen.getByTestId("switcher-terminal-loading")).toBeTruthy();
     expect(screen.queryByText("No terminals yet.")).toBeNull();
   });
 
   it("surfaces a load failure with the host's message and a retry", () => {
-    holder.isError = true;
-    holder.errorMessage = "host unreachable";
-    render(<SwitcherTerminalsList {...PROPS} />);
+    listQuery.isError = true;
+    listQuery.errorMessage = "host unreachable";
+    renderList(openEpicTab());
     expect(screen.getByTestId("switcher-terminal-error").textContent).toContain(
       "host unreachable",
     );
     fireEvent.click(screen.getByTestId("switcher-terminal-retry"));
-    expect(holder.retryCalls).toBe(1);
+    expect(listQuery.refetchCalls).toBe(1);
   });
 
   it("shows the empty state only when the list is genuinely empty", () => {
-    render(<SwitcherTerminalsList {...PROPS} />);
+    durableCollection.value = completeFleet([]);
+    renderList(openEpicTab());
     expect(screen.getByTestId("switcher-terminal-empty")).toBeTruthy();
     expect(screen.getByText("No terminals yet.")).toBeTruthy();
     // The create row stays above it either way.
     expect(screen.getByTestId("switcher-new-terminal")).toBeTruthy();
   });
 
-  it("offers retry and discard for a durable create that failed", () => {
-    holder.failedCreates = [
-      {
-        status: "failed",
-        request: { hostId: "host-A", terminalId: "term-9" },
-        error: { message: "spawn refused" },
-      },
-    ];
-    render(<SwitcherTerminalsList {...PROPS} />);
-    const key = epicTerminalUiIdentityKey("failed", "host-A", "term-9");
-    const row = screen.getByTestId(`switcher-terminal-failed-create-${key}`);
-    expect(row.textContent).toContain("spawn refused");
+  it("offers retry and discard for a durable create that failed", async () => {
+    authority.capability = "unknown";
+    acceptEpicTerminalDurableCreate({
+      hostId: HOST_A,
+      terminalId: "failed-term",
+      epicId: EPIC_ID,
+      cwd: "/tmp/work",
+      cols: 80,
+      rows: 24,
+    });
+    await expect(
+      requestEpicTerminalDurableCreate({
+        hostId: HOST_A,
+        terminalId: "failed-term",
+        ready: true,
+        create: () => Promise.reject(new Error("host offline")),
+        onSuccess: () => undefined,
+        commit: undefined,
+        onCommit: undefined,
+        onFailure: undefined,
+      }),
+    ).rejects.toThrow("host offline");
+
+    renderList(openEpicTab());
+    const key = epicTerminalUiIdentityKey("failed", HOST_A, "failed-term");
+    expect(
+      screen.getByTestId(`switcher-terminal-failed-create-${key}`).textContent,
+    ).toContain("host offline");
     expect(
       screen.getByTestId(`switcher-terminal-failed-retry-${key}`),
     ).toBeTruthy();
     expect(
       screen.getByTestId(`switcher-terminal-failed-discard-${key}`),
     ).toBeTruthy();
-  });
-});
-
-describe("<SwitcherTerminalsList /> rows", () => {
-  it("lists durable rows the raw session list cannot see, with their status", () => {
-    holder.rows = [
-      sessionRow({
-        sessionId: "term-1",
-        durable: true,
-        runtimeStatus: "unknown",
-      }),
-      sessionRow({
-        sessionId: "term-2",
-        durable: false,
-        runtimeStatus: "running",
-      }),
-    ];
-    render(<SwitcherTerminalsList {...PROPS} />);
-    const durable = screen.getByTestId("switcher-terminal-row-term-1");
-    expect(durable.textContent).toContain("Term term-1");
-    // Desktop's per-row status line, which the phone used to drop entirely.
-    expect(durable.textContent).toContain("Runtime status unavailable");
-    const running = screen.getByTestId("switcher-terminal-row-term-2");
-    expect(running.textContent).not.toContain("Runtime status unavailable");
-  });
-
-  it("carries the resource chip when the navigator stats setting is on", () => {
-    holder.showResourceStats = true;
-    holder.rows = [
-      sessionRow({
-        sessionId: "term-1",
-        durable: true,
-        runtimeStatus: "running",
-      }),
-    ];
-    render(<SwitcherTerminalsList {...PROPS} />);
-    expect(screen.getByTestId("owner-resource-chip")).toBeTruthy();
-  });
-
-  it("opens the panel's ref - authority and all - and closes the sheet", () => {
-    holder.rows = [
-      sessionRow({
-        sessionId: "term-1",
-        durable: true,
-        runtimeStatus: "running",
-      }),
-    ];
-    holder.openRefBySessionId = { "term-1": TILE };
-    render(<SwitcherTerminalsList {...PROPS} />);
-    fireEvent.click(screen.getByTestId("switcher-terminal-row-term-1"));
-    expect(holder.openedTiles).toHaveLength(1);
-    expect(holder.openedTiles[0]).toBe(TILE);
-    expect(holder.closeCalls).toBe(1);
-  });
-
-  it("opens nothing and stays put when the row's owner host is unreachable", () => {
-    holder.rows = [
-      sessionRow({
-        sessionId: "term-1",
-        durable: true,
-        runtimeStatus: "running",
-      }),
-    ];
-    holder.openRefBySessionId = { "term-1": null };
-    render(<SwitcherTerminalsList {...PROPS} />);
-    fireEvent.click(screen.getByTestId("switcher-terminal-row-term-1"));
-    expect(holder.openedTiles).toHaveLength(0);
-    expect(holder.closeCalls).toBe(0);
-  });
-
-  it("gives an editor the row menu and a viewer none at all", () => {
-    holder.rows = [
-      sessionRow({
-        sessionId: "term-1",
-        durable: true,
-        runtimeStatus: "running",
-      }),
-    ];
-    const editor = render(<SwitcherTerminalsList {...PROPS} />);
-    expect(screen.getByTestId("switcher-more-term-1")).toBeTruthy();
-    editor.unmount();
-
-    holder.role = "viewer";
-    render(<SwitcherTerminalsList {...PROPS} />);
-    expect(screen.queryByTestId("switcher-more-term-1")).toBeNull();
-  });
-});
-
-describe("terminal row menu entries", () => {
-  it("is the same Rename-then-Close menu wherever it is mounted", () => {
-    const entries = terminalRowMenuEntries({
-      closeDisabled: true,
-      renameDisabled: false,
-      onStartRename: vi.fn(),
-      onRequestClose: vi.fn(),
-      testIds: {
-        rename: { dropdown: "r-d", context: "r-c" },
-        close: { dropdown: "c-d", context: "c-c" },
-      },
-    });
-    expect(entries.map((entry) => entry.id)).toEqual([
-      "rename",
-      "before-close",
-      "close",
-    ]);
-    const close = entries[2];
-    expect(close.kind === "item" && close.label).toBe("Close");
-    expect(close.kind === "item" && close.disabled).toBe(true);
-    expect(close.kind === "item" && close.variant).toBe("destructive");
+    // A failed create is not an empty list.
+    expect(screen.queryByTestId("switcher-terminal-empty")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -165,6 +165,8 @@ function SwitcherAgentRow(props: {
         />
       }
       label={record.name}
+      secondaryLabel={null}
+      badge={null}
       active={isActive}
       onSelect={onSelect}
       selectTestId={`switcher-agent-row-${record.id}`}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -121,6 +121,8 @@ function SwitcherArtifactRow(props: {
     <SwitcherListRow
       icon={<SwitcherArtifactIcon type={record.type} status={record.status} />}
       label={record.name}
+      secondaryLabel={null}
+      badge={null}
       active={isActive}
       onSelect={onSelect}
       selectTestId={`switcher-artifact-row-${record.id}`}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -3,21 +3,39 @@ import { Check, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 /**
- * One flat row in a switcher category list: leading icon, truncating label, a
+ * One flat row in a switcher category list: leading icon, truncating label, an
+ * optional second line of row metadata, an optional trailing badge slot, a
  * check on the active tile, and an optional trailing "…" actions slot. Tapping
  * the row body activates the tile; the actions slot (null for viewers) is a
  * sibling button so its taps never trigger a row open. The 44px min height plus
  * the sheet's coarse-pointer touch scope satisfy the touch-target guideline.
+ *
+ * `secondaryLabel` and `badge` exist so a category whose desktop row carries
+ * per-row metadata (a terminal's runtime status, its resource usage) can show
+ * the same thing here instead of dropping it: the row is one component, so a
+ * surface cannot quietly say less than its desktop counterpart. Categories
+ * with nothing to add pass null.
  */
 export function SwitcherListRow(props: {
   readonly icon: ReactNode;
   readonly label: string;
+  readonly secondaryLabel: string | null;
+  readonly badge: ReactNode;
   readonly active: boolean;
   readonly onSelect: () => void;
   readonly actions: ReactNode;
   readonly selectTestId: string;
 }) {
-  const { icon, label, active, onSelect, actions, selectTestId } = props;
+  const {
+    icon,
+    label,
+    secondaryLabel,
+    badge,
+    active,
+    onSelect,
+    actions,
+    selectTestId,
+  } = props;
   return (
     // `min-w-0` at both this wrapper and the button: the label's truncate
     // only engages while every flex level above it may shrink below its
@@ -35,9 +53,17 @@ export function SwitcherListRow(props: {
         <span className="flex size-4 shrink-0 items-center justify-center">
           {icon}
         </span>
-        <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
-          {label}
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="min-w-0 truncate text-ui-sm text-foreground">
+            {label}
+          </span>
+          {secondaryLabel === null ? null : (
+            <span className="min-w-0 truncate text-ui-xs text-muted-foreground">
+              {secondaryLabel}
+            </span>
+          )}
         </span>
+        {badge}
         {active ? (
           <Check
             className="size-4 shrink-0 text-primary"

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminal-row-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminal-row-actions.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SidebarDropdownMenuItems } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+import { terminalRowMenuEntries } from "@/components/epic-canvas/sidebar/terminal-row-menu-entries";
+import {
+  useEpicTerminalRowActions,
+  type EpicTerminalRowAuthority,
+} from "@/components/epic-canvas/sidebar/use-epic-terminals-panel";
+import { SwitcherRenameDialog } from "@/components/epic-canvas/mobile/switcher-rename-dialog";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
+import type { ListedTerminalSidebarSession } from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
+
+/**
+ * The per-row "…" actions for a raw terminal in the mobile switcher: the same
+ * Rename and Close the desktop row offers, gated by the same lifetime
+ * authority (a durable row renames and closes through the host projection, a
+ * compatibility row through the legacy manager RPCs, an unreachable or
+ * capability-unknown one not at all). Only the rename affordance differs -
+ * desktop edits the row in place, which has no touch analog, so this opens the
+ * shared rename dialog and drives the identical mutation from it.
+ *
+ * Editor-gated on top of that: a viewer's mutation is server-rejected, so an
+ * ungated menu would only lead to a dead end.
+ */
+export function SwitcherTerminalRowActions(props: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly hostId: string;
+  readonly session: ListedTerminalSidebarSession;
+  readonly durable: boolean;
+  readonly authority: EpicTerminalRowAuthority;
+}) {
+  const { authority, durable, epicId, hostId, session, tabId } = props;
+  const canMutate = isEditableRole(useEpicPermissionRole());
+  const [renameOpen, setRenameOpen] = useState(false);
+  const actions = useEpicTerminalRowActions({
+    epicId,
+    tabId,
+    hostId,
+    session,
+    durable,
+    authority,
+  });
+
+  if (!canMutate) return null;
+
+  const entries = terminalRowMenuEntries({
+    closeDisabled: actions.closeDisabled,
+    onStartRename: () => setRenameOpen(true),
+    renameDisabled: !actions.canRename,
+    onRequestClose: actions.requestClose,
+    testIds: {
+      rename: {
+        dropdown: `switcher-terminal-rename-${session.sessionId}`,
+        context: `switcher-terminal-context-rename-${session.sessionId}`,
+      },
+      close: {
+        dropdown: `switcher-terminal-close-${session.sessionId}`,
+        context: `switcher-terminal-context-close-${session.sessionId}`,
+      },
+    },
+  });
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${actions.label}`}
+            data-testid={`switcher-more-${session.sessionId}`}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <SidebarDropdownMenuItems entries={entries} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SwitcherRenameDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        title="Rename terminal"
+        initialValue={actions.label}
+        nodeId={session.sessionId}
+        onSubmit={(value) =>
+          actions.submitRename(value, () => setRenameOpen(false))
+        }
+      />
+    </>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -1,26 +1,35 @@
 import { useCallback } from "react";
 import { Terminal } from "lucide-react";
-import { v4 as uuidv4 } from "uuid";
-import type { CanonicalTerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
-import {
-  SwitcherListEmpty,
-  SwitcherListRow,
-} from "@/components/epic-canvas/mobile/switcher-list-row";
-import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { SwitcherListRow } from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SwitcherTerminalRowActions } from "@/components/epic-canvas/mobile/switcher-terminal-row-actions";
 import { SwitcherNewTerminalRow } from "@/components/epic-canvas/mobile/switcher-create-actions";
-import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useMobileEpicTiles } from "@/components/epic-canvas/mobile/use-mobile-epic-tiles";
+import {
+  FailedTerminalCreateRow,
+  TerminalsEmptyState,
+  TerminalsErrorState,
+  TerminalsLoadingState,
+} from "@/components/epic-canvas/sidebar/terminal-list-states";
+import {
+  useEpicTerminalsPanel,
+  type EpicTerminalsPanel,
+} from "@/components/epic-canvas/sidebar/use-epic-terminals-panel";
+import { OwnerResourceChip } from "@/components/resources/resource-usage-chip";
 import { useEpicPermissionRole } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
-import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
-import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
-import { useEpicSessionHostId } from "@/hooks/epic/use-epic-session-host-id";
-import { useTerminalList } from "@/hooks/terminal/use-terminal-list-query";
-import { isVisibleEpicTerminalSession } from "@/lib/terminals/terminal-session-filters";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
+import { terminalSessionLabel } from "@/lib/terminals/terminal-title";
+import type { TerminalSidebarSessionRow } from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
 import {
-  deriveTitleSourceFromSessionTitle,
-  terminalSessionTitle,
-} from "@/lib/terminals/terminal-title";
-import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
+  findOpenTileInTab,
+  useEpicCanvasStore,
+  useIsActiveTile,
+} from "@/stores/epics/canvas/store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+
+/** Every test id this list's shared states and rows are grabbed by. */
+const TERMINALS_TEST_ID_PREFIX = "switcher-terminal";
 
 interface SwitcherListProps {
   readonly epicId: string;
@@ -29,24 +38,57 @@ interface SwitcherListProps {
 }
 
 /**
- * Terminals category: raw PTY sessions from the host `terminal.list` query
- * (NOT the Y.Doc projection), filtered by the shared visibility rule. Sessions
- * on an unreachable host are still shown (decision); opening one lands on the
- * existing dead-tile handling.
+ * Terminals category. Rows, load/error/empty states and every mutation come
+ * from `useEpicTerminalsPanel`, the same layer the desktop Terminals panel
+ * mounts - so a phone lists the identical reconciled set (durable
+ * `terminal.plain.list` projections included, which a raw `terminal.list` read
+ * cannot see once a host is capable) and never opens a durable terminal as a
+ * legacy-authority tile. Sessions on an unreachable host are still shown
+ * (decision); opening one is refused with a reason rather than landing a dead
+ * tile.
+ *
+ * This file owns only the touch chrome: a flat scroller instead of the
+ * desktop's draggable tree rows, and a tap that lands the chosen terminal as
+ * the single full-screen mobile tile.
  */
 export function SwitcherTerminalsList(props: SwitcherListProps) {
   const { epicId, tabId, onClose } = props;
-  // The Epic SESSION's client, never the ambient one: during a re-point the
-  // window can address host B while this canvas still projects host A's Epic,
-  // and an ambient read would list (and mutate) B's terminals under A's rows -
-  // the same defect the desktop sidebar fixed (see epic-terminal-sidebar).
-  const hostClient = useEpicSessionHostClient();
-  const list = useTerminalList({ kind: "epic", epicId }, hostClient);
-  const sessions = (list.data?.sessions ?? []).filter((session) =>
-    isVisibleEpicTerminalSession(session, epicId),
+  const panel = useEpicTerminalsPanel({ epicId });
+  const canMutate = isEditableRole(useEpicPermissionRole());
+  const { selectTile } = useMobileEpicTiles(tabId);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
   );
 
-  const canMutate = isEditableRole(useEpicPermissionRole());
+  const prepareOpenRow = panel.prepareOpenRow;
+  const openRow = useCallback(
+    (row: TerminalSidebarSessionRow) => {
+      const tile = prepareOpenRow(row);
+      if (tile === null) return;
+      // By REF, not by content id: two fleet terminals can share a terminalId
+      // across hosts, and "focus the one already open" must not hand back the
+      // other machine's tile.
+      const found = findOpenTileInTab(tabId, tile);
+      if (found === null) {
+        navigateNested(epicId, tabId, () =>
+          prepareOpenTileInTabFocusTarget(tabId, tile),
+        );
+      } else {
+        selectTile(found.paneId, found.instanceId);
+      }
+      onClose();
+    },
+    [
+      epicId,
+      navigateNested,
+      onClose,
+      prepareOpenRow,
+      prepareOpenTileInTabFocusTarget,
+      selectTile,
+      tabId,
+    ],
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain p-1 pb-safe-bottom">
@@ -60,70 +102,116 @@ export function SwitcherTerminalsList(props: SwitcherListProps) {
           onClose={onClose}
         />
       ) : null}
-      {sessions.length === 0 ? (
-        <SwitcherListEmpty message="No terminals yet." />
-      ) : (
-        sessions.map((session) => (
-          <SwitcherTerminalRow
-            key={session.sessionId}
-            session={session}
-            epicId={epicId}
-            tabId={tabId}
-            onClose={onClose}
-          />
-        ))
-      )}
+      <SwitcherTerminalsBody
+        panel={panel}
+        epicId={epicId}
+        tabId={tabId}
+        onOpen={openRow}
+      />
     </div>
   );
 }
 
-function SwitcherTerminalRow(props: {
-  readonly session: CanonicalTerminalSessionInfo;
+function SwitcherTerminalsBody(props: {
+  readonly panel: EpicTerminalsPanel;
   readonly epicId: string;
   readonly tabId: string;
-  readonly onClose: () => void;
+  readonly onOpen: (row: TerminalSidebarSessionRow) => void;
 }) {
-  const { session, epicId, tabId, onClose } = props;
-  const activate = useSwitcherActivate(epicId, tabId, onClose);
-  const isActive = useIsActiveEpicArtifact(tabId, session.sessionId);
-  const hostId = useEpicSessionHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
-  const label = terminalSessionTitle({
-    title: session.title,
-    activeProcessName: session.activeProcessName,
-    currentCwd: session.cwd,
-  });
+  const { panel } = props;
+  if (panel.isLoading) {
+    return <TerminalsLoadingState testIdPrefix={TERMINALS_TEST_ID_PREFIX} />;
+  }
+  if (panel.isError) {
+    return (
+      <TerminalsErrorState
+        message={panel.errorMessage}
+        isRetrying={panel.isRetrying}
+        onRetry={panel.retry}
+        testIdPrefix={TERMINALS_TEST_ID_PREFIX}
+      />
+    );
+  }
+  if (panel.rows.length === 0 && panel.failedCreates.length === 0) {
+    return <TerminalsEmptyState testIdPrefix={TERMINALS_TEST_ID_PREFIX} />;
+  }
+  return (
+    <>
+      {panel.rows.map((row) => (
+        <SwitcherTerminalRow
+          key={epicTerminalUiIdentityKey(
+            "session",
+            row.hostId,
+            row.session.sessionId,
+          )}
+          row={row}
+          epicId={props.epicId}
+          tabId={props.tabId}
+          panel={panel}
+          onOpen={() => props.onOpen(row)}
+        />
+      ))}
+      {panel.failedCreates.map((job) => (
+        <FailedTerminalCreateRow
+          key={epicTerminalUiIdentityKey(
+            "failed",
+            job.request.hostId,
+            job.request.terminalId,
+          )}
+          job={job}
+          testIdPrefix={TERMINALS_TEST_ID_PREFIX}
+        />
+      ))}
+    </>
+  );
+}
 
-  const onSelect = useCallback(() => {
-    activate(session.sessionId, () => ({
-      id: session.sessionId,
-      instanceId: uuidv4(),
-      type: "terminal",
-      name: terminalSessionTitle({
-        title: session.title,
-        activeProcessName: session.activeProcessName,
-        currentCwd: session.cwd,
-      }),
-      titleSource: deriveTitleSourceFromSessionTitle(session.title),
-      hostId,
-      cwd: session.cwd,
-    }));
-  }, [activate, hostId, session]);
+function SwitcherTerminalRow(props: {
+  readonly row: TerminalSidebarSessionRow;
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly panel: EpicTerminalsPanel;
+  readonly onOpen: () => void;
+}) {
+  const { row, epicId, tabId, panel, onOpen } = props;
+  const { hostId, session } = row;
+  // Host-scoped, like desktop: two fleet terminals sharing a terminalId must
+  // not both read as the current tile.
+  const isActive = useIsActiveTile(tabId, session.sessionId, hostId);
+  const showNavigatorResourceStats = useSettingsStore(
+    (state) => state.showNavigatorResourceStats,
+  );
+  const label = terminalSessionLabel(session);
 
   return (
     <SwitcherListRow
       icon={<Terminal className="size-4 shrink-0 text-muted-foreground" />}
       label={label}
+      secondaryLabel={
+        row.runtimeStatus === "unknown" ? "Runtime status unavailable" : null
+      }
+      badge={
+        showNavigatorResourceStats ? (
+          <OwnerResourceChip
+            epicId={epicId}
+            kind="terminal"
+            ownerId={session.sessionId}
+            hostId={hostId}
+            className={undefined}
+          />
+        ) : null
+      }
       active={isActive}
-      onSelect={onSelect}
+      onSelect={onOpen}
       selectTestId={`switcher-terminal-row-${session.sessionId}`}
       actions={
-        <SwitcherRowActions
+        <SwitcherTerminalRowActions
           epicId={epicId}
           tabId={tabId}
-          kind="terminal"
-          nodeId={session.sessionId}
-          name={label}
-          cascadeSummary={null}
+          hostId={hostId}
+          session={session}
+          durable={row.durable}
+          authority={panel}
         />
       }
     />

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -6,6 +6,11 @@
  * that session as a canvas tab; the "+" action opens a fresh terminal whose
  * tile creates the underlying PTY on mount.
  *
+ * Rows, states and per-row mutations all come from `useEpicTerminalsPanel` /
+ * `useEpicTerminalRowActions`, which the phone switcher's Terminals category
+ * mounts too; this file owns only the desktop chrome around them (drag to a
+ * pane, hover "…", context menu, inline rename).
+ *
  * Exports `TerminalsPanelBody` and `TerminalsPanelActions` consumed by
  * `epic-sidebar.tsx`'s `PANEL_COMPONENTS["terminals"]`. Agent terminals
  * (`terminal-agent` artifacts) live in the Agents panel instead.
@@ -19,17 +24,8 @@ import {
   type KeyboardEvent,
 } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { toast } from "sonner";
 import { useDraggable } from "@dnd-kit/core";
-import {
-  MoreHorizontal,
-  Pencil,
-  Terminal as TerminalIcon,
-  Trash2,
-} from "lucide-react";
-import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
-import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
-import { createReportIssueContext } from "@/lib/report-issue-context";
+import { MoreHorizontal, Terminal as TerminalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -49,7 +45,6 @@ import {
 } from "@/components/ui/sidebar";
 import type { LeftPanelSlotProps } from "@/components/epic-canvas/sidebar/left-panel-registry";
 import { NewTerminalPicker } from "@/components/epic-canvas/sidebar/new-terminal-picker";
-import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
 import { SnapshotGate } from "@/components/epic-canvas/snapshots/snapshot-loading-context";
 import { TerminalsPanelSkeleton } from "@/components/epic-canvas/skeletons/terminals-panel-skeleton";
 import {
@@ -58,17 +53,7 @@ import {
   TERMINAL_TILE_DND_TYPE,
   type EpicCanvasTerminalTileDragData,
 } from "@/components/epic-canvas/dnd/dnd";
-import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
-import { useTerminalKillFor } from "@/hooks/terminal/use-terminal-kill-for-mutation";
-import { useTerminalList } from "@/hooks/terminal/use-terminal-list-query";
-import { useTerminalRenameFor } from "@/hooks/terminal/use-terminal-rename-for-mutation";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
-import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
-import { useEpicSessionHostId } from "@/hooks/epic/use-epic-session-host-id";
-import {
-  DEFAULT_TERMINAL_TITLE,
-  terminalSessionLabel,
-} from "@/lib/terminals/terminal-title";
 import { OwnerResourceChip } from "@/components/resources/resource-usage-chip";
 import { cn } from "@/lib/utils";
 import {
@@ -81,61 +66,34 @@ import {
   useLeftPanelSectionCollapsed,
 } from "@/stores/epics/left-panel-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
-import { isUnsupportedEpicTerminalRef } from "@/stores/epics/canvas/types";
 import {
   SidebarContextMenuItems,
   SidebarDropdownMenuItems,
-  type SidebarRowMenuEntry,
 } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
-import { useHostPlainTerminalAuthority } from "@/hooks/terminal/use-plain-terminal-authority";
-import { useDelayedTerminalFleetWarning } from "@/hooks/terminal/use-delayed-terminal-fleet-warning";
-import { useHostPlainTerminalMutations } from "@/hooks/terminal/use-plain-terminal-mutations";
-import { requestEpicTerminalLifetimeClose } from "@/lib/terminals/epic-terminal-close-coordinator";
+import { terminalRowMenuEntries } from "@/components/epic-canvas/sidebar/terminal-row-menu-entries";
 import {
-  discardEpicTerminalDurableCreate,
-  retryEpicTerminalDurableCreate,
-  settleEpicTerminalDurableCreate,
-  type EpicTerminalDurableCreateJobView,
-} from "@/lib/terminals/epic-terminal-durable-create-coordinator";
-import { useEpicTerminalDurableCreateJobViews } from "@/hooks/terminal/use-epic-terminal-durable-create";
+  useEpicTerminalRowActions,
+  useEpicTerminalsPanel,
+  type EpicTerminalRowAuthority,
+  type EpicTerminalsPanel,
+} from "@/components/epic-canvas/sidebar/use-epic-terminals-panel";
 import {
-  epicTerminalUiIdentityKey,
-  failedCreateHasAuthoritativeRow,
-} from "@/lib/terminals/pending-create-identity";
-import {
-  getPlainTerminal,
-  plainTerminalCapabilityTopology,
-  plainTerminalCollectionIdentityKey,
-  plainTerminalCollectionValues,
-  type PlainTerminalCollection,
-} from "@/lib/terminals/plain-terminal-authority";
+  FailedTerminalCreateRow,
+  TerminalsEmptyState,
+  TerminalsErrorState,
+  TerminalsLoadingState,
+} from "@/components/epic-canvas/sidebar/terminal-list-states";
+import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
 import { makeListedEpicTerminalRef } from "@/lib/terminals/listed-epic-terminal-ref";
-import {
-  reconcileTerminalSidebarSessions,
-  type ListedTerminalSidebarSession,
-  type TerminalSidebarSessionRow,
+import type {
+  ListedTerminalSidebarSession,
+  TerminalSidebarSessionRow,
 } from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
-import { useResolvePlainTerminalOwnerHostClient } from "@/lib/terminals/resolve-plain-terminal-owner-client";
 
 const TERMINALS_PANEL_SKELETON = <TerminalsPanelSkeleton />;
 
-function failedCreateMatchesAuthoritativeRow(args: {
-  readonly job: EpicTerminalDurableCreateJobView;
-  readonly hostId: string;
-  readonly durableCollection: PlainTerminalCollection | undefined;
-}): boolean {
-  return failedCreateHasAuthoritativeRow({
-    jobHostId: args.job.request.hostId,
-    jobTerminalId: args.job.request.terminalId,
-    sessionHostId: args.hostId,
-    durableHasTerminalId: (terminalId) =>
-      getPlainTerminal(
-        args.durableCollection,
-        args.job.request.hostId,
-        terminalId,
-      ) !== undefined,
-  });
-}
+/** Every test id this panel's shared states and rows are grabbed by. */
+const TERMINALS_TEST_ID_PREFIX = "epic-terminal-sidebar";
 
 /**
  * Body for the "terminals" left-panel rail entry. Lists raw host
@@ -157,31 +115,7 @@ function TerminalsPanelBodyLive(props: {
   readonly tabId: string;
 }) {
   const { epicId, tabId } = props;
-  // The Epic SESSION's host, not the app-wide effective one. This panel is a
-  // sibling of the canvas and therefore outside every tile `TabHostProvider`,
-  // which is exactly the case `useEpicSessionHostId` was written for: "host
-  // RPCs issued by the sidebar must use the session transport's host instead
-  // of ... independently re-reading the app-wide active host". `terminal.list`
-  // is such an RPC, and the pair below has to come from ONE source - the list
-  // names the machine whose terminals it shows, and the id it hands to
-  // `makeTerminalRef` binds each opened tile to that machine for life.
-  //
-  // Reading ambient made both wrong together the moment they disagreed:
-  // activation or failover moves the effective host while `EpicSessionProvider`
-  // is still rendering its previous session (and for the whole of a
-  // re-point that is establishing, or one that failed), so an Epic projected
-  // from host A listed, killed and renamed host B's terminals, and opened them
-  // as B-bound tiles under A's Epic.
-  const hostClient = useEpicSessionHostClient();
-  const list = useTerminalList({ kind: "epic", epicId }, hostClient);
-  // Manual escape hatch for a stranded error state: host-scoped queries get
-  // no automatic retry/refetch routes (transport already retried), so without
-  // this the only recoveries are accidental (collapse/re-expand remounts the
-  // body) or the stream-driven `availability-recovered` invalidation.
-  const refetchList = list.refetch;
-  const retryList = useCallback(() => {
-    void refetchList();
-  }, [refetchList]);
+  const panel = useEpicTerminalsPanel({ epicId });
   const navigateNested = useEpicNestedFocusNavigation();
   const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
     (s) => s.prepareOpenTileInTabFocusTarget,
@@ -189,55 +123,12 @@ function TerminalsPanelBodyLive(props: {
   const prepareSetActiveTileTabFocusTarget = useEpicCanvasStore(
     (s) => s.prepareSetActiveTileTabFocusTarget,
   );
-  const activeHostId = useEpicSessionHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
-  const durableAuthority = useHostPlainTerminalAuthority({
-    hostId: activeHostId,
-    scope: { kind: "epic", epicId },
-  });
-  const durableMutations = useHostPlainTerminalMutations(durableAuthority);
-  const resolveOwnerClient = useResolvePlainTerminalOwnerHostClient();
-  const requestDurableClose = (hostId: string, terminalId: string) => {
-    const pending = requestEpicTerminalLifetimeClose({
-      hostId,
-      terminalId,
-      capability: durableAuthority.capability.status,
-      canMutate: durableAuthority.canMutate,
-      close: async () => {
-        await durableMutations.close.mutateAsync({ hostId, terminalId });
-      },
-    });
-    if (pending === null) return;
-    void pending.catch(() => undefined);
-  };
-  const requestDurableRename = (
-    hostId: string,
-    terminalId: string,
-    manualTitle: string,
-    onSuccess: () => void,
-  ) => {
-    if (!durableAuthority.canMutate || durableMutations.rename.isPending) {
-      return;
-    }
-    durableMutations.rename.mutate(
-      { hostId, terminalId, manualTitle },
-      { onSuccess },
-    );
-  };
 
+  const prepareOpenRow = panel.prepareOpenRow;
   const openExisting = useCallback(
     (row: TerminalSidebarSessionRow) => {
-      if (row.durable && resolveOwnerClient(row.hostId) === null) {
-        toast(
-          `Can't open this terminal right now - host ${row.hostId} is not reachable.`,
-        );
-        return;
-      }
-      const tile = makeListedEpicTerminalRef({
-        session: row.session,
-        hostId: row.hostId,
-        instanceId: uuidv4(),
-        durable: row.durable,
-      });
+      const tile = prepareOpenRow(row);
+      if (tile === null) return;
       const found = findOpenTileInTab(tabId, tile);
       if (found !== null) {
         navigateNested(epicId, tabId, () =>
@@ -256,136 +147,22 @@ function TerminalsPanelBodyLive(props: {
     [
       epicId,
       navigateNested,
+      prepareOpenRow,
       prepareOpenTileInTabFocusTarget,
       prepareSetActiveTileTabFocusTarget,
-      resolveOwnerClient,
       tabId,
     ],
   );
-
-  // Host keeps exited sessions for a 60s grace window; filter so a
-  // single kill click feels like "remove" instead of "mark dead".
-  const reconciled = useMemo(
-    () =>
-      reconcileTerminalSidebarSessions({
-        epicId,
-        servingHostId: activeHostId,
-        capability: durableAuthority.capability.status,
-        topology:
-          plainTerminalCapabilityTopology(durableAuthority.capability) ??
-          "fleet",
-        coverage: durableAuthority.coverage ?? null,
-        listed: list.data?.sessions ?? [],
-        durableCollection: durableAuthority.collection,
-      }),
-    [
-      activeHostId,
-      durableAuthority.capability,
-      durableAuthority.collection,
-      durableAuthority.coverage,
-      epicId,
-      list.data?.sessions,
-    ],
-  );
-  const sessions = reconciled.rows;
-  const incompleteFleet = reconciled.incompleteFleet;
-  // The sidebar no longer captions partial fleet coverage - the epic status
-  // pill owns that signal (one amber light, the sentence on hover). The grace
-  // still matters here: until it elapses a catalog that is merely hydrating
-  // must not read as "No terminals yet.", so the loading state holds instead.
-  const fleetGapSettled = useDelayedTerminalFleetWarning(
-    incompleteFleet,
-    JSON.stringify([activeHostId, epicId]),
-  );
-  const createJobs = useEpicTerminalDurableCreateJobViews(epicId);
-  const failedCreates = useMemo(
-    () =>
-      createJobs.filter((job) => {
-        if (job.status !== "failed") return false;
-        if (job.request.hostId !== activeHostId) return false;
-        return !failedCreateMatchesAuthoritativeRow({
-          job,
-          hostId: activeHostId,
-          durableCollection: durableAuthority.collection,
-        });
-      }),
-    [activeHostId, createJobs, durableAuthority.collection],
-  );
-  const unmarkTerminalPendingCreate = useEpicCanvasStore(
-    (state) => state.unmarkTerminalPendingCreate,
-  );
-  useEffect(() => {
-    for (const job of createJobs) {
-      if (job.status !== "failed") continue;
-      if (
-        !failedCreateMatchesAuthoritativeRow({
-          job,
-          hostId: activeHostId,
-          durableCollection: durableAuthority.collection,
-        })
-      ) {
-        continue;
-      }
-      settleEpicTerminalDurableCreate(
-        job.request.hostId,
-        job.request.terminalId,
-      );
-      unmarkTerminalPendingCreate(job.request.hostId, job.request.terminalId);
-    }
-  }, [
-    activeHostId,
-    createJobs,
-    durableAuthority.collection,
-    unmarkTerminalPendingCreate,
-  ]);
 
   return (
     <SidebarContent className="min-h-0">
       <SidebarGroup className="min-h-0 flex-1 px-2 py-1">
         <SidebarGroupContent className="flex min-h-0 flex-1 flex-col">
           <TerminalSidebarBody
-            isLoading={
-              failedCreates.length === 0 &&
-              (durableAuthority.capability.status === "unknown" ||
-                (incompleteFleet &&
-                  !fleetGapSettled &&
-                  sessions.length === 0) ||
-                (sessions.length === 0 &&
-                  (list.isPending ||
-                    (durableAuthority.capability.status === "capable" &&
-                      durableAuthority.collection === undefined))))
-            }
-            isError={Boolean(
-              durableAuthority.capability.status !== "unknown" &&
-              list.isError &&
-              sessions.length === 0,
-            )}
-            errorMessage={list.error?.message ?? null}
-            isRetrying={list.isFetching}
-            onRetry={retryList}
-            sessions={sessions}
-            failedCreates={failedCreates}
+            panel={panel}
             epicId={epicId}
             tabId={tabId}
-            hostId={activeHostId}
             onOpen={openExisting}
-            closeCapability={durableAuthority.capability.status}
-            closeCanMutate={durableAuthority.canMutate}
-            closePending={durableMutations.close.isPending}
-            onDurableClose={requestDurableClose}
-            durableRenameIdentityKeys={
-              new Set(
-                plainTerminalCollectionValues(durableAuthority.collection).map(
-                  (terminal) =>
-                    plainTerminalCollectionIdentityKey(
-                      terminal.record.hostId,
-                      terminal.record.terminalId,
-                    ),
-                ),
-              )
-            }
-            durableRenamePending={durableMutations.rename.isPending}
-            onDurableRename={requestDurableRename}
           />
         </SidebarGroupContent>
       </SidebarGroup>
@@ -419,115 +196,29 @@ export function TerminalsPanelActions(props: LeftPanelSlotProps) {
 }
 
 interface TerminalSidebarBodyProps {
-  readonly isLoading: boolean;
-  readonly isError: boolean;
-  readonly errorMessage: string | null;
-  readonly isRetrying: boolean;
-  readonly onRetry: () => void;
-  readonly sessions: ReadonlyArray<TerminalSidebarSessionRow>;
-  readonly failedCreates: ReadonlyArray<EpicTerminalDurableCreateJobView>;
+  readonly panel: EpicTerminalsPanel;
   readonly epicId: string;
   readonly tabId: string;
-  readonly hostId: string;
   readonly onOpen: (row: TerminalSidebarSessionRow) => void;
-  readonly closeCapability: "unknown" | "legacy" | "capable";
-  readonly closeCanMutate: boolean;
-  readonly closePending: boolean;
-  readonly onDurableClose: (hostId: string, terminalId: string) => void;
-  readonly durableRenameIdentityKeys: ReadonlySet<string>;
-  readonly durableRenamePending: boolean;
-  readonly onDurableRename: (
-    hostId: string,
-    terminalId: string,
-    manualTitle: string,
-    onSuccess: () => void,
-  ) => void;
-}
-
-type TerminalSidebarRenameMode = "disabled" | "legacy" | "capable";
-
-/**
- * Which lifetime authority owns a row's rename. `capability` and `canMutate`
- * are host-wide, but the sidebar merges durable projection rows with
- * manager-owned compatibility rows from `terminal.list`.
- */
-function resolveTerminalSidebarRenameMode(args: {
-  readonly capability: "unknown" | "legacy" | "capable";
-  readonly canMutate: boolean;
-  readonly hasProjection: boolean;
-}): TerminalSidebarRenameMode {
-  if (args.capability === "legacy") return "legacy";
-  if (args.capability !== "capable") return "disabled";
-  if (!args.canMutate) return "disabled";
-  // A row with no durable projection is a manager-owned compatibility row.
-  // The host still serves `terminal.rename` for it.
-  if (!args.hasProjection) return "legacy";
-  return "capable";
 }
 
 function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
-  if (props.isLoading) {
-    return (
-      <div className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-muted-foreground">
-        <AgentSpinningDots
-          className="shrink-0 text-muted-foreground/70"
-          testId={undefined}
-          variant={undefined}
-        />
-        <span>Loading terminals…</span>
-      </div>
-    );
+  const { panel } = props;
+  if (panel.isLoading) {
+    return <TerminalsLoadingState testIdPrefix={TERMINALS_TEST_ID_PREFIX} />;
   }
-  if (props.isError) {
+  if (panel.isError) {
     return (
-      <div
-        className="flex flex-col gap-2 px-2 py-1.5 text-ui-sm text-destructive"
-        data-testid="epic-terminal-sidebar-error"
-      >
-        <span className="min-w-0">
-          {props.errorMessage ?? "Failed to load terminals."}
-        </span>
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={props.isRetrying}
-            data-testid="epic-terminal-sidebar-retry"
-            onClick={props.onRetry}
-          >
-            {props.isRetrying ? (
-              <AgentSpinningDots
-                className="shrink-0"
-                testId={undefined}
-                variant={undefined}
-              />
-            ) : null}
-            Retry
-          </Button>
-          <ReportIssueAction
-            context={createReportIssueContext({
-              title: "Failed to load terminals",
-              message: "The terminal list could not be loaded.",
-              code: null,
-              source: "Terminals",
-            })}
-            presentation="icon"
-            className="text-current"
-          />
-        </div>
-      </div>
-    );
-  }
-  if (props.sessions.length === 0 && props.failedCreates.length === 0) {
-    return (
-      <SidebarPanelEmptyState
-        icon={TerminalIcon}
-        title="No terminals yet."
-        description={null}
-        testId="epic-terminal-sidebar-empty"
+      <TerminalsErrorState
+        message={panel.errorMessage}
+        isRetrying={panel.isRetrying}
+        onRetry={panel.retry}
+        testIdPrefix={TERMINALS_TEST_ID_PREFIX}
       />
     );
+  }
+  if (panel.rows.length === 0 && panel.failedCreates.length === 0) {
+    return <TerminalsEmptyState testIdPrefix={TERMINALS_TEST_ID_PREFIX} />;
   }
   return (
     <ul
@@ -535,7 +226,7 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
       className="space-y-0.5"
       data-testid="epic-terminal-sidebar-list"
     >
-      {props.sessions.map((row) => (
+      {panel.rows.map((row) => (
         <TerminalRow
           key={epicTerminalUiIdentityKey(
             "session",
@@ -549,96 +240,24 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
           runtimeStatus={row.runtimeStatus}
           durable={row.durable}
           onOpen={() => props.onOpen(row)}
-          closeCapability={props.closeCapability}
-          closeCanMutate={props.closeCanMutate}
-          closePending={props.closePending}
-          onDurableClose={props.onDurableClose}
-          renameMode={resolveTerminalSidebarRenameMode({
-            capability: props.closeCapability,
-            canMutate: props.closeCanMutate,
-            hasProjection: props.durableRenameIdentityKeys.has(
-              plainTerminalCollectionIdentityKey(
-                row.hostId,
-                row.session.sessionId,
-              ),
-            ),
-          })}
-          durableRenamePending={props.durableRenamePending}
-          onDurableRename={props.onDurableRename}
+          authority={panel}
         />
       ))}
-      {props.failedCreates.map((job) => (
-        <FailedHeadlessTerminalCreateRow
+      {panel.failedCreates.map((job) => (
+        <li
           key={epicTerminalUiIdentityKey(
             "failed",
             job.request.hostId,
             job.request.terminalId,
           )}
-          job={job}
-        />
+        >
+          <FailedTerminalCreateRow
+            job={job}
+            testIdPrefix={TERMINALS_TEST_ID_PREFIX}
+          />
+        </li>
       ))}
     </ul>
-  );
-}
-
-function FailedHeadlessTerminalCreateRow(props: {
-  readonly job: EpicTerminalDurableCreateJobView;
-}) {
-  const { job } = props;
-  const unmarkPendingCreate = useEpicCanvasStore(
-    (state) => state.unmarkTerminalPendingCreate,
-  );
-  const title = DEFAULT_TERMINAL_TITLE;
-  const message = job.error?.message ?? "Could not create terminal.";
-  const identityKey = epicTerminalUiIdentityKey(
-    "failed",
-    job.request.hostId,
-    job.request.terminalId,
-  );
-  return (
-    <li
-      className="rounded-md px-2 py-1.5"
-      data-testid={`epic-terminal-sidebar-failed-create-${identityKey}`}
-    >
-      <div className="flex min-w-0 items-start gap-1.5 text-ui-sm">
-        <TerminalIcon className="mt-0.5 size-3.5 shrink-0 text-destructive/70" />
-        <div className="min-w-0 flex-1">
-          <div className="truncate font-medium text-foreground/80">{title}</div>
-          <div className="truncate text-destructive">{message}</div>
-          <div className="mt-1 flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              data-testid={`epic-terminal-sidebar-failed-retry-${identityKey}`}
-              onClick={() => {
-                retryEpicTerminalDurableCreate(
-                  job.request.hostId,
-                  job.request.terminalId,
-                );
-              }}
-            >
-              Retry
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              data-testid={`epic-terminal-sidebar-failed-discard-${identityKey}`}
-              onClick={() => {
-                discardEpicTerminalDurableCreate(
-                  job.request.hostId,
-                  job.request.terminalId,
-                );
-                unmarkPendingCreate(job.request.hostId, job.request.terminalId);
-              }}
-            >
-              Discard
-            </Button>
-          </div>
-        </div>
-      </div>
-    </li>
   );
 }
 
@@ -650,75 +269,35 @@ interface TerminalRowProps {
   readonly runtimeStatus: "running" | "dormant" | "unknown";
   readonly durable: boolean;
   readonly onOpen: () => void;
-  readonly closeCapability: "unknown" | "legacy" | "capable";
-  readonly closeCanMutate: boolean;
-  readonly closePending: boolean;
-  readonly onDurableClose: (hostId: string, terminalId: string) => void;
-  readonly renameMode: TerminalSidebarRenameMode;
-  readonly durableRenamePending: boolean;
-  readonly onDurableRename: (
-    hostId: string,
-    terminalId: string,
-    manualTitle: string,
-    onSuccess: () => void,
-  ) => void;
+  readonly authority: EpicTerminalRowAuthority;
 }
 
 function TerminalRow(props: TerminalRowProps) {
   const {
-    closeCapability,
-    closeCanMutate,
-    closePending,
-    durableRenamePending,
+    authority,
+    durable,
     epicId,
     hostId,
-    runtimeStatus,
-    durable,
-    onDurableClose,
-    onDurableRename,
     onOpen,
+    runtimeStatus,
     session,
     tabId,
   } = props;
   // Per-row boolean subscription so selecting a session re-renders only the two
   // rows whose active state flips, not every row.
   const isActive = useIsActiveTile(tabId, session.sessionId, hostId);
-  // The row's terminal lives on the host this sidebar LISTS (the Epic
-  // session's - see the list above), so kill and rename go to that same
-  // client. The app-wide wrappers were the last two reads that stayed on
-  // the ambient host after the list moved: during a re-point they killed and
-  // renamed host B's sessions from host A's rows.
-  const rowHostClient = useEpicSessionHostClient();
-  const kill = useTerminalKillFor(
-    rowHostClient,
-    "Couldn't close the terminal.",
-    true,
-  );
-  const legacyRename = useTerminalRenameFor(rowHostClient);
-  const navigateNested = useEpicNestedFocusNavigation();
-  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareCloseCanvasTabFocusTarget,
-  );
+  const actions = useEpicTerminalRowActions({
+    epicId,
+    tabId,
+    hostId,
+    session,
+    durable,
+    authority,
+  });
   const showNavigatorResourceStats = useSettingsStore(
     (state) => state.showNavigatorResourceStats,
   );
-  const hasUnsupportedFutureRef = useEpicCanvasStore((state) =>
-    Object.values(state.canvasByTabId).some((canvas) =>
-      Object.values(canvas?.tilesByInstanceId ?? {}).some(
-        (ref) =>
-          ref?.type === "terminal" &&
-          ref.hostId === hostId &&
-          ref.id === session.sessionId &&
-          isUnsupportedEpicTerminalRef(ref),
-      ),
-    ),
-  );
-  const renameMode = hasUnsupportedFutureRef ? "disabled" : props.renameMode;
-  let renamePending = false;
-  if (renameMode === "capable") renamePending = durableRenamePending;
-  if (renameMode === "legacy") renamePending = legacyRename.isPending;
-  const canRename = renameMode !== "disabled" && !renamePending;
-  const label = terminalSessionLabel(session);
+  const label = actions.label;
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -762,34 +341,17 @@ function TerminalRow(props: TerminalRowProps) {
   }, [isRenaming]);
 
   const startRename = () => {
-    if (!canRename) return;
+    if (!actions.canRename) return;
     setRenameValue(label);
     setIsRenaming(true);
   };
 
   const commitRename = () => {
-    if (!canRename) return;
-    const trimmed = renameValue.trim();
-    if (trimmed.length === 0 || trimmed === label) {
-      setIsRenaming(false);
-      return;
-    }
-    // The mutation optimistically patches the cached `terminal.list` rows,
-    // so this row AND any open canvas tab for the session update before the
-    // host round-trip (with rollback on error).
-    const finish = (): void => setIsRenaming(false);
-    if (renameMode === "capable") {
-      onDurableRename(hostId, session.sessionId, trimmed, finish);
-      return;
-    }
-    legacyRename.mutate(
-      { sessionId: session.sessionId, title: trimmed },
-      { onSuccess: finish },
-    );
+    actions.submitRename(renameValue, () => setIsRenaming(false));
   };
 
   const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (renamePending) return;
+    if (actions.renamePending) return;
     if (event.key === "Enter") {
       event.preventDefault();
       commitRename();
@@ -799,55 +361,25 @@ function TerminalRow(props: TerminalRowProps) {
     }
   };
 
-  // "Close" terminates the PTY AND closes its open canvas tab. Killing alone
-  // only drops the host session (and its sidebar row); the open tile would
-  // otherwise linger until the exit frame round-trips - and not at all if the
-  // tile is currently unmounted. Closing the tab here makes the action
-  // immediate and mount-independent. `findOpenTileInTab` returns null when
-  // no tab is open for this session, so a sidebar-only session just gets killed.
-  const requestClose = () => {
-    if (hasUnsupportedFutureRef) return;
-    if (durable) {
-      if (closeCapability !== "capable" || !closeCanMutate || closePending) {
-        return;
-      }
-      onDurableClose(hostId, session.sessionId);
-      return;
-    }
-    if (closeCapability === "unknown" || kill.isPending) return;
-    const found = findOpenTileInTab(
-      tabId,
-      makeListedEpicTerminalRef({
-        session,
-        hostId,
-        instanceId: "legacy-close-lookup",
-        durable: false,
-      }),
-    );
-    if (found !== null) {
-      navigateNested(epicId, tabId, () =>
-        prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
-      );
-    }
-    kill.mutate({ sessionId: session.sessionId });
-  };
-
   const handleDoubleClick = () => {
-    if (isRenaming || !canRename) return;
+    if (isRenaming || !actions.canRename) return;
     startRename();
   };
   const rowMenuEntries = terminalRowMenuEntries({
-    sessionId: session.sessionId,
-    // Not a pending flag: it also encodes "not permitted" (unsupported future
-    // ref, unknown capability, no mutation authority).
-    closeDisabled:
-      hasUnsupportedFutureRef ||
-      (durable
-        ? closeCapability !== "capable" || !closeCanMutate || closePending
-        : closeCapability === "unknown" || kill.isPending),
+    closeDisabled: actions.closeDisabled,
     onStartRename: startRename,
-    renameDisabled: !canRename,
-    onRequestClose: requestClose,
+    renameDisabled: !actions.canRename,
+    onRequestClose: actions.requestClose,
+    testIds: {
+      rename: {
+        dropdown: `epic-terminal-sidebar-rename-${session.sessionId}`,
+        context: `epic-terminal-sidebar-context-rename-${session.sessionId}`,
+      },
+      close: {
+        dropdown: `epic-terminal-sidebar-kill-menu-${session.sessionId}`,
+        context: `epic-terminal-sidebar-context-kill-${session.sessionId}`,
+      },
+    },
   });
 
   return (
@@ -867,7 +399,7 @@ function TerminalRow(props: TerminalRowProps) {
                   ref={renameInputRef}
                   data-testid={`epic-terminal-sidebar-rename-input-${session.sessionId}`}
                   value={renameValue}
-                  disabled={renamePending}
+                  disabled={actions.renamePending}
                   onChange={(event) => setRenameValue(event.target.value)}
                   onBlur={commitRename}
                   onKeyDown={handleRenameKeyDown}
@@ -945,48 +477,4 @@ function TerminalRow(props: TerminalRowProps) {
       </ContextMenu>
     </li>
   );
-}
-
-interface TerminalRowMenuEntriesProps {
-  readonly sessionId: string;
-  readonly closeDisabled: boolean;
-  readonly onStartRename: () => void;
-  readonly renameDisabled: boolean;
-  readonly onRequestClose: () => void;
-}
-
-function terminalRowMenuEntries(
-  props: TerminalRowMenuEntriesProps,
-): ReadonlyArray<SidebarRowMenuEntry> {
-  return [
-    {
-      kind: "item",
-      id: "rename",
-      label: "Rename",
-      icon: <Pencil className="size-3.5" />,
-      disabled: props.renameDisabled,
-      disabledTooltip: null,
-      variant: "default",
-      testIds: {
-        dropdown: `epic-terminal-sidebar-rename-${props.sessionId}`,
-        context: `epic-terminal-sidebar-context-rename-${props.sessionId}`,
-      },
-      onSelect: props.onStartRename,
-    },
-    { kind: "separator", id: "before-close" },
-    {
-      kind: "item",
-      id: "close",
-      label: "Close",
-      icon: <Trash2 className="size-3.5" />,
-      disabled: props.closeDisabled,
-      disabledTooltip: null,
-      variant: "destructive",
-      testIds: {
-        dropdown: `epic-terminal-sidebar-kill-menu-${props.sessionId}`,
-        context: `epic-terminal-sidebar-context-kill-${props.sessionId}`,
-      },
-      onSelect: props.onRequestClose,
-    },
-  ];
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/terminal-list-states.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/terminal-list-states.tsx
@@ -1,0 +1,170 @@
+/**
+ * The non-row states of a raw-terminal list - loading, load failure, empty,
+ * and a durable create that failed - shared by the desktop left panel and the
+ * phone switcher's Terminals category.
+ *
+ * These carry the surface's answers to "why is this list not showing me a
+ * terminal", which is exactly where a re-implemented list drifts: a phone that
+ * renders only rows shows "No terminals yet." while the query is still
+ * pending, and again when it has failed outright, with no way back. Sharing
+ * them means both surfaces say the same true thing, and the phone gets the
+ * retry path too. Test ids differ per surface via `testIdPrefix`; the copy and
+ * the actions do not.
+ */
+import { Terminal as TerminalIcon } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { DEFAULT_TERMINAL_TITLE } from "@/lib/terminals/terminal-title";
+import {
+  discardEpicTerminalDurableCreate,
+  retryEpicTerminalDurableCreate,
+  type EpicTerminalDurableCreateJobView,
+} from "@/lib/terminals/epic-terminal-durable-create-coordinator";
+import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+
+export function TerminalsLoadingState(props: {
+  readonly testIdPrefix: string;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-muted-foreground"
+      data-testid={`${props.testIdPrefix}-loading`}
+    >
+      <AgentSpinningDots
+        className="shrink-0 text-muted-foreground/70"
+        testId={undefined}
+        variant={undefined}
+      />
+      <span>Loading terminals…</span>
+    </div>
+  );
+}
+
+export function TerminalsErrorState(props: {
+  readonly message: string | null;
+  readonly isRetrying: boolean;
+  readonly onRetry: () => void;
+  readonly testIdPrefix: string;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2 px-2 py-1.5 text-ui-sm text-destructive"
+      data-testid={`${props.testIdPrefix}-error`}
+    >
+      <span className="min-w-0">
+        {props.message ?? "Failed to load terminals."}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={props.isRetrying}
+          data-testid={`${props.testIdPrefix}-retry`}
+          onClick={props.onRetry}
+        >
+          {props.isRetrying ? (
+            <AgentSpinningDots
+              className="shrink-0"
+              testId={undefined}
+              variant={undefined}
+            />
+          ) : null}
+          Retry
+        </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Failed to load terminals",
+            message: "The terminal list could not be loaded.",
+            code: null,
+            source: "Terminals",
+          })}
+          presentation="icon"
+          className="text-current"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function TerminalsEmptyState(props: { readonly testIdPrefix: string }) {
+  return (
+    <SidebarPanelEmptyState
+      icon={TerminalIcon}
+      title="No terminals yet."
+      description={null}
+      testId={`${props.testIdPrefix}-empty`}
+    />
+  );
+}
+
+/**
+ * A durable create that failed and has no authoritative row to stand for it.
+ * Offers the two ways out - try again, or forget it - so a failed launch is
+ * never a silently missing terminal.
+ */
+export function FailedTerminalCreateRow(props: {
+  readonly job: EpicTerminalDurableCreateJobView;
+  readonly testIdPrefix: string;
+}) {
+  const { job, testIdPrefix } = props;
+  const unmarkPendingCreate = useEpicCanvasStore(
+    (state) => state.unmarkTerminalPendingCreate,
+  );
+  const title = DEFAULT_TERMINAL_TITLE;
+  const message = job.error?.message ?? "Could not create terminal.";
+  const identityKey = epicTerminalUiIdentityKey(
+    "failed",
+    job.request.hostId,
+    job.request.terminalId,
+  );
+  return (
+    <div
+      className="rounded-md px-2 py-1.5"
+      data-testid={`${testIdPrefix}-failed-create-${identityKey}`}
+    >
+      <div className="flex min-w-0 items-start gap-1.5 text-ui-sm">
+        <TerminalIcon className="mt-0.5 size-3.5 shrink-0 text-destructive/70" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-foreground/80">{title}</div>
+          <div className="truncate text-destructive">{message}</div>
+          <div className="mt-1 flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid={`${testIdPrefix}-failed-retry-${identityKey}`}
+              onClick={() => {
+                retryEpicTerminalDurableCreate(
+                  job.request.hostId,
+                  job.request.terminalId,
+                );
+              }}
+            >
+              Retry
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              data-testid={`${testIdPrefix}-failed-discard-${identityKey}`}
+              onClick={() => {
+                discardEpicTerminalDurableCreate(
+                  job.request.hostId,
+                  job.request.terminalId,
+                );
+                unmarkPendingCreate(job.request.hostId, job.request.terminalId);
+              }}
+            >
+              Discard
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/terminal-row-menu-entries.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/terminal-row-menu-entries.tsx
@@ -1,0 +1,56 @@
+import { Pencil, Trash2 } from "lucide-react";
+import type { SidebarRowMenuEntry } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+
+/**
+ * Per-surface test ids for the two terminal row actions. The actions
+ * themselves - which entries exist, in what order, with which labels and
+ * disabled state - are the same everywhere; only what a test grabs them by
+ * follows the surface's own naming.
+ */
+export interface TerminalRowMenuTestIds {
+  readonly rename: { readonly dropdown: string; readonly context: string };
+  readonly close: { readonly dropdown: string; readonly context: string };
+}
+
+export interface TerminalRowMenuEntriesProps {
+  readonly closeDisabled: boolean;
+  readonly onStartRename: () => void;
+  readonly renameDisabled: boolean;
+  readonly onRequestClose: () => void;
+  readonly testIds: TerminalRowMenuTestIds;
+}
+
+/**
+ * The "…" menu of a raw-terminal row: Rename, then a destructive Close.
+ * Shared so a phone's menu can never quietly offer fewer actions - or
+ * differently-gated ones - than the desktop row it mirrors.
+ */
+export function terminalRowMenuEntries(
+  props: TerminalRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
+  return [
+    {
+      kind: "item",
+      id: "rename",
+      label: "Rename",
+      icon: <Pencil className="size-3.5" />,
+      disabled: props.renameDisabled,
+      disabledTooltip: null,
+      variant: "default",
+      testIds: props.testIds.rename,
+      onSelect: props.onStartRename,
+    },
+    { kind: "separator", id: "before-close" },
+    {
+      kind: "item",
+      id: "close",
+      label: "Close",
+      icon: <Trash2 className="size-3.5" />,
+      disabled: props.closeDisabled,
+      disabledTooltip: null,
+      variant: "destructive",
+      testIds: props.testIds.close,
+      onSelect: props.onRequestClose,
+    },
+  ];
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/use-epic-terminals-panel.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/use-epic-terminals-panel.ts
@@ -1,0 +1,492 @@
+/**
+ * The Terminals surface's data + action layer, independent of its chrome.
+ *
+ * Listing a raw terminal is not a "render the rows" problem: which rows exist
+ * is a three-authority reconciliation (durable `terminal.plain.list`
+ * projections, manager-owned `terminal.list` compatibility rows, a genuinely
+ * legacy host's full list), and renaming or closing one has to be routed to
+ * whichever authority owns that particular row. Every surface that lists
+ * terminals - the desktop left panel and the phone tab switcher's Terminals
+ * category - mounts these hooks, so both list the same sessions and mutate
+ * them through the same host authority; only the chrome around them differs.
+ */
+import { useCallback, useEffect, useMemo } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { toast } from "sonner";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import { useTerminalKillFor } from "@/hooks/terminal/use-terminal-kill-for-mutation";
+import { useTerminalList } from "@/hooks/terminal/use-terminal-list-query";
+import { useTerminalRenameFor } from "@/hooks/terminal/use-terminal-rename-for-mutation";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
+import { useEpicSessionHostId } from "@/hooks/epic/use-epic-session-host-id";
+import { terminalSessionLabel } from "@/lib/terminals/terminal-title";
+import {
+  findOpenTileInTab,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
+import {
+  isUnsupportedEpicTerminalRef,
+  type EpicTerminalRef,
+} from "@/stores/epics/canvas/types";
+import { useHostPlainTerminalAuthority } from "@/hooks/terminal/use-plain-terminal-authority";
+import { useDelayedTerminalFleetWarning } from "@/hooks/terminal/use-delayed-terminal-fleet-warning";
+import { useHostPlainTerminalMutations } from "@/hooks/terminal/use-plain-terminal-mutations";
+import { requestEpicTerminalLifetimeClose } from "@/lib/terminals/epic-terminal-close-coordinator";
+import {
+  settleEpicTerminalDurableCreate,
+  type EpicTerminalDurableCreateJobView,
+} from "@/lib/terminals/epic-terminal-durable-create-coordinator";
+import { useEpicTerminalDurableCreateJobViews } from "@/hooks/terminal/use-epic-terminal-durable-create";
+import { failedCreateHasAuthoritativeRow } from "@/lib/terminals/pending-create-identity";
+import {
+  getPlainTerminal,
+  plainTerminalCapabilityTopology,
+  plainTerminalCollectionIdentityKey,
+  plainTerminalCollectionValues,
+  type PlainTerminalCollection,
+} from "@/lib/terminals/plain-terminal-authority";
+import { makeListedEpicTerminalRef } from "@/lib/terminals/listed-epic-terminal-ref";
+import {
+  reconcileTerminalSidebarSessions,
+  type ListedTerminalSidebarSession,
+  type TerminalSidebarSessionRow,
+} from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
+import { useResolvePlainTerminalOwnerHostClient } from "@/lib/terminals/resolve-plain-terminal-owner-client";
+
+export type TerminalCloseCapability = "unknown" | "legacy" | "capable";
+
+export type TerminalSidebarRenameMode = "disabled" | "legacy" | "capable";
+
+/** The lifetime authority a single row's rename and close have to go through. */
+export interface EpicTerminalRowAuthority {
+  readonly closeCapability: TerminalCloseCapability;
+  readonly closeCanMutate: boolean;
+  readonly closePending: boolean;
+  readonly onDurableClose: (hostId: string, terminalId: string) => void;
+  readonly durableRenameIdentityKeys: ReadonlySet<string>;
+  readonly durableRenamePending: boolean;
+  readonly onDurableRename: (
+    hostId: string,
+    terminalId: string,
+    manualTitle: string,
+    onSuccess: () => void,
+  ) => void;
+}
+
+export interface EpicTerminalsPanel extends EpicTerminalRowAuthority {
+  readonly rows: ReadonlyArray<TerminalSidebarSessionRow>;
+  readonly failedCreates: ReadonlyArray<EpicTerminalDurableCreateJobView>;
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly errorMessage: string | null;
+  readonly isRetrying: boolean;
+  readonly retry: () => void;
+  /** The Epic session's host - the machine whose terminals these rows are. */
+  readonly hostId: string;
+  /**
+   * The canvas ref for a row, or null when its owner host is unreachable (the
+   * user is told why). Callers own what they do with the ref, because
+   * "activate" means a different thing on a split canvas than on a phone's
+   * single-tile view - the identity of the thing being opened does not.
+   */
+  readonly prepareOpenRow: (
+    row: TerminalSidebarSessionRow,
+  ) => EpicTerminalRef | null;
+}
+
+function failedCreateMatchesAuthoritativeRow(args: {
+  readonly job: EpicTerminalDurableCreateJobView;
+  readonly hostId: string;
+  readonly durableCollection: PlainTerminalCollection | undefined;
+}): boolean {
+  return failedCreateHasAuthoritativeRow({
+    jobHostId: args.job.request.hostId,
+    jobTerminalId: args.job.request.terminalId,
+    sessionHostId: args.hostId,
+    durableHasTerminalId: (terminalId) =>
+      getPlainTerminal(
+        args.durableCollection,
+        args.job.request.hostId,
+        terminalId,
+      ) !== undefined,
+  });
+}
+
+/**
+ * Which lifetime authority owns a row's rename. `capability` and `canMutate`
+ * are host-wide, but the list merges durable projection rows with
+ * manager-owned compatibility rows from `terminal.list`.
+ */
+export function resolveTerminalSidebarRenameMode(args: {
+  readonly capability: TerminalCloseCapability;
+  readonly canMutate: boolean;
+  readonly hasProjection: boolean;
+}): TerminalSidebarRenameMode {
+  if (args.capability === "legacy") return "legacy";
+  if (args.capability !== "capable") return "disabled";
+  if (!args.canMutate) return "disabled";
+  // A row with no durable projection is a manager-owned compatibility row.
+  // The host still serves `terminal.rename` for it.
+  if (!args.hasProjection) return "legacy";
+  return "capable";
+}
+
+export function useEpicTerminalsPanel(args: {
+  readonly epicId: string;
+}): EpicTerminalsPanel {
+  const { epicId } = args;
+  // The Epic SESSION's host, not the app-wide effective one. Every surface
+  // that mounts this sits OUTSIDE the tiles' `TabHostProvider` - the desktop
+  // panel is a sibling of the canvas, the phone switcher a sibling of the
+  // shown tile - which is exactly the case `useEpicSessionHostId` was written
+  // for: "host RPCs issued by the sidebar must use the session transport's
+  // host instead of ... independently re-reading the app-wide active host".
+  // `terminal.list` is such an RPC, and the pair below has to come from ONE
+  // source - the list names the machine whose terminals it shows, and the id
+  // it hands to `makeListedEpicTerminalRef` binds each opened tile to that
+  // machine for life.
+  //
+  // Reading ambient made both wrong together the moment they disagreed:
+  // activation or failover moves the effective host while `EpicSessionProvider`
+  // is still rendering its previous session (and for the whole of a
+  // re-point that is establishing, or one that failed), so an Epic projected
+  // from host A listed, killed and renamed host B's terminals, and opened them
+  // as B-bound tiles under A's Epic.
+  const hostClient = useEpicSessionHostClient();
+  const list = useTerminalList({ kind: "epic", epicId }, hostClient);
+  // Manual escape hatch for a stranded error state: host-scoped queries get
+  // no automatic retry/refetch routes (transport already retried), so without
+  // this the only recoveries are accidental (collapse/re-expand remounts the
+  // body) or the stream-driven `availability-recovered` invalidation.
+  const refetchList = list.refetch;
+  const retry = useCallback(() => {
+    void refetchList();
+  }, [refetchList]);
+  const activeHostId = useEpicSessionHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
+  const durableAuthority = useHostPlainTerminalAuthority({
+    hostId: activeHostId,
+    scope: { kind: "epic", epicId },
+  });
+  const durableMutations = useHostPlainTerminalMutations(durableAuthority);
+  const resolveOwnerClient = useResolvePlainTerminalOwnerHostClient();
+
+  const closeCapability = durableAuthority.capability.status;
+  const closeCanMutate = durableAuthority.canMutate;
+  const closeMutation = durableMutations.close;
+  const renameMutation = durableMutations.rename;
+
+  const onDurableClose = useCallback(
+    (hostId: string, terminalId: string) => {
+      const pending = requestEpicTerminalLifetimeClose({
+        hostId,
+        terminalId,
+        capability: closeCapability,
+        canMutate: closeCanMutate,
+        close: async () => {
+          await closeMutation.mutateAsync({ hostId, terminalId });
+        },
+      });
+      if (pending === null) return;
+      void pending.catch(() => undefined);
+    },
+    [closeCanMutate, closeCapability, closeMutation],
+  );
+
+  const onDurableRename = useCallback(
+    (
+      hostId: string,
+      terminalId: string,
+      manualTitle: string,
+      onSuccess: () => void,
+    ) => {
+      if (!closeCanMutate || renameMutation.isPending) return;
+      renameMutation.mutate({ hostId, terminalId, manualTitle }, { onSuccess });
+    },
+    [closeCanMutate, renameMutation],
+  );
+
+  const prepareOpenRow = useCallback(
+    (row: TerminalSidebarSessionRow): EpicTerminalRef | null => {
+      if (row.durable && resolveOwnerClient(row.hostId) === null) {
+        toast(
+          `Can't open this terminal right now - host ${row.hostId} is not reachable.`,
+        );
+        return null;
+      }
+      return makeListedEpicTerminalRef({
+        session: row.session,
+        hostId: row.hostId,
+        instanceId: uuidv4(),
+        durable: row.durable,
+      });
+    },
+    [resolveOwnerClient],
+  );
+
+  // Host keeps exited sessions for a 60s grace window; filter so a
+  // single kill click feels like "remove" instead of "mark dead".
+  const reconciled = useMemo(
+    () =>
+      reconcileTerminalSidebarSessions({
+        epicId,
+        servingHostId: activeHostId,
+        capability: closeCapability,
+        topology:
+          plainTerminalCapabilityTopology(durableAuthority.capability) ??
+          "fleet",
+        coverage: durableAuthority.coverage ?? null,
+        listed: list.data?.sessions ?? [],
+        durableCollection: durableAuthority.collection,
+      }),
+    [
+      activeHostId,
+      closeCapability,
+      durableAuthority.capability,
+      durableAuthority.collection,
+      durableAuthority.coverage,
+      epicId,
+      list.data?.sessions,
+    ],
+  );
+  const rows = reconciled.rows;
+  const incompleteFleet = reconciled.incompleteFleet;
+  // The list no longer captions partial fleet coverage - the epic status
+  // pill owns that signal (one amber light, the sentence on hover). The grace
+  // still matters here: until it elapses a catalog that is merely hydrating
+  // must not read as "No terminals yet.", so the loading state holds instead.
+  const fleetGapSettled = useDelayedTerminalFleetWarning(
+    incompleteFleet,
+    JSON.stringify([activeHostId, epicId]),
+  );
+  const createJobs = useEpicTerminalDurableCreateJobViews(epicId);
+  const failedCreates = useMemo(
+    () =>
+      createJobs.filter((job) => {
+        if (job.status !== "failed") return false;
+        if (job.request.hostId !== activeHostId) return false;
+        return !failedCreateMatchesAuthoritativeRow({
+          job,
+          hostId: activeHostId,
+          durableCollection: durableAuthority.collection,
+        });
+      }),
+    [activeHostId, createJobs, durableAuthority.collection],
+  );
+  const unmarkTerminalPendingCreate = useEpicCanvasStore(
+    (state) => state.unmarkTerminalPendingCreate,
+  );
+  useEffect(() => {
+    for (const job of createJobs) {
+      if (job.status !== "failed") continue;
+      if (
+        !failedCreateMatchesAuthoritativeRow({
+          job,
+          hostId: activeHostId,
+          durableCollection: durableAuthority.collection,
+        })
+      ) {
+        continue;
+      }
+      settleEpicTerminalDurableCreate(
+        job.request.hostId,
+        job.request.terminalId,
+      );
+      unmarkTerminalPendingCreate(job.request.hostId, job.request.terminalId);
+    }
+  }, [
+    activeHostId,
+    createJobs,
+    durableAuthority.collection,
+    unmarkTerminalPendingCreate,
+  ]);
+
+  const durableRenameIdentityKeys = useMemo(
+    () =>
+      new Set(
+        plainTerminalCollectionValues(durableAuthority.collection).map(
+          (terminal) =>
+            plainTerminalCollectionIdentityKey(
+              terminal.record.hostId,
+              terminal.record.terminalId,
+            ),
+        ),
+      ),
+    [durableAuthority.collection],
+  );
+
+  return {
+    rows,
+    failedCreates,
+    isLoading:
+      failedCreates.length === 0 &&
+      (closeCapability === "unknown" ||
+        (incompleteFleet && !fleetGapSettled && rows.length === 0) ||
+        (rows.length === 0 &&
+          (list.isPending ||
+            (closeCapability === "capable" &&
+              durableAuthority.collection === undefined)))),
+    isError: Boolean(
+      closeCapability !== "unknown" && list.isError && rows.length === 0,
+    ),
+    errorMessage: list.error?.message ?? null,
+    isRetrying: list.isFetching,
+    retry,
+    hostId: activeHostId,
+    prepareOpenRow,
+    closeCapability,
+    closeCanMutate,
+    closePending: closeMutation.isPending,
+    onDurableClose,
+    durableRenameIdentityKeys,
+    durableRenamePending: renameMutation.isPending,
+    onDurableRename,
+  };
+}
+
+export interface EpicTerminalRowActions {
+  /** What the session is called on screen, from the one shared definition. */
+  readonly label: string;
+  readonly canRename: boolean;
+  readonly renamePending: boolean;
+  /**
+   * Commits a rename through whichever authority owns this row. A blank or
+   * unchanged title is a no-op that still reports done, so a surface can close
+   * its editor on the same call either way.
+   */
+  readonly submitRename: (next: string, onDone: () => void) => void;
+  /**
+   * Not a pending flag: it also encodes "not permitted" (unsupported future
+   * ref, unknown capability, no mutation authority).
+   */
+  readonly closeDisabled: boolean;
+  readonly requestClose: () => void;
+}
+
+/**
+ * A single row's rename and close, routed to the authority that owns it.
+ */
+export function useEpicTerminalRowActions(args: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly hostId: string;
+  readonly session: ListedTerminalSidebarSession;
+  readonly durable: boolean;
+  readonly authority: EpicTerminalRowAuthority;
+}): EpicTerminalRowActions {
+  const { authority, durable, epicId, hostId, session, tabId } = args;
+  // The row's terminal lives on the host this surface LISTS (the Epic
+  // session's - see the list above), so kill and rename go to that same
+  // client. The app-wide wrappers were the last two reads that stayed on
+  // the ambient host after the list moved: during a re-point they killed and
+  // renamed host B's sessions from host A's rows.
+  const rowHostClient = useEpicSessionHostClient();
+  const kill = useTerminalKillFor(
+    rowHostClient,
+    "Couldn't close the terminal.",
+    true,
+  );
+  const legacyRename = useTerminalRenameFor(rowHostClient);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+  const hasUnsupportedFutureRef = useEpicCanvasStore((state) =>
+    Object.values(state.canvasByTabId).some((canvas) =>
+      Object.values(canvas?.tilesByInstanceId ?? {}).some(
+        (ref) =>
+          ref?.type === "terminal" &&
+          ref.hostId === hostId &&
+          ref.id === session.sessionId &&
+          isUnsupportedEpicTerminalRef(ref),
+      ),
+    ),
+  );
+
+  const renameMode = hasUnsupportedFutureRef
+    ? "disabled"
+    : resolveTerminalSidebarRenameMode({
+        capability: authority.closeCapability,
+        canMutate: authority.closeCanMutate,
+        hasProjection: authority.durableRenameIdentityKeys.has(
+          plainTerminalCollectionIdentityKey(hostId, session.sessionId),
+        ),
+      });
+  let renamePending = false;
+  if (renameMode === "capable") renamePending = authority.durableRenamePending;
+  if (renameMode === "legacy") renamePending = legacyRename.isPending;
+  const canRename = renameMode !== "disabled" && !renamePending;
+  const label = terminalSessionLabel(session);
+
+  const submitRename = (next: string, onDone: () => void): void => {
+    if (!canRename) return;
+    const trimmed = next.trim();
+    if (trimmed.length === 0 || trimmed === label) {
+      onDone();
+      return;
+    }
+    // The mutation optimistically patches the cached `terminal.list` rows,
+    // so this row AND any open canvas tab for the session update before the
+    // host round-trip (with rollback on error).
+    if (renameMode === "capable") {
+      authority.onDurableRename(hostId, session.sessionId, trimmed, onDone);
+      return;
+    }
+    legacyRename.mutate(
+      { sessionId: session.sessionId, title: trimmed },
+      { onSuccess: onDone },
+    );
+  };
+
+  // "Close" terminates the PTY AND closes its open canvas tab. Killing alone
+  // only drops the host session (and its row); the open tile would
+  // otherwise linger until the exit frame round-trips - and not at all if the
+  // tile is currently unmounted. Closing the tab here makes the action
+  // immediate and mount-independent. `findOpenTileInTab` returns null when
+  // no tab is open for this session, so a list-only session just gets killed.
+  const requestClose = (): void => {
+    if (hasUnsupportedFutureRef) return;
+    if (durable) {
+      if (
+        authority.closeCapability !== "capable" ||
+        !authority.closeCanMutate ||
+        authority.closePending
+      ) {
+        return;
+      }
+      authority.onDurableClose(hostId, session.sessionId);
+      return;
+    }
+    if (authority.closeCapability === "unknown" || kill.isPending) return;
+    const found = findOpenTileInTab(
+      tabId,
+      makeListedEpicTerminalRef({
+        session,
+        hostId,
+        instanceId: "legacy-close-lookup",
+        durable: false,
+      }),
+    );
+    if (found !== null) {
+      navigateNested(epicId, tabId, () =>
+        prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
+      );
+    }
+    kill.mutate({ sessionId: session.sessionId });
+  };
+
+  return {
+    label,
+    canRename,
+    renamePending,
+    submitRename,
+    closeDisabled:
+      hasUnsupportedFutureRef ||
+      (durable
+        ? authority.closeCapability !== "capable" ||
+          !authority.closeCanMutate ||
+          authority.closePending
+        : authority.closeCapability === "unknown" || kill.isPending),
+    requestClose,
+  };
+}


### PR DESCRIPTION
## Problem

The phone tab switcher's **Terminals** category re-implemented the list instead of mounting the desktop panel's logic. It read `terminal.list` directly and rendered rows — nothing else. That diverged from `TerminalsPanelBody` on every axis that matters:

| Axis | Desktop | Mobile (before) |
| --- | --- | --- |
| Row source | `reconcileTerminalSidebarSessions` over durable `terminal.plain.list` + manager-owned compatibility rows | raw `terminal.list` only — **durable projections invisible on a capable host** |
| Opened tile | `makeListedEpicTerminalRef` (`authority: "host"`, `legacyFallback`, `lifecycleOwner`, provider-login/setup origin) | hand-built legacy ref — a host-owned terminal opened as a legacy-authority tile |
| Unreachable owner host | refused with a reason | opened anyway |
| Loading | "Loading terminals…" | "No terminals yet." |
| Load failure | message + Retry + Report issue | "No terminals yet.", no way back |
| Failed durable create | row with Retry / Discard | nothing — a failed launch was a silently missing terminal |
| Row metadata | "Runtime status unavailable"; `OwnerResourceChip` under the navigator-stats setting | none |
| Active / already-open match | by ref (id **and** host) | by content id — two fleet terminals sharing a terminalId collided |
| Rename | durable projection or legacy RPC, per row's authority; gated on capability, mutation rights, unsupported future refs | always legacy `terminal.rename`, ungated |
| Close | durable close coordinator or legacy kill, same gating | always legacy kill |
| Empty state | icon + title | bare text |
| Menu items | Rename, Close | Rename, Close ✓ |
| Header name | "Terminals" | "Terminals" ✓ |
| Create | header "+" → `NewTerminalPicker` | "New terminal" row → same picker body in a dialog ✓ |

## Change

Extract the surface-independent half of the Terminals panel and mount it from both:

- `use-epic-terminals-panel.ts` — `useEpicTerminalsPanel` (reconciled rows, loading/error/retry, failed creates, durable close+rename authority, `prepareOpenRow` for the reachability-guarded canvas ref) and `useEpicTerminalRowActions` (a row's rename/close routed to the authority that owns it).
- `terminal-list-states.tsx` — loading, error+retry+report, empty, failed-create row; test ids per surface via `testIdPrefix`.
- `terminal-row-menu-entries.tsx` — the Rename / Close menu, so a phone cannot quietly offer fewer or differently-gated actions.

`epic-terminal-sidebar.tsx` keeps only desktop chrome (drag to a pane, hover "…", context menu, inline rename); its behavior and every existing test id are unchanged. `switcher-terminals-list.tsx` keeps only touch chrome (flat scroller, tap lands the single full-screen tile, rename in the shared dialog).

`SwitcherListRow` gained `secondaryLabel` / `badge` so a category with desktop row metadata can show it rather than drop it; the agents and artifacts rows pass `null`.

## Verification

- `eslint --max-warnings 0` + `prettier --check` clean on all touched files.
- `switcher-terminals-list.test.tsx` (new) + `switcher-lists.test.tsx` — 25 pass. Terminals coverage moved into its own file.
- The seven desktop `terminal-sidebar-*` suites — 50 pass, unchanged.
- Simulator verification is batched with the rest of the epic-tab sweep.