### PR TITLE
feat(mobile): bring the epic switcher's artifacts tab to desktop parity

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-artifacts-tree.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-artifacts-tree.test.tsx
@@ -307,12 +307,24 @@ describe("<SwitcherArtifactsList /> shared panel controls", () => {
   });
 
   it("hides a filtered-out root while keeping the ones that match", () => {
+    holder.nodes = [
+      ...NESTED_FIXTURE,
+      {
+        id: "rv-1",
+        parentId: null,
+        title: "Review One",
+        type: "review",
+        status: null,
+        updatedAt: 3,
+      },
+    ];
     useLeftPanelStore.getState().toggleArtifactKind("epic-1", "ticket");
     render(<SwitcherArtifactsList {...PROPS} />);
-    // The parent spec survives as the matched ticket's ancestor - a match must
-    // stay reachable - while the filter is what decides the set.
     expect(screen.getByTestId("switcher-artifact-row-tk-1")).toBeTruthy();
+    // The parent spec survives as the matched ticket's ancestor - a match must
+    // stay reachable - while a root with nothing matching under it does not.
     expect(screen.getByTestId("switcher-artifact-row-spec-1")).toBeTruthy();
+    expect(screen.queryByTestId("switcher-artifact-row-rv-1")).toBeNull();
   });
 
   it("offers the desktop filter menu, viewer included", () => {
@@ -333,8 +345,10 @@ describe("<SwitcherArtifactsList /> row actions", () => {
 
     openMenu("switcher-more-tk-1");
     fireEvent.click(screen.getByTestId("switcher-export-pdf-tk-1"));
-    expect(holder.exportCalls).toHaveLength(2);
-    expect(holder.exportCalls[1].format).toBe("pdf");
+    expect(holder.exportCalls).toEqual([
+      { format: "markdown", ids: ["tk-1"] },
+      { format: "pdf", ids: ["tk-1"] },
+    ]);
   });
 
   it("keeps export available to a viewer, without the mutations", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-artifacts-tree.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-artifacts-tree.test.tsx
@@ -1,0 +1,363 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
+import { STATUS_DOT_CLASSES } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
+import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
+import { useEpicSidebarExpansionStore } from "@/stores/epics/epic-sidebar-expansion-store";
+
+/**
+ * The switcher's artifacts category, exercised as the TREE it now is: the same
+ * projector index the desktop panel walks, the same per-tab filter/sort/
+ * expansion state, rendered as touch rows. Everything below the tree index is
+ * stubbed at the module boundary - the point under test is that hierarchy,
+ * ordering and the panel's shared controls reach the phone, not how the store
+ * projects.
+ */
+interface FixtureNode {
+  readonly id: string;
+  readonly parentId: string | null;
+  readonly title: string;
+  readonly type: string;
+  readonly status: number | null;
+  readonly updatedAt: number;
+}
+
+interface Holder {
+  nodes: ReadonlyArray<FixtureNode>;
+  role: "owner" | "viewer";
+  activeId: string | null;
+  createCalls: { parentId: string | null; artifactType: string }[];
+  exportCalls: { format: string; ids: readonly string[] }[];
+}
+
+const holder = vi.hoisted((): Holder => ({
+  nodes: [],
+  role: "owner",
+  activeId: null,
+  createCalls: [],
+  exportCalls: [],
+}));
+
+function nodeById(): Record<string, FixtureNode> {
+  return Object.fromEntries(holder.nodes.map((node) => [node.id, node]));
+}
+function childrenByParent(): Record<string, readonly string[]> {
+  const map: Record<string, string[]> = {};
+  for (const node of holder.nodes) {
+    if (node.parentId === null) continue;
+    map[node.parentId] = [...(map[node.parentId] ?? []), node.id];
+  }
+  return map;
+}
+function rootIds(): readonly string[] {
+  return holder.nodes.flatMap((node) =>
+    node.parentId === null ? [node.id] : [],
+  );
+}
+function findNode(id: string): FixtureNode | null {
+  return holder.nodes.find((node) => node.id === id) ?? null;
+}
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useRootIds: () => rootIds(),
+  useChildIds: (parentId: string) => childrenByParent()[parentId] ?? [],
+  useEpicTreeIndex: () => ({
+    rootIds: rootIds(),
+    childrenByParent: childrenByParent(),
+    nodeById: nodeById(),
+  }),
+  useEpicTreeNode: (id: string) => findNode(id),
+  useEpicArtifactStatus: (id: string) => findNode(id)?.status ?? null,
+  useEpicArtifactRecords: () =>
+    holder.nodes.map((node) => ({
+      id: node.id,
+      parentId: node.parentId,
+      name: node.title,
+      type: node.type,
+      status: node.status,
+      hostId: "host-A",
+    })),
+  useAncestorIds: () => new Set<string>(),
+  useEpicPermissionRole: () => holder.role,
+}));
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      artifacts: {
+        allIds: holder.nodes.flatMap((node) =>
+          node.type === "chat" ? [] : [node.id],
+        ),
+        byId: Object.fromEntries(
+          holder.nodes.flatMap((node) =>
+            node.type === "chat"
+              ? []
+              : [
+                  [
+                    node.id,
+                    {
+                      id: node.id,
+                      kind: node.type,
+                      status: node.status,
+                      updatedAt: node.updatedAt,
+                    },
+                  ],
+                ],
+          ),
+        ),
+      },
+    }),
+}));
+vi.mock("@/stores/epics/canvas/canvas-selectors", () => ({
+  useActiveEpicArtifactId: () => holder.activeId,
+  useIsActiveEpicArtifact: (_tabId: string, id: string) =>
+    holder.activeId === id,
+  findOpenArtifactInTab: () => null,
+}));
+vi.mock("@/stores/epics/canvas/store", () => ({
+  useEpicCanvasStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      prepareOpenTileInTabFocusTarget: vi.fn(),
+      prepareCloseCanvasTabFocusTarget: vi.fn(),
+    }),
+}));
+vi.mock("@/components/epic-canvas/mobile/use-switcher-activate", () => ({
+  useSwitcherActivate: () => vi.fn(),
+}));
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useOpenEpicHandle: () => ({ store: { getState: () => ({}) } }),
+}));
+vi.mock("@/hooks/epic/use-epic-session-host-id", () => ({
+  useEpicSessionHostId: () => "host-A",
+}));
+vi.mock("@/hooks/epic/use-epic-session-host-client", () => ({
+  useEpicSessionHostClient: () => null,
+}));
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => vi.fn(),
+}));
+vi.mock("@/hooks/epic/use-epic-node-mutations", () => ({
+  useEpicCreateArtifact: () => ({
+    mutate: (vars: { parentId: string | null; artifactType: string }) => {
+      holder.createCalls.push({
+        parentId: vars.parentId,
+        artifactType: vars.artifactType,
+      });
+    },
+    isPending: false,
+  }),
+  useEpicDeleteArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicRenameArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicRenameChat: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicDeleteChat: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/epic/use-epic-tui-agent-mutations", () => ({
+  useEpicRenameTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicDeleteTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/terminal/use-terminal-kill-for-mutation", () => ({
+  useTerminalKillFor: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/terminal/use-terminal-rename-for-mutation", () => ({
+  useTerminalRenameFor: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/epic/use-epic-export-artifacts-mutation", () => ({
+  useEpicExportArtifacts: () => ({
+    mutate: (vars: {
+      readonly artifacts: ReadonlyArray<{ readonly id: string }>;
+      readonly format: string;
+    }) => {
+      holder.exportCalls.push({
+        format: vars.format,
+        ids: vars.artifacts.map((artifact) => artifact.id),
+      });
+    },
+    isPending: false,
+  }),
+}));
+
+/**
+ * Radix's DropdownMenuTrigger opens on pointerdown, not click - a plain click
+ * leaves the menu closed and every entry unqueryable.
+ */
+function openMenu(triggerTestId: string): void {
+  fireEvent.pointerDown(screen.getByTestId(triggerTestId), { button: 0 });
+}
+
+const PROPS = { epicId: "epic-1", tabId: "tab-1", onClose: () => {} };
+
+/** Spec "Parent" with a ticket child, plus a chat the list must ignore. */
+const NESTED_FIXTURE: ReadonlyArray<FixtureNode> = [
+  {
+    id: "spec-1",
+    parentId: null,
+    title: "Parent Spec",
+    type: "spec",
+    status: null,
+    updatedAt: 1,
+  },
+  {
+    id: "tk-1",
+    parentId: "spec-1",
+    title: "Child Ticket",
+    type: "ticket",
+    status: 1,
+    updatedAt: 5,
+  },
+  {
+    id: "chat-1",
+    parentId: null,
+    title: "Alpha",
+    type: "chat",
+    status: null,
+    updatedAt: 9,
+  },
+];
+
+beforeEach(() => {
+  holder.nodes = NESTED_FIXTURE;
+  holder.role = "owner";
+  holder.activeId = null;
+  holder.createCalls = [];
+  holder.exportCalls = [];
+  useLeftPanelStore.getState().resetArtifactView("epic-1");
+  useEpicSidebarExpansionStore.setState({
+    userExpandedByScope: {},
+    userCollapsedByScope: {},
+  });
+});
+afterEach(cleanup);
+
+describe("<SwitcherArtifactsList /> tree", () => {
+  it("nests a child under its parent instead of listing both at the root", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    const child = screen.getByTestId("switcher-artifact-row-tk-1");
+    // The child sits inside a `role="group"` owned by the parent's treeitem -
+    // the structural claim, independent of how the indent is painted.
+    const group = child.closest('ul[role="group"]');
+    expect(group).not.toBeNull();
+    expect(
+      group
+        ?.closest('li[role="treeitem"]')
+        ?.contains(screen.getByTestId("switcher-artifact-row-spec-1")),
+    ).toBe(true);
+    // Chats belong to the Agents category, never this one.
+    expect(screen.queryByTestId("switcher-artifact-row-chat-1")).toBeNull();
+  });
+
+  it("indents by depth, so a child is not flush with its parent", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    const parentIndent = screen
+      .getByTestId("switcher-artifact-row-spec-1")
+      .closest<HTMLElement>("[style]");
+    const childIndent = screen
+      .getByTestId("switcher-artifact-row-tk-1")
+      .closest<HTMLElement>("[style]");
+    expect(parentIndent?.style.paddingLeft).toBe("8px");
+    expect(childIndent?.style.paddingLeft).toBe("28px");
+  });
+
+  it("collapses and re-expands a subtree from the row's own chevron", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    const chevron = screen.getByTestId("switcher-artifact-row-spec-1-toggle");
+    expect(chevron.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(chevron);
+    expect(screen.queryByTestId("switcher-artifact-row-tk-1")).toBeNull();
+    fireEvent.click(screen.getByTestId("switcher-artifact-row-spec-1-toggle"));
+    expect(screen.getByTestId("switcher-artifact-row-tk-1")).toBeTruthy();
+  });
+
+  it("gives a childless row no chevron control", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    expect(
+      screen.queryByTestId("switcher-artifact-row-tk-1-toggle"),
+    ).toBeNull();
+  });
+
+  it("names the status a dot stands for, since a phone cannot hover it", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    const dot = screen.getByLabelText("In Progress");
+    expect(dot.className).toContain(STATUS_DOT_CLASSES[1]);
+  });
+});
+
+describe("<SwitcherArtifactsList /> shared panel controls", () => {
+  it("distinguishes an empty epic from one whose filters hide everything", () => {
+    const empty = render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.queryByTestId("switcher-artifacts-filter-empty")).toBeNull();
+    empty.unmount();
+
+    // Only reviews may pass; the fixture has none, so the tree is filtered
+    // empty rather than genuinely empty.
+    useLeftPanelStore.getState().toggleArtifactKind("epic-1", "review");
+    render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-artifacts-filter-empty")).toBeTruthy();
+    expect(screen.queryByTestId("switcher-artifacts-empty")).toBeNull();
+    expect(
+      screen.getByText("Status, Type, or Read state may be hiding artifacts."),
+    ).toBeTruthy();
+  });
+
+  it("shows the empty state when the epic has no artifacts at all", () => {
+    holder.nodes = [];
+    render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-artifacts-empty")).toBeTruthy();
+    expect(screen.getByText("No artifacts yet.")).toBeTruthy();
+  });
+
+  it("hides a filtered-out root while keeping the ones that match", () => {
+    useLeftPanelStore.getState().toggleArtifactKind("epic-1", "ticket");
+    render(<SwitcherArtifactsList {...PROPS} />);
+    // The parent spec survives as the matched ticket's ancestor - a match must
+    // stay reachable - while the filter is what decides the set.
+    expect(screen.getByTestId("switcher-artifact-row-tk-1")).toBeTruthy();
+    expect(screen.getByTestId("switcher-artifact-row-spec-1")).toBeTruthy();
+  });
+
+  it("offers the desktop filter menu, viewer included", () => {
+    holder.role = "viewer";
+    render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.getByLabelText(/Filter artifacts/)).toBeTruthy();
+    // Creating is still editor-only.
+    expect(screen.queryByTestId("switcher-new-artifact")).toBeNull();
+  });
+});
+
+describe("<SwitcherArtifactsList /> row actions", () => {
+  it("exports a single artifact in both desktop formats", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    openMenu("switcher-more-tk-1");
+    fireEvent.click(screen.getByTestId("switcher-export-markdown-tk-1"));
+    expect(holder.exportCalls).toEqual([{ format: "markdown", ids: ["tk-1"] }]);
+
+    openMenu("switcher-more-tk-1");
+    fireEvent.click(screen.getByTestId("switcher-export-pdf-tk-1"));
+    expect(holder.exportCalls).toHaveLength(2);
+    expect(holder.exportCalls[1].format).toBe("pdf");
+  });
+
+  it("keeps export available to a viewer, without the mutations", () => {
+    holder.role = "viewer";
+    render(<SwitcherArtifactsList {...PROPS} />);
+    openMenu("switcher-more-tk-1");
+    expect(screen.getByTestId("switcher-export-markdown-tk-1")).toBeTruthy();
+    expect(screen.queryByTestId("switcher-rename-tk-1")).toBeNull();
+    expect(screen.queryByTestId("switcher-delete-tk-1")).toBeNull();
+  });
+
+  it("creates a child under the row it was launched from", () => {
+    render(<SwitcherArtifactsList {...PROPS} />);
+    openMenu("switcher-add-child-spec-1");
+    fireEvent.click(screen.getByTestId("switcher-add-child-spec-1-ticket"));
+    expect(holder.createCalls).toEqual([
+      { parentId: "spec-1", artifactType: "ticket" },
+    ]);
+  });
+
+  it("gives a viewer no create affordance on a row", () => {
+    holder.role = "viewer";
+    render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.queryByTestId("switcher-add-child-spec-1")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-create-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-create-actions.test.tsx
@@ -103,6 +103,8 @@ describe("<SwitcherNewArtifactMenu />", () => {
     );
     fireEvent.pointerDown(screen.getByTestId("switcher-new-artifact"));
     fireEvent.click(screen.getByTestId("switcher-new-artifact-spec"));
-    expect(spies.createArtifact).toHaveBeenCalledWith("spec");
+    // The category's "+" creates at the ROOT; a row's add-child menu is what
+    // passes a parent id through the same hook.
+    expect(spies.createArtifact).toHaveBeenCalledWith("spec", null);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -1,8 +1,6 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-agents-list";
-import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
-import { STATUS_DOT_CLASSES } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
 
 interface FixtureRecord {
@@ -456,40 +454,6 @@ describe("<SwitcherTerminalsList />", () => {
   });
 });
 
-describe("<SwitcherArtifactsList />", () => {
-  it("renders artifact rows with a status dot for a ticket", () => {
-    holder.records = [
-      {
-        id: "chat-1",
-        parentId: null,
-        name: "Alpha",
-        type: "chat",
-        status: null,
-        hostId: "host-A",
-      },
-      {
-        id: "tk-1",
-        parentId: null,
-        name: "Ticket One",
-        type: "ticket",
-        status: 1,
-        hostId: "host-A",
-      },
-    ];
-    render(<SwitcherArtifactsList {...PROPS} />);
-    // Chats are excluded from the artifacts list.
-    expect(screen.queryByTestId("switcher-artifact-row-chat-1")).toBeNull();
-    const row = screen.getByTestId("switcher-artifact-row-tk-1");
-    expect(row.textContent).toContain("Ticket One");
-    // The status dot is a decorative (`aria-hidden`) touch-surface affordance
-    // with no title/aria-label - status color is the only signal, mirroring
-    // the desktop `STATUS_DOT_CLASSES` palette.
-    const statusDot = row.querySelector(".rounded-full");
-    expect(statusDot).not.toBeNull();
-    expect(statusDot?.className).toContain(STATUS_DOT_CLASSES[1]);
-  });
-});
-
 describe("switcher create affordances (editor-gated)", () => {
   it("shows the New chat row as the first row for an editor and hides it for a viewer", () => {
     holder.records = [
@@ -551,15 +515,5 @@ describe("switcher create affordances (editor-gated)", () => {
     render(<SwitcherTerminalsList {...PROPS} />);
     expect(screen.getByTestId("switcher-new-terminal")).toBeTruthy();
     expect(screen.getByText("No terminals yet.")).toBeTruthy();
-  });
-
-  it("shows New artifact for an editor and hides it for a viewer", () => {
-    const editor = render(<SwitcherArtifactsList {...PROPS} />);
-    expect(screen.getByTestId("new-artifact-action")).toBeTruthy();
-    editor.unmount();
-
-    holder.role = "viewer";
-    render(<SwitcherArtifactsList {...PROPS} />);
-    expect(screen.queryByTestId("new-artifact-action")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -5,6 +5,7 @@ import {
   SwitcherListEmpty,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SWITCHER_ROW_FLAT } from "@/components/epic-canvas/mobile/switcher-row-nesting";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { SwitcherNewChatRow } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
@@ -154,6 +155,9 @@ function SwitcherAgentRow(props: {
 
   return (
     <SwitcherListRow
+      labelPrefix={null}
+      trailing={null}
+      nesting={SWITCHER_ROW_FLAT}
       icon={
         // No host prop: the icon resolves the row's owner host itself, from the
         // same selector `openHostId` above uses. `record.hostId` is the ACTIVE

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifact-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifact-row.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { v4 as uuidv4 } from "uuid";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SwitcherListRow } from "@/components/epic-canvas/mobile/switcher-list-row";
+import type { SwitcherRowNesting } from "@/components/epic-canvas/mobile/switcher-row-nesting";
+import { SwitcherArtifactKindItems } from "@/components/epic-canvas/mobile/switcher-create-actions";
+import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useSwitcherCreateArtifact } from "@/components/epic-canvas/mobile/use-switcher-create-artifact";
+import { ArtifactUnreadMarker } from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-tree";
+import {
+  ARTIFACTS_TREE_FILTER,
+  useArtifactUnreadMarkerVariant,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-shared";
+import { useFilteredPanelChildIds } from "@/components/epic-canvas/sidebar/epic-sidebar-filter";
+import {
+  STATUS_DOT_CLASSES,
+  STATUS_LABELS,
+  computeArtifactNodeStatusDot,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
+import {
+  EPIC_NODE_ICONS,
+  isEpicArtifactKind,
+  type EpicNodeKind,
+} from "@/lib/artifacts/node-display";
+import {
+  computeDescendantCountsFromTree,
+  formatCascadeSummary,
+} from "@/lib/epic-tree-cascade";
+import {
+  useEpicArtifactStatus,
+  useEpicTreeIndex,
+  useEpicTreeNode,
+} from "@/lib/epic-selectors";
+import { useEpicSessionHostId } from "@/hooks/epic/use-epic-session-host-id";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
+import {
+  isOpenableEpicNodeKind,
+  makeOpenableNodeRef,
+} from "@/stores/epics/canvas/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * Expansion wiring handed down the tree, so every level toggles through the one
+ * store scope the desktop panel uses (`tabId` + `artifacts`) instead of holding
+ * per-row local state that a re-mounted sheet would forget.
+ */
+export interface SwitcherExpansionController {
+  readonly expandedIds: ReadonlySet<string>;
+  readonly toggleExpanded: (id: string) => void;
+  readonly ensureExpanded: (id: string) => void;
+}
+
+interface SwitcherArtifactNodeProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly nodeId: string;
+  readonly depth: number;
+  readonly expansion: SwitcherExpansionController;
+  readonly canMutate: boolean;
+  readonly onClose: () => void;
+}
+
+/**
+ * One artifact in the switcher's tree, plus its expanded children.
+ *
+ * The desktop `ArtifactNode` is not mountable here - it is welded to dnd-kit
+ * dragging, hover-reveal controls and 28px rows, none of which survive a touch
+ * surface. What IS shared is everything above presentation: the same tree
+ * selectors (`useEpicTreeNode` + `useFilteredPanelChildIds`), the same
+ * per-sibling ordering and visibility filtering through the sidebar filter
+ * contexts, the same unread-marker derivation, the same status-dot rule, and
+ * the same create/rename/delete/export mutations.
+ *
+ * The touch geometry - 44px rows, the indent step, a chevron with a tap target
+ * of its own - is `SwitcherListRow`'s, shared with every other category, so the
+ * artifacts tree cannot drift from the agents tree it sits beside.
+ */
+export function SwitcherArtifactNode(props: SwitcherArtifactNodeProps) {
+  const { epicId, tabId, nodeId, depth, expansion, canMutate, onClose } = props;
+  const node = useEpicTreeNode(nodeId);
+  const childIds = useFilteredPanelChildIds(nodeId, ARTIFACTS_TREE_FILTER);
+  const tree = useEpicTreeIndex();
+  const statusValue = useEpicArtifactStatus(nodeId);
+  const isActive = useIsActiveEpicArtifact(tabId, nodeId);
+  const activate = useSwitcherActivate(epicId, tabId, onClose);
+  const activeHostId = useEpicSessionHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
+
+  const expanded = expansion.expandedIds.has(nodeId);
+  const hasChildren = childIds.length > 0;
+  const artifactType: EpicNodeKind = node?.type ?? "spec";
+  const nodeName = node?.title ?? "";
+
+  const unreadMarkerVariant = useArtifactUnreadMarkerVariant({
+    epicId,
+    nodeId,
+    isArtifactKind: isEpicArtifactKind(artifactType),
+    expanded,
+    selfUpdatedAt: node?.updatedAt ?? 0,
+    tree,
+  });
+
+  const onSelect = useCallback(() => {
+    if (!isOpenableEpicNodeKind(artifactType)) return;
+    activate(nodeId, () =>
+      makeOpenableNodeRef({
+        id: nodeId,
+        instanceId: uuidv4(),
+        type: artifactType,
+        name: nodeName,
+        hostId: activeHostId,
+      }),
+    );
+  }, [activate, activeHostId, artifactType, nodeId, nodeName]);
+
+  const onToggle = useCallback(() => {
+    expansion.toggleExpanded(nodeId);
+  }, [expansion, nodeId]);
+
+  const cascadeSummary = useMemo(
+    () => formatCascadeSummary(computeDescendantCountsFromTree(tree, nodeId)),
+    [tree, nodeId],
+  );
+  const nesting = useMemo<SwitcherRowNesting>(
+    () => ({ depth, hasChildren, expanded, onToggle }),
+    [depth, hasChildren, expanded, onToggle],
+  );
+
+  if (node === null) return null;
+  if (!ARTIFACTS_TREE_FILTER(node.type)) return null;
+
+  return (
+    <li role="treeitem" aria-selected={isActive}>
+      <SwitcherListRow
+        labelPrefix={
+          <ArtifactUnreadMarker nodeId={nodeId} variant={unreadMarkerVariant} />
+        }
+        trailing={null}
+        nesting={nesting}
+        icon={<SwitcherArtifactIcon type={artifactType} status={statusValue} />}
+        label={nodeName}
+        active={isActive}
+        onSelect={onSelect}
+        selectTestId={`switcher-artifact-row-${nodeId}`}
+        actions={
+          <>
+            {canMutate ? (
+              <SwitcherArtifactAddChildMenu
+                epicId={epicId}
+                tabId={tabId}
+                parentId={nodeId}
+                parentName={nodeName}
+                onExpandParent={expansion.ensureExpanded}
+                onClose={onClose}
+              />
+            ) : null}
+            <SwitcherRowActions
+              epicId={epicId}
+              tabId={tabId}
+              kind="artifact"
+              nodeId={nodeId}
+              name={nodeName}
+              cascadeSummary={cascadeSummary}
+            />
+          </>
+        }
+      />
+      {hasChildren && expanded ? (
+        <ul role="group">
+          {childIds.map((childId) => (
+            <SwitcherArtifactNode
+              key={childId}
+              epicId={epicId}
+              tabId={tabId}
+              nodeId={childId}
+              depth={depth + 1}
+              expansion={expansion}
+              canMutate={canMutate}
+              onClose={onClose}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * Type glyph with the desktop status dot overlaid. The dot carries its status
+ * as an accessible name rather than desktop's hover tooltip, which a touch
+ * surface can never open - so the row announces "Ticket One, In Progress" and
+ * colour stops being the only carrier of the signal.
+ */
+export function SwitcherArtifactIcon(props: {
+  readonly type: EpicNodeKind;
+  readonly status: number | null;
+}) {
+  const { type, status } = props;
+  const Icon = EPIC_NODE_ICONS[type];
+  const showDot = computeArtifactNodeStatusDot(type, status);
+  return (
+    <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
+      <Icon aria-hidden className="size-4 text-muted-foreground" />
+      {showDot && status !== null ? (
+        <span
+          role="img"
+          aria-label={STATUS_LABELS[status] ?? "Unknown"}
+          className={cn(
+            "absolute -right-1 -bottom-1 size-1.5 rounded-full ring-1 ring-popover",
+            STATUS_DOT_CLASSES[status],
+          )}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * The row's "add child artifact" menu - desktop's hover-revealed "+" as a
+ * permanent control, since a phone row has no rest state to reveal from. Any
+ * artifact can parent any kind, so the menu is the same four entries the
+ * category's own "+" offers; creating expands the parent first so the new child
+ * is not filed somewhere the user cannot see.
+ */
+function SwitcherArtifactAddChildMenu(props: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly parentId: string;
+  readonly parentName: string;
+  readonly onExpandParent: (id: string) => void;
+  readonly onClose: () => void;
+}) {
+  const { epicId, tabId, parentId, parentName, onExpandParent, onClose } =
+    props;
+  const [open, setOpen] = useState(false);
+  const { create, isPending } = useSwitcherCreateArtifact(
+    epicId,
+    tabId,
+    onClose,
+  );
+  const addChild = useCallback(
+    (kind: EpicArtifactKind) => {
+      onExpandParent(parentId);
+      create(kind, parentId);
+    },
+    [create, onExpandParent, parentId],
+  );
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`Add child artifact to ${parentName}`}
+          data-testid={`switcher-add-child-${parentId}`}
+          disabled={isPending}
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          {isPending ? (
+            <AgentSpinningDots
+              className="size-4"
+              testId={undefined}
+              variant="dots2"
+            />
+          ) : (
+            <Plus className="size-4" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <SwitcherArtifactKindItems
+          testIdPrefix={`switcher-add-child-${parentId}`}
+          onSelect={addChild}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifact-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifact-row.tsx
@@ -139,7 +139,11 @@ export function SwitcherArtifactNode(props: SwitcherArtifactNodeProps) {
   if (!ARTIFACTS_TREE_FILTER(node.type)) return null;
 
   return (
-    <li role="treeitem" aria-selected={isActive}>
+    <li
+      role="treeitem"
+      aria-selected={isActive}
+      aria-expanded={hasChildren ? expanded : undefined}
+    >
       <SwitcherListRow
         labelPrefix={
           <ArtifactUnreadMarker nodeId={nodeId} variant={unreadMarkerVariant} />

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -1,35 +1,38 @@
 import { useCallback, useMemo } from "react";
-import { v4 as uuidv4 } from "uuid";
-import {
-  SwitcherListEmpty,
-  SwitcherListHeader,
-  SwitcherListRow,
-} from "@/components/epic-canvas/mobile/switcher-list-row";
-import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { FileText } from "lucide-react";
+import { SwitcherListHeader } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherNewArtifactMenu } from "@/components/epic-canvas/mobile/switcher-create-actions";
-import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
-import { useOrderedSwitcherRecords } from "@/components/epic-canvas/mobile/switcher-record-order";
 import {
-  useEpicArtifactRecords,
-  useEpicPermissionRole,
-  type EpicTreeRecord,
-} from "@/lib/epic-selectors";
+  SwitcherArtifactNode,
+  type SwitcherExpansionController,
+} from "@/components/epic-canvas/mobile/switcher-artifact-row";
+import {
+  applyVisibleFilter,
+  mergeForcedExpanded,
+  SidebarFilterVisibilityContext,
+  SidebarSortContext,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-filter";
+import { ArtifactFilterMenu } from "@/components/epic-canvas/sidebar/epic-sidebar-filter-menu";
+import {
+  useArtifactPanelRootIds,
+  useArtifactVisibleIds,
+  useUnreadArtifactReadTargets,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-shared";
+import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
+import { useAncestorIds, useEpicPermissionRole } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
 import {
-  computeDescendantCounts,
-  formatCascadeSummary,
-} from "@/lib/epic-tree-cascade";
-import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
+  isDefaultSort,
+  makeNodeComparator,
+  type NodeComparator,
+} from "@/lib/epic-sort";
+import { useArtifactSort } from "@/stores/epics/left-panel-store";
+import { useActiveEpicArtifactId } from "@/stores/epics/canvas/canvas-selectors";
 import {
-  STATUS_DOT_CLASSES,
-  computeArtifactNodeStatusDot,
-} from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
-import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
-import {
-  isOpenableEpicNodeKind,
-  makeOpenableNodeRef,
-} from "@/stores/epics/canvas/types";
-import { cn } from "@/lib/utils";
+  useEpicSidebarEffectiveExpanded,
+  useEpicSidebarExpansionStore,
+} from "@/stores/epics/epic-sidebar-expansion-store";
+import { useArtifactReadStateStore } from "@/stores/epics/artifact-read-state-store";
 
 interface SwitcherListProps {
   readonly epicId: string;
@@ -37,126 +40,153 @@ interface SwitcherListProps {
   readonly onClose: () => void;
 }
 
+/** The desktop left panel this list stands in for; keys its shared state. */
+const PANEL_ID = "artifacts";
+
 /**
- * Artifacts category: spec / ticket / story / review as a flat list over the
- * shared `useEpicArtifactRecords()` projection (everything that is not a chat or
- * terminal-agent). Reuses the desktop status-dot helpers; no tree rendering.
+ * Artifacts category: spec / ticket / story / review as the same TREE the
+ * desktop sidebar renders, from the same projector index.
+ *
+ * The list used to filter the flat `useEpicArtifactRecords()` array and sort
+ * the whole slice by recency, which dropped hierarchy entirely and could leave
+ * a child nowhere near its parent. It now walks `rootIds` -> `childIds` through
+ * the shared sidebar selectors, so ordering is per-sibling exactly as it is on
+ * desktop, and the panel's status / type / read filters, sort mode and
+ * expansion state are the SAME per-tab state - change either surface and the
+ * other agrees.
+ *
+ * The two contexts are what make that sharing work: `useFilteredPanelChildIds`
+ * and the unread rollup read the active filter and comparator from them at
+ * every level, so this body publishes them once instead of threading props
+ * through the recursion.
  */
 export function SwitcherArtifactsList(props: SwitcherListProps) {
   const { epicId, tabId, onClose } = props;
-  const records = useEpicArtifactRecords();
-  const filtered = useMemo(
-    () =>
-      records.filter(
-        (record) => record.type !== "chat" && record.type !== "terminal-agent",
-      ),
-    [records],
-  );
-  const artifacts = useOrderedSwitcherRecords(filtered);
   const canMutate = isEditableRole(useEpicPermissionRole());
 
+  const sort = useArtifactSort(epicId);
+  const comparator = useMemo<NodeComparator | null>(
+    () => (isDefaultSort(sort) ? null : makeNodeComparator(sort)),
+    [sort],
+  );
+  const allRootIds = useArtifactPanelRootIds(comparator);
+  const visibleIds = useArtifactVisibleIds(epicId);
+  const rootIds = useMemo(
+    () => applyVisibleFilter(allRootIds, visibleIds),
+    [allRootIds, visibleIds],
+  );
+
+  const activeArtifactId = useActiveEpicArtifactId(tabId);
+  const ancestorIdsOfActive = useAncestorIds(activeArtifactId);
+  const forcedExpandedIds = useMemo(
+    () => mergeForcedExpanded(ancestorIdsOfActive, visibleIds),
+    [ancestorIdsOfActive, visibleIds],
+  );
+  const expandedIds = useEpicSidebarEffectiveExpanded(
+    tabId,
+    PANEL_ID,
+    rootIds,
+    forcedExpandedIds,
+  );
+  const expandAction = useEpicSidebarExpansionStore((s) => s.expand);
+  const collapseAction = useEpicSidebarExpansionStore((s) => s.collapse);
+  const toggleExpanded = useCallback(
+    (id: string) => {
+      if (expandedIds.has(id)) collapseAction(tabId, PANEL_ID, id);
+      else expandAction(tabId, PANEL_ID, id);
+    },
+    [tabId, expandedIds, expandAction, collapseAction],
+  );
+  const ensureExpanded = useCallback(
+    (id: string) => {
+      expandAction(tabId, PANEL_ID, id);
+    },
+    [tabId, expandAction],
+  );
+  const expansion = useMemo<SwitcherExpansionController>(
+    () => ({ expandedIds, toggleExpanded, ensureExpanded }),
+    [expandedIds, toggleExpanded, ensureExpanded],
+  );
+  const unreadArtifacts = useUnreadArtifactReadTargets(epicId);
+  const markRead = useArtifactReadStateStore((state) => state.markRead);
+  const markAllRead = useCallback(() => {
+    unreadArtifacts.forEach((artifact) => {
+      markRead(epicId, artifact.id, artifact.updatedAt);
+    });
+  }, [epicId, markRead, unreadArtifacts]);
+
+  // "Nothing here" and "nothing MATCHES" are different answers, and the second
+  // one has to name the filters as the cause - otherwise a phone user who left
+  // a status filter on reads an epic full of artifacts as empty, with the
+  // control that hid them one tap away and no reason to look at it.
+  const showEmptyState = visibleIds === null && allRootIds.length === 0;
+  const showFilteredEmptyState = visibleIds !== null && rootIds.length === 0;
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <SwitcherListHeader
-        action={
-          canMutate ? (
-            <SwitcherNewArtifactMenu
-              epicId={epicId}
-              tabId={tabId}
-              onClose={onClose}
+    <SidebarSortContext.Provider value={comparator}>
+      <SidebarFilterVisibilityContext.Provider value={visibleIds}>
+        <div className="flex min-h-0 flex-1 flex-col">
+          <SwitcherListHeader
+            action={
+              <>
+                {canMutate ? (
+                  <SwitcherNewArtifactMenu
+                    epicId={epicId}
+                    tabId={tabId}
+                    onClose={onClose}
+                  />
+                ) : null}
+                <ArtifactFilterMenu
+                  epicId={epicId}
+                  tabId={tabId}
+                  collapsed={false}
+                  onMarkAllRead={markAllRead}
+                  markAllReadDisabled={unreadArtifacts.length === 0}
+                />
+              </>
+            }
+          />
+          {showEmptyState || showFilteredEmptyState ? (
+            <SidebarPanelEmptyState
+              icon={FileText}
+              title={
+                showEmptyState
+                  ? "No artifacts yet."
+                  : "No matches for the current filters."
+              }
+              description={
+                showEmptyState
+                  ? null
+                  : "Status, Type, or Read state may be hiding artifacts."
+              }
+              testId={
+                showEmptyState
+                  ? "switcher-artifacts-empty"
+                  : "switcher-artifacts-filter-empty"
+              }
             />
-          ) : null
-        }
-      />
-      {artifacts.length === 0 ? (
-        <SwitcherListEmpty message="No artifacts yet." />
-      ) : (
-        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain p-1 pb-safe-bottom">
-          {artifacts.map((record) => (
-            <SwitcherArtifactRow
-              key={record.id}
-              record={record}
-              records={records}
-              epicId={epicId}
-              tabId={tabId}
-              onClose={onClose}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SwitcherArtifactRow(props: {
-  readonly record: EpicTreeRecord;
-  readonly records: ReadonlyArray<EpicTreeRecord>;
-  readonly epicId: string;
-  readonly tabId: string;
-  readonly onClose: () => void;
-}) {
-  const { record, records, epicId, tabId, onClose } = props;
-  const activate = useSwitcherActivate(epicId, tabId, onClose);
-  const isActive = useIsActiveEpicArtifact(tabId, record.id);
-
-  const onSelect = useCallback(() => {
-    const type = record.type;
-    if (!isOpenableEpicNodeKind(type)) return;
-    activate(record.id, () =>
-      makeOpenableNodeRef({
-        id: record.id,
-        instanceId: uuidv4(),
-        type,
-        name: record.name,
-        hostId: record.hostId,
-      }),
-    );
-  }, [activate, record]);
-
-  const cascadeSummary = formatCascadeSummary(
-    computeDescendantCounts(records, record.id),
-  );
-
-  return (
-    <SwitcherListRow
-      icon={<SwitcherArtifactIcon type={record.type} status={record.status} />}
-      label={record.name}
-      active={isActive}
-      onSelect={onSelect}
-      selectTestId={`switcher-artifact-row-${record.id}`}
-      actions={
-        <SwitcherRowActions
-          epicId={epicId}
-          tabId={tabId}
-          kind="artifact"
-          nodeId={record.id}
-          name={record.name}
-          cascadeSummary={cascadeSummary}
-        />
-      }
-    />
-  );
-}
-
-function SwitcherArtifactIcon(props: {
-  readonly type: EpicTreeRecord["type"];
-  readonly status: number | null;
-}) {
-  const { type, status } = props;
-  const Icon = EPIC_NODE_ICONS[type];
-  const showDot = computeArtifactNodeStatusDot(type, status);
-  return (
-    <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
-      <Icon aria-hidden className="size-4 text-muted-foreground" />
-      {showDot && status !== null ? (
-        <span
-          aria-hidden
-          className={cn(
-            "absolute -right-1 -bottom-1 size-1.5 rounded-full ring-1 ring-popover",
-            STATUS_DOT_CLASSES[status],
+          ) : (
+            <ul
+              role="tree"
+              aria-label="Epic artifacts tree"
+              className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain p-1 pb-safe-bottom"
+            >
+              {rootIds.map((nodeId) => (
+                <SwitcherArtifactNode
+                  key={nodeId}
+                  epicId={epicId}
+                  tabId={tabId}
+                  nodeId={nodeId}
+                  depth={0}
+                  expansion={expansion}
+                  canMutate={canMutate}
+                  onClose={onClose}
+                />
+              ))}
+            </ul>
           )}
-        />
-      ) : null}
-    </span>
+        </div>
+      </SidebarFilterVisibilityContext.Provider>
+    </SidebarSortContext.Provider>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-create-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-create-actions.tsx
@@ -90,6 +90,32 @@ export function SwitcherNewTerminalRow(props: SwitcherCreateProps) {
 }
 
 /**
+ * The four artifact kinds as menu items, shared by the category's "New
+ * artifact" menu and a row's "add child" menu so both offer the same set under
+ * the same labels and icons. `testIdPrefix` scopes the ids to the surface that
+ * mounted them (`switcher-new-artifact`, `switcher-add-child-<nodeId>`).
+ */
+export function SwitcherArtifactKindItems(props: {
+  readonly testIdPrefix: string;
+  readonly onSelect: (kind: EpicArtifactKind) => void;
+}) {
+  const { testIdPrefix, onSelect } = props;
+  return ARTIFACT_KINDS.map((kind) => {
+    const Icon = EPIC_NODE_ICONS[kind];
+    return (
+      <DropdownMenuItem
+        key={kind}
+        data-testid={`${testIdPrefix}-${kind}`}
+        onSelect={() => onSelect(kind)}
+      >
+        <Icon className="size-3.5" />
+        {EPIC_NODE_LABELS[kind]}
+      </DropdownMenuItem>
+    );
+  });
+}
+
+/**
  * "New artifact" affordance for the Artifacts category: a curated kind menu
  * (spec / ticket / story / review) that fires the exact desktop create path
  * (`useEpicCreateArtifact` + open-when-projected). The artifact tile is not an
@@ -132,19 +158,10 @@ export function SwitcherNewArtifactMenu(props: {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {ARTIFACT_KINDS.map((kind) => {
-          const Icon = EPIC_NODE_ICONS[kind];
-          return (
-            <DropdownMenuItem
-              key={kind}
-              data-testid={`switcher-new-artifact-${kind}`}
-              onSelect={() => create(kind)}
-            >
-              <Icon className="size-3.5" />
-              {EPIC_NODE_LABELS[kind]}
-            </DropdownMenuItem>
-          );
-        })}
+        <SwitcherArtifactKindItems
+          testIdPrefix="switcher-new-artifact"
+          onSelect={(kind) => create(kind, null)}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -1,29 +1,82 @@
 import type { ReactNode } from "react";
 import { Check, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { TreeChevron, TreeChevronSpacer } from "@/components/ui/tree-chevron";
+import {
+  SWITCHER_ROW_BASE_PAD_LEFT,
+  SWITCHER_ROW_INDENT_PX,
+  type SwitcherRowNesting,
+} from "@/components/epic-canvas/mobile/switcher-row-nesting";
 
 /**
- * One flat row in a switcher category list: leading icon, truncating label, a
- * check on the active tile, and an optional trailing "…" actions slot. Tapping
- * the row body activates the tile; the actions slot (null for viewers) is a
- * sibling button so its taps never trigger a row open. The 44px min height plus
- * the sheet's coarse-pointer touch scope satisfy the touch-target guideline.
+ * One row in a switcher category list: an indent-and-chevron nesting cluster,
+ * leading icon, truncating label, a trailing metadata slot, a check on the
+ * active tile, and an optional "…" actions slot. Tapping the row body activates
+ * the tile; the chevron and the actions slot are SIBLING buttons, so neither
+ * their taps nor their touch targets ever trigger a row open.
+ *
+ * The 44px min height plus the sheet's coarse-pointer touch scope satisfy the
+ * touch-target guideline, and they are why the chevron is a real 44px control
+ * rather than the desktop tree's 14px hover glyph: expand/collapse is the only
+ * way to reach a deep child on a phone, so it cannot be the hardest thing on
+ * the row to hit.
  */
 export function SwitcherListRow(props: {
   readonly icon: ReactNode;
   readonly label: string;
+  /** Rendered immediately before the label, inside the truncating cluster. */
+  readonly labelPrefix: ReactNode;
+  /** Right-aligned metadata (relative time, shared glyph); null for none. */
+  readonly trailing: ReactNode;
+  readonly nesting: SwitcherRowNesting;
   readonly active: boolean;
   readonly onSelect: () => void;
   readonly actions: ReactNode;
   readonly selectTestId: string;
 }) {
-  const { icon, label, active, onSelect, actions, selectTestId } = props;
+  const {
+    icon,
+    label,
+    labelPrefix,
+    trailing,
+    nesting,
+    active,
+    onSelect,
+    actions,
+    selectTestId,
+  } = props;
   return (
     // `min-w-0` at both this wrapper and the button: the label's truncate
     // only engages while every flex level above it may shrink below its
     // content. One level with an auto min-width re-inflates the row to the
     // full label width, and the list scrolls sideways instead of ellipsizing.
-    <div className="flex min-w-0 items-center gap-1">
+    <div
+      className="flex min-w-0 items-center gap-1"
+      style={{
+        paddingLeft: `${nesting.depth * SWITCHER_ROW_INDENT_PX + SWITCHER_ROW_BASE_PAD_LEFT}px`,
+      }}
+    >
+      {nesting.hasChildren ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={nesting.onToggle}
+          aria-label={`${nesting.expanded ? "Collapse" : "Expand"} ${label}`}
+          aria-expanded={nesting.expanded}
+          data-testid={`${selectTestId}-toggle`}
+          className="size-11 shrink-0 text-muted-foreground"
+        >
+          <TreeChevron expanded={nesting.expanded} onToggle={undefined} />
+        </Button>
+      ) : (
+        // Keeps every leaf's icon on its siblings' column. Sized to the chevron
+        // BUTTON, not the glyph, or a leaf would sit 30px left of a parent at
+        // the same depth and the indent would stop reading as depth at all.
+        <span className="flex size-11 shrink-0 items-center justify-center">
+          <TreeChevronSpacer />
+        </span>
+      )}
       <Button
         type="button"
         variant="ghost"
@@ -35,9 +88,13 @@ export function SwitcherListRow(props: {
         <span className="flex size-4 shrink-0 items-center justify-center">
           {icon}
         </span>
-        <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
-          {label}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5">
+          {labelPrefix}
+          <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
+            {label}
+          </span>
         </span>
+        {trailing}
         {active ? (
           <Check
             className="size-4 shrink-0 text-primary"

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { FileDown, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -21,6 +22,7 @@ import { isEditableRole } from "@/lib/epic-permissions";
 import { useEpicDeleteChat } from "@/hooks/epic/use-epic-chat-mutations";
 import { useEpicDeleteTuiAgent } from "@/hooks/epic/use-epic-tui-agent-mutations";
 import { useEpicDeleteArtifact } from "@/hooks/epic/use-epic-node-mutations";
+import { useEpicExportArtifacts } from "@/hooks/epic/use-epic-export-artifacts-mutation";
 import { useTerminalKillFor } from "@/hooks/terminal/use-terminal-kill-for-mutation";
 import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
@@ -45,17 +47,97 @@ const RENAME_TITLE: Record<SwitcherRowKind, string> = {
   terminal: "Rename terminal",
 };
 
+const NO_LEADING_ENTRIES: ReadonlyArray<SidebarRowMenuEntry> = [];
+
 /**
- * The per-row "…" actions for the switcher's flat lists: Rename + Delete for
- * agents/artifacts (delete confirmed), Rename + Close for PTY terminals (Close
- * is immediate, matching desktop parity). Reuses the exact desktop mutation
- * hooks and the shared row-menu item renderer; the whole affordance is
- * editor-gated (a viewer gets no menu at all, so no dead-end mutations). Delete
- * also closes the item's open canvas tile so the mobile view never lands on a
- * dead tile.
+ * The per-row "…" actions for the switcher's lists: Export + Rename + Delete
+ * for artifacts, Rename + Delete for agents (delete confirmed), Rename + Close
+ * for PTY terminals (Close is immediate, matching desktop parity). Reuses the
+ * exact desktop mutation hooks and the shared row-menu item renderer.
+ *
+ * Mutations are editor-gated, so a viewer sees no dead-end rename/delete. The
+ * artifact exports are NOT - they read, exactly as the desktop artifact row's
+ * menu offers them to a viewer - so an artifact row keeps its menu for a viewer
+ * with the two export entries alone, and every other row kind still drops the
+ * whole affordance.
+ *
+ * Delete also closes the item's open canvas tile so the mobile view never lands
+ * on a dead tile.
+ *
+ * Artifact rows go through their own component rather than a branch inside the
+ * body: the export mutation is an artifact concern, and a hook called in the
+ * shared body would make every agent and terminal row instantiate it too.
  */
 export function SwitcherRowActions(props: SwitcherRowActionsProps) {
-  const { epicId, tabId, kind, nodeId, name, cascadeSummary } = props;
+  if (props.kind === "artifact")
+    return <SwitcherArtifactRowActions {...props} />;
+  return (
+    <SwitcherRowActionsMenu {...props} leadingEntries={NO_LEADING_ENTRIES} />
+  );
+}
+
+/** Artifact rows, whose menu opens with the two desktop export entries. */
+function SwitcherArtifactRowActions(props: SwitcherRowActionsProps) {
+  const { nodeId, name } = props;
+  const exportArtifacts = useEpicExportArtifacts();
+  const exportOne = (format: "markdown" | "pdf"): void => {
+    exportArtifacts.mutate({
+      artifacts: [{ id: nodeId, title: name }],
+      format,
+      archive: false,
+      archiveTitle: null,
+    });
+  };
+  const exportIcon = exportArtifacts.isPending ? (
+    <AgentSpinningDots
+      className={undefined}
+      testId={undefined}
+      variant={undefined}
+    />
+  ) : (
+    <FileDown className="size-3.5" />
+  );
+  const entries: ReadonlyArray<SidebarRowMenuEntry> = [
+    {
+      kind: "item",
+      id: "export-markdown",
+      label: "Export as Markdown",
+      icon: exportIcon,
+      disabled: exportArtifacts.isPending,
+      disabledTooltip: null,
+      variant: "default",
+      testIds: {
+        dropdown: `switcher-export-markdown-${nodeId}`,
+        context: `switcher-export-markdown-ctx-${nodeId}`,
+      },
+      onSelect: () => exportOne("markdown"),
+    },
+    {
+      kind: "item",
+      id: "export-pdf",
+      label: "Export as PDF",
+      icon: exportIcon,
+      disabled: exportArtifacts.isPending,
+      disabledTooltip: null,
+      variant: "default",
+      testIds: {
+        dropdown: `switcher-export-pdf-${nodeId}`,
+        context: `switcher-export-pdf-ctx-${nodeId}`,
+      },
+      onSelect: () => exportOne("pdf"),
+    },
+  ];
+  return <SwitcherRowActionsMenu {...props} leadingEntries={entries} />;
+}
+
+function SwitcherRowActionsMenu(
+  props: SwitcherRowActionsProps & {
+    /** Read-only entries shown above the editor-gated ones. */
+    readonly leadingEntries: ReadonlyArray<SidebarRowMenuEntry>;
+  },
+) {
+  const { epicId, tabId, kind, nodeId, name, cascadeSummary, leadingEntries } =
+    props;
   const canMutate = isEditableRole(useEpicPermissionRole());
   const [renameOpen, setRenameOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -130,8 +212,6 @@ export function SwitcherRowActions(props: SwitcherRowActionsProps) {
     killTerminal.mutate({ sessionId: nodeId });
   }, [closeOpenTile, killTerminal, nodeId]);
 
-  if (!canMutate) return null;
-
   const isTerminal = kind === "terminal";
   const deleteLabel = isTerminal ? "Close" : "Delete";
   const deletePending =
@@ -139,37 +219,52 @@ export function SwitcherRowActions(props: SwitcherRowActionsProps) {
     deleteTuiAgent.isPending ||
     deleteArtifact.isPending;
 
-  const entries: ReadonlyArray<SidebarRowMenuEntry> = [
-    {
-      kind: "item",
-      id: "rename",
-      label: "Rename",
-      icon: <Pencil className="size-3.5" />,
-      disabled: false,
-      disabledTooltip: null,
-      variant: "default",
-      testIds: {
-        dropdown: `switcher-rename-${nodeId}`,
-        context: `switcher-rename-ctx-${nodeId}`,
-      },
-      onSelect: () => setRenameOpen(true),
-    },
-    { kind: "separator", id: "before-delete" },
-    {
-      kind: "item",
-      id: "delete",
-      label: deleteLabel,
-      icon: <Trash2 className="size-3.5" />,
-      disabled: isTerminal ? killTerminal.isPending : false,
-      disabledTooltip: null,
-      variant: "destructive",
-      testIds: {
-        dropdown: `switcher-delete-${nodeId}`,
-        context: `switcher-delete-ctx-${nodeId}`,
-      },
-      onSelect: isTerminal ? closeTerminal : () => setConfirmOpen(true),
-    },
-  ];
+  const mutateEntries: ReadonlyArray<SidebarRowMenuEntry> = canMutate
+    ? [
+        {
+          kind: "item",
+          id: "rename",
+          label: "Rename",
+          icon: <Pencil className="size-3.5" />,
+          disabled: false,
+          disabledTooltip: null,
+          variant: "default",
+          testIds: {
+            dropdown: `switcher-rename-${nodeId}`,
+            context: `switcher-rename-ctx-${nodeId}`,
+          },
+          onSelect: () => setRenameOpen(true),
+        },
+        { kind: "separator", id: "before-delete" },
+        {
+          kind: "item",
+          id: "delete",
+          label: deleteLabel,
+          icon: <Trash2 className="size-3.5" />,
+          disabled: isTerminal ? killTerminal.isPending : false,
+          disabledTooltip: null,
+          variant: "destructive",
+          testIds: {
+            dropdown: `switcher-delete-${nodeId}`,
+            context: `switcher-delete-ctx-${nodeId}`,
+          },
+          onSelect: isTerminal ? closeTerminal : () => setConfirmOpen(true),
+        },
+      ]
+    : [];
+
+  // The joining separator belongs to neither group: it exists only when both
+  // are present, so a viewer's export-only menu has no dangling rule.
+  const entries: ReadonlyArray<SidebarRowMenuEntry> =
+    leadingEntries.length > 0 && mutateEntries.length > 0
+      ? [
+          ...leadingEntries,
+          { kind: "separator", id: "after-export" },
+          ...mutateEntries,
+        ]
+      : [...leadingEntries, ...mutateEntries];
+
+  if (entries.length === 0) return null;
 
   return (
     <>

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-nesting.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-nesting.ts
@@ -1,0 +1,22 @@
+/** Indent per tree level, and the pad the shallowest row still gets. Wider than
+ *  the desktop sidebar's 16px: a phone row carries no vertical guide rail, so
+ *  the step itself has to carry the level, and it is read at arm's length. */
+export const SWITCHER_ROW_INDENT_PX = 20;
+export const SWITCHER_ROW_BASE_PAD_LEFT = 8;
+
+/** The nesting controls of a row that has children, or the spacer that keeps a
+ *  leaf's icon on the same optical column as its siblings'. */
+export interface SwitcherRowNesting {
+  readonly depth: number;
+  readonly hasChildren: boolean;
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+}
+
+/** A leaf at the top level: the shape a category that has no tree passes. */
+export const SWITCHER_ROW_FLAT: SwitcherRowNesting = {
+  depth: 0,
+  hasChildren: false,
+  expanded: false,
+  onToggle: () => undefined,
+};

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -6,6 +6,7 @@ import {
   SwitcherListEmpty,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SWITCHER_ROW_FLAT } from "@/components/epic-canvas/mobile/switcher-row-nesting";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { SwitcherNewTerminalRow } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
@@ -111,6 +112,9 @@ function SwitcherTerminalRow(props: {
 
   return (
     <SwitcherListRow
+      labelPrefix={null}
+      trailing={null}
+      nesting={SWITCHER_ROW_FLAT}
       icon={<Terminal className="size-4 shrink-0 text-muted-foreground" />}
       label={label}
       active={isActive}

--- a/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-create-artifact.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-create-artifact.ts
@@ -11,7 +11,7 @@ import { DEFAULT_EPIC_NODE_NAMES } from "@/lib/artifacts/node-display";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
 
 export interface SwitcherCreateArtifact {
-  readonly create: (type: EpicArtifactKind) => void;
+  readonly create: (type: EpicArtifactKind, parentId: string | null) => void;
   readonly isPending: boolean;
 }
 
@@ -23,6 +23,12 @@ export interface SwitcherCreateArtifact {
  * the sheet's active-tile watcher to close. The desktop's inline
  * pending-create staging (a left-panel-only UI) is intentionally omitted; the
  * create + open functions are identical.
+ *
+ * `parentId` names the artifact the new one nests under - `null` for the
+ * category's root "+", a node id for a row's "add child". The desktop
+ * add-child path also requests editor focus on the opened tile; the switcher
+ * omits that, matching the app's other phone surfaces, which never autofocus a
+ * field the user did not tap.
  */
 export function useSwitcherCreateArtifact(
   epicId: string,
@@ -38,11 +44,11 @@ export function useSwitcherCreateArtifact(
   const activeHostId = useEpicSessionHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
 
   const create = useCallback(
-    (type: EpicArtifactKind) => {
+    (type: EpicArtifactKind, parentId: string | null) => {
       createArtifact.mutate(
         {
           epicId,
-          parentId: null,
+          parentId,
           artifactType: type,
           title: DEFAULT_EPIC_NODE_NAMES[type],
         },

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-shared.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-shared.ts
@@ -12,11 +12,7 @@ import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { isEpicArtifactKind } from "@/lib/artifacts/node-display";
 import { sortNodeIds, type NodeComparator } from "@/lib/epic-sort";
-import {
-  useEpicArtifactRecords,
-  useEpicTreeIndex,
-  useRootIds,
-} from "@/lib/epic-selectors";
+import { useEpicTreeIndex, useRootIds } from "@/lib/epic-selectors";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import {
   isArtifactUnread,
@@ -238,11 +234,17 @@ export function useArtifactUnreadMarkerVariant(args: {
 /**
  * Every artifact in the epic that currently reads as unread, with the version
  * that would mark it read - the input to a panel's "Mark all as read".
+ *
+ * Derived from the tree index rather than `useEpicArtifactRecords()` for the
+ * reason {@link useArtifactPanelRootIds} documents: that array is rebuilt, with
+ * fresh record objects, on every store tick, so a streaming chat re-ran this
+ * whole scan per token. `nodeById` is built from the same artifact entries and
+ * carries the same `type` and `updatedAt`, and is identity-stable while
+ * streaming.
  */
 export function useUnreadArtifactReadTargets(
   epicId: string,
 ): ReadonlyArray<ArtifactReadTarget> {
-  const records = useEpicArtifactRecords();
   const tree = useEpicTreeIndex();
   const readState = useArtifactReadStateStore(
     useShallow((s) => ({
@@ -252,20 +254,18 @@ export function useUnreadArtifactReadTargets(
   );
   return useMemo(
     () =>
-      records.flatMap((record) => {
-        if (!isEpicArtifactKind(record.type)) return [];
-        if (!Object.hasOwn(tree.nodeById, record.id)) return [];
-        const node = tree.nodeById[record.id];
+      Object.values(tree.nodeById).flatMap((node) => {
+        if (!isEpicArtifactKind(node.type)) return [];
         return isArtifactUnread({
           epicId,
-          artifactId: record.id,
+          artifactId: node.id,
           updatedAt: node.updatedAt,
           seedAtByEpic: readState.seedAtByEpic,
           lastSeenByArtifact: readState.lastSeenByArtifact,
         })
-          ? [{ id: record.id, updatedAt: node.updatedAt }]
+          ? [{ id: node.id, updatedAt: node.updatedAt }]
           : [];
       }),
-    [epicId, readState, records, tree],
+    [epicId, readState, tree],
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-shared.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-shared.ts
@@ -1,0 +1,271 @@
+/**
+ * The artifact panel's shared, presentation-free logic: which nodes belong to
+ * the panel, which of them a filter leaves visible, how a row's unread marker
+ * is derived, and what "mark all as read" would clear.
+ *
+ * It lives apart from `epic-sidebar-artifact-tree.tsx` because two surfaces
+ * render the same artifact tree from it - the desktop sidebar panel and the
+ * mobile tab-switcher's Artifacts category - and neither may fork the rules
+ * that decide WHICH artifacts a user sees. Only the rows differ.
+ */
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { isEpicArtifactKind } from "@/lib/artifacts/node-display";
+import { sortNodeIds, type NodeComparator } from "@/lib/epic-sort";
+import {
+  useEpicArtifactRecords,
+  useEpicTreeIndex,
+  useRootIds,
+} from "@/lib/epic-selectors";
+import { useEpicStore } from "@/hooks/use-epic-store";
+import {
+  isArtifactUnread,
+  useArtifactReadStateStore,
+} from "@/stores/epics/artifact-read-state-store";
+import {
+  isArtifactFilterActive,
+  useArtifactFilter,
+} from "@/stores/epics/left-panel-store";
+import type { TreeSlice } from "@/stores/epics/open-epic/types";
+import {
+  collectWithAncestors,
+  useSidebarVisibleIds,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-filter";
+
+export type TreeFilterFn = (type: string | null | undefined) => boolean;
+
+export const ARTIFACTS_TREE_FILTER: TreeFilterFn = (type) =>
+  type !== null &&
+  type !== undefined &&
+  type !== "chat" &&
+  type !== "terminal" &&
+  type !== "terminal-agent";
+
+export type ArtifactUnreadMarkerVariant = "self" | "descendant";
+
+interface ArtifactDescendantEntry {
+  readonly id: string;
+  readonly updatedAt: number;
+}
+
+interface ArtifactReadTarget {
+  readonly id: string;
+  readonly updatedAt: number;
+}
+
+const EMPTY_DESCENDANT_ENTRIES: ReadonlyArray<ArtifactDescendantEntry> = [];
+
+export function useArtifactPanelRootIds(
+  comparator: NodeComparator | null,
+): ReadonlyArray<string> {
+  const yDocRootIds = useRootIds();
+  // Filter roots by the TREE node's type, not the projected artifact records.
+  // `useEpicArtifactRecords()` rebuilds a fresh record array (and fresh record
+  // objects) on every store tick, so during chat streaming the active chat's
+  // record changes identity each token and `liveRecords` churns - which used to
+  // recompute this memo, churn `rootIds` -> `expandedIds` -> the `expansion`
+  // controller, and re-render every memoized `ArtifactNode`. The tree index
+  // (`s.tree`) does NOT change on chat tokens, and its `nodeById[id].type` is
+  // the same value space this `treeFilter` already uses for CHILD nodes
+  // (`usePanelChildIds`), so the result is identical but identity-stable while
+  // streaming.
+  const tree = useEpicTreeIndex();
+  return useMemo(() => {
+    const treeFilter = ARTIFACTS_TREE_FILTER;
+    const roots = yDocRootIds.filter(
+      (rootId) =>
+        Object.hasOwn(tree.nodeById, rootId) &&
+        treeFilter(tree.nodeById[rootId].type),
+    );
+    // `yDocRootIds` is in projector (default) order; re-sort only for a
+    // non-default mode (`comparator !== null`).
+    return sortNodeIds(roots, tree.nodeById, comparator);
+  }, [tree, yDocRootIds, comparator]);
+}
+
+/**
+ * Visible-id set for an active artifact filter (status / kind / read), expanded
+ * to include ancestors so a matched ticket nested under a spec stays reachable.
+ * Status and read are evaluated only against artifacts that carry them; specs
+ * and reviews (status `null`, never assignable) drop out whenever a status or
+ * kind constraint excludes them. `null` when no filter is active.
+ */
+export function useArtifactVisibleIds(
+  epicId: string,
+): ReadonlySet<string> | null {
+  const filter = useArtifactFilter(epicId);
+  const artifacts = useEpicStore((s) => s.artifacts);
+  const tree = useEpicTreeIndex();
+  const readState = useArtifactReadStateStore(
+    useShallow((s) => ({
+      seedAtByEpic: s.seedAtByEpic,
+      lastSeenByArtifact: s.lastSeenByArtifact,
+    })),
+  );
+  return useMemo(() => {
+    if (!isArtifactFilterActive(filter)) return null;
+    const statusSet = new Set<number>(filter.statuses);
+    const kindSet = new Set<string>(filter.kinds);
+    const matches: string[] = [];
+    for (const id of artifacts.allIds) {
+      if (!Object.hasOwn(artifacts.byId, id)) continue;
+      const artifact = artifacts.byId[id];
+      if (kindSet.size > 0 && !kindSet.has(artifact.kind)) continue;
+      if (
+        statusSet.size > 0 &&
+        (artifact.status === null || !statusSet.has(artifact.status))
+      ) {
+        continue;
+      }
+      if (filter.read !== "all") {
+        const unread = isArtifactUnread({
+          epicId,
+          artifactId: artifact.id,
+          updatedAt: artifact.updatedAt,
+          seedAtByEpic: readState.seedAtByEpic,
+          lastSeenByArtifact: readState.lastSeenByArtifact,
+        });
+        if (filter.read === "unread" && !unread) continue;
+        if (filter.read === "read" && unread) continue;
+      }
+      matches.push(artifact.id);
+    }
+    return collectWithAncestors(matches, tree.nodeById);
+  }, [filter, artifacts, tree, readState, epicId]);
+}
+
+/**
+ * Collect the artifact-kind descendants of `nodeId` (id + version) so a
+ * collapsed parent can roll up "contains unread artifacts" without mounting its
+ * children. When a filter is active (`visibleIds !== null`), descendants hidden
+ * by the filter are skipped along with their subtree - the rollup must never
+ * point at a child the user cannot reach by expanding. Cycle-guarded via
+ * `visited`.
+ */
+function collectDescendantArtifactEntries(
+  nodeId: string,
+  tree: TreeSlice,
+  visibleIds: ReadonlySet<string> | null,
+): ReadonlyArray<ArtifactDescendantEntry> {
+  const rootChildren = Object.hasOwn(tree.childrenByParent, nodeId)
+    ? tree.childrenByParent[nodeId]
+    : null;
+  if (rootChildren === null || rootChildren.length === 0) {
+    return EMPTY_DESCENDANT_ENTRIES;
+  }
+  const entries: ArtifactDescendantEntry[] = [];
+  const visited = new Set<string>([nodeId]);
+  const stack = [...rootChildren];
+  while (stack.length > 0) {
+    const id = stack.pop();
+    if (id === undefined || visited.has(id)) continue;
+    visited.add(id);
+    // A filtered-out node has no visible descendants (the visible set is
+    // matches plus their ancestors), so skip its whole subtree.
+    if (visibleIds !== null && !visibleIds.has(id)) continue;
+    if (!Object.hasOwn(tree.nodeById, id)) continue;
+    const node = tree.nodeById[id];
+    if (isEpicArtifactKind(node.type)) {
+      entries.push({ id, updatedAt: node.updatedAt });
+    }
+    if (Object.hasOwn(tree.childrenByParent, id)) {
+      for (const childId of tree.childrenByParent[id]) stack.push(childId);
+    }
+  }
+  return entries;
+}
+
+/**
+ * Per-node unread marker variant, subscribed narrowly so marking one artifact
+ * read re-renders only the affected row and its collapsed ancestors - never the
+ * whole tree. The read-state selector returns a scalar variant, so Zustand
+ * bails the render for any node whose variant did not flip. Returns:
+ *   - "self": this artifact itself has unread changes.
+ *   - "descendant": this collapsed parent hides unread artifacts.
+ *   - null: nothing to show (non-artifact row, or expanded parent with no self
+ *     unread).
+ * This mirrors the per-entity `useIsActive...` pattern instead of threading a
+ * tab-wide map through the recursive node tree.
+ */
+export function useArtifactUnreadMarkerVariant(args: {
+  readonly epicId: string;
+  readonly nodeId: string;
+  readonly isArtifactKind: boolean;
+  readonly expanded: boolean;
+  readonly selfUpdatedAt: number;
+  readonly tree: TreeSlice;
+}): ArtifactUnreadMarkerVariant | null {
+  const { epicId, nodeId, isArtifactKind, expanded, selfUpdatedAt, tree } =
+    args;
+  const visibleIds = useSidebarVisibleIds();
+  const descendantEntries = useMemo(
+    () =>
+      !isArtifactKind || expanded
+        ? EMPTY_DESCENDANT_ENTRIES
+        : collectDescendantArtifactEntries(nodeId, tree, visibleIds),
+    [isArtifactKind, expanded, nodeId, tree, visibleIds],
+  );
+  return useArtifactReadStateStore((state) => {
+    if (!isArtifactKind) return null;
+    if (
+      isArtifactUnread({
+        epicId,
+        artifactId: nodeId,
+        updatedAt: selfUpdatedAt,
+        seedAtByEpic: state.seedAtByEpic,
+        lastSeenByArtifact: state.lastSeenByArtifact,
+      })
+    ) {
+      return "self";
+    }
+    for (const entry of descendantEntries) {
+      if (
+        isArtifactUnread({
+          epicId,
+          artifactId: entry.id,
+          updatedAt: entry.updatedAt,
+          seedAtByEpic: state.seedAtByEpic,
+          lastSeenByArtifact: state.lastSeenByArtifact,
+        })
+      ) {
+        return "descendant";
+      }
+    }
+    return null;
+  });
+}
+
+/**
+ * Every artifact in the epic that currently reads as unread, with the version
+ * that would mark it read - the input to a panel's "Mark all as read".
+ */
+export function useUnreadArtifactReadTargets(
+  epicId: string,
+): ReadonlyArray<ArtifactReadTarget> {
+  const records = useEpicArtifactRecords();
+  const tree = useEpicTreeIndex();
+  const readState = useArtifactReadStateStore(
+    useShallow((s) => ({
+      seedAtByEpic: s.seedAtByEpic,
+      lastSeenByArtifact: s.lastSeenByArtifact,
+    })),
+  );
+  return useMemo(
+    () =>
+      records.flatMap((record) => {
+        if (!isEpicArtifactKind(record.type)) return [];
+        if (!Object.hasOwn(tree.nodeById, record.id)) return [];
+        const node = tree.nodeById[record.id];
+        return isArtifactUnread({
+          epicId,
+          artifactId: record.id,
+          updatedAt: node.updatedAt,
+          seedAtByEpic: readState.seedAtByEpic,
+          lastSeenByArtifact: readState.lastSeenByArtifact,
+        })
+          ? [{ id: record.id, updatedAt: node.updatedAt }]
+          : [];
+      }),
+    [epicId, readState, records, tree],
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -50,9 +50,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  isArtifactFilterActive,
   useAcknowledgedRootCreatePending,
-  useArtifactFilter,
   useArtifactSort,
   useLocalRootCreatePending,
   type RootCreatePanelId,
@@ -60,7 +58,6 @@ import {
 import {
   isDefaultSort,
   makeNodeComparator,
-  sortNodeIds,
   type NodeComparator,
 } from "@/lib/epic-sort";
 import {
@@ -78,10 +75,7 @@ import {
   useEpicSidebarEffectiveExpanded,
   useEpicSidebarExpansionStore,
 } from "@/stores/epics/epic-sidebar-expansion-store";
-import {
-  isArtifactUnread,
-  useArtifactReadStateStore,
-} from "@/stores/epics/artifact-read-state-store";
+import { useArtifactReadStateStore } from "@/stores/epics/artifact-read-state-store";
 import {
   useAncestorIds,
   useEpicArtifactStatus,
@@ -89,7 +83,6 @@ import {
   useEpicPermissionRole,
   useEpicTreeIndex,
   useEpicTreeNode,
-  useRootIds,
 } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
 import { useSettingsStore } from "@/stores/settings/settings-store";
@@ -129,20 +122,17 @@ import {
 import { TreeGroupGuide } from "./epic-sidebar-tree-guide";
 import {
   applyVisibleFilter,
-  collectWithAncestors,
   isFilteredTreeEmpty,
   mergeForcedExpanded,
   SidebarFilterVisibilityContext,
   SidebarSortContext,
   useFilteredPanelChildIds,
-  useSidebarVisibleIds,
 } from "./epic-sidebar-filter";
 import {
   collectVisibleSidebarTreeIds,
   useMaybeSidebarBulkSelection,
 } from "./epic-sidebar-selection";
 import { useEpicStore } from "@/hooks/use-epic-store";
-import { useShallow } from "zustand/react/shallow";
 import {
   getSidebarNodeDragId,
   getPaneScopedDndId,
@@ -151,31 +141,29 @@ import {
 } from "@/components/epic-canvas/dnd/dnd";
 import { SidebarReparentRowDropWrapper } from "@/components/epic-canvas/sidebar/sidebar-reparent-row-drop-wrapper";
 import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
-import type { ArtifactsSlice, TreeSlice } from "@/stores/epics/open-epic/types";
+import type { ArtifactsSlice } from "@/stores/epics/open-epic/types";
 import {
   SidebarContextMenuItems,
   SidebarDropdownMenuItems,
   type SidebarRowMenuEntry,
 } from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+import {
+  ARTIFACTS_TREE_FILTER,
+  useArtifactPanelRootIds,
+  useArtifactUnreadMarkerVariant,
+  useArtifactVisibleIds,
+  type ArtifactUnreadMarkerVariant,
+  type TreeFilterFn,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-shared";
 
 interface ArtifactTreePanelBodyProps {
   readonly epicId: string;
   readonly tabId: string;
 }
 
-type TreeFilterFn = (type: string | null | undefined) => boolean;
-
-const ARTIFACTS_TREE_FILTER: TreeFilterFn = (type) =>
-  type !== null &&
-  type !== undefined &&
-  type !== "chat" &&
-  type !== "terminal" &&
-  type !== "terminal-agent";
-
 const EMPTY_SELECTED_IDS: ReadonlySet<string> = new Set<string>();
 const noopToggleSelection = (_id: string): void => undefined;
 const noopRowAction = (): void => undefined;
-const EMPTY_DESCENDANT_ENTRIES: ReadonlyArray<ArtifactDescendantEntry> = [];
 
 interface ExpansionController {
   expandedIds: ReadonlySet<string>;
@@ -183,194 +171,9 @@ interface ExpansionController {
   ensureExpanded: (id: string) => void;
 }
 
-type ArtifactUnreadMarkerVariant = "self" | "descendant";
-
 interface ArtifactReadSeedEntry {
   readonly id: string;
   readonly updatedAt: number;
-}
-
-interface ArtifactDescendantEntry {
-  readonly id: string;
-  readonly updatedAt: number;
-}
-
-function usePanelRootIds(
-  comparator: NodeComparator | null,
-): ReadonlyArray<string> {
-  const yDocRootIds = useRootIds();
-  // Filter roots by the TREE node's type, not the projected artifact records.
-  // `useEpicArtifactRecords()` rebuilds a fresh record array (and fresh record
-  // objects) on every store tick, so during chat streaming the active chat's
-  // record changes identity each token and `liveRecords` churns - which used to
-  // recompute this memo, churn `rootIds` -> `expandedIds` -> the `expansion`
-  // controller, and re-render every memoized `ArtifactNode`. The tree index
-  // (`s.tree`) does NOT change on chat tokens, and its `nodeById[id].type` is
-  // the same value space this `treeFilter` already uses for CHILD nodes
-  // (`usePanelChildIds`), so the result is identical but identity-stable while
-  // streaming.
-  const tree = useEpicTreeIndex();
-  return useMemo(() => {
-    const treeFilter = ARTIFACTS_TREE_FILTER;
-    const roots = yDocRootIds.filter(
-      (rootId) =>
-        Object.hasOwn(tree.nodeById, rootId) &&
-        treeFilter(tree.nodeById[rootId].type),
-    );
-    // `yDocRootIds` is in projector (default) order; re-sort only for a
-    // non-default mode (`comparator !== null`).
-    return sortNodeIds(roots, tree.nodeById, comparator);
-  }, [tree, yDocRootIds, comparator]);
-}
-
-/**
- * Visible-id set for an active artifact filter (status / kind / read), expanded
- * to include ancestors so a matched ticket nested under a spec stays reachable.
- * Status and read are evaluated only against artifacts that carry them; specs
- * and reviews (status `null`, never assignable) drop out whenever a status or
- * kind constraint excludes them. `null` when no filter is active.
- */
-function useArtifactVisibleIds(epicId: string): ReadonlySet<string> | null {
-  const filter = useArtifactFilter(epicId);
-  const artifacts = useEpicStore((s) => s.artifacts);
-  const tree = useEpicTreeIndex();
-  const readState = useArtifactReadStateStore(
-    useShallow((s) => ({
-      seedAtByEpic: s.seedAtByEpic,
-      lastSeenByArtifact: s.lastSeenByArtifact,
-    })),
-  );
-  return useMemo(() => {
-    if (!isArtifactFilterActive(filter)) return null;
-    const statusSet = new Set<number>(filter.statuses);
-    const kindSet = new Set<string>(filter.kinds);
-    const matches: string[] = [];
-    for (const id of artifacts.allIds) {
-      if (!Object.hasOwn(artifacts.byId, id)) continue;
-      const artifact = artifacts.byId[id];
-      if (kindSet.size > 0 && !kindSet.has(artifact.kind)) continue;
-      if (
-        statusSet.size > 0 &&
-        (artifact.status === null || !statusSet.has(artifact.status))
-      ) {
-        continue;
-      }
-      if (filter.read !== "all") {
-        const unread = isArtifactUnread({
-          epicId,
-          artifactId: artifact.id,
-          updatedAt: artifact.updatedAt,
-          seedAtByEpic: readState.seedAtByEpic,
-          lastSeenByArtifact: readState.lastSeenByArtifact,
-        });
-        if (filter.read === "unread" && !unread) continue;
-        if (filter.read === "read" && unread) continue;
-      }
-      matches.push(artifact.id);
-    }
-    return collectWithAncestors(matches, tree.nodeById);
-  }, [filter, artifacts, tree, readState, epicId]);
-}
-
-/**
- * Collect the artifact-kind descendants of `nodeId` (id + version) so a
- * collapsed parent can roll up "contains unread artifacts" without mounting its
- * children. When a filter is active (`visibleIds !== null`), descendants hidden
- * by the filter are skipped along with their subtree - the rollup must never
- * point at a child the user cannot reach by expanding. Cycle-guarded via
- * `visited`.
- */
-function collectDescendantArtifactEntries(
-  nodeId: string,
-  tree: TreeSlice,
-  visibleIds: ReadonlySet<string> | null,
-): ReadonlyArray<ArtifactDescendantEntry> {
-  const rootChildren = Object.hasOwn(tree.childrenByParent, nodeId)
-    ? tree.childrenByParent[nodeId]
-    : null;
-  if (rootChildren === null || rootChildren.length === 0) {
-    return EMPTY_DESCENDANT_ENTRIES;
-  }
-  const entries: ArtifactDescendantEntry[] = [];
-  const visited = new Set<string>([nodeId]);
-  const stack = [...rootChildren];
-  while (stack.length > 0) {
-    const id = stack.pop();
-    if (id === undefined || visited.has(id)) continue;
-    visited.add(id);
-    // A filtered-out node has no visible descendants (the visible set is
-    // matches plus their ancestors), so skip its whole subtree.
-    if (visibleIds !== null && !visibleIds.has(id)) continue;
-    if (!Object.hasOwn(tree.nodeById, id)) continue;
-    const node = tree.nodeById[id];
-    if (isEpicArtifactKind(node.type)) {
-      entries.push({ id, updatedAt: node.updatedAt });
-    }
-    if (Object.hasOwn(tree.childrenByParent, id)) {
-      for (const childId of tree.childrenByParent[id]) stack.push(childId);
-    }
-  }
-  return entries;
-}
-
-/**
- * Per-node unread marker variant, subscribed narrowly so marking one artifact
- * read re-renders only the affected row and its collapsed ancestors - never the
- * whole tree. The read-state selector returns a scalar variant, so Zustand
- * bails the render for any node whose variant did not flip. Returns:
- *   - "self": this artifact itself has unread changes.
- *   - "descendant": this collapsed parent hides unread artifacts.
- *   - null: nothing to show (non-artifact row, or expanded parent with no self
- *     unread).
- * This mirrors the per-entity `useIsActive...` pattern instead of threading a
- * tab-wide map through the recursive node tree.
- */
-function useArtifactUnreadMarkerVariant(args: {
-  readonly epicId: string;
-  readonly nodeId: string;
-  readonly isArtifactKind: boolean;
-  readonly expanded: boolean;
-  readonly selfUpdatedAt: number;
-  readonly tree: TreeSlice;
-}): ArtifactUnreadMarkerVariant | null {
-  const { epicId, nodeId, isArtifactKind, expanded, selfUpdatedAt, tree } =
-    args;
-  const visibleIds = useSidebarVisibleIds();
-  const descendantEntries = useMemo(
-    () =>
-      !isArtifactKind || expanded
-        ? EMPTY_DESCENDANT_ENTRIES
-        : collectDescendantArtifactEntries(nodeId, tree, visibleIds),
-    [isArtifactKind, expanded, nodeId, tree, visibleIds],
-  );
-  return useArtifactReadStateStore((state) => {
-    if (!isArtifactKind) return null;
-    if (
-      isArtifactUnread({
-        epicId,
-        artifactId: nodeId,
-        updatedAt: selfUpdatedAt,
-        seedAtByEpic: state.seedAtByEpic,
-        lastSeenByArtifact: state.lastSeenByArtifact,
-      })
-    ) {
-      return "self";
-    }
-    for (const entry of descendantEntries) {
-      if (
-        isArtifactUnread({
-          epicId,
-          artifactId: entry.id,
-          updatedAt: entry.updatedAt,
-          seedAtByEpic: state.seedAtByEpic,
-          lastSeenByArtifact: state.lastSeenByArtifact,
-        })
-      ) {
-        return "descendant";
-      }
-    }
-    return null;
-  });
 }
 
 function artifactsForReadSeed(
@@ -438,7 +241,7 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
     () => (isDefaultSort(sort) ? null : makeNodeComparator(sort)),
     [sort],
   );
-  const allRootIds = usePanelRootIds(comparator);
+  const allRootIds = useArtifactPanelRootIds(comparator);
   const visibleIds = useArtifactVisibleIds(epicId);
   const rootIds = useMemo(
     () => applyVisibleFilter(allRootIds, visibleIds),
@@ -1730,7 +1533,7 @@ function StaticSidebarNodeIcon(props: {
   );
 }
 
-function ArtifactUnreadMarker(props: {
+export function ArtifactUnreadMarker(props: {
   readonly nodeId: string;
   readonly variant: ArtifactUnreadMarkerVariant | null;
 }) {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -62,6 +62,7 @@ import {
   ArtifactReadLifecycleBridge,
   ArtifactTreePanelBody,
 } from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-tree";
+import { useUnreadArtifactReadTargets } from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-shared";
 import { SharingPanel } from "@/components/epic-canvas/panels/epic-sharing/panel";
 import { SnapshotGate } from "@/components/epic-canvas/snapshots/snapshot-loading-context";
 import { AddNodeDropdown } from "@/components/epic-canvas/add-node-dropdown";
@@ -157,10 +158,7 @@ import {
   isEpicArtifactKind,
   type EpicNodeKind,
 } from "@/lib/artifacts/node-display";
-import {
-  isArtifactUnread,
-  useArtifactReadStateStore,
-} from "@/stores/epics/artifact-read-state-store";
+import { useArtifactReadStateStore } from "@/stores/epics/artifact-read-state-store";
 import { revealCommentThreadAnchor } from "@/lib/comments/comment-editor-registry";
 import { useArtifactSearchAvailable } from "@/components/epic-canvas/sidebar/artifact-search-availability";
 import { usePanelHeaderSearchStore } from "@/stores/epics/panel-header-search-store";
@@ -222,14 +220,7 @@ import {
   classifyBindingsFailure,
   type BindingsFailure,
 } from "@/lib/worktree/bindings-failure";
-import { useShallow } from "zustand/react/shallow";
-
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
-interface ArtifactReadTarget {
-  readonly id: string;
-  readonly updatedAt: number;
-}
-
 const CHATS_PANEL_SKELETON = <ChatsPanelSkeleton />;
 const ARTIFACTS_PANEL_SKELETON = <ArtifactsPanelSkeleton />;
 const COMMENTS_PANEL_SKELETON = <CommentsPanelSkeleton />;
@@ -2053,37 +2044,6 @@ function ChatsPanelActions(props: LeftPanelHeaderSlotProps) {
         canArchive={canArchive}
       />
     </div>
-  );
-}
-
-function useUnreadArtifactReadTargets(
-  epicId: string,
-): ReadonlyArray<ArtifactReadTarget> {
-  const records = useEpicArtifactRecords();
-  const tree = useEpicTreeIndex();
-  const readState = useArtifactReadStateStore(
-    useShallow((s) => ({
-      seedAtByEpic: s.seedAtByEpic,
-      lastSeenByArtifact: s.lastSeenByArtifact,
-    })),
-  );
-  return useMemo(
-    () =>
-      records.flatMap((record) => {
-        if (!isEpicArtifactKind(record.type)) return [];
-        if (!Object.hasOwn(tree.nodeById, record.id)) return [];
-        const node = tree.nodeById[record.id];
-        return isArtifactUnread({
-          epicId,
-          artifactId: record.id,
-          updatedAt: node.updatedAt,
-          seedAtByEpic: readState.seedAtByEpic,
-          lastSeenByArtifact: readState.lastSeenByArtifact,
-        })
-          ? [{ id: record.id, updatedAt: node.updatedAt }]
-          : [];
-      }),
-    [epicId, readState, records, tree],
   );
 }
 


### PR DESCRIPTION
## Problem

The mobile epic switcher's **Artifacts** category filtered the flat
`useEpicArtifactRecords()` array and sorted the whole slice by recency. Nesting
never reached the phone, and because the sort was global rather than
per-sibling, a child could render nowhere near its parent. Beside that, the row
menu offered Rename + Delete only, the header "+" could create at the root
alone, and the status dot carried no label.

## Gap table

| Surface | Desktop offers | Mobile had | Now |
| --- | --- | --- | --- |
| Header name | "Artifacts" | "Artifacts" | unchanged (no override existed) |
| Tree | nested, indent + chevrons, per-sibling order | flat, global recency | nested, per-sibling order, 44px chevron |
| Filters / sort | Ordering, Status, Type, Read state, Mark all as read, Reset view | none | the desktop `ArtifactFilterMenu`, mounted as-is |
| Row menu | Export as Markdown, Export as PDF, Rename, Delete | Rename, Delete | all four |
| Row "+" | add child artifact (hover-revealed) | — | permanent add-child menu (any of the four kinds) |
| Status dot | dot + tooltip w/ `STATUS_LABELS` | bare `aria-hidden` dot | dot with an accessible label |
| Unread marker | self / descendant bar | — | same bar, same derivation |
| Empty states | "No artifacts yet." and "No matches for the current filters." | "No artifacts yet." only | both |
| Row timestamps | none | none | none — deliberate |

## How

Behaviour is shared, not forked. Everything that decides *which* artifacts a
user sees moves to `sidebar/epic-sidebar-artifact-shared.ts` — the panel root
ids, the filter's visible-id set, the unread-marker derivation, the mark-all-read
targets — and both surfaces import it. The switcher publishes the same
`SidebarSortContext` / `SidebarFilterVisibilityContext` the desktop panel does,
so `useFilteredPanelChildIds` filters and orders identically at every level, and
expansion is the same `(tabId, "artifacts")` store scope: collapse a subtree on
one surface and the other agrees.

Only geometry is phone-specific, and it is the switcher's shared
`SwitcherListRow` (nesting cluster, 44px chevron, indent step) rather than an
artifacts-only row, so this tree cannot drift from the agents tree beside it.

Two deliberate calls, both matching desktop rather than inventing:

- Exports stay available to a **viewer** — they read, exactly as the desktop
  artifact row offers them — while rename/delete/add-child stay editor-gated.
  Artifact rows therefore route through their own component so agent and
  terminal rows never instantiate the export mutation.
- Add-child creates and opens the new artifact but does **not** request editor
  focus the way desktop does; no phone surface here autofocuses a field the user
  did not tap.

## Out of scope

Header search and the header "…" more-menu (Collapse all / Select artifacts):
both are sidebar-shell surfaces, and a shared header-surface pass covers every
category at once. Row timestamps are deliberately absent — desktop artifact rows
have none.

## Verification

- `eslint --max-warnings 0` + `prettier --check` clean on every touched file
  (type-aware rules are on, so this type-checks them too)
- `vitest run src/components/epic-canvas/mobile/__tests__/` — 11 files, 117
  tests, all passing, including a new `switcher-artifacts-tree.test.tsx`
  covering nesting, indent, chevron toggle, filtered-vs-empty states, export
  entries, viewer gating and parented create
- Simulator verification is batched with the other tab PRs

## Merge note

Shares `switcher-list-row.tsx` / `switcher-row-nesting.ts` with the agents tab
PR — those two files were taken **verbatim** from that branch so the two diffs
converge; an add/add conflict there resolves to either side. `switcher-row-actions.tsx`
overlaps that PR's refactor: whoever merges second re-applies the artifact export
entries into the `useSwitcherRowActions` / `SwitcherRowMenu` shape.