### PR TITLE
fix(protocol): freeze config.shell.listDetected@1.0 and open 1.1 for wslHealth

### DIFF
--- a/protocol/src/host/config/contracts.ts
+++ b/protocol/src/host/config/contracts.ts
@@ -1,4 +1,7 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import {
   configEnvDeleteRequestSchema,
   configEnvDeleteResponseSchema,
@@ -16,6 +19,7 @@ import {
   configShellGetResponseSchema,
   configShellListDetectedRequestSchema,
   configShellListDetectedResponseSchema,
+  configShellListDetectedResponseSchemaV10,
   configShellProbeRequestSchema,
   configShellProbeResponseSchema,
   configShellRemoveRequestSchema,
@@ -71,12 +75,42 @@ export const configShellRevertArgsV10 = defineRpcContract({
   responseSchema: configShellRevertArgsResponseSchema,
 });
 
-/** Shell discovery runs against the connected host's own filesystem. */
+/**
+ * Shell discovery runs against the connected host's own filesystem.
+ *
+ * v1.0 is frozen at the shape that shipped, before the WSL health probe; v1.1
+ * carries the optional `wslHealth` annotation. Additive growth on a released
+ * line takes the next MINOR, not a new major: `versioned-rpc.ts` rejects a
+ * major bump that carries no breaking change, and one optional field is not
+ * one. A peer that negotiated 1.0 keeps receiving the 1.0 shape because the
+ * transport re-parses the response through the frozen 1.0 schema, so the key
+ * only reaches a peer whose own wire contract describes it.
+ */
 export const configShellListDetectedV10 = defineRpcContract({
   method: "config.shell.listDetected",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: configShellListDetectedRequestSchema,
+  responseSchema: configShellListDetectedResponseSchemaV10,
+});
+
+export const configShellListDetectedV11 = defineRpcContract({
+  method: "config.shell.listDetected",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: configShellListDetectedRequestSchema,
   responseSchema: configShellListDetectedResponseSchema,
+});
+
+// The request is unchanged across the minor, and an unannotated 1.0 row is
+// already a valid 1.1 row - absence is the healthy/not-probed/not-wsl.exe
+// reading - so both halves of the upgrade are the identity.
+export const configShellListDetectedUpgradeV10ToV11 = defineUpgradePath<
+  typeof configShellListDetectedV10,
+  typeof configShellListDetectedV11
+>({
+  from: configShellListDetectedV10.schemaVersion,
+  to: configShellListDetectedV11.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
 });
 
 /** Shell executable probing runs against the connected host's filesystem. */

--- a/protocol/src/host/config/schemas.ts
+++ b/protocol/src/host/config/schemas.ts
@@ -109,17 +109,35 @@ export type ConfigShellListDetectedRequest = z.infer<
   typeof configShellListDetectedRequestSchema
 >;
 
-export const configDetectedShellSchema = z.object({
+// ── Frozen protocol-1.0 detected-shell row (before the WSL health probe) ────
+// This is the shape `config.shell.listDetected@1.0` serializes, and the only
+// shape a peer that negotiated 1.0 ever described on the wire. `wslHealth`
+// rides 1.1 above it; the transport re-parses a 1.1 response through this
+// schema when the negotiated version is 1.0, which strips the key.
+export const configDetectedShellSchemaV10 = z.object({
   name: z.string(),
   path: shellPathSchema,
   isDefault: z.boolean(),
   source: z.enum(["detected", "added"]),
   missing: z.boolean(),
-  // Optional both ways: absent from hosts predating the probe, and absent on
-  // every healthy or non-WSL row. See `DetectedShell.wslHealth`.
+});
+export type ConfigDetectedShellV10 = z.infer<
+  typeof configDetectedShellSchemaV10
+>;
+
+export const configDetectedShellSchema = configDetectedShellSchemaV10.extend({
+  // Absent on every healthy or non-WSL row, and on every 1.0 payload. See
+  // `DetectedShell.wslHealth`.
   wslHealth: z.enum(["not-installed", "no-distro"]).optional(),
 });
 export type ConfigDetectedShell = z.infer<typeof configDetectedShellSchema>;
+
+export const configShellListDetectedResponseSchemaV10 = z.object({
+  shells: z.array(configDetectedShellSchemaV10),
+});
+export type ConfigShellListDetectedResponseV10 = z.infer<
+  typeof configShellListDetectedResponseSchemaV10
+>;
 
 export const configShellListDetectedResponseSchema = z.object({
   shells: z.array(configDetectedShellSchema),

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -243,7 +243,9 @@ import {
   configLogLevelsSetV10,
   configShellAddV10,
   configShellGetV10,
+  configShellListDetectedUpgradeV10ToV11,
   configShellListDetectedV10,
+  configShellListDetectedV11,
   configShellProbeV10,
   configShellRemoveV10,
   configShellResetV10,
@@ -3767,14 +3769,22 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
+  // 1.0 is frozen at the shape that shipped; 1.1 adds the optional `wslHealth`
+  // annotation. No cross-major downgrade is needed - a 1.0 peer negotiates 1.0
+  // within the same major, where the transport re-parses the response through
+  // the frozen 1.0 schema and strips the key.
   "config.shell.listDetected": {
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: configShellListDetectedV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: configShellListDetectedV11,
+          upgradeFromPreviousVersion: configShellListDetectedUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## Summary

The Protocol Compatibility gate has been red on `main` since eed54b3cf (#1378):

```
[BREAKING] unary config.shell.listDetected@1.0 response
  at properties.shells.items.properties.wslHealth
  new property added (tolerated via optional/.catch()/default) at a released
  version on a host→client slot
```

#1378 added `wslHealth` **in place** on `config.shell.listDetected@1.0` — an
already-released line. That is a same-version wire-shape change on a host→client
slot: a released peer's payload never carries the key, so its presence is a
runtime coin flip rather than a version fact. This is precisely the
`providers.list` #258 shape the gate was built to block, and `.optional()`
tolerance is parse-time hardening, not a versioning mechanism.

**This PR freezes 1.0 at the shape that shipped and opens 1.1 carrying the
annotation.** No behavior change: `wslHealth` still rides the wire for any peer
that negotiates 1.1.

| File | Change |
| --- | --- |
| `host/config/schemas.ts` | `configDetectedShellSchemaV10` / `configShellListDetectedResponseSchemaV10` — the frozen pre-probe shape; the live schema now `.extend()`s it with `wslHealth` |
| `host/config/contracts.ts` | `configShellListDetectedV10` binds the frozen response; new `V11` binds live; identity `UpgradeV10ToV11` |
| `host/registry.ts` | `latestMinor: 1`, minor `1` installed |

## Why this remedy and not the alternatives

**Not `compat-exceptions.json`.** That file's own `$comment` scopes it to
host→client paths that are **catalog-gated** and states it is "Not a per-change
review mechanism." Nothing negotiated gates `wslHealth`'s emission — it is a
plain new key on a released response, not an id behind a catalog the client
already fetched. The existing optional-property entries there
(`**.workspaceMode`, `**.activeProcessName`, `**.ackCreditSupported`) are static
policy over shapes whose absence is a *defined protocol state*; granting an
entry here to unblock one PR is exactly how the #258 hole reopens.

**Not a new major, despite the hint text.** The finding and
`released-baseline-compat.test.ts` both say "open a new major with downgrade
bridges (amp `003d7586` / devin `407d110` template)". That is right for the
growth those templates had in mind — ids/enums on a catalog payload — and wrong
here: `versioned-rpc.ts`'s cross-major check **rejects** a purely additive major
(`"Major bump 1 -> 2 for method '…' is not a breaking change (could have shipped
as a minor)"`), so a `2.0` would fail at registry load. One optional field is not
a breaking change.

This is the same correction already recorded in-tree for `providers.list@7.0 →
7.1` (`frozen-catalog-lines.test.ts:86-89`, `registry.ts:1711-1717`): *"the new
line is a MINOR … two optional fields are not one. Additive growth on a frozen
head takes the next minor."*

**No hand-written downgrade bridge is needed.** The skew is *within* a major, so
`downgradePathsFromLatest` (which only spans majors) stays empty. A peer that
negotiated 1.0 gets the projection the framework already performs — the newer
peer re-parses its latest-shape payload through the older installed schema
(`json-schema-fingerprint.ts`'s "frozen response reparse"), and the frozen 1.0
object strips `wslHealth`. That is also why the addition is legal as a minor at
all: field addition is additive under both `lenient` and `no-value-growth`; only
enum/union *value* growth is strict on unary responses.

## Verification

- `bun run --filter @traycer/protocol test src/host/__tests__/released-baseline-compat.test.ts` — **1/1 pass** (was the failing gate).
- Adjacent registry/versioning + config suites, 19 files / **305 tests pass**:
  `released-surface-compat`, `two-sided-release-invariant`, `released-floor`,
  `frozen-catalog-lines`, `src/config/__tests__`. The registry validator runs on
  import, so `latestMinor`/upgrade-path structure is checked by every one of them.
- `bun run --filter @traycer/protocol compile` and `lint` — clean.
- Nothing outside `protocol/` is touched; the live `ConfigDetectedShell` type is
  unchanged, so the host resolver, GUI picker and CLI printer compile as-is.

Deliberately not run locally: the full monorepo suite — CI owns it.

## Checklist

- [x] Pre-commit static checks pass
- [x] Separate CI test checks pass — see Verification
- [x] Tests added/updated where it makes sense (the existing gate is the test; it goes green)
- [x] Commits are signed off (`git commit -s`) per the DCO
