### PR TITLE
fix(protocol): move wslHealth to config.shell.listDetected v1.1

### DIFF
--- a/protocol/src/host/config/contracts.ts
+++ b/protocol/src/host/config/contracts.ts
@@ -1,4 +1,7 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import {
   configEnvDeleteRequestSchema,
   configEnvDeleteResponseSchema,
@@ -16,6 +19,7 @@ import {
   configShellGetResponseSchema,
   configShellListDetectedRequestSchema,
   configShellListDetectedResponseSchema,
+  configShellListDetectedResponseSchemaV10,
   configShellProbeRequestSchema,
   configShellProbeResponseSchema,
   configShellRemoveRequestSchema,
@@ -76,7 +80,36 @@ export const configShellListDetectedV10 = defineRpcContract({
   method: "config.shell.listDetected",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: configShellListDetectedRequestSchema,
+  responseSchema: configShellListDetectedResponseSchemaV10,
+});
+
+// v1.1 adds the optional `wslHealth` annotation to each row (a Windows
+// wsl.exe that cannot host a terminal: the installer stub, or no registered
+// distribution). Shipped as a minor rather than an in-place change to v1.0
+// because cli-v1.2.0 released the v1.0 response shape: a released peer never
+// sends the key, so it may only exist at a version that peer does not
+// negotiate. The extra object key is strippable by the within-major skew
+// handler, so a v1.1 host answering a v1.0 client drops it on the wire. See
+// the RPC backward-compat decision log.
+export const configShellListDetectedV11 = defineRpcContract({
+  method: "config.shell.listDetected",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: configShellListDetectedRequestSchema,
   responseSchema: configShellListDetectedResponseSchema,
+});
+
+// The request is empty either way, and a v1.0 response is already a valid
+// v1.1 response - `wslHealth` is optional and its absence means "no verdict",
+// exactly what a host that never probed should express - so both upgrades are
+// the identity.
+export const configShellListDetectedUpgradeV10ToV11 = defineUpgradePath<
+  typeof configShellListDetectedV10,
+  typeof configShellListDetectedV11
+>({
+  from: configShellListDetectedV10.schemaVersion,
+  to: configShellListDetectedV11.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
 });
 
 /** Shell executable probing runs against the connected host's filesystem. */

--- a/protocol/src/host/config/schemas.ts
+++ b/protocol/src/host/config/schemas.ts
@@ -109,17 +109,34 @@ export type ConfigShellListDetectedRequest = z.infer<
   typeof configShellListDetectedRequestSchema
 >;
 
-export const configDetectedShellSchema = z.object({
+/**
+ * The v1.0 row, FROZEN as released (cli-v1.2.0 shipped this shape). Adding a
+ * key here - even an optional one - changes the wire schema at a released
+ * version, which the protocol-compat gate rightly blocks; growth happens at
+ * v1.1 below instead.
+ */
+export const configDetectedShellSchemaV10 = z.object({
   name: z.string(),
   path: shellPathSchema,
   isDefault: z.boolean(),
   source: z.enum(["detected", "added"]),
   missing: z.boolean(),
-  // Optional both ways: absent from hosts predating the probe, and absent on
-  // every healthy or non-WSL row. See `DetectedShell.wslHealth`.
+});
+
+/**
+ * v1.1 adds `wslHealth`: optional both ways - absent from hosts predating the
+ * probe, and absent on every healthy or non-WSL row. See
+ * `DetectedShell.wslHealth`. This unversioned name stays the canonical row
+ * shape clients import.
+ */
+export const configDetectedShellSchema = configDetectedShellSchemaV10.extend({
   wslHealth: z.enum(["not-installed", "no-distro"]).optional(),
 });
 export type ConfigDetectedShell = z.infer<typeof configDetectedShellSchema>;
+
+export const configShellListDetectedResponseSchemaV10 = z.object({
+  shells: z.array(configDetectedShellSchemaV10),
+});
 
 export const configShellListDetectedResponseSchema = z.object({
   shells: z.array(configDetectedShellSchema),

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -243,7 +243,9 @@ import {
   configLogLevelsSetV10,
   configShellAddV10,
   configShellGetV10,
+  configShellListDetectedUpgradeV10ToV11,
   configShellListDetectedV10,
+  configShellListDetectedV11,
   configShellProbeV10,
   configShellRemoveV10,
   configShellResetV10,
@@ -3770,11 +3772,15 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
   "config.shell.listDetected": {
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: configShellListDetectedV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: configShellListDetectedV11,
+          upgradeFromPreviousVersion: configShellListDetectedUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## Summary

Fixes the `protocol-compat` and `test (@traycer/protocol)` failures on `main` after #1378 merged.

**What happened:** the compat gate resolves released baselines from release tags *at run time*. `cli-v1.2.0` was released in the window between #1378's green CI run and its merge, freezing `config.shell.listDetected@1.0` as a shipped wire surface. The merged tree then failed on `main`: `wslHealth` had been added inside the v1.0 response schema, and a released v1.2.0 peer never sends that key at that version — exactly the divergence the gate exists to block. Same tree, same code; only the set of released baselines changed underneath it.

**The fix**, following the `host.getRateLimitUsage` v1.1/v1.2 template:

- `configDetectedShellSchemaV10` / `configShellListDetectedResponseSchemaV10` freeze the released v1.0 shapes (no `wslHealth`), and `configShellListDetectedV10` points back at them.
- `configShellListDetectedV11` carries the row schema with the optional `wslHealth`, registered as minor 1.1 with `configShellListDetectedUpgradeV10ToV11`. Both upgrade directions are the identity: the request is empty, and a v1.0 response is already a valid v1.1 response — the key's absence means "no verdict", which is exactly what a host that never probed should express. The within-major skew handler strips the key when a v1.1 host answers a v1.0 client.
- No client or host code changes: the unversioned `configDetectedShellSchema` / `ConfigDetectedShell` names keep the v1.1 shape every consumer already imports.

## Related issue

Post-merge CI failures on `main` from #1378 (runs 32812282116, 32812282139).

## Checklist

- [x] Pre-commit static checks pass (protocol typecheck, eslint, prettier clean)
- [x] Separate CI test checks pass — `released-baseline-compat.test.ts` (the failing test) passes locally; full `src/host` + `src/framework` suites: 109 files / 2185 tests; gui-app settings suite: 85 files / 1389 tests
- [x] Tests added/updated where it makes sense — covered by the existing registry minor-additivity self-validation and released-baseline suites; no new surface
- [x] Commits are signed off (`git commit -s`) per the DCO
