### PR TITLE
feat(mobile): bring the epic switcher's agents tab to desktop parity

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -44,6 +44,12 @@ interface Holder {
   indicatorChatIdCalls: ReadonlyArray<string>[];
   /** What `useEpicNodeHostId` answers - the row's OWN owner host. */
   ownerHostIdByNodeId: Record<string, string>;
+  /** Rows the projection reports as archived. */
+  archivedIds: ReadonlySet<string>;
+  /** Per-row last activity, for the trailing compact timestamp. */
+  updatedAtByNodeId: Record<string, number>;
+  /** Whether the epic's host advertises `epic.setChatArchived`. */
+  archiveSupported: boolean;
   indicators: IndicatorFixture;
 }
 
@@ -72,8 +78,60 @@ const holder = vi.hoisted((): Holder => ({
   activityTiers: new Map<string, "turn" | "background">(),
   indicatorChatIdCalls: [],
   ownerHostIdByNodeId: {},
+  archivedIds: new Set<string>(),
+  updatedAtByNodeId: {},
+  archiveSupported: false,
   indicators: { epics: {}, chats: {} },
 }));
+
+/**
+ * The projector's tree index, rebuilt from the fixture records' `parentId` -
+ * roots and each sibling bucket in last-updated-desc order, exactly as
+ * `projectTreeSlice` emits them. The agents list WALKS this index now, so a
+ * fixture that returned an empty `rootIds` would render an empty tree however
+ * many records it declared.
+ */
+function fixtureTree(): {
+  readonly rootIds: readonly string[];
+  readonly childrenByParent: Readonly<Record<string, readonly string[]>>;
+  readonly nodeById: Readonly<Record<string, TreeNodeFixture>>;
+} {
+  const nodeById: Record<string, TreeNodeFixture> = {};
+  holder.records.forEach((record, index) => {
+    nodeById[record.id] = {
+      id: record.id,
+      type: record.type,
+      parentId: record.parentId,
+      title: record.name,
+      createdAt: index,
+      updatedAt: index,
+    };
+  });
+  const byRecency = (a: string, b: string): number =>
+    nodeById[b].updatedAt - nodeById[a].updatedAt;
+  const childrenByParent: Record<string, string[]> = {};
+  const rootIds: string[] = [];
+  for (const record of holder.records) {
+    const parentId = record.parentId;
+    if (parentId === null || !Object.hasOwn(nodeById, parentId)) {
+      rootIds.push(record.id);
+      continue;
+    }
+    (childrenByParent[parentId] ??= []).push(record.id);
+  }
+  rootIds.sort(byRecency);
+  for (const ids of Object.values(childrenByParent)) ids.sort(byRecency);
+  return { rootIds, childrenByParent, nodeById };
+}
+
+interface TreeNodeFixture {
+  readonly id: string;
+  readonly type: string;
+  readonly parentId: string | null;
+  readonly title: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
 
 vi.mock("@/lib/epic-selectors", () => ({
   useEpicArtifactRecords: () => holder.records,
@@ -82,31 +140,55 @@ vi.mock("@/lib/epic-selectors", () => ({
   useEpicChatHarnessId: () => null,
   useMaybeEpicTuiAgentHarnessId: () => null,
   useEpicPermissionRole: () => holder.role,
+  useEpicChatIds: () =>
+    holder.records
+      .filter((record) => record.type === "chat")
+      .map((record) => record.id),
   // The chat projection's OWN host. Deliberately distinct from the `hostId` on
   // the records above, which is the app-wide ACTIVE host for chat rows.
   useEpicNodeHostId: (nodeId: string) =>
     holder.ownerHostIdByNodeId[nodeId] ?? null,
-  // The lists sort by tree-node recency; expose nodes for the fixtures so the
-  // real epic-sort comparator resolves every id.
-  useEpicTreeIndex: () => ({
-    rootIds: [],
-    childrenByParent: {},
-    nodeById: Object.fromEntries(
-      holder.records.map((record, index) => [
-        record.id,
-        {
-          id: record.id,
-          title: record.name,
-          createdAt: index,
-          updatedAt: index,
-        },
-      ]),
-    ),
-  }),
+  useEpicNodeArchived: (nodeId: string) => holder.archivedIds.has(nodeId),
+  useEpicNodeUpdatedAt: (nodeId: string) =>
+    holder.updatedAtByNodeId[nodeId] ?? 0,
+  useAncestorIds: () => new Set<string>(),
+  useEpicTreeIndex: () => fixtureTree(),
+  useEpicTreeNode: (nodeId: string) => fixtureTree().nodeById[nodeId] ?? null,
+  useChildIds: (parentId: string) =>
+    fixtureTree().childrenByParent[parentId] ?? [],
+}));
+// The row menus' per-list facts. Both capabilities default OFF, which is the
+// fail-closed production default too: Archive and Make private only appear once
+// a handshake proves the host advertises them.
+vi.mock("@/hooks/epic/use-chat-archive-support", () => ({
+  useChatArchiveSupported: () => holder.archiveSupported,
+}));
+vi.mock("@/hooks/epic/use-chat-sharing-support", () => ({
+  useCloudChatVisibilitySupported: () => false,
+}));
+vi.mock("@/hooks/epics/use-epic-collaborators-query", () => ({
+  useEpicCollaboratorsQuery: () => ({ data: undefined }),
+}));
+vi.mock("@/hooks/chats/use-cloud-chat-queries", () => ({
+  useCloudChatList: () => ({ data: undefined }),
+}));
+vi.mock("@/hooks/chats/use-chat-publication-targets", () => ({
+  useChatPublicationTargets: () => ({ data: undefined }),
+  publicationTargetMap: () => new Map<string, string>(),
+}));
+vi.mock("@/hooks/epic/use-epic-chat-visibility-mutations", () => ({
+  useEpicSetCloudChatVisibility: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/lib/chats/chat-sharing-inflight", () => ({
+  useChatSharingInFlight: () => false,
 }));
 vi.mock("@/stores/epics/canvas/canvas-selectors", () => ({
   useIsActiveEpicArtifact: (_tabId: string, id: string) =>
     holder.activeId === id,
+  // The focused tile, whose ancestors the agents tree expands implicitly. The
+  // canvas store re-exports these, so a partial mock here leaves the store's
+  // re-export undefined rather than falling back to the real hook.
+  useActiveEpicArtifactId: () => holder.activeId,
   findOpenArtifactInTab: () => null,
 }));
 vi.mock("@/components/epic-canvas/mobile/use-switcher-activate", () => ({
@@ -134,6 +216,7 @@ vi.mock("@/lib/terminals/terminal-session-filters", () => ({
 vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
   useEpicRenameChat: () => ({ mutate: vi.fn(), isPending: false }),
   useEpicDeleteChat: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicArchiveChat: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 vi.mock("@/hooks/epic/use-epic-tui-agent-mutations", () => ({
   useEpicRenameTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
@@ -198,6 +281,9 @@ beforeEach(() => {
   holder.activityTiers = new Map<string, "turn" | "background">();
   holder.indicatorChatIdCalls = [];
   holder.ownerHostIdByNodeId = {};
+  holder.archivedIds = new Set<string>();
+  holder.updatedAtByNodeId = {};
+  holder.archiveSupported = false;
   holder.indicators = { epics: {}, chats: {} };
 });
 afterEach(cleanup);
@@ -418,6 +504,97 @@ describe("<SwitcherAgentsList />", () => {
     // Agents only - the spec artifact in the fixture is not a chat entity, and
     // the ids are sorted so the query key does not churn on every re-sort.
     expect(chatIds).toEqual(["chat-1", "tui-1"]);
+  });
+
+  it("nests a child agent under its parent, and collapsing the parent hides it", () => {
+    holder.records = [
+      {
+        id: "chat-1",
+        parentId: null,
+        name: "Alpha",
+        type: "chat",
+        status: null,
+        hostId: "host-A",
+      },
+      {
+        id: "chat-2",
+        parentId: "chat-1",
+        name: "Child",
+        type: "chat",
+        status: null,
+        hostId: "host-A",
+      },
+    ];
+    render(<SwitcherAgentsList {...PROPS} />);
+    const parent = screen.getByTestId("switcher-agent-row-chat-1");
+    const child = screen.getByTestId("switcher-agent-row-chat-2");
+    // The child follows its parent in document order rather than landing
+    // wherever a global recency sort would have put it.
+    expect(
+      parent.compareDocumentPosition(child) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // …and reads as one level deeper: the indent is on the row's wrapper.
+    const padding = (element: Element): string =>
+      (element.parentElement as HTMLElement).style.paddingLeft;
+    expect(padding(parent)).toBe("8px");
+    expect(padding(child)).toBe("28px");
+
+    // Roots are expanded implicitly, so the parent starts open and its chevron
+    // closes it.
+    fireEvent.click(screen.getByTestId("switcher-agent-row-chat-1-toggle"));
+    expect(screen.queryByTestId("switcher-agent-row-chat-2")).toBeNull();
+  });
+
+  it("gives a leaf no chevron and a parent an expand control", () => {
+    holder.records = [
+      {
+        id: "chat-1",
+        parentId: null,
+        name: "Alpha",
+        type: "chat",
+        status: null,
+        hostId: "host-A",
+      },
+      {
+        id: "chat-2",
+        parentId: "chat-1",
+        name: "Child",
+        type: "chat",
+        status: null,
+        hostId: "host-A",
+      },
+    ];
+    render(<SwitcherAgentsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-agent-row-chat-1-toggle")).toBeTruthy();
+    expect(screen.queryByTestId("switcher-agent-row-chat-2-toggle")).toBeNull();
+  });
+
+  it("renders each row's last activity on the shared compact ladder", () => {
+    // Offset past the hour boundary: the shared clock samples `now` at module
+    // load, so an exactly-3h delta has already floored to "2h" by the time this
+    // renders.
+    const now = Date.now();
+    holder.updatedAtByNodeId = {
+      "chat-1": now - (3 * 60 + 5) * 60 * 1000,
+      "tui-1": now,
+    };
+    render(<SwitcherAgentsList {...PROPS} />);
+    expect(
+      screen.getByTestId("switcher-agent-row-chat-1").textContent,
+    ).toContain("3h");
+    expect(
+      screen.getByTestId("switcher-agent-row-tui-1").textContent,
+    ).toContain("now");
+  });
+
+  it("lists an archived agent rather than hiding it, and marks it", () => {
+    holder.archivedIds = new Set<string>(["chat-1"]);
+    render(<SwitcherAgentsList {...PROPS} />);
+    const row = screen.getByTestId("switcher-agent-row-chat-1");
+    expect(row.textContent).toContain("Archived");
+    expect(
+      screen.getByTestId("switcher-agent-row-tui-1").textContent,
+    ).not.toContain("Archived");
   });
 
   it("shows the '…' menu for an editor and hides it entirely for a viewer", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -4,6 +4,7 @@ import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-age
 import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
 import { STATUS_DOT_CLASSES } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
+import { useEpicSidebarExpansionStore } from "@/stores/epics/epic-sidebar-expansion-store";
 
 interface FixtureRecord {
   readonly id: string;
@@ -285,6 +286,12 @@ beforeEach(() => {
   holder.updatedAtByNodeId = {};
   holder.archiveSupported = false;
   holder.indicators = { epics: {}, chats: {} };
+  // Module-level and shared with the desktop sidebar, so one test's collapse
+  // would otherwise decide the next test's chevron state - and its label.
+  useEpicSidebarExpansionStore.setState({
+    userExpandedByScope: {},
+    userCollapsedByScope: {},
+  });
 });
 afterEach(cleanup);
 
@@ -541,7 +548,7 @@ describe("<SwitcherAgentsList />", () => {
 
     // Roots are expanded implicitly, so the parent starts open and its chevron
     // closes it.
-    fireEvent.click(screen.getByTestId("switcher-agent-row-chat-1-toggle"));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse Alpha" }));
     expect(screen.queryByTestId("switcher-agent-row-chat-2")).toBeNull();
   });
 
@@ -565,8 +572,13 @@ describe("<SwitcherAgentsList />", () => {
       },
     ];
     render(<SwitcherAgentsList {...PROPS} />);
-    expect(screen.getByTestId("switcher-agent-row-chat-1-toggle")).toBeTruthy();
-    expect(screen.queryByTestId("switcher-agent-row-chat-2-toggle")).toBeNull();
+    // By role, not test id: the control's accessible name and `aria-expanded`
+    // ARE the contract a phone user reaches it through, and a test-id query
+    // would still pass with both dropped.
+    expect(screen.getByRole("button", { name: "Collapse Alpha" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /(Collapse|Expand) Child/ }),
+    ).toBeNull();
   });
 
   it("renders each row's last activity on the shared compact ladder", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -109,7 +109,7 @@ const TAB_ID = "tab-switcher-test";
 const EPIC_ID = "epic-1";
 const HOST_ID = "host-A";
 const CATEGORY_NAMES = [
-  "Chats",
+  "Agents",
   "Artifacts",
   "File Tree",
   "Git Diff",
@@ -163,9 +163,11 @@ describe("<TabSwitcherSheet />", () => {
     expect(screen.getAllByRole("tab")).toHaveLength(5);
   });
 
-  it("labels the chats category 'Chats' and renders the active tab as an underline, not a box", () => {
+  it("labels the chats category 'Agents' and renders the active tab as an underline, not a box", () => {
     renderSheet(true, () => {});
-    const active = screen.getByRole("tab", { name: "Chats" });
+    // The panel registry's own title, with no mobile override on top of it: a
+    // category is the same product noun on every form factor.
+    const active = screen.getByRole("tab", { name: "Agents" });
     expect(active.getAttribute("data-state")).toBe("active");
     // The base `data-active:bg-*` fill is neutralised, so the active line tab
     // never paints a solid fill behind the label.
@@ -261,7 +263,7 @@ describe("<TabSwitcherSheet />", () => {
     ).toBe("active");
   });
 
-  it("clamps a persisted pull-requests selection to Chats when the epic has no PRs", () => {
+  it("clamps a persisted pull-requests selection to Agents when the epic has no PRs", () => {
     useLeftPanelStore.setState({
       activePanelIdByTabId: { [TAB_ID]: "pull-requests" },
     });
@@ -269,7 +271,7 @@ describe("<TabSwitcherSheet />", () => {
     // The tab is gone, so the sheet must fall back rather than strand itself
     // on a category with no trigger and no body.
     expect(
-      screen.getByRole("tab", { name: "Chats" }).getAttribute("data-state"),
+      screen.getByRole("tab", { name: "Agents" }).getAttribute("data-state"),
     ).toBe("active");
     expect(screen.getByTestId("mock-agents-list")).toBeTruthy();
   });
@@ -293,7 +295,7 @@ describe("<TabSwitcherSheet />", () => {
     });
     renderSheet(true, () => {});
     expect(
-      screen.getByRole("tab", { name: "Chats" }).getAttribute("data-state"),
+      screen.getByRole("tab", { name: "Agents" }).getAttribute("data-state"),
     ).toBe("active");
     expect(screen.getByTestId("mock-agents-list")).toBeTruthy();
   });

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agent-row-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agent-row-actions.tsx
@@ -1,0 +1,158 @@
+import { useCallback } from "react";
+import { SwitcherRowMenu } from "@/components/epic-canvas/mobile/switcher-row-menu";
+import {
+  useSwitcherRowActions,
+  type SwitcherRowActionState,
+} from "@/components/epic-canvas/mobile/use-switcher-row-actions";
+import {
+  chatRowArchiveEntry,
+  chatRowMenuEntries,
+  useChatRowArchiveInputs,
+  useChatRowSessionActivity,
+  useChatRowSharing,
+  useNewChildAgentAction,
+  type ChatRowArchiveEntry,
+  type ChatRowArchiveInputs,
+} from "@/components/epic-canvas/sidebar/chat-row-menu";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
+
+export type SwitcherAgentKind = "chat" | "terminal-agent";
+
+interface SwitcherAgentRowActionsProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly nodeId: string;
+  readonly name: string;
+  readonly artifactType: SwitcherAgentKind;
+  /** The row's OWN owner host, for the session the archive gate reads. */
+  readonly ownerHostId: string | null;
+  /** "… and N nested" summary for a cascading delete; null when none. */
+  readonly cascadeSummary: string | null;
+  /** The sheet cannot stay up behind the New Conversation modal. */
+  readonly onClose: () => void;
+}
+
+/**
+ * An agent row's "…" menu on the phone: the SAME entry set the desktop chat
+ * tree offers - New child agent, Rename, Archive/Unarchive, Make private/Share
+ * with task, Delete - built by the desktop's own `chatRowMenuEntries` so the
+ * two surfaces cannot drift in what they offer, in what each entry does, or in
+ * when one is refused and why.
+ *
+ * What the phone drops is only the desktop's POINTER shortcuts: there is no
+ * hover Archive button and no right-click menu, so every action lives in this
+ * one touch target.
+ */
+export function SwitcherAgentRowActions(props: SwitcherAgentRowActionsProps) {
+  const canMutate = isEditableRole(useEpicPermissionRole());
+  const archive = useChatRowArchiveInputs({
+    epicId: props.epicId,
+    nodeId: props.nodeId,
+    canMutate,
+  });
+  const state = useSwitcherRowActions({
+    epicId: props.epicId,
+    tabId: props.tabId,
+    kind: props.artifactType,
+    nodeId: props.nodeId,
+  });
+
+  // A viewer's writes are all server-rejected, so an ungated menu would only
+  // lead to dead ends. Placed after the hooks, never between them.
+  if (!canMutate) return null;
+  if (archive.supported) {
+    return (
+      <ArchivableAgentRowMenu {...props} archive={archive} state={state} />
+    );
+  }
+  return (
+    <AgentRowMenu
+      {...props}
+      archive={archive}
+      archiveEntry={null}
+      state={state}
+    />
+  );
+}
+
+/**
+ * The archive-capable arm. Split at a component boundary for the reason the
+ * desktop tree splits its own: resolving the row's live activity costs an
+ * awareness read, a session-handle lookup and two store subscriptions, and a
+ * host that cannot archive would pay all of it to render an entry it never
+ * shows.
+ */
+function ArchivableAgentRowMenu(
+  props: SwitcherAgentRowActionsProps & {
+    readonly archive: ChatRowArchiveInputs;
+    readonly state: SwitcherRowActionState;
+  },
+) {
+  const activity = useChatRowSessionActivity({
+    epicId: props.epicId,
+    nodeId: props.nodeId,
+    ownerHostId: props.ownerHostId,
+    artifactType: props.artifactType,
+  });
+  return (
+    <AgentRowMenu
+      {...props}
+      archiveEntry={chatRowArchiveEntry({
+        isArchived: props.archive.isArchived,
+        archivePending: props.archive.pending,
+        running: activity.running,
+      })}
+    />
+  );
+}
+
+function AgentRowMenu(
+  props: SwitcherAgentRowActionsProps & {
+    readonly archive: ChatRowArchiveInputs;
+    readonly archiveEntry: ChatRowArchiveEntry | null;
+    readonly state: SwitcherRowActionState;
+  },
+) {
+  const { epicId, tabId, nodeId, name, artifactType, archive, state, onClose } =
+    props;
+  // Re-read rather than threaded: this arm is only ever reached past its
+  // parent's edit gate, and the selector is a per-epic boolean subscription.
+  const canMutate = isEditableRole(useEpicPermissionRole());
+  const sharing = useChatRowSharing(epicId, nodeId, artifactType, canMutate);
+  const newChildAgent = useNewChildAgentAction({
+    epicId,
+    tabId,
+    nodeId,
+    canMutate,
+  });
+  // The modal REPLACES the sheet on a phone rather than opening over it, so the
+  // sheet closes as the modal opens - the same handoff the category's own
+  // "New agent" row performs.
+  const onNewChildAgent = useCallback(() => {
+    newChildAgent();
+    onClose();
+  }, [newChildAgent, onClose]);
+
+  return (
+    <SwitcherRowMenu
+      nodeId={nodeId}
+      name={name}
+      renameTitle="Rename agent"
+      entries={chatRowMenuEntries({
+        nodeId,
+        canMutate,
+        archiveEntry: props.archiveEntry,
+        sharingEntry: sharing.entry,
+        onNewChildAgent,
+        onStartRename: state.openRename,
+        onToggleArchive: archive.onToggle,
+        onToggleSharing: sharing.onToggle,
+        onPerformDelete: state.requestDelete,
+      })}
+      state={state}
+      confirmDescription="This permanently deletes the agent and its history."
+      cascadeSummary={props.cascadeSummary}
+    />
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -324,6 +324,11 @@ function SwitcherAgentRow(props: {
             <Users
               className="size-3 shrink-0 text-muted-foreground"
               data-testid={`switcher-shared-${nodeId}`}
+              // `role` is explicit: lucide drops its default `aria-hidden` once
+              // any a11y prop is passed, and a bare labelled <svg> maps to
+              // `graphics-document` rather than an image, so the label reaches
+              // assistive technology inconsistently without it.
+              role="img"
               aria-label="Shared with task"
             />
           ) : null}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -1,26 +1,53 @@
-import { useCallback, useMemo } from "react";
+import { createContext, useCallback, useContext, useMemo } from "react";
+import { Users } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import { SwitcherAgentIcon } from "@/components/epic-canvas/mobile/switcher-agent-icon";
 import {
   SwitcherListEmpty,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
-import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import {
+  SwitcherAgentRowActions,
+  type SwitcherAgentKind,
+} from "@/components/epic-canvas/mobile/switcher-agent-row-actions";
 import { SwitcherNewChatRow } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
-import { useOrderedSwitcherRecords } from "@/components/epic-canvas/mobile/switcher-record-order";
 import {
+  ArchivedTitlePrefix,
+  ChatRowIdleTime,
+  ChatRowMenuFactsProvider,
+} from "@/components/epic-canvas/sidebar/chat-row-chrome";
+import { useChatRowSharing } from "@/components/epic-canvas/sidebar/chat-row-menu";
+import {
+  CHATS_TREE_FILTER,
+  sidebarTreeRootIds,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-selection";
+import { useFilteredPanelChildIds } from "@/components/epic-canvas/sidebar/epic-sidebar-filter";
+import {
+  useAncestorIds,
   useEpicArtifactRecords,
+  useEpicNodeArchived,
   useEpicNodeHostId,
+  useEpicNodeUpdatedAt,
   useEpicPermissionRole,
+  useEpicTreeIndex,
+  useEpicTreeNode,
   type EpicTreeRecord,
 } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import {
   computeDescendantCounts,
   formatCascadeSummary,
 } from "@/lib/epic-tree-cascade";
-import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
+import {
+  useActiveEpicArtifactId,
+  useIsActiveEpicArtifact,
+} from "@/stores/epics/canvas/store";
+import {
+  useEpicSidebarEffectiveExpanded,
+  useEpicSidebarExpansionStore,
+} from "@/stores/epics/epic-sidebar-expansion-store";
 import {
   isOpenableEpicNodeKind,
   makeOpenableNodeRef,
@@ -35,37 +62,100 @@ interface SwitcherListProps {
   readonly onClose: () => void;
 }
 
+/** The panel scope the expansion store keys this tree by - the same one the
+ *  desktop chats panel uses, so a subtree the user opened on one surface is
+ *  open on the other for as long as the tab lives. */
+const AGENTS_PANEL_ID = "chats";
+
+interface SwitcherAgentTreeValue {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+  /** The whole flat projection, for a row's delete-cascade copy. */
+  readonly records: ReadonlyArray<EpicTreeRecord>;
+  /** Each record's projected host, the fallback for a row with no owner. */
+  readonly recordHostIdById: ReadonlyMap<string, string>;
+  readonly expandedIds: ReadonlySet<string>;
+  readonly canMutate: boolean;
+}
+
 /**
- * Agents category: GUI chats and TUI agents interleaved in one flat list
- * (decision: interleaved, flat, no gui/tui filter v1) over the shared
- * `useEpicArtifactRecords()` projection - no duplicated data path and none of
- * the desktop tree's dnd / indentation / hover machinery.
+ * List-scoped values every node in the recursion needs. A context rather than
+ * six props threaded through each level: nothing here varies per node, and the
+ * recursion is otherwise a plain `nodeId` + `depth` walk.
+ */
+const SwitcherAgentTreeContext = createContext<SwitcherAgentTreeValue | null>(
+  null,
+);
+
+function useSwitcherAgentTree(): SwitcherAgentTreeValue {
+  const value = useContext(SwitcherAgentTreeContext);
+  if (value === null) {
+    throw new Error("SwitcherAgentNode rendered outside its tree provider");
+  }
+  return value;
+}
+
+/**
+ * Agents category: GUI chats and TUI agents as the TREE they are, walked from
+ * the same projector index and through the same child-id hook the desktop
+ * sidebar walks - `rootIds` then `useFilteredPanelChildIds` per level, so a
+ * child sits under its parent and siblings order by recency WITHIN their
+ * bucket. A flat recency list put a child anywhere but next to its parent, and
+ * nesting is how this product expresses which agent spawned which.
+ *
+ * What differs from the sidebar is the row, not the walk: 44px touch rows, a
+ * real chevron button instead of a hover glyph, and none of the desktop tree's
+ * dnd, bulk selection or rename-in-place machinery.
+ *
+ * Archived agents are listed here, marked, rather than hidden: the sheet has no
+ * archive filter to reveal them again, so hiding them would make an archived
+ * agent unreachable from a phone.
  */
 export function SwitcherAgentsList(props: SwitcherListProps) {
   const { epicId, tabId, onClose } = props;
   const records = useEpicArtifactRecords();
-  const filtered = useMemo(
-    () =>
-      records.filter(
-        (record) => record.type === "chat" || record.type === "terminal-agent",
-      ),
-    [records],
-  );
-  const agents = useOrderedSwitcherRecords(filtered);
+  const tree = useEpicTreeIndex();
   const canMutate = isEditableRole(useEpicPermissionRole());
-  // Sorted for a stable query key: the list itself re-sorts by recency on every
-  // turn, and an order-sensitive key would refetch each time without the set
-  // having changed.
-  const indicatorChatIds = useMemo(
-    () => filtered.map((record) => record.id).sort(),
-    [filtered],
+
+  // Projector order (`comparator: null`) is last-updated desc, which is the
+  // desktop panel's default sort - applied per sibling bucket by construction.
+  const rootIds = useMemo(
+    () =>
+      sidebarTreeRootIds({
+        tree,
+        treeFilter: CHATS_TREE_FILTER,
+        comparator: null,
+      }),
+    [tree],
   );
-  // The rows' status glyphs read notification state out of this context. Mobile
-  // had no provider at all, so every host/cloud-derived flag resolved against
-  // the empty default and a failed or waiting agent read as plain idle. Scoped
-  // to the EPIC SESSION host for the same reason the desktop chat tree is: these
-  // agents are this session's, `chatId` is host-minted, and the app-wide active
-  // host would answer about agents it does not own.
+  const activeArtifactId = useActiveEpicArtifactId(tabId);
+  const ancestorIds = useAncestorIds(activeArtifactId);
+  // Roots and the open tile's ancestors are expanded implicitly, so the tree
+  // opens on the levels the user is actually working in and the rest stays
+  // collapsed behind its chevron.
+  const expandedIds = useEpicSidebarEffectiveExpanded(
+    tabId,
+    AGENTS_PANEL_ID,
+    rootIds,
+    ancestorIds,
+  );
+
+  // Sorted for a stable query key: an order-sensitive key would refetch on
+  // every turn without the set having changed. Taken from the whole tree index
+  // rather than the rendered rows - a collapsed subtree's agents still own the
+  // status their ancestor has to be able to stand for.
+  const indicatorChatIds = useMemo(
+    () =>
+      Object.keys(tree.nodeById)
+        .filter((id) => CHATS_TREE_FILTER(tree.nodeById[id].type))
+        .sort(),
+    [tree],
+  );
+  // The rows' status glyphs read notification state out of this context. Scoped
+  // to the EPIC SESSION host for the same reason the desktop chat tree is:
+  // these agents are this session's, `chatId` is host-minted, and the app-wide
+  // active host would answer about agents it does not own.
   const epicSessionHostId = useEpicSessionHostId();
   const indicators = useNotificationIndicators({
     hostId: epicSessionHostId,
@@ -74,108 +164,188 @@ export function SwitcherAgentsList(props: SwitcherListProps) {
     enabled: indicatorChatIds.length > 0,
   });
 
+  const recordHostIdById = useMemo(
+    () => new Map(records.map((record) => [record.id, record.hostId])),
+    [records],
+  );
+  const value = useMemo<SwitcherAgentTreeValue>(
+    () => ({
+      epicId,
+      tabId,
+      onClose,
+      records,
+      recordHostIdById,
+      expandedIds,
+      canMutate,
+    }),
+    [epicId, tabId, onClose, records, recordHostIdById, expandedIds, canMutate],
+  );
+
   return (
     <NotificationIndicatorsProvider indicators={indicators}>
-      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain p-1 pb-safe-bottom">
-        {/* Editor-gated: a viewer's create is server-rejected, so an ungated row
-            would only lead to a dead end. Inside the scroll region and above the
-            items, so it is the first thing in the list either way. */}
-        {canMutate ? (
-          <SwitcherNewChatRow epicId={epicId} tabId={tabId} onClose={onClose} />
-        ) : null}
-        {agents.length === 0 ? (
-          <SwitcherListEmpty message="No agents yet." />
-        ) : (
-          agents.map((record) => (
-            <SwitcherAgentRow
-              key={record.id}
-              record={record}
-              records={records}
-              epicId={epicId}
-              tabId={tabId}
-              onClose={onClose}
-            />
-          ))
-        )}
-      </div>
+      <ChatRowMenuFactsProvider epicId={epicId}>
+        <SwitcherAgentTreeContext.Provider value={value}>
+          <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain p-1 pb-safe-bottom">
+            {/* Editor-gated: a viewer's create is server-rejected, so an
+                ungated row would only lead to a dead end. Inside the scroll
+                region and above the items, so it is the first thing in the list
+                either way. */}
+            {canMutate ? (
+              <SwitcherNewChatRow
+                epicId={epicId}
+                tabId={tabId}
+                onClose={onClose}
+              />
+            ) : null}
+            {rootIds.length === 0 ? (
+              <SwitcherListEmpty message="No agents yet." />
+            ) : (
+              rootIds.map((nodeId) => (
+                <SwitcherAgentNode key={nodeId} nodeId={nodeId} depth={0} />
+              ))
+            )}
+          </div>
+        </SwitcherAgentTreeContext.Provider>
+      </ChatRowMenuFactsProvider>
     </NotificationIndicatorsProvider>
   );
 }
 
-function SwitcherAgentRow(props: {
-  readonly record: EpicTreeRecord;
-  readonly records: ReadonlyArray<EpicTreeRecord>;
-  readonly epicId: string;
-  readonly tabId: string;
-  readonly onClose: () => void;
+/** One node and, while expanded, its children - the whole recursion. */
+function SwitcherAgentNode(props: {
+  readonly nodeId: string;
+  readonly depth: number;
 }) {
-  const { record, records, epicId, tabId, onClose } = props;
+  const { nodeId, depth } = props;
+  const { tabId, expandedIds } = useSwitcherAgentTree();
+  const node = useEpicTreeNode(nodeId);
+  const childIds = useFilteredPanelChildIds(nodeId, CHATS_TREE_FILTER);
+  const expand = useEpicSidebarExpansionStore((s) => s.expand);
+  const collapse = useEpicSidebarExpansionStore((s) => s.collapse);
+  const expanded = expandedIds.has(nodeId);
+  const onToggle = useCallback(() => {
+    if (expanded) collapse(tabId, AGENTS_PANEL_ID, nodeId);
+    else expand(tabId, AGENTS_PANEL_ID, nodeId);
+  }, [collapse, expand, expanded, nodeId, tabId]);
+
+  // A node the projection dropped between the parent's child list and this
+  // render has nothing to draw and no children left to reach.
+  if (node === null) return null;
+
+  return (
+    <>
+      <SwitcherAgentRow
+        nodeId={nodeId}
+        name={node.title}
+        type={node.type === "terminal-agent" ? "terminal-agent" : "chat"}
+        depth={depth}
+        hasChildren={childIds.length > 0}
+        expanded={expanded}
+        onToggle={onToggle}
+      />
+      {expanded
+        ? childIds.map((childId) => (
+            <SwitcherAgentNode
+              key={childId}
+              nodeId={childId}
+              depth={depth + 1}
+            />
+          ))
+        : null}
+    </>
+  );
+}
+
+function SwitcherAgentRow(props: {
+  readonly nodeId: string;
+  readonly name: string;
+  readonly type: SwitcherAgentKind;
+  readonly depth: number;
+  readonly hasChildren: boolean;
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+}) {
+  const { nodeId, name, type, depth, hasChildren, expanded, onToggle } = props;
+  const { epicId, tabId, onClose, records, recordHostIdById, canMutate } =
+    useSwitcherAgentTree();
   const activate = useSwitcherActivate(epicId, tabId, onClose);
-  const isActive = useIsActiveEpicArtifact(tabId, record.id);
-  const agentType: "chat" | "terminal-agent" =
-    record.type === "terminal-agent" ? "terminal-agent" : "chat";
+  const isActive = useIsActiveEpicArtifact(tabId, nodeId);
+  const isArchived = useEpicNodeArchived(nodeId);
+  // Read from the PROJECTION, not the tree node - the tree node's `updatedAt`
+  // is a lagging copy, and using it made the desktop row disagree with its own
+  // hover card.
+  const updatedAt = useEpicNodeUpdatedAt(nodeId);
+  const sharing = useChatRowSharing(epicId, nodeId, type, canMutate);
 
   // The host the opened tile BINDS TO, and a tab's host binding is for life -
-  // so this has to be the row's owner, exactly as the desktop row resolves it
-  // (`openHostId = useEpicNodeHostId(nodeId) ?? activeHostId`). `record.hostId`
-  // alone is not that host: `recordForChat` stamps chat rows with the app-wide
-  // ACTIVE host, so a retained epic tab bound to host A would permanently open
-  // an A-owned chat against host B once the user switched hosts, and ask the
-  // wrong machine for the transcript forever after.
+  // so this has to be the row's owner, exactly as the desktop row resolves it.
+  // The records' `hostId` is not that host: `recordForChat` stamps chat rows
+  // with the app-wide ACTIVE host, so a retained epic tab bound to host A would
+  // permanently open an A-owned chat against host B once the user switched
+  // hosts, and ask the wrong machine for the transcript forever after.
   //
-  // The fallback covers a legacy chat carrying no projected host, and is the
-  // active host by construction - that is precisely what `recordForChat`
-  // stamped - reusing the value already in hand rather than re-subscribing the
-  // row to `useAddressableHostId()`. It differs from the desktop row only
-  // in the no-active-host degenerate case, where this yields the records'
-  // `UNKNOWN_HOST_PLACEHOLDER` and the sidebar its own "unknown-host" literal;
-  // neither is dialable. TUI rows are unaffected either way - both sides of
-  // the `??` read the same projection field for them.
-  const ownerHostId = useEpicNodeHostId(record.id);
-  const openHostId = ownerHostId ?? record.hostId;
+  // The record fallback covers a legacy chat carrying no projected host, and is
+  // the active host by construction - precisely what `recordForChat` stamped -
+  // so a tap always opens something. TUI rows are unaffected either way: both
+  // sides read the same projection field for them. The placeholder is the last
+  // resort for a node the flat projection has already dropped; it is not
+  // dialable, and neither is anything else that could stand in for it.
+  const ownerHostId = useEpicNodeHostId(nodeId);
+  const openHostId =
+    ownerHostId ?? recordHostIdById.get(nodeId) ?? UNKNOWN_HOST_PLACEHOLDER;
 
   const onSelect = useCallback(() => {
-    const type = record.type;
     if (!isOpenableEpicNodeKind(type)) return;
-    activate(record.id, () =>
+    activate(nodeId, () =>
       makeOpenableNodeRef({
-        id: record.id,
+        id: nodeId,
         instanceId: uuidv4(),
         type,
-        name: record.name,
+        name,
         hostId: openHostId,
       }),
     );
-  }, [activate, record, openHostId]);
-
-  const cascadeSummary = formatCascadeSummary(
-    computeDescendantCounts(records, record.id),
-  );
+  }, [activate, name, nodeId, openHostId, type]);
 
   return (
     <SwitcherListRow
       icon={
         // No host prop: the icon resolves the row's owner host itself, from the
-        // same selector `openHostId` above uses. `record.hostId` is the ACTIVE
-        // host for chat rows and is never the right answer for either.
-        <SwitcherAgentIcon
-          epicId={epicId}
-          nodeId={record.id}
-          type={agentType}
-        />
+        // same selector `ownerHostId` above uses.
+        <SwitcherAgentIcon epicId={epicId} nodeId={nodeId} type={type} />
       }
-      label={record.name}
+      label={name}
+      labelPrefix={isArchived ? <ArchivedTitlePrefix /> : null}
+      trailing={
+        <span className="flex flex-none items-center gap-1.5">
+          {sharing.showIndicator ? (
+            // The desktop glyph carries a hover tooltip; a phone row has no
+            // hover, so the meaning rides its accessible name instead.
+            <Users
+              className="size-3 shrink-0 text-muted-foreground"
+              data-testid={`switcher-shared-${nodeId}`}
+              aria-label="Shared with task"
+            />
+          ) : null}
+          <ChatRowIdleTime updatedAt={updatedAt} />
+        </span>
+      }
+      nesting={{ depth, hasChildren, expanded, onToggle }}
       active={isActive}
       onSelect={onSelect}
-      selectTestId={`switcher-agent-row-${record.id}`}
+      selectTestId={`switcher-agent-row-${nodeId}`}
       actions={
-        <SwitcherRowActions
+        <SwitcherAgentRowActions
           epicId={epicId}
           tabId={tabId}
-          kind={agentType}
-          nodeId={record.id}
-          name={record.name}
-          cascadeSummary={cascadeSummary}
+          nodeId={nodeId}
+          name={name}
+          artifactType={type}
+          ownerHostId={ownerHostId}
+          cascadeSummary={formatCascadeSummary(
+            computeDescendantCounts(records, nodeId),
+          )}
+          onClose={onClose}
         />
       }
     />

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -5,6 +5,7 @@ import {
   SwitcherListHeader,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SWITCHER_ROW_FLAT } from "@/components/epic-canvas/mobile/switcher-row-nesting";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { SwitcherNewArtifactMenu } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
@@ -121,6 +122,9 @@ function SwitcherArtifactRow(props: {
     <SwitcherListRow
       icon={<SwitcherArtifactIcon type={record.type} status={record.status} />}
       label={record.name}
+      labelPrefix={null}
+      trailing={null}
+      nesting={SWITCHER_ROW_FLAT}
       active={isActive}
       onSelect={onSelect}
       selectTestId={`switcher-artifact-row-${record.id}`}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
@@ -74,22 +74,6 @@ export function visibleSwitcherCategoryDefs(
 }
 
 /**
- * Mobile-only display-label overrides for the category tabs. The desktop
- * `LEFT_PANEL_DEFINITIONS` title stays "Agents" (id `chats`); on mobile the user
- * wants the tab labelled "Chats" to correlate directly with what it lists. The
- * id (persisted selection, store key) is untouched - only the label changes.
- */
-const MOBILE_SWITCHER_TITLE_OVERRIDES: Partial<Record<LeftPanelId, string>> = {
-  chats: "Chats",
-};
-
-export function switcherCategoryTitle(
-  definition: LeftPanelMetadataDefinition,
-): string {
-  return MOBILE_SWITCHER_TITLE_OVERRIDES[definition.id] ?? definition.title;
-}
-
-/**
  * Clamp a persisted active left-panel id to the categories currently on the
  * bar, so a selection with no tab behind it falls back to Agents rather than
  * leaving the sheet with no matching tab. Two ways that happens: a category

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  switcherCategoryTitle,
-  visibleSwitcherCategoryDefs,
-} from "@/components/epic-canvas/mobile/switcher-categories";
+import { visibleSwitcherCategoryDefs } from "@/components/epic-canvas/mobile/switcher-categories";
 import { cn } from "@/lib/utils";
 
 interface ScrollEdges {
@@ -120,7 +117,7 @@ export function SwitcherCategoryTabs(props: SwitcherCategoryTabsProps) {
             data-testid={`mobile-switcher-tab-${definition.id}`}
           >
             <Icon className="size-4" />
-            {switcherCategoryTitle(definition)}
+            {definition.title}
           </TabsTrigger>
         );
       })}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -1,29 +1,82 @@
 import type { ReactNode } from "react";
 import { Check, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { TreeChevron, TreeChevronSpacer } from "@/components/ui/tree-chevron";
+import {
+  SWITCHER_ROW_BASE_PAD_LEFT,
+  SWITCHER_ROW_INDENT_PX,
+  type SwitcherRowNesting,
+} from "@/components/epic-canvas/mobile/switcher-row-nesting";
 
 /**
- * One flat row in a switcher category list: leading icon, truncating label, a
- * check on the active tile, and an optional trailing "…" actions slot. Tapping
- * the row body activates the tile; the actions slot (null for viewers) is a
- * sibling button so its taps never trigger a row open. The 44px min height plus
- * the sheet's coarse-pointer touch scope satisfy the touch-target guideline.
+ * One row in a switcher category list: an indent-and-chevron nesting cluster,
+ * leading icon, truncating label, a trailing metadata slot, a check on the
+ * active tile, and an optional "…" actions slot. Tapping the row body activates
+ * the tile; the chevron and the actions slot are SIBLING buttons, so neither
+ * their taps nor their touch targets ever trigger a row open.
+ *
+ * The 44px min height plus the sheet's coarse-pointer touch scope satisfy the
+ * touch-target guideline, and they are why the chevron is a real 44px control
+ * rather than the desktop tree's 14px hover glyph: expand/collapse is the only
+ * way to reach a deep child on a phone, so it cannot be the hardest thing on
+ * the row to hit.
  */
 export function SwitcherListRow(props: {
   readonly icon: ReactNode;
   readonly label: string;
+  /** Rendered immediately before the label, inside the truncating cluster. */
+  readonly labelPrefix: ReactNode;
+  /** Right-aligned metadata (relative time, shared glyph); null for none. */
+  readonly trailing: ReactNode;
+  readonly nesting: SwitcherRowNesting;
   readonly active: boolean;
   readonly onSelect: () => void;
   readonly actions: ReactNode;
   readonly selectTestId: string;
 }) {
-  const { icon, label, active, onSelect, actions, selectTestId } = props;
+  const {
+    icon,
+    label,
+    labelPrefix,
+    trailing,
+    nesting,
+    active,
+    onSelect,
+    actions,
+    selectTestId,
+  } = props;
   return (
     // `min-w-0` at both this wrapper and the button: the label's truncate
     // only engages while every flex level above it may shrink below its
     // content. One level with an auto min-width re-inflates the row to the
     // full label width, and the list scrolls sideways instead of ellipsizing.
-    <div className="flex min-w-0 items-center gap-1">
+    <div
+      className="flex min-w-0 items-center gap-1"
+      style={{
+        paddingLeft: `${nesting.depth * SWITCHER_ROW_INDENT_PX + SWITCHER_ROW_BASE_PAD_LEFT}px`,
+      }}
+    >
+      {nesting.hasChildren ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={nesting.onToggle}
+          aria-label={`${nesting.expanded ? "Collapse" : "Expand"} ${label}`}
+          aria-expanded={nesting.expanded}
+          data-testid={`${selectTestId}-toggle`}
+          className="size-11 shrink-0 text-muted-foreground"
+        >
+          <TreeChevron expanded={nesting.expanded} onToggle={undefined} />
+        </Button>
+      ) : (
+        // Keeps every leaf's icon on its siblings' column. Sized to the chevron
+        // BUTTON, not the glyph, or a leaf would sit 30px left of a parent at
+        // the same depth and the indent would stop reading as depth at all.
+        <span className="flex size-11 shrink-0 items-center justify-center">
+          <TreeChevronSpacer />
+        </span>
+      )}
       <Button
         type="button"
         variant="ghost"
@@ -35,9 +88,13 @@ export function SwitcherListRow(props: {
         <span className="flex size-4 shrink-0 items-center justify-center">
           {icon}
         </span>
-        <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
-          {label}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5">
+          {labelPrefix}
+          <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
+            {label}
+          </span>
         </span>
+        {trailing}
         {active ? (
           <Check
             className="size-4 shrink-0 text-primary"

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -5,6 +5,7 @@ import { TreeChevron, TreeChevronSpacer } from "@/components/ui/tree-chevron";
 import {
   SWITCHER_ROW_BASE_PAD_LEFT,
   SWITCHER_ROW_INDENT_PX,
+  SWITCHER_ROW_MAX_INDENT_DEPTH,
   type SwitcherRowNesting,
 } from "@/components/epic-canvas/mobile/switcher-row-nesting";
 
@@ -53,7 +54,7 @@ export function SwitcherListRow(props: {
     <div
       className="flex min-w-0 items-center gap-1"
       style={{
-        paddingLeft: `${nesting.depth * SWITCHER_ROW_INDENT_PX + SWITCHER_ROW_BASE_PAD_LEFT}px`,
+        paddingLeft: `${Math.min(nesting.depth, SWITCHER_ROW_MAX_INDENT_DEPTH) * SWITCHER_ROW_INDENT_PX + SWITCHER_ROW_BASE_PAD_LEFT}px`,
       }}
     >
       {nesting.hasChildren ? (

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
@@ -1,144 +1,49 @@
-import { useCallback, useState } from "react";
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  SidebarDropdownMenuItems,
-  type SidebarRowMenuEntry,
-} from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
-import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
-import { SwitcherRenameDialog } from "@/components/epic-canvas/mobile/switcher-rename-dialog";
-import {
-  useSwitcherRename,
-  type SwitcherRowKind,
-} from "@/components/epic-canvas/mobile/use-switcher-rename";
+import { Pencil, Trash2 } from "lucide-react";
+import type { SidebarRowMenuEntry } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+import { SwitcherRowMenu } from "@/components/epic-canvas/mobile/switcher-row-menu";
+import { useSwitcherRowActions } from "@/components/epic-canvas/mobile/use-switcher-row-actions";
+import type { SwitcherRowKind } from "@/components/epic-canvas/mobile/use-switcher-rename";
 import { useEpicPermissionRole } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
-import { useEpicDeleteChat } from "@/hooks/epic/use-epic-chat-mutations";
-import { useEpicDeleteTuiAgent } from "@/hooks/epic/use-epic-tui-agent-mutations";
-import { useEpicDeleteArtifact } from "@/hooks/epic/use-epic-node-mutations";
-import { useTerminalKillFor } from "@/hooks/terminal/use-terminal-kill-for-mutation";
-import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
-import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
-import { findOpenArtifactInTab } from "@/stores/epics/canvas/canvas-selectors";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 
 interface SwitcherRowActionsProps {
   readonly epicId: string;
   readonly tabId: string;
-  readonly kind: SwitcherRowKind;
-  /** Content id: the node id for agents/artifacts, the session id for a PTY. */
+  readonly kind: Extract<SwitcherRowKind, "artifact" | "terminal">;
+  /** Content id: the node id for an artifact, the session id for a PTY. */
   readonly nodeId: string;
   readonly name: string;
   /** "… and N nested" summary for a cascading delete; null when none / N/A. */
   readonly cascadeSummary: string | null;
 }
 
-const RENAME_TITLE: Record<SwitcherRowKind, string> = {
-  chat: "Rename agent",
-  "terminal-agent": "Rename agent",
+const RENAME_TITLE: Record<
+  Extract<SwitcherRowKind, "artifact" | "terminal">,
+  string
+> = {
   artifact: "Rename artifact",
   terminal: "Rename terminal",
 };
 
 /**
- * The per-row "…" actions for the switcher's flat lists: Rename + Delete for
- * agents/artifacts (delete confirmed), Rename + Close for PTY terminals (Close
- * is immediate, matching desktop parity). Reuses the exact desktop mutation
- * hooks and the shared row-menu item renderer; the whole affordance is
- * editor-gated (a viewer gets no menu at all, so no dead-end mutations). Delete
- * also closes the item's open canvas tile so the mobile view never lands on a
- * dead tile.
+ * The per-row "…" actions for the switcher's artifact and terminal lists:
+ * Rename + Delete for artifacts (delete confirmed), Rename + Close for PTY
+ * terminals (Close is immediate, matching desktop parity). Agent rows carry the
+ * full chat-row menu instead - see `SwitcherAgentRowActions`.
+ *
+ * Reuses the exact desktop mutation hooks and the shared row-menu item
+ * renderer; the whole affordance is editor-gated (a viewer gets no menu at all,
+ * so no dead-end mutations). Delete also closes the item's open canvas tile so
+ * the mobile view never lands on a dead tile.
  */
 export function SwitcherRowActions(props: SwitcherRowActionsProps) {
   const { epicId, tabId, kind, nodeId, name, cascadeSummary } = props;
   const canMutate = isEditableRole(useEpicPermissionRole());
-  const [renameOpen, setRenameOpen] = useState(false);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-
-  const rename = useSwitcherRename(epicId);
-  const deleteChat = useEpicDeleteChat();
-  const deleteTuiAgent = useEpicDeleteTuiAgent();
-  const deleteArtifact = useEpicDeleteArtifact();
-  // The row's terminal lives on the host the switcher LISTS (the Epic
-  // session's), so kill goes to that same client - never the ambient one.
-  const killTerminal = useTerminalKillFor(
-    useEpicSessionHostClient(),
-    "Couldn't close the terminal.",
-    true,
-  );
-
-  const navigateNested = useEpicNestedFocusNavigation();
-  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareCloseCanvasTabFocusTarget,
-  );
-
-  // Deleting/closing an item that is open must also close its canvas tile, or
-  // the single mobile tile view would keep rendering a now-dead tile.
-  const closeOpenTile = useCallback(() => {
-    const found = findOpenArtifactInTab(tabId, nodeId);
-    if (found === null) return;
-    navigateNested(epicId, tabId, () =>
-      prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
-    );
-  }, [epicId, nodeId, navigateNested, prepareCloseCanvasTabFocusTarget, tabId]);
-
-  const submitRename = useCallback(
-    (title: string) => {
-      rename(kind, nodeId, title);
-      setRenameOpen(false);
-    },
-    [kind, nodeId, rename],
-  );
-
-  const confirmDelete = useCallback(() => {
-    if (kind === "chat")
-      deleteChat.mutate(
-        { epicId, chatId: nodeId },
-        { onSuccess: closeOpenTile },
-      );
-    else if (kind === "terminal-agent")
-      deleteTuiAgent.mutate(
-        { epicId, tuiAgentId: nodeId },
-        { onSuccess: closeOpenTile },
-      );
-    else if (kind === "artifact")
-      deleteArtifact.mutate(
-        { epicId, artifactId: nodeId },
-        { onSuccess: closeOpenTile },
-      );
-    setConfirmOpen(false);
-  }, [
-    closeOpenTile,
-    deleteArtifact,
-    deleteChat,
-    deleteTuiAgent,
-    epicId,
-    kind,
-    nodeId,
-  ]);
-
-  // Terminal "Close" terminates the PTY immediately (no confirm - desktop
-  // parity), closing the open tile first so the action is mount-independent.
-  const closeTerminal = useCallback(() => {
-    if (killTerminal.isPending) return;
-    closeOpenTile();
-    killTerminal.mutate({ sessionId: nodeId });
-  }, [closeOpenTile, killTerminal, nodeId]);
+  const state = useSwitcherRowActions({ epicId, tabId, kind, nodeId });
 
   if (!canMutate) return null;
 
   const isTerminal = kind === "terminal";
-  const deleteLabel = isTerminal ? "Close" : "Delete";
-  const deletePending =
-    deleteChat.isPending ||
-    deleteTuiAgent.isPending ||
-    deleteArtifact.isPending;
-
   const entries: ReadonlyArray<SidebarRowMenuEntry> = [
     {
       kind: "item",
@@ -152,68 +57,36 @@ export function SwitcherRowActions(props: SwitcherRowActionsProps) {
         dropdown: `switcher-rename-${nodeId}`,
         context: `switcher-rename-ctx-${nodeId}`,
       },
-      onSelect: () => setRenameOpen(true),
+      onSelect: state.openRename,
     },
     { kind: "separator", id: "before-delete" },
     {
       kind: "item",
       id: "delete",
-      label: deleteLabel,
+      label: isTerminal ? "Close" : "Delete",
       icon: <Trash2 className="size-3.5" />,
-      disabled: isTerminal ? killTerminal.isPending : false,
+      disabled: isTerminal ? state.terminalClosePending : false,
       disabledTooltip: null,
       variant: "destructive",
       testIds: {
         dropdown: `switcher-delete-${nodeId}`,
         context: `switcher-delete-ctx-${nodeId}`,
       },
-      onSelect: isTerminal ? closeTerminal : () => setConfirmOpen(true),
+      onSelect: isTerminal ? state.closeTerminal : state.requestDelete,
     },
   ];
 
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={`Actions for ${name}`}
-            data-testid={`switcher-more-${nodeId}`}
-            className="shrink-0 text-muted-foreground hover:text-foreground"
-          >
-            <MoreHorizontal className="size-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <SidebarDropdownMenuItems entries={entries} />
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <SwitcherRenameDialog
-        open={renameOpen}
-        onOpenChange={setRenameOpen}
-        title={RENAME_TITLE[kind]}
-        initialValue={name}
-        nodeId={nodeId}
-        onSubmit={submitRename}
-      />
-      {isTerminal ? null : (
-        <ConfirmDestructiveDialog
-          open={confirmOpen}
-          onOpenChange={setConfirmOpen}
-          title={`Delete "${name}"?`}
-          description={
-            kind === "artifact"
-              ? "This permanently deletes the artifact."
-              : "This permanently deletes the agent and its history."
-          }
-          cascadeSummary={cascadeSummary}
-          actionLabel="Delete"
-          isPending={deletePending}
-          onConfirm={confirmDelete}
-        />
-      )}
-    </>
+    <SwitcherRowMenu
+      nodeId={nodeId}
+      name={name}
+      renameTitle={RENAME_TITLE[kind]}
+      entries={entries}
+      state={state}
+      confirmDescription={
+        isTerminal ? null : "This permanently deletes the artifact."
+      }
+      cascadeSummary={cascadeSummary}
+    />
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-menu.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-menu.tsx
@@ -1,0 +1,90 @@
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  SidebarDropdownMenuItems,
+  type SidebarRowMenuEntry,
+} from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
+import { SwitcherRenameDialog } from "@/components/epic-canvas/mobile/switcher-rename-dialog";
+import type { SwitcherRowActionState } from "@/components/epic-canvas/mobile/use-switcher-row-actions";
+
+/**
+ * The "…" trigger and the two dialogs behind it, shared by every switcher row
+ * whatever entries its menu carries. The entries themselves are the caller's:
+ * an agent row builds them from the desktop tree's own
+ * `chatRowMenuEntries`, an artifact or terminal row from its shorter pair.
+ *
+ * Rename opens as a dialog rather than the desktop's inline edit - a 44px row
+ * inside a bottom sheet is no place to grow a text field - and it drives the
+ * same rename mutation.
+ */
+export function SwitcherRowMenu(props: {
+  readonly nodeId: string;
+  readonly name: string;
+  readonly renameTitle: string;
+  readonly entries: ReadonlyArray<SidebarRowMenuEntry>;
+  readonly state: SwitcherRowActionState;
+  /**
+   * What a delete permanently removes, or `null` for a row whose destructive
+   * action needs no confirm (a PTY close, which is immediate on desktop too).
+   */
+  readonly confirmDescription: string | null;
+  /** "… and N nested" summary for a cascading delete; null when none / N/A. */
+  readonly cascadeSummary: string | null;
+}) {
+  const {
+    nodeId,
+    name,
+    renameTitle,
+    entries,
+    state,
+    confirmDescription,
+    cascadeSummary,
+  } = props;
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${name}`}
+            data-testid={`switcher-more-${nodeId}`}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <SidebarDropdownMenuItems entries={entries} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SwitcherRenameDialog
+        open={state.renameOpen}
+        onOpenChange={state.setRenameOpen}
+        title={renameTitle}
+        initialValue={name}
+        nodeId={nodeId}
+        onSubmit={state.submitRename}
+      />
+      {confirmDescription === null ? null : (
+        <ConfirmDestructiveDialog
+          open={state.confirmOpen}
+          onOpenChange={state.setConfirmOpen}
+          title={`Delete "${name}"?`}
+          description={confirmDescription}
+          cascadeSummary={cascadeSummary}
+          actionLabel="Delete"
+          isPending={state.deletePending}
+          onConfirm={state.confirmDelete}
+        />
+      )}
+    </>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-nesting.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-nesting.ts
@@ -3,6 +3,15 @@
  *  the step itself has to carry the level, and it is read at arm's length. */
 export const SWITCHER_ROW_INDENT_PX = 20;
 export const SWITCHER_ROW_BASE_PAD_LEFT = 8;
+/**
+ * Where the indent stops growing. Depth is USER-controlled - every agent row
+ * offers "New child agent" - and the row already spends its width on a 44px
+ * chevron, the status icon, the trailing time and the actions button. Past this
+ * level a narrow phone would have nothing left for the label, so the row would
+ * stop identifying its agent; the chevron state and the parent order still
+ * carry the nesting from there.
+ */
+export const SWITCHER_ROW_MAX_INDENT_DEPTH = 6;
 
 /** The nesting controls of a row that has children, or the spacer that keeps a
  *  leaf's icon on the same optical column as its siblings'. */

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-nesting.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-nesting.ts
@@ -1,0 +1,22 @@
+/** Indent per tree level, and the pad the shallowest row still gets. Wider than
+ *  the desktop sidebar's 16px: a phone row carries no vertical guide rail, so
+ *  the step itself has to carry the level, and it is read at arm's length. */
+export const SWITCHER_ROW_INDENT_PX = 20;
+export const SWITCHER_ROW_BASE_PAD_LEFT = 8;
+
+/** The nesting controls of a row that has children, or the spacer that keeps a
+ *  leaf's icon on the same optical column as its siblings'. */
+export interface SwitcherRowNesting {
+  readonly depth: number;
+  readonly hasChildren: boolean;
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+}
+
+/** A leaf at the top level: the shape a category that has no tree passes. */
+export const SWITCHER_ROW_FLAT: SwitcherRowNesting = {
+  depth: 0,
+  hasChildren: false,
+  expanded: false,
+  onToggle: () => undefined,
+};

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -6,6 +6,7 @@ import {
   SwitcherListEmpty,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SWITCHER_ROW_FLAT } from "@/components/epic-canvas/mobile/switcher-row-nesting";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { SwitcherNewTerminalRow } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
@@ -113,6 +114,9 @@ function SwitcherTerminalRow(props: {
     <SwitcherListRow
       icon={<Terminal className="size-4 shrink-0 text-muted-foreground" />}
       label={label}
+      labelPrefix={null}
+      trailing={null}
+      nesting={SWITCHER_ROW_FLAT}
       active={isActive}
       onSelect={onSelect}
       selectTestId={`switcher-terminal-row-${session.sessionId}`}

--- a/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-row-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-row-actions.ts
@@ -1,0 +1,137 @@
+import { useCallback, useState } from "react";
+import { useSwitcherRename } from "@/components/epic-canvas/mobile/use-switcher-rename";
+import type { SwitcherRowKind } from "@/components/epic-canvas/mobile/use-switcher-rename";
+import { useEpicDeleteChat } from "@/hooks/epic/use-epic-chat-mutations";
+import { useEpicDeleteTuiAgent } from "@/hooks/epic/use-epic-tui-agent-mutations";
+import { useEpicDeleteArtifact } from "@/hooks/epic/use-epic-node-mutations";
+import { useTerminalKillFor } from "@/hooks/terminal/use-terminal-kill-for-mutation";
+import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { findOpenArtifactInTab } from "@/stores/epics/canvas/canvas-selectors";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+
+export interface SwitcherRowActionState {
+  readonly renameOpen: boolean;
+  readonly openRename: () => void;
+  readonly setRenameOpen: (open: boolean) => void;
+  readonly submitRename: (title: string) => void;
+  readonly confirmOpen: boolean;
+  readonly requestDelete: () => void;
+  readonly setConfirmOpen: (open: boolean) => void;
+  readonly confirmDelete: () => void;
+  readonly deletePending: boolean;
+  /** Terminates a PTY row immediately - no confirm, matching desktop. */
+  readonly closeTerminal: () => void;
+  readonly terminalClosePending: boolean;
+}
+
+/**
+ * Every mutation and dialog a switcher row's "…" menu drives, independent of
+ * WHICH entries that menu offers. The agents list and the artifact/terminal
+ * lists present different entry sets over exactly this state, so rename, delete
+ * (with its confirm) and the open-tile cleanup are defined once here rather
+ * than once per list.
+ *
+ * The mutations are the desktop ones unchanged - the phone forks the surface,
+ * never the write.
+ */
+export function useSwitcherRowActions(args: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly kind: SwitcherRowKind;
+  /** Content id: the node id for agents/artifacts, the session id for a PTY. */
+  readonly nodeId: string;
+}): SwitcherRowActionState {
+  const { epicId, tabId, kind, nodeId } = args;
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const rename = useSwitcherRename(epicId);
+  const deleteChat = useEpicDeleteChat();
+  const deleteTuiAgent = useEpicDeleteTuiAgent();
+  const deleteArtifact = useEpicDeleteArtifact();
+  // The row's terminal lives on the host the switcher LISTS (the Epic
+  // session's), so kill goes to that same client - never the ambient one.
+  const killTerminal = useTerminalKillFor(
+    useEpicSessionHostClient(),
+    "Couldn't close the terminal.",
+    true,
+  );
+
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+
+  // Deleting/closing an item that is open must also close its canvas tile, or
+  // the single mobile tile view would keep rendering a now-dead tile.
+  const closeOpenTile = useCallback(() => {
+    const found = findOpenArtifactInTab(tabId, nodeId);
+    if (found === null) return;
+    navigateNested(epicId, tabId, () =>
+      prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
+    );
+  }, [epicId, nodeId, navigateNested, prepareCloseCanvasTabFocusTarget, tabId]);
+
+  const submitRename = useCallback(
+    (title: string) => {
+      rename(kind, nodeId, title);
+      setRenameOpen(false);
+    },
+    [kind, nodeId, rename],
+  );
+
+  const confirmDelete = useCallback(() => {
+    if (kind === "chat")
+      deleteChat.mutate(
+        { epicId, chatId: nodeId },
+        { onSuccess: closeOpenTile },
+      );
+    else if (kind === "terminal-agent")
+      deleteTuiAgent.mutate(
+        { epicId, tuiAgentId: nodeId },
+        { onSuccess: closeOpenTile },
+      );
+    else if (kind === "artifact")
+      deleteArtifact.mutate(
+        { epicId, artifactId: nodeId },
+        { onSuccess: closeOpenTile },
+      );
+    setConfirmOpen(false);
+  }, [
+    closeOpenTile,
+    deleteArtifact,
+    deleteChat,
+    deleteTuiAgent,
+    epicId,
+    kind,
+    nodeId,
+  ]);
+
+  // Closes the open tile first so the action is mount-independent.
+  const closeTerminal = useCallback(() => {
+    if (killTerminal.isPending) return;
+    closeOpenTile();
+    killTerminal.mutate({ sessionId: nodeId });
+  }, [closeOpenTile, killTerminal, nodeId]);
+
+  const openRename = useCallback(() => setRenameOpen(true), []);
+  const requestDelete = useCallback(() => setConfirmOpen(true), []);
+
+  return {
+    renameOpen,
+    openRename,
+    setRenameOpen,
+    submitRename,
+    confirmOpen,
+    requestDelete,
+    setConfirmOpen,
+    confirmDelete,
+    deletePending:
+      deleteChat.isPending ||
+      deleteTuiAgent.isPending ||
+      deleteArtifact.isPending,
+    closeTerminal,
+    terminalClosePending: killTerminal.isPending,
+  };
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/chat-row-chrome.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/chat-row-chrome.tsx
@@ -1,0 +1,70 @@
+/**
+ * The presentational scraps an agent row wears on both form factors: the
+ * archived marker, the trailing relative time, and the provider that mounts the
+ * row-menu facts for a list body that has no other use for them.
+ *
+ * Split from `chat-row-menu`, which decides row BEHAVIOUR and exports no
+ * components: a module that mixes the two loses fast refresh for everything in
+ * it.
+ */
+import type { ReactNode } from "react";
+import { useCompactRelativeTime } from "@/lib/relative-time";
+import {
+  SidebarArchiveSupportedContext,
+  SidebarChatSharingContext,
+  useChatRowMenuFacts,
+} from "@/components/epic-canvas/sidebar/chat-row-menu";
+
+/**
+ * Mounts {@link useChatRowMenuFacts} onto the two contexts the rows read, for a
+ * list body that has no other use for the values. The desktop panel body reads
+ * `canArchive` for its own empty-state copy and so provides them itself.
+ */
+export function ChatRowMenuFactsProvider(props: {
+  readonly epicId: string;
+  readonly children: ReactNode;
+}) {
+  const facts = useChatRowMenuFacts(props.epicId);
+  return (
+    <SidebarArchiveSupportedContext.Provider value={facts.canArchive}>
+      <SidebarChatSharingContext.Provider value={facts.sharing}>
+        {props.children}
+      </SidebarChatSharingContext.Provider>
+    </SidebarArchiveSupportedContext.Provider>
+  );
+}
+
+/**
+ * Keeps the archival state attached to the title rather than competing with
+ * timestamps and controls in the trailing metadata cluster.
+ */
+export function ArchivedTitlePrefix(): ReactNode {
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-1 text-muted-foreground"
+      data-testid="chat-row-archived-label"
+    >
+      <span className="font-semibold">Archived</span>
+      <span aria-hidden="true">·</span>
+    </span>
+  );
+}
+
+/**
+ * The row's trailing last-activity time, on the shared compact ladder
+ * (`now` / `10m` / `4h` / `1d` / `1w` / short date). Isolated in its own leaf
+ * so the shared 60s clock tick repaints this span rather than the whole row.
+ */
+export function ChatRowIdleTime(props: {
+  readonly updatedAt: number;
+}): ReactNode {
+  const relative = useCompactRelativeTime(props.updatedAt);
+  return (
+    <span
+      className="flex-none tabular-nums text-ui-xs text-muted-foreground"
+      data-testid="chat-row-idle-time"
+    >
+      {relative}
+    </span>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/chat-row-menu.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/chat-row-menu.tsx
@@ -1,0 +1,570 @@
+/**
+ * Everything an agent row offers BESIDES its own layout: the ⋯ / right-click
+ * menu entries, the per-row facts those entries are decided from (archive
+ * support, sharing capability, the cloud fold), the archive/sharing/new-child
+ * actions themselves, and the two trailing/leading scraps of chrome that travel
+ * with them.
+ *
+ * It lives outside `epic-sidebar-chat-tree` because a chat row is rendered by
+ * two surfaces with two different LAYOUTS - the desktop sidebar's 28px
+ * hover-reveal tree row and the phone switcher's 44px touch row - and exactly
+ * one BEHAVIOUR. Everything that decides what an action does, when it is
+ * offered, and why it is refused belongs here so the two can only ever differ
+ * in presentation.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
+import {
+  Archive,
+  ArchiveRestore,
+  Lock,
+  Pencil,
+  Plus,
+  Trash2,
+  Users,
+} from "lucide-react";
+import type { CloudChatSummary } from "@traycer/protocol/host/epic/cloud-chat";
+import { useEpicArchiveChat } from "@/hooks/epic/use-epic-chat-mutations";
+import { useChatArchiveSupported } from "@/hooks/epic/use-chat-archive-support";
+import { useCloudChatVisibilitySupported } from "@/hooks/epic/use-chat-sharing-support";
+import { useEpicSetCloudChatVisibility } from "@/hooks/epic/use-epic-chat-visibility-mutations";
+import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
+import { useEpicCollaboratorsQuery } from "@/hooks/epics/use-epic-collaborators-query";
+import { useChatSharingInFlight } from "@/lib/chats/chat-sharing-inflight";
+import { useCloudChatList } from "@/hooks/chats/use-cloud-chat-queries";
+import {
+  publicationTargetMap,
+  useChatPublicationTargets,
+} from "@/hooks/chats/use-chat-publication-targets";
+import { indexOwnCloudChatsByLocalId } from "@/lib/chats/unified-chat-list";
+import {
+  decideChatSharingMenuEntry,
+  shouldShowSharedWithTaskIndicator,
+  taskHasCollaborators,
+  type ChatSharingMenuDecision,
+} from "@/lib/chats/chat-sharing-ux";
+import {
+  useEpicChatIds,
+  useEpicNodeArchived,
+  useEpicAgentActivityTiers,
+} from "@/lib/epic-selectors";
+import type { EpicNodeKind } from "@/lib/artifacts/node-display";
+import type { SidebarRowMenuEntry } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+import { useExistingChatSessionHandle } from "@/lib/registries/chat-session-registry";
+import { chatActivityIndicator } from "@/components/epic-canvas/renderers/chat-tile-session-state";
+import { type IndicatorRunningKind } from "@/components/notifications/notification-indicator-icon";
+import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
+import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
+
+/**
+ * Whether the epic's host advertises `epic.setChatArchived`. Resolved ONCE per
+ * list body and read by the rows: it is a per-host fact, identical for every
+ * row, and re-subscribing each row to the manifest registry would buy nothing.
+ * `false` is the fail-closed default - every archive affordance stays hidden
+ * until a handshake proves the method present.
+ */
+export const SidebarArchiveSupportedContext = createContext<boolean>(false);
+
+export interface SidebarChatSharingValue {
+  readonly visibilitySupported: boolean;
+  readonly ownCloudChatByLocalId: ReadonlyMap<string, CloudChatSummary>;
+  readonly hasCollaborators: boolean;
+}
+
+const EMPTY_OWN_CLOUD_CHATS: ReadonlyMap<string, CloudChatSummary> = new Map();
+
+/**
+ * Per-chat sharing facts that are identical for every row (capability, the
+ * fold of local ids onto cloud rows, whether this task has an audience).
+ * Resolved once per list body and read by the rows, matching
+ * {@link SidebarArchiveSupportedContext}.
+ */
+export const SidebarChatSharingContext = createContext<SidebarChatSharingValue>(
+  {
+    visibilitySupported: false,
+    ownCloudChatByLocalId: EMPTY_OWN_CLOUD_CHATS,
+    hasCollaborators: false,
+  },
+);
+
+/** Frozen so an absent cloud list does not re-run the fold every render. */
+const EMPTY_CLOUD_CHATS: readonly CloudChatSummary[] = [];
+
+export interface ChatRowMenuFacts {
+  readonly canArchive: boolean;
+  readonly sharing: SidebarChatSharingValue;
+}
+
+/**
+ * The two per-list facts every agent row's menu is decided against, resolved
+ * once for the whole list.
+ *
+ * Sharing fold, mutations, and cache keys all address the Epic SESSION host.
+ * The redirect map is host-LOCAL (only the epic's host knows C1→C2), so
+ * reading it from the active host would make "Make private" mutate the wrong
+ * lineage after a fork.
+ */
+export function useChatRowMenuFacts(epicId: string): ChatRowMenuFacts {
+  const canArchive = useChatArchiveSupported();
+  const canSetVisibility = useCloudChatVisibilitySupported();
+  const sessionHostClient = useEpicSessionHostClient();
+  const localChatIds = useEpicChatIds();
+  const collaboratorsQuery = useEpicCollaboratorsQuery(epicId, {
+    client: sessionHostClient,
+    poll: undefined,
+    staleTime: undefined,
+  });
+  const hasCollaborators = taskHasCollaborators(collaboratorsQuery.data);
+  const sharingCloudChats = useCloudChatList({
+    client: sessionHostClient,
+    taskId: epicId,
+    enabled: epicId.length > 0,
+  });
+  const sharingPublicationTargets = useChatPublicationTargets({
+    client: sessionHostClient,
+    epicId,
+    chatIds: localChatIds,
+    enabled: epicId.length > 0,
+  });
+  const ownCloudChatByLocalId = useMemo(
+    () =>
+      indexOwnCloudChatsByLocalId({
+        chats: sharingCloudChats.data?.chats ?? EMPTY_CLOUD_CHATS,
+        localChatIds,
+        publicationChatIdByChatId: publicationTargetMap(
+          sharingPublicationTargets.data,
+        ),
+      }),
+    [localChatIds, sharingCloudChats.data, sharingPublicationTargets.data],
+  );
+  const sharing = useMemo<SidebarChatSharingValue>(
+    () => ({
+      visibilitySupported: canSetVisibility,
+      ownCloudChatByLocalId,
+      hasCollaborators,
+    }),
+    [canSetVisibility, hasCollaborators, ownCloudChatByLocalId],
+  );
+  return { canArchive, sharing };
+}
+
+export interface ChatRowSessionActivity {
+  /** The tier the row is busy at, or `false` for idle. */
+  readonly running: IndicatorRunningKind;
+  /** Whether this row's chat is currently open as a session. */
+  readonly hasSession: boolean;
+  /** The open session's own access role, `null` while unopened or unknown. */
+  readonly sessionRole: string | null;
+}
+
+/**
+ * The row's live activity, read from its OWN chat session when one is open and
+ * backfilled by epic awareness otherwise.
+ *
+ * Authority order matters: an open chat's session tri-state wins, epic
+ * awareness covers the subscription-gap window and every unopened row. The
+ * snapshots are deliberately PRIMITIVES, so a subscriber re-renders only when
+ * the tier actually flips rather than on every queue or background-item tick.
+ *
+ * Terminal-agent rows have no chat session (their PTY runs host-side), so they
+ * resolve from awareness alone.
+ */
+export function useChatRowSessionActivity(args: {
+  readonly epicId: string;
+  readonly nodeId: string;
+  /** The row's OWN owner host - agent ids are host-minted, so a same-id agent
+   *  on another machine must not answer for this row. */
+  readonly ownerHostId: string | null;
+  readonly artifactType: EpicNodeKind;
+}): ChatRowSessionActivity {
+  const { epicId, nodeId, ownerHostId, artifactType } = args;
+  const awarenessTier = useEpicAgentActivityTiers().get(nodeId);
+  const isChat = artifactType === "chat";
+  const sessionHandle = useExistingChatSessionHandle(
+    epicId,
+    nodeId,
+    ownerHostId,
+  );
+  const subscribeSession = useMemo(
+    () => (onChange: () => void) => {
+      if (sessionHandle === null) return () => undefined;
+      return sessionHandle.store.subscribe(onChange);
+    },
+    [sessionHandle],
+  );
+  const sessionActivity = useSyncExternalStore(subscribeSession, () =>
+    sessionHandle === null
+      ? null
+      : chatActivityIndicator(sessionHandle.store.getState()),
+  );
+  const sessionRole = useSyncExternalStore(subscribeSession, () =>
+    sessionHandle === null
+      ? null
+      : (sessionHandle.store.getState().access?.role ?? null),
+  );
+  if (sessionHandle === null || !isChat) {
+    return {
+      running: awarenessTier ?? false,
+      hasSession: false,
+      sessionRole: null,
+    };
+  }
+  return {
+    running: sessionActivity ?? awarenessTier ?? false,
+    hasSession: true,
+    sessionRole,
+  };
+}
+
+/**
+ * The row's archive menu state, or `null` on a host that lacks
+ * `epic.setChatArchived` - in which case the entry is absent from both menus
+ * rather than present-but-disabled.
+ */
+export interface ChatRowArchiveEntry {
+  readonly isArchived: boolean;
+  readonly disabled: boolean;
+  /** Populated only for the busy arm; `null` whenever `disabled` is false. */
+  readonly disabledTooltip: string | null;
+}
+
+/**
+ * A row's archive INPUTS, grouped because they are one concept and always
+ * travel together: whether the host can archive at all, whether this row
+ * already is, whether a toggle is in flight, and how to toggle it.
+ */
+export interface ChatRowArchiveInputs {
+  readonly supported: boolean;
+  readonly isArchived: boolean;
+  readonly pending: boolean;
+  readonly onToggle: () => void;
+}
+
+/**
+ * Copy for a refused archive, matched to the tier so the row explains the
+ * ACTUAL reason - "working" and "has background items running" are different
+ * things to wait on, and a single generic string would misdescribe one of them.
+ *
+ * This tooltip is the ONLY message these rows get. The entry is soft-disabled,
+ * which prevents `onSelect`, so the host's own refusal - and the toast that
+ * rewrites it into user-facing copy - never fire from here. Advice that is
+ * wrong in this string is wrong with nothing behind it to correct it.
+ *
+ * So the background arm must not say "stop it". Every stop affordance routes
+ * into `ChatSession.stopActiveTurn()`, which early-returns when no turn is
+ * running, so an agent held only by a detached subagent, a workflow or a
+ * scheduled wake cannot be stopped into an archivable state - the user would
+ * press Stop, see nothing change, and be told the same thing again. It names
+ * the per-item controls in the chat instead, which is the affordance that
+ * actually clears them.
+ */
+function archiveBlockedReason(
+  // Excludes the idle tier rather than trusting the caller's `running !== false`
+  // guard. Without it a future caller could pass an idle row and silently get
+  // the background-items copy, which describes a state that is not blocked at
+  // all - a wrong explanation, not a missing one.
+  running: Exclude<IndicatorRunningKind, false>,
+): string {
+  if (running === "turn") {
+    // Hedged, because this tier is NOT "a turn is running". `chatActivityIndicator`
+    // deliberately maps a detached subagent or workflow fleet outliving its turn
+    // into `"turn"` - it is the agent working, so it earns the busy spinner
+    // rather than the muted background glyph - while `resolvedTurnStatus`
+    // reports no active turn for that same state, precisely so a Stop-turn
+    // affordance does not surface. Promising a stop here would contradict that
+    // and send the user after an action the host early-returns from.
+    return "Can't archive while this agent is working. Stopping it ends a turn, but not a detached subagent or workflow. Wait for it to go idle, or stop it, then archive.";
+  }
+  return "Can't archive while this agent has background items running. Stopping the agent won't clear them — wait for them to finish, or stop them from its chat.";
+}
+
+/**
+ * The archive MENU entry for a row whose host supports the method: present on
+ * every such row, and merely SOFT-disabled while the row is busy (`aria-disabled`,
+ * not Radix's `disabled`) so it stays in the arrow-key order and can still
+ * announce its reason - see `softDisabledProps` in `sidebar-row-menu-items`.
+ * The entry, not any hover shortcut, is what carries the explanation.
+ *
+ * Busy is read off the raw running tier, NOT off a folded status kind. Folding
+ * loses exactly the case this gate exists for: gating on
+ * `kind === "working" | "background"` left Archive ENABLED on any running chat
+ * that also had a pending approval or interview, which is most of them at the
+ * moment a human is looking. The host refuses such an archive anyway; matching
+ * it here is what keeps the affordance honest instead of offering an action
+ * that will only come back as a toast.
+ *
+ * "Busy" means everything the host counts, which includes a chat owning a
+ * running shell - not just an in-flight turn - so it must stay whatever
+ * `chatActivityIndicator` reports.
+ *
+ * UNARCHIVING is never gated on busy - the host allows it, and an archived row
+ * can be working (an inbound message auto-unarchives and wakes it, so the flag
+ * and the run legitimately overlap). Only `archivePending` disables that
+ * direction, to stop a double-submit.
+ */
+export function chatRowArchiveEntry(args: {
+  readonly isArchived: boolean;
+  readonly archivePending: boolean;
+  readonly running: IndicatorRunningKind;
+}): ChatRowArchiveEntry {
+  // The tier that BLOCKS, or `false` for none. Carrying the narrowed value
+  // rather than a separate boolean is what lets `archiveBlockedReason` refuse
+  // the idle tier by type: a bare `blocksArchive` flag proves nothing to the
+  // compiler about the tier at the call below.
+  const blockingRun: IndicatorRunningKind = args.isArchived
+    ? false
+    : args.running;
+  return {
+    isArchived: args.isArchived,
+    disabled: blockingRun !== false || args.archivePending,
+    disabledTooltip:
+      blockingRun === false ? null : archiveBlockedReason(blockingRun),
+  };
+}
+
+/**
+ * A row's archive inputs, bound to the shared mutation and the per-list
+ * capability context. The toggle is inert without edit rights or host support,
+ * so a caller cannot route around the gate by rendering the entry itself.
+ */
+export function useChatRowArchiveInputs(args: {
+  readonly epicId: string;
+  readonly nodeId: string;
+  readonly canMutate: boolean;
+}): ChatRowArchiveInputs {
+  const { epicId, nodeId, canMutate } = args;
+  const archiveSupported = useContext(SidebarArchiveSupportedContext);
+  const isArchived = useEpicNodeArchived(nodeId);
+  const archiveChat = useEpicArchiveChat();
+  const onToggle = useCallback(() => {
+    if (!canMutate || !archiveSupported) return;
+    archiveChat.mutate({ epicId, chatId: nodeId, archived: !isArchived });
+  }, [archiveChat, archiveSupported, canMutate, epicId, isArchived, nodeId]);
+  return useMemo(
+    () => ({
+      supported: archiveSupported,
+      isArchived,
+      pending: archiveChat.isPending,
+      onToggle,
+    }),
+    [archiveSupported, isArchived, archiveChat.isPending, onToggle],
+  );
+}
+
+export function useChatRowSharing(
+  epicId: string,
+  nodeId: string,
+  artifactType: EpicNodeKind,
+  canMutate: boolean,
+): {
+  readonly entry: ChatSharingMenuDecision;
+  readonly onToggle: () => void;
+  readonly showIndicator: boolean;
+} {
+  const sharing = useContext(SidebarChatSharingContext);
+  const setVisibility = useEpicSetCloudChatVisibility();
+  const sharingInFlight = useChatSharingInFlight(epicId);
+  const cloudChat = sharing.ownCloudChatByLocalId.get(nodeId);
+  const visibility = cloudChat?.visibility ?? null;
+  return {
+    entry: decideChatSharingMenuEntry({
+      supported: sharing.visibilitySupported,
+      isChat: artifactType === "chat",
+      canMutate,
+      visibility,
+      pending: sharingInFlight,
+    }),
+    onToggle: () => {
+      if (
+        !canMutate ||
+        !sharing.visibilitySupported ||
+        sharingInFlight ||
+        cloudChat === undefined
+      ) {
+        return;
+      }
+      setVisibility.mutate({
+        taskId: cloudChat.identity.taskId,
+        chatId: cloudChat.identity.chatId,
+        visibility: cloudChat.visibility === "task" ? "private" : "task",
+      });
+    },
+    showIndicator: shouldShowSharedWithTaskIndicator({
+      visibility,
+      hasCollaborators: sharing.hasCollaborators,
+    }),
+  };
+}
+
+/**
+ * "New child agent" opens the shared New Conversation modal seeded with this
+ * row as the parent - the same action the top-level new-agent trigger fires,
+ * so it preserves the modal's remembered interface.
+ */
+export function useNewChildAgentAction(args: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly nodeId: string;
+  readonly canMutate: boolean;
+}): () => void {
+  const { epicId, tabId, nodeId, canMutate } = args;
+  const openNewConversationModal = useNewConversationModalOpenStore(
+    (state) => state.open,
+  );
+  return useCallback(() => {
+    if (!canMutate) return;
+    openNewConversationModal({
+      epicId,
+      tabId,
+      placement: ACTIVE_TILE_PLACEMENT,
+      parentId: nodeId,
+      // Names no host, exactly like the panel's own `+`: the modal resolves
+      // this Epic's placement memory (last created chat's host, else the
+      // session's host) with the picker live. The PARENT row's owner host is
+      // deliberately not passed - naming it would freeze the picker and a child
+      // is not required to live on its parent's machine.
+      hostId: null,
+    });
+  }, [canMutate, epicId, nodeId, openNewConversationModal, tabId]);
+}
+
+export interface ChatRowMenuEntriesProps {
+  readonly nodeId: string;
+  readonly canMutate: boolean;
+  readonly archiveEntry: ChatRowArchiveEntry | null;
+  readonly sharingEntry: ChatSharingMenuDecision;
+  readonly onNewChildAgent: () => void;
+  readonly onStartRename: () => void;
+  readonly onToggleArchive: () => void;
+  readonly onToggleSharing: () => void;
+  readonly onPerformDelete: () => void;
+}
+
+/**
+ * The Archive / Unarchive entry, or nothing at all. Kept as a spreadable list
+ * so `chatRowMenuEntries` stays one flat literal - the ⋯ and right-click menus
+ * both render from it, so a single definition covers both surfaces.
+ *
+ * The label is the ACTION, not the state: an archived row offers "Unarchive".
+ */
+function archiveMenuEntries(
+  props: ChatRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
+  const { archiveEntry } = props;
+  if (archiveEntry === null) return [];
+  return [
+    {
+      kind: "item",
+      id: "archive",
+      label: archiveEntry.isArchived ? "Unarchive" : "Archive",
+      icon: archiveEntry.isArchived ? (
+        <ArchiveRestore className="size-3.5" />
+      ) : (
+        <Archive className="size-3.5" />
+      ),
+      disabled: !props.canMutate || archiveEntry.disabled,
+      // Only the busy arm explains itself. `!canMutate` greys out every entry
+      // in the menu at once, so a per-entry tooltip there would be noise.
+      disabledTooltip: props.canMutate ? archiveEntry.disabledTooltip : null,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-archive-item-${props.nodeId}`,
+        context: `epic-sidebar-context-archive-${props.nodeId}`,
+      },
+      onSelect: props.onToggleArchive,
+    },
+  ];
+}
+
+/**
+ * The Share with task / Make private entry, or nothing at all. Same spread
+ * shape as {@link archiveMenuEntries} so both the ⋯ and right-click menus
+ * pick it up from one definition.
+ *
+ * The label is the ACTION, not the state: a task-visible row offers
+ * "Make private".
+ */
+function sharingMenuEntries(
+  props: ChatRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
+  const { sharingEntry } = props;
+  if (sharingEntry.kind === "hidden") return [];
+  const makePrivate = sharingEntry.action === "make-private";
+  return [
+    {
+      kind: "item",
+      id: "share",
+      label: makePrivate ? "Make private" : "Share with task",
+      icon: makePrivate ? (
+        <Lock className="size-3.5" />
+      ) : (
+        <Users className="size-3.5" />
+      ),
+      disabled: !props.canMutate || sharingEntry.disabled,
+      disabledTooltip: props.canMutate ? sharingEntry.disabledTooltip : null,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-share-item-${props.nodeId}`,
+        context: `epic-sidebar-context-share-${props.nodeId}`,
+      },
+      onSelect: props.onToggleSharing,
+    },
+  ];
+}
+
+export function chatRowMenuEntries(
+  props: ChatRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
+  return [
+    {
+      kind: "item",
+      id: "new-child-agent",
+      label: "New child agent",
+      icon: <Plus className="size-3.5" />,
+      disabled: !props.canMutate,
+      disabledTooltip: null,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-new-child-${props.nodeId}`,
+        context: `epic-sidebar-context-new-child-${props.nodeId}`,
+      },
+      onSelect: props.onNewChildAgent,
+    },
+    {
+      kind: "item",
+      id: "rename",
+      label: "Rename",
+      icon: <Pencil className="size-3.5" />,
+      disabled: !props.canMutate,
+      disabledTooltip: null,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-rename-${props.nodeId}`,
+        context: `epic-sidebar-context-rename-${props.nodeId}`,
+      },
+      onSelect: props.onStartRename,
+    },
+    ...archiveMenuEntries(props),
+    ...sharingMenuEntries(props),
+    { kind: "separator", id: "before-delete" },
+    {
+      kind: "item",
+      id: "delete",
+      label: "Delete",
+      icon: <Trash2 className="size-3.5" />,
+      disabled: !props.canMutate,
+      disabledTooltip: null,
+      variant: "destructive",
+      testIds: {
+        dropdown: `epic-sidebar-delete-${props.nodeId}`,
+        context: `epic-sidebar-context-delete-${props.nodeId}`,
+      },
+      onSelect: props.onPerformDelete,
+    },
+  ];
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -12,16 +12,10 @@ import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { makePublishedChatTileRef } from "@/stores/epics/canvas/tile-schema/published-chat-tile";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
-  useEpicArchiveChat,
   useEpicDeleteChat,
   useEpicRenameChat,
 } from "@/hooks/epic/use-epic-chat-mutations";
-import { useChatArchiveSupported } from "@/hooks/epic/use-chat-archive-support";
-import { useCloudChatVisibilitySupported } from "@/hooks/epic/use-chat-sharing-support";
-import { useEpicSetCloudChatVisibility } from "@/hooks/epic/use-epic-chat-visibility-mutations";
 import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
-import { useChatSharingInFlight } from "@/lib/chats/chat-sharing-inflight";
-import { useEpicCollaboratorsQuery } from "@/hooks/epics/use-epic-collaborators-query";
 import {
   useEpicDeleteTuiAgent,
   useEpicRenameTuiAgent,
@@ -37,7 +31,6 @@ import {
 } from "@/lib/epic-tree-cascade";
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { cn } from "@/lib/utils";
-import { useCompactRelativeTime } from "@/lib/relative-time";
 import { OwnerResourceChip } from "@/components/resources/resource-usage-chip";
 import type { ResourceOwnerKindWire } from "@traycer/protocol/host/resources/subscribe";
 import { ChatProgressIcon } from "@/components/chat/chat-progress-icon";
@@ -128,7 +121,6 @@ import {
   useEpicArtifactRecords,
   useEpicChatIds,
   useEpicConnectionStatus,
-  useEpicNodeArchived,
   useEpicNodeUpdatedAt,
   useEpicNodeHostId,
   useEpicNodeHostIds,
@@ -149,17 +141,10 @@ import {
   useChatPublicationTargets,
 } from "@/hooks/chats/use-chat-publication-targets";
 import {
-  indexOwnCloudChatsByLocalId,
   mergeChatListEntries,
   selectUnfoldedCloudChats,
 } from "@/lib/chats/unified-chat-list";
-import {
-  decideChatSharingMenuEntry,
-  shouldShowSharedWithTaskIndicator,
-  SHARED_WITH_TASK_TOOLTIP,
-  taskHasCollaborators,
-  type ChatSharingMenuDecision,
-} from "@/lib/chats/chat-sharing-ux";
+import { SHARED_WITH_TASK_TOOLTIP } from "@/lib/chats/chat-sharing-ux";
 import { AgentRoleBadges } from "./agent-role-badges";
 import { AgentHoverTooltip } from "@/components/epic-canvas/sidebar/agent-hover-tooltip";
 import { isEditableRole } from "@/lib/epic-permissions";
@@ -171,10 +156,7 @@ import {
   MessagesSquare,
   MoreHorizontal,
   Lock,
-  Pencil,
-  Plus,
   SearchX,
-  Trash2,
   Users,
 } from "lucide-react";
 import {
@@ -188,7 +170,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   type KeyboardEvent,
   type ReactNode,
 } from "react";
@@ -251,10 +232,23 @@ import {
   SidebarDropdownMenuItems,
   type SidebarRowMenuEntry,
 } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
-import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
-import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
-import { useExistingChatSessionHandle } from "@/lib/registries/chat-session-registry";
-import { chatActivityIndicator } from "@/components/epic-canvas/renderers/chat-tile-session-state";
+import {
+  ArchivedTitlePrefix,
+  ChatRowIdleTime,
+} from "@/components/epic-canvas/sidebar/chat-row-chrome";
+import {
+  chatRowArchiveEntry,
+  chatRowMenuEntries,
+  SidebarArchiveSupportedContext,
+  SidebarChatSharingContext,
+  useChatRowArchiveInputs,
+  useChatRowMenuFacts,
+  useChatRowSessionActivity,
+  useChatRowSharing,
+  useNewChildAgentAction,
+  type ChatRowArchiveEntry,
+  type ChatRowArchiveInputs,
+} from "@/components/epic-canvas/sidebar/chat-row-menu";
 import { type IndicatorRunningKind } from "@/components/notifications/notification-indicator-icon";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
@@ -280,36 +274,6 @@ type TreeFilterFn = (type: string | null | undefined) => boolean;
  * keeping that icon, not an oversight this context still eliminates.
  */
 const SidebarViewerContext = createContext<boolean>(false);
-
-/**
- * Whether the epic's host advertises `epic.setChatArchived`. Resolved ONCE in
- * `ChatTreePanelBody` and read by the rows, for the same reason
- * {@link SidebarViewerContext} exists: it is a per-host fact, identical for
- * every row, and re-subscribing each row to the manifest registry would buy
- * nothing. `false` is the fail-closed default - every archive affordance stays
- * hidden until a handshake proves the method present.
- */
-const SidebarArchiveSupportedContext = createContext<boolean>(false);
-
-interface SidebarChatSharingValue {
-  readonly visibilitySupported: boolean;
-  readonly ownCloudChatByLocalId: ReadonlyMap<string, CloudChatSummary>;
-  readonly hasCollaborators: boolean;
-}
-
-const EMPTY_OWN_CLOUD_CHATS: ReadonlyMap<string, CloudChatSummary> = new Map();
-
-/**
- * Per-chat sharing facts that are identical for every row (capability, the
- * fold of local ids onto cloud rows, whether this task has an audience).
- * Resolved once in `ChatTreePanelBody` and read by the rows, matching
- * {@link SidebarArchiveSupportedContext}.
- */
-const SidebarChatSharingContext = createContext<SidebarChatSharingValue>({
-  visibilitySupported: false,
-  ownCloudChatByLocalId: EMPTY_OWN_CLOUD_CHATS,
-  hasCollaborators: false,
-});
 
 /** Frozen so an absent cloud list does not re-run the fold every render. */
 const EMPTY_CLOUD_CHATS: readonly CloudChatSummary[] = [];
@@ -748,18 +712,14 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
   // tree, so it answers both axes directly.
   const chatFilter = useChatFilter(epicId);
   const baseArchiveHiddenIds = useSidebarArchiveHiddenIds(epicId);
-  const canArchive = useChatArchiveSupported();
-  const canSetVisibility = useCloudChatVisibilitySupported();
+  // The per-list facts every row menu is decided from, resolved once for the
+  // whole panel and shared with the phone switcher's agents list. `canArchive`
+  // also drives this panel's archive empty-state copy.
+  const { canArchive, sharing: chatSharingValue } = useChatRowMenuFacts(epicId);
   // Epic-session-bound like every other sharing fact in this tree: the
   // shared-with-task glyph must reflect the tab's owning host, not whichever
   // host the app is active on.
   const sessionHostClient = useEpicSessionHostClient();
-  const collaboratorsQuery = useEpicCollaboratorsQuery(epicId, {
-    client: sessionHostClient,
-    poll: undefined,
-    staleTime: undefined,
-  });
-  const hasCollaborators = taskHasCollaborators(collaboratorsQuery.data);
   const filterRootIds = useMemo(
     () => applyVisibleFilter(allRootIds, narrowedVisibleIds),
     [allRootIds, narrowedVisibleIds],
@@ -883,41 +843,6 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
         ),
       }),
     [cloudChats.data, localChatIds, publicationTargets.data],
-  );
-  // Sharing fold, mutations, and cache keys all address the Epic session
-  // host. The v2 rendered list above stays on the app-wide client — that
-  // hook is shipped and is not this ticket. The redirect map is host-LOCAL
-  // (only the epic's host knows C1→C2), so reading it from the active host
-  // would make "Make private" mutate the wrong lineage after a fork.
-  const sharingCloudChats = useCloudChatList({
-    client: sessionHostClient,
-    taskId: epicId,
-    enabled: epicId.length > 0,
-  });
-  const sharingPublicationTargets = useChatPublicationTargets({
-    client: sessionHostClient,
-    epicId,
-    chatIds: localChatIds,
-    enabled: epicId.length > 0,
-  });
-  const ownCloudChatByLocalId = useMemo(
-    () =>
-      indexOwnCloudChatsByLocalId({
-        chats: sharingCloudChats.data?.chats ?? EMPTY_CLOUD_CHATS,
-        localChatIds,
-        publicationChatIdByChatId: publicationTargetMap(
-          sharingPublicationTargets.data,
-        ),
-      }),
-    [localChatIds, sharingCloudChats.data, sharingPublicationTargets.data],
-  );
-  const chatSharingValue = useMemo<SidebarChatSharingValue>(
-    () => ({
-      visibilitySupported: canSetVisibility,
-      ownCloudChatByLocalId,
-      hasCollaborators,
-    }),
-    [canSetVisibility, hasCollaborators, ownCloudChatByLocalId],
   );
   // The sidebar's own filters apply to cloud rows too. They were reaching only
   // the local tree, so an "Unarchived only" list still drew archived remote
@@ -1430,23 +1355,7 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
     deleteTerminalAgent.isPending,
   ]);
 
-  const archiveSupported = useContext(SidebarArchiveSupportedContext);
-  const isArchived = useEpicNodeArchived(nodeId);
-  const archiveChat = useEpicArchiveChat();
-  const toggleArchive = useCallback(() => {
-    if (!canMutate || !archiveSupported) return;
-    archiveChat.mutate({ epicId, chatId: nodeId, archived: !isArchived });
-  }, [archiveChat, archiveSupported, canMutate, epicId, isArchived, nodeId]);
-  const archivePending = archiveChat.isPending;
-  const archiveRow = useMemo<ChatRowArchiveInputs>(
-    () => ({
-      supported: archiveSupported,
-      isArchived,
-      pending: archivePending,
-      onToggle: toggleArchive,
-    }),
-    [archiveSupported, isArchived, archivePending, toggleArchive],
-  );
+  const archiveRow = useChatRowArchiveInputs({ epicId, nodeId, canMutate });
 
   // The tab must bind to the chat's OWNER host, not whichever host happens to
   // be active: a connected peer host's chat reaches this tree through the
@@ -1896,29 +1805,14 @@ function ChatNodeShellBody(
     onToggleSelection,
   } = props;
 
-  // "New child agent" opens the shared New Conversation modal seeded with this
-  // row as the parent - the same action the standalone hover "+" used to
-  // trigger, now consolidated into the row menu (right-click + ⋯) so there is a
-  // single hover affordance. It preserves the modal's remembered interface,
-  // matching the top-level new-agent trigger.
-  const openNewConversationModal = useNewConversationModalOpenStore(
-    (state) => state.open,
-  );
-  const handleNewChildAgent = useCallback(() => {
-    if (!canMutate) return;
-    openNewConversationModal({
-      epicId,
-      tabId,
-      placement: ACTIVE_TILE_PLACEMENT,
-      parentId: nodeId,
-      // Names no host, exactly like the panel's own `+`: the modal resolves
-      // this Epic's placement memory (last created chat's host, else the
-      // session's host) with the picker live. The PARENT row's owner host is
-      // deliberately not passed - naming it would freeze the picker (§55) and
-      // a child is not required to live on its parent's machine.
-      hostId: null,
-    });
-  }, [canMutate, epicId, nodeId, openNewConversationModal, tabId]);
+  // Consolidated into the row menu (right-click + ⋯) rather than a standalone
+  // hover "+", so the row keeps a single hover affordance.
+  const handleNewChildAgent = useNewChildAgentAction({
+    epicId,
+    tabId,
+    nodeId,
+    canMutate,
+  });
   const { decision } = props;
   const sharing = useChatRowSharing(epicId, nodeId, artifactType, canMutate);
   const rowMenuEntries = chatRowMenuEntries({
@@ -2920,39 +2814,6 @@ function ChatRowButton(props: ChatRowButtonProps) {
   );
 }
 
-/**
- * Keeps the archival state attached to the title rather than competing with
- * timestamps and controls in the trailing metadata cluster.
- */
-function ArchivedTitlePrefix(): ReactNode {
-  return (
-    <span
-      className="inline-flex shrink-0 items-center gap-1 text-muted-foreground"
-      data-testid="chat-row-archived-label"
-    >
-      <span className="font-semibold">Archived</span>
-      <span aria-hidden="true">·</span>
-    </span>
-  );
-}
-
-/**
- * The row's trailing last-activity time, on the shared compact ladder
- * (`now` / `10m` / `4h` / `1d` / `1w` / short date). Isolated in its own leaf
- * so the shared 60s clock tick repaints this span rather than the whole row.
- */
-function ChatRowIdleTime(props: { readonly updatedAt: number }): ReactNode {
-  const relative = useCompactRelativeTime(props.updatedAt);
-  return (
-    <span
-      className="flex-none tabular-nums text-ui-xs text-muted-foreground"
-      data-testid="chat-row-idle-time"
-    >
-      {relative}
-    </span>
-  );
-}
-
 // Glyph and color come from the shared notification tones so the nested
 // variant cannot drift from the per-row icon; "running" stays local because
 // it is an activity tier, not a notification state.
@@ -3142,80 +3003,9 @@ interface ChatRowStatus {
   readonly running: IndicatorRunningKind;
 }
 
-/**
- * The row's archive menu state, or `null` on a host that lacks
- * `epic.setChatArchived` - in which case the entry is absent from both menus
- * rather than present-but-disabled.
- */
-interface ChatRowArchiveEntry {
-  readonly isArchived: boolean;
-  readonly disabled: boolean;
-  /** Populated only for the busy arm; `null` whenever `disabled` is false. */
-  readonly disabledTooltip: string | null;
-}
-
-/**
- * A row's archive INPUTS, grouped because they are one concept and always
- * travel together: whether the host can archive at all, whether this row
- * already is, whether a toggle is in flight, and how to toggle it. Passing
- * them as four loose props made the row's prop list four booleans wider for
- * one feature.
- *
- * Distinct from {@link ChatRowArchiveDecision}, which is what the row renders
- * from once those inputs plus the resolved status kind have been folded.
- */
-interface ChatRowArchiveInputs {
-  readonly supported: boolean;
-  readonly isArchived: boolean;
-  readonly pending: boolean;
-  readonly onToggle: () => void;
-}
-
 interface ChatRowArchiveDecision {
   readonly entry: ChatRowArchiveEntry | null;
   readonly showButton: boolean;
-}
-
-/**
- * Copy for a refused archive, matched to the tier so the row explains the
- * ACTUAL reason - "working" and "has background items running" are different
- * things to wait on, and a single generic string would misdescribe one of them.
- *
- * This tooltip is the ONLY message these rows get. The entry is soft-disabled,
- * which prevents `onSelect`, so the host's own refusal - and the toast that
- * rewrites it into user-facing copy - never fire from here. Advice that is
- * wrong in this string is wrong with nothing behind it to correct it.
- *
- * So the background arm must not say "stop it". Every stop affordance routes
- * into `ChatSession.stopActiveTurn()`, which early-returns when no turn is
- * running, so an agent held only by a detached subagent, a workflow or a
- * scheduled wake cannot be stopped into an archivable state - the user would
- * press Stop, see nothing change, and be told the same thing again. It names
- * the per-item controls in the chat instead, which is the affordance that
- * actually clears them.
- *
- * The host's `archiveBlockedMessage` splits on exactly this distinction and
- * keeps its two arms disjoint under test; this is the same split one surface
- * earlier, where the user actually is.
- */
-function archiveBlockedReason(
-  // Excludes the idle tier rather than trusting the caller's `running !== false`
-  // guard. Without it a future caller could pass an idle row and silently get
-  // the background-items copy, which describes a state that is not blocked at
-  // all - a wrong explanation, not a missing one.
-  running: Exclude<IndicatorRunningKind, false>,
-): string {
-  if (running === "turn") {
-    // Hedged, because this tier is NOT "a turn is running". `chatActivityIndicator`
-    // deliberately maps a detached subagent or workflow fleet outliving its turn
-    // into `"turn"` - it is the agent working, so it earns the busy spinner
-    // rather than the muted background glyph - while `resolvedTurnStatus`
-    // reports no active turn for that same state, precisely so a Stop-turn
-    // affordance does not surface. Promising a stop here would contradict that
-    // and send the user after an action the host early-returns from.
-    return "Can't archive while this agent is working. Stopping it ends a turn, but not a detached subagent or workflow. Wait for it to go idle, or stop it, then archive.";
-  }
-  return "Can't archive while this agent has background items running. Stopping the agent won't clear them — wait for them to finish, or stop them from its chat.";
 }
 
 /**
@@ -3223,10 +3013,9 @@ function archiveBlockedReason(
  * whose host supports the method.
  *
  * They are deliberately gated differently, and the MENU entry is the surface
- * that must always work: present on every row, and merely SOFT-disabled while
- * the row is busy (`aria-disabled`, not Radix's `disabled`) so it stays in the
- * arrow-key order and can still announce its reason - see `softDisabledProps`
- * in `sidebar-row-menu-items`. The hover BUTTON is a pointer shortcut that
+ * that must always work - it comes straight from the shared
+ * {@link chatRowArchiveEntry}, which every agent row on every form factor
+ * decides from. The hover BUTTON added here is a desktop pointer shortcut that
  * TAKES OVER the trailing status slot, so it may only appear when that slot is
  * showing the idle time and nothing else.
  *
@@ -3234,7 +3023,7 @@ function archiveBlockedReason(
  * row - archived or not - the button is hidden while the entry remains. That
  * is why the entry, not the button, carries the explanation.
  *
- * That last condition is stricter than "my own status is idle", which is why
+ * The button's condition is stricter than "my own status is idle", which is why
  * `hasChildren`/`expanded` are inputs. A COLLAPSED PARENT's leading slot renders
  * `ChatRowLeadingIconWithNestedRollup`, which may show a muted rollup glyph
  * standing in for a hidden descendant that needs attention - the only signal
@@ -3244,32 +3033,6 @@ function archiveBlockedReason(
  * tell which way the rollup resolved without duplicating its subscription, so
  * every collapsed parent is excluded; the menu entry stays the archive path for
  * those rows.
- *
- * Busy is read off `status.running`, NOT off the folded `status.kind`. Folding
- * loses exactly the case this gate exists for - see {@link ChatRowStatus} - so
- * gating on `kind === "working" | "background"` left Archive ENABLED on any
- * running chat that also had a pending approval or interview, which is most of
- * them at the moment a human is looking. The host refuses such an archive
- * anyway; matching it here is what keeps the affordance honest instead of
- * offering an action that will only come back as a toast.
- *
- * "Busy" here means everything the host counts, which includes a chat owning a
- * running shell - not just an in-flight turn. Narrowing this read to exclude
- * shells is what once left Archive offered on a chat the host would bounce, so
- * it must stay whatever {@link chatActivityIndicator} reports.
- *
- * That "the host refuses it anyway" backstop holds only for an agent on the
- * host this RPC goes to. `AgentActivityTracker` is host-LOCAL, while this
- * predicate unions every host's awareness entry, so for a row running on
- * another host the UI gate is the only one that fires on busy-ness. The host
- * refuses those outright (`TARGET_NOT_LOCAL`) rather than guessing, so the
- * failure mode is an explanatory toast, not a bad archive - but the row is
- * still offered, which is a known gap.
- *
- * UNARCHIVING is never gated on busy - the host allows it, and an archived row
- * can be working (an inbound message auto-unarchives and wakes it, so the flag
- * and the run legitimately overlap). Only `archivePending` disables that
- * direction, to stop a double-submit.
  */
 function chatRowArchiveState(args: {
   readonly canMutate: boolean;
@@ -3281,21 +3044,13 @@ function chatRowArchiveState(args: {
   readonly hasChildren: boolean;
   readonly expanded: boolean;
 }): ChatRowArchiveDecision {
-  // The tier that BLOCKS, or `false` for none. Carrying the narrowed value
-  // rather than a separate boolean is what lets `archiveBlockedReason` refuse
-  // the idle tier by type: a bare `blocksArchive` flag proves nothing to the
-  // compiler about `status.running` at the call below.
-  const blockingRun: IndicatorRunningKind = args.isArchived
-    ? false
-    : args.status.running;
   const slotMayShowRollup = args.hasChildren && !args.expanded;
   return {
-    entry: {
+    entry: chatRowArchiveEntry({
       isArchived: args.isArchived,
-      disabled: blockingRun !== false || args.archivePending,
-      disabledTooltip:
-        blockingRun === false ? null : archiveBlockedReason(blockingRun),
-    },
+      archivePending: args.archivePending,
+      running: args.status.running,
+    }),
     showButton:
       args.canMutate &&
       args.status.kind === "idle" &&
@@ -3303,187 +3058,6 @@ function chatRowArchiveState(args: {
       !args.selectionMode &&
       !args.isRenaming,
   };
-}
-
-interface ChatRowMenuEntriesProps {
-  readonly nodeId: string;
-  readonly canMutate: boolean;
-  readonly archiveEntry: ChatRowArchiveEntry | null;
-  readonly sharingEntry: ChatSharingMenuDecision;
-  readonly onNewChildAgent: () => void;
-  readonly onStartRename: () => void;
-  readonly onToggleArchive: () => void;
-  readonly onToggleSharing: () => void;
-  readonly onPerformDelete: () => void;
-}
-
-/**
- * The Archive / Unarchive entry, or nothing at all. Kept as a spreadable list
- * so `chatRowMenuEntries` stays one flat literal - the ⋯ and right-click menus
- * both render from it, so a single definition covers both surfaces.
- *
- * The label is the ACTION, not the state: an archived row offers "Unarchive".
- */
-function archiveMenuEntries(
-  props: ChatRowMenuEntriesProps,
-): ReadonlyArray<SidebarRowMenuEntry> {
-  const { archiveEntry } = props;
-  if (archiveEntry === null) return [];
-  return [
-    {
-      kind: "item",
-      id: "archive",
-      label: archiveEntry.isArchived ? "Unarchive" : "Archive",
-      icon: archiveEntry.isArchived ? (
-        <ArchiveRestore className="size-3.5" />
-      ) : (
-        <Archive className="size-3.5" />
-      ),
-      disabled: !props.canMutate || archiveEntry.disabled,
-      // Only the busy arm explains itself. `!canMutate` greys out every entry
-      // in the menu at once, so a per-entry tooltip there would be noise.
-      disabledTooltip: props.canMutate ? archiveEntry.disabledTooltip : null,
-      variant: "default",
-      testIds: {
-        dropdown: `epic-sidebar-archive-item-${props.nodeId}`,
-        context: `epic-sidebar-context-archive-${props.nodeId}`,
-      },
-      onSelect: props.onToggleArchive,
-    },
-  ];
-}
-
-/**
- * The Share with task / Make private entry, or nothing at all. Same spread
- * shape as {@link archiveMenuEntries} so both the ⋯ and right-click menus
- * pick it up from one definition.
- *
- * The label is the ACTION, not the state: a task-visible row offers
- * "Make private".
- */
-function sharingMenuEntries(
-  props: ChatRowMenuEntriesProps,
-): ReadonlyArray<SidebarRowMenuEntry> {
-  const { sharingEntry } = props;
-  if (sharingEntry.kind === "hidden") return [];
-  const makePrivate = sharingEntry.action === "make-private";
-  return [
-    {
-      kind: "item",
-      id: "share",
-      label: makePrivate ? "Make private" : "Share with task",
-      icon: makePrivate ? (
-        <Lock className="size-3.5" />
-      ) : (
-        <Users className="size-3.5" />
-      ),
-      disabled: !props.canMutate || sharingEntry.disabled,
-      disabledTooltip: props.canMutate ? sharingEntry.disabledTooltip : null,
-      variant: "default",
-      testIds: {
-        dropdown: `epic-sidebar-share-item-${props.nodeId}`,
-        context: `epic-sidebar-context-share-${props.nodeId}`,
-      },
-      onSelect: props.onToggleSharing,
-    },
-  ];
-}
-
-function useChatRowSharing(
-  epicId: string,
-  nodeId: string,
-  artifactType: EpicNodeKind,
-  canMutate: boolean,
-): {
-  readonly entry: ChatSharingMenuDecision;
-  readonly onToggle: () => void;
-  readonly showIndicator: boolean;
-} {
-  const sharing = useContext(SidebarChatSharingContext);
-  const setVisibility = useEpicSetCloudChatVisibility();
-  const sharingInFlight = useChatSharingInFlight(epicId);
-  const cloudChat = sharing.ownCloudChatByLocalId.get(nodeId);
-  const visibility = cloudChat?.visibility ?? null;
-  return {
-    entry: decideChatSharingMenuEntry({
-      supported: sharing.visibilitySupported,
-      isChat: artifactType === "chat",
-      canMutate,
-      visibility,
-      pending: sharingInFlight,
-    }),
-    onToggle: () => {
-      if (
-        !canMutate ||
-        !sharing.visibilitySupported ||
-        sharingInFlight ||
-        cloudChat === undefined
-      ) {
-        return;
-      }
-      setVisibility.mutate({
-        taskId: cloudChat.identity.taskId,
-        chatId: cloudChat.identity.chatId,
-        visibility: cloudChat.visibility === "task" ? "private" : "task",
-      });
-    },
-    showIndicator: shouldShowSharedWithTaskIndicator({
-      visibility,
-      hasCollaborators: sharing.hasCollaborators,
-    }),
-  };
-}
-
-function chatRowMenuEntries(
-  props: ChatRowMenuEntriesProps,
-): ReadonlyArray<SidebarRowMenuEntry> {
-  return [
-    {
-      kind: "item",
-      id: "new-child-agent",
-      label: "New child agent",
-      icon: <Plus className="size-3.5" />,
-      disabled: !props.canMutate,
-      disabledTooltip: null,
-      variant: "default",
-      testIds: {
-        dropdown: `epic-sidebar-new-child-${props.nodeId}`,
-        context: `epic-sidebar-context-new-child-${props.nodeId}`,
-      },
-      onSelect: props.onNewChildAgent,
-    },
-    {
-      kind: "item",
-      id: "rename",
-      label: "Rename",
-      icon: <Pencil className="size-3.5" />,
-      disabled: !props.canMutate,
-      disabledTooltip: null,
-      variant: "default",
-      testIds: {
-        dropdown: `epic-sidebar-rename-${props.nodeId}`,
-        context: `epic-sidebar-context-rename-${props.nodeId}`,
-      },
-      onSelect: props.onStartRename,
-    },
-    ...archiveMenuEntries(props),
-    ...sharingMenuEntries(props),
-    { kind: "separator", id: "before-delete" },
-    {
-      kind: "item",
-      id: "delete",
-      label: "Delete",
-      icon: <Trash2 className="size-3.5" />,
-      disabled: !props.canMutate,
-      disabledTooltip: null,
-      variant: "destructive",
-      testIds: {
-        dropdown: `epic-sidebar-delete-${props.nodeId}`,
-        context: `epic-sidebar-context-delete-${props.nodeId}`,
-      },
-      onSelect: props.onPerformDelete,
-    },
-  ];
 }
 
 /**
@@ -3517,50 +3091,21 @@ function useChatRowOwnStatusKind(args: {
     { epicId, chatId: nodeId },
     ownerHostId,
   );
-  const awarenessTier = useEpicAgentActivityTiers().get(nodeId);
+  const activity = useChatRowSessionActivity(args);
   const isViewer = useContext(SidebarViewerContext);
   // Terminal-agent rows have no chat session and never carried a read-only
   // lock (their PTY runs host-side), so the viewer arm is chat-only.
   const isChat = artifactType === "chat";
-  const sessionHandle = useExistingChatSessionHandle(
-    epicId,
-    nodeId,
-    ownerHostId,
-  );
-  const subscribeSession = useMemo(
-    () => (onChange: () => void) => {
-      if (sessionHandle === null) return () => undefined;
-      return sessionHandle.store.subscribe(onChange);
-    },
-    [sessionHandle],
-  );
-  const sessionActivity = useSyncExternalStore(subscribeSession, () =>
-    sessionHandle === null
-      ? null
-      : chatActivityIndicator(sessionHandle.store.getState()),
-  );
-  const sessionRole = useSyncExternalStore(subscribeSession, () =>
-    sessionHandle === null
-      ? null
-      : (sessionHandle.store.getState().access?.role ?? null),
-  );
-  if (sessionHandle === null || !isChat) {
-    const running = awarenessTier ?? false;
-    return {
-      kind: chatOwnStatusKind(indicatorState, running, isChat && isViewer),
-      running,
-    };
-  }
-  const running = sessionActivity ?? awarenessTier ?? false;
+  // A session's own access snapshot overrides the epic-level viewer role, but
+  // only once it has arrived: staying neutral while it is unknown is what keeps
+  // an owner from seeing a read-only row flash before it does.
+  const isReadOnly =
+    activity.hasSession && isChat
+      ? activity.sessionRole !== null && activity.sessionRole !== "owner"
+      : isChat && isViewer;
   return {
-    kind: chatOwnStatusKind(
-      indicatorState,
-      running,
-      // Stay neutral while the access snapshot is unknown so an owner never
-      // sees a read-only row flash before it arrives.
-      sessionRole !== null && sessionRole !== "owner",
-    ),
-    running,
+    kind: chatOwnStatusKind(indicatorState, activity.running, isReadOnly),
+    running: activity.running,
   };
 }
 


### PR DESCRIPTION
The phone's Agents category listed the same agents as the desktop sidebar but offered a fraction of what that surface offers. Four defects, from a side-by-side comparison:

| # | Defect | Fix |
| --- | --- | --- |
| 1 | Tab called **"chats"**; desktop calls it **Agents** | Dropped the mobile-only label override. `LEFT_PANEL_DEFINITIONS` already titles this panel "Agents"; only mobile forked the copy. |
| 2 | **No timestamps**; desktop right-aligns a relative time per row | Mounts the sidebar's own `ChatRowIdleTime` on the compact ladder (`now` / `10m` / `4h` / `1d` / `1w`), reading `useEpicNodeUpdatedAt` (the live projection) rather than the lagging tree copy. |
| 3 | Row menu had **Rename + Delete only** | Now built by the desktop's own `chatRowMenuEntries`: **New child agent, Rename, Archive/Unarchive, Make private/Share with task, Delete** (destructive). Same archive busy-gate, same sharing predicates, same mutations. |
| 4 | **Nesting broken** — a flat, globally recency-sorted list | Walks the projector tree the sidebar walks (`rootIds` → `useFilteredPanelChildIds` per level), so a child sits under its parent and siblings sort by recency *within* their bucket. |

## How

Presentation adapts, behaviour is shared. Everything that decides what an action does, when it is offered, and why it is refused moved out of `epic-sidebar-chat-tree.tsx` into two modules both surfaces mount:

- `sidebar/chat-row-menu.tsx` — the archive/sharing contexts and the per-list facts behind them, the row's live activity read, the archive-entry decision, the sharing decision, the new-child action, and `chatRowMenuEntries`. No component exports.
- `sidebar/chat-row-chrome.tsx` — `ArchivedTitlePrefix`, `ChatRowIdleTime`, and the facts provider.

The desktop tree keeps only what is genuinely desktop: the hover Archive button, the right-click menu, dnd reparenting, bulk selection. Its behaviour is unchanged — the archive gate, the sharing entry and the menu order all come from the same functions as before, now imported.

On mobile the row grows a nesting cluster: 20px indent per level (wider than desktop's 16px — a phone row has no vertical guide rail) and a real 44px chevron button, because expand/collapse is the only way to reach a deep child on a phone. Expansion shares the sidebar's per-`(tab, panel)` store, so a subtree opened on one surface is open on the other for as long as the tab lives.

## Deliberate calls

- **Archived agents are listed and marked, not hidden.** Desktop hides them behind a filter the sheet does not have; hiding them here would make an archived agent unreachable from a phone.
- **Rename stays a dialog** (a 44px row in a bottom sheet is no place to grow a text field) driving the same rename mutation.
- **`New child agent` closes the sheet** as the modal opens, the same handoff the category's own create row performs.

## Still missing on this tab (not in scope here)

Header search, the filter/sort menu (ownership / origin / archive visibility), collapse-all, bulk selection, dnd reparenting, and the interleaved cloud-chat rows. Each is a surface of its own rather than a row affordance.

## Verification

- `bun run --filter @traycer-clients/gui-app compile` — clean
- `eslint --max-warnings 0` + `prettier` over every touched path — clean
- `switcher-lists.test.tsx` — 23/23, including new coverage for nesting + collapse, leaf-vs-parent chevron, the compact timestamp, and the archived marker

Simulator verification of the visible changes follows before merge.
