### PR TITLE
feat(gui-app): phone navigation model — a switcher tap recycles the one tile

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -18,6 +18,7 @@ interface FixtureRecord {
  * fixture that dropped it is why a wrong-host ref went unnoticed here.
  */
 interface ActivateRef {
+  readonly id: string;
   readonly type: string;
   readonly hostId: string;
 }
@@ -101,14 +102,12 @@ vi.mock("@/stores/epics/canvas/canvas-selectors", () => ({
   findOpenArtifactInTab: () => null,
 }));
 vi.mock("@/components/epic-canvas/mobile/use-switcher-activate", () => ({
-  useSwitcherActivate:
-    () =>
-    (
-      id: string,
-      buildRef: () => { readonly type: string; readonly hostId: string },
-    ) => {
-      holder.activateCalls.push({ id, ref: buildRef() });
-    },
+  // The row hands over the REF alone; the content id it names is the ref's own
+  // `id`, which is also what the canvas dedups against.
+  useSwitcherActivate: () => (buildRef: () => ActivateRef) => {
+    const ref = buildRef();
+    holder.activateCalls.push({ id: ref.id, ref });
+  },
 }));
 vi.mock("@/lib/host", () => ({ useHostClient: () => null }));
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-terminals-list.test.tsx
@@ -386,6 +386,40 @@ describe("<SwitcherTerminalsList /> rows", () => {
     expect(tile.hostId).toBe(HOST_B);
     expect("authority" in tile && tile.authority === "host").toBe(true);
     expect(onClose).toHaveBeenCalledTimes(1);
+    // As the pane's PREVIEW: a tap on this surface recycles the one tile it
+    // can show rather than leaving a second one behind it.
+    const root = useEpicCanvasStore.getState().canvasByTabId[tabId]?.root;
+    if (root?.kind !== "pane") throw new Error("expected a single-pane root");
+    expect(root.previewTabId).toBe(tile.instanceId);
+  });
+
+  it("recycles the preview when a second row is tapped", () => {
+    durableCollection.value = completeFleet([
+      durableTerminal({
+        hostId: HOST_B,
+        terminalId: "first-term",
+        title: "First shell",
+        runtime: runningRuntime("first-term"),
+      }),
+      durableTerminal({
+        hostId: HOST_B,
+        terminalId: "second-term",
+        title: "Second shell",
+        runtime: runningRuntime("second-term"),
+      }),
+    ]);
+    const tabId = openEpicTab();
+    renderList(tabId);
+    fireEvent.click(screen.getByRole("button", { name: /^First shell/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Second shell/ }));
+
+    const tiles = Object.values(
+      useEpicCanvasStore.getState().canvasByTabId[tabId]?.tilesByInstanceId ??
+        {},
+    );
+    // One tile, not two - the count is the whole assertion.
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0]?.id).toBe("second-term");
   });
 
   it("carries the resource chip for the row's owner host when stats are on", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/use-switcher-activate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/use-switcher-activate.test.tsx
@@ -21,6 +21,8 @@ vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
 
 const TAB_ID = "tab-activate";
 const EPIC_ID = "epic-1";
+const HOST_A = "host-A";
+const HOST_B = "host-B";
 
 function spec(n: number, instanceId: string): EpicArtifactRef {
   return {
@@ -28,18 +30,26 @@ function spec(n: number, instanceId: string): EpicArtifactRef {
     instanceId,
     type: "spec",
     name: `Spec ${n}`,
-    hostId: "host-A",
+    hostId: HOST_A,
   };
 }
 
+function chat(id: string, instanceId: string, hostId: string): EpicArtifactRef {
+  return { id, instanceId, type: "chat", name: id, hostId };
+}
+
+/**
+ * `inst-1` is a KEPT tile and `inst-2` the pane's preview - the two states a
+ * tap has to tell apart.
+ */
 function singlePaneCanvas(): EpicCanvasState {
   const root: TilePane = {
     kind: "pane",
     id: "pane-A",
     tabInstanceIds: ["inst-1", "inst-2"],
-    activeTabId: "inst-1",
-    previewTabId: null,
-    activationHistory: ["inst-1"],
+    activeTabId: "inst-2",
+    previewTabId: "inst-2",
+    activationHistory: ["inst-2", "inst-1"],
   };
   return {
     root,
@@ -52,10 +62,10 @@ function singlePaneCanvas(): EpicCanvasState {
   };
 }
 
-function seed(): void {
+function seed(canvas: EpicCanvasState): void {
   useEpicCanvasStore.setState({
     tabsById: { [TAB_ID]: { tabId: TAB_ID, epicId: EPIC_ID, name: "Epic 1" } },
-    canvasByTabId: { [TAB_ID]: singlePaneCanvas() },
+    canvasByTabId: { [TAB_ID]: canvas },
   });
 }
 
@@ -63,51 +73,120 @@ function activeArtifactId(): string | null {
   return makeSelectActiveEpicArtifactId(TAB_ID)(useEpicCanvasStore.getState());
 }
 
+function pane(): TilePane {
+  const root = useEpicCanvasStore.getState().canvasByTabId[TAB_ID]?.root;
+  if (root?.kind !== "pane") throw new Error("expected a single-pane root");
+  return root;
+}
+
+function renderActivate(onClose: () => void) {
+  return renderHook(() => useSwitcherActivate(EPIC_ID, TAB_ID, onClose));
+}
+
 describe("useSwitcherActivate", () => {
   afterEach(() => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   });
 
-  it("activates an already-open tile without disturbing the split structure or sizes, then closes", () => {
-    seed();
+  it("recycles the pane's preview rather than stacking another tile", () => {
+    seed(singlePaneCanvas());
     const onClose = vi.fn();
-    const before = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
-    const { result } = renderHook(() =>
-      useSwitcherActivate(EPIC_ID, TAB_ID, onClose),
-    );
+    const { result } = renderActivate(onClose);
 
     act(() => {
-      // spec-2 is already open (inst-2) - never used the buildRef path.
-      result.current("spec-2", () => spec(2, "unused"));
+      result.current(() => spec(3, "inst-3"));
     });
 
-    expect(activeArtifactId()).toBe("spec-2");
-    const after = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
-    const beforePane = before?.root;
-    const afterPane = after?.root;
-    if (beforePane?.kind !== "pane" || afterPane?.kind !== "pane") {
-      throw new Error("expected a single-pane root");
-    }
-    // Only activation moved: same tabs in the same order, sizes untouched.
-    expect(afterPane.tabInstanceIds).toEqual(beforePane.tabInstanceIds);
-    expect(after?.sizesByGroupId).toEqual(before?.sizesByGroupId);
+    // The tab COUNT is the assertion: a permanent open would make this three.
+    expect(pane().tabInstanceIds).toEqual(["inst-1", "inst-3"]);
+    expect(pane().previewTabId).toBe("inst-3");
+    expect(activeArtifactId()).toBe("spec-3");
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("opens a not-yet-open item as a new tile, then closes", () => {
-    seed();
-    const onClose = vi.fn();
-    const { result } = renderHook(() =>
-      useSwitcherActivate(EPIC_ID, TAB_ID, onClose),
-    );
+  it("preserves the replaced tile's payload so back/forward can re-present it", () => {
+    seed(singlePaneCanvas());
+    const { result } = renderActivate(vi.fn());
 
     act(() => {
-      result.current("spec-3", () => spec(3, "inst-3"));
+      result.current(() => spec(3, "inst-3"));
     });
 
-    expect(activeArtifactId()).toBe("spec-3");
-    const after = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
-    expect(after?.tilesByInstanceId["inst-3"]?.id).toBe("spec-3");
+    // Replacing is not destroying: the evicted preview is recoverable by the
+    // exact instance id its history entry addresses.
+    const preserved =
+      useEpicCanvasStore.getState().closedTilePayloadsByTabId[TAB_ID];
+    expect(preserved?.["inst-2"]?.node.id).toBe("spec-2");
+  });
+
+  it("never evicts a kept tile, only the preview beside it", () => {
+    seed(singlePaneCanvas());
+    const { result } = renderActivate(vi.fn());
+
+    act(() => {
+      result.current(() => spec(3, "inst-3"));
+    });
+    act(() => {
+      result.current(() => spec(4, "inst-4"));
+    });
+
+    // `inst-1` was never the preview, so no number of taps reaches it - which
+    // is what keeps a kept chat inside the pane's retention window.
+    expect(pane().tabInstanceIds).toEqual(["inst-1", "inst-4"]);
+    expect(pane().activationHistory).toContain("inst-1");
+  });
+
+  it("focuses an already-open tile without demoting it to preview", () => {
+    seed(singlePaneCanvas());
+    const onClose = vi.fn();
+    const before = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
+    const { result } = renderActivate(onClose);
+
+    act(() => {
+      // spec-1 is open and KEPT; the fresh instanceId is never used, because
+      // dedup finds the existing tab first.
+      result.current(() => spec(1, "unused"));
+    });
+
+    expect(activeArtifactId()).toBe("spec-1");
+    expect(pane().previewTabId).toBe("inst-2");
+    // Only activation moved: same tabs in the same order, sizes untouched.
+    expect(pane().tabInstanceIds).toEqual(["inst-1", "inst-2"]);
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[TAB_ID]?.sizesByGroupId,
+    ).toEqual(before?.sizesByGroupId);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedups by host, so a shared content id on another host opens its own tile", () => {
+    const root: TilePane = {
+      kind: "pane",
+      id: "pane-A",
+      tabInstanceIds: ["inst-a"],
+      activeTabId: "inst-a",
+      previewTabId: null,
+      activationHistory: ["inst-a"],
+    };
+    seed({
+      root,
+      activePaneId: "pane-A",
+      tilesByInstanceId: { "inst-a": chat("chat-1", "inst-a", HOST_A) },
+      sizesByGroupId: {},
+    });
+    const { result } = renderActivate(vi.fn());
+
+    act(() => {
+      result.current(() => chat("chat-1", "inst-b", HOST_B));
+    });
+
+    // A cross-host clone carries the source's chat id verbatim, so matching on
+    // the id alone would hand back the other machine's tile.
+    expect(pane().tabInstanceIds).toEqual(["inst-a", "inst-b"]);
+    const opened =
+      useEpicCanvasStore.getState().canvasByTabId[TAB_ID]?.tilesByInstanceId[
+        "inst-b"
+      ];
+    if (opened?.type !== "chat") throw new Error("expected a chat tile");
+    expect(opened.hostId).toBe(HOST_B);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -137,7 +137,7 @@ function SwitcherAgentRow(props: {
   const onSelect = useCallback(() => {
     const type = record.type;
     if (!isOpenableEpicNodeKind(type)) return;
-    activate(record.id, () =>
+    activate(() =>
       makeOpenableNodeRef({
         id: record.id,
         instanceId: uuidv4(),

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -102,7 +102,7 @@ function SwitcherArtifactRow(props: {
   const onSelect = useCallback(() => {
     const type = record.type;
     if (!isOpenableEpicNodeKind(type)) return;
-    activate(record.id, () =>
+    activate(() =>
       makeOpenableNodeRef({
         id: record.id,
         instanceId: uuidv4(),

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -3,7 +3,7 @@ import { Terminal } from "lucide-react";
 import { SwitcherListRow } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherTerminalRowActions } from "@/components/epic-canvas/mobile/switcher-terminal-row-actions";
 import { SwitcherNewTerminalRow } from "@/components/epic-canvas/mobile/switcher-create-actions";
-import { useMobileEpicTiles } from "@/components/epic-canvas/mobile/use-mobile-epic-tiles";
+import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
 import {
   FailedTerminalCreateRow,
   TerminalsEmptyState,
@@ -17,15 +17,10 @@ import {
 import { OwnerResourceChip } from "@/components/resources/resource-usage-chip";
 import { useEpicPermissionRole } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
-import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
 import { terminalSessionLabel } from "@/lib/terminals/terminal-title";
 import type { TerminalSidebarSessionRow } from "@/lib/terminals/reconcile-terminal-sidebar-sessions";
-import {
-  findOpenTileInTab,
-  useEpicCanvasStore,
-  useIsActiveTile,
-} from "@/stores/epics/canvas/store";
+import { useIsActiveTile } from "@/stores/epics/canvas/store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 
 /** Every test id this list's shared states and rows are grabbed by. */
@@ -48,46 +43,26 @@ interface SwitcherListProps {
  * tile.
  *
  * This file owns only the touch chrome: a flat scroller instead of the
- * desktop's draggable tree rows, and a tap that lands the chosen terminal as
- * the single full-screen mobile tile.
+ * desktop's draggable tree rows. The tap itself goes through
+ * {@link useSwitcherActivate}, so this category recycles the one shown tile on
+ * exactly the terms every other category does.
  */
 export function SwitcherTerminalsList(props: SwitcherListProps) {
   const { epicId, tabId, onClose } = props;
   const panel = useEpicTerminalsPanel({ epicId });
   const canMutate = isEditableRole(useEpicPermissionRole());
-  const { selectTile } = useMobileEpicTiles(tabId);
-  const navigateNested = useEpicNestedFocusNavigation();
-  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareOpenTileInTabFocusTarget,
-  );
+  const activate = useSwitcherActivate(epicId, tabId, onClose);
 
   const prepareOpenRow = panel.prepareOpenRow;
   const openRow = useCallback(
     (row: TerminalSidebarSessionRow) => {
+      // A refused row (unreachable owner host) never reaches the canvas, and
+      // leaves the sheet open on the toast explaining why.
       const tile = prepareOpenRow(row);
       if (tile === null) return;
-      // By REF, not by content id: two fleet terminals can share a terminalId
-      // across hosts, and "focus the one already open" must not hand back the
-      // other machine's tile.
-      const found = findOpenTileInTab(tabId, tile);
-      if (found === null) {
-        navigateNested(epicId, tabId, () =>
-          prepareOpenTileInTabFocusTarget(tabId, tile),
-        );
-      } else {
-        selectTile(found.paneId, found.instanceId);
-      }
-      onClose();
+      activate(() => tile);
     },
-    [
-      epicId,
-      navigateNested,
-      onClose,
-      prepareOpenRow,
-      prepareOpenTileInTabFocusTarget,
-      selectTile,
-      tabId,
-    ],
+    [activate, prepareOpenRow],
   );
 
   return (

--- a/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-activate.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-activate.ts
@@ -1,53 +1,59 @@
 import { useCallback } from "react";
-import { useMobileEpicTiles } from "@/components/epic-canvas/mobile/use-mobile-epic-tiles";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
-import { findOpenArtifactInTab } from "@/stores/epics/canvas/canvas-selectors";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
 
-export type SwitcherActivate = (
-  contentId: string,
-  buildRef: () => EpicNodeRef,
-) => void;
+export type SwitcherActivate = (buildRef: () => EpicCanvasTileRef) => void;
 
 /**
- * Shared row-tap handler for the switcher's flat lists. If the item is already
- * an open tile in this tab, activate it via the existing desktop tab-selection
- * path (`useMobileEpicTiles().selectTile`); otherwise open it permanently
- * (`openTileInTab`) through `navigateNested` + the lint-blessed
- * `prepareOpenTileInTabFocusTarget` (raw canvas actions are ESLint-banned).
- * Either way the sheet closes, so the chosen tile becomes the full-screen
- * mobile tile.
+ * Shared row-tap handler for the switcher's flat lists.
+ *
+ * A tap is a single click: the chosen item lands as the destination pane's
+ * PREVIEW tile, replacing whatever preview was there. That is what keeps a
+ * viewport showing ONE tile at a time from accumulating tiles it never
+ * displays and offers no way to close - these lists enumerate CONTENT, never
+ * open tiles, so a permanently-opened tile whose content has no row is
+ * unreachable once something else takes the screen.
+ *
+ * The already-open case needs no branch here: `openTile`'s dedup focuses the
+ * existing tab in place and focusing an already-open tab never demotes it to
+ * preview, so a kept tile stays kept and only the pane's activation moves.
+ * That dedup matches by REF - content id AND host - which is the only correct
+ * rule for host-bound kinds, where two fleet items can share a content id
+ * across hosts and "focus the one already open" must not hand back the other
+ * machine's tile.
+ *
+ * Replacing is not destroying: an evicted preview's payload is preserved for
+ * the back/forward history path, and a tile the user kept is never the one
+ * evicted.
+ *
+ * Runs through `navigateNested` + the lint-blessed
+ * `prepareOpenTilePreviewInTabFocusTarget`, since raw canvas actions are
+ * ESLint-banned. The sheet closes either way, so the chosen tile becomes the
+ * full-screen mobile tile.
  */
 export function useSwitcherActivate(
   epicId: string,
   tabId: string,
   onClose: () => void,
 ): SwitcherActivate {
-  const { selectTile } = useMobileEpicTiles(tabId);
   const navigateNested = useEpicNestedFocusNavigation();
-  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareOpenTileInTabFocusTarget,
+  const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
   );
 
   return useCallback(
-    (contentId, buildRef) => {
-      const found = findOpenArtifactInTab(tabId, contentId);
-      if (found !== null) {
-        selectTile(found.paneId, found.instanceId);
-      } else {
-        navigateNested(epicId, tabId, () =>
-          prepareOpenTileInTabFocusTarget(tabId, buildRef()),
-        );
-      }
+    (buildRef) => {
+      navigateNested(epicId, tabId, () =>
+        prepareOpenTilePreviewInTabFocusTarget(tabId, buildRef()),
+      );
       onClose();
     },
     [
       epicId,
       navigateNested,
       onClose,
-      prepareOpenTileInTabFocusTarget,
-      selectTile,
+      prepareOpenTilePreviewInTabFocusTarget,
       tabId,
     ],
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -205,6 +205,10 @@ const modelListeners = new Set<() => void>();
 // invoke it directly, the same way Pierre invokes it on a real row click.
 let capturedOnSelectionChange: ((paths: ReadonlyArray<string>) => void) | null =
   null;
+// Row geometry the panel asked Pierre for. Only observable here: `useFileTree`
+// reads its options once, at construction, and the model exposes no getter the
+// panel could be asked afterwards.
+let capturedItemHeight: number | undefined = undefined;
 
 function notifyModel(): void {
   for (const listener of modelListeners) listener();
@@ -350,8 +354,10 @@ vi.mock("@pierre/trees/react", () => ({
     useSyncExternalStore(subscribeToSearchSnapshot, getSearchSnapshot),
   useFileTree: (options: {
     readonly onSelectionChange: (paths: ReadonlyArray<string>) => void;
+    readonly itemHeight: number | undefined;
   }) => {
     capturedOnSelectionChange = options.onSelectionChange;
+    capturedItemHeight = options.itemHeight;
     return { model: mockModel };
   },
 }));
@@ -1351,5 +1357,109 @@ describe("reveal in sidebar", () => {
         { path: "a.ts", options: { offset: "nearest" } },
       ]);
     });
+  });
+});
+
+/**
+ * The same panel body under the phone tab switcher, where it is the File tree
+ * category rather than a sidebar column. `useIsMobileViewport` reads
+ * `window.innerWidth` directly, so overriding it before render is what forces
+ * the touch presentation - same pattern as the composer-menu and providers
+ * panel mobile suites.
+ */
+describe("file tree on a touch viewport", () => {
+  const TAB_ID = "tab-1";
+  let openPermanentSpy: Mock<
+    (tabId: string, node: EpicCanvasTileRef) => NestedFocusTarget | null
+  >;
+  let openPreviewSpy: Mock<
+    (tabId: string, node: EpicCanvasTileRef) => NestedFocusTarget | null
+  >;
+
+  beforeEach(() => {
+    useSettingsStore.setState({
+      diffViewerPreferences: {
+        ...DEFAULT_DIFF_VIEWER_PREFERENCES,
+        ignoreWhitespace: false,
+      },
+    });
+    mockListedPaths = [];
+    mockSearchValue = "";
+    mockSearchSnapshot = { isOpen: false, value: "", matchingPaths: [] };
+    searchSnapshotListeners.clear();
+    listFileTreeCalls.length = 0;
+    resetPathsCalls.length = 0;
+    setSearchCalls.length = 0;
+    searchCalls.length = 0;
+    expandedInModel.clear();
+    expandedAtLastReset.clear();
+    selectedInModel.clear();
+    scrollToPathCalls.length = 0;
+    modelListeners.clear();
+    capturedOnSelectionChange = null;
+    capturedItemHeight = undefined;
+    installSearchHost({});
+    __resetWorkspaceFileListSubscriptionsForTesting();
+    useFileTreeStore.setState({ expandedPathsByScope: {} });
+    openPermanentSpy = vi.fn(() => null);
+    openPreviewSpy = vi.fn(() => null);
+    useEpicCanvasStore.setState({
+      prepareOpenTileInTabFocusTarget: openPermanentSpy,
+      prepareOpenTilePreviewInTabFocusTarget: openPreviewSpy,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetWorkspaceFileListSubscriptionsForTesting();
+    useFileTreeStore.setState({ expandedPathsByScope: {} });
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    pinnedStreamBindingRef.value = null;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
+  });
+
+  it("asks for touch-sized rows instead of the sidebar's compact ones", () => {
+    renderPanel(new MockWsStreamClient("unknown"));
+
+    expect(capturedItemHeight).toBe(44);
+  });
+
+  it("opens a tapped row permanently, because there is no tab strip to promote it from", () => {
+    const client = new MockWsStreamClient("unknown");
+    renderPanel(client);
+    act(() => {
+      client.sessions[0].emitFrame({
+        kind: "listing",
+        directoryPath: "",
+        entries: [
+          {
+            path: "readme.md",
+            name: "readme.md",
+            kind: "file",
+            ignored: false,
+          },
+        ],
+        truncated: false,
+        hasBinaryPayload: false,
+      });
+    });
+
+    act(() => {
+      capturedOnSelectionChange?.(["readme.md"]);
+    });
+
+    expect(openPreviewSpy).not.toHaveBeenCalled();
+    expect(openPermanentSpy).toHaveBeenCalledTimes(1);
+    expect(openPermanentSpy).toHaveBeenCalledWith(
+      TAB_ID,
+      expect.objectContaining({ filePath: "readme.md" }),
+    );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -17,7 +17,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useSyncExternalStore, type ReactNode } from "react";
+import { useState, useSyncExternalStore, type ReactNode } from "react";
 import type {
   IStreamSession,
   ServerFrameHandler,
@@ -357,7 +357,12 @@ vi.mock("@pierre/trees/react", () => ({
     readonly itemHeight: number | undefined;
   }) => {
     capturedOnSelectionChange = options.onSelectionChange;
-    capturedItemHeight = options.itemHeight;
+    // Mount-captured, exactly like the real hook's `useState(() => new
+    // FileTree(options))`. Recording it per RENDER instead would make the row
+    // geometry look reactive here when it is not, and the viewport-transition
+    // case below would pass without the body ever having been rebuilt.
+    const [itemHeightAtConstruction] = useState(() => options.itemHeight);
+    capturedItemHeight = itemHeightAtConstruction;
     return { model: mockModel };
   },
 }));
@@ -1369,6 +1374,58 @@ describe("reveal in sidebar", () => {
  */
 describe("file tree on a touch viewport", () => {
   const TAB_ID = "tab-1";
+  const MOBILE_WIDTH = 390;
+  const DESKTOP_WIDTH = 1024;
+
+  // The shared setup's `matchMedia` never notifies, which is right for suites
+  // that only need one width. Crossing the breakpoint mid-test needs a real
+  // one: `useIsMobileViewport` is a `useSyncExternalStore` over this event, so
+  // without it a width change reaches no render at all.
+  const breakpointListeners = new Set<() => void>();
+  function installLiveMatchMedia(): void {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: window.innerWidth < 768,
+        media: query,
+        onchange: null,
+        addEventListener: (_type: string, listener: () => void) => {
+          breakpointListeners.add(listener);
+        },
+        removeEventListener: (_type: string, listener: () => void) => {
+          breakpointListeners.delete(listener);
+        },
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+  function restoreInertMatchMedia(): void {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+  function setViewportWidth(width: number): void {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+    for (const listener of [...breakpointListeners]) listener();
+  }
+
   let openPermanentSpy: Mock<
     (tabId: string, node: EpicCanvasTileRef) => NestedFocusTarget | null
   >;
@@ -1407,10 +1464,9 @@ describe("file tree on a touch viewport", () => {
       prepareOpenTileInTabFocusTarget: openPermanentSpy,
       prepareOpenTilePreviewInTabFocusTarget: openPreviewSpy,
     });
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      value: 390,
-    });
+    breakpointListeners.clear();
+    installLiveMatchMedia();
+    setViewportWidth(MOBILE_WIDTH);
   });
 
   afterEach(() => {
@@ -1419,9 +1475,11 @@ describe("file tree on a touch viewport", () => {
     useFileTreeStore.setState({ expandedPathsByScope: {} });
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     pinnedStreamBindingRef.value = null;
+    breakpointListeners.clear();
+    restoreInertMatchMedia();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
-      value: 1024,
+      value: DESKTOP_WIDTH,
     });
   });
 
@@ -1461,5 +1519,19 @@ describe("file tree on a touch viewport", () => {
       TAB_ID,
       expect.objectContaining({ filePath: "readme.md" }),
     );
+  });
+
+  it("rebuilds the tree when the window crosses the breakpoint, rather than leaving the other class's rows", () => {
+    setViewportWidth(DESKTOP_WIDTH);
+    renderPanel(new MockWsStreamClient("unknown"));
+    expect(capturedItemHeight).toBeUndefined();
+
+    act(() => {
+      setViewportWidth(MOBILE_WIDTH);
+    });
+
+    // Only a rebuilt model can report this: the mocked hook, like the real
+    // one, reads `itemHeight` once at construction.
+    expect(capturedItemHeight).toBe(44);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -1431,7 +1431,7 @@ describe("file tree on a touch viewport", () => {
     expect(capturedItemHeight).toBe(44);
   });
 
-  it("opens a tapped row permanently, because there is no tab strip to promote it from", () => {
+  it("recycles the single preview tile for a tapped row rather than accumulating one per file", () => {
     const client = new MockWsStreamClient("unknown");
     renderPanel(client);
     act(() => {
@@ -1455,9 +1455,9 @@ describe("file tree on a touch viewport", () => {
       capturedOnSelectionChange?.(["readme.md"]);
     });
 
-    expect(openPreviewSpy).not.toHaveBeenCalled();
-    expect(openPermanentSpy).toHaveBeenCalledTimes(1);
-    expect(openPermanentSpy).toHaveBeenCalledWith(
+    expect(openPermanentSpy).not.toHaveBeenCalled();
+    expect(openPreviewSpy).toHaveBeenCalledTimes(1);
+    expect(openPreviewSpy).toHaveBeenCalledWith(
       TAB_ID,
       expect.objectContaining({ filePath: "readme.md" }),
     );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -81,6 +81,7 @@ import {
   useWorkspaceSearchPaths,
 } from "@/hooks/workspace/use-workspace-search-paths-query";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
 import { gitChangedFileToPierreStatusEntry } from "@/lib/git/panel-file-rendering";
 import {
   StreamRuntimeContext,
@@ -115,6 +116,19 @@ const WORKSPACE_FILE_LIST_METHOD = "workspace.subscribeFileList";
 
 /** Filter-box pause before either filter source runs. */
 const SEARCH_DEBOUNCE_MS = 200;
+
+/**
+ * Tree row height (px) under a touch viewport, where the panel is the phone tab
+ * switcher's File tree category rather than a sidebar column. Pierre's
+ * `compact` preset is 24px, and its rows live in a shadow root that the mobile
+ * shell's hit-area stylesheet cannot reach - so the row itself has to be the
+ * 44px target the rest of the phone surfaces use (`min-h-11`).
+ *
+ * Read once: `useFileTree` constructs the model from its options on first
+ * render and exposes no height setter, so a viewport that flips mid-session
+ * keeps the height it mounted with until the panel remounts.
+ */
+const TOUCH_TREE_ROW_HEIGHT_PX = 44;
 
 const EMPTY_TREE_PATHS: ReadonlyArray<string> = Object.freeze([]);
 const EMPTY_GIT_STATUS: ReadonlyArray<GitStatusEntry> = Object.freeze([]);
@@ -509,6 +523,7 @@ function FileTreeBodyForResolvedHost(
   // so they keep resolving against the same host after a later swap
   // (CLAUDE.md: tabs are bound to a host for life).
   const { hostId, onLatchHost } = props;
+  const isMobileViewport = useIsMobileViewport();
   // The box is a filter, not a search field: the query is applied on a pause,
   // and the same debounced value gates both the host RPC and the local row
   // filter so the two can never disagree about what is being filtered for.
@@ -571,13 +586,27 @@ function FileTreeBodyForResolvedHost(
       onLatchHost();
       navigateNested(props.epicId, props.tabId, () => open(props.tabId, ref));
     };
+    // Preview-vs-permanent is a tab-strip concept, and a touch viewport has no
+    // tab strip: it shows one tile at a time and navigates through the switcher.
+    // There a preview tile is silently replaced by the next row tapped, and the
+    // double-click that promotes it to permanent has no touch equivalent - so
+    // the file tree would be the one surface a phone can never open two of.
+    // Tapping a row opens permanently instead, which is also what every other
+    // switcher category's row does (`useSwitcherActivate`). `openTile` dedupes
+    // on the ref either way, so a re-tap focuses the tile already open.
     handlersRef.current.onSelect = (treePath) => {
-      openInTab(treePath, prepareOpenTilePreviewInTabFocusTarget);
+      openInTab(
+        treePath,
+        isMobileViewport
+          ? prepareOpenTileInTabFocusTarget
+          : prepareOpenTilePreviewInTabFocusTarget,
+      );
     };
     handlersRef.current.onOpen = (treePath) => {
       openInTab(treePath, prepareOpenTileInTabFocusTarget);
     };
   }, [
+    isMobileViewport,
     navigateNested,
     workspaceFileRefForTreePath,
     props.epicId,
@@ -600,7 +629,8 @@ function FileTreeBodyForResolvedHost(
   const { model } = useFileTree({
     paths: treePaths,
     initialExpansion: "closed",
-    density: "compact",
+    density: isMobileViewport ? "default" : "compact",
+    itemHeight: isMobileViewport ? TOUCH_TREE_ROW_HEIGHT_PX : undefined,
     icons: "complete",
     stickyFolders: true,
     gitStatus,
@@ -743,7 +773,12 @@ function FileTreeBodyForResolvedHost(
       className="relative flex min-h-0 flex-1 flex-col px-2 pb-2"
       onDoubleClickCapture={handleDoubleClick}
     >
-      <InputGroup className="mb-1.5 h-7 shrink-0">
+      {/* The sidebar's 28px filter row is below the touch target every other
+          phone control meets, and this one is a text field the user has to hit
+          precisely rather than a control with room for invisible hit-slop. */}
+      <InputGroup
+        className={cn("mb-1.5 shrink-0", isMobileViewport ? "h-11" : "h-7")}
+      >
         <InputGroupAddon align="inline-start">
           <Search className="size-3.5" aria-hidden />
         </InputGroupAddon>

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -124,9 +124,9 @@ const SEARCH_DEBOUNCE_MS = 200;
  * shell's hit-area stylesheet cannot reach - so the row itself has to be the
  * 44px target the rest of the phone surfaces use (`min-h-11`).
  *
- * Read once: `useFileTree` constructs the model from its options on first
- * render and exposes no height setter, so a viewport that flips mid-session
- * keeps the height it mounted with until the panel remounts.
+ * `useFileTree` constructs its model from these options once and exposes no
+ * height setter, so the body is keyed on the viewport class to rebuild it -
+ * see {@link FileTreePanelBodyForWorkspace}.
  */
 const TOUCH_TREE_ROW_HEIGHT_PX = 44;
 
@@ -508,9 +508,23 @@ export function FileTreePanelBodyForWorkspace(
   // The value to PROVIDE: ambient while following, the pin's own binding once
   // built, null while pending - never the ambient socket for a pinned host.
   const pinnedStreamBinding = useSurfaceHostStreamBinding(props.hostId);
+  // Keyed on the viewport CLASS, which is the one remount this body wants.
+  // Pierre reads `density` / `itemHeight` when it constructs the model and
+  // offers no setter for either, and its row height is not merely painted -
+  // it is the virtualizer's arithmetic (total height, sticky-row tops, scroll
+  // offsets), so re-painting the CSS variables alone would leave the layout
+  // disagreeing with the positions. Without the key a window crossing the
+  // breakpoint gets the other class's filter box over rows that kept their
+  // original geometry. Expansion survives the rebuild - it is persisted per
+  // (epic, host, workspace) and re-seeded on the next reset; the filter query
+  // does not, which is the right answer for a layout change.
+  const isTouchViewport = useIsMobileViewport();
   return (
     <StreamRuntimeContext.Provider value={pinnedStreamBinding}>
-      <FileTreeBodyForResolvedHost {...props} />
+      <FileTreeBodyForResolvedHost
+        key={isTouchViewport ? "touch" : "pointer"}
+        {...props}
+      />
     </StreamRuntimeContext.Provider>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -586,27 +586,20 @@ function FileTreeBodyForResolvedHost(
       onLatchHost();
       navigateNested(props.epicId, props.tabId, () => open(props.tabId, ref));
     };
-    // Preview-vs-permanent is a tab-strip concept, and a touch viewport has no
-    // tab strip: it shows one tile at a time and navigates through the switcher.
-    // There a preview tile is silently replaced by the next row tapped, and the
-    // double-click that promotes it to permanent has no touch equivalent - so
-    // the file tree would be the one surface a phone can never open two of.
-    // Tapping a row opens permanently instead, which is also what every other
-    // switcher category's row does (`useSwitcherActivate`). `openTile` dedupes
-    // on the ref either way, so a re-tap focuses the tile already open.
+    // Preview is right on a touch viewport too, even though the double-click
+    // that promotes it there has no touch equivalent: that viewport shows ONE
+    // tile at a time, none of its lists surfaces an open workspace-file tile,
+    // and nothing there can close one - so a permanent open buys nothing
+    // visible and leaves an unreachable tile behind. Recycling the single
+    // preview is what browsing a tree by tap wants, and the row itself is the
+    // way back to a file already visited.
     handlersRef.current.onSelect = (treePath) => {
-      openInTab(
-        treePath,
-        isMobileViewport
-          ? prepareOpenTileInTabFocusTarget
-          : prepareOpenTilePreviewInTabFocusTarget,
-      );
+      openInTab(treePath, prepareOpenTilePreviewInTabFocusTarget);
     };
     handlersRef.current.onOpen = (treePath) => {
       openInTab(treePath, prepareOpenTileInTabFocusTarget);
     };
   }, [
-    isMobileViewport,
     navigateNested,
     workspaceFileRefForTreePath,
     props.epicId,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -724,11 +724,19 @@ function FileTreeBodyForResolvedHost(
         pierreSearch.value.length > 0 &&
         pierreSearch.matchingPaths.length === 0;
 
-  const handleDoubleClick = useCallback((event: MouseEvent<HTMLElement>) => {
-    const treePath = extractPierreItemPathFromEvent(event);
-    if (treePath === null) return;
-    handlersRef.current.onOpen(treePath);
-  }, []);
+  const handleDoubleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      // A touch browser synthesises `dblclick` from a rapid double tap, which
+      // would promote the preview to a permanent tile - the one outcome this
+      // viewport cannot undo, since nothing there lists or closes an open
+      // workspace-file tile. Promotion stays a pointer gesture.
+      if (isMobileViewport) return;
+      const treePath = extractPierreItemPathFromEvent(event);
+      if (treePath === null) return;
+      handlersRef.current.onOpen(treePath);
+    },
+    [isMobileViewport],
+  );
 
   // Bridge Pierre's shadow-DOM rows into the root dnd-kit drag flow. Files keep
   // their canvas-openable source; directory rows carry a composer-only mention


### PR DESCRIPTION
## What

On a touch viewport an epic shows exactly **one** tile full-screen, and the switcher's lists enumerate **content** (agents, artifacts, terminals, tree, diffs) — never open tiles. A permanent open there leaves a tile behind the one on screen that nothing lists and nothing can close.

Files and diffs already opened as previews for that reason. This makes agents, artifacts and terminals do the same, so a tap always replaces what you are looking at.

Also folds in the File-tree touch work previously on `fix/mobile-files-tab` (#1414) — those four commits are kept as-is rather than squashed, per the decision to handle the phone tile model in one PR. **#1414's earlier review does not carry over; this needs a fresh cycle.**

## How

`useSwitcherActivate` now dispatches `prepareOpenTilePreviewInTabFocusTarget`.

The already-open case needs no branch. `openTile` dedups globally and its contract is *"focusing an already-open tab never demotes it to preview"* — so a kept tile stays kept and only the pane's activation moves. That collapses the hand-rolled found/not-found branch, and `switcher-terminals-list.tsx`, which open-coded the same shape, moves onto the shared hook.

**Incidental fix, called out so it does not read as scope creep:** the hook deduped with `findOpenArtifactInTab`, which matches **content id only**. `openTile` matches id **and** bound host. A chat row's id is not host-unique — a cross-host clone carries the source's chat id verbatim — which is why `switcher-terminals-list.tsx` already refused content-id dedup in its own comment. All three call sites are now on the host-aware rule; there is a regression test for it.

## Why this is viewport-gated for free

The switcher sheet only mounts under `useIsMobileViewport()` (`tile-canvas.tsx`), so these three lists cannot render at ≥768px. A narrow desktop browser window gets the same behaviour, which is intended — replace-semantics follow the layout. Desktop's split canvas is untouched.

## Retention and history

- **Replacing is not destroying.** `updateTabCanvas` captures every removed tile's payload into `closedTilePayloadsByTabId`, so back/forward re-presents an evicted preview through the existing `restoreClosedTilePreview` path.
- **A kept tile is never the one evicted** — only the pane's current preview is, so a kept chat stays inside `activationHistory` and inside the per-pane retention window (`RETAINED_PANE_CHAT_CAP`).
- History semantics are unchanged: activation recording in `openTile` already *is* the bridge rule.

## Invariants

`repairLayout` governs the **top-level tab strip** and is not touched — this only changes which canvas tile a tap opens inside one epic tab. The canvas analog, `insertTabInstance` + `reconcileCanvasInvariants`, already sets the active tab and re-prunes activation history in the same transaction on a preview eviction; files and diffs have exercised that path on both viewports since #1404. Asserted by test rather than changed.

## Out of scope

Eviction tuning, bottom-bar redesign, and "close" semantics. `MobileCurrentTileBar` is untouched — it never listed open tiles.

**Open, tracked separately:** whether a preview should promote to kept on edit. There is no such rule in the tree to port — desktop promotes on double-click (row or tab) and on drag, never on typing — so adding one would be new semantics, and it would manufacture kept tiles on a surface with no close affordance. Deliberately not in this PR.

## Verification

`bun run compile` clean, `eslint --max-warnings 0` clean, 68 tests pass across the four affected mobile suites.

New coverage in `use-switcher-activate.test.tsx`: preview recycling (the tab **count** is the assertion — one tile on screen looks identical either way), payload preservation for back/forward, a kept tile surviving repeated taps, focus-without-demotion, and host-aware dedup. `switcher-terminals-list.test.tsx` asserts the same recycling through the real store.

Simulator verification of tap→replace and back-swipe→re-present is required before merge and is queued separately.