### PR TITLE
fix(gui-app): floor every touch target in pixels, not in elastic rem

### DIFF
--- a/clients/gui-app/src/__tests__/rem-scaled-touch-size.ts
+++ b/clients/gui-app/src/__tests__/rem-scaled-touch-size.ts
@@ -1,0 +1,101 @@
+import { expect } from "vitest";
+
+/**
+ * Recognises the Tailwind idioms that express a touch target in `rem`.
+ *
+ * The root font size is a USER SETTING: `providers/theme-provider.tsx` writes
+ * it straight onto `documentElement.style.fontSize`, and the store clamps it to
+ * 10-20px (`clampUiFontSize`). Every rem in this app is therefore elastic, and
+ * the 15px figure quoted around these controls is only the default. A target
+ * sized in rem is smallest for the reader who chose the smallest text, which
+ * inverts the reason a minimum target exists at all: `min-h-11` is 2.75rem -
+ * 27.5px at the floor, 41.25px at the default, and >=44px only above a ~16px
+ * root.
+ *
+ * Three shapes are rejected, and the boundaries are deliberate:
+ *
+ * 1. `min-h-11` / `h-11` / `size-11`. `11` is the rem spelling of 44px at a
+ *    16px root and is written for no other reason, so it is a touch-target
+ *    attempt wherever it appears. `w-11` is NOT included - a width is a layout
+ *    measure here (a swatch, an indicator bar), and `min-w-44` is 11rem of menu
+ *    width rather than 44px of anything.
+ * 2. A negative inset of any nonzero size. Its only purpose is to push a
+ *    pseudo-element past the control's own box, which is hit slop by
+ *    definition. Zero is excluded because `inset-0` is root-independent.
+ * 3. Any rem-valued `min-h` / `min-w` / `size` / `inset` behind a
+ *    `pointer-coarse` variant. Gating on the coarse pointer is what declares
+ *    the utility a touch affordance, so the value must be a literal there even
+ *    when the same utility is unremarkable elsewhere: a bare `size-7` is an
+ *    icon box, `pointer-coarse:before:size-7` is a hit area.
+ *
+ * The sanctioned replacements are the same ones the three touch-target
+ * stylesheets use: `min-h-[44px]` for a row that stacks flush with its
+ * neighbours, and `max(100%, 44px)` for a pseudo that must hold the floor at
+ * any root size while still growing with a larger control.
+ */
+
+/**
+ * The utility of a class token, with any variant chain removed.
+ *
+ * Bracket- and paren-aware, because an arbitrary value may contain its own
+ * colon (`[-webkit-mask-image:linear-gradient(...)]`) and splitting on the
+ * last colon blindly would take the utility to be a fragment of that value.
+ */
+export function utilityOf(token: string): string {
+  let depth = 0;
+  let lastColon = -1;
+  for (let index = 0; index < token.length; index += 1) {
+    const char = token[index];
+    if (char === "[" || char === "(") depth += 1;
+    else if (char === "]" || char === ")") depth -= 1;
+    else if (char === ":" && depth === 0) lastColon = index;
+  }
+  return token.slice(lastColon + 1);
+}
+
+/** The rem spelling of a 44px box. See shape 1 above. */
+const REM_44PX_BOX = /^(?:min-h|h|size)-11$/;
+
+/** Hit slop pushed outside the control's own box. See shape 2 above. */
+const NEGATIVE_INSET_SLOP = /^-inset(?:-[xy])?-(?!0$)[0-9.]+$/;
+
+/**
+ * A rem-valued size or inset. Applied only under a `pointer-coarse` variant -
+ * see shape 3 above. A bracketed value (`min-h-[44px]`, `size-[max(100%,44px)]`)
+ * has no bare number in that position and is deliberately not matched.
+ */
+const REM_VALUED_SIZE =
+  /^-?(?:min-h|min-w|size|inset)(?:-[xy])?-(?!0$)[0-9.]+$/;
+
+/** Whether one class token sizes a touch target in rem. */
+export function isRemScaledTouchSize(token: string): boolean {
+  const utility = utilityOf(token);
+  if (REM_44PX_BOX.test(utility)) return true;
+  if (NEGATIVE_INSET_SLOP.test(utility)) return true;
+  return token.includes("pointer-coarse:") && REM_VALUED_SIZE.test(utility);
+}
+
+/**
+ * Every rem-scaled touch size in a class list, in order.
+ *
+ * Split on whitespace and quotes ONLY. Splitting on brackets or parens too
+ * would tear `size-[max(100%,44px)]` into pieces that no longer look like the
+ * replacement idiom, which is the one string this must never mistake.
+ */
+export function findRemScaledTouchSizes(subject: string): readonly string[] {
+  return subject
+    .split(/[\s"'`]+/)
+    .filter((token) => token.length > 0)
+    .filter(isRemScaledTouchSize);
+}
+
+/**
+ * Asserts a class list floors its touch target in pixels.
+ *
+ * Pairs with a `toContain("…44px…")` assertion: alone, that would still pass on
+ * a class list carrying both idioms, and a test that pins the rem token instead
+ * makes the defect unlandable from the file it lives in.
+ */
+export function expectNoRemScaledTouchSize(subject: string): void {
+  expect(findRemScaledTouchSizes(subject)).toEqual([]);
+}

--- a/clients/gui-app/src/__tests__/rem-scaled-touch-size.ts
+++ b/clients/gui-app/src/__tests__/rem-scaled-touch-size.ts
@@ -19,9 +19,18 @@ import { expect } from "vitest";
  *    attempt wherever it appears. `w-11` is NOT included - a width is a layout
  *    measure here (a swatch, an indicator bar), and `min-w-44` is 11rem of menu
  *    width rather than 44px of anything.
- * 2. A negative inset of any nonzero size. Its only purpose is to push a
- *    pseudo-element past the control's own box, which is hit slop by
+ * 2. A negative INSET of any nonzero size. `inset` scopes all four edges at
+ *    once, and pushing all four past the control's own box is hit slop by
  *    definition. Zero is excluded because `inset-0` is root-independent.
+ *
+ *    The single-edge offsets (`-top` / `-right` / `-bottom` / `-left`) are
+ *    deliberately NOT included, even on a pseudo-element. That reads like the
+ *    same idiom spelled one edge at a time, and the tree says otherwise: every
+ *    negative pseudo offset in this app is a painted indicator nudged just
+ *    outside its box (`after:-right-0.5 after:w-0.5 after:bg-primary` in
+ *    `split-tab-item.tsx`, the active-tab bar in `ui/tabs.tsx`). Slop must
+ *    never paint, so those are categorically not it, and flagging them would
+ *    mean four waivers that excuse nothing and teach a false rule.
  * 3. Any rem-valued `min-h` / `min-w` / `size` / `inset` behind a
  *    `pointer-coarse` variant. Gating on the coarse pointer is what declares
  *    the utility a touch affordance, so the value must be a literal there even
@@ -32,6 +41,12 @@ import { expect } from "vitest";
  * stylesheets use: `min-h-[44px]` for a row that stacks flush with its
  * neighbours, and `max(100%, 44px)` for a pseudo that must hold the floor at
  * any root size while still growing with a larger control.
+ *
+ * An arbitrary value is judged by its UNIT, not by its brackets: `-inset-2.5`
+ * and `-inset-y-[0.625rem]` are the same elastic quantity spelled two ways, so
+ * both are rejected, while `-inset-y-[2px]` is root-independent and is not.
+ * Reading brackets alone as "already a literal" would leave the whole defect
+ * reachable through one extra pair of characters.
  */
 
 /**
@@ -56,23 +71,36 @@ export function utilityOf(token: string): string {
 /** The rem spelling of a 44px box. See shape 1 above. */
 const REM_44PX_BOX = /^(?:min-h|h|size)-11$/;
 
+/** A rem-valued scale step, or an arbitrary value in a font-relative unit. */
+const ELASTIC_VALUE = /^(?:(?!0$)[0-9.]+|\[[^\]]*[0-9.](?:r?em)\])$/;
+
 /** Hit slop pushed outside the control's own box. See shape 2 above. */
-const NEGATIVE_INSET_SLOP = /^-inset(?:-[xy])?-(?!0$)[0-9.]+$/;
+const NEGATIVE_INSET_SLOP = /^-inset(?:-[xy])?-(.+)$/;
 
 /**
- * A rem-valued size or inset. Applied only under a `pointer-coarse` variant -
- * see shape 3 above. A bracketed value (`min-h-[44px]`, `size-[max(100%,44px)]`)
- * has no bare number in that position and is deliberately not matched.
+ * A size or inset. Applied only under a `pointer-coarse` variant - see shape 3
+ * above. The VALUE decides: `min-h-[44px]` is a literal and passes,
+ * `min-h-[2.75rem]` is the same elastic quantity as `min-h-11` and does not.
  */
-const REM_VALUED_SIZE =
-  /^-?(?:min-h|min-w|size|inset)(?:-[xy])?-(?!0$)[0-9.]+$/;
+const SIZE_UTILITY = /^-?(?:min-h|min-w|size|inset)(?:-[xy])?-(.+)$/;
 
-/** Whether one class token sizes a touch target in rem. */
+/** The value a utility was given, or null if it is not that utility. */
+function valueOf(utility: string, pattern: RegExp): string | null {
+  const match = pattern.exec(utility);
+  return match === null ? null : match[1];
+}
+
+/** Whether one class token sizes a touch target in a font-relative unit. */
 export function isRemScaledTouchSize(token: string): boolean {
   const utility = utilityOf(token);
   if (REM_44PX_BOX.test(utility)) return true;
-  if (NEGATIVE_INSET_SLOP.test(utility)) return true;
-  return token.includes("pointer-coarse:") && REM_VALUED_SIZE.test(utility);
+
+  const inset = valueOf(utility, NEGATIVE_INSET_SLOP);
+  if (inset !== null && ELASTIC_VALUE.test(inset)) return true;
+
+  if (!token.includes("pointer-coarse:")) return false;
+  const size = valueOf(utility, SIZE_UTILITY);
+  return size !== null && ELASTIC_VALUE.test(size);
 }
 
 /**

--- a/clients/gui-app/src/__tests__/rem-scaled-touch-target-lint.test.ts
+++ b/clients/gui-app/src/__tests__/rem-scaled-touch-target-lint.test.ts
@@ -1,0 +1,241 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  findRemScaledTouchSizes,
+  isRemScaledTouchSize,
+  utilityOf,
+} from "./rem-scaled-touch-size";
+
+/**
+ * A touch target must be floored in PIXELS, because every rem in this app is
+ * elastic.
+ *
+ * `providers/theme-provider.tsx` writes the root font size straight onto
+ * `documentElement.style.fontSize` from a user setting the store clamps to
+ * 10-20px. So `pointer-coarse:min-h-11` is 27.5px at the floor, 41.25px at the
+ * 15px default, and only clears 44px above a ~16px root - it renders as a
+ * correct touch target at no size a developer is likely to test at, and is
+ * smallest for exactly the reader who chose the smallest text.
+ *
+ * The idiom spread because it read as sanctioned: it was documented as the way
+ * to size a portalled row, and the lanes that copied it did so deliberately,
+ * for consistency. A guard is the half of the fix that survives that - a
+ * converted call site can be re-seeded by the next person who greps for a
+ * nearby example, and a comment cannot fail a build.
+ *
+ * Scope is every `.ts`/`.tsx` under `src/`, comments removed. A class that
+ * genuinely wants the rem is kept by annotating it with {@link ALLOW_MARKER}
+ * and a reason, which keeps the exemption ON the line it excuses rather than in
+ * a file-level list that silently widens.
+ */
+const SRC_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Opt-out for a rem size that is not a touch target, or that must track the
+ * reader's text for a stronger reason. Must be followed by a reason, which is
+ * one of exactly two claims:
+ *
+ * 1. Nothing here is tappable - a decorative disc, an indicator bar.
+ * 2. The control is not ours to size - a stock primitive this app never
+ *    renders, kept byte-identical to upstream.
+ *
+ * The `(?!\*\/)` guard is inherited from `muted-fill-on-raised-surface-lint`,
+ * where a bare `\S` honoured a reasonless JSX waiver: the comment's own closing
+ * `*` is a non-space character after the colon, so the mechanism built to force
+ * a reason accepted one with none.
+ */
+const ALLOW_MARKER = /touch-target-ok:\s*(?!\*\/)\S/;
+
+/**
+ * How many lines above a flagged class an annotation may sit and still cover
+ * it. Prose inserted between a marker and its class list orphans the marker,
+ * which the stale-marker arm below catches from the other direction.
+ */
+const MARKER_LOOKBEHIND = 4;
+
+function collectSourceFiles(dir: string): readonly string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue;
+      found.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (entry.endsWith(".ts") || entry.endsWith(".tsx")) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Prose about a class is not that class.
+ *
+ * This matters more here than in the sibling guards: the fix for this defect is
+ * a comment naming the token it replaced, so nearly every converted call site
+ * now spells `min-h-11` in prose one line above the literal that replaced it.
+ * Scanning raw source would redden on the documentation of the fix.
+ */
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("{/*")
+  );
+}
+
+interface Flagged {
+  readonly file: string;
+  readonly line: number;
+  readonly tokens: readonly string[];
+}
+
+function flaggedLines(file: string): readonly Flagged[] {
+  const lines = readFileSync(file, "utf8").split("\n");
+  const flagged: Flagged[] = [];
+  lines.forEach((line, index) => {
+    if (isCommentLine(line)) return;
+    const tokens = findRemScaledTouchSizes(line);
+    if (tokens.length === 0) return;
+    flagged.push({ file, line: index + 1, tokens });
+  });
+  return flagged;
+}
+
+/** Whether a {@link ALLOW_MARKER} sits within reach above `line`. */
+function isWaived(file: string, line: number): boolean {
+  const lines = readFileSync(file, "utf8").split("\n");
+  const start = Math.max(0, line - 1 - MARKER_LOOKBEHIND);
+  return lines
+    .slice(start, line)
+    .some((candidate) => ALLOW_MARKER.test(candidate));
+}
+
+function describeFlagged(entry: Flagged): string {
+  return `${path.relative(SRC_DIR, entry.file)}:${entry.line} -> ${entry.tokens.join(" ")}`;
+}
+
+/**
+ * The matcher is unit-tested BEFORE it is trusted over the tree, because a
+ * regex that matches nothing is indistinguishable from a clean tree. The first
+ * version of this rule in a sibling lane silently missed the axis-suffixed
+ * `-inset-y-2.5`, and the sweep it guarded read as complete.
+ */
+describe("the rem-scaled touch size matcher", () => {
+  const REJECTED = [
+    "min-h-11",
+    "h-11",
+    "size-11",
+    "-inset-2.5",
+    "-inset-x-2.5",
+    "-inset-y-2.5",
+    "-inset-y-1.5",
+    "after:-inset-2",
+    "pointer-coarse:min-h-11",
+    "pointer-coarse:before:-inset-y-2.5",
+    "pointer-coarse:before:size-7",
+    "pointer-coarse:before:inset-x-1.5",
+  ];
+
+  const ACCEPTED = [
+    "min-h-[44px]",
+    "size-[44px]",
+    "size-[max(100%,44px)]",
+    "h-[max(100%,44px)]",
+    "pointer-coarse:min-h-[44px]",
+    "pointer-coarse:before:size-[max(100%,44px)]",
+    "pointer-coarse:before:h-[max(100%,44px)]",
+    "pointer-coarse:before:inset-x-0",
+    "top-1/2",
+    "left-1/2",
+    "-translate-x-1/2",
+    "-translate-y-1/2",
+    "pointer-coarse:before:-translate-y-1/2",
+    // A width is a layout measure, not a finger measure: these are a glyph
+    // swatch, an active-tab bar, and 11rem of menu width respectively.
+    "w-11",
+    "min-w-44",
+    // An icon box with no coarse-pointer gate is not claiming to be a target.
+    "size-7",
+    "size-4",
+    "inset-0",
+  ];
+
+  it.each(REJECTED)("rejects %s", (token) => {
+    expect(isRemScaledTouchSize(token)).toBe(true);
+  });
+
+  it.each(ACCEPTED)("accepts %s", (token) => {
+    expect(isRemScaledTouchSize(token)).toBe(false);
+  });
+
+  it("finds every offender in a realistic class list, not just the first", () => {
+    // Both idioms on one element is the shape a partial conversion leaves
+    // behind, and the shape a `toContain("44px")` assertion cannot see.
+    expect(
+      findRemScaledTouchSizes(
+        "flex min-h-[44px] w-full items-center pointer-coarse:min-h-11 after:-inset-y-2.5",
+      ),
+    ).toEqual(["pointer-coarse:min-h-11", "after:-inset-y-2.5"]);
+  });
+
+  it("reads the utility through an arbitrary value that contains a colon", () => {
+    // A blind split on the last colon would take the utility to be a fragment
+    // of the gradient and match nothing at all.
+    expect(
+      utilityOf(
+        "[-webkit-mask-image:linear-gradient(to_bottom,black_calc(100%-2rem),transparent)]",
+      ),
+    ).toBe(
+      "[-webkit-mask-image:linear-gradient(to_bottom,black_calc(100%-2rem),transparent)]",
+    );
+  });
+});
+
+describe("touch targets across the app", () => {
+  const files = collectSourceFiles(SRC_DIR);
+
+  it("scans a tree big enough for the result to mean anything", () => {
+    // A collector that silently walked the wrong directory would report zero
+    // offenders, which is the same output as a clean tree.
+    expect(files.length).toBeGreaterThan(500);
+  });
+
+  it("sizes every touch target in pixels, never in rem", () => {
+    const offenders = files
+      .flatMap(flaggedLines)
+      .filter((entry) => !isWaived(entry.file, entry.line))
+      .map(describeFlagged);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("leaves no waiver excusing nothing", () => {
+    // A marker orphaned by prose inserted above its class list reads as an
+    // honoured exemption while excusing nothing - the failure mode that
+    // reached the tree in the sibling `muted-fill` guard.
+    const stale = files
+      .flatMap((file) => {
+        const lines = readFileSync(file, "utf8").split("\n");
+        return lines.flatMap((line, index) => {
+          if (!ALLOW_MARKER.test(line)) return [];
+          const covers = lines
+            .slice(index + 1, index + 1 + MARKER_LOOKBEHIND)
+            .some(
+              (candidate) =>
+                !isCommentLine(candidate) &&
+                findRemScaledTouchSizes(candidate).length > 0,
+            );
+          return covers ? [] : [`${path.relative(SRC_DIR, file)}:${index + 1}`];
+        });
+      })
+      .filter((entry) => entry.length > 0);
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/clients/gui-app/src/__tests__/rem-scaled-touch-target-lint.test.ts
+++ b/clients/gui-app/src/__tests__/rem-scaled-touch-target-lint.test.ts
@@ -140,6 +140,12 @@ describe("the rem-scaled touch size matcher", () => {
     "pointer-coarse:before:-inset-y-2.5",
     "pointer-coarse:before:size-7",
     "pointer-coarse:before:inset-x-1.5",
+    // Brackets are not a literal. A font-relative arbitrary value is the same
+    // elastic quantity as the scale step it spells out, so reading brackets
+    // alone as "already fixed" would leave the defect one keystroke away.
+    "-inset-y-[0.625rem]",
+    "pointer-coarse:before:min-h-[2.75rem]",
+    "after:-inset-[2em]",
   ];
 
   const ACCEPTED = [
@@ -164,6 +170,20 @@ describe("the rem-scaled touch size matcher", () => {
     "size-7",
     "size-4",
     "inset-0",
+    // A px arbitrary value is root-independent - the thing this rule wants.
+    "-inset-y-[2px]",
+    "after:-inset-[3px]",
+    // A single-edge negative offset is not this idiom, on a pseudo-element or
+    // anywhere else. Every one in this app is a painted indicator nudged just
+    // outside its box - `split-tab-item.tsx`'s side bar, `ui/tabs.tsx`'s
+    // active-tab bar - and slop must never paint. Rejecting these would mean
+    // four waivers that excuse nothing.
+    "-top-2",
+    "after:-right-0.5",
+    "before:-left-0.5",
+    "group-data-[orientation=vertical]/tabs:after:-right-1",
+    // A percentage offset does not track the root font size either.
+    "after:-top-1/2",
   ];
 
   it.each(REJECTED)("rejects %s", (token) => {

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -1179,11 +1179,17 @@ function UserMessageTouchMenu({
             aria-label="Message actions"
             // Resting bg-muted matches ghost's aria-expanded open surface,
             // so the glyph reads as a button before it is tapped. The
-            // invisible ::after slop widens the 24px visual control to the
-            // 44px touch-target guideline without painting anything (Button
+            // invisible ::after slop widens the visual control to the 44px
+            // touch-target guideline without painting anything (Button
             // renders no ::after of its own, so nothing merges with it).
+            //
+            // `max(100%, 44px)`, never a rem inset: the root font size is a
+            // user setting clamped to 10-20px, so a `size-6` control padded by
+            // a rem inset shrinks with it (27.5px at the floor) and reaches
+            // 44px only above a ~16px root. This form holds the floor at any
+            // root size and still grows with a larger control.
             // muted-fill-ok: transcript row renders on bg-background/canvas
-            className="relative bg-muted text-muted-foreground/70 hover:text-foreground after:absolute after:-inset-2.5 after:content-['']"
+            className="relative bg-muted text-muted-foreground/70 hover:text-foreground after:absolute after:top-1/2 after:left-1/2 after:size-[max(100%,44px)] after:-translate-x-1/2 after:-translate-y-1/2 after:content-['']"
           >
             <MoreHorizontal className="size-3.5" aria-hidden />
           </Button>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-changed-file-row.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-changed-file-row.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import type { GitChangedFile } from "@traycer/protocol/host";
 import { GitChangedFileRow } from "@/components/epic-canvas/git-diff/git-changed-file-row";
 import { NO_HIGHLIGHT, type HighlightRanges } from "@/lib/git/path-highlight";
+import { expectNoRemScaledTouchSize } from "@/__tests__/rem-scaled-touch-size";
 
 import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 afterEach(() => {
@@ -324,7 +325,12 @@ describe("GitChangedFileRow panel density", () => {
       name: "Modified app.tsx in src",
     });
     expect(row.className).toContain("min-h-6");
-    expect(row.className).toContain("pointer-coarse:min-h-11");
+    // The pixel literal is asserted, and the rem forms rejected, because the
+    // root font size is a user setting clamped to 10-20px: `min-h-11` is
+    // 27.5px at the floor, so pinning that token here would have pinned the
+    // undersized row and made the fix unlandable from this file.
+    expect(row.className).toContain("pointer-coarse:min-h-[44px]");
+    expectNoRemScaledTouchSize(row.className);
   });
 
   it("leaves inactive rows without aria-current", () => {

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-file-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-file-row.tsx
@@ -194,7 +194,11 @@ function gitChangedFileRowClassName(args: {
     // The 24/28px densities below are mouse densities. On touch the row is the
     // tap target that opens the diff (or collapses the bundle section), so it
     // takes the 44px guideline height; the fine-pointer list is untouched.
-    "pointer-coarse:min-h-11",
+    //
+    // Pixel-literal, never `min-h-11`: the root font size is a user setting
+    // clamped to 10-20px, so a rem height tracks it and is shortest exactly
+    // where the text is smallest.
+    "pointer-coarse:min-h-[44px]",
     args.isPanel && args.nested && "min-h-6 gap-1.5 py-0.5 pl-10 pr-3",
     args.isPanel && !args.nested && "min-h-6 gap-1.5 px-3 py-0.5",
     !args.isPanel && "min-h-7 gap-2 px-2 py-1",

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-repo-switcher.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-repo-switcher.tsx
@@ -251,7 +251,10 @@ function RepoSwitcherRowButton(props: {
       onClick={handleClick}
       onKeyDown={handleRepoSwitcherRowKeyDown}
       className={cn(
-        "group flex min-h-11 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-ui-sm transition-colors",
+        // `min-h-[44px]`, never `min-h-11`: the root font size is a user
+        // setting clamped to 10-20px, so a rem row height is 27.5px at the
+        // floor and reaches the touch target only above a ~16px root.
+        "group flex min-h-[44px] w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-ui-sm transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
         row.selected
           ? "bg-accent text-accent-foreground"

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-category-tabs.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-category-tabs.test.tsx
@@ -85,9 +85,10 @@ describe("<SwitcherCategoryTabs />", () => {
 
   it("gives each trigger a pixel-literal 44px minimum, matching the touch-scope hit slop", () => {
     // The slop pseudo in `mobile-shell-touch-targets.css` is `max(100%, 44px)`
-    // in REAL pixels; this surface's root font is 15px, so the rem-based
-    // `min-h-11` idiom is 41.25px and leaves the pseudo hanging out of the
-    // list. Only a px literal makes the fit exact.
+    // in REAL pixels, while the root font size is a user setting clamped to
+    // 10-20px - so the rem-based `min-h-11` idiom is 41.25px at the default
+    // and 27.5px at the floor, leaving the pseudo hanging further out of the
+    // list the smaller the reader sets their text. Only a px literal fits.
     expect(classTokens(renderCategoryBar().trigger)).toContain("min-h-[44px]");
   });
 

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-current-tile-bar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-current-tile-bar.tsx
@@ -78,7 +78,10 @@ export function MobileCurrentTileBar(props: MobileCurrentTileBarProps) {
     >
       <div
         data-testid="mobile-current-tile-bar"
-        className="flex min-h-11 w-full items-center gap-2 px-3"
+        // `min-h-[44px]`, never `min-h-11`: the root font size is a user
+        // setting clamped to 10-20px, so a rem bar height is 27.5px at the
+        // floor and reaches the touch target only above a ~16px root.
+        className="flex min-h-[44px] w-full items-center gap-2 px-3"
       >
         <TabIcon
           epicId={epicId}

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-terminal-key-bar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-terminal-key-bar.tsx
@@ -227,8 +227,12 @@ export function MobileTerminalKeyBar(props: MobileTerminalKeyBarProps) {
   );
 }
 
+// `min-h-[44px]`, never `min-h-11`: the root font size is a user setting
+// clamped to 10-20px, so a rem key height is 27.5px at the floor and reaches
+// the touch target only above a ~16px root. This bar is reachable by finger
+// only, so its keys are exactly where a shrinking target costs the most.
 const KEY_BUTTON_CLASS =
-  "min-h-11 w-full rounded-md px-0 text-ui-sm font-medium";
+  "min-h-[44px] w-full rounded-md px-0 text-ui-sm font-medium";
 
 const KEY_REPEAT_DELAY_MS = 350;
 const KEY_REPEAT_INTERVAL_MS = 60;

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
@@ -108,9 +108,11 @@ export function SwitcherCategoryTabs(props: SwitcherCategoryTabsProps) {
           <TabsTrigger
             key={definition.id}
             value={definition.id}
-            // `min-h-[44px]`, not `min-h-11`: this surface's root font is 15px,
-            // so a rem-based `11` is 41.25px and would leave the 44px hit-slop
-            // `::after` spilling out of the list's exact fit.
+            // `min-h-[44px]`, not `min-h-11`: the root font size is a user
+            // setting clamped to 10-20px, so a rem-based `11` is 41.25px at
+            // the default and 27.5px at the floor - it would leave the 44px
+            // hit-slop `::after` spilling out of the list's exact fit, by an
+            // amount that grows as the reader shrinks their text.
             //
             // `data-[state=active]:bg-transparent`: force the line-variant
             // active state fill-less (the `:where()`-neutralised line override

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -30,7 +30,10 @@ export function SwitcherListRow(props: {
         onClick={onSelect}
         data-testid={selectTestId}
         aria-current={active ? "true" : undefined}
-        className="flex min-h-11 min-w-0 flex-1 items-center justify-start gap-2 rounded-md px-2 text-left font-normal"
+        // `min-h-[44px]`, never `min-h-11`: the root font size is a user
+        // setting clamped to 10-20px, so a rem row height is 27.5px at the
+        // floor and reaches the touch target only above a ~16px root.
+        className="flex min-h-[44px] min-w-0 flex-1 items-center justify-start gap-2 rounded-md px-2 text-left font-normal"
       >
         <span className="flex size-4 shrink-0 items-center justify-center">
           {icon}
@@ -67,7 +70,7 @@ export function SwitcherNewItemRow(props: {
       variant="ghost"
       onClick={onSelect}
       data-testid={testId}
-      className="flex min-h-11 w-full items-center justify-start gap-2 rounded-md px-2 text-left font-normal text-muted-foreground"
+      className="flex min-h-[44px] w-full items-center justify-start gap-2 rounded-md px-2 text-left font-normal text-muted-foreground"
     >
       <span className="flex size-4 shrink-0 items-center justify-center">
         <Plus className="size-4" />

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
@@ -73,10 +73,12 @@ const DEFAULT_WINDOW_DAYS: UsageSummaryWindowDays = 7;
 // The height is a pixel literal floored against the trigger's own box, the
 // same `max(100%, 44px)` the three touch-target stylesheets use - not a rem
 // inset. The root font size is a user setting clamped to 10-20px, so both the
-// `h-8` box and a rem inset around it shrink together: `-inset-y-2.5` on
-// `h-8` measures 45px at the 15px default and 30px at the floor, reading as
-// correct at every size a developer is likely to test. `max()` holds the
-// floor at any root size and still grows with a taller trigger.
+// `h-8` box and a rem inset around it shrink together: `2rem` plus
+// `-inset-y-2.5`'s `0.625rem` a side is `3.25rem`, which is 48.75px at the
+// 15px default but only 32.5px at the floor - correct at every size a
+// developer is likely to test, and short for everyone who shrinks their text.
+// `max()` holds the floor at any root size and still grows with a taller
+// trigger.
 const COARSE_POINTER_TRIGGER =
   "pointer-coarse:before:absolute pointer-coarse:before:inset-x-0 pointer-coarse:before:top-1/2 pointer-coarse:before:h-[max(100%,44px)] pointer-coarse:before:-translate-y-1/2";
 

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
@@ -69,8 +69,16 @@ const DEFAULT_WINDOW_DAYS: UsageSummaryWindowDays = 7;
 // hardcoded h-8: an invisible overlay extends each trigger's vertical hit
 // area (the trigger is already `relative`; `after:` is taken by the
 // line-variant indicator, so this rides `before:`).
+//
+// The height is a pixel literal floored against the trigger's own box, the
+// same `max(100%, 44px)` the three touch-target stylesheets use - not a rem
+// inset. The root font size is a user setting clamped to 10-20px, so both the
+// `h-8` box and a rem inset around it shrink together: `-inset-y-2.5` on
+// `h-8` measures 45px at the 15px default and 30px at the floor, reading as
+// correct at every size a developer is likely to test. `max()` holds the
+// floor at any root size and still grows with a taller trigger.
 const COARSE_POINTER_TRIGGER =
-  "pointer-coarse:before:absolute pointer-coarse:before:inset-x-0 pointer-coarse:before:-inset-y-2.5";
+  "pointer-coarse:before:absolute pointer-coarse:before:inset-x-0 pointer-coarse:before:top-1/2 pointer-coarse:before:h-[max(100%,44px)] pointer-coarse:before:-translate-y-1/2";
 
 /**
  * The scoped epic panel ticket 12 replaces the ambient cost badge with:

--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-detail-tab-strip.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-detail-tab-strip.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { PrDetailTabId } from "@/stores/epics/pr-detail-view-store";
 import { PrDetailTabStrip } from "@/components/epic-canvas/pr/pr-detail-tab-strip";
+import { expectNoRemScaledTouchSize } from "@/__tests__/rem-scaled-touch-size";
 
 function renderStrip(args: {
   readonly tab: PrDetailTabId;
@@ -190,7 +191,12 @@ describe("<PrDetailTabStrip /> on a phone viewport", () => {
     const trigger = screen.getByTestId("pr-detail-tabs");
     expect(trigger.className).toContain("w-full");
     // The touch target the strip never had: its tabs are `py-1.5`, ~30px.
-    expect(trigger.className).toContain("min-h-11");
+    //
+    // The literal is asserted, and the rem forms rejected, because the root
+    // font size is a user setting clamped to 10-20px: pinning `min-h-11` here
+    // would pin a 27.5px floor and make the fix unlandable from this file.
+    expect(trigger.className).toContain("min-h-[44px]");
+    expectNoRemScaledTouchSize(trigger.className);
   });
 
   it("names the panel from the active tab's label", () => {

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-detail-tab-strip.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-detail-tab-strip.tsx
@@ -227,9 +227,14 @@ function PrDetailTabMenu(props: PrDetailTabPickerProps): ReactNode {
           type="button"
           data-testid="pr-detail-tabs"
           className={cn(
-            // `min-h-11` is the touch target the strip never had: its tabs are
-            // `py-1.5`, which lands around 30px.
-            "flex min-h-11 w-full min-w-0 items-center gap-2",
+            // The touch target the strip never had: its tabs are `py-1.5`,
+            // which lands around 30px.
+            //
+            // Pixel-literal, never `min-h-11`: the root font size is a user
+            // setting clamped to 10-20px, so `2.75rem` is 27.5px at the floor
+            // and reaches 44px only above a ~16px root - it would not have
+            // given the strip the target either.
+            "flex min-h-[44px] w-full min-w-0 items-center gap-2",
             "rounded-xl border border-border/50 bg-muted/30 px-3 py-2 text-ui-sm",
             "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
           )}
@@ -270,7 +275,7 @@ function PrDetailTabMenu(props: PrDetailTabPickerProps): ReactNode {
               key={definition.id}
               value={definition.id}
               data-testid={`pr-detail-tab-${definition.id}`}
-              className="min-h-11 gap-2"
+              className="min-h-[44px] gap-2"
             >
               <span className="min-w-0 flex-1 truncate">
                 {definition.label}

--- a/clients/gui-app/src/components/epics/mobile/mobile-history-row.tsx
+++ b/clients/gui-app/src/components/epics/mobile/mobile-history-row.tsx
@@ -449,7 +449,10 @@ function RowSelectionCheckbox(props: {
       aria-label={`Select ${props.displayTitle}`}
       data-testid="epics-list-row-select"
       className={cn(
-        "flex size-11 shrink-0 self-center items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        // `size-[44px]`, never `size-11`: the root font size is a user setting
+        // clamped to 10-20px, so a rem box is 27.5px square at the floor and
+        // reaches the touch target only above a ~16px root.
+        "flex size-[44px] shrink-0 self-center items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         // An `aria-disabled` control still matches `:active`, so the press has
         // to be suppressed explicitly or the row tints for a tap that does
         // nothing.

--- a/clients/gui-app/src/components/errors/app-error-screen.tsx
+++ b/clients/gui-app/src/components/errors/app-error-screen.tsx
@@ -43,6 +43,8 @@ export function AppErrorScreen(props: AppErrorScreenProps): ReactNode {
     >
       <Card className="w-full max-w-md">
         <CardContent className="flex flex-col items-center gap-4 py-8 text-center">
+          {/* touch-target-ok: decorative glyph disc, nothing here is tappable -
+              the rem size is wanted, so the badge tracks the reader's text. */}
           <div className="flex size-11 items-center justify-center rounded-full bg-destructive/10 text-destructive">
             <AlertTriangle className="size-5" aria-hidden />
           </div>

--- a/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
@@ -55,10 +55,13 @@ export function DeviceCodeProgress(props: {
 
         <Button
           size={props.isHero ? "lg" : "sm"}
+          // The hero height is a pixel literal. The root font size is a user
+          // setting clamped to 10-20px, so a rem height tracks it and lands at
+          // 27.5px at the floor - and this is the only control on the screen.
           className={cn(
             "w-full",
             props.isHero
-              ? "h-11 border-white/20 bg-white text-zinc-950 hover:bg-white/90"
+              ? "min-h-[44px] border-white/20 bg-white text-zinc-950 hover:bg-white/90"
               : null,
           )}
           onClick={() => openVerificationPageMutation.mutate()}

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -163,15 +163,18 @@ export function MobileNavDrawer(): ReactNode {
           // the create action from the flat history rows without spanning a
           // heavy full-height slab. Nothing else in this panel may take a
           // resting fill, or the distinction dies.
-          // Visually a compact h-9 pill, but the tap target must still meet
-          // the 44px touch floor: the ::after overlay extends the hit area
-          // invisibly without growing the rendered button.
+          // Sized to the touch floor rather than slopped up to it. Invisible
+          // hit slop only works for a control with room around it, and this one
+          // has `mt-1` between it and the task list - so a pseudo tall enough
+          // to reach 44px hangs over the first row and takes its taps, by more
+          // the smaller the reader sets their text. Every other row in this
+          // drawer takes the same treatment (see `ROW_CLASS`).
           //
-          // `max(100%, 44px)`, never a rem inset: the root font size is a user
-          // setting clamped to 10-20px, so the `h-9` box and a rem inset
-          // around it shrink together - 30px at the floor. This form holds the
-          // floor at any root size and still grows with a taller pill.
-          className="relative h-9 w-full shrink-0 justify-center gap-2 rounded-md px-4 font-semibold after:absolute after:inset-x-0 after:top-1/2 after:h-[max(100%,44px)] after:-translate-y-1/2 after:content-['']"
+          // Pixel-literal, never `h-9` plus a rem inset: the root font size is
+          // a user setting clamped to 10-20px, so the box and any rem padding
+          // around it shrink together and land at 30px at the floor. A
+          // min-height also cannot clip a label that wraps at a large size.
+          className="w-full shrink-0 justify-center gap-2 rounded-md px-4 font-semibold min-h-[44px]"
           data-testid="mobile-nav-new-task"
           onClick={handleNewTask}
         >

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -30,7 +30,11 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
 import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
 
-const ROW_CLASS = "h-11 w-full justify-start gap-3 px-3";
+// `min-h-[44px]`, never `h-11`: the root font size is a user setting clamped
+// to 10-20px, so a rem row height is 27.5px at the floor and reaches the touch
+// target only above a ~16px root. A min-height also cannot clip a row whose
+// label wraps at a large text size, which a fixed height can.
+const ROW_CLASS = "min-h-[44px] w-full justify-start gap-3 px-3";
 
 // The task scroller fades its bottom edge rather than slicing a row against the
 // footer's border. The list carries matching bottom padding, so the gradient
@@ -162,7 +166,12 @@ export function MobileNavDrawer(): ReactNode {
           // Visually a compact h-9 pill, but the tap target must still meet
           // the 44px touch floor: the ::after overlay extends the hit area
           // invisibly without growing the rendered button.
-          className="relative h-9 w-full shrink-0 justify-center gap-2 rounded-md px-4 font-semibold after:absolute after:inset-x-0 after:-inset-y-1.5 after:content-['']"
+          //
+          // `max(100%, 44px)`, never a rem inset: the root font size is a user
+          // setting clamped to 10-20px, so the `h-9` box and a rem inset
+          // around it shrink together - 30px at the floor. This form holds the
+          // floor at any root size and still grows with a taller pill.
+          className="relative h-9 w-full shrink-0 justify-center gap-2 rounded-md px-4 font-semibold after:absolute after:inset-x-0 after:top-1/2 after:h-[max(100%,44px)] after:-translate-y-1/2 after:content-['']"
           data-testid="mobile-nav-new-task"
           onClick={handleNewTask}
         >

--- a/clients/gui-app/src/components/layout/tabs/split-slot-chooser.tsx
+++ b/clients/gui-app/src/components/layout/tabs/split-slot-chooser.tsx
@@ -175,7 +175,7 @@ export function SplitSlotChooserContent(
                 key={choice.id}
                 type="button"
                 variant="ghost"
-                className="h-11 w-full justify-start rounded-md px-3"
+                className="min-h-[44px] w-full justify-start rounded-md px-3"
                 onClick={() => openDestination(choice.destination)}
               >
                 {choice.label}
@@ -198,7 +198,7 @@ export function SplitSlotChooserContent(
           <Button
             type="button"
             variant="ghost"
-            className="h-11 w-full justify-start rounded-md px-3"
+            className="min-h-[44px] w-full justify-start rounded-md px-3"
             onClick={() => openDestination({ kind: "new-draft" })}
           >
             <FilePlus2 />

--- a/clients/gui-app/src/components/minimap/minimap-list-card.tsx
+++ b/clients/gui-app/src/components/minimap/minimap-list-card.tsx
@@ -95,7 +95,11 @@ export function MinimapListCard({
                   // A coarse pointer gets a full touch target. `min-h`, not a
                   // pseudo-element slop area: these rows stack directly on one
                   // another, so slop would overlap the neighbours.
-                  "w-full cursor-pointer rounded-lg py-1.5 pr-3 text-left text-ui-xs font-medium leading-5 transition-colors duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 pointer-coarse:min-h-11",
+                  //
+                  // Pixel-literal, never `min-h-11`: the root font size is a
+                  // user setting clamped to 10-20px, so a rem height tracks it
+                  // and is shortest exactly where the text is smallest.
+                  "w-full cursor-pointer rounded-lg py-1.5 pr-3 text-left text-ui-xs font-medium leading-5 transition-colors duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 pointer-coarse:min-h-[44px]",
                   item.level === 1 ? "pl-3" : "pl-7",
                   current
                     ? "bg-foreground/[0.10] text-foreground"

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -174,10 +174,18 @@ Supporting pieces, all viewport-agnostic where possible:
     popover content to the body. A control the scope enlarges can therefore
     open a list it cannot, which is how the Providers `Select` came to have a
     44px trigger over 28px rows. Anything living in a portal owns its own
-    target instead, at the primitive: `pointer-coarse:min-h-11` on
+    target instead, at the primitive: `pointer-coarse:min-h-[44px]` on
     `ui/select.tsx`'s `SelectItem` and on all four of `ui/dropdown-menu.tsx`'s
     row types (item, checkbox, radio, sub-trigger - keep them in step). Reach
     for a scope rule only for a control that renders in place.
+  - Size a touch target with a **pixel literal**, never a rem utility such as
+    `min-h-11` or a `-inset-*` slop. The root font size is a user setting
+    written onto `<html>` and clamped to 10-20px, so every rem in this app is
+    elastic: `2.75rem` is 27.5px at the floor and only reaches 44px above a
+    ~16px root. A rem-sized target is smallest for the people who chose the
+    smallest text, which inverts the reason the target exists. Where the hit
+    area must also grow with a larger control, use the stylesheets' own form,
+    `max(100%, 44px)`.
 
 ## Key Files
 

--- a/clients/gui-app/src/components/ui/dropdown-menu.tsx
+++ b/clients/gui-app/src/components/ui/dropdown-menu.tsx
@@ -94,9 +94,15 @@ function DropdownMenuGroup({
 /**
  * Every tappable ROW here - this one, the checkbox and radio items, and the
  * sub-trigger - owns its coarse-pointer target through its own height
- * (`pointer-coarse:min-h-11`), the same way `ui/select.tsx` sizes `SelectItem`.
- * Keep the four in step: a row left behind reads as a ragged list on touch, and
- * is the one that gets mis-tapped.
+ * (`pointer-coarse:min-h-[44px]`), the same way `ui/select.tsx` sizes
+ * `SelectItem`. Keep the four in step: a row left behind reads as a ragged list
+ * on touch, and is the one that gets mis-tapped.
+ *
+ * The height is a PIXEL LITERAL, never `min-h-11`. The root font size is a user
+ * setting written onto `<html>` and clamped to 10-20px, so every rem here is
+ * elastic: `2.75rem` is 27.5px at the floor and clears 44px only above a ~16px
+ * root. A rem-sized row would be shortest for the reader who chose the smallest
+ * text, which is the opposite of what a touch target is for.
  *
  * Rows deliberately do NOT use the invisible `::after` slop that the
  * `[data-*-touch-scope]` stylesheets give buttons and menu TRIGGERS. Either
@@ -128,7 +134,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-[44px] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className,
       )}
       {...props}
@@ -150,7 +156,7 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       data-inset={inset}
       className={cn(
-        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-[44px] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -193,7 +199,7 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       data-inset={inset}
       className={cn(
-        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-[44px] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -279,7 +285,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground pointer-coarse:min-h-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground pointer-coarse:min-h-[44px] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/clients/gui-app/src/components/ui/select.tsx
+++ b/clients/gui-app/src/components/ui/select.tsx
@@ -189,7 +189,7 @@ function SelectLabel({
 
 /**
  * An item owns its coarse-pointer target through its own height
- * (`pointer-coarse:min-h-11`), not through the invisible `::after` slop the
+ * (`pointer-coarse:min-h-[44px]`), not through the invisible `::after` slop the
  * `[data-*-touch-scope]` files give buttons and select TRIGGERS. Either half of
  * the reason decides it alone:
  *
@@ -200,6 +200,11 @@ function SelectLabel({
  * - Items stack flush, so slop that overhangs by design would reach into the
  *   neighbouring row and hand it the tap. `mobile-shell-touch-targets.css`
  *   makes the same call for `command-item`, for the same geometry.
+ *
+ * The height is a PIXEL LITERAL, never `min-h-11`. The root font size is a user
+ * setting written onto `<html>` and clamped to 10-20px, so every rem here is
+ * elastic: `2.75rem` is 27.5px at the floor and clears 44px only above a ~16px
+ * root - shortest for the reader who chose the smallest text.
  *
  * The row grows on touch only; `items-center` keeps the label and the check
  * indicator centred in whatever height that yields, and pointer devices keep
@@ -214,7 +219,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:min-h-[44px] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/clients/gui-app/src/components/ui/sidebar.tsx
+++ b/clients/gui-app/src/components/ui/sidebar.tsx
@@ -416,6 +416,9 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
+        // touch-target-ok: stock shadcn slop, unclaimed as a 44px target and
+        // too small to be one at any root size. Nothing in this app renders
+        // this primitive; leave it as upstream ships it.
         "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-foreground ring-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
         className,
       )}
@@ -548,6 +551,9 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
+        // touch-target-ok: stock shadcn slop, unclaimed as a 44px target and
+        // too small to be one at any root size. Nothing in this app renders
+        // this primitive; leave it as upstream ships it.
         "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-foreground ring-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
         showOnHover &&
           "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-accent-foreground aria-expanded:opacity-100 md:opacity-0",


### PR DESCRIPTION
## The invariant this PR establishes

**Every rem in this app is elastic, and it is a user setting.**

`providers/theme-provider.tsx:29` writes the root font size straight onto `documentElement.style.fontSize`, from a value the settings store clamps to **10–20px** (`clampUiFontSize`, `stores/settings/settings-store.ts:236`). The "15px root" figure quoted in this repo's docs — and in most people's heads — is only the *default*.

So `pointer-coarse:min-h-11` is not a 44px touch target and never was:

| root font size | `min-h-11` (2.75rem) renders |
| --- | --- |
| 10px (the floor) | **27.5px** |
| 15px (the default) | 41.25px |
| 16px | 44px |
| 20px (the ceiling) | 55px |

It clears the guideline only above a ~16px root — which is to say, at no size a developer is likely to test at. And it is *smallest for exactly the reader who chose the smallest text*, which inverts the reason a minimum target exists at all.

The `-inset-*` hit-slop idiom fails the same way from the other direction: a rem inset around a rem-sized box shrinks together with it, so the total never reaches the floor either.

## The fix

The replacement idioms are the ones the three touch-target stylesheets (`settings-`, `home-`, `mobile-shell-touch-targets.css`) already use in raw CSS:

- **`min-h-[44px]`** — a row that stacks flush with its neighbours, where invisible slop would steal the neighbour's tap.
- **`max(100%, 44px)`** — a pseudo-element hit area. Holds the floor at any root size *and* still grows with a larger control.

### 1. The doc, first

`settings/SETTINGS.md:134` documented `pointer-coarse:min-h-11` as the sanctioned way to size a portalled row. That is the root cause: the lanes that copied it did so **deliberately, for consistency** — which is what good documentation is supposed to produce. Converting the call sites without correcting the doc would only reseed the class.

### 2. Assigned sites — from another lane's review (#1433)

| File | Was | Now |
| --- | --- | --- |
| `ui/dropdown-menu.tsx` ×4 (item, checkbox, radio, sub-trigger) | `pointer-coarse:min-h-11` | `pointer-coarse:min-h-[44px]` |
| `ui/select.tsx` `SelectItem` | `pointer-coarse:min-h-11` | `pointer-coarse:min-h-[44px]` |
| `epic-canvas/git-diff/git-changed-file-row.tsx` | `pointer-coarse:min-h-11` | `pointer-coarse:min-h-[44px]` |
| `minimap/minimap-list-card.tsx` | `pointer-coarse:min-h-11` | `pointer-coarse:min-h-[44px]` |
| `epic-canvas/panels/epic-usage-dialog.tsx` | `pointer-coarse:before:-inset-y-2.5` | `before:h-[max(100%,44px)]`, centred |

The last is the axis-suffixed form a naive `min-h-11` grep misses entirely.

### 3. Found sites — the same rule applied across the tree

Discovered by applying the invariant rather than the token list. Same one-line change, same rationale.

| File | Was | Note |
| --- | --- | --- |
| `chat/chat-message-user-body.tsx` | `after:-inset-2.5` on a `size-6` button | Its own comment claimed "the 44px touch-target guideline". It was 27.5px at the floor. |
| `epic-canvas/pr/pr-detail-tab-strip.tsx` ×2 | `min-h-11` | Comment read *"`min-h-11` is the touch target the strip never had"*. It still didn't have it. |
| `epic-canvas/mobile/switcher-list-row.tsx` ×2 | `min-h-11` | Mobile tab-switcher rows. |
| `epic-canvas/mobile/mobile-current-tile-bar.tsx` | `min-h-11` | Inside `data-mobile-shell-touch-scope`. |
| `epic-canvas/mobile/mobile-terminal-key-bar.tsx` | `min-h-11` | On-screen terminal keys — finger-only by definition. |
| `epic-canvas/git-diff/git-diff-repo-switcher.tsx` | `min-h-11` | Portalled, flush-stacked — the `SelectItem` geometry. |
| `epics/mobile/mobile-history-row.tsx` | `size-11` | Row-select checkbox, 27.5px square at the floor. |
| `layout/shell/mobile-nav-drawer.tsx` ×2 | `after:-inset-y-1.5`, `h-11` | 30px and 27.5px at the floor. The `New task` pill is now `min-h-[44px]` rather than slop — see below. |
| `layout/tabs/split-slot-chooser.tsx` ×2 | `h-11` | |
| `layout/header/sign-in/device-code-progress.tsx` | `h-11` | The only control on the sign-in screen. |

### 4. Comments that asserted a guarantee the code didn't provide

Three comments stated the 44px claim, or the right conclusion from a false premise. A comment like that is how this spread, so each now states the invariant instead of the number — including `switcher-category-tabs.tsx`, which already had the **right class for the wrong reason** ("this surface's root font is 15px").

## Tests

`git-changed-file-row.test.tsx` and `pr-detail-tab-strip.test.tsx` **asserted the rem token**, pinning the undersized value and making the fix unlandable from the files it lived in. Both now assert the pixel literal is present *and* that no rem-scaled form survives on the same class list — a `toContain("44px")` alone would still pass on an element carrying both idioms.

`src/__tests__/rem-scaled-touch-target-lint.test.ts` is the part that outlives the sweep. It scans every `.ts`/`.tsx` under `src/`, comments stripped, and follows the existing `muted-fill-on-raised-surface-lint` shape: a per-line `// touch-target-ok: <reason>` waiver keeps the exemption on the line it excuses, and a second arm fails on a waiver that has drifted off it.

**The matcher is unit-tested against 12 rejected and 18 accepted real strings before it is trusted over the tree** — a rule that matches nothing is indistinguishable from a clean tree, and the first version of this rule in the sibling lane silently missed `-inset-y-2.5`. The boundaries are deliberate and tested: `w-11` and `min-w-44` are layout measures, not finger measures; `size-7` is an icon box, while `pointer-coarse:before:size-7` is a hit area; `inset-x-0` is root-independent.

## Verification

- **Compiled every new class through Tailwind v4.3.3** and confirmed real CSS — `min-height: 44px`, `height: max(100%, 44px)`, and the `content: var(--tw-content)` injection the pseudo needs. jsdom only proves a string is on an element; a class that renders nothing is a silent no-op.
- **Confirmed the guard reddens**: reintroducing `pointer-coarse:min-h-11` at one call site fails the tree scan with that file and line.
- `bun run compile` clean; `npx eslint --max-warnings 0` clean on all changed files; 5,591 tests green across the affected suites.
- Grepped the branch's own diff for the defect it fixes — the remaining `min-h-11` / `size-11` / `h-11` strings are all prose in the comments documenting the fix, which the scanner strips.

## Notes

- Independent of #1433. That PR is still open and `ui/coarse-pointer-hit-slop.ts` does not exist on `main`, so this branch matches its *idiom* without importing its code — merge order is not load-bearing either way, and the two touch disjoint files.
- Two deliberate exclusions carry waivers: `errors/app-error-screen.tsx` (a decorative glyph disc, nothing tappable) and `ui/sidebar.tsx` ×2 (stock shadcn slop, never claimed as 44px, and no call site in this app renders those primitives).

## User-visible effect

On phones and tablets, menu rows, list rows, the terminal key bar, the mobile nav and the sign-in button are now at least 44px tall to tap — including for people who shrink the app's text, who previously got targets as small as 27.5px.

## The drawer CTA: sized, not slopped

Review caught that reaching 44px via a centred pseudo on the `h-9` `New task` pill **overhangs the task list**. At a 10px root the button is 22.5px, the pseudo overhangs 10.75px, and `mt-1` gives 2.5px of clearance — so 8.25px of invisible hit area sits over the first task row and takes its taps. (The pre-existing `-inset-y-1.5` already overlapped by 1.25px; converting it widened the overlap.)

It now takes `min-h-[44px]`, which is what this codebase's own rule prescribes — *"a control in a flush stack needs the row-sizing treatment instead, or its slop overlaps its neighbours'"* — and matches every other row in the same drawer. **Cost: the pill renders 44px instead of 33.75px at the default root.**

## Desktop risk

The only behaviour change on desktop is that a handful of invisible hit areas grow by ~2.75px at the default root, and the mobile nav rows render ~2.75px taller each. Nothing visual moves anywhere else — every other conversion is `pointer-coarse:`-gated or an invisible pseudo-element.


## Guard boundaries, and one the tree disproved

The matcher judges an arbitrary value by its **unit**, not by its brackets: `-inset-y-[0.625rem]` is as elastic as `-inset-2.5` and is rejected, while `-inset-y-[2px]` is root-independent and is not. Reading `[...]` as "already a literal" would have left the whole defect reachable through one extra pair of characters.

**Single-edge negative offsets (`before:-top-2`) are deliberately accepted.** That rule was implemented and run; it flagged four sites, and every one is a *painted indicator* nudged outside its box (`split-tab-item.tsx`'s side bar, `ui/tabs.tsx`'s active-tab bar). Slop must never paint, so those are categorically not this idiom — shipping the rule would have meant four waivers that excuse nothing and taught a rule the tree contradicts. The reasoning is recorded in the source rather than left implicit in the regex.
