### PR TITLE
fix(git-diff): mobile parity for the epic canvas diffs surface

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-changed-file-row.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-changed-file-row.test.tsx
@@ -296,6 +296,37 @@ describe("GitChangedFileRow panel density", () => {
     expect(row.className).toContain("text-accent-foreground");
   });
 
+  it("reveals the counts in flow on a coarse pointer, where hover never fires", () => {
+    renderRow({
+      file: makeFile({ path: "src/app.tsx", previousPath: null }),
+      density: "panel",
+      active: false,
+      pathRanges: NO_HIGHLIGHT,
+    });
+
+    const stats = screen.getByText("+3").parentElement;
+    expect(stats?.className).toContain("group-hover:flex");
+    expect(stats?.className).toContain("pointer-coarse:flex");
+    // In flow, not the hover overlay: nothing may cover the row's tail on a
+    // surface where the overlay can never be dismissed by moving a cursor away.
+    expect(stats?.className).toContain("pointer-coarse:static");
+  });
+
+  it("gives touch rows the 44px tap target without changing mouse density", () => {
+    renderRow({
+      file: makeFile({ path: "src/app.tsx", previousPath: null }),
+      density: "panel",
+      active: false,
+      pathRanges: NO_HIGHLIGHT,
+    });
+
+    const row = screen.getByRole("button", {
+      name: "Modified app.tsx in src",
+    });
+    expect(row.className).toContain("min-h-6");
+    expect(row.className).toContain("pointer-coarse:min-h-11");
+  });
+
   it("leaves inactive rows without aria-current", () => {
     renderRow({
       file: makeFile({ path: "src/app.tsx", previousPath: null }),

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-actions.test.tsx
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { GitDiffPanelActions } from "../git-diff-panel-actions";
+import {
+  GitDiffPanelActions,
+  GitDiffPanelInlineActions,
+} from "../git-diff-panel-actions";
 import { useGitPanelStore } from "@/stores/epics/git-panel-store";
 import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
 import { useSettingsStore } from "@/stores/settings/settings-store";
@@ -197,5 +200,71 @@ describe("<GitDiffPanelActions />", () => {
     expect(usePanelHeaderMenuStore.getState().openBySurfaceKey).toEqual(
       expect.objectContaining({ '["tab-1","git-diff","more"]': true }),
     );
+  });
+});
+
+describe("<GitDiffPanelInlineActions />", () => {
+  beforeEach(() => {
+    cleanup();
+    testState.refresh.mockReset();
+    testState.refresh.mockResolvedValue(undefined);
+    testState.refreshArgs = [];
+    useGitPanelStore.setState({ stateByEpicId: {} });
+    usePanelHeaderMenuStore.setState({ openBySurfaceKey: {} });
+    useSettingsStore.setState({
+      diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
+    });
+    useGitPanelStore.getState().setSelectedRepo("epic-1", {
+      hostId: "host-1",
+      rootRunningDir: "/repo",
+      repoRoot: "/repo",
+    });
+  });
+
+  it("offers the same menu the sidebar header does", () => {
+    const { wrapper } = setup();
+    render(<GitDiffPanelInlineActions epicId="epic-1" />, { wrapper });
+
+    openMoreMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: "Switch to tree view" }),
+    ).toBeDefined();
+    expect(screen.getByRole("menuitem", { name: "Refresh" })).toBeDefined();
+  });
+
+  it("drives the same layout mutation as the sidebar header", () => {
+    const { wrapper } = setup();
+    render(<GitDiffPanelInlineActions epicId="epic-1" />, { wrapper });
+
+    openMoreMenu();
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Switch to tree view" }),
+    );
+
+    expect(useGitPanelStore.getState().stateByEpicId["epic-1"].listLayout).toBe(
+      "tree",
+    );
+  });
+
+  it("refreshes the active root's nested snapshot slot", () => {
+    const { wrapper } = setup();
+    render(<GitDiffPanelInlineActions epicId="epic-1" />, { wrapper });
+
+    openMoreMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Refresh" }));
+
+    expect(testState.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps its open state local to the trigger", () => {
+    const { wrapper } = setup();
+    render(<GitDiffPanelInlineActions epicId="epic-1" />, { wrapper });
+
+    openMoreMenu();
+
+    // No sidebar section to reopen behind it, so the panel-header menu store
+    // stays untouched - it is the sidebar's collapse-survival mechanism.
+    expect(usePanelHeaderMenuStore.getState().openBySurfaceKey).toEqual({});
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-shell.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-shell.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { FileDiff } from "lucide-react";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
 
 const DiffTabHeaderAccessoryContext = createContext<HTMLElement | null>(null);
 
@@ -15,11 +17,21 @@ interface DiffTabShellProps {
 export function DiffTabShell(props: DiffTabShellProps) {
   const [headerAccessoryTarget, setHeaderAccessoryTarget] =
     useState<HTMLElement | null>(null);
+  // The whole diff toolbar - view mode, refresh, settings, collapse-all - is
+  // `icon-sm` controls sized for a mouse. Below md they are the tile's only
+  // affordances and the phone shell's hit-slop scope (header, drawer, sheets)
+  // does not reach a canvas tile, so this header opts into it directly. Scope
+  // only where the mobile layout is live, keeping the rule's "desktop never
+  // carries the scope" invariant intact.
+  const isMobileViewport = useIsMobileViewport();
 
   return (
     <DiffTabHeaderAccessoryContext.Provider value={headerAccessoryTarget}>
       <div className="flex h-full min-h-0 w-full flex-col bg-background">
-        <div className="z-10 flex min-h-[clamp(2.5rem,5dvh,3rem)] shrink-0 items-center justify-between gap-3 border-b border-border/70 bg-background px-3 py-2">
+        <div
+          data-mobile-shell-touch-scope={isMobileViewport ? "" : undefined}
+          className="z-10 flex min-h-[clamp(2.5rem,5dvh,3rem)] shrink-0 items-center justify-between gap-3 border-b border-border/70 bg-background px-3 py-2"
+        >
           <div className="flex min-w-0 items-center gap-2">
             <FileDiff className="size-4 shrink-0 text-muted-foreground" />
             <div className="min-w-0">

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-file-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-file-row.tsx
@@ -168,7 +168,14 @@ function PanelRowContent(props: {
       {props.showStats ? (
         <GitChangedFileStats
           file={props.file}
-          className="pointer-events-none absolute right-3 top-1/2 hidden -translate-y-1/2 rounded bg-background/95 px-1 py-0.5 shadow-sm group-hover:flex group-focus-visible:flex"
+          className={cn(
+            "pointer-events-none absolute right-3 top-1/2 hidden -translate-y-1/2 rounded bg-background/95 px-1 py-0.5 shadow-sm group-hover:flex group-focus-visible:flex",
+            // A coarse pointer never hovers, so the overlay above would never
+            // appear and the row's +/- counts would be mobile-only invisible.
+            // Render them in flow at the end of the row instead: nothing is
+            // covered, and the directory name simply truncates sooner.
+            "pointer-coarse:static pointer-coarse:flex pointer-coarse:translate-y-0 pointer-coarse:bg-transparent pointer-coarse:px-0 pointer-coarse:shadow-none",
+          )}
         />
       ) : null}
     </>
@@ -184,6 +191,10 @@ function gitChangedFileRowClassName(args: {
 }): string {
   return cn(
     "group relative flex w-full items-center text-left text-ui-sm",
+    // The 24/28px densities below are mouse densities. On touch the row is the
+    // tap target that opens the diff (or collapses the bundle section), so it
+    // takes the 44px guideline height; the fine-pointer list is untouched.
+    "pointer-coarse:min-h-11",
     args.isPanel && args.nested && "min-h-6 gap-1.5 py-0.5 pl-10 pr-3",
     args.isPanel && !args.nested && "min-h-6 gap-1.5 px-3 py-0.5",
     !args.isPanel && "min-h-7 gap-2 px-2 py-1",

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { FolderTree, List, MoreHorizontal } from "lucide-react";
 import type { LeftPanelHeaderSlotProps } from "@/components/epic-canvas/sidebar/epic-sidebar";
 import { Button } from "@/components/ui/button";
@@ -26,7 +26,13 @@ import {
 // Safety cap so a hung host fetch can't wedge the spinning/disabled state.
 const GIT_REFRESH_TIMEOUT_MS = 10_000;
 
-export function GitDiffPanelActions(props: LeftPanelHeaderSlotProps) {
+/**
+ * The Git Diff panel's overflow-menu items and the mutations behind them. Every
+ * container that hosts the menu mounts these - the sidebar header below, and the
+ * phone body header, which has no panel header to hang a slot from. Placement is
+ * the container's business; what the menu DOES is not.
+ */
+function GitDiffPanelMenuItems(props: { readonly epicId: string }): ReactNode {
   const listLayout = useGitPanelStore(
     (s) => selectGitPanelEpicState(props.epicId)(s).listLayout,
   );
@@ -61,6 +67,33 @@ export function GitDiffPanelActions(props: LeftPanelHeaderSlotProps) {
     externalRefreshing: isRefreshing,
     timeoutMs: GIT_REFRESH_TIMEOUT_MS,
   });
+
+  return (
+    <>
+      <DropdownMenuItem
+        onSelect={handleToggleLayout}
+        data-testid="git-diff-panel-layout-toggle"
+      >
+        {listLayout === "sections" ? (
+          <FolderTree className="size-4" />
+        ) : (
+          <List className="size-4" />
+        )}
+        {layoutToggleLabel}
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={refresh.trigger}
+        disabled={selectedRepo === null || refresh.refreshing}
+        data-testid="git-diff-panel-refresh"
+      >
+        <RefreshIcon refreshing={refresh.refreshing} />
+        Refresh
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+export function GitDiffPanelActions(props: LeftPanelHeaderSlotProps) {
   const menuOpen = usePanelHeaderMenuOpen(props.tabId, "git-diff", "more");
   const setMenuOpen = usePanelHeaderMenuStore((state) => state.setMenuOpen);
   const setPanelSectionCollapsed = useEpicLeftPanelStore(
@@ -104,25 +137,49 @@ export function GitDiffPanelActions(props: LeftPanelHeaderSlotProps) {
         avoidCollisions={false}
         className="w-[var(--radix-dropdown-menu-content-available-width)] min-w-0 max-w-52"
       >
-        <DropdownMenuItem
-          onSelect={handleToggleLayout}
-          data-testid="git-diff-panel-layout-toggle"
+        <GitDiffPanelMenuItems epicId={props.epicId} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * The same overflow menu, for the phone tab switcher - which mounts the panel
+ * BODY alone, with no left-panel header to carry the Actions slot. Without it
+ * the list-layout toggle and the manual refresh have no reachable trigger on a
+ * phone at all. The items and their mutations are the sidebar's; only the
+ * trigger's home and the menu's placement differ, so the menu opens downward
+ * from the body header instead of sideways out of a rail.
+ *
+ * Open state is local rather than the panel-header menu store: that store exists
+ * to survive a collapsing sidebar section, and there is no such section here.
+ */
+export function GitDiffPanelInlineActions(props: {
+  readonly epicId: string;
+}): ReactNode {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="More Git Diff actions"
+          data-testid="git-diff-panel-more"
+          className="shrink-0 text-muted-foreground hover:text-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground"
         >
-          {listLayout === "sections" ? (
-            <FolderTree className="size-4" />
-          ) : (
-            <List className="size-4" />
-          )}
-          {layoutToggleLabel}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={refresh.trigger}
-          disabled={selectedRepo === null || refresh.refreshing}
-          data-testid="git-diff-panel-refresh"
-        >
-          <RefreshIcon refreshing={refresh.refreshing} />
-          Refresh
-        </DropdownMenuItem>
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side="bottom"
+        align="end"
+        sideOffset={4}
+        className="min-w-0 max-w-[min(16rem,calc(100vw-2rem))]"
+      >
+        <GitDiffPanelMenuItems epicId={props.epicId} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
@@ -177,7 +177,10 @@ export function GitDiffPanelInlineActions(props: {
         side="bottom"
         align="end"
         sideOffset={4}
-        className="min-w-0 max-w-[min(16rem,calc(100vw-2rem))]"
+        // No `max-w-*` here: the primitive owns `max-w-safe-dvw`, and CSS
+        // allows one width clamp per element, so a cap named by the caller
+        // DISPLACES the safe-area one instead of tightening it.
+        className="min-w-0"
       >
         <GitDiffPanelMenuItems epicId={props.epicId} />
       </DropdownMenuContent>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-body-live.tsx
@@ -57,7 +57,9 @@ import { withoutResolvedMissingRows } from "@/lib/worktree/worktree-row-resolved
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { WorkspacePickerWithOpener } from "@/components/worktree/workspace-picker-with-opener";
 import { WorktreePickerHostSection } from "@/components/worktree/worktree-picker-host-section";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
 import { CapabilityGate } from "./capability-gate";
+import { GitDiffPanelInlineActions } from "./git-diff-panel-actions";
 import { DiffLoadingSkeleton } from "./diff-loading-skeleton";
 import { GitBindingsUnreadable } from "./empty-states/git-bindings-unreadable";
 import { GitHostUnreachable } from "./empty-states/git-host-unreachable";
@@ -549,6 +551,7 @@ function GitDiffPanelDegraded(props: GitDiffPanelDegradedProps): ReactNode {
   const [repoSwitcherOpen, setRepoSwitcherOpen] = useState(false);
   const setSelectedRepo = useGitPanelStore((s) => s.setSelectedRepo);
   const { epicId, onLatchHost } = props;
+  const isMobileViewport = useIsMobileViewport();
 
   const roots: ReadonlyArray<GitDiffRepoSwitcherRootInput> = useMemo(
     () =>
@@ -599,6 +602,12 @@ function GitDiffPanelDegraded(props: GitDiffPanelDegradedProps): ReactNode {
             hostClient={props.client}
           />
         </div>
+        {/* Degraded keeps the overflow menu for the same reason it keeps the
+            picker: desktop's panel header carries it in every state, and the
+            phone has no other home for it. */}
+        {isMobileViewport ? (
+          <GitDiffPanelInlineActions epicId={epicId} />
+        ) : null}
       </div>
       {/* The bodies below are written as `h-full` blocks (they used to be the
           panel's ONLY child). A percentage height needs a definite parent, so
@@ -646,6 +655,11 @@ function GitDiffPanelLoaded(props: GitDiffPanelLoadedProps): ReactNode {
     (s) => s.diffViewerPreferences.ignoreWhitespace,
   );
   const setSelectedRepo = useGitPanelStore((s) => s.setSelectedRepo);
+  // Below md the epic sidebar - and with it this panel's header Actions slot -
+  // is never mounted; the tab switcher shows the body alone. The overflow menu
+  // moves into the body header there so the layout toggle and the manual
+  // refresh stay reachable, and stays out of it wherever the header exists.
+  const isMobileViewport = useIsMobileViewport();
 
   // Live parent status for the active root: drives the nested-snapshot refetch
   // (its fingerprint is the change token) and the immediate pre-snapshot render.
@@ -818,6 +832,9 @@ function GitDiffPanelLoaded(props: GitDiffPanelLoadedProps): ReactNode {
           className={undefined}
           compact={false}
         />
+        {isMobileViewport ? (
+          <GitDiffPanelInlineActions epicId={epicId} />
+        ) : null}
       </div>
       <CapabilityGate
         hostId={selectedRootRow.hostId}


### PR DESCRIPTION
Mobile parity for the **Git diff** tab. One tab, split out of the parity wave so
it can be reviewed on its own.

The switcher mounts the Git Diff panel *body* alone, so the left-panel header's
Actions slot — the list/tree layout toggle and manual refresh — had **no trigger
at all below `md`**. The same menu items now mount from the body header,
sharing the sidebar's handlers and mutations; only the trigger's home and the
menu's placement differ.

The row's `+`/`-` counts were a hover-reveal overlay, which a coarse pointer can
never fire, so they were invisible on touch. They render in flow there. Rows and
the diff tile's toolbar take the 44px touch target on coarse pointers, where
24/28px mouse densities are unusable.

## Also here: a review fix from integration

The panel menu carried `max-w-[min(16rem,calc(100vw-2rem))]`. That did not
tighten the dropdown primitive's `max-w-safe-dvw`, it **replaced** it — the
primitive documents that a caller `max-w-*` sits ahead of its own, and CSS
allows one width clamp per element. So the cap was discarding the safe-area
insets it was meant to respect, and its `100vw` half cannot see them at all.
Dropped rather than restated, since the primitive already applies it.

Original work: PR #1403. The agents and artifacts tabs follow separately, held
pending design review of their nesting.
