### PR TITLE
fix(gui-app): add a word-wrap toggle to the workspace file viewer

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-word-wrap.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-word-wrap.test.tsx
@@ -1,0 +1,173 @@
+import "../../../../../__tests__/test-browser-apis";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import type { WorkspaceFileRef } from "@/stores/epics/canvas/types";
+import { fileEditRuntimeRegistry } from "@/lib/workspace/file-edit-runtime-registry";
+
+interface WordWrapTestState {
+  coarsePointer: boolean;
+  readonly rendererWordWrap: Mock<(wordWrap: boolean) => void>;
+}
+
+const state = vi.hoisted((): WordWrapTestState => ({
+  coarsePointer: false,
+  rendererWordWrap: vi.fn(),
+}));
+
+vi.mock("@/components/diff/diff-edit-provider-loader", () => ({
+  preloadDiffEditProvider: () => Promise.resolve(),
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => ({ status: "reachable", hostLabel: "Host A" }),
+}));
+
+vi.mock("@/hooks/host/use-tab-host-client", () => ({
+  useTabHostClient: () => null,
+}));
+
+vi.mock("@/hooks/host/use-host-supports-method", () => ({
+  useHostSupportsMethod: () => false,
+}));
+
+vi.mock("@/hooks/workspace/use-read-file-query", () => ({
+  useWorkspaceReadFile: () => ({
+    data: { content: "const value = 1;\n", error: null, truncated: false },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+// The pointer class is the whole input to the default, and jsdom's
+// `matchMedia` answers `false` to every query - so it is stubbed here rather
+// than inferred from the environment.
+vi.mock("@/hooks/ui/use-coarse-pointer", () => ({
+  useCoarsePointer: () => state.coarsePointer,
+}));
+
+vi.mock(
+  "@/components/epic-canvas/workspace-file/workspace-file-renderer",
+  () => ({
+    WorkspaceFileRenderer: (props: {
+      readonly wordWrap: boolean;
+    }): ReactNode => {
+      state.rendererWordWrap(props.wordWrap);
+      return <div data-testid="workspace-file-source" />;
+    },
+  }),
+);
+
+import { WorkspaceFileTile } from "../workspace-file-tile";
+import { TabHostProvider } from "../../tab-host-provider";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+
+const NODE: WorkspaceFileRef = {
+  id: "workspace-file:host-A:/work/repo:src/index.ts",
+  instanceId: "workspace-file-instance",
+  type: "workspace-file",
+  name: "index.ts",
+  hostId: "host-A",
+  workspacePath: "/work/repo",
+  filePath: "src/index.ts",
+};
+
+describe("<WorkspaceFileTile /> word wrap", () => {
+  beforeEach(() => {
+    fileEditRuntimeRegistry.resetForTesting();
+    state.coarsePointer = false;
+    state.rendererWordWrap.mockReset();
+    useSettingsStore.setState({ workspaceFileWordWrap: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    fileEditRuntimeRegistry.resetForTesting();
+    useSettingsStore.setState({ workspaceFileWordWrap: null });
+  });
+
+  it("wraps by default on a coarse pointer and not on a fine one", () => {
+    renderTile(NODE);
+    expect(lastWordWrap()).toBe(false);
+    cleanup();
+
+    state.coarsePointer = true;
+    state.rendererWordWrap.mockReset();
+    renderTile(NODE);
+    expect(lastWordWrap()).toBe(true);
+  });
+
+  it("keeps an explicit choice, so the pointer default stops applying", () => {
+    state.coarsePointer = true;
+    renderTile(NODE);
+    expect(lastWordWrap()).toBe(true);
+
+    toggleWordWrap();
+
+    expect(lastWordWrap()).toBe(false);
+    // `false`, not `null`: the device default must not be able to win it back.
+    expect(useSettingsStore.getState().workspaceFileWordWrap).toBe(false);
+  });
+
+  it("turns wrapping on from the toolbar on a fine pointer", () => {
+    renderTile(NODE);
+    expect(lastWordWrap()).toBe(false);
+
+    toggleWordWrap();
+
+    expect(lastWordWrap()).toBe(true);
+    expect(useSettingsStore.getState().workspaceFileWordWrap).toBe(true);
+  });
+
+  it("shares one stored choice across two tiles showing different files", () => {
+    renderTile(NODE);
+    toggleWordWrap();
+    cleanup();
+    state.rendererWordWrap.mockReset();
+
+    renderTile({
+      ...NODE,
+      id: "workspace-file:host-A:/work/repo:src/other.ts",
+      instanceId: "workspace-file-other",
+      name: "other.ts",
+      filePath: "src/other.ts",
+    });
+
+    expect(lastWordWrap()).toBe(true);
+  });
+});
+
+function lastWordWrap(): boolean {
+  const calls = state.rendererWordWrap.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][0];
+}
+
+function toggleWordWrap(): void {
+  fireEvent.click(screen.getByRole("button", { name: "File view settings" }));
+  fireEvent.click(screen.getByRole("switch"));
+}
+
+function renderTile(node: WorkspaceFileRef) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TabHostProvider hostId="host-A">
+        <WorkspaceFileTile node={node} viewTabId="view-1" isActive />
+      </TabHostProvider>
+    </QueryClientProvider>,
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
@@ -13,7 +13,7 @@ import {
   type ReportIssueContext,
 } from "@/lib/report-issue-context";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, Settings2 } from "lucide-react";
 import { SvgViewToggleButton } from "@/components/epic-canvas/renderers/svg-view-toggle-button";
 import { cn } from "@/lib/utils";
 import { TraycerMarkdown } from "@/markdown";
@@ -46,6 +46,16 @@ import { useNativeDivScrollRestoration } from "@/hooks/scroll/use-native-div-scr
 import { WorkspaceFileDeadTileBanner } from "./dead-tile-banner";
 import { WorkspaceMarkdownLinkProvider } from "@/components/epic-canvas/workspace-file/workspace-markdown-link-provider";
 import { WorkspaceFileRenderer } from "@/components/epic-canvas/workspace-file/workspace-file-renderer";
+import { useWorkspaceFileWordWrap } from "@/components/epic-canvas/workspace-file/workspace-file-word-wrap";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
 import { FileAutosaveStatus } from "@/components/diff/file-autosave-status";
 import {
   useDiffClickToEdit,
@@ -409,6 +419,7 @@ function WorkspaceFileTileLive(props: {
     [node.name],
   );
   const [viewMode, setViewMode] = useState<WorkspaceFileViewMode>("source");
+  const { wordWrap, setWordWrap } = useWorkspaceFileWordWrap();
   const editIdentity = useMemo(
     () => ({
       userId,
@@ -675,6 +686,8 @@ function WorkspaceFileTileLive(props: {
           viewMode={effectiveViewMode}
           editing={editing}
           onViewModeChange={setViewMode}
+          wordWrap={wordWrap}
+          onWordWrapChange={setWordWrap}
           svgToggle={props.svgToggle}
           status={
             <FileAutosaveStatus
@@ -708,6 +721,7 @@ function WorkspaceFileTileLive(props: {
             isLoading={query.isLoading}
             language={language}
             viewMode={effectiveViewMode}
+            wordWrap={wordWrap}
             revealLine={revealTarget?.line ?? null}
             revealNonce={revealTarget?.nonce ?? null}
             sourceFindTarget={sourceFindTarget}
@@ -734,12 +748,22 @@ function WorkspaceFileToolbar(props: {
   readonly viewMode: WorkspaceFileViewMode;
   readonly editing: boolean;
   readonly onViewModeChange: (mode: WorkspaceFileViewMode) => void;
+  readonly wordWrap: boolean;
+  readonly onWordWrapChange: (value: boolean) => void;
   readonly status: ReactNode;
   readonly svgToggle: ReactNode;
 }) {
+  // The settings trigger is an `icon-sm` control - below the 44px touch-target
+  // guideline, and on a phone this toolbar is the tile's own chrome, outside
+  // the mobile shell's hit-slop scope (header, drawer, sheets). Opt in here,
+  // and only where the mobile layout is live, so desktop never carries the
+  // scope. Same arrangement as the diff tab header.
+  const isMobileViewport = useIsMobileViewport();
+
   return (
     <div
       className="flex h-9 shrink-0 items-center gap-2 border-b border-canvas-border/70 px-3"
+      data-mobile-shell-touch-scope={isMobileViewport ? "" : undefined}
       data-testid="workspace-file-toolbar"
     >
       <StartTruncatedText className="min-w-0 flex-1 text-ui-xs text-muted-foreground">
@@ -758,8 +782,62 @@ function WorkspaceFileToolbar(props: {
           onModeChange={props.onViewModeChange}
         />
       ) : null}
+      {/* Wrapping only describes the source surface. Rendered markdown reflows
+          on its own and has no line to wrap, so the control stays out of the
+          preview's toolbar rather than sitting there doing nothing. */}
+      {props.viewMode === "source" ? (
+        <WorkspaceFileSettingsMenu
+          wordWrap={props.wordWrap}
+          onWordWrapChange={props.onWordWrapChange}
+        />
+      ) : null}
       {props.svgToggle}
     </div>
+  );
+}
+
+/**
+ * The file viewer's view-options menu, mirroring the diff tab's settings
+ * popover: an `icon-sm` trigger opening one switch row per option. It serves
+ * both pointer classes - this toolbar is part of the tile body, so a phone
+ * rendering the tile full-screen reaches the same menu the desktop chrome
+ * shows, and there is no second placement to keep in step with this one.
+ */
+function WorkspaceFileSettingsMenu(props: {
+  readonly wordWrap: boolean;
+  readonly onWordWrapChange: (value: boolean) => void;
+}): ReactNode {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <TooltipWrapper
+          label="File view settings"
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="File view settings"
+            data-testid="workspace-file-settings"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <Settings2 className="size-4" />
+          </Button>
+        </TooltipWrapper>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[min(80vw,15rem)] gap-0 p-1">
+        <Label className="cursor-pointer justify-between gap-3 rounded-md px-2 py-1.5 font-normal transition-colors hover:bg-accent">
+          <span>Word wrap</span>
+          <Switch
+            checked={props.wordWrap}
+            onCheckedChange={props.onWordWrapChange}
+          />
+        </Label>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -799,6 +877,7 @@ function WorkspaceFilePreviewContent(props: {
   readonly isLoading: boolean;
   readonly language: string;
   readonly viewMode: WorkspaceFileViewMode;
+  readonly wordWrap: boolean;
   readonly revealLine: number | null;
   readonly revealNonce: number | null;
   readonly sourceFindTarget: WorkspaceFileSourceFindTargetWithNonce | null;
@@ -865,6 +944,7 @@ function WorkspaceFilePreviewContent(props: {
       fileName={props.fileName}
       editing={props.editing}
       editAdapter={props.editAdapter}
+      wordWrap={props.wordWrap}
       revealLine={props.revealLine}
       revealNonce={props.revealNonce}
       findTarget={props.sourceFindTarget}

--- a/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
@@ -1029,6 +1029,7 @@ function MarkdownViewModeToggle(props: {
                   "inline-flex h-6 items-center rounded-[3px] px-1.5 text-ui-xs leading-none font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none",
                   disabled &&
                     "cursor-not-allowed opacity-45 hover:text-muted-foreground",
+                  // muted-fill-ok: toolbar row on bg-canvas, never inside this file's popover; --canvas never equals --muted
                   active && "bg-muted text-foreground",
                 )}
                 onClick={() => {

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-empty-multiline-console-regression.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-empty-multiline-console-regression.test.tsx
@@ -127,6 +127,7 @@ function EmptyFileEditHarness(): ReactNode {
         language="text"
         editing={editing}
         editAdapter={editAdapter}
+        wordWrap={false}
         revealLine={null}
         revealNonce={null}
         findTarget={null}

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-readonly-reactivation-console-regression.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-readonly-reactivation-console-regression.test.tsx
@@ -78,6 +78,7 @@ function ReadOnlyFileHarness(props: { readonly content: string }): ReactNode {
       language="typescript"
       editing={false}
       editAdapter={editAdapter}
+      wordWrap={false}
       revealLine={null}
       revealNonce={null}
       findTarget={null}

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-renderer-cachekey-lifecycle.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-renderer-cachekey-lifecycle.test.tsx
@@ -103,6 +103,7 @@ function CacheKeyLifecycleHarness(): ReactNode {
         language="typescript"
         editing={editing}
         editAdapter={editAdapter}
+        wordWrap={false}
         revealLine={null}
         revealNonce={null}
         findTarget={null}

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-renderer.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/__tests__/workspace-file-renderer.test.tsx
@@ -31,6 +31,7 @@ const highlightPool = vi.hoisted(() => ({
   mountCount: 0,
   unmountCount: 0,
   lastEdit: null as boolean | null,
+  lastOverflow: null as string | null,
 }));
 
 vi.mock("@/providers/use-resolved-theme", () => ({
@@ -45,6 +46,7 @@ vi.mock("@pierre/diffs/react", () => ({
     readonly edit: boolean;
     readonly file: { readonly contents: string };
     readonly options: {
+      readonly overflow?: string;
       readonly onPostRender?: (
         node: HTMLElement,
         instance: unknown,
@@ -60,6 +62,7 @@ function MockDiffsFile(props: {
   readonly edit: boolean;
   readonly file: { readonly contents: string };
   readonly options: {
+    readonly overflow?: string;
     readonly onPostRender?: (
       node: HTMLElement,
       instance: unknown,
@@ -69,6 +72,10 @@ function MockDiffsFile(props: {
 }): ReactNode {
   const DiffsContainer = "diffs-container" as "div";
   const hostRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    highlightPool.lastOverflow = props.options.overflow ?? null;
+  }, [props.options.overflow]);
 
   useEffect(() => {
     highlightPool.lastEdit = props.edit;
@@ -107,6 +114,7 @@ beforeEach(() => {
   highlightPool.mountCount = 0;
   highlightPool.unmountCount = 0;
   highlightPool.lastEdit = null;
+  highlightPool.lastOverflow = null;
 });
 
 afterEach(() => {
@@ -115,6 +123,38 @@ afterEach(() => {
 });
 
 describe("<WorkspaceFileRenderer />", () => {
+  // Unwrapped, Diffs gives its code area a horizontal scroll box of its own,
+  // nested inside the tile's vertical one - the pair a touch drag feeds at the
+  // same time. Wrapping is what removes that box, so the two must not drift
+  // apart: this asserts the prop reaches the library option that decides it.
+  it("selects the Diffs overflow mode that matches the requested wrapping", async () => {
+    const editAdapter = createEditAdapter(vi.fn(), undefined);
+    const tree = (wordWrap: boolean): ReactNode => (
+      <WorkspaceFileRenderer
+        content={"const value = 1;\n"}
+        fileName="source.ts"
+        language="typescript"
+        editing={false}
+        editAdapter={editAdapter}
+        wordWrap={wordWrap}
+        revealLine={null}
+        revealNonce={null}
+        findTarget={null}
+        onRevealConsumed={vi.fn()}
+        fileIdentity={null}
+      />
+    );
+    const rendered = render(tree(false));
+    await waitFor(() => {
+      expect(highlightPool.lastOverflow).toBe("scroll");
+    });
+
+    rendered.rerender(tree(true));
+    await waitFor(() => {
+      expect(highlightPool.lastOverflow).toBe("wrap");
+    });
+  });
+
   it("keeps the same diffs-container DOM node across read → edit", async () => {
     const onChange = vi.fn();
     const editAdapter = createEditAdapter(onChange, undefined);
@@ -125,6 +165,7 @@ describe("<WorkspaceFileRenderer />", () => {
         language="typescript"
         editing={false}
         editAdapter={editAdapter}
+        wordWrap={false}
         revealLine={null}
         revealNonce={null}
         findTarget={null}
@@ -154,6 +195,7 @@ describe("<WorkspaceFileRenderer />", () => {
         language="typescript"
         editing
         editAdapter={editAdapter}
+        wordWrap={false}
         revealLine={null}
         revealNonce={null}
         findTarget={null}
@@ -188,6 +230,7 @@ describe("<WorkspaceFileRenderer />", () => {
         language="typescript"
         editing={false}
         editAdapter={editAdapter}
+        wordWrap={false}
         revealLine={null}
         revealNonce={null}
         findTarget={null}
@@ -214,6 +257,7 @@ describe("<WorkspaceFileRenderer />", () => {
           language="plaintext"
           editing={false}
           editAdapter={createEditAdapter(vi.fn(), undefined)}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -238,6 +282,7 @@ describe("<WorkspaceFileRenderer />", () => {
           language="typescript"
           editing={false}
           editAdapter={createEditAdapter(vi.fn(), undefined)}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -260,6 +305,7 @@ describe("<WorkspaceFileRenderer />", () => {
             activateEmptyOrigin: vi.fn(),
             attached: true,
           })}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -283,6 +329,7 @@ describe("<WorkspaceFileRenderer />", () => {
             activateEmptyOrigin,
             attached: false,
           })}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -307,6 +354,7 @@ describe("<WorkspaceFileRenderer />", () => {
             activateEmptyOrigin,
             attached: false,
           })}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -335,6 +383,7 @@ describe("<WorkspaceFileRenderer />", () => {
             activateEmptyOrigin: vi.fn(),
             attached: false,
           })}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -361,6 +410,7 @@ describe("<WorkspaceFileRenderer />", () => {
             activateEmptyOrigin: vi.fn(),
             attached: true,
           })}
+          wordWrap={false}
           revealLine={null}
           revealNonce={null}
           findTarget={null}
@@ -394,6 +444,7 @@ describe("<WorkspaceFileRenderer />", () => {
         language="typescript"
         editing={false}
         editAdapter={createEditAdapter(vi.fn(), undefined)}
+        wordWrap={false}
         revealLine={null}
         revealNonce={null}
         findTarget={null}
@@ -439,6 +490,7 @@ describe("<WorkspaceFileRenderer />", () => {
         language="typescript"
         editing={false}
         editAdapter={createEditAdapter(vi.fn(), undefined)}
+        wordWrap={false}
         revealLine={2}
         revealNonce={1}
         findTarget={null}
@@ -483,6 +535,7 @@ describe("<WorkspaceFileRenderer />", () => {
         language="typescript"
         editing={false}
         editAdapter={createEditAdapter(vi.fn(), undefined)}
+        wordWrap={false}
         revealLine={2}
         revealNonce={1}
         findTarget={null}
@@ -521,6 +574,7 @@ describe("<WorkspaceFileRenderer />", () => {
       language: "typescript",
       editing: false,
       editAdapter: createEditAdapter(vi.fn(), undefined),
+      wordWrap: false,
       revealLine: null,
       revealNonce: null,
       findTarget: null,

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/workspace-file-renderer.tsx
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/workspace-file-renderer.tsx
@@ -61,6 +61,13 @@ export function WorkspaceFileRenderer(props: {
   readonly language: string;
   readonly editing: boolean;
   readonly editAdapter: DiffClickToEditAdapter;
+  /**
+   * Wrap long lines instead of scrolling them. Unwrapped, Diffs gives its code
+   * area its own horizontal scroll box (`overflow-x` on `[data-code]`, with the
+   * gutter stuck to its left edge), which sits inside the tile's vertical
+   * scroller; wrapped, that box does not exist and the tile scrolls in one axis.
+   */
+  readonly wordWrap: boolean;
   readonly revealLine: number | null;
   readonly revealNonce: number | null;
   readonly findTarget: WorkspaceFileSourceFindTargetWithNonce | null;
@@ -82,6 +89,7 @@ export function WorkspaceFileRenderer(props: {
     onRevealConsumed,
     revealLine,
     revealNonce,
+    wordWrap,
   } = props;
   const { resolvedTheme } = useResolvedTheme();
   const themeName = resolveDiffThemeName(resolvedTheme);
@@ -147,7 +155,7 @@ export function WorkspaceFileRenderer(props: {
   const options = useMemo<FileOptions<undefined>>(
     () => ({
       disableFileHeader: true,
-      overflow: "scroll",
+      overflow: wordWrap ? "wrap" : "scroll",
       useTokenTransformer: true,
       theme: themeName,
       themeType: resolvedTheme,
@@ -157,7 +165,13 @@ export function WorkspaceFileRenderer(props: {
         handlePostRender(node, phase);
       },
     }),
-    [editAdapter.fileOptions, handlePostRender, resolvedTheme, themeName],
+    [
+      editAdapter.fileOptions,
+      handlePostRender,
+      resolvedTheme,
+      themeName,
+      wordWrap,
+    ],
   );
 
   useEffect(() => {

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/workspace-file-word-wrap.ts
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/workspace-file-word-wrap.ts
@@ -1,0 +1,42 @@
+import { useCoarsePointer } from "@/hooks/ui/use-coarse-pointer";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+
+/**
+ * The file viewer's effective line wrapping.
+ *
+ * `stored` is the user's explicit choice, or `null` when they have never made
+ * one. With no choice, a coarse pointer wraps and a fine pointer does not.
+ *
+ * The asymmetry is about what unwrapped code costs each input device.
+ * Unwrapped, the renderer puts a horizontal scroll box inside the viewer's
+ * vertical one, and a touch drag feeds both at once - so reading down a file
+ * drifts sideways. A fine pointer drives those two axes separately (a wheel,
+ * a scrollbar, a caret) and gets long lines kept intact in exchange.
+ *
+ * The resolution deliberately lives here rather than in the persisted default:
+ * a stored boolean would carry the device it was chosen on to every other one.
+ */
+export function resolveWorkspaceFileWordWrap(
+  stored: boolean | null,
+  coarsePointer: boolean,
+): boolean {
+  return stored ?? coarsePointer;
+}
+
+export interface WorkspaceFileWordWrapControl {
+  readonly wordWrap: boolean;
+  /** Records an explicit choice; the device default is no longer consulted. */
+  readonly setWordWrap: (value: boolean) => void;
+}
+
+export function useWorkspaceFileWordWrap(): WorkspaceFileWordWrapControl {
+  const stored = useSettingsStore((state) => state.workspaceFileWordWrap);
+  const setWordWrap = useSettingsStore(
+    (state) => state.setWorkspaceFileWordWrap,
+  );
+  const coarsePointer = useCoarsePointer();
+  return {
+    wordWrap: resolveWorkspaceFileWordWrap(stored, coarsePointer),
+    setWordWrap,
+  };
+}

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -143,6 +143,18 @@ export interface SettingsState {
    * is not part of this shape - it stays on the diff tile payload.
    */
   diffViewerPreferences: DiffViewerPreferences;
+  /**
+   * Line wrapping in the workspace file viewer. `null` means the user has made
+   * no choice, and the render site resolves it from the pointer type instead -
+   * a persisted boolean would carry one device's answer to every other device,
+   * and whether wrapping is the right default is a fact about the input
+   * hardware, not about the account.
+   *
+   * Deliberately separate from `diffViewerPreferences.wordWrap`: a file being
+   * read is not a diff, and a wrap choice made while reading one must not
+   * re-render every open diff.
+   */
+  workspaceFileWordWrap: boolean | null;
   setTheme: (theme: ThemeMode) => void;
   setThemePreset: (preset: ThemePreset) => void;
   setComposerMode: (mode: ComposerMode) => void;
@@ -171,6 +183,7 @@ export interface SettingsState {
   setSteerOnModEnterEnabled: (value: boolean) => void;
   setDiffViewerPreferences: (preferences: DiffViewerPreferences) => void;
   patchDiffViewerPreferences: (patch: DiffViewerPreferencesPatch) => void;
+  setWorkspaceFileWordWrap: (value: boolean | null) => void;
 }
 
 type PersistedSettingsState = Pick<
@@ -205,6 +218,7 @@ type PersistedSettingsState = Pick<
   | "quoteReplyEnabled"
   | "steerOnModEnterEnabled"
   | "diffViewerPreferences"
+  | "workspaceFileWordWrap"
 >;
 
 type SetFn = (
@@ -273,6 +287,7 @@ function partializeSettingsState(state: SettingsState): PersistedSettingsState {
     quoteReplyEnabled: state.quoteReplyEnabled,
     steerOnModEnterEnabled: state.steerOnModEnterEnabled,
     diffViewerPreferences: state.diffViewerPreferences,
+    workspaceFileWordWrap: state.workspaceFileWordWrap,
   };
 }
 
@@ -309,6 +324,7 @@ export const useSettingsStore = create<SettingsState>()(
       quoteReplyEnabled: true,
       steerOnModEnterEnabled: true,
       diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
+      workspaceFileWordWrap: null,
       setTheme: makeSetter(set, "theme"),
       setThemePreset: makeSetter(set, "themePreset"),
       setComposerMode: makeSetter(set, "composerMode"),
@@ -384,6 +400,7 @@ export const useSettingsStore = create<SettingsState>()(
           },
         }));
       },
+      setWorkspaceFileWordWrap: makeSetter(set, "workspaceFileWordWrap"),
     }),
     {
       ...basePersistOptions(persistKey(STORE_KEYS.settings)),
@@ -393,8 +410,13 @@ export const useSettingsStore = create<SettingsState>()(
       // otherwise corrupted localStorage value would otherwise rehydrate
       // verbatim (the default shallow merge takes persisted fields as-is),
       // flow straight into branch composition, and still mount the editor
-      // showing it as healthy. Every other field keeps the default shallow
-      // merge behavior.
+      // showing it as healthy. `workspaceFileWordWrap` is re-derived for a
+      // narrower reason: its `null` carries meaning ("the user has not
+      // chosen"), and any non-boolean that rehydrated verbatim would be
+      // neither `true`, `false`, nor that third state - a truthy string would
+      // read as "wrap on, chosen deliberately" and the pointer-type default
+      // could never be reached again. Every other field keeps the default
+      // shallow merge behavior.
       merge: (persistedState, currentState) => {
         const persisted: Record<string, unknown> = isRecord(persistedState)
           ? persistedState
@@ -414,6 +436,10 @@ export const useSettingsStore = create<SettingsState>()(
             persistedMinimapSide === "hide"
               ? persistedMinimapSide
               : DEFAULT_MINIMAP_SIDE,
+          workspaceFileWordWrap:
+            typeof merged.workspaceFileWordWrap === "boolean"
+              ? merged.workspaceFileWordWrap
+              : null,
         };
       },
     },


### PR DESCRIPTION
## The problem

Reading a file on a phone fights back: the viewer pans freely in both axes, so a vertical scroll drifts sideways. And there was no wrap control anywhere - desktop included.

## Why it happens

Two nested scrollers with **orthogonal** axes, one of them inside a vendor shadow root:

- **Y** - the tile's own container, `workspace-file-tile.tsx`: `min-h-0 flex-1 overflow-auto`.
- **X** - `@pierre/diffs`' own code area. Its stylesheet declares `[data-code] { overflow: var(--diffs-overflow-override, scroll) clip }`, i.e. **overflow-x: scroll, overflow-y: clip**, with `[data-overflow="scroll"] [data-gutter] { position: sticky; left: 0 }`.

That `data-overflow` attribute comes from `options.overflow`, which `workspace-file-renderer.tsx` hardcoded to `"scroll"`. A touch gesture starting over code hands X to the inner box and chains Y to the outer one - both consume in the same drag. Nothing sets `touch-action` on the code surface, so nothing constrains it.

Not the epic canvas: a phone mounts one tile full-screen (`MobileEpicTileView`), with no pan/zoom layer involved.

## The change

The file viewer was not missing a mechanism, only the wire to one that already exists - `resolvePierreOverflow(wordWrap)` does exactly this for the diffs surface. So:

- `WorkspaceFileRenderer` takes a `wordWrap` prop and selects `overflow: "wrap" | "scroll"`. Wrapped, `[data-code]` stops overflowing and the inner scroller ceases to exist - one axis remains.
- A **Word wrap** switch in a `Settings2` popover on the file toolbar, mirroring `DiffTabToolbar`. It is one control for both pointer classes: the toolbar is part of the tile body, so a phone showing the tile full-screen reaches the same menu the desktop chrome shows. The toolbar opts into `data-mobile-shell-touch-scope` under `useIsMobileViewport()`, as the diff tab header does.
- A new `workspaceFileWordWrap: boolean | null` setting, **separate** from `diffViewerPreferences.wordWrap` - a file being read is not a diff, and a wrap choice made while reading one should not re-render every open diff.

## The `null`

`null` means *the user has not chosen*, and the render site resolves it as `stored ?? coarsePointer`. So a coarse pointer wraps by default and a fine one does not, while the persisted store never holds a viewport-blind boolean that one device would export to every other. An explicit toggle writes `true`/`false` and the device default stops applying. Desktop's default stays unwrapped for free.

Rehydration re-derives the field: any non-boolean would be neither `true`, `false`, nor that third state, and a truthy string would read as a deliberate choice the pointer default could never win back.

## Deliberately not done

**Axis-locked panning when unwrapped.** CSS cannot express a per-gesture directional lock - `touch-action` is read at gesture start and is a capability filter, not a "dominant axis wins" rule, so `pan-y` would answer a request for the horizontal axis by removing it. With wrap defaulting on for touch, the drifting state is no longer the only state; it is now one a user opts into. A single-scroller variant (overriding `[data-code]`'s overflow through `unsafeCSS`) would remove the drift in every state and is being weighed separately - it re-anchors a sticky gutter inside a third-party shadow root, so it is a device question rather than a review one.

## Verification

- `bun run compile` clean; `eslint --max-warnings 0` and `prettier --check` clean on every changed file.
- 632 tests across `renderers/__tests__` + `diff/__tests__`, plus the workspace-file and settings suites, pass.
- New: `workspace-file-tile-word-wrap.test.tsx` (pointer default both ways, an explicit choice overriding it, and the choice shared across tiles) and a renderer test pinning `wordWrap` to the library overflow mode it selects.
- Mobile behaviour is pending simulator verification with screenshots before any merge-ask.