### PR TITLE
fix(gui-app): don't offer "Link a phone" in the mobile app

### DIFF
--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -74,9 +74,10 @@ History keeps its modal on every viewport.
 Everything above is VIEWPORT (`useIsMobileViewport()`) - it flips when a window
 is resized, and a narrow desktop window gets all of it. A separate, smaller set
 of rows is gated on the BUILD (`isMobileApp()`, the Capacitor bundle), because
-what they need is a capability the shell does not have at any width. Do not
-reach for the viewport hook for these: a narrow desktop window still has a
-power bridge and a hardware keyboard.
+what they need is either a capability the shell does not have at any width or a
+product role that build does not play. Do not reach for the viewport hook for
+these: a narrow desktop window still has a power bridge and a hardware
+keyboard, and is still the end of a pairing that shows the code.
 
 - **Voice input** (`voice-settings-section.tsx`) - the build refuses dictation.
 - **Prevent sleep while running** (`prevent-sleep-settings-section.tsx`) - the
@@ -88,6 +89,15 @@ power bridge and a hardware keyboard.
 - **The Keybindings SECTION** - chord capture is `window` `keydown` only
   (`chord-capture-core.tsx`): a tap arms the chip to "Press chord…" and nothing
   can commit it, and a binding clears only with Backspace.
