### PR TITLE
fix(mobile): stop the switcher's category bar scrolling vertically again

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-category-tabs.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-category-tabs.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { SwitcherCategoryTabs } from "@/components/epic-canvas/mobile/switcher-category-tabs";
+
+/**
+ * The category bar is a horizontal scroll container, so its `overflow-y`
+ * computes to `auto` and ANY vertical spill turns into a real, draggable
+ * vertical scroller instead of clipping. It stays flat only because the bar
+ * overrides two things `ui/tabs` imposes on every list - the fixed list height
+ * and the active-state fill - and an override lands only when tailwind-merge
+ * recognises it as the same utility, which it does only when the two spell
+ * their Tailwind modifier the same way.
+ *
+ * That coupling is invisible in the bar's own source: its classes stay valid
+ * Tailwind and the component keeps rendering when the primitive re-spells its
+ * modifiers, so the overrides silently stop replacing anything and the base
+ * height comes back. So these assertions never restate the primitive's
+ * spelling - they read it off a plain `ui/tabs` render and require the bar to
+ * have overridden THAT.
+ */
+
+function classTokens(element: Element): readonly string[] {
+  return element.className.split(/\s+/).filter((token) => token.length > 0);
+}
+
+/** The utility a Tailwind class ends in, with its variant modifiers stripped. */
+function utilityOf(token: string): string {
+  return token.replace(/^.*:/, "");
+}
+
+/** The `variant:` chain a Tailwind class carries, trailing colon included. */
+function modifierOf(token: string): string {
+  return token.slice(0, token.length - utilityOf(token).length);
+}
+
+function renderBaselineTabs(): { list: Element; trigger: Element } {
+  const { container } = render(
+    <Tabs defaultValue="baseline">
+      <TabsList variant="line">
+        <TabsTrigger value="baseline">Baseline</TabsTrigger>
+      </TabsList>
+    </Tabs>,
+  );
+  const list = container.querySelector('[data-slot="tabs-list"]');
+  const trigger = container.querySelector('[data-slot="tabs-trigger"]');
+  if (list === null || trigger === null)
+    throw new Error("ui/tabs rendered no list/trigger");
+  return { list, trigger };
+}
+
+function renderCategoryBar(): { list: Element; trigger: Element } {
+  const { container } = render(
+    <Tabs defaultValue="chats">
+      <SwitcherCategoryTabs hasPullRequests={false} />
+    </Tabs>,
+  );
+  const list = container.querySelector('[data-slot="tabs-list"]');
+  const trigger = container.querySelector(
+    '[data-testid="mobile-switcher-tab-chats"]',
+  );
+  if (list === null || trigger === null)
+    throw new Error("category bar rendered no list/trigger");
+  return { list, trigger };
+}
+
+describe("<SwitcherCategoryTabs />", () => {
+  afterEach(cleanup);
+
+  it("replaces the fixed list height ui/tabs imposes, so nothing spills into the horizontal scroller", () => {
+    const baseline = classTokens(renderBaselineTabs().list);
+    const imposedHeight = baseline.find((token) =>
+      /^h-\d/.test(utilityOf(token)),
+    );
+    // Positive control: a guard that derives nothing reports success forever.
+    // If `ui/tabs` ever stops sizing its list, this is where that shows up -
+    // and the override below has become dead weight rather than load-bearing.
+    expect(imposedHeight).toBeDefined();
+    if (imposedHeight === undefined) return;
+
+    const bar = classTokens(renderCategoryBar().list);
+    expect(bar).not.toContain(imposedHeight);
+    expect(bar).toContain(`${modifierOf(imposedHeight)}h-auto`);
+  });
+
+  it("gives each trigger a pixel-literal 44px minimum, matching the touch-scope hit slop", () => {
+    // The slop pseudo in `mobile-shell-touch-targets.css` is `max(100%, 44px)`
+    // in REAL pixels; this surface's root font is 15px, so the rem-based
+    // `min-h-11` idiom is 41.25px and leaves the pseudo hanging out of the
+    // list. Only a px literal makes the fit exact.
+    expect(classTokens(renderCategoryBar().trigger)).toContain("min-h-[44px]");
+  });
+
+  it("keeps the active trigger fill-less and carries its own underline on the primitive's active modifier", () => {
+    const baseline = classTokens(renderBaselineTabs().trigger);
+    const activeFill = baseline.find(
+      (token) =>
+        utilityOf(token) === "bg-background" && modifierOf(token).length > 0,
+    );
+    expect(activeFill).toBeDefined();
+    if (activeFill === undefined) return;
+    const activeModifier = modifierOf(activeFill);
+
+    const bar = classTokens(renderCategoryBar().trigger);
+    // The fill is replaced, not merely competed with: a surviving
+    // `bg-background` paints a box wherever the active `--background` differs
+    // from the sheet surface.
+    expect(bar).not.toContain(activeFill);
+    expect(bar).toContain(`${activeModifier}bg-transparent`);
+    // The bar draws its own `::before` underline because the touch scope claims
+    // every trigger's single `::after`. It has to fire on the SAME modifier the
+    // primitive uses for active, or the active tab is unmarked.
+    expect(bar).toContain(`${activeModifier}before:opacity-100`);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-category-tabs.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-category-tabs.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SwitcherCategoryTabs } from "@/components/epic-canvas/mobile/switcher-category-tabs";
@@ -7,17 +7,17 @@ import { SwitcherCategoryTabs } from "@/components/epic-canvas/mobile/switcher-c
  * The category bar is a horizontal scroll container, so its `overflow-y`
  * computes to `auto` and ANY vertical spill turns into a real, draggable
  * vertical scroller instead of clipping. It stays flat only because the bar
- * overrides two things `ui/tabs` imposes on every list - the fixed list height
- * and the active-state fill - and an override lands only when tailwind-merge
- * recognises it as the same utility, which it does only when the two spell
- * their Tailwind modifier the same way.
+ * overrides what `ui/tabs` imposes on every list and trigger - the fixed list
+ * height, the active-state fill, the indicator offset - and an override lands
+ * only when tailwind-merge recognises it as the same utility, which it does
+ * only when the two spell their Tailwind modifier the same way.
  *
  * That coupling is invisible in the bar's own source: its classes stay valid
  * Tailwind and the component keeps rendering when the primitive re-spells its
  * modifiers, so the overrides silently stop replacing anything and the base
- * height comes back. So these assertions never restate the primitive's
- * spelling - they read it off a plain `ui/tabs` render and require the bar to
- * have overridden THAT.
+ * comes back. So these assertions never restate the primitive's spelling -
+ * they read it off a plain `ui/tabs` render and require the bar to have
+ * overridden THAT.
  */
 
 function classTokens(element: Element): readonly string[] {
@@ -34,7 +34,7 @@ function modifierOf(token: string): string {
   return token.slice(0, token.length - utilityOf(token).length);
 }
 
-function renderBaselineTabs(): { list: Element; trigger: Element } {
+function renderBaselineTabs(): { list: HTMLElement; trigger: HTMLElement } {
   const { container } = render(
     <Tabs defaultValue="baseline">
       <TabsList variant="line">
@@ -42,26 +42,26 @@ function renderBaselineTabs(): { list: Element; trigger: Element } {
       </TabsList>
     </Tabs>,
   );
-  const list = container.querySelector('[data-slot="tabs-list"]');
-  const trigger = container.querySelector('[data-slot="tabs-trigger"]');
-  if (list === null || trigger === null)
-    throw new Error("ui/tabs rendered no list/trigger");
-  return { list, trigger };
+  // Scoped to this render's own container: a test that renders the baseline
+  // AND the bar has two tablists on screen at once.
+  const scope = within(container);
+  return {
+    list: scope.getByRole("tablist"),
+    trigger: scope.getByRole("tab", { name: "Baseline" }),
+  };
 }
 
-function renderCategoryBar(): { list: Element; trigger: Element } {
+function renderCategoryBar(): { list: HTMLElement; trigger: HTMLElement } {
   const { container } = render(
     <Tabs defaultValue="chats">
       <SwitcherCategoryTabs hasPullRequests={false} />
     </Tabs>,
   );
-  const list = container.querySelector('[data-slot="tabs-list"]');
-  const trigger = container.querySelector(
-    '[data-testid="mobile-switcher-tab-chats"]',
-  );
-  if (list === null || trigger === null)
-    throw new Error("category bar rendered no list/trigger");
-  return { list, trigger };
+  const scope = within(container);
+  return {
+    list: scope.getByRole("tablist", { name: "Tab categories" }),
+    trigger: scope.getByRole("tab", { name: "Chats" }),
+  };
 }
 
 describe("<SwitcherCategoryTabs />", () => {
@@ -91,25 +91,64 @@ describe("<SwitcherCategoryTabs />", () => {
     expect(classTokens(renderCategoryBar().trigger)).toContain("min-h-[44px]");
   });
 
-  it("keeps the active trigger fill-less and carries its own underline on the primitive's active modifier", () => {
+  it("keeps the active trigger fill-less in both themes and carries its own underline on the primitive's active modifier", () => {
     const baseline = classTokens(renderBaselineTabs().trigger);
-    const activeFill = baseline.find(
+    // Every fill the primitive can paint on the TRIGGER ITSELF: the light one
+    // and the `dark:`-scoped one, which is a separate utility tailwind-merge
+    // only replaces when the bar scopes its own the same way. Already-
+    // transparent utilities are not a box and need no override, and a pseudo's
+    // paint is a different surface - ui/tabs' `after:bg-foreground` indicator
+    // is deliberately left alone, since the touch scope neutralises it.
+    const isPseudo = (modifier: string): boolean =>
+      modifier.includes("before:") || modifier.includes("after:");
+    const imposedFills = baseline.filter(
       (token) =>
-        utilityOf(token) === "bg-background" && modifierOf(token).length > 0,
+        utilityOf(token).startsWith("bg-") &&
+        utilityOf(token) !== "bg-transparent" &&
+        modifierOf(token).length > 0 &&
+        !isPseudo(modifierOf(token)),
     );
-    expect(activeFill).toBeDefined();
-    if (activeFill === undefined) return;
-    const activeModifier = modifierOf(activeFill);
+    expect(imposedFills.length).toBeGreaterThan(0);
 
     const bar = classTokens(renderCategoryBar().trigger);
-    // The fill is replaced, not merely competed with: a surviving
-    // `bg-background` paints a box wherever the active `--background` differs
-    // from the sheet surface.
-    expect(bar).not.toContain(activeFill);
-    expect(bar).toContain(`${activeModifier}bg-transparent`);
+    const activeModifiers: string[] = [];
+    for (const fill of imposedFills) {
+      // The fill is replaced, not merely competed with: a surviving
+      // `bg-background` paints a box wherever the active `--background` differs
+      // from the sheet surface.
+      expect(bar).not.toContain(fill);
+      expect(bar).toContain(`${modifierOf(fill)}bg-transparent`);
+      activeModifiers.push(modifierOf(fill));
+    }
+
     // The bar draws its own `::before` underline because the touch scope claims
     // every trigger's single `::after`. It has to fire on the SAME modifier the
-    // primitive uses for active, or the active tab is unmarked.
+    // primitive uses for active, or the active tab is unmarked. That is the
+    // unscoped one - the `dark:` variant would only mark it in one theme.
+    const activeModifier = activeModifiers.find(
+      (modifier) => !modifier.startsWith("dark:"),
+    );
+    expect(activeModifier).toBeDefined();
+    if (activeModifier === undefined) return;
     expect(bar).toContain(`${activeModifier}before:opacity-100`);
+  });
+
+  it("pins the primitive's own indicator flush, so it cannot hang below the trigger", () => {
+    // ui/tabs offsets its `::after` indicator BELOW the trigger. On a coarse
+    // pointer the touch scope's slop overrides that geometry, but this shell
+    // also renders in a narrow desktop window, where nothing does and the
+    // offset spills straight back into the scroller.
+    const baseline = classTokens(renderBaselineTabs().trigger);
+    const imposedOffset = baseline.find(
+      (token) =>
+        modifierOf(token).includes("after:") &&
+        utilityOf(token).startsWith("bottom-"),
+    );
+    expect(imposedOffset).toBeDefined();
+    if (imposedOffset === undefined) return;
+
+    const bar = classTokens(renderCategoryBar().trigger);
+    expect(bar).not.toContain(imposedOffset);
+    expect(bar).toContain(`${modifierOf(imposedOffset)}bottom-0`);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -167,9 +167,6 @@ describe("<TabSwitcherSheet />", () => {
     renderSheet(true, () => {});
     const active = screen.getByRole("tab", { name: "Chats" });
     expect(active.getAttribute("data-state")).toBe("active");
-    // The base `data-active:bg-*` fill is neutralised, so the active line tab
-    // never paints a solid fill behind the label.
-    expect(active.className).toContain("data-active:bg-transparent");
     // The visible active indicator is a collision-free `::before` underline. The
     // trigger's single `::after` is claimed by the mobile touch hit-slop, so
     // ui/tabs' `after:bg-foreground` indicator legitimately stays in the class
@@ -178,7 +175,11 @@ describe("<TabSwitcherSheet />", () => {
     // mechanism.
     expect(active.className).toContain("after:bg-foreground");
     expect(active.className).toContain("before:bg-foreground");
-    expect(active.className).toContain("data-active:before:opacity-100");
+    // That the underline actually fires, and that the base fill is neutralised
+    // rather than merely competed with, both hang on the bar spelling its
+    // active-state modifier the way ui/tabs spells its own. Restating that
+    // spelling here would only re-assert what the bar's own source says, so
+    // `switcher-category-tabs.test.tsx` derives it from the primitive instead.
   });
 
   it("forces the mobile touch hit-slop ::after transparent so a merged indicator can't box the tab", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
@@ -87,11 +87,17 @@ export function SwitcherCategoryTabs(props: SwitcherCategoryTabsProps) {
       // nothing may exceed the list's height: it sizes to its triggers
       // (`h-auto` on the base height's exact modifier so tailwind-merge
       // replaces the fixed `h-8`), and the triggers themselves carry the full
-      // 44px touch height (min-h-11 below), which also collapses the
+      // 44px touch height (min-h-[44px] below), which also collapses the
       // coarse-pointer hit-slop `::after` (`height: max(100%, 44px)` in
       // mobile-shell-touch-targets.css) to an exact fit.
+      //
+      // Every override here has to spell its modifier the way `ui/tabs` spells
+      // its own, or tailwind-merge sees two unrelated utilities and keeps
+      // BOTH - the base height wins and the spill is back. That coupling is
+      // what `switcher-category-tabs.test.tsx` derives from the primitive
+      // rather than restates.
       className={cn(
-        "no-scrollbar w-full justify-start gap-1 overflow-x-auto px-2 group-data-horizontal/tabs:h-auto",
+        "no-scrollbar w-full justify-start gap-1 overflow-x-auto px-2 group-data-[orientation=horizontal]/tabs:h-auto",
         fadeClassForEdges(edges),
       )}
       aria-label="Tab categories"
@@ -102,12 +108,16 @@ export function SwitcherCategoryTabs(props: SwitcherCategoryTabsProps) {
           <TabsTrigger
             key={definition.id}
             value={definition.id}
-            // `data-active:bg-transparent`: force the line-variant active state
-            // fill-less (the `:where()`-neutralised line override can't
-            // out-specify the base `data-active:bg-*`; same prefix here, so
-            // tailwind-merge drops it) - otherwise it paints a box wherever the
-            // active `--background` differs from the sheet surface, e.g. a white
-            // box in a light portal.
+            // `min-h-[44px]`, not `min-h-11`: this surface's root font is 15px,
+            // so a rem-based `11` is 41.25px and would leave the 44px hit-slop
+            // `::after` spilling out of the list's exact fit.
+            //
+            // `data-[state=active]:bg-transparent`: force the line-variant
+            // active state fill-less (the `:where()`-neutralised line override
+            // can't out-specify the base `data-[state=active]:bg-*`; same prefix
+            // here, so tailwind-merge drops it) - otherwise it paints a box
+            // wherever the active `--background` differs from the sheet surface,
+            // e.g. a white box in a light portal.
             //
             // The active indicator is a `::before` underline, NOT ui/tabs'
             // `::after` one: the mobile-shell hit-slop
@@ -116,7 +126,13 @@ export function SwitcherCategoryTabs(props: SwitcherCategoryTabsProps) {
             // that `::after` is the (now transparent) slop, not the indicator.
             // `::before` is untouched by both ui/tabs and the slop rule, so it
             // renders the underline cleanly with no shared-pseudo collision.
-            className="min-h-11 flex-none gap-1.5 data-active:bg-transparent dark:data-active:bg-transparent before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-0.5 before:rounded-full before:bg-foreground before:opacity-0 before:transition-opacity data-active:before:opacity-100"
+            // ui/tabs' own `::after` still carries a `bottom-[-5px]` offset for
+            // the indicator it thinks it owns, which on a fine pointer - a
+            // narrow desktop window, where this shell also renders and no slop
+            // rule overrides the geometry - hangs 5px below the trigger and
+            // reopens the spill; pinning it flush is the same "nothing exceeds
+            // the list" rule as the height above.
+            className="min-h-[44px] flex-none gap-1.5 data-[state=active]:bg-transparent dark:data-[state=active]:bg-transparent group-data-[orientation=horizontal]/tabs:after:bottom-0 before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-0.5 before:rounded-full before:bg-foreground before:opacity-0 before:transition-opacity data-[state=active]:before:opacity-100"
             data-testid={`mobile-switcher-tab-${definition.id}`}
           >
             <Icon className="size-4" />


### PR DESCRIPTION
## Summary

The mobile switcher's category bar (Agents / Artifacts / File tree / Git diff / Terminals) scrolls vertically on a phone. It is a regression, and it is not from the tab-parity wave — it has been on `main` since #1377.

The bar is a horizontal scroll container, so `overflow-y` computes to `auto` and any vertical spill becomes a real, draggable vertical scroller instead of clipping. It stays flat only because it overrides two things `ui/tabs` imposes on every list — the fixed `h-8` and the active-state fill — and an override lands only when tailwind-merge sees the same utility, which it does only when both spell their Tailwind modifier identically.

#1377 corrected `ui/tabs` from the bare Radix forms to the attribute forms Radix actually emits (`data-horizontal:` → `data-[orientation=horizontal]:`, `data-active:` → `data-[state=active]:`) — `@radix-ui/react-tabs@1.1.20` emits only `data-orientation` and `data-state`, so the bare forms had never matched anything. The bar kept the old spelling.

That broke nothing loudly: the classes stayed valid Tailwind and the component kept rendering. It broke three things silently, at once:

1. The base `h-8` came alive and the bar's `h-auto` stopped replacing it, so the list pinned to 2rem while its triggers are 41.25px + a 44px slop pseudo — ~11px of vertical spill, the reported scroll.
2. `data-active:bg-transparent` stopped replacing `data-[state=active]:bg-background`, so the active tab can paint a fill box.
3. `data-active:before:opacity-100` went dead — the active tab has had **no underline** since #1377.

## Changes

- Move the bar's overrides onto the primitive's current spelling. This restores the original mechanism rather than replacing it.
- `min-h-11` → `min-h-[44px]`. The original comment claims "the full 44px touch height", but this surface's root font is 15px, so `min-h-11` renders 41.25 and leaves the touch scope's `max(100%, 44px)` slop pseudo — a real-pixel literal — hanging out of the exact fit the comment describes. The px literal makes the stated intent true.
- Pin `ui/tabs`' own `::after` indicator flush. #1377 also woke its `bottom-[-5px]` offset, which on a fine pointer — a narrow desktop window, where this shell also renders and no slop rule overrides the geometry — hangs 5px below the trigger and reopens the same spill.

## Test

The guard that existed asserted the bar's own class strings back at it, which is exactly why all three breakages were silent. The new `switcher-category-tabs.test.tsx` never restates the primitive's spelling: it renders a plain `ui/tabs` list and trigger, reads the imposed fixed height and the active-state modifier off **that**, and requires the bar to have overridden them — with a positive control that fails loudly if `ui/tabs` ever stops imposing a height, so a guard that has quietly stopped guarding cannot read as a clean tree.

The two self-referential literal assertions in `tab-switcher-sheet.test.tsx` are removed and pointed at the derived suite.

## Validation

- `bunx vitest run src/components/epic-canvas/mobile/__tests__/` — 11 files, 109 tests pass
- Negative control: all three new assertions fail on the pre-fix source (`expected [...] to not include 'group-data-[orientation=horizontal]/tabs:h-8'`), all three pass after
- `eslint` clean on the three changed files; `prettier` applied
- Pre-commit affected checks: hygiene, build · compile · lint · format — passed
- Simulator: real-drag verification on the phone rig is scheduled separately; this PR is the code fix

## Related issue

None.
