### PR TITLE
fix(gui-app): keep dialog actions above the soft keyboard

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-keyboard-height.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-keyboard-height.test.tsx
@@ -1,0 +1,232 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HostWorkspaceControlsHostScope } from "@/components/home/host-workspace-selector/host-workspace-controls-scope";
+
+/**
+ * Geometry contract for `chat-fork-dialog.tsx`.
+ *
+ * The dialog carries a title field, a harness picker, stacked workspace
+ * controls and a notice stack - a stack taller than a phone viewport before a
+ * soft keyboard is anywhere near it. Uncapped, a centre-translated `fixed`
+ * dialog puts Fork past the bottom edge with nothing able to scroll to it.
+ *
+ * The structural guarantee, not pixels: the height cap is applied, the middle
+ * region owns the scroll, and the footer sits outside that region so Fork
+ * stays put while the form scrolls under it.
+ */
+
+const dialogMocks = vi.hoisted(() => ({
+  createMutate: vi.fn(),
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicCreateChatForHost: () => ({
+    mutate: dialogMocks.createMutate,
+    isPending: false,
+  }),
+  // The full `UseMutationResult` surface: a partial stub fails every case at
+  // once on a member the test never mentions.
+  useEpicCreateChatForHostClient: () => ({
+    mutate: dialogMocks.createMutate,
+    isPending: false,
+    reset: () => undefined,
+    error: null,
+    variables: null,
+    data: null,
+    isError: false,
+    isSuccess: false,
+    isIdle: true,
+    status: "idle",
+    mutateAsync: () => Promise.reject(new Error("unused")),
+    failureCount: 0,
+    failureReason: null,
+    isPaused: false,
+    submittedAt: 0,
+    context: null,
+  }),
+}));
+
+const TAB_HOST_ID = "tab-host-id";
+
+vi.mock("@/hooks/chats/use-clone-source-owner", () => ({
+  useCloneSourceOwnerUserId: () => null,
+}));
+
+vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
+  useHostDirectoryList: () => ({
+    data: [
+      {
+        hostId: TAB_HOST_ID,
+        label: "Tab host",
+        kind: "local",
+        websocketUrl: "ws://127.0.0.1:1/rpc",
+        version: "0.0.0-test",
+        transportDialability: "dialable",
+      },
+    ],
+    isLoading: false,
+    isError: false,
+    refetch: () => Promise.resolve(),
+  }),
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return { ...actual, useHostClient: () => null };
+});
+
+vi.mock("@/hooks/host/use-tab-host-client", () => ({
+  useTabHostClient: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/hooks/use-tab-host-id", () => ({
+  useTabHostId: () => TAB_HOST_ID,
+}));
+
+vi.mock("@/hooks/host/use-host-query", () => ({
+  useHostQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("@/components/home/pickers/harness-model-picker", () => ({
+  HarnessModelPicker: () => (
+    <button type="button" aria-label="Harness picker">
+      Claude Opus
+    </button>
+  ),
+}));
+
+vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
+  useGuiHarnessesQueryForClient: () => ({
+    data: {
+      harnesses: [
+        {
+          id: "claude",
+          label: "Claude Code",
+          available: true,
+          error: null,
+          modes: ["gui", "tui"],
+          requiresApiKey: false,
+          supportedPermissionModes: ["supervised"],
+        },
+      ],
+    },
+    isPending: false,
+  }),
+  useGuiHarnessModelsQueryForClient: () => ({
+    data: {
+      models: [
+        {
+          harnessId: "claude",
+          slug: "claude-opus-4-7",
+          label: "Claude Opus",
+          description: null,
+          contextWindow: null,
+          maxOutputTokens: null,
+          defaultReasoningEffort: null,
+          supportedReasoningEfforts: [],
+          defaultServiceTier: null,
+          supportedServiceTiers: [],
+          metadata: {},
+        },
+      ],
+    },
+    isPending: false,
+  }),
+}));
+
+// The workspace controls are the tallest thing in the stack, and their own
+// geometry is not what this suite is about; a stand-in keeps the assertions
+// pointed at the dialog's three regions.
+vi.mock(
+  "@/components/home/host-workspace-selector/host-workspace-selector",
+  () => ({
+    ActiveHostWorkspaceControls: (_props: {
+      readonly hostScope: HostWorkspaceControlsHostScope;
+    }) => <div data-testid="workspace-controls-stub" />,
+  }),
+);
+
+import { ChatForkDialog, type ChatForkDialogTarget } from "../chat-fork-dialog";
+
+function forkTarget(): ChatForkDialogTarget {
+  return {
+    sourceChatId: "source-chat",
+    sourceChatTitle: "Source chat",
+    assistantMessageId: "assistant-message-1",
+    interviewBlockId: null,
+    parentId: null,
+    settingsSeed: {
+      harnessId: "claude",
+      model: "claude-opus-4-7",
+      permissionMode: "supervised",
+      reasoningEffort: "high",
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: null,
+    },
+    workspaceSeed: {
+      workspace: { folders: [], folderInfoByPath: {}, primaryPath: null },
+      intent: null,
+    },
+    seedIntentOverride: null,
+    carriedInterviews: "settled",
+    forkMode: "plain",
+    initialHostId: null,
+  };
+}
+
+function renderDialog(): void {
+  render(
+    <ChatForkDialog
+      open
+      target={forkTarget()}
+      epicId="epic-test"
+      tabId="tab-test"
+      onOpenChange={() => undefined}
+    />,
+  );
+}
+
+describe("<ChatForkDialog /> height cap and footer", () => {
+  afterEach(() => {
+    dialogMocks.createMutate.mockReset();
+    cleanup();
+  });
+
+  it("caps its height against the viewport instead of growing past it", () => {
+    renderDialog();
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("max-h-[min(86dvh,calc(100dvh-2rem))]");
+    // Header / scroller / footer: the middle track is the only one allowed to
+    // take the leftover height, and `minmax(0,…)` is what lets it shrink below
+    // its content so the scroll can happen at all.
+    expect(dialog.className).toContain("grid-rows-[auto_minmax(0,1fr)_auto]");
+  });
+
+  it("scrolls the form and leaves Fork outside the scrolled region", () => {
+    renderDialog();
+
+    const scroller = screen.getByTestId("chat-fork-dialog-scroller");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller.className).toContain("min-h-0");
+    // The field that raises the keyboard is inside the scroll region...
+    expect(scroller.contains(screen.getByLabelText("Fork agent title"))).toBe(
+      true,
+    );
+
+    const footer = screen
+      .getByRole("dialog")
+      .querySelector('[data-slot="dialog-footer"]');
+    expect(footer).not.toBeNull();
+    // ...and the action it exists to reach is not, so scrolling the form never
+    // carries Fork off the bottom.
+    expect(scroller.contains(footer)).toBe(false);
+    expect(footer?.contains(screen.getByRole("button", { name: "Fork" }))).toBe(
+      true,
+    );
+  });
+});

