### PR TITLE
feat(reasonix): add harness protocol and GUI support

### DIFF
--- a/clients/gui-app/src/components/home/data/harness-icon-map.ts
+++ b/clients/gui-app/src/components/home/data/harness-icon-map.ts
@@ -17,6 +17,7 @@ import {
   OpenRouterIcon,
   PiIcon,
   QwenIcon,
+  ReasonixIcon,
   TraycerIcon,
   type HarnessIcon,
 } from "@/components/home/pickers/harness-icons";
@@ -47,4 +48,5 @@ export const PROVIDER_ICON_CONFIG: Record<ProviderId, HarnessIconConfig> = {
   pi: { Icon: PiIcon, className: "text-foreground" },
   hermes: { Icon: HermesIcon, className: "text-foreground" },
   omp: { Icon: OmpIcon, className: "text-foreground" },
+  reasonix: { Icon: ReasonixIcon, className: "text-foreground" },
 };

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -126,6 +126,48 @@ export const OmpIcon: HarnessIcon = (props) => (
   </svg>
 );
 
+// Reasonix (esengine/DeepSeek-Reasonix) has no lobehub entry and publishes no
+// brand asset, so this is a hand-rolled mark: a premise node fanning out to two
+// conclusion nodes — an inference step, which is what the product is named for.
+//
+// Deliberately NOT DeepSeek's whale, even though `@lobehub/icons` ships one and
+// the upstream repo carries "DeepSeek" in its name. Reasonix is a third-party
+// CLI whose backend is user-configured: its shipped presets cover Kimi, GLM/Z.AI,
+// Qwen, MiniMax, StepFun, LongCat and Nvidia alongside DeepSeek, and Kimi and
+// Qwen are already their own rows here with their own marks. A vendor mark on
+// this row would claim a backend the user may not be running — the same
+// mis-identification hazard the checklist records for reusing a sibling's icon,
+// arriving from the model side instead of the sibling side.
+//
+// Monochrome `currentColor` so it follows `text-foreground` like the other
+// hand-rolled marks; there is no brand accent to keep literal.
+export const ReasonixIcon: HarnessIcon = (props) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {/* Premise → two conclusions */}
+    <path d="M8 12h3.5l3 -5.5" />
+    <path d="M11.5 12l3 5.5" />
+    <rect
+      x="2.6"
+      y="9.4"
+      width="5.2"
+      height="5.2"
+      rx="1.4"
+      fill="currentColor"
+      stroke="none"
+    />
+    <circle cx="17.6" cy="6" r="2.6" fill="currentColor" stroke="none" />
+    <circle cx="17.6" cy="18" r="2.6" />
+  </svg>
+);
+
 // Traycer does not have a lobehub entry — hand-rolled from the brand mark.
 export const TraycerIcon: HarnessIcon = (props) => (
   <svg {...props} viewBox={TRAYCER_MARK_VIEWBOX} fill="currentColor">

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -180,6 +180,7 @@ describe("OnboardingDetectedAgents", () => {
       "Pi",
       "Hermes Agent",
       "Oh My Pi",
+      "Reasonix",
     ];
     const textOrEmpty = (text: string | null): string => text ?? "";
     // Longest match, not first match: display names overlap ("Pi" is a

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
@@ -45,6 +45,7 @@ describe("OnboardingDiorama", () => {
       "Pi",
       "Hermes Agent",
       "Oh My Pi",
+      "Reasonix",
     ];
     const textOrEmpty = (text: string | null): string => text ?? "";
     // Longest match, not first match: display names overlap ("Pi" is a

--- a/clients/gui-app/src/components/settings/panels/add-provider-profile-dialog.tsx
+++ b/clients/gui-app/src/components/settings/panels/add-provider-profile-dialog.tsx
@@ -99,6 +99,7 @@ const PROVIDER_SHARES_SKILLS_AND_PLUGINS: Record<
   pi: false,
   hermes: false,
   omp: false,
+  reasonix: false,
 };
 
 export interface FailedProviderProfileAttempt {

--- a/clients/gui-app/src/components/settings/panels/provider-api-key-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-api-key-section.tsx
@@ -56,6 +56,11 @@ const API_KEY_DASHBOARD_URL: Record<ProviderId, string | null> = {
   pi: null,
   hermes: null,
   omp: null,
+  // Reasonix keys are pasted into its own terminal `setup` wizard, which
+  // writes them to Reasonix's global store - there is no Reasonix-hosted key
+  // page to send the user to, and the provider key page it would name depends
+  // on which model provider they configured.
+  reasonix: null,
 };
 
 function apiKeyStatusLabel(apiKey: ProviderCliState["apiKey"]): string {

--- a/clients/gui-app/src/components/settings/panels/provider-cli-candidates-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-cli-candidates-section.tsx
@@ -116,6 +116,9 @@ const SHARED_CLI_CANDIDATE_SOURCE: Record<ProviderId, ProviderId | null> = {
   pi: null,
   hermes: null,
   omp: null,
+  // Reasonix ships its own self-contained binary (six prebuilt targets), so it
+  // borrows nobody's.
+  reasonix: null,
 };
 
 /**
@@ -158,6 +161,10 @@ const PROVIDER_INSTALL_GUIDE_URL: Record<ProviderId, string | null> = {
   hermes:
     "https://hermes-agent.nousresearch.com/docs/getting-started/installation",
   omp: null,
+  // Reasonix IS bundled, so this empty state is not its normal path - it only
+  // appears if the managed binary is missing on this machine. Left null rather
+  // than shipping an unverified upstream install page for that edge.
+  reasonix: null,
 };
 
 interface ProviderCandidateConfig {

--- a/clients/gui-app/src/components/settings/panels/provider-env-name-placeholder.ts
+++ b/clients/gui-app/src/components/settings/panels/provider-env-name-placeholder.ts
@@ -32,6 +32,11 @@ const ENV_NAME_PLACEHOLDER: Record<ProviderId, string> = {
   // OpenRouter, ...) in its own credential store; the env name is illustrative
   // only, same as Hermes above.
   omp: "OPENROUTER_API_KEY",
+  // Reasonix names a DIFFERENT env var per configured provider - the config's
+  // `api_key_env` key chooses it, and the value lives in Reasonix's own global
+  // `.env`, not in the shell. There is no single well-known variable to show,
+  // so this is the default provider preset's name and is illustrative only.
+  reasonix: "DEEPSEEK_API_KEY",
 };
 
 export function envNamePlaceholder(providerId: ProviderId): string {

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -211,6 +211,8 @@ const PROVIDER_DESCRIPTIONS: Record<ProviderId, string> = {
   pi: "Pi agent - pi.dev coding agent via your configured model API key (BYOK).",
   hermes: "Hermes Agent - Nous Research's coding CLI via your Hermes account.",
   omp: "Oh My Pi - can1357's coding CLI via your linked provider subscriptions.",
+  reasonix:
+    "Reasonix - a coding CLI you point at your own model provider; keys live in Reasonix's own store, set up from its terminal wizard.",
 };
 
 function hasPendingProviderProbe(

--- a/clients/gui-app/src/components/settings/panels/terminal-agent-args-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/terminal-agent-args-section.tsx
@@ -31,6 +31,7 @@ const TERMINAL_AGENT_ARGS_PLACEHOLDER: Record<ProviderId, string> = {
   pi: "CLI arguments (optional)",
   hermes: "CLI arguments (optional)",
   omp: "CLI arguments (optional)",
+  reasonix: "CLI arguments (optional)",
 };
 
 function terminalAgentArgsPlaceholder(providerId: ProviderId): string {

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -109,6 +109,7 @@ export type AnalyticsHarness =
   | "openrouter"
   | "pi"
   | "qwen"
+  | "reasonix"
   | "traycer";
 
 /** Product vocabulary only - never the internal host/app-local/global source
@@ -204,6 +205,7 @@ export type AnalyticsProvider =
   | "openrouter"
   | "pi"
   | "qwen"
+  | "reasonix"
   | "traycer";
 
 export type AnalyticsRole = "editor" | "owner" | "viewer";
@@ -984,6 +986,7 @@ const ANALYTICS_HARNESSES = new Set<string>([
   "openrouter",
   "pi",
   "qwen",
+  "reasonix",
   "traycer",
 ]);
 
@@ -1006,6 +1009,7 @@ const ANALYTICS_PROVIDERS = new Set<string>([
   "openrouter",
   "pi",
   "qwen",
+  "reasonix",
   "traycer",
 ]);
 

--- a/clients/gui-app/src/lib/chat/sender-display.ts
+++ b/clients/gui-app/src/lib/chat/sender-display.ts
@@ -154,6 +154,7 @@ const AGENT_PROVIDER_LABEL: Record<GuiHarnessId, string> = {
   pi: "Pi",
   hermes: "Hermes Agent",
   omp: "Oh My Pi",
+  reasonix: "Reasonix",
 };
 
 export function agentProviderLabel(provider: GuiHarnessId): string {

--- a/clients/gui-app/src/lib/chats/compact-conversation.ts
+++ b/clients/gui-app/src/lib/chats/compact-conversation.ts
@@ -17,8 +17,11 @@ import { isOptimisticQueuedItem } from "@/stores/chats/optimistic-queue";
  * devin, and from the SDK command catalog for claude.
  *
  * Copilot deliberately reads `false`: it compacts automatically and advertises
- * no command, so it supports compaction but not on demand. amp, droid and
- * cursor have no compaction at all.
+ * no command, so it supports compaction but not on demand. Reasonix is the same
+ * shape for a different reason - it has `/compact` in its TUI but NOT in its ACP
+ * `available_commands_update`, and compacts on a `compact_ratio` threshold plus
+ * a model-facing `compress` tool, so there is no command to stamp. amp, droid
+ * and cursor have no compaction at all.
  */
 export function findManualCompactCommand(
   commands: ReadonlyArray<GuiAgentCommandOption>,

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -29,6 +29,7 @@ const PROVIDER_ID_ORDER = [
   "pi",
   "hermes",
   "omp",
+  "reasonix",
 ] as const satisfies ReadonlyArray<ProviderId>;
 
 type MissingProviderIdFromOrder = Exclude<
@@ -63,6 +64,7 @@ const GUI_HARNESS_BY_PROVIDER_ID = {
   pi: "pi",
   hermes: "hermes",
   omp: "omp",
+  reasonix: "reasonix",
 } satisfies Readonly<Record<ProviderId, GuiHarnessId>>;
 
 export const ORDERED_PROVIDERS: ExhaustiveOrderedProviders =

--- a/protocol/scripts/compat/snapshot-frozen-catalog-lines.ts
+++ b/protocol/scripts/compat/snapshot-frozen-catalog-lines.ts
@@ -1,7 +1,10 @@
 /**
- * Snapshot frozen catalog response schemas for the three id-carrying methods,
- * plus the frozen `providers.list` REQUEST lines (that method is the one whose
- * request shape has its own freeze history - see the `native` rows below).
+ * Snapshot frozen response schemas for every method whose response embeds a
+ * growing harness/provider id enum - the three canonical id-carrying catalog
+ * methods, plus `epic.getChatRunSettings` (see its rows below for why "three"
+ * was never the real boundary) - plus the frozen `providers.list` REQUEST lines
+ * (that method is the one whose request shape has its own freeze history - see
+ * the `native` rows below).
  *
  *   bun run protocol/scripts/compat/snapshot-frozen-catalog-lines.ts > \
  *     protocol/src/host/__tests__/__fixtures__/frozen-catalog-lines.ts
@@ -17,6 +20,8 @@ import {
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
   listAgentsResponseSchemaV60,
+  listAgentsResponseSchemaV70,
+  listAgentsResponseSchema,
 } from "../../src/host/agent/shared";
 import {
   listGuiHarnessesResponseSchemaV10,
@@ -27,13 +32,19 @@ import {
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
   listGuiHarnessesResponseSchemaV70,
+  listGuiHarnessesResponseSchemaV71,
   listGuiHarnessesResponseSchema,
 } from "../../src/host/agent/gui/unary-schemas";
+import {
+  getChatRunSettingsResponseSchema,
+  getChatRunSettingsResponseSchemaV10,
+} from "../../src/host/epic/chat-records";
 import {
   providersListRequestSchema,
   providersListRequestSchemaBeforeV70,
   providersListResponseSchema,
   providersListResponseSchemaV70,
+  providersListResponseSchemaV71,
   providersListResponseSchemaV10,
   providersListResponseSchemaV20,
   providersListResponseSchemaV30,
@@ -67,15 +78,28 @@ const FIXTURES = {
   // and are byte-identical to what they were, which is why the freeze added
   // rows here without changing any existing one.
   "agent.gui.listHarnesses@7.0": dump(listGuiHarnessesResponseSchemaV70),
-  // The head line, pinned for the same reason `providers.list@7.1` is: growth
+  // 7.1 froze when 8.0 opened for Reasonix. It could not simply absorb the id:
+  // 7.0 is released, and `versioned-rpc.ts` refuses a minor whose response
+  // grows an enum over its predecessor - so no minor of major 7 can carry an id
+  // 7.0 lacks, released or not. Its dump is unchanged by that freeze.
+  "agent.gui.listHarnesses@7.1": dump(listGuiHarnessesResponseSchemaV71),
+  // The head line, pinned for the same reason `providers.list@8.0` is: growth
   // of the live row now has nothing else to fail against.
-  "agent.gui.listHarnesses@7.1": dump(listGuiHarnessesResponseSchema),
+  "agent.gui.listHarnesses@8.0": dump(listGuiHarnessesResponseSchema),
   "agent.list@1.0": dump(listAgentsResponseSchemaV10),
   "agent.list@2.0": dump(listAgentsResponseSchemaV20),
   "agent.list@3.0": dump(listAgentsResponseSchemaV30),
   "agent.list@4.0": dump(listAgentsResponseSchemaV40),
   "agent.list@5.0": dump(listAgentsResponseSchemaV50),
   "agent.list@6.0": dump(listAgentsResponseSchemaV60),
+  // v7.0 froze when the v1.2.0 tags shipped it; until then it pointed at the
+  // live canonical schema, the same defect that let `omp` ride v5.0 and
+  // `huggingface` v6.0. `agent.list` had no row for its head line at all before
+  // this, which is why nothing local caught it - only the tag-based gate could.
+  "agent.list@7.0": dump(listAgentsResponseSchemaV70),
+  // The head line, pinned so the NEXT attempt to grow the live shape goes red
+  // here rather than on the release that ships it.
+  "agent.list@8.0": dump(listAgentsResponseSchema),
   "providers.list@1.0": dump(providersListResponseSchemaV10),
   "providers.list@2.0": dump(providersListResponseSchemaV20),
   // Frozen with Amp, before `profiles` (the v4.0 cut) - pinned now that this
@@ -111,17 +135,49 @@ const FIXTURES = {
   // this snapshot. When that happens, hand-freeze the sub-schema that grew (the
   // `*V70Preimage` shapes are the precedent); do not regenerate to green.
   "providers.list@7.0": dump(providersListResponseSchemaV70),
-  // The head line. It inherits v7.0's old job here: it dumps the LIVE schema,
+  // That response applied again, one line later: 7.1 dumped the live schema
+  // until Reasonix, then froze under `providersListResponseSchemaV71` and 8.0
+  // opened against live. Note 7.1 froze even though no tag has shipped it - a
+  // released 7.0 forbids any minor of major 7 from growing the enum, so the
+  // "wait for the release" reading does not apply to a MINOR. Its dump is
+  // unchanged by the freeze.
+  "providers.list@7.1": dump(providersListResponseSchemaV71),
+  // The head line. It inherits 7.1's old job here: it dumps the LIVE schema,
   // so the FIRST attempt to grow the live shape goes red on this row rather
   // than on the release that ships the growth. Same response then applies -
   // freeze the line that stopped being head, open the next one.
-  "providers.list@7.1": dump(providersListResponseSchema),
+  "providers.list@8.0": dump(providersListResponseSchema),
   // The REQUEST lines carry their own freeze history (`native` grew the
   // already-shipped v4.0/v5.0/v6.0 requests before `host-v1.1.10` re-pinned
   // them), and nothing pinned them locally until now - the tag-based gate was
   // the only thing that could see it. Two rows cover every line: v1.0..v6.0 all
   // share `providersListRequestSchemaBeforeV70`, and v7.0 has its own.
+  // A FOURTH method, added when Reasonix found it the hard way. Its response
+  // embeds the PERSISTED `guiHarnessIdSchema` - a second copy of the harness
+  // enum, on a method whose name suggests no catalog at all - and it is
+  // `degrade: unsupported`, so it sits outside `RELEASED_FLOOR` and every local
+  // test stayed green while it silently absorbed `reasonix`. Only the tag-based
+  // `protocol-compat` gate caught it.
+  //
+  // These two rows are what make that class fail locally from now on: 1.0 is
+  // the frozen released line, 2.0 dumps LIVE so the next growth attempt goes
+  // red here first. The lesson generalizes - "the three id-carrying methods" was
+  // never the real boundary; grep RESPONSES for id enums.
+  "epic.getChatRunSettings@1.0": dump(getChatRunSettingsResponseSchemaV10),
+  "epic.getChatRunSettings@2.0": dump(getChatRunSettingsResponseSchema),
   "providers.list@1.0..6.0 request": dump(providersListRequestSchemaBeforeV70),
+  // This row DOES get regenerated when a provider id is added, and it is the
+  // one row here where that is the right answer rather than the forbidden one.
+  // It dumps the LIVE request (which v7.0 and v8.0 both bind), and the growth
+  // reaches it through `nativeListQuerySchema.providerId`. A request is a
+  // client->host slot: `surface-compat.ts` scores enum growth there ADVISORY,
+  // because a released client never emits the new value and a new client
+  // sending it to an old host fails per-call with a clear upgrade path. The
+  // row exists to make that growth VISIBLE, not to forbid it.
+  //
+  // The response rows are the opposite and must never be regenerated to green
+  // - see `providers.list@7.0` above, and `providerManagedVersionsSchemaV70`
+  // for the sub-schema freeze that kept it byte-identical when Reasonix landed.
   "providers.list@7.0 request": dump(providersListRequestSchema),
 };
 

--- a/protocol/src/common/_internal/schemas.ts
+++ b/protocol/src/common/_internal/schemas.ts
@@ -68,4 +68,5 @@ export const harnessIdSchema = z.enum([
   "hermes",
   "omp",
   "huggingface",
+  "reasonix",
 ]);

--- a/protocol/src/host/__tests__/__fixtures__/frozen-catalog-lines.ts
+++ b/protocol/src/host/__tests__/__fixtures__/frozen-catalog-lines.ts
@@ -933,6 +933,132 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
       ],
       "additionalProperties": false
     },
+    "agent.gui.listHarnesses@8.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "harnesses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
+                  "claude",
+                  "codex",
+                  "opencode",
+                  "traycer",
+                  "cursor",
+                  "grok",
+                  "qwen",
+                  "kiro",
+                  "droid",
+                  "kimi",
+                  "copilot",
+                  "kilocode",
+                  "openrouter",
+                  "amp",
+                  "devin",
+                  "pi",
+                  "hermes",
+                  "omp",
+                  "huggingface",
+                  "reasonix"
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "enabled": {
+                "default": true,
+                "type": "boolean"
+              },
+              "available": {
+                "type": "boolean"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "gui",
+                    "tui"
+                  ]
+                }
+              },
+              "requiresApiKey": {
+                "type": "boolean"
+              },
+              "supportedPermissionModes": {
+                "default": [
+                  "supervised",
+                  "auto_accept_edits",
+                  "full_access"
+                ],
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "supervised",
+                    "auto_accept_edits",
+                    "full_access"
+                  ]
+                }
+              },
+              "availabilityPending": {
+                "default": false,
+                "type": "boolean"
+              },
+              "authStatus": {
+                "type": "string",
+                "enum": [
+                  "authenticated",
+                  "unauthenticated",
+                  "configured",
+                  "unavailable",
+                  "unknown"
+                ]
+              },
+              "enablementMode": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "on",
+                  "off"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "label",
+              "enabled",
+              "available",
+              "error",
+              "modes",
+              "requiresApiKey",
+              "supportedPermissionModes",
+              "availabilityPending"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "harnesses"
+      ],
+      "additionalProperties": false
+    },
     "agent.list@1.0": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -1826,6 +1952,467 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
               "active",
               "folderPaths",
               "isWorktree"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "caller",
+        "scope",
+        "agents"
+      ],
+      "additionalProperties": false
+    },
+    "agent.list@7.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "caller": {
+          "type": "object",
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "canSendMessages": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "agentId",
+            "canSendMessages"
+          ],
+          "additionalProperties": false
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "user",
+            "all"
+          ]
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "parentId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "hostId": {
+                "type": "string"
+              },
+              "isLocal": {
+                "type": "boolean"
+              },
+              "surface": {
+                "type": "string",
+                "enum": [
+                  "gui",
+                  "tui"
+                ]
+              },
+              "harnessId": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "claude",
+                      "codex",
+                      "opencode",
+                      "traycer",
+                      "cursor",
+                      "grok",
+                      "qwen",
+                      "kiro",
+                      "droid",
+                      "kimi",
+                      "copilot",
+                      "kilocode",
+                      "openrouter",
+                      "amp",
+                      "devin",
+                      "pi",
+                      "hermes",
+                      "omp",
+                      "huggingface"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "isSelf": {
+                "type": "boolean"
+              },
+              "title": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "capabilities": {
+                "type": "object",
+                "properties": {
+                  "readTranscript": {
+                    "type": "boolean"
+                  },
+                  "sendMessage": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "readTranscript",
+                  "sendMessage"
+                ],
+                "additionalProperties": false
+              },
+              "active": {
+                "type": "boolean"
+              },
+              "folderPaths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "isWorktree": {
+                "type": "boolean"
+              },
+              "runConfig": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "const": "concrete"
+                              },
+                              "slug": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "slug"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "const": "provider-default"
+                              }
+                            },
+                            "required": [
+                              "kind"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "reasoningEffort": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "fastMode": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "model",
+                      "reasoningEffort",
+                      "fastMode"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "parentId",
+              "hostId",
+              "isLocal",
+              "surface",
+              "harnessId",
+              "isSelf",
+              "title",
+              "capabilities",
+              "active",
+              "folderPaths",
+              "isWorktree",
+              "runConfig"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "caller",
+        "scope",
+        "agents"
+      ],
+      "additionalProperties": false
+    },
+    "agent.list@8.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "caller": {
+          "type": "object",
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "canSendMessages": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "agentId",
+            "canSendMessages"
+          ],
+          "additionalProperties": false
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "user",
+            "all"
+          ]
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "parentId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "hostId": {
+                "type": "string"
+              },
+              "isLocal": {
+                "type": "boolean"
+              },
+              "surface": {
+                "type": "string",
+                "enum": [
+                  "gui",
+                  "tui"
+                ]
+              },
+              "harnessId": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "claude",
+                      "codex",
+                      "opencode",
+                      "traycer",
+                      "cursor",
+                      "grok",
+                      "qwen",
+                      "kiro",
+                      "droid",
+                      "kimi",
+                      "copilot",
+                      "kilocode",
+                      "openrouter",
+                      "amp",
+                      "devin",
+                      "pi",
+                      "hermes",
+                      "omp",
+                      "huggingface",
+                      "reasonix"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "isSelf": {
+                "type": "boolean"
+              },
+              "title": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "capabilities": {
+                "type": "object",
+                "properties": {
+                  "readTranscript": {
+                    "type": "boolean"
+                  },
+                  "sendMessage": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "readTranscript",
+                  "sendMessage"
+                ],
+                "additionalProperties": false
+              },
+              "active": {
+                "type": "boolean"
+              },
+              "folderPaths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "isWorktree": {
+                "type": "boolean"
+              },
+              "runConfig": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "const": "concrete"
+                              },
+                              "slug": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "slug"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "const": "provider-default"
+                              }
+                            },
+                            "required": [
+                              "kind"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "reasoningEffort": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "fastMode": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "model",
+                      "reasoningEffort",
+                      "fastMode"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "parentId",
+              "hostId",
+              "isLocal",
+              "surface",
+              "harnessId",
+              "isSelf",
+              "title",
+              "capabilities",
+              "active",
+              "folderPaths",
+              "isWorktree",
+              "runConfig"
             ],
             "additionalProperties": false
           }
@@ -10650,6 +11237,3057 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
       ],
       "additionalProperties": false
     },
+    "providers.list@8.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "providerId": {
+                "type": "string",
+                "enum": [
+                  "claude-code",
+                  "codex",
+                  "opencode",
+                  "cursor",
+                  "traycer",
+                  "grok",
+                  "qwen",
+                  "kiro",
+                  "droid",
+                  "kimi",
+                  "copilot",
+                  "kilocode",
+                  "openrouter",
+                  "amp",
+                  "devin",
+                  "pi",
+                  "hermes",
+                  "omp",
+                  "huggingface",
+                  "reasonix"
+                ]
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "disabledBy": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "userId": {
+                        "type": "string"
+                      },
+                      "handle": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "at": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "userId",
+                      "handle",
+                      "at"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "selected": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "bundled"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "path"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "custom"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "path"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "candidates": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "bundled",
+                        "path",
+                        "custom"
+                      ]
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "versionPending": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "path",
+                    "version",
+                    "available",
+                    "versionPending"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "authPending": {
+                "type": "boolean"
+              },
+              "checkedAt": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "apiKey": {
+                "type": "object",
+                "properties": {
+                  "supported": {
+                    "type": "boolean"
+                  },
+                  "configured": {
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "stored",
+                          "env"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "supported",
+                  "configured",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              "terminalAgentArgs": {
+                "default": "",
+                "type": "string"
+              },
+              "envOverrides": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "loginCapability": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "oauthArgs": {
+                        "anyOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "token": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "vars": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "vars"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "codePaste": {
+                        "default": null,
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "terminalLogin": {
+                        "default": null,
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "oauthArgs",
+                      "token",
+                      "codePaste",
+                      "terminalLogin"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "availabilityPending": {
+                "default": false,
+                "type": "boolean"
+              },
+              "profiles": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "profileId": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "ambient",
+                        "managed"
+                      ]
+                    },
+                    "authType": {
+                      "type": "string",
+                      "enum": [
+                        "oauth"
+                      ]
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "auth": {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "authenticated",
+                            "unauthenticated",
+                            "configured",
+                            "unavailable",
+                            "unknown"
+                          ]
+                        },
+                        "badgeText": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "label": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "detail": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "badgeText",
+                        "label",
+                        "detail"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "identity": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "tier": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "accountUuid": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "email",
+                            "tier",
+                            "accountUuid"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "usageUpdatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "rateLimitStatus": {
+                      "default": "unknown",
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "near_limit",
+                        "hard_limit",
+                        "unknown"
+                      ]
+                    },
+                    "rateLimitLimitedScopes": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "family": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "severity": {
+                                "type": "string",
+                                "enum": [
+                                  "near_limit",
+                                  "hard_limit"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "family",
+                              "severity"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "duplicateOfProfileId": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ambientDriftNotice": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "previousEmail": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "changedAt": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "previousEmail",
+                            "changedAt"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "accentColor": {
+                      "default": null,
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "#ef4444",
+                            "#f97316",
+                            "#f59e0b",
+                            "#84cc16",
+                            "#10b981",
+                            "#14b8a6",
+                            "#06b6d4",
+                            "#3b82f6",
+                            "#8b5cf6",
+                            "#a855f7",
+                            "#d946ef",
+                            "#ec4899"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "reusedTombstone": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "accentColor": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "#ef4444",
+                                    "#f97316",
+                                    "#f59e0b",
+                                    "#84cc16",
+                                    "#10b981",
+                                    "#14b8a6",
+                                    "#06b6d4",
+                                    "#3b82f6",
+                                    "#8b5cf6",
+                                    "#a855f7",
+                                    "#d946ef",
+                                    "#ec4899"
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "label",
+                            "accentColor"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "profileId",
+                    "kind",
+                    "authType",
+                    "label",
+                    "auth",
+                    "identity",
+                    "usageUpdatedAt",
+                    "rateLimitStatus",
+                    "rateLimitLimitedScopes",
+                    "duplicateOfProfileId",
+                    "ambientDriftNotice",
+                    "accentColor"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "managedInstallState": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "const": "absent"
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "const": "downloading"
+                          },
+                          "percent": {
+                            "anyOf": [
+                              {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "version": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "percent"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "const": "installed"
+                          },
+                          "version": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "const": "error"
+                          },
+                          "reason": {
+                            "type": "string",
+                            "enum": [
+                              "disk-full",
+                              "network",
+                              "verification",
+                              "unknown",
+                              "unrepairable",
+                              "live-owner-stalled",
+                              "trust-unavailable",
+                              "local-storage-mismatch"
+                            ]
+                          },
+                          "version": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "retryAtMs": {
+                            "anyOf": [
+                              {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "reason",
+                          "message",
+                          "retryAtMs"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "versionVisibility": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "differingSessionCount": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "differingSessionCount"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "advisory": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "stale-channel",
+                          "cannot-confirm-eligibility",
+                          "yank-keep-running",
+                          "yank-rollback",
+                          "row-incompatibility"
+                        ]
+                      },
+                      "detail": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "detail"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cliBinaryResolved": {
+                "default": true,
+                "type": "boolean"
+              },
+              "packId": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managedVersions": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "autoDownload": {
+                        "type": "boolean"
+                      },
+                      "pinnedVersion": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "updateAvailable": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "version"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "sharedWithProviders": {
+                        "default": [],
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "claude-code",
+                            "codex",
+                            "opencode",
+                            "cursor",
+                            "traycer",
+                            "grok",
+                            "qwen",
+                            "kiro",
+                            "droid",
+                            "kimi",
+                            "copilot",
+                            "kilocode",
+                            "openrouter",
+                            "amp",
+                            "devin",
+                            "pi",
+                            "hermes",
+                            "omp",
+                            "huggingface",
+                            "reasonix"
+                          ]
+                        }
+                      },
+                      "totalSizeBytes": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "available": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "version": {
+                              "type": "string"
+                            },
+                            "sizeBytes": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "certification": {
+                              "type": "string",
+                              "enum": [
+                                "eligible",
+                                "yanked",
+                                "below-security-floor",
+                                "host-ineligible",
+                                "uncertified"
+                              ]
+                            },
+                            "recommended": {
+                              "type": "boolean"
+                            },
+                            "current": {
+                              "type": "boolean"
+                            },
+                            "installState": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "status": {
+                                      "type": "string",
+                                      "const": "absent"
+                                    }
+                                  },
+                                  "required": [
+                                    "status"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "status": {
+                                      "type": "string",
+                                      "const": "downloading"
+                                    },
+                                    "percent": {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "minimum": 0,
+                                          "maximum": 100
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "status",
+                                    "percent"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "status": {
+                                      "type": "string",
+                                      "const": "installed"
+                                    }
+                                  },
+                                  "required": [
+                                    "status"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "status": {
+                                      "type": "string",
+                                      "const": "unusable"
+                                    },
+                                    "reason": {
+                                      "type": "string",
+                                      "enum": [
+                                        "condemned",
+                                        "quarantined",
+                                        "corrupt",
+                                        "unverified"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "status",
+                                    "reason"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "status": {
+                                      "type": "string",
+                                      "const": "error"
+                                    },
+                                    "reason": {
+                                      "type": "string",
+                                      "enum": [
+                                        "disk-full",
+                                        "network",
+                                        "verification",
+                                        "unknown",
+                                        "unrepairable",
+                                        "live-owner-stalled",
+                                        "trust-unavailable",
+                                        "local-storage-mismatch"
+                                      ]
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "retryAtMs": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer",
+                                          "minimum": 0,
+                                          "maximum": 9007199254740991
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "status",
+                                    "reason",
+                                    "message",
+                                    "retryAtMs"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "version",
+                            "sizeBytes",
+                            "certification",
+                            "recommended",
+                            "current",
+                            "installState"
+                          ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": [
+                      "autoDownload",
+                      "pinnedVersion",
+                      "updateAvailable",
+                      "sharedWithProviders",
+                      "totalSizeBytes",
+                      "available"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managedVersionsUnavailable": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "registry-unconfigured",
+                          "registry-unreachable",
+                          "registry-not-yet-checked",
+                          "install-manager-unavailable"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "reason"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "nextRunBinary": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "managed",
+                          "bundled",
+                          "path",
+                          "custom"
+                        ]
+                      },
+                      "path": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "version": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "path",
+                      "version"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "enablementMode": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "on",
+                  "off"
+                ]
+              },
+              "enablementSource": {
+                "type": "string",
+                "enum": [
+                  "sticky",
+                  "auto-detected",
+                  "auto-undetected"
+                ]
+              },
+              "auth": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "authenticated",
+                      "unauthenticated",
+                      "configured",
+                      "unavailable",
+                      "unknown"
+                    ]
+                  },
+                  "badgeText": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "detail": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "status",
+                  "badgeText",
+                  "label",
+                  "detail"
+                ],
+                "additionalProperties": false
+              },
+              "nativeCapabilities": {
+                "default": {
+                  "supportedTabs": [
+                    "general",
+                    "env",
+                    "usage"
+                  ],
+                  "mcp": null,
+                  "plugins": null,
+                  "skills": null,
+                  "modelProviders": null
+                },
+                "type": "object",
+                "properties": {
+                  "supportedTabs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "general",
+                        "env",
+                        "usage",
+                        "mcp",
+                        "plugins",
+                        "skills",
+                        "modelProviders"
+                      ]
+                    }
+                  },
+                  "envOverrideScope": {
+                    "type": "string",
+                    "enum": [
+                      "harness-and-native-config",
+                      "native-config-only"
+                    ]
+                  },
+                  "mcp": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "transports": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "stdio",
+                                "http",
+                                "sse"
+                              ]
+                            }
+                          },
+                          "authTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "none",
+                                "header",
+                                "env",
+                                "oauth"
+                              ]
+                            }
+                          },
+                          "authActions": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "login",
+                                "submitCode",
+                                "logout",
+                                "clearAuth",
+                                "forceReauth"
+                              ]
+                            }
+                          },
+                          "actionScopes": {
+                            "type": "object",
+                            "properties": {
+                              "list": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "add": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "update": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "remove": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "toggleServer": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "toggleTool": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "discover": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "auth": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "list",
+                              "add",
+                              "update",
+                              "remove",
+                              "toggleServer",
+                              "toggleTool",
+                              "discover",
+                              "auth"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "addServer": {
+                            "type": "string",
+                            "enum": [
+                              "cli",
+                              "patch",
+                              "none"
+                            ]
+                          },
+                          "removeServer": {
+                            "type": "string",
+                            "enum": [
+                              "cli",
+                              "patch",
+                              "none"
+                            ]
+                          },
+                          "updateServer": {
+                            "type": "string",
+                            "enum": [
+                              "cli",
+                              "patch",
+                              "none"
+                            ]
+                          },
+                          "supportsMultipleHeaders": {
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "oauthFields": {
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "clientId",
+                                "resource"
+                              ]
+                            }
+                          },
+                          "perToolBacking": {
+                            "type": "string",
+                            "enum": [
+                              "native",
+                              "store",
+                              "degraded-server-level",
+                              "none"
+                            ]
+                          },
+                          "statusSource": {
+                            "type": "string",
+                            "enum": [
+                              "native",
+                              "probe",
+                              "none"
+                            ]
+                          },
+                          "toolsSource": {
+                            "type": "string",
+                            "enum": [
+                              "native",
+                              "probe",
+                              "none"
+                            ]
+                          },
+                          "schemasSource": {
+                            "type": "string",
+                            "enum": [
+                              "native",
+                              "probe",
+                              "none"
+                            ]
+                          },
+                          "instructionsSource": {
+                            "type": "string",
+                            "enum": [
+                              "probe",
+                              "none"
+                            ]
+                          },
+                          "traycerSessionsOnlyEnforcement": {
+                            "type": "boolean"
+                          },
+                          "stdioDegradeNotice": {
+                            "type": "boolean"
+                          },
+                          "oauthDegradesToConfigOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "transports",
+                          "authTypes",
+                          "authActions",
+                          "actionScopes",
+                          "addServer",
+                          "removeServer",
+                          "updateServer",
+                          "perToolBacking",
+                          "statusSource",
+                          "toolsSource",
+                          "schemasSource",
+                          "instructionsSource",
+                          "traycerSessionsOnlyEnforcement",
+                          "stdioDegradeNotice",
+                          "oauthDegradesToConfigOnly"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "plugins": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "addModes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "cli-source",
+                                "marketplace",
+                                "file-drop",
+                                "patch",
+                                "read-only"
+                              ]
+                            }
+                          },
+                          "marketplaceBrowse": {
+                            "type": "boolean"
+                          },
+                          "actionScopes": {
+                            "type": "object",
+                            "properties": {
+                              "list": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "add": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "remove": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "setEnabled": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "list",
+                              "add",
+                              "remove",
+                              "setEnabled"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "traycerSessionToolsNotice": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "addModes",
+                          "marketplaceBrowse",
+                          "actionScopes",
+                          "traycerSessionToolsNotice"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "skills": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "actionScopes": {
+                            "type": "object",
+                            "properties": {
+                              "list": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "add": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "create": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "import": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "remove": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "inspect": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "edit": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              },
+                              "update": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "global",
+                                    "project"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "list",
+                              "add",
+                              "create",
+                              "import",
+                              "remove"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "actionScopes"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "modelProviders": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "actions": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "connect",
+                                "oauth",
+                                "disconnect",
+                                "createCustom",
+                                "updateCustom"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "actions"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "supportedTabs",
+                  "mcp",
+                  "plugins",
+                  "skills",
+                  "modelProviders"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "providerId",
+              "enabled",
+              "disabledBy",
+              "selected",
+              "candidates",
+              "authPending",
+              "checkedAt",
+              "apiKey",
+              "terminalAgentArgs",
+              "envOverrides",
+              "loginCapability",
+              "availabilityPending",
+              "profiles",
+              "auth",
+              "nativeCapabilities"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "native": {
+          "default": null,
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        "kind": {
+                          "type": "string",
+                          "const": "mcp"
+                        },
+                        "servers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "transport": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "stdio"
+                                      },
+                                      "command": {
+                                        "type": "string"
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "hasValue": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "name",
+                                                "hasValue"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "command",
+                                      "env"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "http"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "auth": {
+                                        "anyOf": [
+                                          {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "header"
+                                                  },
+                                                  "name": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "hasValue": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "name",
+                                                  "hasValue"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "env"
+                                                  },
+                                                  "name": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "hasValue": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "name",
+                                                  "hasValue"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "oauth"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "url",
+                                      "auth"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "sse"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "auth": {
+                                        "anyOf": [
+                                          {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "header"
+                                                  },
+                                                  "name": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "hasValue": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "name",
+                                                  "hasValue"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "env"
+                                                  },
+                                                  "name": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "hasValue": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "name",
+                                                  "hasValue"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "oauth"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "url",
+                                      "auth"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "connected",
+                                  "disconnected",
+                                  "connecting",
+                                  "needs_auth",
+                                  "error",
+                                  "unknown",
+                                  "config_only"
+                                ]
+                              },
+                              "statusSource": {
+                                "type": "string",
+                                "enum": [
+                                  "native",
+                                  "probe",
+                                  "none"
+                                ]
+                              },
+                              "statusDetail": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "tools": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "inputSchema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {}
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "enabled": {
+                                      "type": "boolean"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "denySources": {
+                                      "default": [],
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "enum": [
+                                          "user",
+                                          "shared",
+                                          "local"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "description",
+                                    "inputSchema",
+                                    "enabled",
+                                    "readOnly"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "discoveryPending": {
+                                "type": "boolean"
+                              },
+                              "instructions": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "configOnly": {
+                                "type": "boolean"
+                              },
+                              "stdioDegraded": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "enabled",
+                              "transport",
+                              "status",
+                              "statusSource",
+                              "statusDetail",
+                              "tools",
+                              "discoveryPending",
+                              "instructions",
+                              "configOnly",
+                              "stdioDegraded"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "kind",
+                        "servers"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        "kind": {
+                          "type": "string",
+                          "const": "plugins"
+                        },
+                        "plugins": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "source": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "description": {
+                                "default": null,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "displayName": {
+                                "default": null,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "hasIcon": {
+                                "default": false,
+                                "type": "boolean"
+                              },
+                              "hasDarkIcon": {
+                                "default": false,
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "version",
+                              "enabled",
+                              "source",
+                              "readOnly"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "kind",
+                        "plugins"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        "kind": {
+                          "type": "string",
+                          "const": "skills"
+                        },
+                        "skills": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string",
+                                "enum": [
+                                  "shared",
+                                  "provider",
+                                  "plugin",
+                                  "managed"
+                                ]
+                              },
+                              "origin": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "conflict": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "description",
+                              "path",
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "kind",
+                        "skills"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        "kind": {
+                          "type": "string",
+                          "const": "mcpDiscover"
+                        },
+                        "server": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "transport": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "stdio"
+                                    },
+                                    "command": {
+                                      "type": "string"
+                                    },
+                                    "env": {
+                                      "anyOf": [
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "hasValue": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "hasValue"
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "command",
+                                    "env"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "http"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "auth": {
+                                      "anyOf": [
+                                        {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "header"
+                                                },
+                                                "name": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "hasValue": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "name",
+                                                "hasValue"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "env"
+                                                },
+                                                "name": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "hasValue": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "name",
+                                                "hasValue"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "oauth"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "url",
+                                    "auth"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "sse"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "auth": {
+                                      "anyOf": [
+                                        {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "header"
+                                                },
+                                                "name": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "hasValue": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "name",
+                                                "hasValue"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "env"
+                                                },
+                                                "name": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "hasValue": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "name",
+                                                "hasValue"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "oauth"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "url",
+                                    "auth"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "connected",
+                                "disconnected",
+                                "connecting",
+                                "needs_auth",
+                                "error",
+                                "unknown",
+                                "config_only"
+                              ]
+                            },
+                            "statusSource": {
+                              "type": "string",
+                              "enum": [
+                                "native",
+                                "probe",
+                                "none"
+                              ]
+                            },
+                            "statusDetail": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "tools": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "inputSchema": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "propertyNames": {
+                                          "type": "string"
+                                        },
+                                        "additionalProperties": {}
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "enabled": {
+                                    "type": "boolean"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "denySources": {
+                                    "default": [],
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "user",
+                                        "shared",
+                                        "local"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "description",
+                                  "inputSchema",
+                                  "enabled",
+                                  "readOnly"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "discoveryPending": {
+                              "type": "boolean"
+                            },
+                            "instructions": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "configOnly": {
+                              "type": "boolean"
+                            },
+                            "stdioDegraded": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "enabled",
+                            "transport",
+                            "status",
+                            "statusSource",
+                            "statusDetail",
+                            "tools",
+                            "discoveryPending",
+                            "instructions",
+                            "configOnly",
+                            "stdioDegraded"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "kind",
+                        "server"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        "kind": {
+                          "type": "string",
+                          "const": "pluginIcon"
+                        },
+                        "icon": {
+                          "type": "object",
+                          "properties": {
+                            "dataUri": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "error": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "dataUri",
+                            "error"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "kind",
+                        "icon"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "duplicate_name",
+                        "unsupported_scope",
+                        "unsupported_action",
+                        "no_change_detected",
+                        "external_drift",
+                        "store_version_unsupported",
+                        "rollback_failed",
+                        "config_unreadable"
+                      ]
+                    },
+                    "detail": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "code",
+                    "detail"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "providers",
+        "native"
+      ],
+      "additionalProperties": false
+    },
+    "epic.getChatRunSettings@1.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "harnessId": {
+                  "type": "string",
+                  "enum": [
+                    "claude",
+                    "codex",
+                    "opencode",
+                    "traycer",
+                    "cursor",
+                    "grok",
+                    "qwen",
+                    "kiro",
+                    "droid",
+                    "kimi",
+                    "copilot",
+                    "kilocode",
+                    "openrouter",
+                    "amp",
+                    "devin",
+                    "pi",
+                    "hermes",
+                    "omp",
+                    "huggingface"
+                  ]
+                },
+                "model": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "permissionMode": {
+                  "type": "string",
+                  "enum": [
+                    "supervised",
+                    "auto_accept_edits",
+                    "full_access"
+                  ]
+                },
+                "reasoningEffort": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "serviceTier": {
+                  "default": null,
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "agentMode": {
+                  "type": "string",
+                  "enum": [
+                    "regular",
+                    "epic"
+                  ]
+                },
+                "profileId": {
+                  "default": null,
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "harnessId",
+                "model",
+                "permissionMode",
+                "reasoningEffort",
+                "serviceTier",
+                "agentMode",
+                "profileId"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "settings"
+      ],
+      "additionalProperties": false
+    },
+    "epic.getChatRunSettings@2.0": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "harnessId": {
+                  "type": "string",
+                  "enum": [
+                    "claude",
+                    "codex",
+                    "opencode",
+                    "traycer",
+                    "cursor",
+                    "grok",
+                    "qwen",
+                    "kiro",
+                    "droid",
+                    "kimi",
+                    "copilot",
+                    "kilocode",
+                    "openrouter",
+                    "amp",
+                    "devin",
+                    "pi",
+                    "hermes",
+                    "omp",
+                    "huggingface",
+                    "reasonix"
+                  ]
+                },
+                "model": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "permissionMode": {
+                  "type": "string",
+                  "enum": [
+                    "supervised",
+                    "auto_accept_edits",
+                    "full_access"
+                  ]
+                },
+                "reasoningEffort": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "serviceTier": {
+                  "default": null,
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "agentMode": {
+                  "type": "string",
+                  "enum": [
+                    "regular",
+                    "epic"
+                  ]
+                },
+                "profileId": {
+                  "default": null,
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "harnessId",
+                "model",
+                "permissionMode",
+                "reasoningEffort",
+                "serviceTier",
+                "agentMode",
+                "profileId"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "settings"
+      ],
+      "additionalProperties": false
+    },
     "providers.list@1.0..6.0 request": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10700,7 +14338,8 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "scope": {
@@ -10757,7 +14396,8 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "scope": {
@@ -10814,7 +14454,8 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "scope": {
@@ -10871,7 +14512,8 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "scope": {
@@ -10937,7 +14579,8 @@ export const FROZEN_CATALOG_LINE_SNAPSHOTS = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "scope": {

--- a/protocol/src/host/__tests__/frozen-catalog-lines.test.ts
+++ b/protocol/src/host/__tests__/frozen-catalog-lines.test.ts
@@ -7,6 +7,8 @@ import {
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
   listAgentsResponseSchemaV60,
+  listAgentsResponseSchemaV70,
+  listAgentsResponseSchema,
 } from "@traycer/protocol/host/agent/shared";
 import {
   listGuiHarnessesResponseSchemaV10,
@@ -17,12 +19,14 @@ import {
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
   listGuiHarnessesResponseSchemaV70,
+  listGuiHarnessesResponseSchemaV71,
   listGuiHarnessesResponseSchema,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   providersListRequestSchema,
   providersListRequestSchemaBeforeV70,
   providersListResponseSchemaV70,
+  providersListResponseSchemaV71,
   providersListResponseSchemaV10,
   providersListResponseSchemaV20,
   providersListResponseSchemaV30,
@@ -31,6 +35,10 @@ import {
   providersListResponseSchema,
   providersListResponseSchemaV60,
 } from "@traycer/protocol/host/provider-schemas";
+import {
+  getChatRunSettingsResponseSchema,
+  getChatRunSettingsResponseSchemaV10,
+} from "@traycer/protocol/host/epic/chat-records";
 import { FROZEN_CATALOG_LINE_SNAPSHOTS } from "./__fixtures__/frozen-catalog-lines";
 
 /**
@@ -62,14 +70,24 @@ const LIVE_FROZEN_EXPORTS = {
   // they were half-frozen; they now share the hand-frozen
   // `guiHarnessOptionBaseShapeV70` and dump exactly as they did before.
   "agent.gui.listHarnesses@7.0": listGuiHarnessesResponseSchemaV70,
-  // The head line, pinned for the same reason `providers.list@7.1` is.
-  "agent.gui.listHarnesses@7.1": listGuiHarnessesResponseSchema,
+  // 7.1 froze when 8.0 opened for Reasonix - a released 7.0 forbids ANY minor
+  // of major 7 from growing the id enum (`versioned-rpc.ts` refuses it), so
+  // 7.1 could not absorb the id even though no tag has shipped 7.1 itself.
+  "agent.gui.listHarnesses@7.1": listGuiHarnessesResponseSchemaV71,
+  // The head line, pinned for the same reason `providers.list@8.0` is.
+  "agent.gui.listHarnesses@8.0": listGuiHarnessesResponseSchema,
   "agent.list@1.0": listAgentsResponseSchemaV10,
   "agent.list@2.0": listAgentsResponseSchemaV20,
   "agent.list@3.0": listAgentsResponseSchemaV30,
   "agent.list@4.0": listAgentsResponseSchemaV40,
   "agent.list@5.0": listAgentsResponseSchemaV50,
   "agent.list@6.0": listAgentsResponseSchemaV60,
+  // v7.0 froze when the v1.2.0 tags shipped it. Until then it pointed at the
+  // live schema and `agent.list` had NO head-line row here at all, so nothing
+  // local could have caught the growth - only the tag-based gate.
+  "agent.list@7.0": listAgentsResponseSchemaV70,
+  // The head line, pinned so the next growth attempt fails here first.
+  "agent.list@8.0": listAgentsResponseSchema,
   "providers.list@1.0": providersListResponseSchemaV10,
   "providers.list@2.0": providersListResponseSchemaV20,
   "providers.list@3.0": providersListResponseSchemaV30,
@@ -91,7 +109,16 @@ const LIVE_FROZEN_EXPORTS = {
   // The head line now, holding v7.0's old job: it names the LIVE schema, so
   // the next attempt to grow it fails here first. Same response - freeze the
   // line that stopped being head, open the next one, do not regenerate.
-  "providers.list@7.1": providersListResponseSchema,
+  // 7.1 froze when 8.0 opened for Reasonix, for the same reason
+  // `agent.gui.listHarnesses@7.1` did.
+  "providers.list@7.1": providersListResponseSchemaV71,
+  "providers.list@8.0": providersListResponseSchema,
+  // The fourth method (see the snapshot script for why it is here): its
+  // response carries the PERSISTED harness enum, it is off the released floor,
+  // and nothing local guarded it until Reasonix grew it and only the tag gate
+  // noticed.
+  "epic.getChatRunSettings@1.0": getChatRunSettingsResponseSchemaV10,
+  "epic.getChatRunSettings@2.0": getChatRunSettingsResponseSchema,
   "providers.list@1.0..6.0 request": providersListRequestSchemaBeforeV70,
   "providers.list@7.0 request": providersListRequestSchema,
 } as const;

--- a/protocol/src/host/__tests__/list-harnesses-enabled-compat.test.ts
+++ b/protocol/src/host/__tests__/list-harnesses-enabled-compat.test.ts
@@ -106,7 +106,7 @@ describe("frozen agent.gui.listHarnesses lines predate enabled/availabilityPendi
     // value so 2.1 callers are never fed a fabricated default.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["agent.gui.listHarnesses"],
-      7,
+      8,
       2,
       { harnesses: [harnessRow("claude", false)] },
     );
@@ -125,7 +125,7 @@ describe("frozen agent.gui.listHarnesses lines predate enabled/availabilityPendi
   it("latest → major-1 downgrade strips both fields before the frozen 1.0 parse", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["agent.gui.listHarnesses"],
-      7,
+      8,
       1,
       { harnesses: [harnessRow("claude", false)] },
     );

--- a/protocol/src/host/__tests__/provider-model-providers-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-model-providers-compat.test.ts
@@ -284,7 +284,7 @@ describe("the tab id can only reach a decoder that knows it", () => {
     for (const targetMajor of [1, 2, 3, 4, 5, 6] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         targetMajor,
         liveResponse,
       );
@@ -324,7 +324,7 @@ describe("providers.list head line -> every older major", () => {
       ).toBeDefined();
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         targetMajor,
         liveResponse,
       );
@@ -343,7 +343,7 @@ describe("providers.list head line -> every older major", () => {
     // drop it wholesale and the ids survive untouched.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       6,
       liveResponse,
     );
@@ -1957,7 +1957,7 @@ describe("no downgrade hop fails a whole response over one unsupported provider"
     (targetMajor) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         targetMajor,
         { providers: [newestProvider, claudeState], native: null },
       );

--- a/protocol/src/host/__tests__/provider-native-schemas.test.ts
+++ b/protocol/src/host/__tests__/provider-native-schemas.test.ts
@@ -56,10 +56,10 @@ import {
 } from "@traycer/protocol/host/provider-schemas";
 import {
   hostRpcRegistry,
-  providersListDowngradeV7ToV1,
-  providersListDowngradeV7ToV2,
-  providersListDowngradeV7ToV3,
-  providersListDowngradeV7ToV6,
+  providersListDowngradeV8ToV1,
+  providersListDowngradeV8ToV2,
+  providersListDowngradeV8ToV3,
+  providersListDowngradeV8ToV6,
   providersListUpgradeV3ToV4,
   providersListUpgradeV5ToV6,
   providersListUpgradeV6ToV7,
@@ -342,7 +342,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
   });
 
   it("downgrades v7.0 → v6.0 requests by stripping native", () => {
-    const result = providersListDowngradeV7ToV6.downgradeRequest(
+    const result = providersListDowngradeV8ToV6.downgradeRequest(
       providersListRequestSchema.parse({
         forceAuthRefresh: true,
         native: {
@@ -372,7 +372,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
       ],
       native: { ok: true, kind: "mcp", servers: [] },
     });
-    const result = providersListDowngradeV7ToV6.downgradeResponse(
+    const result = providersListDowngradeV8ToV6.downgradeResponse(
       providersListResponseSchema.parse(v70),
     );
     expect(result.ok).toBe(true);
@@ -409,7 +409,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
         },
       ],
     });
-    const result = providersListDowngradeV7ToV3.downgradeResponse(
+    const result = providersListDowngradeV8ToV3.downgradeResponse(
       providersListResponseSchema.parse(v31),
     );
     expect(result.ok).toBe(true);
@@ -434,7 +434,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
         },
       ],
     });
-    const result = providersListDowngradeV7ToV2.downgradeResponse(
+    const result = providersListDowngradeV8ToV2.downgradeResponse(
       providersListResponseSchema.parse(v31),
     );
     expect(result.ok).toBe(true);
@@ -469,7 +469,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
     const list = providersListResponseSchema.parse({
       providers: [latest],
     });
-    const listResult = providersListDowngradeV7ToV1.downgradeResponse(
+    const listResult = providersListDowngradeV8ToV1.downgradeResponse(
       providersListResponseSchema.parse(list),
     );
     expect(listResult.ok).toBe(true);

--- a/protocol/src/host/__tests__/provider-profiles-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-profiles-compat.test.ts
@@ -335,7 +335,7 @@ describe("providers.list latest -> v2.0 downgrade strips profiles[]", () => {
     // `profiles`.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       2,
       providersListResponseSchema.parse({
         providers: [stateWithProfile],
@@ -395,7 +395,7 @@ describe("providers.list v3.0 line predates profiles[]", () => {
   it("latest -> v3.0 downgrade never leaks profile identity to a v3.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       3,
       providersListResponseSchema.parse({
         providers: [stateWithProfile],

--- a/protocol/src/host/__tests__/provider-registry-fields-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-registry-fields-compat.test.ts
@@ -137,7 +137,7 @@ describe("cliBinaryResolved additive field (binary-absent explanation)", () => {
     for (const target of [2, 3] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         target,
         providersListResponseSchema.parse({
           providers: [state],
@@ -333,7 +333,7 @@ describe("old-client behavior on the error arm", () => {
     (targetMajor) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         targetMajor,
         providersListResponseSchema.parse({
           providers: [erroredState],
@@ -528,7 +528,7 @@ describe("providers.list latest -> v2.0/v3.0 downgrade strips the new fields", (
   it("latest -> v2.0 downgrade never leaks the new fields to a v2.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       2,
       providersListResponseSchema.parse({
         providers: [stateWithRegistryFields],
@@ -547,7 +547,7 @@ describe("providers.list latest -> v2.0/v3.0 downgrade strips the new fields", (
   it("latest -> v3.0 downgrade never leaks the new fields to a v3.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       3,
       providersListResponseSchema.parse({
         providers: [stateWithRegistryFields],
@@ -656,7 +656,7 @@ describe("providers.list v6.0 is frozen against the registry fields", () => {
     // an older major's table is kept for the record, not consulted.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       6,
       // `native` is required here and absent from the major-6 cases above
       // because the live response shape carries it - v6.0 froze before it
@@ -700,7 +700,7 @@ describe("providers.list v5.0 is frozen against the registry fields", () => {
     // cannot reach it.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       5,
       providersListResponseSchema.parse({
         providers: [stateWithRegistryFields],

--- a/protocol/src/host/__tests__/provider-schemas-v70-pins.test.ts
+++ b/protocol/src/host/__tests__/provider-schemas-v70-pins.test.ts
@@ -21,6 +21,7 @@ import {
   providersListResponseSchemaV60,
   providersListResponseSchemaV70,
   providersListResponseSchemaV70Preimage,
+  providersListResponseSchemaV71,
 } from "@traycer/protocol/host/provider-schemas";
 
 /**
@@ -175,34 +176,45 @@ describe("the v7-era schemas are distinct objects from the canonical live ones",
     );
   });
 
-  it("v7.1 is the head and names the canonical response; v7.0 names its freeze", () => {
-    // This assertion has now flipped twice, and the flips ARE the judgement the
-    // freeze rule exists to force. While an unreleased v8.0 sat above v7.0,
-    // v7.0 was pinned; collapsing that major made v7.0 the head and it tracked
-    // live again; opening v7.1 for the auth-aware enablement fields made it a
-    // non-head line once more, so it is pinned again - this time to the REAL
-    // v7.0 freeze (`providersListResponseSchemaV70`), not to the pre-image,
-    // which still backs no contract and remains the v6 -> v7 bridge's
-    // first-pass target.
+  it("v8.0 is the head and names the canonical response; 7.1 and 7.0 name their freezes", () => {
+    // This assertion has now flipped three times, and the flips ARE the
+    // judgement the freeze rule exists to force. While an unreleased v8.0 sat
+    // above v7.0, v7.0 was pinned; collapsing that major made v7.0 the head and
+    // it tracked live again; opening v7.1 for the auth-aware enablement fields
+    // pinned v7.0 to the REAL freeze (`providersListResponseSchemaV70`); and
+    // Reasonix has now pinned 7.1 too and opened a real v8.0.
+    //
+    // 7.1 froze even though no TAG has shipped it, which is the part worth
+    // reading twice. The "an unreleased line may widen in place" allowance is
+    // about a MAJOR: `versioned-rpc.ts` separately refuses a MINOR whose
+    // response grows an enum over its predecessor, and 7.0 is released - so no
+    // minor of major 7 can ever carry a provider id 7.0 lacks, released or not.
     //
     // "A line that has STOPPED being the head still points at live" is the
-    // defect being guarded, so both halves are asserted: the head names live,
-    // and the line below it does not.
+    // defect being guarded, so every half is asserted: the head names live, and
+    // neither line below it does.
     const v70 = hostRpcRegistry["providers.list"][7].versions[0].contract;
     const v71 = hostRpcRegistry["providers.list"][7].versions[1].contract;
-    expect(v71.responseSchema).toBe(providersListResponseSchema);
+    const v80 = hostRpcRegistry["providers.list"][8].versions[0].contract;
+    expect(v80.responseSchema).toBe(providersListResponseSchema);
+    expect(v71.responseSchema).toBe(providersListResponseSchemaV71);
+    expect(v71.responseSchema).not.toBe(providersListResponseSchema);
     expect(v70.responseSchema).toBe(providersListResponseSchemaV70);
     expect(v70.responseSchema).not.toBe(providersListResponseSchema);
     expect(v70.responseSchema).not.toBe(providersListResponseSchemaV70Preimage);
-    // The REQUEST side did not move: the freeze covered only the response, so
-    // both minors still bind the live request and `providersListRequestSchemaV70`
-    // remains the hand-copy held equal to it by the pin above.
+    // The REQUEST side did not move: the freezes covered only the response, so
+    // all three lines still bind the live request and
+    // `providersListRequestSchemaV70` remains the hand-copy held equal to it by
+    // the pin above. Request-side enum growth is advisory (a released client
+    // never emits a new value), which is why it is allowed to track live here
+    // while the response is not.
     expect(v70.requestSchema).toBe(providersListRequestSchema);
     expect(v71.requestSchema).toBe(providersListRequestSchema);
+    expect(v80.requestSchema).toBe(providersListRequestSchema);
     expect(v70.requestSchema).not.toBe(providersListRequestSchemaV70);
   });
 
-  it("providerIdSchemaV70 includes huggingface, the sole v7.0-only provider id", () => {
+  it("providerIdSchemaV70 includes huggingface, the newest id major 7 can carry", () => {
     expect(providerIdSchemaV70.options).toContain("huggingface");
   });
 
@@ -216,10 +228,25 @@ describe("the v7-era schemas are distinct objects from the canonical live ones",
   // represent. The point is that it must be a DECISION. Adding a harness now
   // fails here until someone states, in this file, which side the new id
   // belongs on.
-  it("the live and frozen provider id sets have not drifted apart", () => {
+  it("every live provider id is either in the v7.0 set or a stated post-v7.0 id", () => {
+    // THE STATED DECISION, which is what this test is for. `reasonix` is the
+    // first id added since the v1.2.0 tags shipped `providers.list@7.0`, and it
+    // belongs on the LIVE side only: a major-7 caller cannot represent it, so
+    // `providersListDowngradeV8ToV7` filters its row out and that caller simply
+    // does not see the provider. Dropping is the right answer here - the
+    // alternative, letting the id ride a released line, is the omp/huggingface
+    // incident - but it has to be a decision recorded here, not a diff nobody
+    // read.
+    //
+    // Add the next id to this list at the same time you add it to
+    // `providerIdSchema`, and only after deciding it cannot ride major 7.
+    const POST_V70_PROVIDER_IDS = ["reasonix"] as const;
     expect([...providerIdSchema.options].sort()).toEqual(
-      [...providerIdSchemaV70.options].sort(),
+      [...providerIdSchemaV70.options, ...POST_V70_PROVIDER_IDS].sort(),
     );
+    for (const id of POST_V70_PROVIDER_IDS) {
+      expect(providerIdSchemaV70.options).not.toContain(id);
+    }
   });
 });
 
@@ -469,7 +496,7 @@ describe("downgrade bridges v7.0 -> v6.0..v1.0 still work through the real regis
     (target) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         target,
         providersListResponseSchema.parse({
           providers: [state],
@@ -489,7 +516,7 @@ describe("downgrade bridges v7.0 -> v6.0..v1.0 still work through the real regis
       });
       const downgraded = downgradeRequestAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         target,
         canonical,
       );
@@ -506,7 +533,7 @@ describe("downgrade bridges v7.0 -> v6.0..v1.0 still work through the real regis
     for (const target of [6, 5, 4, 3, 2, 1] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         target,
         providersListResponseSchema.parse({
           providers: [huggingfaceState],

--- a/protocol/src/host/__tests__/provider-schemas-version-manager.test.ts
+++ b/protocol/src/host/__tests__/provider-schemas-version-manager.test.ts
@@ -112,7 +112,7 @@ describe("providers.list@7.0 carries the version manager and bridges older lines
 
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      7,
+      8,
       6,
       response,
     );
@@ -151,7 +151,7 @@ describe("providers.list@7.0 carries the version manager and bridges older lines
     for (const target of [6, 5, 4, 3, 2, 1] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         target,
         response,
       );
@@ -183,7 +183,7 @@ describe("providers.list@7.0 carries the version manager and bridges older lines
     for (const target of [6, 5, 4, 3, 2, 1] as const) {
       const downgraded = downgradeRequestAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         target,
         request,
       );
@@ -257,7 +257,7 @@ describe("providers.list@6.0 -> @7.0 upgrades", () => {
 
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        7,
+        8,
         6,
         response,
       );

--- a/protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts
+++ b/protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts
@@ -159,7 +159,7 @@ describe("providers.list request lines 1.0..6.0 <-> 7.0", () => {
     for (const major of RELEASED_REQUEST_MAJORS) {
       const down = downgradeRequestAcrossMajors(
         providersListRegistry,
-        7,
+        8,
         major,
         canonical,
       );
@@ -256,7 +256,7 @@ describe("providers.list request lines 1.0..6.0 <-> 7.0", () => {
     });
     const down = downgradeResponseAcrossMajors(
       providersListRegistry,
-      7,
+      8,
       6,
       canonicalResponse,
     );

--- a/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
@@ -573,18 +573,20 @@ describe("optional-method capability negotiation", () => {
       split.manifest["agent.getProviderProfileRateLimits"],
     ).toBeUndefined();
     expect(split.manifest["agent.configure"]).toBeUndefined();
-    // list/configure and rate-limit reads all sit on the v4.0 line: the
-    // OpenCode arm and credentialGeneration ride major 4 rather than a
-    // separate 5, since 4 has never shipped.
+    // All three now sit on the v5.0 line. Major 4 DID ship - the v1.2.0 tags
+    // (2026-08-24) carry it - so the sentence this comment used to end with
+    // ("since 4 has never shipped") stopped being true, and with it the reason
+    // these three could keep absorbing ids in place. `reasonix` opened major 5
+    // on each, with fail-closed v5->v4 bridges.
     expect(split.optionalManifest["agent.listProviderProfiles"]).toEqual({
-      major: 4,
+      major: 5,
       minor: 0,
     });
     expect(
       split.optionalManifest["agent.getProviderProfileRateLimits"],
-    ).toEqual({ major: 4, minor: 0 });
+    ).toEqual({ major: 5, minor: 0 });
     expect(split.optionalManifest["agent.configure"]).toEqual({
-      major: 4,
+      major: 5,
       minor: 0,
     });
   });

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -31,12 +31,14 @@ import {
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
   listAgentsResponseSchemaV60,
+  listAgentsResponseSchemaV70,
   agentSummarySchemaV10,
   agentSummarySchemaV20,
   agentSummarySchemaV30,
   agentSummarySchemaV40,
   agentSummarySchemaV50,
   agentSummarySchemaV60,
+  agentSummarySchemaV70,
   sendAgentMessageRequestSchema,
   sendAgentMessageResponseSchema,
   stopAgentRequestSchema,
@@ -710,7 +712,11 @@ export const agentListV70 = defineRpcContract({
   method: "agent.list",
   schemaVersion: { major: 7, minor: 0 } as const,
   requestSchema: listAgentsRequestSchema,
-  responseSchema: listAgentsResponseSchema,
+  // Frozen: the v1.2.0 tags shipped this line, so it must serve the v7.0
+  // harness id set rather than the live one. Before that release it pointed at
+  // the canonical schema - the same defect that let `omp` first try to ride
+  // v5.0 and `huggingface` v6.0, one line later each time.
+  responseSchema: listAgentsResponseSchemaV70,
 });
 
 export const agentListUpgradeV6ToV7 = defineUpgradePath<
@@ -719,10 +725,14 @@ export const agentListUpgradeV6ToV7 = defineUpgradePath<
 >({
   from: { major: 6, minor: 0 },
   to: { major: 7, minor: 0 },
-  // The request shape is identical. Parsing the response through the live v7
-  // schema default-fills `runConfig: null` on every released v6 row.
+  // The request shape is identical. Parsing the response through the v7 schema
+  // default-fills `runConfig: null` on every released v6 row. Parses through
+  // the FROZEN v7.0 shape, not the live one: the target of this hop is
+  // `agentListV70`, and a hop that parses through a schema wider than its own
+  // target is how a fill silently starts producing values the target line
+  // cannot carry.
   upgradeRequest: (request) => request,
-  upgradeResponse: (response) => listAgentsResponseSchema.parse(response),
+  upgradeResponse: (response) => listAgentsResponseSchemaV70.parse(response),
 });
 
 export const agentListDowngradeV7ToV6 = defineDowngradePath<
@@ -828,6 +838,162 @@ export const agentListDowngradeV7ToV1 = defineDowngradePath<
   typeof agentListV10
 >({
   from: { major: 7, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV10.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV10.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListV80 = defineRpcContract({
+  method: "agent.list",
+  schemaVersion: { major: 8, minor: 0 } as const,
+  requestSchema: listAgentsRequestSchema,
+  responseSchema: listAgentsResponseSchema,
+});
+
+export const agentListUpgradeV7ToV8 = defineUpgradePath<
+  typeof agentListV70,
+  typeof agentListV80
+>({
+  from: { major: 7, minor: 0 },
+  to: { major: 8, minor: 0 },
+  // The request shape is identical, and a v7.0 response without Reasonix
+  // agents is a valid v8.0 response (purely additive) - both upgrades are
+  // identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListDowngradeV8ToV7 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV70
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 7, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Reasonix agents so an already-shipped v7.0 client's strict decode
+  // never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV70.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV70.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV8ToV6 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV60
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Hugging Face/Reasonix agents so an already-shipped v6.0 client's
+  // strict decode never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV60.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV60.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV8ToV5 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV50
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop omp/Hugging Face/Reasonix agents so an already-shipped v5.0 client's
+  // strict decode never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV50.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV50.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV8ToV4 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV40
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Hermes/omp/Hugging Face/Reasonix agents so an already-shipped v4.0
+  // client's strict decode never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV40.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV40.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV8ToV3 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV30
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Devin/Pi/Hermes/omp/Hugging Face/Reasonix agents so an
+  // already-shipped v3.0 client's strict decode never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV30.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV30.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV8ToV2 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV20
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV20.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV20.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV8ToV1 = defineDowngradePath<
+  typeof agentListV80,
+  typeof agentListV10
+>({
+  from: { major: 8, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
   downgradeResponse: (response) => ({

--- a/protocol/src/host/agent/gui/__tests__/auth-aware-enablement-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/auth-aware-enablement-versioning.test.ts
@@ -24,6 +24,8 @@ import {
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
   listGuiHarnessesResponseSchemaV70,
+  guiHarnessOptionSchemaV71,
+  listGuiHarnessesResponseSchemaV71,
   type GuiHarnessOption,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
@@ -46,6 +48,7 @@ import {
   providersListResponseSchemaV50,
   providersListResponseSchemaV60,
   providersListResponseSchemaV70,
+  providersListResponseSchemaV71,
   providersSetEnabledRequestSchemaV10,
   providersSetEnabledRequestSchemaV21,
   providersSetEnabledRequestSchemaV22,
@@ -72,8 +75,13 @@ interface HarnessOptionOverrides {
   readonly enablementMode?: GuiHarnessOption["enablementMode"];
 }
 
+// Built through the FROZEN 7.1 row rather than the live one: 7.1 is pinned to
+// the v7.0 id set (a released 7.0 forbids any minor of major 7 from growing the
+// enum), so the live row is strictly wider than anything this line serializes.
+// Parsing through the live shape here would let a post-7.0 id reach a v7 bridge
+// in a test and nowhere else.
 function harnessOption(id: string, overrides: HarnessOptionOverrides) {
-  return guiHarnessOptionSchema.parse({
+  return guiHarnessOptionSchemaV71.parse({
     id,
     label: id,
     available: true,
@@ -147,7 +155,7 @@ describe("agent.gui.listHarnesses@7.1 (auth-aware enablement row fields)", () =>
   ] as const)(
     "the 7.1 -> %s downgrade strips authStatus/enablementMode while preserving decodable rows",
     (_label, downgrade, responseSchema, rowSchema) => {
-      const v71Response = guiHarnessOptionSchema
+      const v71Response = guiHarnessOptionSchemaV71
         .array()
         .parse([
           harnessOption("claude", {
@@ -168,15 +176,17 @@ describe("agent.gui.listHarnesses@7.1 (auth-aware enablement row fields)", () =>
   );
 
   it("the 7.1 -> v1.0 downgrade strips both fields and every post-v1.0 harness", () => {
-    const result = agentGuiListHarnessesDowngradeV7ToV1.downgradeResponse({
-      harnesses: [
-        harnessOption("claude", {
-          authStatus: "unauthenticated",
-          enablementMode: "off",
-        }),
-        harnessOption("grok", {}),
-      ],
-    });
+    const result = agentGuiListHarnessesDowngradeV7ToV1.downgradeResponse(
+      listGuiHarnessesResponseSchemaV71.parse({
+        harnesses: [
+          harnessOption("claude", {
+            authStatus: "unauthenticated",
+            enablementMode: "off",
+          }),
+          harnessOption("grok", {}),
+        ],
+      }),
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.harnesses.map((h) => h.id)).toEqual(["claude"]);
@@ -277,7 +287,10 @@ describe("providers.list@7.1 (auth-aware enablement provider fields)", () => {
   ] as const)(
     "the 7.1 -> %s downgrade strips enablementMode/enablementSource while preserving decodable rows",
     (_label, downgrade, responseSchema) => {
-      const liveResponse = providersListResponseSchema.parse({
+      // Parsed through the FROZEN 7.1 response, not the live one: 7.1 is
+      // pinned to the v7.0 provider id set, so the live shape is strictly
+      // wider than anything this line serializes.
+      const v71Response = providersListResponseSchemaV71.parse({
         providers: [
           providerState("claude-code", {
             enablementMode: "on",
@@ -286,7 +299,7 @@ describe("providers.list@7.1 (auth-aware enablement provider fields)", () => {
         ],
         native: null,
       });
-      const result = downgrade.downgradeResponse(liveResponse);
+      const result = downgrade.downgradeResponse(v71Response);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.providers[0]).not.toHaveProperty("enablementMode");
@@ -318,7 +331,7 @@ describe("providers.list@7.1 (auth-aware enablement provider fields)", () => {
     "the 7.1 -> v1.0 downgrade strips both fields and PRESERVES the row",
     () => {
       const result = providersListDowngradeV7ToV1.downgradeResponse(
-        providersListResponseSchema.parse({
+        providersListResponseSchemaV71.parse({
           providers: [
             providerState("claude-code", {
               enablementMode: "off",
@@ -346,7 +359,7 @@ describe("providers.list@7.1 (auth-aware enablement provider fields)", () => {
 
   it("the 7.1 -> v1.0 downgrade PRESERVES a row carrying no enablement fields, dropping only the post-v1.0 provider (unaffected baseline)", () => {
     const result = providersListDowngradeV7ToV1.downgradeResponse(
-      providersListResponseSchema.parse({
+      providersListResponseSchemaV71.parse({
         providers: [providerState("claude-code", {}), providerState("grok", {})],
         native: null,
       }),

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -16,12 +16,13 @@ import {
   agentListDowngradeV6ToV3,
   agentListDowngradeV6ToV4,
   agentListDowngradeV6ToV5,
-  agentListDowngradeV7ToV1,
-  agentListDowngradeV7ToV2,
-  agentListDowngradeV7ToV3,
-  agentListDowngradeV7ToV4,
-  agentListDowngradeV7ToV5,
-  agentListDowngradeV7ToV6,
+  agentListDowngradeV8ToV1,
+  agentListDowngradeV8ToV2,
+  agentListDowngradeV8ToV3,
+  agentListDowngradeV8ToV4,
+  agentListDowngradeV8ToV5,
+  agentListDowngradeV8ToV6,
+  agentListDowngradeV8ToV7,
 } from "@traycer/protocol/host/agent/contracts";
 import {
   listAgentsResponseSchema,
@@ -31,6 +32,7 @@ import {
   listAgentsResponseSchemaV40,
   listAgentsResponseSchemaV50,
   listAgentsResponseSchemaV60,
+  listAgentsResponseSchemaV70,
 } from "@traycer/protocol/host/agent/shared";
 import {
   agentGuiListHarnessesDowngradeV2ToV1,
@@ -48,12 +50,13 @@ import {
   agentGuiListHarnessesDowngradeV6ToV3,
   agentGuiListHarnessesDowngradeV6ToV4,
   agentGuiListHarnessesDowngradeV6ToV5,
-  agentGuiListHarnessesDowngradeV7ToV1,
-  agentGuiListHarnessesDowngradeV7ToV2,
-  agentGuiListHarnessesDowngradeV7ToV3,
-  agentGuiListHarnessesDowngradeV7ToV4,
-  agentGuiListHarnessesDowngradeV7ToV5,
-  agentGuiListHarnessesDowngradeV7ToV6,
+  agentGuiListHarnessesDowngradeV8ToV1,
+  agentGuiListHarnessesDowngradeV8ToV2,
+  agentGuiListHarnessesDowngradeV8ToV3,
+  agentGuiListHarnessesDowngradeV8ToV4,
+  agentGuiListHarnessesDowngradeV8ToV5,
+  agentGuiListHarnessesDowngradeV8ToV6,
+  agentGuiListHarnessesDowngradeV8ToV7,
 } from "@traycer/protocol/host/agent/gui/contracts";
 import {
   guiHarnessOptionSchema,
@@ -65,6 +68,7 @@ import {
   listGuiHarnessesResponseSchemaV40,
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
+  listGuiHarnessesResponseSchemaV71,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   PROVIDER_AUTH_STATUS_SCHEMA,
@@ -77,6 +81,7 @@ import {
   providersListResponseSchemaV40,
   providersListResponseSchemaV50,
   providersListResponseSchemaV60,
+  providersListResponseSchemaV71,
   providersSetApiKeyResponseSchemaV10,
 } from "@traycer/protocol/host/provider-schemas";
 // Importing from the registry runs `defineVersionedRpcRegistry` (full structural
@@ -98,12 +103,13 @@ import {
   providersListDowngradeV6ToV3,
   providersListDowngradeV6ToV4,
   providersListDowngradeV6ToV5,
-  providersListDowngradeV7ToV1,
-  providersListDowngradeV7ToV2,
-  providersListDowngradeV7ToV3,
-  providersListDowngradeV7ToV4,
-  providersListDowngradeV7ToV5,
-  providersListDowngradeV7ToV6,
+  providersListDowngradeV8ToV1,
+  providersListDowngradeV8ToV2,
+  providersListDowngradeV8ToV3,
+  providersListDowngradeV8ToV4,
+  providersListDowngradeV8ToV5,
+  providersListDowngradeV8ToV6,
+  providersListDowngradeV8ToV7,
   providersSetApiKeyDowngradeV21ToV10,
 } from "@traycer/protocol/host/registry";
 
@@ -439,7 +445,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       ],
     });
 
-    const toV3 = providersListDowngradeV7ToV3.downgradeResponse(liveResponse);
+    const toV3 = providersListDowngradeV8ToV3.downgradeResponse(liveResponse);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -449,7 +455,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       providersListResponseSchemaV30.parse(toV3.value),
     ).not.toThrow();
 
-    const toV2 = providersListDowngradeV7ToV2.downgradeResponse(liveResponse);
+    const toV2 = providersListDowngradeV8ToV2.downgradeResponse(liveResponse);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -459,7 +465,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       providersListResponseSchemaV20.parse(toV2.value),
     ).not.toThrow();
 
-    const toV1 = providersListDowngradeV7ToV1.downgradeResponse(liveResponse);
+    const toV1 = providersListDowngradeV8ToV1.downgradeResponse(liveResponse);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -605,13 +611,15 @@ describe("post-v3.0 Devin/Pi downgrade bridges (agent.gui.listHarnesses/agent.li
   });
 });
 
-describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
-  // These three catalog methods all had to open a new major when the v1.1.9
-  // tags froze their previous line: `huggingface` cannot ride a released
-  // version, so the live shape sits on v7.0 and every older caller gets it
-  // filtered out.
-  it("drops Hugging Face from agent.gui.listHarnesses for every released caller down to v1.0", () => {
-    const v7Response = listGuiHarnessesResponseSchema.parse({
+describe("post-v6.0 Hugging Face/Reasonix non-breaking downgrade bridges", () => {
+  // These three catalog methods each opened a new major when a release froze
+  // their previous line: `huggingface` could not ride v6.0 and opened v7.0,
+  // and `reasonix` cannot ride ANY minor of major 7 - the v1.2.0 tags shipped
+  // 7.0, and `versioned-rpc.ts` refuses a minor that grows a response enum
+  // over its predecessor - so the live shape now sits on v8.0 and every older
+  // caller gets the ids it predates filtered out.
+  it("drops Hugging Face/Reasonix from agent.gui.listHarnesses for every released caller down to v1.0", () => {
+    const v8Response = listGuiHarnessesResponseSchema.parse({
       harnesses: [
         harnessOption("claude"),
         harnessOption("cursor"),
@@ -621,12 +629,33 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
         harnessOption("hermes"),
         harnessOption("omp"),
         harnessOption("huggingface"),
+        harnessOption("reasonix"),
       ],
     });
 
-    // v6.0 shipped with omp, so it keeps omp and loses only Hugging Face.
+    // Major 7 shipped with Hugging Face, so it keeps it and loses only
+    // Reasonix. The bridge lands on 7.1, major 7's latest installed minor.
+    const toV7 =
+      agentGuiListHarnessesDowngradeV8ToV7.downgradeResponse(v8Response);
+    expect(toV7.ok).toBe(true);
+    if (!toV7.ok) return;
+    expect(toV7.value.harnesses.map((harness) => harness.id)).toEqual([
+      "claude",
+      "cursor",
+      "amp",
+      "devin",
+      "pi",
+      "hermes",
+      "omp",
+      "huggingface",
+    ]);
+    expect(() =>
+      listGuiHarnessesResponseSchemaV71.parse(toV7.value),
+    ).not.toThrow();
+
+    // v6.0 shipped with omp, so it keeps omp and loses Hugging Face/Reasonix.
     const toV6 =
-      agentGuiListHarnessesDowngradeV7ToV6.downgradeResponse(v7Response);
+      agentGuiListHarnessesDowngradeV8ToV6.downgradeResponse(v8Response);
     expect(toV6.ok).toBe(true);
     if (!toV6.ok) return;
     expect(toV6.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -643,7 +672,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV5 =
-      agentGuiListHarnessesDowngradeV7ToV5.downgradeResponse(v7Response);
+      agentGuiListHarnessesDowngradeV8ToV5.downgradeResponse(v8Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -659,7 +688,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV4 =
-      agentGuiListHarnessesDowngradeV7ToV4.downgradeResponse(v7Response);
+      agentGuiListHarnessesDowngradeV8ToV4.downgradeResponse(v8Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -674,7 +703,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV3 =
-      agentGuiListHarnessesDowngradeV7ToV3.downgradeResponse(v7Response);
+      agentGuiListHarnessesDowngradeV8ToV3.downgradeResponse(v8Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -687,7 +716,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV2 =
-      agentGuiListHarnessesDowngradeV7ToV2.downgradeResponse(v7Response);
+      agentGuiListHarnessesDowngradeV8ToV2.downgradeResponse(v8Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -699,7 +728,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     ).not.toThrow();
 
     const toV1 =
-      agentGuiListHarnessesDowngradeV7ToV1.downgradeResponse(v7Response);
+      agentGuiListHarnessesDowngradeV8ToV1.downgradeResponse(v8Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -711,8 +740,8 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     ).not.toThrow();
   });
 
-  it("drops Hugging Face agents from agent.list for every released caller down to v1.0", () => {
-    const v7Response = listAgentsResponseSchema.parse({
+  it("drops Hugging Face/Reasonix agents from agent.list for every released caller down to v1.0", () => {
+    const v8Response = listAgentsResponseSchema.parse({
       caller: { agentId: "self", canSendMessages: true },
       scope: "all",
       agents: [
@@ -723,13 +752,33 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
         agentSummary("a-hermes", "hermes"),
         agentSummary("a-omp", "omp"),
         agentSummary("a-hf", "huggingface"),
+        agentSummary("a-reasonix", "reasonix"),
         agentSummary("a-null", null),
       ],
     });
 
-    // v6.0 shipped with omp, so an omp agent row survives; only Hugging Face
-    // goes.
-    const toV6 = agentListDowngradeV7ToV6.downgradeResponse(v7Response);
+    // v7.0 shipped with Hugging Face, so that row survives; only Reasonix
+    // goes. `runConfig` survives too - it is a v7.0 field, unlike every hop
+    // below, where the frozen shape predates it and the reparse drops it.
+    const toV7 = agentListDowngradeV8ToV7.downgradeResponse(v8Response);
+    expect(toV7.ok).toBe(true);
+    if (!toV7.ok) return;
+    expect(toV7.value.agents.map((agent) => agent.id)).toEqual([
+      "a-claude",
+      "a-amp",
+      "a-devin",
+      "a-pi",
+      "a-hermes",
+      "a-omp",
+      "a-hf",
+      "a-null",
+    ]);
+    expect(toV7.value.agents.every((agent) => "runConfig" in agent)).toBe(true);
+    expect(() => listAgentsResponseSchemaV70.parse(toV7.value)).not.toThrow();
+
+    // v6.0 shipped with omp, so an omp agent row survives; Hugging Face and
+    // Reasonix go.
+    const toV6 = agentListDowngradeV8ToV6.downgradeResponse(v8Response);
     expect(toV6.ok).toBe(true);
     if (!toV6.ok) return;
     expect(toV6.value.agents.map((agent) => agent.id)).toEqual([
@@ -746,7 +795,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     );
     expect(() => listAgentsResponseSchemaV60.parse(toV6.value)).not.toThrow();
 
-    const toV5 = agentListDowngradeV7ToV5.downgradeResponse(v7Response);
+    const toV5 = agentListDowngradeV8ToV5.downgradeResponse(v8Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.agents.map((agent) => agent.id)).toEqual([
@@ -762,7 +811,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     );
     expect(() => listAgentsResponseSchemaV50.parse(toV5.value)).not.toThrow();
 
-    const toV4 = agentListDowngradeV7ToV4.downgradeResponse(v7Response);
+    const toV4 = agentListDowngradeV8ToV4.downgradeResponse(v8Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.agents.map((agent) => agent.id)).toEqual([
@@ -777,7 +826,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     );
     expect(() => listAgentsResponseSchemaV40.parse(toV4.value)).not.toThrow();
 
-    const toV3 = agentListDowngradeV7ToV3.downgradeResponse(v7Response);
+    const toV3 = agentListDowngradeV8ToV3.downgradeResponse(v8Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.agents.map((agent) => agent.id)).toEqual([
@@ -790,7 +839,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     );
     expect(() => listAgentsResponseSchemaV30.parse(toV3.value)).not.toThrow();
 
-    const toV2 = agentListDowngradeV7ToV2.downgradeResponse(v7Response);
+    const toV2 = agentListDowngradeV8ToV2.downgradeResponse(v8Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.agents.map((agent) => agent.id)).toEqual([
@@ -802,7 +851,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     );
     expect(() => listAgentsResponseSchemaV20.parse(toV2.value)).not.toThrow();
 
-    const toV1 = agentListDowngradeV7ToV1.downgradeResponse(v7Response);
+    const toV1 = agentListDowngradeV8ToV1.downgradeResponse(v8Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.agents.map((agent) => agent.id)).toEqual([
@@ -815,11 +864,12 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
     expect(() => listAgentsResponseSchemaV10.parse(toV1.value)).not.toThrow();
   });
 
-  it("drops Hugging Face from providers.list for every released caller down to v1.0", () => {
-    // `cli-v1.1.9` shipped v6.0, so `huggingface` could not join it and every
-    // v6.0-and-older caller must have it filtered out. Driven from v7.0, the
-    // newest line, which carries the id because it is still unreleased.
-    const v7Response = providersListResponseSchema.parse({
+  it("drops Hugging Face/Reasonix from providers.list for every released caller down to v1.0", () => {
+    // `cli-v1.1.9` shipped v6.0 and `cli-v1.2.0` shipped v7.0, so neither
+    // `huggingface` nor `reasonix` could join the line below it. Driven from
+    // v8.0, the newest line, which carries both because it is still
+    // unreleased.
+    const v8Response = providersListResponseSchema.parse({
       providers: [
         providerState("cursor", "unknown"),
         providerState("amp", "unknown"),
@@ -828,10 +878,23 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
         providerState("hermes", "unknown"),
         providerState("omp", "unknown"),
         providerState("huggingface", "unknown"),
+        providerState("reasonix", "unknown"),
       ],
     });
 
-    const toV6 = providersListDowngradeV7ToV6.downgradeResponse(v7Response);
+    // Major 7 keeps Hugging Face and loses only Reasonix; the bridge lands on
+    // 7.1, major 7's latest installed minor.
+    const toV7 = providersListDowngradeV8ToV7.downgradeResponse(v8Response);
+    expect(toV7.ok).toBe(true);
+    if (!toV7.ok) return;
+    expect(toV7.value.providers.map((provider) => provider.providerId)).toEqual(
+      ["cursor", "amp", "devin", "pi", "hermes", "omp", "huggingface"],
+    );
+    expect(() =>
+      providersListResponseSchemaV71.parse(toV7.value),
+    ).not.toThrow();
+
+    const toV6 = providersListDowngradeV8ToV6.downgradeResponse(v8Response);
     expect(toV6.ok).toBe(true);
     if (!toV6.ok) return;
     expect(toV6.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -841,7 +904,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
       providersListResponseSchemaV60.parse(toV6.value),
     ).not.toThrow();
 
-    const toV5 = providersListDowngradeV7ToV5.downgradeResponse(v7Response);
+    const toV5 = providersListDowngradeV8ToV5.downgradeResponse(v8Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -851,7 +914,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
       providersListResponseSchemaV50.parse(toV5.value),
     ).not.toThrow();
 
-    const toV4 = providersListDowngradeV7ToV4.downgradeResponse(v7Response);
+    const toV4 = providersListDowngradeV8ToV4.downgradeResponse(v8Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -861,7 +924,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
       providersListResponseSchemaV40.parse(toV4.value),
     ).not.toThrow();
 
-    const toV3 = providersListDowngradeV7ToV3.downgradeResponse(v7Response);
+    const toV3 = providersListDowngradeV8ToV3.downgradeResponse(v8Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -871,7 +934,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
       providersListResponseSchemaV30.parse(toV3.value),
     ).not.toThrow();
 
-    const toV2 = providersListDowngradeV7ToV2.downgradeResponse(v7Response);
+    const toV2 = providersListDowngradeV8ToV2.downgradeResponse(v8Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -881,7 +944,7 @@ describe("post-v5.0 omp/Hugging Face non-breaking downgrade bridges", () => {
       providersListResponseSchemaV20.parse(toV2.value),
     ).not.toThrow();
 
-    const toV1 = providersListDowngradeV7ToV1.downgradeResponse(v7Response);
+    const toV1 = providersListDowngradeV8ToV1.downgradeResponse(v8Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.providers.map((provider) => provider.providerId)).toEqual(

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -1019,6 +1019,14 @@ export const huggingFaceUserMessageAnchorResolvedSchema = z.object({
   opencodeUserMessageId: z.string(),
 });
 
+export const reasonixUserMessageAnchorResolvedSchema = z.object({
+  harnessId: z.literal("reasonix"),
+  sessionId: z.string(),
+  // The ACP session id the `reasonix acp` process assigned for this turn.
+  // Null until `session/new` resolves; used to resume the same ACP session.
+  reasonixSessionId: z.string().nullable(),
+});
+
 export const userMessageAnchorResolvedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("user_message.anchor_resolved"),
@@ -1043,6 +1051,7 @@ export const userMessageAnchorResolvedEventSchema = z.object({
     hermesUserMessageAnchorResolvedSchema,
     ompUserMessageAnchorResolvedSchema,
     huggingFaceUserMessageAnchorResolvedSchema,
+    reasonixUserMessageAnchorResolvedSchema,
   ]),
 });
 export type UserMessageAnchorResolvedEvent = z.infer<

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -19,6 +19,7 @@ import {
   listGuiHarnessesResponseSchemaV40,
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
+  listGuiHarnessesResponseSchemaV71,
   listGuiHarnessesResponseSchemaV70,
   guiHarnessOptionSchemaV10,
   guiHarnessOptionSchemaV21,
@@ -26,6 +27,7 @@ import {
   guiHarnessOptionSchemaV40,
   guiHarnessOptionSchemaV50,
   guiHarnessOptionSchemaV60,
+  guiHarnessOptionSchemaV71,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   chatSubscribeV10,
@@ -509,7 +511,165 @@ export const agentGuiListHarnessesV71 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 7, minor: 1 } as const,
   requestSchema: listGuiHarnessesRequestSchema,
+  // Frozen at the v7.0 ID SET, not the live one - see
+  // `listGuiHarnessesResponseSchemaV71`'s comment. 7.0 is released, and a minor
+  // may not grow a response enum over its predecessor, so no minor of major 7
+  // can carry a harness id 7.0 lacks. The REQUEST stays live: it is a
+  // client->host slot, so widening the harness enum a caller may send is not a
+  // released-peer break.
+  responseSchema: listGuiHarnessesResponseSchemaV71,
+});
+
+export const agentGuiListHarnessesV80 = defineRpcContract({
+  method: "agent.gui.listHarnesses",
+  schemaVersion: { major: 8, minor: 0 } as const,
+  requestSchema: listGuiHarnessesRequestSchema,
   responseSchema: listGuiHarnessesResponseSchema,
+});
+
+export const agentGuiListHarnessesUpgradeV71ToV80 = defineUpgradePath<
+  typeof agentGuiListHarnessesV71,
+  typeof agentGuiListHarnessesV80
+>({
+  from: { major: 7, minor: 1 },
+  to: { major: 8, minor: 0 },
+  // Request shape is identical; a v7.1 response without Reasonix is a valid
+  // v8.0 response (purely additive), so both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV7 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV71
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 7, minor: 1 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Reasonix so an already-shipped major-7 client's strict decode never
+  // sees it. Lands on 7.1, major 7's latest installed minor; a frozen-7.0
+  // caller's own contract parse then strips the 7.1-only `authStatus` /
+  // `enablementMode` keys.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV71.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV71.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV6 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV60
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Hugging Face/Reasonix so an already-shipped v6.0 client's strict
+  // decode never sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV60.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV60.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV5 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV50
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop omp/Hugging Face/Reasonix so an already-shipped v5.0 client's strict
+  // decode never sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV50.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV50.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV4 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV40
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Hermes/omp/Hugging Face/Reasonix so an already-shipped v4.0 client's
+  // strict decode never sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV40.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV40.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV3 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV30
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Devin/Pi/Hermes/omp/Hugging Face/Reasonix so an already-shipped v3.0
+  // client's strict decode never sees them.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV30.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV30.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV2 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV21
+>({
+  from: { major: 8, minor: 0 },
+  // Lands on 2.1, major 2's latest installed minor; a frozen-2.0 caller's
+  // contract parse then strips the 2.1-only `enabled` field.
+  to: { major: 2, minor: 1 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV21.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV21.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV8ToV1 = defineDowngradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV10
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV10.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV10.safeParse(harness).success,
+      ),
+    }),
+  }),
 });
 
 export const agentGuiListHarnessesUpgradeV70ToV71 = defineUpgradePath<

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -387,6 +387,41 @@ export const listGuiHarnessesResponseSchemaV70 = z.object({
 export type ListGuiHarnessesResponseV70 = z.infer<
   typeof listGuiHarnessesResponseSchemaV70
 >;
+
+// ── Frozen protocol-v7.1 catalog row + response (pre-Reasonix) ─────────────
+// 7.1 is where `authStatus` / `enablementMode` formally enter the major-7 line.
+// It is frozen here at the v7.0 ID SET even though no tag has shipped 7.1 yet,
+// which is the part worth stating: a minor may not GROW A RESPONSE ENUM over
+// its predecessor (`versioned-rpc.ts`'s projection-feasibility check refuses
+// it), and 7.0 IS released, so no minor of major 7 can ever carry a harness id
+// 7.0 does not. Reasonix therefore opens 8.0 rather than riding 7.1, exactly as
+// it would if 7.1 were released.
+//
+// That refusal is the whole safety property here. A 7.0 peer receives a 7.1
+// response through a within-major re-parse, which STRIPS unknown keys but
+// REJECTS an unknown enum value - so a Reasonix row on 7.1 would not degrade,
+// it would fail the entire `listHarnesses` response and empty that peer's
+// picker. Only a cross-major bridge can filter rows.
+//
+// Do NOT add fields or ids here; add fields to `guiHarnessOptionSchema` above,
+// which only v8.0 (the head line) binds.
+const guiHarnessOptionBaseShapeV71 = {
+  ...guiHarnessOptionBaseShapeV70,
+  authStatus: PROVIDER_AUTH_STATUS_SCHEMA.optional().catch(undefined),
+  enablementMode: providerEnablementModeSchema.optional().catch(undefined),
+};
+
+export const guiHarnessOptionSchemaV71 = z.object({
+  id: guiHarnessIdSchemaV70,
+  ...guiHarnessOptionBaseShapeV71,
+});
+export const listGuiHarnessesResponseSchemaV71 = z.object({
+  harnesses: z.array(guiHarnessOptionSchemaV71),
+});
+export type ListGuiHarnessesResponseV71 = z.infer<
+  typeof listGuiHarnessesResponseSchemaV71
+>;
+
 export type ListGuiHarnessesResponse = z.infer<
   typeof listGuiHarnessesResponseSchema
 >;

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -23,6 +23,7 @@ import {
   providerIdSchemaV40,
   providerIdSchemaV50,
   providerIdSchemaV60,
+  providerIdSchemaV70,
   providerProfileRateLimitStatusSchema,
 } from "@traycer/protocol/host/provider-schemas";
 import {
@@ -33,6 +34,7 @@ import {
   providerRateLimitsSchemaV40,
   providerRateLimitsSchemaV50,
   providerRateLimitsSchemaV60,
+  providerRateLimitsSchemaV70,
 } from "@traycer/protocol/host/rate-limit/schemas";
 import {
   agentFacingHarnessIdSchema,
@@ -41,6 +43,7 @@ import {
   guiHarnessIdSchemaV40,
   guiHarnessIdSchemaV50,
   guiHarnessIdSchemaV60,
+  guiHarnessIdSchemaV70,
 } from "@traycer/protocol/host/agent/shared";
 
 // ─── `agent.listProviderProfiles@1.0` ─────────────────────────────────────
@@ -173,9 +176,37 @@ export const agentListProviderProfilesV30 = defineRpcContract({
   responseSchema: agentListProviderProfilesResponseSchemaV3,
 });
 
+/**
+ * Frozen `agent.listProviderProfiles@4.0` response, pinned to the pre-Reasonix
+ * provider id set (`providerIdSchemaV70`) so an already-shipped v4.0 caller's
+ * strict decode never sees `reasonix`.
+ *
+ * This line IS released - the v1.2.0 tags (2026-08-24) shipped it. Until then
+ * it pointed at the live `agentListProviderProfilesResponseSchema`, which is
+ * the same defect that let `omp` first try to ride v2.0 and `huggingface` v3.0.
+ * The v5.0 line now carries the live schema, with a v5->v4 downgrade bridge
+ * that fails closed (`DOWNGRADE_UNSUPPORTED`) for a post-v7.0-only provider id.
+ * Do NOT widen this schema - extend the latest schema and use the v5 bridge
+ * instead.
+ */
+export const agentListProviderProfilesResponseSchemaV4 = z.object({
+  providerId: providerIdSchemaV70,
+  profiles: z.array(agentProviderProfileSummarySchema),
+});
+export type AgentListProviderProfilesResponseV4 = z.infer<
+  typeof agentListProviderProfilesResponseSchemaV4
+>;
+
 export const agentListProviderProfilesV40 = defineRpcContract({
   method: "agent.listProviderProfiles",
   schemaVersion: { major: 4, minor: 0 } as const,
+  requestSchema: agentListProviderProfilesRequestSchema,
+  responseSchema: agentListProviderProfilesResponseSchemaV4,
+});
+
+export const agentListProviderProfilesV50 = defineRpcContract({
+  method: "agent.listProviderProfiles",
+  schemaVersion: { major: 5, minor: 0 } as const,
   requestSchema: agentListProviderProfilesRequestSchema,
   responseSchema: agentListProviderProfilesResponseSchema,
 });
@@ -384,6 +415,127 @@ export const agentListProviderProfilesDowngradeV40ToV10 = defineDowngradePath<
   },
 });
 
+export const agentListProviderProfilesUpgradeV40ToV50 = defineUpgradePath<
+  typeof agentListProviderProfilesV40,
+  typeof agentListProviderProfilesV50
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 5, minor: 0 },
+  // Request shape is identical across both majors - only the response's
+  // `providerId` enum grows (reasonix).
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListProviderProfilesDowngradeV50ToV40 = defineDowngradePath<
+  typeof agentListProviderProfilesV50,
+  typeof agentListProviderProfilesV40
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // A v4.0 caller only ever lists a pre-Reasonix provider, so the common case
+    // reparses cleanly through the frozen schema. Fails closed (rather than
+    // silently mis-decoding) for any provider unrepresentable on the frozen
+    // v4.0 wire. This response carries exactly one provider - there is nothing
+    // to filter out, so the only honest options are pass-through or refuse. The
+    // message deliberately names no provider so it stays honest as the enum
+    // grows.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV4.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV50ToV30 = defineDowngradePath<
+  typeof agentListProviderProfilesV50,
+  typeof agentListProviderProfilesV30
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Same fail-closed rule as the v5->v4 bridge, against the narrower v3.0
+    // enum: anything post-v6.0 (huggingface, reasonix) is unrepresentable here.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV50ToV20 = defineDowngradePath<
+  typeof agentListProviderProfilesV50,
+  typeof agentListProviderProfilesV20
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Same fail-closed rule against the narrower v2.0 enum: anything post-v5.0
+    // (omp, huggingface, reasonix) is unrepresentable here.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV50ToV10 = defineDowngradePath<
+  typeof agentListProviderProfilesV50,
+  typeof agentListProviderProfilesV10
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Same fail-closed rule against the narrowest enum: anything post-v4.0
+    // (Hermes, omp, huggingface, reasonix) is unrepresentable here.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV1.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
 // ─── `agent.getProviderProfileRateLimits@1.0` ─────────────────────────────
 //
 // On-demand detailed rate-limit read for one concrete profile selection
@@ -499,19 +651,50 @@ export const agentGetProviderProfileRateLimitsV30 = defineRpcContract({
   responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV3,
 });
 
-// The LIVE line: ranges over `providerRateLimitsSchema` rather than a frozen
-// snapshot, because `4` is the newest major and no released peer has ever
-// negotiated it (the newest released baseline tops out at `3`).
+/**
+ * Frozen `agent.getProviderProfileRateLimits@4.0` response, pinned to the
+ * pre-Reasonix `rateLimits.provider` enum (`providerRateLimitsSchemaV70`, whose
+ * `available: false` arm carries `providerIdSchemaV70`) so an already-shipped
+ * v4.0 caller's strict decode never sees `reasonix`.
+ *
+ * This line IS released - the v1.2.0 tags (2026-08-24) shipped it. Its comment
+ * used to read "`4` is the newest major and no released peer has ever
+ * negotiated it", which is exactly the sentence that stops being true the
+ * moment a tag ships, and exactly how `omp` first tried to ride v2.0. The v5.0
+ * line now carries the live schema, with a v5->v4 downgrade bridge that fails
+ * closed (`DOWNGRADE_UNSUPPORTED`). Do NOT widen this schema - extend the
+ * latest schema and use the v5 bridge instead.
+ */
 export const agentGetProviderProfileRateLimitsResponseSchemaV4 = z.object({
-  rateLimits: providerRateLimitsSchema,
+  rateLimits: providerRateLimitsSchemaV70,
   usageUpdatedAt: z.number().nullable(),
 });
+export type AgentGetProviderProfileRateLimitsResponseV4 = z.infer<
+  typeof agentGetProviderProfileRateLimitsResponseSchemaV4
+>;
 
 export const agentGetProviderProfileRateLimitsV40 = defineRpcContract({
   method: "agent.getProviderProfileRateLimits",
   schemaVersion: { major: 4, minor: 0 } as const,
   requestSchema: agentGetProviderProfileRateLimitsRequestSchema,
   responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV4,
+});
+
+// The LIVE line: ranges over `providerRateLimitsSchema` rather than a frozen
+// snapshot, because `5` is the newest major and no released peer has ever
+// negotiated it (the newest released baseline tops out at `4`). It stops being
+// the live line the moment a tag ships it - see the v4.0 block above for what
+// that costs when it is missed.
+export const agentGetProviderProfileRateLimitsResponseSchemaV5 = z.object({
+  rateLimits: providerRateLimitsSchema,
+  usageUpdatedAt: z.number().nullable(),
+});
+
+export const agentGetProviderProfileRateLimitsV50 = defineRpcContract({
+  method: "agent.getProviderProfileRateLimits",
+  schemaVersion: { major: 5, minor: 0 } as const,
+  requestSchema: agentGetProviderProfileRateLimitsRequestSchema,
+  responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV5,
 });
 
 export const agentGetProviderProfileRateLimitsUpgradeV10ToV20 =
@@ -769,6 +952,155 @@ export const agentGetProviderProfileRateLimitsDowngradeV40ToV10 =
   });
 
 