+- **The Link a phone SECTION** - the one entry here that is a PRODUCT call
+  rather than a capability limit, and the distinction is worth keeping. The
+  panel DISPLAYS a QR and a one-time code for another device to read, and in
+  the mobile app that device is the one holding the panel: the phone is the
+  SCANNER (`layout/header/sign-in/link-code-sign-in.tsx` redeems a code this
+  panel mints, and its own copy says "On your desktop, open Settings → Link a
+  phone"). A phone _could_ show the code to a second phone; linking that way is
+  given up knowingly, because a pairing surface that names the wrong end of
+  itself costs more than the case it serves.
 
 Each returns `null` outright rather than rendering disabled with rewritten
 copy: a control the build will never perform is worse than no control.
@@ -100,12 +110,14 @@ resolving one that is not offered. Three surfaces present a choice and so read
 the offered list: the sidebar, the palette's settings sub-page
 (`navigation.source.ts`), and the leader digits (`keybindings/dispatch.ts`,
 which indexes positionally and must walk the same list the sidebar badges).
-Three more can arrive holding an id and each resolves it: the route
-(`settings.keybindings.tsx` `beforeLoad` redirects to `/settings/general` with
-`replace`), the modal (falls back to General for any section the build does not
-offer, since its section is persisted across launches), and the palette's
-`help:keybindings` row, which is dropped rather than left as the one entry
-point that routes around the rest.
+Three more can arrive holding an id and each resolves it: the route (each
+omitted section's own `beforeLoad` redirects to `/settings/general` with
+`replace` - `settings.keybindings.tsx`, `settings.link-phone.tsx`), the modal
+(falls back to General for any section the build does not offer, since its
+section is persisted across launches), and the palette's `help:keybindings`
+row, which is dropped rather than left as the one entry point that routes
+around the rest. Only Keybindings needs that last one; nothing navigates
+directly to Link a phone, so it gets no machinery it does not need.
 
 The gate is by SHELL, not by attached hardware: an iPad running the mobile app
 with a keyboard paired loses the section, which is the accepted cost of

--- a/clients/gui-app/src/components/settings/__tests__/settings-sidebar.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/settings-sidebar.test.tsx
@@ -109,6 +109,38 @@ describe("<SettingsSidebar /> leader hints", () => {
     expect(screen.queryByRole("link", { name: "Keybindings" })).toBeNull();
   });
 
+  // The panel is the DISPLAY end of a pairing whose scanner end is the mobile
+  // app itself, so that build does not offer it either.
+  it("omits the Link a phone entry in the installed mobile app", async () => {
+    setMobileApp(true);
+    const router = buildRouter("/settings/general");
+    render(
+      <KeybindingProvider router={router}>
+        <RouterProvider router={router} />
+      </KeybindingProvider>,
+    );
+
+    expect(await screen.findByRole("link", { name: "General" })).toBeDefined();
+    expect(screen.queryByRole("link", { name: "Link a phone" })).toBeNull();
+    // Its Account-group sibling stays, so what is asserted is one row's
+    // absence rather than a group that failed to render.
+    expect(screen.getByRole("link", { name: "Sessions" })).toBeDefined();
+  });
+
+  it("renders the Link a phone entry on other builds", async () => {
+    setMobileApp(false);
+    const router = buildRouter("/settings/general");
+    render(
+      <KeybindingProvider router={router}>
+        <RouterProvider router={router} />
+      </KeybindingProvider>,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Link a phone" }),
+    ).toBeDefined();
+  });
+
   it("renders the Keybindings entry on other builds", async () => {
     setMobileApp(false);
     const router = buildRouter("/settings/general");

--- a/clients/gui-app/src/lib/__tests__/settings-sections-mobile-app.test.ts
+++ b/clients/gui-app/src/lib/__tests__/settings-sections-mobile-app.test.ts
@@ -1,10 +1,11 @@
 /**
- * Keybindings is not offered in the installed mobile app: chord capture reads
- * `keydown` on `window`, a binding commits on the next full chord and clears
- * only with Backspace, so on a touch shell the chip arms and can never resolve.
+ * Two sections are not offered in the installed mobile app, for two different
+ * reasons: Keybindings because chord capture reads `keydown` on `window` and a
+ * touch shell can never commit one, and Link a phone because the panel is the
+ * DISPLAY end of a pairing whose scanner end is the mobile app itself.
  *
- * The table itself keeps the section, because ids resolve routes, remembered
- * tab paths and titles; only the OFFERED list drops it.
+ * The table itself keeps both, because ids resolve routes, remembered tab
+ * paths and titles; only the OFFERED list drops them.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -25,6 +26,7 @@ describe("visibleSettingsSections", () => {
     // Identity, not just equality: consumers memoize on this list.
     expect(visibleSettingsSections()).toBe(SETTINGS_SECTIONS);
     expect(isSettingsSectionVisible("keybindings")).toBe(true);
+    expect(isSettingsSectionVisible("link-phone")).toBe(true);
   });
 
   it("omits keybindings in the installed mobile app", () => {
@@ -34,18 +36,26 @@ describe("visibleSettingsSections", () => {
     expect(isSettingsSectionVisible("keybindings")).toBe(false);
   });
 
+  it("omits link-phone in the installed mobile app", () => {
+    setMobileApp(true);
+    const ids = visibleSettingsSections().map((section) => section.id);
+    expect(ids).not.toContain("link-phone");
+    expect(isSettingsSectionVisible("link-phone")).toBe(false);
+  });
+
   it("drops nothing else in the installed mobile app", () => {
     setMobileApp(true);
     const ids = visibleSettingsSections().map((section) => section.id);
     const expected = SETTINGS_SECTIONS.map((section) => section.id).filter(
-      (id) => id !== "keybindings",
+      (id) => id !== "keybindings" && id !== "link-phone",
     );
     expect(ids).toEqual(expected);
   });
 
-  it("keeps the section in the resolver table so its id still resolves", () => {
+  it("keeps both sections in the resolver table so their ids still resolve", () => {
     setMobileApp(true);
     const ids = SETTINGS_SECTIONS.map((section) => section.id);
     expect(ids).toContain("keybindings");
+    expect(ids).toContain("link-phone");
   });
 });

--- a/clients/gui-app/src/lib/settings-sections.ts
+++ b/clients/gui-app/src/lib/settings-sections.ts
@@ -233,18 +233,26 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
 ];
 
 /**
- * Sections the installed mobile app does not offer, because the shell cannot
- * drive them at all.
+ * Sections the installed mobile app does not offer. Two different reasons sit
+ * here, and the difference is worth keeping straight:
  *
- * Keybindings is one: every chord in it is captured from a `keydown` on
- * `window` (`chord-capture-core.tsx`), a binding is cleared with Backspace and
- * committed by the next full chord, so on a touch shell the chip arms to
- * "Press chord…" and can never resolve — and an existing binding can never be
- * removed. A section whose every control needs a hardware keyboard is a dead
- * end on a phone, not a sparse page.
+ * - **Keybindings — the shell cannot drive it.** Every chord is captured from
+ *   a `keydown` on `window` (`chord-capture-core.tsx`), a binding is cleared
+ *   with Backspace and committed by the next full chord, so on a touch shell
+ *   the chip arms to "Press chord…" and can never resolve, and an existing
+ *   binding can never be removed. A section whose every control needs a
+ *   hardware keyboard is a dead end on a phone, not a sparse page.
+ * - **Link a phone — the role is backwards.** The panel DISPLAYS a QR and a
+ *   one-time code for another device to read, and in the mobile app that
+ *   device is the one holding the panel: the phone is the SCANNER
+ *   (`link-code-sign-in.tsx` redeems a code this panel mints, and its own copy
+ *   says "On your desktop, open Settings → Link a phone"). A phone could
+ *   physically show the code to a second phone, so this is a product decision
+ *   about which end of the pairing each build is, not an inability.
  */
 const MOBILE_APP_OMITTED_SECTION_IDS: ReadonlySet<SettingsSectionId> = new Set([
   "keybindings",
+  "link-phone",
 ]);
 
 /**

--- a/clients/gui-app/src/routes/__tests__/settings-link-phone-mobile-app-redirect.test.tsx
+++ b/clients/gui-app/src/routes/__tests__/settings-link-phone-mobile-app-redirect.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * `/settings/link-phone` keeps its route on every build, because a URL
+ * outlives the build that produced it - a bookmark, a remembered tab path, or
+ * a settings entry point handed a stored section id all navigate here. Where
+ * the section is not offered, the route lands on General instead of rendering
+ * a panel the navigation beside it has no row for.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { setMobileApp } from "@/lib/mobile-app";
+import { Route as LinkPhoneRoute } from "@/routes/settings.link-phone";
+
+afterEach(() => {
+  setMobileApp(false);
+});
+
+// The route's own `beforeLoad`, mounted into a throwaway route tree rather
+// than invoked directly: a redirect is only worth anything if the ROUTER
+// honors it, so matching, redirect handling and history replacement all have
+// to run. TanStack parameterizes the callback on the full file-route context
+// and this one reads none of it, so a permissive sentinel keeps the fixture
+// decoupled from that type.
+const linkPhoneBeforeLoad = LinkPhoneRoute.options.beforeLoad as (args: {
+  context: object;
+}) => void;
+
+function buildRouter(initialPath: string) {
+  const rootRoute = createRootRoute();
+  const linkPhoneRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings/link-phone",
+    beforeLoad: () => linkPhoneBeforeLoad({ context: {} }),
+    component: () => <div data-testid="link-phone-panel" />,
+  });
+  const generalRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings/general",
+    component: () => <div data-testid="general-panel" />,
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([linkPhoneRoute, generalRoute]),
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+describe("/settings/link-phone route", () => {
+  it("stays on the section for builds that offer it", async () => {
+    setMobileApp(false);
+    const router = buildRouter("/settings/link-phone");
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/settings/link-phone");
+    // The real route renders the panel; the fixture above substitutes a stub
+    // for it, so what is asserted here is that the route resolves rather than
+    // redirects.
+    expect(LinkPhoneRoute.options.component).toBeDefined();
+  });
+
+  it("lands on General in the installed mobile app", async () => {
+    setMobileApp(true);
+    const router = buildRouter("/settings/link-phone");
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/settings/general");
+    // `replace`, so the link-phone entry is overwritten rather than pushed -
+    // Back leaves Settings instead of bouncing off this route into General
+    // again.
+    expect(router.history.length).toBe(1);
+  });
+
+  it("leaves other settings routes alone in the installed mobile app", async () => {
+    setMobileApp(true);
+    const router = buildRouter("/settings/general");
+    await router.load();
+
+    expect(router.state.location.pathname).toBe("/settings/general");
+  });
+});

--- a/clients/gui-app/src/routes/settings.link-phone.tsx
+++ b/clients/gui-app/src/routes/settings.link-phone.tsx
@@ -1,6 +1,26 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { LinkPhonePanel } from "@/components/settings/panels/link-phone-panel";
+import { isSettingsSectionVisible } from "@/lib/settings-sections";
 
 export const Route = createFileRoute("/settings/link-phone")({
+  /**
+   * Builds that do not offer this section still have its route, because a URL
+   * outlives the build that produced it - a bookmark, a remembered tab path,
+   * or a settings entry point handed a stored section id all land here. They
+   * land on General instead, which is where `/settings` itself resolves and
+   * what the settings modal falls back to, rather than on a page with no row
+   * in the navigation beside it.
+   *
+   * `throw: true` makes `redirect()` throw the redirect Response itself instead
+   * of returning it - the canonical TanStack Router short-circuit, with the
+   * explicit `throw` keyword kept out of our source so the `only-throw-error`
+   * lint stays happy. `replace: true` keeps the redirected-from entry out of
+   * the history stack, so Back leaves Settings instead of bouncing off this
+   * route again.
+   */
+  beforeLoad: () => {
+    if (isSettingsSectionVisible("link-phone")) return;
+    redirect({ throw: true, to: "/settings/general", replace: true });
+  },
   component: LinkPhonePanel,
 });


### PR DESCRIPTION
## The bug

Settings → **Link a phone** displays a QR and a one-time code for *another* device to read. In the mobile app, that other device is the one holding the panel — the phone is the **scanner**, not the display.

The app already says so. `layout/header/sign-in/link-code-sign-in.tsx` redeems the code this panel mints, and its own on-screen copy reads:

> On your desktop, open Settings → Link a phone, then scan the QR — or type the code.

So the phone told you the panel lives on your desktop, while its own sidebar offered you that panel one tap away.

## The fix

One entry in `visibleSettingsSections()`'s omitted set, which is the mechanism #1431 established: `SETTINGS_SECTIONS` stays whole as the **resolver** table (ids are a compatibility surface for routes, remembered tab paths and titles), while the **offered** list drops the section — covering the sidebar, the palette's settings sub-page, and the leader digits in one edit, since the digits index positionally and must walk the same list the sidebar badges.

Plus the route guard, because a URL outlives the build that produced it: `settings.link-phone.tsx` gains the same `beforeLoad` redirect to `/settings/general` with `replace: true`, so a bookmark, a remembered tab path or a stored section id lands on the page every other settings entry point resolves to. The persisted-modal-section case needs nothing new — `isSettingsSectionVisible` already covers it.

**And nothing else, deliberately.** Keybindings needed a palette row dropped because `help:keybindings` navigated straight into it. This section has no such entry point — verified by grepping `navigateSettingsSection`, `settingsRouteOptions` and the id itself. Adding that machinery "for symmetry" would be carrying a fix past the problem it was for.

## Why `isMobileApp()`, and why the doc comment now names two reasons

The other build-gated controls are **capability** facts: `resolveDesktopPowerBridge` returns null, so the prevent-sleep switch *cannot* work; chord capture needs a `keydown` a touch shell *cannot* produce.

This one is not. A phone **can** display a QR for another phone to scan. What is wrong is the **role** — which end of the pairing this build is — and that is a product fact about the shell, fixed at build time. Still `isMobileApp()` and still not the viewport (a narrow desktop window is very much still the end that shows the code), but justified differently.

So `MOBILE_APP_OMITTED_SECTION_IDS` now documents **both** reasons — *the shell cannot drive it* and *the role is backwards* — rather than letting a second entry silently widen a rule the comment stated as one. A set whose doc implies one rule while holding entries justified by two is how the next person copies the wrong rationale into a third.

## The deliberate loss

**Linking a second phone by displaying the QR on the first is sacrificed knowingly.** That flow is possible in principle and is given up: a pairing surface that names the wrong end of itself costs more than the case it serves. If it is ever wanted back, the honest shape is a mobile-specific presentation that says which device is which — not un-hiding a panel written for the desktop.

## Verification

`compile` clean. `eslint --max-warnings 0` and `prettier --check` clean on changed files. **22 tests pass across 4 files:**

- `settings-sections-mobile-app.test.ts` — `link-phone` omitted on the mobile build and present elsewhere, *only* it and `keybindings` dropped, both still in the resolver table, and the off-mobile return still identical by reference.
- `settings-link-phone-mobile-app-redirect.test.tsx` — new, built like the one CodeRabbit blessed on #1431: the route's real `beforeLoad` mounted into a memory router and loaded, so matching, redirect handling and history replacement actually run. Asserts `/settings/general` and `history.length === 1`.
- `settings-sidebar.test.tsx` — two added cases; the mobile one also asserts the Account group's sibling row (**Sessions**) still renders, so it pins one row's absence rather than a group that failed to draw.
- `settings-keybindings-mobile-app-redirect.test.tsx` — unchanged and still green, which is the no-regression claim for the shared mechanism.

`SETTINGS.md` moves with the surface per the repo rule, carrying the capability-vs-role split.