--- a/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-keyboard-height.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-fork-dialog-keyboard-height.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HostWorkspaceControlsHostScope } from "@/components/home/host-workspace-selector/host-workspace-controls-scope";
 
 /**
- * Geometry contract for `chat-fork-dialog.tsx`.
+ * Geometry and open-focus contract for `chat-fork-dialog.tsx`.
  *
  * The dialog carries a title field, a harness picker, stacked workspace
  * controls and a notice stack - a stack taller than a phone viewport before a
@@ -13,6 +13,12 @@ import type { HostWorkspaceControlsHostScope } from "@/components/home/host-work
  * The structural guarantee, not pixels: the height cap is applied, the middle
  * region owns the scroll, and the footer sits outside that region so Fork
  * stays put while the form scrolls under it.
+ *
+ * Focus is the other half, and it is what decides whether a keyboard opens at
+ * all. The title field is the first tabbable descendant, so Radix's own
+ * open-autofocus takes it - free on a keyboard-driven machine, a summoned
+ * software keyboard on a touch one. Both arms are pinned here because the
+ * coarse arm is invisible on every developer's desktop.
  */
 
 const dialogMocks = vi.hoisted(() => ({
@@ -190,8 +196,42 @@ function renderDialog(): void {
   );
 }
 
+/**
+ * The global test shim answers every media query with `matches: false`, which
+ * is the fine-pointer arm. This narrows the coarse-pointer query alone so the
+ * rest of the app's queries keep the shim's answer, and the original is put
+ * back afterwards so neither arm leaks into the next case.
+ */
+const originalMatchMedia = window.matchMedia.bind(window);
+
+function stubCoarsePointer(coarse: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: coarse && query === "(pointer: coarse)",
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
 describe("<ChatForkDialog /> height cap and footer", () => {
+  beforeEach(() => {
+    stubCoarsePointer(false);
+  });
+
   afterEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
     dialogMocks.createMutate.mockReset();
     cleanup();
   });
@@ -228,5 +268,28 @@ describe("<ChatForkDialog /> height cap and footer", () => {
     expect(footer?.contains(screen.getByRole("button", { name: "Fork" }))).toBe(
       true,
     );
+  });
+
+  it("focuses the title field when a fine pointer is driving", () => {
+    renderDialog();
+
+    expect(document.activeElement).toBe(
+      screen.getByLabelText("Fork agent title"),
+    );
+  });
+
+  it("leaves the title field unfocused on a coarse pointer", () => {
+    stubCoarsePointer(true);
+    renderDialog();
+
+    // The whole point: no focused text field means no software keyboard over a
+    // form whose common path is "keep the seeded title and press Fork".
+    expect(document.activeElement).not.toBe(
+      screen.getByLabelText("Fork agent title"),
+    );
+    // Declining the field is not a licence to strand focus on the trigger,
+    // outside the focus scope - the dialog itself takes it.
+    const dialog = screen.getByRole("dialog");
+    expect(document.activeElement).toBe(dialog);
   });
 });

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -782,7 +782,13 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="w-[min(94vw,32rem)] gap-2 sm:max-w-[min(94vw,34rem)]"
+        // Capped and split into header / scroller / footer, the shape every
+        // dialog with a form taller than a phone uses. The cap is what keeps
+        // Fork reachable once a soft keyboard is up: both mobile shells shrink
+        // the layout viewport for the keyboard (the app resizes the web view
+        // natively, Android Chrome honours `interactive-widget=resizes-content`),
+        // so `dvh` already resolves against what is left uncovered.
+        className="grid max-h-[min(86dvh,calc(100dvh-2rem))] w-[min(94vw,32rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0 sm:max-w-[min(94vw,34rem)]"
         // Same portal rule as the worktree pickers: the host switcher's list
         // mounts outside this dialog, so a click in it reads as an interaction
         // from outside. Dismissing on that would throw away the form someone is
@@ -802,10 +808,13 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
         {capabilityProbeEntries.map((entry) => (
           <ChatForkHostCapabilityProbe key={entry.hostId} entry={entry} />
         ))}
-        <DialogHeader>
+        <DialogHeader className="px-4 pt-4 pr-12 pb-2">
           <DialogTitle>Fork agent</DialogTitle>
         </DialogHeader>
-        <div className="flex min-w-0 flex-col gap-2">
+        <div
+          className="flex min-h-0 min-w-0 flex-col gap-2 overflow-y-auto px-4 pb-2"
+          data-testid="chat-fork-dialog-scroller"
+        >
           <label htmlFor={titleInputId} className="flex min-w-0 flex-col gap-2">
             <span className="px-0 py-0 font-sans text-overline font-medium uppercase text-muted-foreground/70">
               Title
@@ -869,7 +878,9 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
             publicationNotice={publicationNotice}
           />
         </div>
-        <DialogFooter>
+        {/* `mx-0 mb-0`: the footer's own negative margins bleed it into a
+            `p-4` content, and this one is `p-0`. */}
+        <DialogFooter className="mx-0 mb-0 px-4 py-3">
           <Button
             type="button"
             variant="outline"

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -33,6 +33,7 @@ import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query
 import { useHostNegotiatedMethodVersions } from "@/hooks/host/use-host-negotiated-method-version";
 import { useHostCapabilityProbe } from "@/hooks/host/use-host-capability-probe";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import { useCoarsePointer } from "@/hooks/ui/use-coarse-pointer";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useEpicCreateChatForHostClient } from "@/hooks/epic/use-epic-chat-mutations";
 import { useCloneSourceOwnerUserId } from "@/hooks/chats/use-clone-source-owner";