+export const agentGetProviderProfileRateLimitsUpgradeV40ToV50 =
+  defineUpgradePath<
+    typeof agentGetProviderProfileRateLimitsV40,
+    typeof agentGetProviderProfileRateLimitsV50
+  >({
+    from: { major: 4, minor: 0 },
+    to: { major: 5, minor: 0 },
+    // Request shape is identical across both majors - only the response's
+    // `rateLimits.provider` enum grows (reasonix).
+    upgradeRequest: (request) => request,
+    upgradeResponse: (response) => response,
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV50ToV40 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV50,
+    typeof agentGetProviderProfileRateLimitsV40
+  >({
+    from: { major: 5, minor: 0 },
+    to: { major: 4, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // NO degrade maps here, unlike every bridge below: the frozen v4.0 union
+      // keeps every available arm the live union carries at this cut (grok,
+      // huggingface, opencode and cursor all shipped on 4.0), so an available
+      // snapshot reparses as-is. Only a post-v7.0 provider is unrepresentable,
+      // and it can only ever arrive on the `available: false` arm - Reasonix
+      // exposes no queryable quota API and is outside
+      // `rateLimitCapableProviderIdSchema`. This response carries exactly one
+      // provider, so fail closed rather than mis-decode. The message names no
+      // provider so it stays honest as the enum grows.
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV4.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV50ToV30 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV50,
+    typeof agentGetProviderProfileRateLimitsV30
+  >({
+    from: { major: 5, minor: 0 },
+    to: { major: 3, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // Same shape as the v4->v3 bridge: the frozen v3.0 union keeps grok, so
+      // only OpenCode/cursor degrade, and anything post-v6.0 (huggingface,
+      // reasonix) fails closed.
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV3.safeParse({
+          ...response,
+          rateLimits: mapCursorAvailableToUnavailable(
+            mapOpenCodeAvailableToUnavailable(response.rateLimits),
+          ),
+        });
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV50ToV20 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV50,
+    typeof agentGetProviderProfileRateLimitsV20
+  >({
+    from: { major: 5, minor: 0 },
+    to: { major: 2, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // Same rule against the narrower v2.0 enum: the frozen v2.0 union keeps
+      // grok, so only post-v5.0 providers (omp, huggingface, reasonix) fail
+      // closed. Cursor and OpenCode degrade as they do above.
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV2.safeParse({
+          ...response,
+          rateLimits: mapCursorAvailableToUnavailable(
+            mapOpenCodeAvailableToUnavailable(response.rateLimits),
+          ),
+        });
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV50ToV10 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV50,
+    typeof agentGetProviderProfileRateLimitsV10
+  >({
+    from: { major: 5, minor: 0 },
+    to: { major: 1, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // Like the v4->v1 bridge this one also degrades grok: the frozen v1.0
+      // union predates the grok available arm. Post-v4.0 providers (Hermes,
+      // omp, huggingface, reasonix) stay unrepresentable and fail closed.
+      const rateLimits = mapGrokAvailableToUnavailable(
+        mapCursorAvailableToUnavailable(
+          mapOpenCodeAvailableToUnavailable(response.rateLimits),
+        ),
+      );
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse({
+          ...response,
+          rateLimits,
+        });
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading rate limits for this provider requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
 // ─── `agent.configure@1.0` / `2.0` ─────────────────────────────────────────
 //
 // Released v1.0 atomically switches provider/profile/model while preserving
@@ -954,9 +1286,55 @@ export const agentConfigureV30 = defineRpcContract({
   responseSchema: agentConfigureResponseSchemaV3,
 });
 
+/**
+ * Frozen `agent.configure@4.0` settings/response, pinned to the pre-Reasonix
+ * harness id set (`guiHarnessIdSchemaV70`) so an already-shipped v4.0 caller's
+ * strict decode never sees `harnessId: "reasonix"`.
+ *
+ * This line IS released - the v1.2.0 tags (2026-08-24) shipped it. Until then
+ * it pointed at the live `agentConfigureSettingsSchema` /
+ * `agentConfigureResponseSchema`. The v5.0 line (below) carries the live
+ * schemas; `agentConfigureDowngradeV50ToV40`'s response bridge fails closed
+ * (`DOWNGRADE_UNSUPPORTED`) instead of silently mis-decoding a
+ * Reasonix-configured agent for a v4.0 caller. Do NOT widen this schema -
+ * extend the latest schema and use the v5 bridge instead.
+ *
+ * Only the RESPONSE is frozen. `agentConfigureRequestSchemaV20` keeps the live
+ * harness enum because the request is a client→host slot: a released client
+ * simply never sends `reasonix`, and widening what the host accepts breaks
+ * nobody.
+ */
+export const agentConfigureSettingsSchemaV4 = z.object({
+  harnessId: guiHarnessIdSchemaV70,
+  model: z.string().min(1),
+  profileSelection: concreteProfileSelectionSchema,
+  reasoningEffort: z.string().nullable(),
+  fastMode: z.boolean(),
+  permissionMode: permissionModeSchema,
+  agentMode: agentModeSchema,
+});
+export type AgentConfigureSettingsV4 = z.infer<
+  typeof agentConfigureSettingsSchemaV4
+>;
+
+export const agentConfigureResponseSchemaV4 = z.object({
+  settings: agentConfigureSettingsSchemaV4,
+  warnings: z.array(z.string()),
+});
+export type AgentConfigureResponseV4 = z.infer<
+  typeof agentConfigureResponseSchemaV4
+>;
+
 export const agentConfigureV40 = defineRpcContract({
   method: "agent.configure",
   schemaVersion: { major: 4, minor: 0 } as const,
+  requestSchema: agentConfigureRequestSchemaV20,
+  responseSchema: agentConfigureResponseSchemaV4,
+});
+
+export const agentConfigureV50 = defineRpcContract({
+  method: "agent.configure",
+  schemaVersion: { major: 5, minor: 0 } as const,
   requestSchema: agentConfigureRequestSchemaV20,
   responseSchema: agentConfigureResponseSchema,
 });
@@ -1142,6 +1520,135 @@ export const agentConfigureDowngradeV40ToV10 = defineDowngradePath<
   }),
   downgradeResponse: (response) => {
     // Fails closed for any post-v4.0 harness (Hermes, omp, huggingface).
+    const parsed = agentConfigureResponseSchemaV1.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureUpgradeV40ToV50 = defineUpgradePath<
+  typeof agentConfigureV40,
+  typeof agentConfigureV50
+>({
+  from: { major: 4, minor: 0 },
+  to: { major: 5, minor: 0 },
+  // Request shape is identical across both majors (both reuse
+  // `agentConfigureRequestSchemaV20`) - only the response's `harnessId` enum
+  // grows (reasonix). Both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentConfigureDowngradeV50ToV40 = defineDowngradePath<
+  typeof agentConfigureV50,
+  typeof agentConfigureV40
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 4, minor: 0 },
+  // Like the v4->v3 bridge this request downgrade succeeds: v5.0 added no
+  // request field, so a v5.0 request is already a valid v4.0 one.
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // `settings.harnessId` echoes the configured agent's harness; a v4.0
+    // caller only ever configures a pre-Reasonix harness, so the common case
+    // reparses cleanly through the frozen schema. A response on a post-v7.0
+    // harness (unreachable from a v4.0 REQUEST today, but this bridge must
+    // still hold if that ever changes) cannot be represented on the frozen
+    // v4.0 wire, so this fails closed instead of silently mis-decoding it. The
+    // message names no harness so it stays honest as the enum grows.
+    const parsed = agentConfigureResponseSchemaV4.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV50ToV30 = defineDowngradePath<
+  typeof agentConfigureV50,
+  typeof agentConfigureV30
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Fails closed for any post-v6.0 harness (huggingface, reasonix) - see the
+    // v5->v4 bridge above for the full reasoning.
+    const parsed = agentConfigureResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV50ToV20 = defineDowngradePath<
+  typeof agentConfigureV50,
+  typeof agentConfigureV20
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Fails closed for any post-v5.0 harness (omp, huggingface, reasonix).
+    const parsed = agentConfigureResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV50ToV10 = defineDowngradePath<
+  typeof agentConfigureV50,
+  typeof agentConfigureV10
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 1, minor: 0 },
+  // Same refusal as every other bridge onto v1.0: v1.0 has no
+  // `permissionMode` field, so the explicit choice a v2.0+ caller makes cannot
+  // be carried to a v1.0 host.
+  downgradeRequest: () => ({
+    ok: false,
+    error: {
+      code: "DOWNGRADE_UNSUPPORTED",
+      message:
+        "Selecting an agent permission mode requires a newer Traycer host. Upgrade the host before configuring this agent.",
+    },
+  }),
+  downgradeResponse: (response) => {
+    // Fails closed for any post-v4.0 harness (Hermes, omp, huggingface,
+    // reasonix).
     const parsed = agentConfigureResponseSchemaV1.safeParse(response);
     if (!parsed.success) {
       return {

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -68,6 +68,7 @@ export const guiHarnessIdSchema = harnessIdSchema.extract([
   "hermes",
   "omp",
   "huggingface",
+  "reasonix",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 
@@ -380,6 +381,7 @@ export const AGENT_FACING_HARNESS_IDS = [
   "hermes",
   "omp",
   "huggingface",
+  "reasonix",
 ] as const;
 
 export const AGENT_FACING_HARNESS_ID_LIST = AGENT_FACING_HARNESS_IDS.join(", ");
@@ -904,6 +906,29 @@ export const listAgentsResponseSchemaV60 = listAgentsResponseSchema.extend({
   agents: z.array(agentSummarySchemaV60),
 });
 export type ListAgentsResponseV60 = z.infer<typeof listAgentsResponseSchemaV60>;
+
+// ── Frozen protocol-v7.0 agent.list response (with Hugging Face, pre-Reasonix)
+// `agent.list` enumerates every agent in the epic - including Reasonix GUI
+// harness chats a newer client created - so an already-shipped v7.0 client
+// would hit a strict enum on those rows. This line IS released (`cli-v1.2.0` /
+// `host-v1.2.0`, both tagged 2026-08-24), so it is frozen here as actually
+// shipped; the v8.0 line carries Reasonix rows and v8→v7 … v8→v1 bridges drop
+// them for older callers. Do not add new harnesses here - use the existing v8
+// bridge.
+//
+// The row body is hand-frozen off `releasedAgentSummarySchema` plus the
+// `runConfig` field v7.0 shipped, rather than `agentSummarySchema.extend(...)`:
+// pinning only the id over a LIVE body is the half-freeze
+// `guiHarnessOptionBaseShapeV70` had to correct in `gui/unary-schemas.ts`. A
+// field added to `agentSummarySchema` must not widen this released line.
+export const agentSummarySchemaV70 = releasedAgentSummarySchema.extend({
+  harnessId: guiHarnessIdSchemaV70.nullable(),
+  runConfig: agentRunConfigSchema.nullable().default(null),
+});
+export const listAgentsResponseSchemaV70 = listAgentsResponseSchema.extend({
+  agents: z.array(agentSummarySchemaV70),
+});
+export type ListAgentsResponseV70 = z.infer<typeof listAgentsResponseSchemaV70>;
 
 /**
  * `agent.sendMessage@1.0` - fire-and-forget enqueue from one agent to

--- a/protocol/src/host/epic/chat-records.ts
+++ b/protocol/src/host/epic/chat-records.ts
@@ -7,7 +7,12 @@ import { tuiAgentRecordSummarySchema } from "@traycer/protocol/host/epic/tui-age
 // `serviceTier` or `profileId` existed, and the strict schema exists to stop a
 // partial WRITE from null-clobbering fields it never looked at. Parsing a
 // legacy record with it would fail the read outright.
-import { chatRunSettingsSchema } from "@traycer/protocol/persistence/epic/foundation";
+import {
+  agentModeSchema,
+  chatRunSettingsSchema,
+  guiHarnessIdSchema,
+  permissionModeSchema,
+} from "@traycer/protocol/persistence/epic/foundation";
 
 const textFrameFields = {
   hasBinaryPayload: z.literal(false),
@@ -269,6 +274,77 @@ export const getChatRunSettingsResponseSchema = z.object({
 });
 export type GetChatRunSettingsResponse = z.infer<
   typeof getChatRunSettingsResponseSchema
+>;
+
+/**
+ * Frozen harness id set for `epic.getChatRunSettings@1.0`, as the v1.2.0 tags
+ * (2026-08-24) shipped it.
+ *
+ * This method is the reason the freeze audit cannot stop at the three canonical
+ * id-carrying methods: its response embeds the PERSISTED `guiHarnessIdSchema`
+ * (`persistence/epic/foundation.ts`), a second, deliberately-independent copy of
+ * the harness enum, and nothing about the method's name suggests a catalog. It
+ * is also `degrade: unsupported` and outside `RELEASED_FLOOR`, so a plain
+ * `bun run test` stays green - only the tag-based `protocol-compat` gate saw it,
+ * which is exactly the shape of the Hermes A2A-profiles trap recorded in
+ * `adding-a-harness.md`.
+ *
+ * `.extract()` off the live persisted enum rather than a hand-written list, the
+ * same idiom `guiHarnessIdSchemaV70` uses in `agent/shared.ts`: removing an id
+ * from the live enum then fails to compile here instead of silently narrowing a
+ * released line. Do NOT add ids here - extend the persisted enum and let the
+ * v2.0 line carry them.
+ */
+export const chatRunSettingsHarnessIdSchemaV10 = guiHarnessIdSchema.extract([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+  "grok",
+  "qwen",
+  "kiro",
+  "droid",
+  "kimi",
+  "copilot",
+  "kilocode",
+  "openrouter",
+  "amp",
+  "devin",
+  "pi",
+  "hermes",
+  "omp",
+  "huggingface",
+]);
+
+/**
+ * Frozen `epic.getChatRunSettings@1.0` settings tuple. Hand-copied off
+ * `chatRunSettingsSchema` rather than `.extend()`ed from it, so a field added to
+ * the persisted tuple cannot leak onto this released line - the same discipline
+ * `providerLoginCapabilitySchemaV10` and `guiHarnessOptionBaseShapeV70` follow,
+ * and for the same reason: pinning only the id over a LIVE body is a half
+ * freeze.
+ *
+ * Keeps the persisted variant's `.default(...)` backstops verbatim (see the
+ * import comment at the top of this file): this is a READ of a record that may
+ * predate `serviceTier` / `profileId`, and the strict schema would fail it.
+ */
+export const chatRunSettingsSchemaV10 = z.object({
+  harnessId: chatRunSettingsHarnessIdSchemaV10,
+  model: z.string().min(1),
+  permissionMode: permissionModeSchema,
+  reasoningEffort: z.string().nullable(),
+  serviceTier: z.string().nullable().default(null),
+  agentMode: agentModeSchema,
+  profileId: z.string().nullable().default(null),
+});
+export type ChatRunSettingsV10 = z.infer<typeof chatRunSettingsSchemaV10>;
+
+export const getChatRunSettingsResponseSchemaV10 = z.object({
+  settings: chatRunSettingsSchemaV10.nullable(),
+});
+export type GetChatRunSettingsResponseV10 = z.infer<
+  typeof getChatRunSettingsResponseSchemaV10
 >;
 
 /**

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -1,4 +1,5 @@
 import {
+  defineDowngradePath,
   defineRpcContract,
   defineUpgradePath,
 } from "@traycer/protocol/framework/index";
@@ -142,6 +143,7 @@ import {
   listChatRecordsResponseSchema,
   getChatRunSettingsRequestSchema,
   getChatRunSettingsResponseSchema,
+  getChatRunSettingsResponseSchemaV10,
 } from "@traycer/protocol/host/epic/chat-records";
 import {
   readChatAttachmentRequestSchema,
@@ -891,7 +893,71 @@ export const epicGetChatRunSettingsV10 = defineRpcContract({
   method: "epic.getChatRunSettings",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: getChatRunSettingsRequestSchema,
+  // Frozen at the harness id set the v1.2.0 tags shipped. Until Reasonix this
+  // pointed at the live response, whose `settings.harnessId` is the PERSISTED
+  // `guiHarnessIdSchema` - a second copy of the harness enum, on a method whose
+  // name gives no hint that it carries a catalog id. It is `degrade:
+  // unsupported` and off the released floor, so only the tag-based
+  // `protocol-compat` gate could see the growth; a plain `bun run test` stayed
+  // green. Grep RESPONSES for id enums when adding a harness, not just the
+  // three canonical catalog methods.
+  responseSchema: getChatRunSettingsResponseSchemaV10,
+});
+
+export const epicGetChatRunSettingsV20 = defineRpcContract({
+  method: "epic.getChatRunSettings",
+  schemaVersion: { major: 2, minor: 0 } as const,
+  requestSchema: getChatRunSettingsRequestSchema,
   responseSchema: getChatRunSettingsResponseSchema,
+});
+
+export const epicGetChatRunSettingsUpgradeV10ToV20 = defineUpgradePath<
+  typeof epicGetChatRunSettingsV10,
+  typeof epicGetChatRunSettingsV20
+>({
+  from: { major: 1, minor: 0 },
+  to: { major: 2, minor: 0 },
+  // Request shape is identical; a v1.0 settings tuple is a valid v2.0 one
+  // (only the `harnessId` enum grows), so both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const epicGetChatRunSettingsDowngradeV20ToV10 = defineDowngradePath<
+  typeof epicGetChatRunSettingsV20,
+  typeof epicGetChatRunSettingsV10
+>({
+  from: { major: 2, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // A v1.0 caller only ever asks about a chat on a harness it knows, so the
+    // common case reparses cleanly. This response carries exactly ONE settings
+    // tuple, so - like the `agent.*ProviderProfile*` bridges - there is nothing
+    // to filter and the only honest options are pass-through or refuse.
+    //
+    // Refuse, deliberately, rather than answering `{ settings: null }`. That
+    // arm is in-contract and renders as "nothing to show", which makes it a
+    // tempting degrade - but it is a claim ("this chat has no persisted
+    // settings") that would be FALSE for a Reasonix chat, and the caller has no
+    // way to tell the lie from the truth. The hover card that reads this
+    // already renders the record row's harness mark when the read fails, which
+    // is exactly the documented degrade for a host that predates the method.
+    //
+    // The message names no harness, so it stays honest as the enum grows.
+    const parsed = getChatRunSettingsResponseSchemaV10.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Reading this chat's run settings requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
 });
 
 // The terminal-agent RECORD read (`epic.listTuiAgents@1.0`) lives in

--- a/protocol/src/host/provider-ids.ts
+++ b/protocol/src/host/provider-ids.ts
@@ -20,6 +20,7 @@ export const providerIdSchema = z.enum([
   "hermes",
   "omp",
   "huggingface",
+  "reasonix",
 ]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
 

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -228,6 +228,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   hermes: "Hermes Agent",
   omp: "Oh My Pi",
   huggingface: "Hugging Face",
+  reasonix: "Reasonix",
 };
 
 /**
@@ -688,6 +689,44 @@ export const providerManagedVersionsSchema = z.object({
 });
 export type ProviderManagedVersions = z.infer<
   typeof providerManagedVersionsSchema
+>;
+
+/**
+ * Frozen `providers.list@7.x` version-manager state: identical to the live
+ * schema except `sharedWithProviders` is pinned to `providerIdSchemaV70`.
+ *
+ * This is the sub-schema freeze the `frozen-catalog-lines` fixture's own
+ * instructions call for, and it is the second half of the v7.0 response
+ * freeze. `providerCliStateBaseShapeV70` pins v7.0's KEY SET but deliberately
+ * keeps live references for its leaf schemas, so the id enum reached the
+ * already-released v7.0 wire THROUGH this one array - a host→client enum
+ * addition at a released version, which the compat gate scores `breaking`.
+ * Adding `reasonix` is what surfaced it: the deep dump went red on
+ * `managedVersions.anyOf`, exactly as that fixture's comment predicted, and
+ * the answer it prescribes is this freeze rather than a regenerate-to-green.
+ *
+ * The blast radius was real but narrow, which is worth stating so the next
+ * reader does not conclude the freeze was ceremonial: `sharedWithProviders`
+ * carries `.catch([])`, so a v7.0 client handed an unknown id degrades the
+ * label to "shared with nobody" rather than throwing. Reasonix also ships its
+ * own binary and joins no shared pack, so it can never actually appear here.
+ * Neither fact is a reason to leave a released line tracking a growing enum -
+ * the next id added may well be pack-sharing, and `.catch()` tolerance is
+ * parse-time hardening, not a versioning mechanism.
+ *
+ * Do NOT widen this schema; extend the live one and let the next major
+ * publish it.
+ */
+export const providerManagedVersionsSchemaV70 = z.object({
+  autoDownload: z.boolean(),
+  pinnedVersion: z.string().nullable(),
+  updateAvailable: z.object({ version: z.string() }).nullable(),
+  sharedWithProviders: z.array(providerIdSchemaV70).catch([]),
+  totalSizeBytes: z.number().int().nonnegative().nullable(),
+  available: z.array(providerPackVersionSchema),
+});
+export type ProviderManagedVersionsV70 = z.infer<
+  typeof providerManagedVersionsSchemaV70
 >;
 
 /**
@@ -1940,7 +1979,11 @@ const providerCliStateBaseShapeV70 = {
   advisory: providerAdvisorySchema.nullable().catch(null).optional(),
   cliBinaryResolved: z.boolean().catch(true).optional(),
   packId: z.string().nullable().catch(null).optional(),
-  managedVersions: providerManagedVersionsSchema
+  // The ONE leaf this shape does not keep live - see
+  // `providerManagedVersionsSchemaV70`. Its `sharedWithProviders` array is a
+  // host→client `providerId` enum, so leaving it live let every id added after
+  // v7.0 shipped reach an already-released wire through this key.
+  managedVersions: providerManagedVersionsSchemaV70
     .nullable()
     .catch(null)
     .optional(),
@@ -1967,6 +2010,50 @@ export const providersListResponseSchemaV70 = z.object({
 });
 export type ProvidersListResponseV70 = z.infer<
   typeof providersListResponseSchemaV70
+>;
+
+// ── Frozen `providers.list@7.1` provider state + list response (pre-Reasonix)
+//
+// v7.1 is where the auth-aware enablement fields formally enter the major-7
+// line. It is frozen here at the v7.0 PROVIDER ID SET even though no tag has
+// shipped 7.1 yet, and that is the load-bearing part: a minor may not GROW A
+// RESPONSE ENUM over its predecessor - `versioned-rpc.ts`'s
+// projection-feasibility check refuses it outright - and v7.0 IS released, so
+// no minor of major 7 can ever carry a provider id v7.0 lacks. Reasonix
+// therefore opens 8.0 rather than riding 7.1.
+//
+// The refusal is protecting a real failure, not a formality. A 7.0 peer
+// receives a 7.1 response through a within-major re-parse, which STRIPS
+// unknown keys but REJECTS an unknown enum value - so a Reasonix ROW on 7.1
+// would not degrade to "one provider missing", it would fail the whole
+// `providers.list` response and empty that peer's provider list. Only a
+// cross-major bridge can filter rows.
+//
+// Same key-set-only discipline as `providerCliStateBaseShapeV70` above: the
+// leaf schemas stay live references and the deep `frozen-catalog-lines`
+// snapshot is what catches growth inside them.
+const providerCliStateBaseShapeV71 = {
+  ...providerCliStateBaseShapeV70,
+  enablementMode: providerEnablementModeSchema.optional().catch(undefined),
+  enablementSource: providerEnablementSourceSchema.optional().catch(undefined),
+};
+
+export const providerCliStateSchemaV71 = z.object({
+  providerId: providerIdSchemaV70,
+  ...providerCliStateBaseShapeV71,
+  auth: PROVIDER_AUTH_SCHEMA_V20,
+  nativeCapabilities: providerNativeCapabilitiesSchema.catch(
+    DEFAULT_PROVIDER_NATIVE_CAPABILITIES,
+  ),
+});
+export type ProviderCliStateV71 = z.infer<typeof providerCliStateSchemaV71>;
+
+export const providersListResponseSchemaV71 = z.object({
+  providers: z.array(providerCliStateSchemaV71),
+  native: nativeListResultSchema.nullable().default(null),
+});
+export type ProvidersListResponseV71 = z.infer<
+  typeof providersListResponseSchemaV71
 >;
 
 // Frozen protocol-v1.0 provider state + list response. The v2.0 line of
@@ -3518,6 +3605,27 @@ export function downgradeProviderCliStateListToV60(
 ): ProviderCliStateV60[] {
   return states.flatMap((state) => {
     const parsed = providerCliStateSchemaV60.safeParse(state);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+/**
+ * Same filter-by-reparse as `downgradeProviderCliStateListToV60`, one line up:
+ * drops rows whose `providerId` is not in the frozen v7.0 enum (`reasonix`
+ * today) so a major-7 caller's strict decode never sees one.
+ *
+ * There is nothing to STRIP here - v7.1 and the live shape carry the same keys
+ * at this cut - but the filter still has to exist. A straight pass-through
+ * throws the whole response away on the first Reasonix row rather than losing
+ * one provider, which is exactly the latent bug the `…ToV60` helper was written
+ * to fix for `huggingface` (that bridge passed the array through unfiltered
+ * until #1011).
+ */
+export function downgradeProviderCliStateListToV71(
+  states: readonly unknown[],
+): ProviderCliStateV71[] {
+  return states.flatMap((state) => {
+    const parsed = providerCliStateSchemaV71.safeParse(state);
     return parsed.success ? [parsed.data] : [];
   });
 }

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -8,6 +8,7 @@ import {
   providerIdSchemaV40,
   providerIdSchemaV50,
   providerIdSchemaV60,
+  providerIdSchemaV70,
 } from "@traycer/protocol/host/provider-schemas";
 
 // `host.getRateLimitUsage` v1.0 request: no fields. Non-strict on purpose so a
@@ -796,6 +797,57 @@ export const providerRateLimitsSchemaV60 = z.union([
   unavailableProviderRateLimitsSchemaV60,
 ]);
 export type ProviderRateLimitsV60 = z.infer<typeof providerRateLimitsSchemaV60>;
+
+// Frozen pre-Reasonix unavailable arm: same v2 reason enum, but `provider` is
+// pinned to `providerIdSchemaV70` (the provider id set as shipped in
+// cli-v1.2.0 / host-v1.2.0, with Hugging Face and before Reasonix) so an
+// already-shipped `agent.getProviderProfileRateLimits@4.0` caller's strict
+// decode never sees `"reasonix"` in the `available: false` arm.
+const unavailableProviderRateLimitsSchemaV70 = z.object({
+  provider: providerIdSchemaV70,
+  available: z.literal(false),
+  reason: rateLimitUnavailableReasonSchemaV2,
+});
+
+/**
+ * Frozen `agent.getProviderProfileRateLimits@4.0` provider union - the live
+ * union as the v1.2.0 tags (2026-08-24) shipped it, with the `available: false`
+ * arm's `provider` pinned to `providerIdSchemaV70`.
+ *
+ * A union of this name existed here before and was deliberately REMOVED when
+ * the pre-release collapse put the Hugging Face / OpenCode-Go arms on 4.0 and
+ * nothing bound it any more (see the live union's comment). It is back for the
+ * opposite reason: 4.0 is now RELEASED, so it must stop tracking the live
+ * union. Reasonix is the first id added since that release.
+ *
+ * It KEEPS every available arm the live union carries at the freeze cut -
+ * codex, claude-code, openrouter, kilocode, grok, huggingface, opencode and
+ * cursor all shipped on 4.0 - and the unavailable arm keeps the live shape's
+ * optional `credentialGeneration`. Only the `provider` enum is narrowed.
+ *
+ * Reasonix appears in NEITHER arm: it has no available arm (it exposes no
+ * queryable quota API, so it is outside `rateLimitCapableProviderIdSchema`),
+ * and `providerIdSchemaV70` cannot name it in the unavailable one. Pinning that
+ * arm's enum is what closes the second door - left live, a Reasonix
+ * `unsupported_provider` row would still reach a v4.0 caller naming a provider
+ * that line has never heard of.
+ *
+ * Do NOT widen this schema - extend the latest union and use the v5 bridge.
+ */
+export const providerRateLimitsSchemaV70 = z.union([
+  codexRateLimitsSchema,
+  claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
+  grokRateLimitsSchema,
+  huggingFaceRateLimitsSchema,
+  openCodeRateLimitsSchema,
+  cursorRateLimitsSchema,
+  unavailableProviderRateLimitsSchemaV70.extend({
+    credentialGeneration: z.string().min(1).optional(),
+  }),
+]);
+export type ProviderRateLimitsV70 = z.infer<typeof providerRateLimitsSchemaV70>;
 
 // v1.2 response = v1.0/v1.1 flat aperture fields (unchanged) + a nullable
 // provider-account snapshot, frozen at the v1 reason enum (see

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -45,12 +45,20 @@ import {
   agentListDowngradeV7ToV4,
   agentListDowngradeV7ToV5,
   agentListDowngradeV7ToV6,
+  agentListDowngradeV8ToV1,
+  agentListDowngradeV8ToV2,
+  agentListDowngradeV8ToV3,
+  agentListDowngradeV8ToV4,
+  agentListDowngradeV8ToV5,
+  agentListDowngradeV8ToV6,
+  agentListDowngradeV8ToV7,
   agentListUpgradeV1ToV2,
   agentListUpgradeV2ToV3,
   agentListUpgradeV3ToV4,
   agentListUpgradeV4ToV5,
   agentListUpgradeV5ToV6,
   agentListUpgradeV6ToV7,
+  agentListUpgradeV7ToV8,
   agentListV10,
   agentListV20,
   agentListV30,
@@ -58,6 +66,7 @@ import {
   agentListV50,
   agentListV60,
   agentListV70,
+  agentListV80,
   agentSelectionGuideV10,
   agentSelectionGuideGlobalGetV10,
   agentSelectionGuideGlobalOnboardingDraftGetV10,
@@ -74,39 +83,57 @@ import {
   agentConfigureDowngradeV40ToV10,
   agentConfigureDowngradeV40ToV20,
   agentConfigureDowngradeV40ToV30,
+  agentConfigureDowngradeV50ToV10,
+  agentConfigureDowngradeV50ToV20,
+  agentConfigureDowngradeV50ToV30,
+  agentConfigureDowngradeV50ToV40,
   agentConfigureV10,
   agentConfigureV20,
   agentConfigureV30,
   agentConfigureV40,
+  agentConfigureV50,
   agentConfigureUpgradeV10ToV20,
   agentConfigureUpgradeV20ToV30,
   agentConfigureUpgradeV30ToV40,
+  agentConfigureUpgradeV40ToV50,
   agentGetProviderProfileRateLimitsDowngradeV20ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV20,
   agentGetProviderProfileRateLimitsDowngradeV40ToV10,
   agentGetProviderProfileRateLimitsDowngradeV40ToV20,
   agentGetProviderProfileRateLimitsDowngradeV40ToV30,
+  agentGetProviderProfileRateLimitsDowngradeV50ToV10,
+  agentGetProviderProfileRateLimitsDowngradeV50ToV20,
+  agentGetProviderProfileRateLimitsDowngradeV50ToV30,
+  agentGetProviderProfileRateLimitsDowngradeV50ToV40,
   agentGetProviderProfileRateLimitsV10,
   agentGetProviderProfileRateLimitsV20,
   agentGetProviderProfileRateLimitsV30,
   agentGetProviderProfileRateLimitsV40,
+  agentGetProviderProfileRateLimitsV50,
   agentGetProviderProfileRateLimitsUpgradeV10ToV20,
   agentGetProviderProfileRateLimitsUpgradeV20ToV30,
   agentGetProviderProfileRateLimitsUpgradeV30ToV40,
+  agentGetProviderProfileRateLimitsUpgradeV40ToV50,
   agentListProviderProfilesDowngradeV20ToV10,
   agentListProviderProfilesDowngradeV30ToV10,
   agentListProviderProfilesDowngradeV30ToV20,
   agentListProviderProfilesDowngradeV40ToV10,
   agentListProviderProfilesDowngradeV40ToV20,
   agentListProviderProfilesDowngradeV40ToV30,
+  agentListProviderProfilesDowngradeV50ToV10,
+  agentListProviderProfilesDowngradeV50ToV20,
+  agentListProviderProfilesDowngradeV50ToV30,
+  agentListProviderProfilesDowngradeV50ToV40,
   agentListProviderProfilesV10,
   agentListProviderProfilesV20,
   agentListProviderProfilesV30,
   agentListProviderProfilesV40,
+  agentListProviderProfilesV50,
   agentListProviderProfilesUpgradeV10ToV20,
   agentListProviderProfilesUpgradeV20ToV30,
   agentListProviderProfilesUpgradeV30ToV40,
+  agentListProviderProfilesUpgradeV40ToV50,
 } from "@traycer/protocol/host/agent/profiles";
 import {
   agentInboxAckV10,
@@ -156,6 +183,13 @@ import {
   agentGuiListHarnessesDowngradeV7ToV4,
   agentGuiListHarnessesDowngradeV7ToV5,
   agentGuiListHarnessesDowngradeV7ToV6,
+  agentGuiListHarnessesDowngradeV8ToV1,
+  agentGuiListHarnessesDowngradeV8ToV2,
+  agentGuiListHarnessesDowngradeV8ToV3,
+  agentGuiListHarnessesDowngradeV8ToV4,
+  agentGuiListHarnessesDowngradeV8ToV5,
+  agentGuiListHarnessesDowngradeV8ToV6,
+  agentGuiListHarnessesDowngradeV8ToV7,
   agentGuiListHarnessesUpgradeV1ToV2,
   agentGuiListHarnessesUpgradeV20ToV21,
   agentGuiListHarnessesUpgradeV2ToV3,
@@ -164,6 +198,7 @@ import {
   agentGuiListHarnessesUpgradeV5ToV6,
   agentGuiListHarnessesUpgradeV6ToV7,
   agentGuiListHarnessesUpgradeV70ToV71,
+  agentGuiListHarnessesUpgradeV71ToV80,
   agentGuiListHarnessesV10,
   agentGuiListHarnessesV20,
   agentGuiListHarnessesV21,
@@ -173,6 +208,7 @@ import {
   agentGuiListHarnessesV60,
   agentGuiListHarnessesV70,
   agentGuiListHarnessesV71,
+  agentGuiListHarnessesV80,
   agentGuiListModelsV10,
   chatSubscribeV10,
   chatSubscribeV11,
@@ -313,7 +349,10 @@ import {
   epicChatBackupStatusV10,
   epicChatReplicaReadV10,
   epicListChatRecordsV10,
+  epicGetChatRunSettingsDowngradeV20ToV10,
+  epicGetChatRunSettingsUpgradeV10ToV20,
   epicGetChatRunSettingsV10,
+  epicGetChatRunSettingsV20,
   epicListChatPublicationTargetsV10,
   epicListCloudChatPayloadsV10,
   epicListCloudChatsV10,
@@ -653,6 +692,7 @@ import {
   providersListResponseSchemaV50,
   providersListResponseSchemaV60,
   providersListResponseSchemaV70,
+  providersListResponseSchemaV71,
   providersListModelProvidersRequestSchema,
   providersListModelProvidersResponseSchema,
   providersModelProviderAuthRequestSchema,
@@ -668,6 +708,7 @@ import {
   downgradeProviderCliStateListToV40,
   downgradeProviderCliStateListToV50,
   downgradeProviderCliStateListToV60,
+  downgradeProviderCliStateListToV71,
   providersInstallPackVersionRequestSchema,
   providersInstallPackVersionResponseSchema,
   providersRemovePackVersionRequestSchema,
@@ -1729,7 +1770,58 @@ export const providersListV71 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 7, minor: 1 } as const,
   requestSchema: providersListRequestSchema,
+  // Frozen at the v7.0 PROVIDER ID SET, not the live one - see
+  // `providersListResponseSchemaV71`'s comment. v7.0 is released, and a minor
+  // may not grow a response enum over its predecessor, so no minor of major 7
+  // can carry a provider id v7.0 lacks. The REQUEST stays live for the reason
+  // v7.0's does.
+  responseSchema: providersListResponseSchemaV71,
+});
+
+export const providersListV80 = defineRpcContract({
+  method: "providers.list",
+  schemaVersion: { major: 8, minor: 0 } as const,
+  requestSchema: providersListRequestSchema,
   responseSchema: providersListResponseSchema,
+});
+
+export const providersListUpgradeV71ToV80 = defineUpgradePath<
+  typeof providersListV71,
+  typeof providersListV80
+>({
+  from: { major: 7, minor: 1 },
+  to: { major: 8, minor: 0 },
+  // Request shape is identical (both bind the live request), and a v7.1
+  // response without Reasonix is a valid v8.0 response - purely additive, so
+  // both upgrades are identity. Nothing is filled: 8.0 adds no field, only the
+  // wider provider enum.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const providersListDowngradeV8ToV7 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV71
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 7, minor: 1 },
+  // Both lines bind the live request (v7.x is the only line whose request
+  // models `native`), so the request passes through unchanged - unlike every
+  // bridge below, which has to re-parse it onto
+  // `providersListRequestSchemaBeforeV70`.
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop post-v7.0 providers (`reasonix`) so a major-7 caller's strict decode
+  // never sees one. Nothing to strip: v7.1 and the live shape carry the same
+  // keys at this cut. Lands on 7.1, major 7's latest installed minor; a
+  // frozen-7.0 caller's own contract parse then strips the 7.1-only
+  // `enablementMode` / `enablementSource`.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV71.parse({
+      providers: downgradeProviderCliStateListToV71(response.providers),
+      native: response.native,
+    }),
+  }),
 });
 
 export const providersListUpgradeV5ToV6 = defineUpgradePath<
@@ -1936,6 +2028,30 @@ export const providersListDowngradeV6ToV1 = defineDowngradePath<
   }),
 });
 
+export const providersListDowngradeV8ToV6 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV60
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 6, minor: 0 },
+  // v7.x is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV60.parse({
+      providers: downgradeProviderCliStateListToV60(response.providers),
+    }),
+  }),
+});
+
 export const providersListDowngradeV7ToV6 = defineDowngradePath<
   typeof providersListV71,
   typeof providersListV60
@@ -1966,6 +2082,30 @@ export const providersListDowngradeV7ToV6 = defineDowngradePath<
   }),
 });
 
+export const providersListDowngradeV8ToV5 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV50
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 5, minor: 0 },
+  // v7.x is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV50.parse({
+      providers: downgradeProviderCliStateListToV50(response.providers),
+    }),
+  }),
+});
+
 export const providersListDowngradeV7ToV5 = defineDowngradePath<
   typeof providersListV71,
   typeof providersListV50
