### PR TITLE
fix(interview): scope lifecycle projections

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -1495,7 +1495,6 @@ describe("createChatSessionStore", () => {
       draftAnswers: [],
       delivery: null,
     });
-
     const message = harness.handle.store.getState().messages[0];
     const block =
       message.role === "assistant"
@@ -1508,6 +1507,190 @@ describe("createChatSessionStore", () => {
       outcome: "answered",
       settlement: { settlementId: "settlement-new", source: "gui" },
       delivery: { deliveryId: "delivery-new", status: "failed" },
+    });
+  });
+
+  it("applies a lifecycle frame only to the newest unresolved owner when block ids repeat", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    const historical = persistedInterviewMessage({
+      deliveryId: "delivery-old",
+      status: "pending",
+      retryable: true,
+      generation: 0,
+    });
+    const current = persistedInterviewMessage({
+      deliveryId: "delivery-placeholder",
+      status: "pending",
+      retryable: true,
+      generation: 0,
+    });
+    const currentBlock = current.blocks[0];
+    if (currentBlock.type !== "interview") {
+      throw new Error("Expected interview");
+    }
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [
+        { ...historical, messageId: "assistant-historical" },
+        {
+          ...current,
+          messageId: "assistant-current",
+          blocks: [
+            {
+              ...currentBlock,
+              status: "streaming",
+              answers: [],
+              outcome: null,
+              settlement: null,
+              delivery: null,
+            },
+          ],
+        },
+      ],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+
+    // An unchanged update for the older exact settlement must still count as
+    // routed; it must not fall through and install old authority on the newer
+    // unresolved row that happens to reuse the block id.
+    callbacks.onInterviewAnswered({
+      kind: "interviewAnswered",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId: "interview-delivery-retry",
+      answers: [
+        {
+          questionId: "q1",
+          question: "Which scope?",
+          values: ["Alpha"],
+          notes: null,
+          selection: null,
+        },
+      ],
+      resolvedAt: 4,
+      settlementId: "settlement-1",
+      settlementSource: "gui",
+      delivery: {
+        deliveryId: "delivery-old",
+        status: "pending",
+        retryable: true,
+        generation: 0,
+      },
+    });
+    callbacks.onInterviewAnswered({
+      kind: "interviewAnswered",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId: "interview-delivery-retry",
+      answers: [
+        {
+          questionId: "q1",
+          question: "Which scope?",
+          values: ["Beta"],
+          notes: null,
+          selection: null,
+        },
+      ],
+      resolvedAt: 5,
+      settlementId: "settlement-current",
+      settlementSource: "gui",
+      delivery: null,
+    });
+    callbacks.onInterviewAnswered({
+      kind: "interviewAnswered",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId: "interview-delivery-retry",
+      answers: [
+        {
+          questionId: "q1",
+          question: "Which scope?",
+          values: ["Alpha"],
+          notes: null,
+          selection: null,
+        },
+      ],
+      resolvedAt: 6,
+      settlementId: "settlement-1",
+      settlementSource: "gui",
+      delivery: {
+        deliveryId: "delivery-old",
+        status: "failed",
+        retryable: true,
+        generation: 1,
+      },
+    });
+
+    const messages = harness.handle.store.getState().messages;
+    const oldBlock =
+      messages[0]?.role === "assistant" ? messages[0].blocks[0] : null;
+    const newBlock =
+      messages[1]?.role === "assistant" ? messages[1].blocks[0] : null;
+    expect(oldBlock).toMatchObject({
+      outcome: "answered",
+      answers: [{ values: ["Alpha"] }],
+      settlement: { settlementId: "settlement-1" },
+      delivery: { deliveryId: "delivery-old", generation: 1 },
+    });
+    expect(newBlock).toMatchObject({
+      outcome: "answered",
+      answers: [{ values: ["Beta"] }],
+      settlement: { settlementId: "settlement-current" },
+    });
+  });
+
+  it("does not let an ambiguous legacy cleanup overwrite a terminal outcome", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    const persisted = persistedInterviewMessage({
+      deliveryId: "delivery-legacy",
+      status: "delivered",
+      retryable: false,
+      generation: 0,
+    });
+    const existing = persisted.blocks[0];
+    if (existing.type !== "interview") throw new Error("Expected interview");
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [
+        {
+          ...persisted,
+          blocks: [{ ...existing, settlement: null, delivery: null }],
+        },
+      ],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+
+    callbacks.onInterviewErrored({
+      kind: "interviewErrored",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId: "interview-delivery-retry",
+      reason: "Late ambiguous cleanup",
+      resolvedAt: 6,
+      settlementId: null,
+      settlementSource: null,
+      outcome: null,
+      draftAnswers: [],
+      delivery: null,
+    });
+
+    const message = harness.handle.store.getState().messages[0];
+    const block = message.role === "assistant" ? message.blocks[0] : null;
+    expect(block).toMatchObject({
+      status: "completed",
+      outcome: "answered",
+      answers: [{ values: ["Alpha"] }],
+      error: null,
     });
   });
 

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -1645,6 +1645,157 @@ describe("createChatSessionStore", () => {
     });
   });
 