@@ -190,6 +191,14 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
   const navigateNestedFocus = useEpicNestedFocusNavigation();
   const openCancelsRef = useRef<Set<() => void> | null>(null);
   const stagingSessionRef = useRef<ForkWorkspaceStagingSession | null>(null);
+  // The title field is the first tabbable descendant, so Radix's own
+  // open-autofocus lands on it. On a touch pointer that is a request for a
+  // software keyboard, over a form whose common path is "accept the seeded
+  // title and press Fork". The pointer decides, not the viewport and not the
+  // build: a narrow desktop window types with hardware, a tablet at desktop
+  // width does not.
+  const coarsePointer = useCoarsePointer();
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const openCancels = new Set<() => void>();
@@ -789,6 +798,21 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
         // natively, Android Chrome honours `interactive-widget=resizes-content`),
         // so `dvh` already resolves against what is left uncovered.
         className="grid max-h-[min(86dvh,calc(100dvh-2rem))] w-[min(94vw,32rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0 sm:max-w-[min(94vw,34rem)]"
+        ref={contentRef}
+        onOpenAutoFocus={(event) => {
+          // Focus moves to the dialog itself rather than being merely
+          // declined: Radix leaves focus wherever it was when this is
+          // prevented, which is the trigger - outside the focus scope, and
+          // often already unmounting with the menu it lived in. The content
+          // element carries `tabIndex={-1}` for exactly this, and taking it
+          // announces the dialog to a screen reader without asking for a
+          // keyboard. Fails safe: with no element to move to, Radix's own
+          // default runs instead of being cancelled with nowhere to go.
+          if (!coarsePointer) return;
+          if (contentRef.current === null) return;
+          event.preventDefault();
+          contentRef.current.focus();
+        }}
         // Same portal rule as the worktree pickers: the host switcher's list
         // mounts outside this dialog, so a click in it reads as an interaction
         // from outside. Dismissing on that would throw away the form someone is

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/mobile-new-terminal-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/mobile-new-terminal-dialog.test.tsx
@@ -1,0 +1,220 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { WorktreeBindingSelectorRowV12 } from "@traycer/protocol/host";
+
+/**
+ * The phone "New terminal" dialog, on its two contracts:
+ *
+ * 1. Geometry - header, one scrolled region, and the Launch bar pinned outside
+ *    it under a viewport height cap, so Launch cannot end up below the fold.
+ * 2. Focus - the dialog and the picker body used to disagree about it. The
+ *    dialog declined Radix's open-autofocus precisely so the workspace search
+ *    could claim focus, and the search claimed it unconditionally, which on a
+ *    touch device raises a keyboard over a two-tap pick. The pointer decides
+ *    now, and the two halves move together.
+ */
+
+const bindingsQuery = vi.hoisted(() => ({
+  current: null as {
+    readonly data:
+      | {
+          readonly rows: WorktreeBindingSelectorRowV12[];
+          readonly folderlessCwd: string | null;
+        }
+      | undefined;
+    readonly isPending: boolean;
+    readonly isError: boolean;
+  } | null,
+}));
+
+vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
+  useWorktreeListBindingsForEpic: () => bindingsQuery.current,
+  useWorktreeListBindingsForEpicForClient: () => bindingsQuery.current,
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => ({
+    status: "reachable",
+    hostLabel: "MacBook",
+    unavailability: null,
+  }),
+}));
+
+vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
+  useHostDirectoryList: () => ({
+    data: [{ hostId: "host-1" }],
+    fetchStatus: "idle",
+  }),
+}));
+
+// The host list is not what this suite is about; mocking at the option
+// boundary is the same shape the sidebar picker's suite uses.
+vi.mock("@/components/settings/host-scope/use-host-options", async () => {
+  const { hostOptionsFixture, hostScopeOptionFixture } =
+    await import("@/components/settings/host-scope/host-scope-fixture");
+  return {
+    useHostOptions: () =>
+      hostOptionsFixture({
+        hosts: [hostScopeOptionFixture({ hostId: "host-1", name: "MacBook" })],
+        activeHostId: "host-1",
+      }),
+  };
+});
+
+vi.mock("@/hooks/host/use-addressable-host-id", () => ({
+  useAddressableHostId: () => "host-1",
+}));
+
+vi.mock("@/hooks/host/use-effective-host-id", () => ({
+  useEffectiveHostId: () => "host-1",
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostBinding: () => ({
+    directory: {
+      refresh: () => Promise.resolve([]),
+      selectById: () => undefined,
+    },
+  }),
+}));
+
+import { MobileNewTerminalDialog } from "../mobile-new-terminal-dialog";
+
+const SEARCH_PLACEHOLDER = "Search repo, branch, or path…";
+
+function makeRow(
+  hostId: string,
+  runningDir: string,
+  branch: string,
+): WorktreeBindingSelectorRowV12 {
+  return {
+    hostId,
+    runningDir,
+    workspacePath: "/work/traycer",
+    worktreePath: runningDir,
+    mode: "worktree",
+    isGitRepo: true,
+    repoIdentifier: { owner: "traycer", repo: "traycer" },
+    branch,
+    isPrimary: runningDir.endsWith("traycer"),
+    isImported: false,
+    setupState: "not_required",
+    disabledReason: null,
+    sources: [],
+    isGitResolvePending: false,
+  };
+}
+
+const testQueryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, gcTime: 0 } },
+});
+
+function TestProviders(props: { readonly children: ReactNode }): ReactNode {
+  return (
+    <QueryClientProvider client={testQueryClient}>
+      {props.children}
+    </QueryClientProvider>
+  );
+}
+
+function renderDialog(): void {
+  render(
+    <MobileNewTerminalDialog
+      epicId="epic-1"
+      tabId="tab-1"
+      open
+      onOpenChange={() => undefined}
+      onLaunched={null}
+    />,
+    { wrapper: TestProviders },
+  );
+}
+
+/**
+ * The global test shim answers every media query with `matches: false`, which
+ * is the fine-pointer arm. This narrows the coarse-pointer query alone so the
+ * rest of the app's queries keep the shim's answer.
+ */
+function stubCoarsePointer(coarse: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: coarse && query === "(pointer: coarse)",
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+describe("<MobileNewTerminalDialog />", () => {
+  beforeEach(() => {
+    bindingsQuery.current = {
+      data: {
+        rows: [makeRow("host-1", "/work/traycer", "main")],
+        folderlessCwd: "/Users/tgill",
+      },
+      isPending: false,
+      isError: false,
+    };
+    stubCoarsePointer(false);
+  });
+
+  afterEach(() => {
+    bindingsQuery.current = null;
+    cleanup();
+  });
+
+  it("caps its height and pins Launch outside the scrolled region", () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId("mobile-epic-new-terminal-dialog");
+    expect(dialog.className).toContain("max-h-[min(86dvh,calc(100dvh-2rem))]");
+    expect(dialog.className).toContain("grid-rows-[auto_minmax(0,1fr)_auto]");
+
+    const scroller = screen.getByTestId("new-terminal-picker-scroller");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller.contains(screen.getByTestId("worktree-folder-list"))).toBe(
+      true,
+    );
+    // The whole point of the split: the host and folder pick can run long, and
+    // Launch still cannot be scrolled away from.
+    expect(
+      scroller.contains(screen.getByRole("button", { name: "Launch" })),
+    ).toBe(false);
+  });
+
+  it("focuses the workspace search when a fine pointer is driving", () => {
+    renderDialog();
+
+    expect(document.activeElement).toBe(
+      screen.getByPlaceholderText(SEARCH_PLACEHOLDER),
+    );
+  });
+
+  it("leaves the workspace search alone on a coarse pointer", () => {
+    stubCoarsePointer(true);
+    renderDialog();
+
+    const search = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+    expect(document.activeElement).not.toBe(search);
+    // Focus still has to land inside the dialog - declining the search's claim
+    // is not a licence to strand it on a trigger outside the focus scope.
+    expect(
+      screen
+        .getByTestId("mobile-epic-new-terminal-dialog")
+        .contains(document.activeElement),
+    ).toBe(true);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-rename-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-rename-dialog.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SwitcherRenameDialog } from "../switcher-rename-dialog";
+
+/**
+ * Geometry contract for the mobile switcher's rename dialog: the same three
+ * regions every dialog holding a text field uses. Return still saves here (the
+ * form's `onSubmit`), so Save being reachable is a second route rather than the
+ * only one - which is exactly why the shape has to be asserted rather than
+ * assumed to have been noticed.
+ */
+describe("<SwitcherRenameDialog /> height cap and footer", () => {
+  afterEach(cleanup);
+
+  function renderDialog(): void {
+    render(
+      <SwitcherRenameDialog
+        open
+        onOpenChange={() => undefined}
+        title="Rename agent"
+        initialValue="Old name"
+        nodeId="node-1"
+        onSubmit={() => undefined}
+      />,
+    );
+  }
+
+  it("caps its height against the viewport", () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId("switcher-rename-dialog");
+    expect(dialog.className).toContain("max-h-[min(86dvh,calc(100dvh-2rem))]");
+    expect(dialog.className).toContain("grid-rows-[auto_minmax(0,1fr)]");
+  });
+
+  it("keeps Save outside the scrolled field region", () => {
+    renderDialog();
+
+    const scroller = screen.getByTestId("switcher-rename-scroller");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller.contains(screen.getByLabelText("New name"))).toBe(true);
+
+    const footer = screen
+      .getByTestId("switcher-rename-dialog")
+      .querySelector('[data-slot="dialog-footer"]');
+    expect(footer).not.toBeNull();
+    expect(scroller.contains(footer)).toBe(false);
+    expect(
+      footer?.contains(screen.getByTestId("switcher-rename-save-node-1")),
+    ).toBe(true);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-new-terminal-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-new-terminal-dialog.tsx
@@ -11,6 +11,7 @@ import {
   buildTerminalTileRef,
   type TerminalLaunchTarget,
 } from "@/components/epic-canvas/sidebar/new-terminal-tile-ref";
+import { useCoarsePointer } from "@/hooks/ui/use-coarse-pointer";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useTabSurfaceKey } from "@/hooks/host/use-surface-host-pin";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -64,16 +65,31 @@ export function MobileNewTerminalDialog(props: MobileNewTerminalDialogProps) {
       onLaunched,
     ],
   );
+  // A touch pointer is the one that pays for a focused text field: focusing
+  // the picker's workspace search raises a software keyboard nobody asked for,
+  // over a dialog whose whole job is a two-tap host-then-folder pick. The
+  // pointer, not the viewport and not the build, is what decides that - a
+  // narrow desktop window still has a hardware keyboard and wants the search
+  // focused, and a tablet at desktop width does not.
+  const coarsePointer = useCoarsePointer();
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="w-[min(92vw,28rem)] max-w-[min(92vw,28rem)] gap-0 p-0"
+        // Header / scroller / Launch bar, under the shared height cap. The
+        // picker's own body supplies the scroller and the bar; the cap is what
+        // keeps the bar above a soft keyboard, since both mobile shells shrink
+        // the layout viewport to make room for one.
+        className="grid max-h-[min(86dvh,calc(100dvh-2rem))] w-[min(92vw,28rem)] max-w-[min(92vw,28rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0"
         data-testid="mobile-epic-new-terminal-dialog"
-        // The picker's workspace search input auto-focuses itself; keep Radix
-        // from grabbing focus for the first host row instead.
-        onOpenAutoFocus={(event) => event.preventDefault()}
+        // With the search input focusing itself, Radix's own open-autofocus
+        // would land on the first host row instead and take it away. With the
+        // search input standing down, Radix has to run: preventing it would
+        // strand focus on the trigger, outside the focus scope.
+        onOpenAutoFocus={
+          coarsePointer ? undefined : (event) => event.preventDefault()
+        }
       >
-        <DialogHeader className="border-b border-border/60 px-4 py-3">
+        <DialogHeader className="border-b border-border/60 px-4 py-3 pr-12">
           <DialogTitle>New terminal</DialogTitle>
           <DialogDescription className="sr-only">
             Pick a host and folder for the new terminal.
@@ -83,6 +99,7 @@ export function MobileNewTerminalDialog(props: MobileNewTerminalDialogProps) {
           <NewTerminalPickerBody
             epicId={epicId}
             surfaceKey={surfaceKey}
+            autoFocusSearch={!coarsePointer}
             onLaunch={handleLaunch}
           />
         ) : null}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-rename-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-rename-dialog.tsx
@@ -27,8 +27,16 @@ export function SwitcherRenameDialog(props: {
   const { open, onOpenChange, title, initialValue, nodeId, onSubmit } = props;
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(92vw,28rem)] max-w-[min(92vw,28rem)]">
-        <DialogHeader>
+      <DialogContent
+        // Capped and split into header / scroller / footer like every other
+        // dialog that holds a text field: a soft keyboard shrinks the layout
+        // viewport in both mobile shells, so `dvh` resolves against the
+        // uncovered strip and Save stays above the keyboard rather than under
+        // it.
+        className="grid max-h-[min(86dvh,calc(100dvh-2rem))] w-[min(92vw,28rem)] max-w-[min(92vw,28rem)] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden p-0"
+        data-testid="switcher-rename-dialog"
+      >
+        <DialogHeader className="px-4 pt-4 pr-12 pb-2">
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         {/* Radix unmounts closed content, so the form re-seeds from the current
@@ -62,14 +70,24 @@ function SwitcherRenameForm(props: {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      <Input
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        aria-label="New name"
-        data-testid={`switcher-rename-input-${nodeId}`}
-      />
-      <DialogFooter>
+    <form
+      onSubmit={handleSubmit}
+      className="grid min-h-0 grid-rows-[minmax(0,1fr)_auto]"
+    >
+      <div
+        className="min-h-0 overflow-y-auto px-4 pb-4"
+        data-testid="switcher-rename-scroller"
+      >
+        <Input
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          aria-label="New name"
+          data-testid={`switcher-rename-input-${nodeId}`}
+        />
+      </div>
+      {/* `mx-0 mb-0`: the footer's own negative margins bleed it into a `p-4`
+          content, and this one is `p-0`. */}
+      <DialogFooter className="mx-0 mb-0 px-4 py-3">
         <Button
           type="submit"
           disabled={!canSubmit}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker-body.tsx
@@ -35,11 +35,18 @@ import { PrimaryActionShortcutHint } from "@/components/ui/primary-action-shortc
 export interface NewTerminalPickerBodyProps {
   readonly epicId: string;
   readonly surfaceKey: string;
+  /**
+   * Focus the workspace search input once the list mounts. The caller owns
+   * this because focusing a text field is a request for a keyboard, and
+   * whether that keyboard costs anything depends on the shell the surface is
+   * rendered in, which this body cannot see.
+   */
+  readonly autoFocusSearch: boolean;
   readonly onLaunch: (target: TerminalLaunchTarget) => void;
 }
 
 export function NewTerminalPickerBody(props: NewTerminalPickerBodyProps) {
-  const { epicId, onLaunch, surfaceKey } = props;
+  const { autoFocusSearch, epicId, onLaunch, surfaceKey } = props;
   const [explicitRow, setExplicitRow] =
     useState<WorktreeBindingSelectorRowV12 | null>(null);
   const pin = useSurfaceHostPin(surfaceKey);
@@ -122,23 +129,35 @@ export function NewTerminalPickerBody(props: NewTerminalPickerBodyProps) {
   return (
     <>
       {/*
-        The host section renders the RESOLVED host, which is what keeps this
-        create surface honest without a banner: a pin whose host died resolves
-        to `effective`, and the chip says so before Launch is pressed. The dead
-        host's own row is still in the list, worded `offline` by the shared
-        health vocabulary, so the pin is reselectable the moment it returns.
+        Everything above the Launch bar is one scrollable region, so a host
+        given a bounded height (a capped dialog) keeps Launch pinned and
+        reachable instead of pushing it past its own edge. Unbounded hosts -
+        the sidebar popover - never reach the scroll, since the region is only
+        as tall as its content.
       */}
-      <WorktreePickerHostSection surfaceKey={surfaceKey} />
-      <WorktreeFolderListBody
-        isPending={bindingsQuery.isPending}
-        isError={bindingsQuery.isError}
-        rows={rows}
-        selectedRow={selectedRow}
-        secondaryLabel={(row) => row.runningDir}
-        onSelect={setExplicitRow}
-        autoFocusSearch
-        emptyMessage="No directories available. Open a workspace in the epic first."
-      />
+      <div
+        className="flex min-h-0 flex-col overflow-y-auto"
+        data-testid="new-terminal-picker-scroller"
+      >
+        {/*
+          The host section renders the RESOLVED host, which is what keeps this
+          create surface honest without a banner: a pin whose host died resolves
+          to `effective`, and the chip says so before Launch is pressed. The dead
+          host's own row is still in the list, worded `offline` by the shared
+          health vocabulary, so the pin is reselectable the moment it returns.
+        */}
+        <WorktreePickerHostSection surfaceKey={surfaceKey} />
+        <WorktreeFolderListBody
+          isPending={bindingsQuery.isPending}
+          isError={bindingsQuery.isError}
+          rows={rows}
+          selectedRow={selectedRow}
+          secondaryLabel={(row) => row.runningDir}
+          onSelect={setExplicitRow}
+          autoFocusSearch={autoFocusSearch}
+          emptyMessage="No directories available. Open a workspace in the epic first."
+        />
+      </div>
       <div className="flex items-center justify-between gap-3 border-t border-border/60 bg-muted/20 px-2.5 py-2.5">
         <div className="min-w-0 text-xs text-muted-foreground">
           {folderlessCwdStatus}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
@@ -140,6 +140,7 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
           <NewTerminalPickerBody
             epicId={epicId}
             surfaceKey={surfaceKey}
+            autoFocusSearch
             onLaunch={handleLaunch}
           />
         ) : null}

--- a/clients/gui-app/src/hooks/ui/use-coarse-pointer.ts
+++ b/clients/gui-app/src/hooks/ui/use-coarse-pointer.ts
@@ -4,10 +4,14 @@ import { useSyncExternalStore } from "react";
  * INPUT signal: "is a touch-grade pointer driving this window?"
  *
  * The device counterpart of `useIsMobileViewport()`, which answers a pure
- * layout question. Use this one only for chrome whose CSS is already behind
- * `@media(pointer:fine)` and whose work is worth skipping when it cannot
- * paint - hover affordances that measure. A narrow desktop window is not
- * coarse, and a tablet at desktop width is.
+ * layout question. A narrow desktop window is not coarse, and a tablet at
+ * desktop width is - so this is the signal for anything that turns on the
+ * input hardware rather than on width or on which build is running:
+ *
+ * - chrome whose CSS is already behind `@media(pointer:fine)` and whose work
+ *   is worth skipping when it cannot paint - hover affordances that measure;
+ * - whether an action costs a software keyboard, which is what makes
+ *   auto-focusing a text field free on one device and expensive on another.
  */
 const COARSE_POINTER_QUERY = "(pointer: coarse)";
 


### PR DESCRIPTION
## Problem

Three centred `DialogContent`s carry a text field, have no height cap and no internal scroll, so they grow to their content height:

| Dialog | Unreachable action | Notes |
| --- | --- | --- |
| `chat-fork-dialog.tsx` | Fork / Cancel | Title `<Input>` autofocuses; the stack (title, harness picker, stacked workspace controls, notice stack) is taller than a phone before a keyboard is anywhere near it |
| `mobile-new-terminal-dialog.tsx` | Launch | Also had a focus disagreement — see below |
| `switcher-rename-dialog.tsx` | Save | Lower impact: Return submits, so Save is a second route rather than the only one |

### The mechanism, stated precisely

Not "the keyboard overlays the dialog and covers its footer" — that is iOS **Safari** behaviour, and neither shipping shell does it. Both shells *shrink the layout viewport* when the keyboard opens:

- **iOS app** — `clients/mobile/capacitor.config.ts` sets `Keyboard: { resize: KeyboardResize.Native }`, so WKWebView itself is resized.
- **Android** — `interactive-widget=resizes-content` in `clients/mobile/src/web/index.html`, which Chrome honours.

So `dvh` collapses to the uncovered strip. An uncapped centre-translated `fixed` dialog then overflows that much shorter viewport with nothing able to scroll to its footer — the action is past an edge no gesture can reach. Landscape is the worst case, where the remaining strip is a few hundred pixels and even a one-field dialog can exceed it.

## Fix

Each dialog moves to the height-capped three-region shape already used by `provider-skill-composer-dialog.tsx` and `plan-segment.tsx`:

```
grid max-h-[min(86dvh,calc(100dvh-2rem))] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0
```

Header and footer are `auto` tracks, the middle track takes the leftover height, and `minmax(0,…)` is what lets it shrink below its content so the scroll can happen at all. The rename dialog uses `[auto_minmax(0,1fr)]` with the nested `[minmax(0,1fr)_auto]` on the `<form>` itself — Save is `type="submit"`, so it has to stay inside the form element.

`p-0` on the content means the primitive's `DialogFooter` (`-mx-4 -mb-4 … p-4`, sized for a `p-4` content) would bleed past the rounded corner, so both footers carry `mx-0 mb-0 px-4 py-3`. `tailwind-merge` puts `-mx-4`/`mx-0` in the same group, so the negatives are displaced rather than stacked. Headers carry `pr-12` so the title clears the primitive's absolutely-positioned close button.

`new-terminal-picker-body.tsx` gains one scroller div around the host section and folder list, leaving the Launch bar outside it. `PopoverContent` (the sidebar `+` popover, the body's other host) is `flex flex-col` with no height cap and the div has no `flex-1`, so it sizes to content and never scrolls there — the popover is unchanged.

### Decision: the cap alone, no measured keyboard inset

`useVirtualKeyboardInset()` exists and is deliberately **not** used here. Because both shipping shells resize rather than overlay, the measured inset reads **0** on both — its own doc says so ("when the browser resizes the layout itself … or the Capacitor webview in native-resize mode — both leave nothing covered"). Its two consumers (`mobile-epic-tile-view`, `landing-terminal-panel`) are `h-dvh` **bottom bars**, a shape that additionally has to survive iOS Safari during live-reload dev; a centred dialog does not carry that constraint.

The viewport the cap resolves against has *already* shrunk, so the cap tracks the keyboard with no JS in the loop — and a CSS cap cannot desync from the layout the way a measured value can.

### Decision: autofocus keys off `(pointer: coarse)`

The "New terminal" dialog had two components disagreeing about focus: it declined Radix's open-autofocus specifically so the picker's workspace search could claim focus, and `WorktreeFolderList` claimed it unconditionally — which on a touch device raises a keyboard over a dialog whose whole job is a two-tap host-then-folder pick.

`NewTerminalPickerBody` now takes `autoFocusSearch` from its caller, and the dialog derives both halves from one `useCoarsePointer()` read, so they can no longer disagree. The pointer is the right signal and the two alternatives are not:

| Signal | Why not |
| --- | --- |
| `isMobileApp()` (`lib/mobile-app.ts`) | Build-level and immutable. A tablet **browser** has a soft keyboard and would still autofocus. Its own doc reserves it for UX-policy divergence, not device capability |
| `useIsMobileViewport()` (`hooks/ui/use-mobile-viewport.ts`) | Width. A narrow desktop window has a hardware keyboard and *wants* the search focused |
| `useCoarsePointer()` | Answers the actual question — does focusing this field summon a keyboard. A narrow desktop window is not coarse; a tablet at desktop width is |

With the search standing down, Radix's open-autofocus is left to run rather than prevented, so focus still lands inside the focus scope instead of stranding on the trigger. It takes the first tabbable — a host row, not the search input — and at mount neither exists yet (both render behind pending queries), so it falls back to the content container. No keyboard either way.

## Known sibling, not in this PR

`command-palette-shell.tsx` has the same uncapped shape and is deliberately left alone here. `src/components/ui/dialog.tsx` is untouched — a parallel PR owns that file.

## Verification

- `bun run compile` (gui-app) — clean
- 4 test files / 27 tests pass: the three new geometry-and-focus suites plus the existing `new-terminal-picker.test.tsx`, which covers the now-required `autoFocusSearch` prop
- New tests assert the structural guarantee rather than pixels: the cap is applied, the middle region owns the scroll, the footer sits outside it, and the coarse-pointer arm leaves the search unfocused while keeping focus inside the dialog
- Rebased onto `origin/main` at `dbbe421e7` (#1426), which fixes the `protocol-compat` failure the branch's original base carried

---

## Follow-up: the fork dialog was opening a keyboard on touch

Device feedback on staging: tapping Fork auto-focused the title field and raised the keyboard.

The title `<Input>` is the **first tabbable descendant**, so Radix's own open-autofocus takes it. Worth naming because the mechanism differs from the "New terminal" dialog above even though the symptom is the same — there the first tabbable is a `HostSection` button that doesn't even exist at mount (it renders behind a pending query), so letting Radix run was already harmless. Here it genuinely is the text field.

The dialog now suppresses that autofocus on `(pointer: coarse)` — the same gate the terminal picker's `autoFocusSearch` uses.

**Focus moves rather than being merely declined.** Radix leaves focus where it was when `onOpenAutoFocus` is prevented, which is the trigger — outside the focus scope, and often unmounting along with the menu it lived in. The content element carries `tabIndex={-1}` for exactly this, and taking it announces the dialog to a screen reader without asking for a keyboard. Guard-first so it fails safe: with no element to move to, Radix's default runs rather than being cancelled with nowhere to go. Same shape as `unsynced-close-dialog.tsx`, which moves focus off a destructive first-tabbable for the same structural reason.

```tsx
if (!coarsePointer) return;
if (contentRef.current === null) return;
event.preventDefault();
contentRef.current.focus();
```

**The rename dialog deliberately keeps its autofocus.** Typing is that dialog's entire purpose, so an extra tap to begin would cost more than the keyboard does. Not changed for consistency's sake.

**The height cap is unaffected and still needed.** With the keyboard closed the cap still governs tall content and landscape, where `dvh` collapses hardest.

Tests pin both arms — fine pointer: the title field holds focus; coarse pointer: it does not, and focus is the dialog itself. Verified locally alongside the full `components/chat/__tests__` suite (53 files / 824 tests) so the four sibling fork-dialog suites confirm no focus regression.