@@ -1986,6 +2126,30 @@ export const providersListDowngradeV7ToV5 = defineDowngradePath<
     ok: true,
     value: providersListResponseSchemaV50.parse({
       providers: downgradeProviderCliStateListToV50(response.providers),
+    }),
+  }),
+});
+
+export const providersListDowngradeV8ToV4 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV40
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 4, minor: 0 },
+  // v7.x is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV40.parse({
+      providers: downgradeProviderCliStateListToV40(response.providers),
     }),
   }),
 });
@@ -2014,6 +2178,30 @@ export const providersListDowngradeV7ToV4 = defineDowngradePath<
   }),
 });
 
+export const providersListDowngradeV8ToV3 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV30
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 3, minor: 0 },
+  // v7.x is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV30.parse({
+      providers: downgradeProviderCliStateListToV30(response.providers),
+    }),
+  }),
+});
+
 export const providersListDowngradeV7ToV3 = defineDowngradePath<
   typeof providersListV71,
   typeof providersListV30
@@ -2038,6 +2226,30 @@ export const providersListDowngradeV7ToV3 = defineDowngradePath<
   }),
 });
 
+export const providersListDowngradeV8ToV2 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV20
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 2, minor: 0 },
+  // v7.x is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV20.parse({
+      providers: downgradeProviderCliStateListToV20(response.providers),
+    }),
+  }),
+});
+
 export const providersListDowngradeV7ToV2 = defineDowngradePath<
   typeof providersListV71,
   typeof providersListV20
