### PR TITLE
test(gui-app): pin durable promotion when one preview chat recycles another

### DIFF
--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store-scroll-anchor-eviction.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store-scroll-anchor-eviction.test.ts
@@ -50,8 +50,23 @@ import {
 } from "@/stores/chats/chat-tab-pending-hydration-restore";
 import { evictTileFindUiForEpic } from "@/stores/tile-find/tile-find-store";
 import { TILE_KIND_PUBLISHED_CHAT } from "@/stores/epics/canvas/tile-kinds";
-import type { PublishedChatTileRef } from "@/stores/epics/canvas/types";
+import type {
+  EpicNodeRef,
+  PublishedChatTileRef,
+} from "@/stores/epics/canvas/types";
 import { CHAT_A, SPEC_A } from "./canvas-test-fixtures";
+
+/**
+ * A second chat, so a preview open can recycle {@link CHAT_A}'s preview in the
+ * same pane. Only the identity fields differ - the sweep resolves a removed
+ * tile by kind, content id and epic, so the rest is irrelevant to it.
+ */
+const CHAT_B: EpicNodeRef = {
+  ...CHAT_A,
+  id: "chat-b",
+  instanceId: "inst-chat-b",
+  name: "Chat B",
+};
 
 const EMPTY_TILE_FIND_CAPABILITIES: ReadonlySet<TileFindCapability> = new Set();
 
@@ -247,6 +262,7 @@ beforeEach(() => {
   evictA2AOpenStores([SPEC_A.instanceId]);
   clearTicket5PerTabState(CHAT_A.instanceId, "epic-t5-evict");
   clearTicket5PerTabState(CHAT_A.instanceId, "epic-t5-hide");
+  clearTicket5PerTabState(CHAT_A.instanceId, "epic-t5-recycle");
   useTileFindStore.getState().resetForTests();
   resetPendingHydrationRestoreForTesting();
 });
@@ -262,6 +278,7 @@ afterEach(() => {
   evictA2AOpenStores([SPEC_A.instanceId]);
   clearTicket5PerTabState(CHAT_A.instanceId, "epic-t5-evict");
   clearTicket5PerTabState(CHAT_A.instanceId, "epic-t5-hide");
+  clearTicket5PerTabState(CHAT_A.instanceId, "epic-t5-recycle");
   useTileFindStore.getState().resetForTests();
   resetPendingHydrationRestoreForTesting();
 });
@@ -363,6 +380,24 @@ describe("canvas store ticket-5 per-tab persistence sweep", () => {
     expectTicket5PerTabStatePresent(epicId);
 
     useEpicCanvasStore.getState().closeTabsForEpics([epicId]);
+
+    expectTicket5TabKeysEvicted(epicId);
+  });
+
+  it("promotes durable state when one preview chat RECYCLES another - a replace is a removal, not a close", () => {
+    const epicId = "epic-t5-recycle";
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab(epicId, "Recycle Ticket5");
+    store.openTilePreviewInTab(tabId, CHAT_A);
+    seedTicket5PerTabState(epicId);
+    expectTicket5PerTabStatePresent(epicId);
+
+    // A second preview into the same pane evicts the first ENTIRELY - the
+    // tile leaves `tabInstanceIds`, and that removal is the only signal the
+    // sweep needs. No close action is involved, and the chat's view never
+    // unmounts through a component lifecycle, so this promotion is the ONLY
+    // thing standing between a recycled chat and a lost draft.
+    store.openTilePreviewInTab(tabId, CHAT_B);
 
     expectTicket5TabKeysEvicted(epicId);
   });


### PR DESCRIPTION
Test-only. Follow-up to #1447.

## What this pins

The canvas sweep promotes a removed chat tile's tab-side state to durable before evicting it. It keys off **removal from `tabInstanceIds`**, not off a close action — so recycling one chat preview with another is a removal and must promote.

The sweep's existing coverage only exercised a **permanent close**. On that path a component unmount could plausibly have been doing the work, so it never isolated the sweep's own promotion. This adds the recycle case:

- open a chat as a preview, seed its tab-side state
- open a second chat preview into the same pane, which evicts the first entirely
- assert the tab-key state is gone **and** the durable state still restores

Nothing unmounts through a component lifecycle on this path, which is exactly why it is worth pinning: the sweep's promotion is the only thing standing between a recycled chat and a lost draft.

## Why now

#1447 made every phone switcher tap open a preview, so chat previews are now recycled routinely on that viewport. The machinery itself is **not new** — desktop's chat sidebar has always single-clicked to a preview, so clicking two chats there evicts a chat preview today. This test pins behaviour that already exists rather than covering new code.

It also closes a verification gap: simulator capture of this claim was not possible (no epic on the dev stack has a preview-able chat with a live composer — one epic's chats are all bound to an offline host, the other has a single chat that always arrives kept). A screenshot of a restored draft could not distinguish *"promoted correctly"* from *"never evicted"* in any case; this asserts the promotion itself.

## Verification

`bun run compile` clean, `eslint --max-warnings 0` clean, `prettier` clean. The suite goes 5 → 6 tests, all passing, against the real store and the real sweep.