+  it("preserves the current pending owner when historical lifecycle frames reuse its block id", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    const blockId = "interview-delivery-retry";
+    const historicalAnswered = persistedInterviewMessage({
+      deliveryId: "delivery-historical-answered",
+      status: "pending",
+      retryable: true,
+      generation: 0,
+    });
+    const historicalErrored = persistedInterviewMessage({
+      deliveryId: "delivery-historical-errored",
+      status: "pending",
+      retryable: true,
+      generation: 0,
+    });
+    const current = persistedInterviewMessage({
+      deliveryId: "delivery-current-placeholder",
+      status: "pending",
+      retryable: true,
+      generation: 0,
+    });
+    const answeredBlock = historicalAnswered.blocks[0];
+    const erroredBlock = historicalErrored.blocks[0];
+    const currentBlock = current.blocks[0];
+    if (
+      answeredBlock.type !== "interview" ||
+      erroredBlock.type !== "interview" ||
+      currentBlock.type !== "interview"
+    ) {
+      throw new Error("Expected interview blocks");
+    }
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [
+        {
+          ...historicalAnswered,
+          messageId: "assistant-historical-answered",
+          blocks: [
+            {
+              ...answeredBlock,
+              settlement: {
+                settlementId: "settlement-historical-answered",
+                source: "gui",
+              },
+            },
+          ],
+        },
+        {
+          ...historicalErrored,
+          messageId: "assistant-historical-errored",
+          blocks: [
+            {
+              ...erroredBlock,
+              settlement: {
+                settlementId: "settlement-historical-errored",
+                source: "gui",
+              },
+            },
+          ],
+        },
+        {
+          ...current,
+          messageId: "assistant-current-pending",
+          blocks: [
+            {
+              ...currentBlock,
+              status: "streaming",
+              answers: [],
+              outcome: null,
+              settlement: null,
+              delivery: null,
+            },
+          ],
+        },
+      ],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+      pendingInterviews: [{ blockId, requestedAt: 2 }],
+    });
+    const draft = {
+      pageIndex: 0,
+      answers: [{ selected: ["Beta"], otherText: "", otherSelected: false }],
+    };
+    useInterviewDraftStore.getState().saveDraft(CHAT_ID, blockId, draft);
+    const actionId = harness.handle.store
+      .getState()
+      .interviewAnswer(blockId, []);
+    if (actionId === null) throw new Error("Expected interview answer action");
+
+    const expectCurrentOwnerStatePreserved = (): void => {
+      expect(harness.handle.store.getState().pendingInterviews).toEqual([
+        { blockId, requestedAt: 2 },
+      ]);
+      expect(readInterviewDraftSnapshot(CHAT_ID, blockId)).toEqual(draft);
+    };
+
+    callbacks.onInterviewAnswered({
+      kind: "interviewAnswered",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId,
+      answers: [],
+      resolvedAt: 4,
+      settlementId: "settlement-historical-answered",
+      settlementSource: "gui",
+      delivery: null,
+    });
+    expectCurrentOwnerStatePreserved();
+    expect(
+      harness.handle.store.getState().pendingActions[actionId],
+    ).toBeDefined();
+
+    callbacks.onActionAck({
+      kind: "actionAck",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      clientActionId: actionId,
+      action: "interviewAnswer",
+      status: "accepted",
+      reason: null,
+      code: null,
+      backgroundStopTaskIds: [],
+    });
+    expect(
+      harness.handle.store.getState().acceptedActions[actionId],
+    ).toBeDefined();
+
+    callbacks.onInterviewErrored({
+      kind: "interviewErrored",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      blockId,
+      reason: "Historical failure",
+      resolvedAt: 5,
+      settlementId: "settlement-historical-errored",
+      settlementSource: "gui",
+      outcome: "failed",
+      draftAnswers: [],
+      delivery: null,
+    });
+    expectCurrentOwnerStatePreserved();
+    expect(
+      harness.handle.store.getState().acceptedActions[actionId],
+    ).toBeDefined();
+  });
+
   it("does not let an ambiguous legacy cleanup overwrite a terminal outcome", () => {
     const harness = createHarness();
     const callbacks = harness.callbacks();

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -2599,19 +2599,8 @@ export function createChatSessionStoreWithNotificationDependencies(
           .getState()
           .clearDraft(frame.chatId, frame.blockId);
         set((state) => {
-          const messages = withInterviewLifecycleProjection(state.messages, {
-            kind: "answered",
-            blockId: frame.blockId,
-            settlementId: frame.settlementId,
-            settlementSource: frame.settlementSource,
-            resolvedAt: frame.resolvedAt,
-            answers: frame.answers,
-            reason: null,
-            outcome: "answered",
-            draftAnswers: [],
-            delivery: frame.delivery,
-          });
-          const liveAssistantMessage = withLiveInterviewLifecycleProjection(
+          const lifecycle = withInterviewLifecycleState(
+            state.messages,
             state.liveAssistantMessage,
             {
               kind: "answered",
@@ -2626,6 +2615,7 @@ export function createChatSessionStoreWithNotificationDependencies(
               delivery: frame.delivery,
             },
           );
+          const { messages, liveAssistantMessage } = lifecycle;
           return {
             messages,
             liveAssistantMessage,
@@ -2660,19 +2650,8 @@ export function createChatSessionStoreWithNotificationDependencies(
           .getState()
           .clearDraft(frame.chatId, frame.blockId);
         set((state) => {
-          const messages = withInterviewLifecycleProjection(state.messages, {
-            kind: "errored",
-            blockId: frame.blockId,
-            settlementId: frame.settlementId,
-            settlementSource: frame.settlementSource,
-            resolvedAt: frame.resolvedAt,
-            answers: [],
-            reason: frame.reason,
-            outcome: frame.outcome,
-            draftAnswers: frame.draftAnswers,
-            delivery: frame.delivery,
-          });
-          const liveAssistantMessage = withLiveInterviewLifecycleProjection(
+          const lifecycle = withInterviewLifecycleState(
+            state.messages,
             state.liveAssistantMessage,
             {
               kind: "errored",
@@ -2687,6 +2666,7 @@ export function createChatSessionStoreWithNotificationDependencies(
               delivery: frame.delivery,
             },
           );
+          const { messages, liveAssistantMessage } = lifecycle;
           return {
             messages,
             liveAssistantMessage,
@@ -4845,85 +4825,207 @@ type InterviewLifecycleProjection = {
 function withInterviewLifecycleBlocks(
   blocks: ReadonlyArray<ContentBlock>,
   projection: InterviewLifecycleProjection,
+  allowUnresolvedFallback: boolean,
 ): ReadonlyArray<ContentBlock> {
-  const next = blocks.map((block): ContentBlock => {
-    if (block.type !== "interview" || block.blockId !== projection.blockId) {
-      return block;
-    }
-    if (
-      block.settlement !== null &&
-      projection.settlementId !== null &&
-      block.settlement.settlementId !== projection.settlementId
-    ) {
-      return block;
-    }
-    if (
-      projection.settlementId !== null &&
-      projection.settlementSource !== null &&
-      projection.outcome !== null
-    ) {
-      const reduced = applyInterviewSettlement(block, {
-        settlementId: projection.settlementId,
-        source: projection.settlementSource,
-        outcome: projection.outcome,
-        answers: [...projection.answers],
-        draftAnswers: [...projection.draftAnswers],
-        reason: projection.reason,
-        diagnostic: null,
-        delivery: projection.delivery,
-        timestamp: projection.resolvedAt,
-      });
-      return reduced.changed ? { ...block, ...reduced.patch } : block;
-    }
-    if (block.settlement !== null) return block;
+  const targetIndex = interviewLifecycleBlockIndex(
+    blocks,
+    projection,
+    allowUnresolvedFallback,
+  );
+  if (targetIndex < 0) return blocks;
+  const block = blocks[targetIndex];
+  if (block.type !== "interview") return blocks;
+  let updated: ContentBlock;
+  if (
+    projection.settlementId !== null &&
+    projection.settlementSource !== null &&
+    projection.outcome !== null
+  ) {
+    const reduced = applyInterviewSettlement(block, {
+      settlementId: projection.settlementId,
+      source: projection.settlementSource,
+      outcome: projection.outcome,
+      answers: [...projection.answers],
+      draftAnswers: [...projection.draftAnswers],
+      reason: projection.reason,
+      diagnostic: null,
+      delivery: projection.delivery,
+      timestamp: projection.resolvedAt,
+    });
+    updated = reduced.changed ? { ...block, ...reduced.patch } : block;
+  } else if (block.settlement !== null || block.outcome !== null) {
+    // A partial legacy tuple cannot weaken a terminal fact already projected
+    // for this row. This also makes duplicate legacy cleanup frames monotonic.
+    updated = block;
+  } else {
     const delivery = block.delivery;
-    return projection.kind === "answered"
-      ? {
-          ...block,
-          status: "completed",
-          answers: [...projection.answers],
-          error: null,
-          outcome: "answered",
-          draftAnswers: [],
-          delivery,
-        }
-      : {
-          ...block,
-          status: "errored",
-          error: projection.reason,
-          outcome: projection.outcome,
-          draftAnswers:
-            projection.outcome === "skipped"
-              ? [...projection.draftAnswers]
-              : [],
-          delivery,
-        };
-  });
-  return next.some((block, index) => block !== blocks[index]) ? next : blocks;
+    updated =
+      projection.kind === "answered"
+        ? {
+            ...block,
+            status: "completed",
+            answers: [...projection.answers],
+            error: null,
+            outcome: "answered",
+            draftAnswers: [],
+            delivery,
+          }
+        : {
+            ...block,
+            status: "errored",
+            error: projection.reason,
+            outcome: projection.outcome,
+            draftAnswers:
+              projection.outcome === "skipped"
+                ? [...projection.draftAnswers]
+                : [],
+            delivery,
+          };
+  }
+  if (updated === block) return blocks;
+  const next = blocks.slice();
+  next[targetIndex] = updated;
+  return next;
 }
 
-function withInterviewLifecycleProjection(
+function interviewLifecycleBlockIndex(
+  blocks: ReadonlyArray<ContentBlock>,
+  projection: InterviewLifecycleProjection,
+  allowUnresolvedFallback: boolean,
+): number {
+  if (projection.settlementId !== null) {
+    for (let index = blocks.length - 1; index >= 0; index -= 1) {
+      const block = blocks[index];
+      if (
+        block.type === "interview" &&
+        block.blockId === projection.blockId &&
+        block.settlement?.settlementId === projection.settlementId
+      ) {
+        return index;
+      }
+    }
+  }
+  if (!allowUnresolvedFallback) return -1;
+  // A first lifecycle frame installs authority only on the newest unresolved
+  // owner. Never fall back to an older terminal row that merely reused the id.
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    if (
+      block.type === "interview" &&
+      block.blockId === projection.blockId &&
+      block.status === "streaming" &&
+      block.settlement === null
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function withInterviewLifecycleProjectionPass(
   messages: ReadonlyArray<Message>,
   projection: InterviewLifecycleProjection,
-): ReadonlyArray<Message> {
-  const next = messages.map((message): Message => {
-    if (message.role !== "assistant") return message;
-    const blocks = withInterviewLifecycleBlocks(message.blocks, projection);
-    if (blocks === message.blocks) return message;
-    return { ...message, blocks: [...blocks] };
-  });
-  return next.some((message, index) => message !== messages[index])
-    ? next
-    : messages;
+  allowUnresolvedFallback: boolean,
+): {
+  readonly messages: ReadonlyArray<Message>;
+  readonly matched: boolean;
+} {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== "assistant") continue;
+    if (
+      interviewLifecycleBlockIndex(
+        message.blocks,
+        projection,
+        allowUnresolvedFallback,
+      ) < 0
+    ) {
+      continue;
+    }
+    const blocks = withInterviewLifecycleBlocks(
+      message.blocks,
+      projection,
+      allowUnresolvedFallback,
+    );
+    if (blocks === message.blocks) return { messages, matched: true };
+    const next = messages.slice();
+    next[index] = { ...message, blocks: [...blocks] };
+    return { messages: next, matched: true };
+  }
+  return { messages, matched: false };
 }
 
-function withLiveInterviewLifecycleProjection(
-  message: LiveAssistantMessage | null,
+function withInterviewLifecycleState(
+  messages: ReadonlyArray<Message>,
+  liveAssistantMessage: LiveAssistantMessage | null,
   projection: InterviewLifecycleProjection,
-): LiveAssistantMessage | null {
-  if (message === null) return null;
-  const blocks = withInterviewLifecycleBlocks(message.blocks, projection);
-  return blocks === message.blocks ? message : { ...message, blocks };
+): {
+  readonly messages: ReadonlyArray<Message>;
+  readonly liveAssistantMessage: LiveAssistantMessage | null;
+} {
+  if (projection.settlementId !== null) {
+    const exactMessages = withInterviewLifecycleProjectionPass(
+      messages,
+      projection,
+      false,
+    );
+    if (exactMessages.matched) {
+      return { messages: exactMessages.messages, liveAssistantMessage };
+    }
+    if (liveAssistantMessage !== null) {
+      const exactLiveMatched =
+        interviewLifecycleBlockIndex(
+          liveAssistantMessage.blocks,
+          projection,
+          false,
+        ) >= 0;
+      const exactLiveBlocks = withInterviewLifecycleBlocks(
+        liveAssistantMessage.blocks,
+        projection,
+        false,
+      );
+      if (exactLiveMatched) {
+        return {
+          messages,
+          liveAssistantMessage:
+            exactLiveBlocks === liveAssistantMessage.blocks
+              ? liveAssistantMessage
+              : { ...liveAssistantMessage, blocks: exactLiveBlocks },
+        };
+      }
+    }
+  }
+  if (liveAssistantMessage !== null) {
+    const liveMatched =
+      interviewLifecycleBlockIndex(
+        liveAssistantMessage.blocks,
+        projection,
+        true,
+      ) >= 0;
+    const liveBlocks = withInterviewLifecycleBlocks(
+      liveAssistantMessage.blocks,
+      projection,
+      true,
+    );
+    if (liveMatched) {
+      return {
+        messages,
+        liveAssistantMessage:
+          liveBlocks === liveAssistantMessage.blocks
+            ? liveAssistantMessage
+            : { ...liveAssistantMessage, blocks: liveBlocks },
+      };
+    }
+  }
+  const unresolvedMessages = withInterviewLifecycleProjectionPass(
+    messages,
+    projection,
+    true,
+  );
+  return {
+    messages: unresolvedMessages.messages,
+    liveAssistantMessage,
+  };
 }
 
 function assistantMessageOwnsBlock(message: Message, blockId: string): boolean {

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -2591,104 +2591,117 @@ export function createChatSessionStoreWithNotificationDependencies(
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
           return;
         }
-        // Authoritative resolution boundary: the host accepted the answer, so
-        // the retained draft is now safe to discard (the card unmounts as the
-        // interview leaves the pending set). Also drop this block's pending/
-        // accepted actions so their busy gate can never outlive the interview.
-        useInterviewDraftStore
-          .getState()
-          .clearDraft(frame.chatId, frame.blockId);
-        set((state) => {
-          const lifecycle = withInterviewLifecycleState(
-            state.messages,
-            state.liveAssistantMessage,
-            {
-              kind: "answered",
-              blockId: frame.blockId,
-              settlementId: frame.settlementId,
-              settlementSource: frame.settlementSource,
-              resolvedAt: frame.resolvedAt,
-              answers: frame.answers,
-              reason: null,
-              outcome: "answered",
-              draftAnswers: [],
-              delivery: frame.delivery,
-            },
-          );
-          const { messages, liveAssistantMessage } = lifecycle;
-          return {
+        const state = get();
+        const lifecycle = withInterviewLifecycleState(
+          state.messages,
+          state.liveAssistantMessage,
+          {
+            kind: "answered",
+            blockId: frame.blockId,
+            settlementId: frame.settlementId,
+            settlementSource: frame.settlementSource,
+            resolvedAt: frame.resolvedAt,
+            answers: frame.answers,
+            reason: null,
+            outcome: "answered",
+            draftAnswers: [],
+            delivery: frame.delivery,
+          },
+        );
+        const resolvedPendingOwner =
+          lifecycle.resolvedPendingOwner ||
+          (!lifecycle.matchedOwner &&
+            state.pendingInterviews.some(
+              (interview) => interview.blockId === frame.blockId,
+            ));
+        const { messages, liveAssistantMessage } = lifecycle;
+        set({
+          messages,
+          liveAssistantMessage,
+          pendingInterviews: resolvedPendingOwner
+            ? withoutPendingInterview(state.pendingInterviews, frame.blockId)
+            : state.pendingInterviews,
+          pendingActions: resolvedPendingOwner
+            ? withoutInterviewActionsForBlock(
+                state.pendingActions,
+                frame.blockId,
+              )
+            : state.pendingActions,
+          acceptedActions: withoutSupersededInterviewDeliveryRetryActions(
+            resolvedPendingOwner
+              ? withoutInterviewActionsForBlock(
+                  state.acceptedActions,
+                  frame.blockId,
+                )
+              : state.acceptedActions,
             messages,
             liveAssistantMessage,
-            pendingInterviews: withoutPendingInterview(
-              state.pendingInterviews,
-              frame.blockId,
-            ),
-            pendingActions: withoutInterviewActionsForBlock(
-              state.pendingActions,
-              frame.blockId,
-            ),
-            acceptedActions: withoutSupersededInterviewDeliveryRetryActions(
-              withoutInterviewActionsForBlock(
-                state.acceptedActions,
-                frame.blockId,
-              ),
-              messages,
-              liveAssistantMessage,
-              null,
-            ),
-          };
+            null,
+          ),
         });
+        if (resolvedPendingOwner) {
+          useInterviewDraftStore
+            .getState()
+            .clearDraft(frame.chatId, frame.blockId);
+        }
       },
       onInterviewErrored: (frame) => {
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
           return;
         }
-        // The interview is resolved (skipped/errored) authoritatively; drop the
-        // retained draft and this block's actions on the same lifecycle
-        // boundary as an accepted answer.
-        useInterviewDraftStore
-          .getState()
-          .clearDraft(frame.chatId, frame.blockId);
-        set((state) => {
-          const lifecycle = withInterviewLifecycleState(
-            state.messages,
-            state.liveAssistantMessage,
-            {
-              kind: "errored",
-              blockId: frame.blockId,
-              settlementId: frame.settlementId,
-              settlementSource: frame.settlementSource,
-              resolvedAt: frame.resolvedAt,
-              answers: [],
-              reason: frame.reason,
-              outcome: frame.outcome,
-              draftAnswers: frame.draftAnswers,
-              delivery: frame.delivery,
-            },
-          );
-          const { messages, liveAssistantMessage } = lifecycle;
-          return {
+        const state = get();
+        const lifecycle = withInterviewLifecycleState(
+          state.messages,
+          state.liveAssistantMessage,
+          {
+            kind: "errored",
+            blockId: frame.blockId,
+            settlementId: frame.settlementId,
+            settlementSource: frame.settlementSource,
+            resolvedAt: frame.resolvedAt,
+            answers: [],
+            reason: frame.reason,
+            outcome: frame.outcome,
+            draftAnswers: frame.draftAnswers,
+            delivery: frame.delivery,
+          },
+        );
+        const resolvedPendingOwner =
+          lifecycle.resolvedPendingOwner ||
+          (!lifecycle.matchedOwner &&
+            state.pendingInterviews.some(
+              (interview) => interview.blockId === frame.blockId,
+            ));
+        const { messages, liveAssistantMessage } = lifecycle;
+        set({
+          messages,
+          liveAssistantMessage,
+          pendingInterviews: resolvedPendingOwner
+            ? withoutPendingInterview(state.pendingInterviews, frame.blockId)
+            : state.pendingInterviews,
+          pendingActions: resolvedPendingOwner
+            ? withoutInterviewActionsForBlock(
+                state.pendingActions,
+                frame.blockId,
+              )
+            : state.pendingActions,
+          acceptedActions: withoutSupersededInterviewDeliveryRetryActions(
+            resolvedPendingOwner
+              ? withoutInterviewActionsForBlock(
+                  state.acceptedActions,
+                  frame.blockId,
+                )
+              : state.acceptedActions,
             messages,
             liveAssistantMessage,
-            pendingInterviews: withoutPendingInterview(
-              state.pendingInterviews,
-              frame.blockId,
-            ),
-            pendingActions: withoutInterviewActionsForBlock(
-              state.pendingActions,
-              frame.blockId,
-            ),
-            acceptedActions: withoutSupersededInterviewDeliveryRetryActions(
-              withoutInterviewActionsForBlock(
-                state.acceptedActions,
-                frame.blockId,
-              ),
-              messages,
-              liveAssistantMessage,
-              null,
-            ),
-          };
+            null,
+          ),
         });
+        if (resolvedPendingOwner) {
+          useInterviewDraftStore
+            .getState()
+            .clearDraft(frame.chatId, frame.blockId);
+        }
       },
       onEventAppended: (frame) => {
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
@@ -4962,6 +4975,8 @@ function withInterviewLifecycleState(
 ): {
   readonly messages: ReadonlyArray<Message>;
   readonly liveAssistantMessage: LiveAssistantMessage | null;
+  readonly matchedOwner: boolean;
+  readonly resolvedPendingOwner: boolean;
 } {
   if (projection.settlementId !== null) {
     const exactMessages = withInterviewLifecycleProjectionPass(
@@ -4970,7 +4985,12 @@ function withInterviewLifecycleState(
       false,
     );
     if (exactMessages.matched) {
-      return { messages: exactMessages.messages, liveAssistantMessage };
+      return {
+        messages: exactMessages.messages,
+        liveAssistantMessage,
+        matchedOwner: true,
+        resolvedPendingOwner: false,
+      };
     }
     if (liveAssistantMessage !== null) {
       const exactLiveMatched =
@@ -4991,6 +5011,8 @@ function withInterviewLifecycleState(
             exactLiveBlocks === liveAssistantMessage.blocks
               ? liveAssistantMessage
               : { ...liveAssistantMessage, blocks: exactLiveBlocks },
+          matchedOwner: true,
+          resolvedPendingOwner: false,
         };
       }
     }
@@ -5014,6 +5036,8 @@ function withInterviewLifecycleState(
           liveBlocks === liveAssistantMessage.blocks
             ? liveAssistantMessage
             : { ...liveAssistantMessage, blocks: liveBlocks },
+        matchedOwner: true,
+        resolvedPendingOwner: true,
       };
     }
   }
@@ -5025,6 +5049,8 @@ function withInterviewLifecycleState(
   return {
     messages: unresolvedMessages.messages,
     liveAssistantMessage,
+    matchedOwner: unresolvedMessages.matched,
+    resolvedPendingOwner: unresolvedMessages.matched,
   };
 }
 


### PR DESCRIPTION
## Summary
- route interview lifecycle frames to one authoritative transcript owner instead of every reused block ID
- prefer exact settlement ownership across persisted and live messages before unresolved fallback
- preserve terminal canonical outcomes when legacy frames carry no settlement identity

## Regression coverage
- repeated block IDs with older settled and newer unresolved owners
- exact no-op delivery updates cannot fall through to another owner
- ambiguous legacy cleanup cannot overwrite a terminal answered outcome

## Validation
- focused chat-session-store lifecycle tests passed
- affected build, compile, lint, and format checks passed in the commit hook

Follow-up to #1422 review findings.