@@ -2058,6 +2270,30 @@ export const providersListDowngradeV7ToV2 = defineDowngradePath<
     ok: true,
     value: providersListResponseSchemaV20.parse({
       providers: downgradeProviderCliStateListToV20(response.providers),
+    }),
+  }),
+});
+
+export const providersListDowngradeV8ToV1 = defineDowngradePath<
+  typeof providersListV80,
+  typeof providersListV10
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 1, minor: 0 },
+  // v7.x is the only line whose request models `native`; every target below
+  // it is pinned to `providersListRequestSchemaBeforeV70`. Re-parsed field by
+  // field rather than passed through, so the carrier can never reach a peer
+  // whose schema does not model it.
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse({
+      forceAuthRefresh: request.forceAuthRefresh,
+    }),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV10.parse({
+      providers: downgradeProviderStateListForV10(response.providers),
     }),
   }),
 });
@@ -4637,6 +4873,24 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         6: agentGuiListHarnessesDowngradeV7ToV6,
       },
     },
+    8: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGuiListHarnessesV80,
+          upgradeFromPreviousVersion: agentGuiListHarnessesUpgradeV71ToV80,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentGuiListHarnessesDowngradeV8ToV1,
+        2: agentGuiListHarnessesDowngradeV8ToV2,
+        3: agentGuiListHarnessesDowngradeV8ToV3,
+        4: agentGuiListHarnessesDowngradeV8ToV4,
+        5: agentGuiListHarnessesDowngradeV8ToV5,
+        6: agentGuiListHarnessesDowngradeV8ToV6,
+        7: agentGuiListHarnessesDowngradeV8ToV7,
+      },
+    },
   },
   "agent.gui.listModels": {
     1: {
@@ -4997,6 +5251,24 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         4: agentListDowngradeV7ToV4,
         5: agentListDowngradeV7ToV5,
         6: agentListDowngradeV7ToV6,
+      },
+    },
+    8: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListV80,
+          upgradeFromPreviousVersion: agentListUpgradeV7ToV8,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListDowngradeV8ToV1,
+        2: agentListDowngradeV8ToV2,
+        3: agentListDowngradeV8ToV3,
+        4: agentListDowngradeV8ToV4,
+        5: agentListDowngradeV8ToV5,
+        6: agentListDowngradeV8ToV6,
+        7: agentListDowngradeV8ToV7,
       },
     },
   },
