### PR TITLE
feat(gui-app): give the mobile tab switcher a Sharing category

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-panel-embed.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-panel-embed.test.tsx
@@ -14,6 +14,11 @@ vi.mock("@/components/epic-canvas/git-diff/git-diff-panel-body-live", () => ({
 vi.mock("@/components/epic-canvas/pr/pr-panel-body", () => ({
   PrPanelBody: () => <div data-testid="pr-panel-body" />,
 }));
+vi.mock("@/components/epic-canvas/panels/epic-sharing/panel", () => ({
+  SharingPanel: (props: { readonly epicId: string }) => (
+    <div data-testid="sharing-panel-body" data-epic-id={props.epicId} />
+  ),
+}));
 
 describe("<SwitcherPanelEmbed />", () => {
   afterEach(cleanup);
@@ -37,5 +42,21 @@ describe("<SwitcherPanelEmbed />", () => {
     expect(screen.getByTestId("pr-panel-body")).toBeTruthy();
     expect(screen.queryByTestId("file-tree-body")).toBeNull();
     expect(screen.queryByTestId("git-diff-body")).toBeNull();
+  });
+
+  it("embeds the desktop sharing panel for the sharing category", () => {
+    render(<SwitcherPanelEmbed category="sharing" epicId="e" tabId="t" />);
+    const body = screen.getByTestId("sharing-panel-body");
+    expect(body.dataset.epicId).toBe("e");
+    expect(screen.queryByTestId("pr-panel-body")).toBeNull();
+  });
+
+  // The sharing panel is the one embedded body with no scroller of its own - on
+  // desktop the sidebar's scroll region supplies it - so the embed must.
+  it("gives the sharing panel a scroll region the other embeds own themselves", () => {
+    const { container } = render(
+      <SwitcherPanelEmbed category="sharing" epicId="e" tabId="t" />,
+    );
+    expect(container.querySelector(".overflow-y-auto")).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -114,6 +114,7 @@ const CATEGORY_NAMES = [
   "File Tree",
   "Git Diff",
   "Terminals",
+  "Sharing",
 ];
 
 /**
@@ -155,12 +156,12 @@ describe("<TabSwitcherSheet />", () => {
   });
   afterEach(cleanup);
 
-  it("renders exactly the five always-on category tabs when open on mobile", () => {
+  it("renders exactly the six always-on category tabs when open on mobile", () => {
     renderSheet(true, () => {});
     for (const name of CATEGORY_NAMES) {
       expect(screen.getByRole("tab", { name })).toBeTruthy();
     }
-    expect(screen.getAllByRole("tab")).toHaveLength(5);
+    expect(screen.getAllByRole("tab")).toHaveLength(6);
   });
 
   it("labels the chats category 'Chats' and renders the active tab as an underline, not a box", () => {
@@ -224,7 +225,7 @@ describe("<TabSwitcherSheet />", () => {
     setPullRequestPresence(true);
     renderSheet(true, () => {});
     const tabs = screen.getAllByRole("tab");
-    expect(tabs).toHaveLength(6);
+    expect(tabs).toHaveLength(7);
     expect(tabs.map((tab) => tab.getAttribute("data-testid"))).toEqual([
       "mobile-switcher-tab-chats",
       "mobile-switcher-tab-artifacts",
@@ -232,7 +233,19 @@ describe("<TabSwitcherSheet />", () => {
       "mobile-switcher-tab-git-diff",
       "mobile-switcher-tab-pull-requests",
       "mobile-switcher-tab-terminals",
+      "mobile-switcher-tab-sharing",
     ]);
+  });
+
+  it("shows the embedded desktop sharing panel body when the category is selected", async () => {
+    const user = userEvent.setup();
+    renderSheet(true, () => {});
+    await user.click(screen.getByRole("tab", { name: "Sharing" }));
+    expect(useLeftPanelStore.getState().getActivePanelId(TAB_ID)).toBe(
+      "sharing",
+    );
+    const embed = await screen.findByTestId("mock-panel-embed");
+    expect(embed.dataset.category).toBe("sharing");
   });
 
   it("shows the embedded desktop PR panel body when the category is selected", async () => {
@@ -282,7 +295,7 @@ describe("<TabSwitcherSheet />", () => {
     streamState.prSupport = "unsupported";
     renderSheet(true, () => {});
     expect(screen.queryByRole("tab", { name: "Pull Requests" })).toBeNull();
-    expect(screen.getAllByRole("tab")).toHaveLength(5);
+    expect(screen.getAllByRole("tab")).toHaveLength(6);
   });
 
   it("clamps a persisted pull-requests selection when the host lost stream support", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -248,6 +248,24 @@ describe("<TabSwitcherSheet />", () => {
     expect(embed.dataset.category).toBe("sharing");
   });
 
+  it("opens straight onto a persisted sharing selection instead of clamping it away", async () => {
+    // `sharing` is shared with the desktop rail through this one store, so a
+    // selection made on a desktop lands here on the phone. While the category
+    // was uncurated `clampToSwitcherCategory` sent it back to Chats, which is
+    // the regression this guards: the tab must be the active one on first
+    // paint, with no click to get there.
+    useLeftPanelStore.setState({
+      activePanelIdByTabId: { [TAB_ID]: "sharing" },
+    });
+    renderSheet(true, () => {});
+    expect(
+      screen.getByRole("tab", { name: "Sharing" }).getAttribute("data-state"),
+    ).toBe("active");
+    expect(screen.queryByTestId("mock-agents-list")).toBeNull();
+    const embed = await screen.findByTestId("mock-panel-embed");
+    expect(embed.dataset.category).toBe("sharing");
+  });
+
   it("shows the embedded desktop PR panel body when the category is selected", async () => {
     setPullRequestPresence(true);
     const user = userEvent.setup();

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
@@ -11,10 +11,11 @@ import {
 /**
  * The mobile "Switch tab" sheet exposes the desktop left-panel categories as a
  * horizontally-scrollable tab bar. Curated to Agents (`chats`), Artifacts, File
- * tree, Git diff, Pull requests and Terminals; Sharing is excluded and Comments
- * live inside the artifact tile. `pull-requests` sits directly after `git-diff`
- * exactly as it does in the desktop rail, so the two surfaces read in the same
- * order. Identity (title + icon) is reused verbatim from
+ * tree, Git diff, Pull requests, Terminals and Sharing; only Comments is
+ * excluded, because it lives inside the artifact tile. `pull-requests` sits
+ * directly after `git-diff`, and `sharing` sits last ahead of the excluded
+ * Comments, exactly as they do in the desktop rail, so the two surfaces read in
+ * the same order. Identity (title + icon) is reused verbatim from
  * `LEFT_PANEL_DEFINITIONS` so mobile never forks the category copy.
  */
 const CURATED_ORDER: readonly LeftPanelId[] = [
@@ -24,6 +25,7 @@ const CURATED_ORDER: readonly LeftPanelId[] = [
   "git-diff",
   "pull-requests",
   "terminals",
+  "sharing",
 ];
 
 const DEFINITION_BY_ID = new Map<LeftPanelId, LeftPanelMetadataDefinition>(
@@ -93,7 +95,7 @@ export function switcherCategoryTitle(
  * Clamp a persisted active left-panel id to the categories currently on the
  * bar, so a selection with no tab behind it falls back to Agents rather than
  * leaving the sheet with no matching tab. Two ways that happens: a category
- * mobile never curates (e.g. Sharing, selected on desktop), and `pull-requests`
+ * mobile never curates (Comments, selected on desktop), and `pull-requests`
  * persisted from an epic that has since stopped reporting any PR.
  */
 export function clampToSwitcherCategory(

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-panel-embed.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-panel-embed.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
 import { GitDiffPanelBodyLive } from "@/components/epic-canvas/git-diff/git-diff-panel-body-live";
+import { SharingPanel } from "@/components/epic-canvas/panels/epic-sharing/panel";
 import { PrPanelBody } from "@/components/epic-canvas/pr/pr-panel-body";
 import { FileTreePanelBody } from "@/components/epic-canvas/sidebar/epic-sidebar";
 
 /** The switcher categories whose body is the desktop panel body, unmodified. */
-export type SwitcherEmbedCategory = "file-tree" | "git-diff" | "pull-requests";
+export type SwitcherEmbedCategory =
+  "file-tree" | "git-diff" | "pull-requests" | "sharing";
 
 interface SwitcherPanelEmbedProps {
   readonly category: SwitcherEmbedCategory;
@@ -13,17 +15,24 @@ interface SwitcherPanelEmbedProps {
 }
 
 /**
- * File-tree, Git-diff and Pull-requests categories. Unlike the flat lists these
- * are not row-per-item surfaces: they embed the EXACT desktop panel bodies -
- * already click-driven and Pierre-rendered - rather than being rebuilt. All
- * three mount cleanly here: the app-shell `RootDndProvider` supplies the dnd-kit
- * context the file-tree drag bridge needs (it only activates on pointer drag,
- * never a tap), the canvas-side `SnapshotLoadingProvider` satisfies the
- * file-tree `SnapshotGate`, and the PR body's row click opens its detail tile
- * through the same `useEpicTileNavigation` path desktop uses. Opening a file /
- * diff / PR tile is detected by the sheet's active-tile watcher, which closes
- * the sheet; in-panel navigation (repo / workspace switch, collapsing a repo
- * group) opens no tile and keeps the sheet open.
+ * File-tree, Git-diff, Pull-requests and Sharing categories. Unlike the flat
+ * lists these are not row-per-item surfaces: they embed the EXACT desktop panel
+ * bodies - already click-driven and Pierre-rendered - rather than being rebuilt.
+ * All four mount cleanly here: the app-shell `RootDndProvider` supplies the
+ * dnd-kit context the file-tree drag bridge needs (it only activates on pointer
+ * drag, never a tap), the canvas-side `SnapshotLoadingProvider` satisfies the
+ * file-tree `SnapshotGate`, the PR body's row click opens its detail tile
+ * through the same `useEpicTileNavigation` path desktop uses, and the sharing
+ * panel reads and writes through the Epic session's host client, which the
+ * sheet already sits under. Opening a file / diff / PR tile is detected by the
+ * sheet's active-tile watcher, which closes the sheet; in-panel navigation (repo
+ * / workspace switch, collapsing a repo group) opens no tile and keeps the sheet
+ * open - as does everything in Sharing, which opens no tile at all.
+ *
+ * Scrolling is per-category: File tree, Git diff and Pull requests each own an
+ * internal scroller, while the sharing panel is a plain stack of sections that
+ * relies on the desktop sidebar's scroll region, so it is given an equivalent
+ * one here.
  */
 export function SwitcherPanelEmbed(props: SwitcherPanelEmbedProps) {
   return (
@@ -42,5 +51,11 @@ function SwitcherEmbeddedBody(props: SwitcherPanelEmbedProps): ReactNode {
       return <GitDiffPanelBodyLive epicId={epicId} tabId={tabId} />;
     case "pull-requests":
       return <PrPanelBody epicId={epicId} tabId={tabId} />;
+    case "sharing":
+      return (
+        <div className="h-full overflow-y-auto overscroll-contain">
+          <SharingPanel epicId={epicId} />
+        </div>
+      );
   }
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -42,9 +42,10 @@ import {
 import { cn } from "@/lib/utils";
 import "@/components/layout/shell/mobile-shell-touch-targets.css";
 
-// Lazy so the desktop File-tree / Git-diff / Pull-requests bodies - and the
-// heavy epic-sidebar module they pull in - load only when a phone user opens
-// those categories, and never sit in the mobile tile view's eager module graph.
+// Lazy so the desktop File-tree / Git-diff / Pull-requests / Sharing bodies -
+// and the heavy epic-sidebar module they pull in - load only when a phone user
+// opens those categories, and never sit in the mobile tile view's eager module
+// graph.
 const SwitcherPanelEmbed = lazy(() =>
   import("@/components/epic-canvas/mobile/switcher-panel-embed").then((m) => ({
     default: m.SwitcherPanelEmbed,
@@ -79,8 +80,8 @@ function isEmbedOriginatedTileRef(ref: EpicCanvasTileRef): boolean {
  * The mobile tab switcher: a drag-dismissable `vaul` bottom sheet whose
  * category bar mirrors the desktop left-panel registry and whose content region
  * shows the active category - flat lists for Agents/Terminals/Artifacts, the
- * embedded desktop File-tree / Git-diff / Pull-requests panel bodies for the
- * rest. Creating is a row inside the category that owns the kind, not a
+ * embedded desktop File-tree / Git-diff / Pull-requests / Sharing panel bodies
+ * for the rest. Creating is a row inside the category that owns the kind, not a
  * sheet-level control.
  *
  * Opened from the mobile header's switcher trigger. Only meaningful on phones -
@@ -243,9 +244,10 @@ interface SwitcherCategoryBodyProps {
 
 /**
  * Content-region registry: flat lists for the row-per-item categories; embedded
- * desktop panel bodies for File tree, Git diff and Pull requests. The flat
- * lists call `onClose` on selection; the embeds rely on the sheet's active-tile
- * watcher.
+ * desktop panel bodies for File tree, Git diff, Pull requests and Sharing. The
+ * flat lists call `onClose` on selection; the embeds rely on the sheet's
+ * active-tile watcher, and Sharing - which opens no tile - simply keeps the
+ * sheet open for as long as the user is granting access.
  */
 function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
   const { categoryId, epicId, tabId, onClose } = props;
@@ -295,6 +297,16 @@ function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
         <Suspense fallback={<SwitcherEmbedFallback />}>
           <SwitcherPanelEmbed
             category="pull-requests"
+            epicId={epicId}
+            tabId={tabId}
+          />
+        </Suspense>
+      );
+    case "sharing":
+      return (
+        <Suspense fallback={<SwitcherEmbedFallback />}>
+          <SwitcherPanelEmbed
+            category="sharing"
             epicId={epicId}
             tabId={tabId}
           />


### PR DESCRIPTION
Adds **Sharing** to the mobile epic tab switcher. One tab, split out of the
parity wave so it can be reviewed on its own.

Sharing joins the curated switcher set, **last, ahead of the excluded
Comments** — the desktop rail's own order, so the two surfaces read the same
way. The body is the desktop `SharingPanel` embedded unmodified, given the
scroll region the desktop sidebar would otherwise supply.

A `sharing` selection made on a desktop now survives `clampToSwitcherCategory`
instead of being sent back to Agents: the two surfaces share one left-panel
store, so a persisted selection lands here on first paint.

## Tests

`tab-switcher-sheet.test.tsx` gains the integrated half — a real click on the
Sharing tab, the store landing on `sharing`, and a persisted `sharing`
selection surviving the clamp on first paint — plus the embed routing case in
`switcher-panel-embed.test.tsx`.

Original work: PR #1402. The agents and artifacts tabs follow separately, held
pending design review of their nesting.