@@ -6197,6 +6469,21 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
       },
       downgradePathsFromLatest: {},
     },
+    // Major 2 carries the post-v1.2.0 harness ids. v1.0 is frozen at the id set
+    // those tags shipped: its response embeds the PERSISTED harness enum, so it
+    // absorbed every new id silently until the tag-based gate caught it.
+    2: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicGetChatRunSettingsV20,
+          upgradeFromPreviousVersion: epicGetChatRunSettingsUpgradeV10ToV20,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: epicGetChatRunSettingsDowngradeV20ToV10,
+      },
+    },
     degrade: { kind: "unsupported" },
   },
   // The terminal-agent record read (the TUI eviction). Optional and
@@ -6920,6 +7207,21 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         3: agentListProviderProfilesDowngradeV40ToV30,
       },
     },
+    5: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListProviderProfilesV50,
+          upgradeFromPreviousVersion: agentListProviderProfilesUpgradeV40ToV50,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListProviderProfilesDowngradeV50ToV10,
+        2: agentListProviderProfilesDowngradeV50ToV20,
+        3: agentListProviderProfilesDowngradeV50ToV30,
+        4: agentListProviderProfilesDowngradeV50ToV40,
+      },
+    },
   },
   "agent.getProviderProfileRateLimits": {
     degrade: { kind: "unsupported" },
@@ -6975,6 +7277,22 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         3: agentGetProviderProfileRateLimitsDowngradeV40ToV30,
       },
     },
+    5: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGetProviderProfileRateLimitsV50,
+          upgradeFromPreviousVersion:
+            agentGetProviderProfileRateLimitsUpgradeV40ToV50,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentGetProviderProfileRateLimitsDowngradeV50ToV10,
+        2: agentGetProviderProfileRateLimitsDowngradeV50ToV20,
+        3: agentGetProviderProfileRateLimitsDowngradeV50ToV30,
+        4: agentGetProviderProfileRateLimitsDowngradeV50ToV40,
+      },
+    },
   },
   "agent.configure": {
     degrade: { kind: "unsupported" },
@@ -7023,6 +7341,21 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         1: agentConfigureDowngradeV40ToV10,
         2: agentConfigureDowngradeV40ToV20,
         3: agentConfigureDowngradeV40ToV30,
+      },
+    },
+    5: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentConfigureV50,
+          upgradeFromPreviousVersion: agentConfigureUpgradeV40ToV50,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentConfigureDowngradeV50ToV10,
+        2: agentConfigureDowngradeV50ToV20,
+        3: agentConfigureDowngradeV50ToV30,
+        4: agentConfigureDowngradeV50ToV40,
       },
     },
   },
@@ -7225,6 +7558,24 @@ const HOST_RPC_PROVIDERS_REGISTRY_DEFINITION = {
         4: providersListDowngradeV7ToV4,
         5: providersListDowngradeV7ToV5,
         6: providersListDowngradeV7ToV6,
+      },
+    },
+    8: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: providersListV80,
+          upgradeFromPreviousVersion: providersListUpgradeV71ToV80,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: providersListDowngradeV8ToV1,
+        2: providersListDowngradeV8ToV2,
+        3: providersListDowngradeV8ToV3,
+        4: providersListDowngradeV8ToV4,
+        5: providersListDowngradeV8ToV5,
+        6: providersListDowngradeV8ToV6,
+        7: providersListDowngradeV8ToV7,
       },
     },
   },

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/epic-schema-surface.ts
@@ -86,7 +86,8 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "model": {
@@ -181,7 +182,8 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "sessionId": {
@@ -301,7 +303,8 @@ export const epicSchemaSurfaceBaseline = {
                               "pi",
                               "hermes",
                               "omp",
-                              "huggingface"
+                              "huggingface",
+                              "reasonix"
                             ]
                           },
                           "sessionId": {
@@ -434,7 +437,8 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
-                                  "huggingface"
+                                  "huggingface",
+                                  "reasonix"
                                 ]
                               },
                               "agentId": {
@@ -2621,6 +2625,109 @@ export const epicSchemaSurfaceBaseline = {
                                   "opencodeUserMessageId",
                                   "createdAt"
                                 ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "harnessId": {
+                                    "type": "string",
+                                    "const": "reasonix"
+                                  },
+                                  "hostId": {
+                                    "type": "string"
+                                  },
+                                  "sessionId": {
+                                    "type": "string"
+                                  },
+                                  "sessionWorkspaceSnapshot": {
+                                    "type": "object",
+                                    "properties": {
+                                      "workspaceKind": {
+                                        "type": "string",
+                                        "const": "session-snapshot"
+                                      },
+                                      "primaryWorkspace": {
+                                        "type": "string"
+                                      },
+                                      "secondaryWorkspaces": {
+                                        "default": [],
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "workspaceKind",
+                                      "primaryWorkspace"
+                                    ]
+                                  },
+                                  "createdAt": {
+                                    "type": "number"
+                                  },
+                                  "coveredUntilMessageId": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "profileId": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "labelSnapshot": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "accountUuid": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "accentColor": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "harnessId",
+                                  "hostId",
+                                  "sessionId",
+                                  "sessionWorkspaceSnapshot",
+                                  "createdAt"
+                                ]
                               }
                             ]
                           },
@@ -2678,7 +2785,8 @@ export const epicSchemaSurfaceBaseline = {
                               "pi",
                               "hermes",
                               "omp",
-                              "huggingface"
+                              "huggingface",
+                              "reasonix"
                             ]
                           },
                           "agentId": {
@@ -2813,7 +2921,8 @@ export const epicSchemaSurfaceBaseline = {
                                             "pi",
                                             "hermes",
                                             "omp",
-                                            "huggingface"
+                                            "huggingface",
+                                            "reasonix"
                                           ]
                                         },
                                         "noticeKind": {
@@ -4379,7 +4488,8 @@ export const epicSchemaSurfaceBaseline = {
                                     "pi",
                                     "hermes",
                                     "omp",
-                                    "huggingface"
+                                    "huggingface",
+                                    "reasonix"
                                   ]
                                 },
                                 "source": {
@@ -4406,7 +4516,8 @@ export const epicSchemaSurfaceBaseline = {
                                         "pi",
                                         "hermes",
                                         "omp",
-                                        "huggingface"
+                                        "huggingface",
+                                        "reasonix"
                                       ]
                                     },
                                     "sessionId": {
@@ -5096,7 +5207,8 @@ export const epicSchemaSurfaceBaseline = {
                                                 "pi",
                                                 "hermes",
                                                 "omp",
-                                                "huggingface"
+                                                "huggingface",
+                                                "reasonix"
                                               ]
                                             },
                                             "agentId": {
@@ -5859,7 +5971,8 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
-                                  "huggingface"
+                                  "huggingface",
+                                  "reasonix"
                                 ]
                               },
                               "agentId": {
@@ -7498,7 +7611,8 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "model": {
@@ -7596,7 +7710,8 @@ export const epicSchemaSurfaceBaseline = {
                         "pi",
                         "hermes",
                         "omp",
-                        "huggingface"
+                        "huggingface",
+                        "reasonix"
                       ]
                     },
                     "sessionId": {
@@ -7721,7 +7836,8 @@ export const epicSchemaSurfaceBaseline = {
                               "pi",
                               "hermes",
                               "omp",
-                              "huggingface"
+                              "huggingface",
+                              "reasonix"
                             ]
                           },
                           "sessionId": {
@@ -7861,7 +7977,8 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
-                                  "huggingface"
+                                  "huggingface",
+                                  "reasonix"
                                 ]
                               },
                               "agentId": {
@@ -10210,6 +10327,117 @@ export const epicSchemaSurfaceBaseline = {
                                   "accentColor"
                                 ],
                                 "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "harnessId": {
+                                    "type": "string",
+                                    "const": "reasonix"
+                                  },
+                                  "hostId": {
+                                    "type": "string"
+                                  },
+                                  "sessionId": {
+                                    "type": "string"
+                                  },
+                                  "sessionWorkspaceSnapshot": {
+                                    "type": "object",
+                                    "properties": {
+                                      "workspaceKind": {
+                                        "type": "string",
+                                        "const": "session-snapshot"
+                                      },
+                                      "primaryWorkspace": {
+                                        "type": "string"
+                                      },
+                                      "secondaryWorkspaces": {
+                                        "default": [],
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "workspaceKind",
+                                      "primaryWorkspace",
+                                      "secondaryWorkspaces"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "createdAt": {
+                                    "type": "number"
+                                  },
+                                  "coveredUntilMessageId": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "profileId": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "labelSnapshot": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "accountUuid": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "accentColor": {
+                                    "default": null,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "harnessId",
+                                  "hostId",
+                                  "sessionId",
+                                  "sessionWorkspaceSnapshot",
+                                  "createdAt",
+                                  "coveredUntilMessageId",
+                                  "profileId",
+                                  "labelSnapshot",
+                                  "accountUuid",
+                                  "accentColor"
+                                ],
+                                "additionalProperties": false
                               }
                             ]
                           },
@@ -10268,7 +10496,8 @@ export const epicSchemaSurfaceBaseline = {
                               "pi",
                               "hermes",
                               "omp",
-                              "huggingface"
+                              "huggingface",
+                              "reasonix"
                             ]
                           },
                           "agentId": {
@@ -10408,7 +10637,8 @@ export const epicSchemaSurfaceBaseline = {
                                             "pi",
                                             "hermes",
                                             "omp",
-                                            "huggingface"
+                                            "huggingface",
+                                            "reasonix"
                                           ]
                                         },
                                         "noticeKind": {
@@ -12041,7 +12271,8 @@ export const epicSchemaSurfaceBaseline = {
                                     "pi",
                                     "hermes",
                                     "omp",
-                                    "huggingface"
+                                    "huggingface",
+                                    "reasonix"
                                   ]
                                 },
                                 "source": {
@@ -12068,7 +12299,8 @@ export const epicSchemaSurfaceBaseline = {
                                         "pi",
                                         "hermes",
                                         "omp",
-                                        "huggingface"
+                                        "huggingface",
+                                        "reasonix"
                                       ]
                                     },
                                     "sessionId": {
@@ -12735,7 +12967,8 @@ export const epicSchemaSurfaceBaseline = {
                                                 "pi",
                                                 "hermes",
                                                 "omp",
-                                                "huggingface"
+                                                "huggingface",
+                                                "reasonix"
                                               ]
                                             },
                                             "agentId": {
@@ -13529,7 +13762,8 @@ export const epicSchemaSurfaceBaseline = {
                                   "pi",
                                   "hermes",
                                   "omp",
-                                  "huggingface"
+                                  "huggingface",
+                                  "reasonix"
                                 ]
                               },
                               "agentId": {

--- a/protocol/src/persistence/epic/__tests__/senders.test.ts
+++ b/protocol/src/persistence/epic/__tests__/senders.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { chatSessionAnchorSchema } from "../senders";
+import { chatRunSettingsSchema } from "../foundation";
 
 function claudeAnchorFields() {
   return {
@@ -68,5 +69,87 @@ describe("chatSessionAnchorSchema - accentColor snapshot", () => {
     expect(result.labelSnapshot).toBeNull();
     expect(result.accountUuid).toBeNull();
     expect(result.accentColor).toBeNull();
+  });
+});
+
+// The persisted half of adding a harness, which `adding-a-harness.md` calls the
+// single most dangerous omission in the repo: `persistence/epic/foundation.ts`
+// re-declares its OWN `guiHarnessIdSchema`, deliberately independent of the
+// host RPC enum and kept in sync only by convention. Miss it and every chat run
+// on the new harness becomes unreadable (`CHAT_INVALID`) on reload - a failure
+// that shows up on a user's next launch, not in any compile.
+//
+// Nothing type-checks the two enums against each other, so this asserts the
+// persisted layer directly rather than through anything that imports the RPC
+// enum.
+describe("Reasonix persisted records", () => {
+  it("accepts a reasonix chat run-settings tuple", () => {
+    const settings = chatRunSettingsSchema.parse({
+      harnessId: "reasonix",
+      model: "deepseek-flash/deepseek-v4-flash",
+      permissionMode: "supervised",
+      reasoningEffort: null,
+      agentMode: "regular",
+    });
+
+    expect(settings.harnessId).toBe("reasonix");
+    expect(settings.reasoningEffort).toBeNull();
+    // The two `.default(...)` backstops still apply to a brand-new harness.
+    expect(settings.serviceTier).toBeNull();
+    expect(settings.profileId).toBeNull();
+  });
+
+  // Reasonix's effort surface is DYNAMIC AND PER-MODEL: the levels come from
+  // the session's live `configOptions` array (DeepSeek / Anthropic sets, or an
+  // explicit `supported_efforts`), and that array is replaced wholesale on every
+  // `config_option_update` - so the same install can offer efforts on one model
+  // and none on the next.
+  //
+  // This asserts the persistence layer imposes nothing on top of that. Both a
+  // concrete level and `null` round-trip for `reasonix` exactly as they do for
+  // every other harness, so a per-model catalog is free to grow or shrink
+  // without a persisted record becoming unreadable. Nothing here (and nothing
+  // in the GUI, which reads `supportedReasoningEfforts` off the per-MODEL
+  // catalog row) may hardcode an empty effort set for this harness.
+  it.each([["high"], ["minimal"], [null]])(
+    "round-trips reasoningEffort %s on a reasonix tuple - efforts are per-model, not per-harness",
+    (reasoningEffort) => {
+      const settings = chatRunSettingsSchema.parse({
+        harnessId: "reasonix",
+        model: "deepseek-flash/deepseek-v4-flash",
+        permissionMode: "supervised",
+        reasoningEffort,
+        agentMode: "regular",
+      });
+
+      expect(settings.reasoningEffort).toBe(reasoningEffort);
+    },
+  );
+
+  it("parses a reasonix session anchor as a session-granularity ACP anchor", () => {
+    // Session granularity, like hermes and devin: `session/load` reloads the
+    // whole ACP session and Reasonix has no per-message fork point at all -
+    // `session/fork` answers `-32601`, so there is no truncation id to carry.
+    const anchor = chatSessionAnchorSchema.parse({
+      harnessId: "reasonix",
+      hostId: "host-1",
+      sessionId: "acp-session-1",
+      sessionWorkspaceSnapshot: {
+        workspaceKind: "session-snapshot" as const,
+        primaryWorkspace: "/repo",
+        secondaryWorkspaces: [],
+      },
+      createdAt: 100,
+      coveredUntilMessageId: null,
+    });
+
+    expect(anchor).toMatchObject({
+      harnessId: "reasonix",
+      sessionId: "acp-session-1",
+    });
+    expect(anchor).not.toHaveProperty("opencodeUserMessageId");
+    // Profile snapshot fields default the same way every other anchor's do.
+    expect(anchor.profileId).toBeNull();
+    expect(anchor.accentColor).toBeNull();
   });
 });

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -76,6 +76,7 @@ export const guiHarnessIdSchema = z.enum([
   "hermes",
   "omp",
   "huggingface",
+  "reasonix",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -447,6 +447,23 @@ export type HuggingFaceChatSessionAnchor = z.infer<
   typeof huggingFaceChatSessionAnchorSchema
 >;
 
+// Reasonix (`reasonix acp`) resumes at session granularity only — `session/load`
+// reloads the whole ACP session and there is no per-message truncation/fork
+// point (`session/fork` is genuinely absent: it answers `-32601`) — so the
+// anchor carries just the ACP session id. `sessionId` is that ACP session id.
+export const reasonixChatSessionAnchorSchema = z.object({
+  harnessId: z.literal("reasonix"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  createdAt: z.number(),
+  coveredUntilMessageId: z.string().nullable().default(null),
+  ...profileSnapshotFields,
+});
+export type ReasonixChatSessionAnchor = z.infer<
+  typeof reasonixChatSessionAnchorSchema
+>;
+
 export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   claudeChatSessionAnchorSchema,
   codexChatSessionAnchorSchema,
@@ -467,6 +484,7 @@ export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   hermesChatSessionAnchorSchema,
   ompChatSessionAnchorSchema,
   huggingFaceChatSessionAnchorSchema,
+  reasonixChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;
 


### PR DESCRIPTION
## Summary

- add Reasonix as a first-class GUI harness/provider identity
- version the protocol surfaces that carry harness/provider enums without changing released wire lines
- register Reasonix across onboarding, provider settings, analytics, ordering, chat display, and persistence
- add a neutral Reasonix icon and compatibility coverage for all released protocol baselines

## Validation

- protocol compile, lint, build, and full protocol test suite (2966 tests)
- protocol compatibility against all 17 released baselines
- released-baseline handshake coverage
- gui-app compile/lint and targeted onboarding/provider/settings suites
- clients/shared and traycer-cli compile

## Notes

The corresponding internal host/vendoring PR is being opened in parallel. The protocol changes intentionally introduce new major lines for released enum-bearing responses, including `epic.getChatRunSettings`, rather than widening frozen lines.
